### PR TITLE
[EuiDescriptionListTitle] Fix compressed styles not being correctly applied

### DIFF
--- a/src/components/description_list/__snapshots__/description_list_title.test.tsx.snap
+++ b/src/components/description_list/__snapshots__/description_list_title.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiDescriptionListTitle EuiDescriptionListTitle prop variations align c
 
 exports[`EuiDescriptionListTitle EuiDescriptionListTitle prop variations compressed is rendered 1`] = `
 <dt
-  class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal"
+  class="euiDescriptionList__title emotion-euiDescriptionList__title-row-compressed"
 />
 `;
 

--- a/src/components/description_list/description_list_title.tsx
+++ b/src/components/description_list/description_list_title.tsx
@@ -31,7 +31,7 @@ export const EuiDescriptionListTitle: FunctionComponent<EuiDescriptionListTitleP
   const styles = euiDescriptionListTitleStyles(theme);
 
   let conditionalStyles =
-    compressed && textStyle === 'reverse'
+    compressed && textStyle !== 'reverse'
       ? [styles.fontStyles.compressed]
       : [styles.fontStyles[textStyle]];
 

--- a/upcoming_changelogs/6160.md
+++ b/upcoming_changelogs/6160.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Updated the text size of `EuiDescriptionListTitle` to be 14px when the `EuiDescriptionList` is compressed
+- Fixed the text size of `EuiDescriptionListTitle` when `EuiDescriptionList` is compressed

--- a/upcoming_changelogs/6160.md
+++ b/upcoming_changelogs/6160.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Updated the text size of `EuiDescriptionListTitle` to be 14px when the `EuiDescriptionList` is compressed


### PR DESCRIPTION
### Summary
Resolved a bug that caused `compressed` styles not to be applied to text in the original Emotion conversion of `EuiDescriptionList`. The text within the `DescriptionListTitle` and `DescriptionListDescription` should be 14px when the DescriptionList is compressed.

**Resolved: Text = 14px**
<img width="470" alt="image" src="https://user-images.githubusercontent.com/40739624/186227986-de8eda98-b0fe-4742-bd10-daef1a0284b8.png">

**Previous: Text = 16px**
<img width="468" alt="image" src="https://user-images.githubusercontent.com/40739624/186228055-43f43a02-49fa-4d8b-a5b4-a29b99a49292.png">


### Checklist
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
