### PR TITLE
[useEuiTheme] return a memoized object for performance

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -244,6 +244,7 @@ export class EuiIconClass extends PureComponent<
       style,
       ...rest
     } = this.props;
+    console.log('::render');
 
     const { isLoading, neededLoading, iconTitle } = this.state;
     const isLoaded = !isLoading && neededLoading;

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -244,7 +244,6 @@ export class EuiIconClass extends PureComponent<
       style,
       ...rest
     } = this.props;
-    console.log('::render');
 
     const { isLoading, neededLoading, iconTitle } = this.state;
     const isLoaded = !isLoading && neededLoading;

--- a/src/services/theme/hooks.test.ts
+++ b/src/services/theme/hooks.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { testCustomHook } from '../../test/internal';
+import { useEuiTheme } from './hooks';
+
+describe('useEuiTheme', () => {
+  it('consecutive calls return a stable object', () => {
+    const hookResult = testCustomHook(useEuiTheme);
+    hookResult.updateHookArgs({});
+    expect(hookResult.return).toBe(hookResult.getUpdatedState());
+  });
+});

--- a/src/services/theme/hooks.tsx
+++ b/src/services/theme/hooks.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { forwardRef, useContext } from 'react';
+import React, { forwardRef, useContext, useMemo } from 'react';
 
 import {
   EuiThemeContext,
@@ -30,11 +30,16 @@ export const useEuiTheme = <T extends {} = {}>(): UseEuiTheme<T> => {
   const colorMode = useContext(EuiColorModeContext);
   const modifications = useContext(EuiModificationsContext);
 
-  return {
-    euiTheme: theme as EuiThemeComputed<T>,
-    colorMode,
-    modifications: modifications as EuiThemeModifications<T>,
-  };
+  const assembledTheme = useMemo(
+    () => ({
+      euiTheme: theme as EuiThemeComputed<T>,
+      colorMode,
+      modifications: modifications as EuiThemeModifications<T>,
+    }),
+    [theme, colorMode, modifications]
+  );
+
+  return assembledTheme;
 };
 
 export interface WithEuiThemeProps<P = {}> {
@@ -51,18 +56,8 @@ export const withEuiTheme = <T extends {} = {}, U extends {} = {}>(
     props: Omit<T, keyof WithEuiThemeProps<U>>,
     ref: React.Ref<Omit<T, keyof WithEuiThemeProps<U>>>
   ) => {
-    const { euiTheme, colorMode, modifications } = useEuiTheme<U>();
-    return (
-      <Component
-        theme={{
-          euiTheme,
-          colorMode,
-          modifications,
-        }}
-        ref={ref}
-        {...(props as T)}
-      />
-    );
+    const theme = useEuiTheme<U>();
+    return <Component theme={theme} ref={ref} {...(props as T)} />;
   };
 
   const WithEuiTheme = forwardRef(Render);

--- a/upcoming_changelogs/6165.md
+++ b/upcoming_changelogs/6165.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Added memoization to `useEuiTheme`'s return value, supporting React's shallow prop comparison optimizations  


### PR DESCRIPTION
### Summary

Fixes #6159 

Threw a console.log in **EuiIcon**'s render and verified any time its owner component rendered, the icon would unexpectedly re-render as well. Narrowed it down to a different `theme` prop coming in from `withEuiTheme` on every render, and traced object creation to both `useEuiTheme` and `withEuiTheme`.

* `withEuiTheme` updated to forward `useEuiTheme`'s return value into the wrapped component
* `useEuiTheme` updated with a `useMemo` to keep the resulting object stable
* added a unit test for regression

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
