### PR TITLE
[EuiDataGrid] Fix missing cell popover shadows in Safari

### DIFF
--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -109,6 +109,7 @@
   // Disables the default EuiPopover filter drop-shadow and uses box-shadow instead,
   // since we don't use the popover arrow in any case for cell popovers
   filter: none;
+  // sass-lint:disable-block mixins-before-declarations
   @include euiBottomShadow; // TODO: Convert to euiShadowMedium() in Emotion
 }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -104,6 +104,12 @@
   max-width: 400px !important;
   max-height: 400px !important;
   z-index: $euiZDataGridCellPopover !important;
+  // Workaround for a Safari CSS bug when using both `overflow: auto` & `filter: drop-shadow`
+  // (see https://github.com/elastic/eui/issues/6151)
+  // Disables the default EuiPopover filter drop-shadow and uses box-shadow instead,
+  // since we don't use the popover arrow in any case for cell popovers
+  filter: none;
+  @include euiBottomShadow; // TODO: Convert to euiShadowMedium() in Emotion
 }
 
 .euiDataGridRowCell__expandFlex {

--- a/upcoming_changelogs/6163.md
+++ b/upcoming_changelogs/6163.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed missing `EuiDataGrid` cell popover shadows in Safari


### PR DESCRIPTION
### Summary

closes https://github.com/elastic/eui/issues/6151 - see issue for more discussion/context

### Before:
<img width="532" alt="" src="https://user-images.githubusercontent.com/549407/186253856-dc150743-ca46-44bf-ba27-e51c353c76d8.png">

### After:
<img width="573" alt="" src="https://user-images.githubusercontent.com/549407/186253716-3b0d6481-d8e7-4e46-89dd-4b7ee33edafb.png">

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
