### PR TITLE
[EuiIcon] Correct isMounted logic

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -133,7 +133,7 @@ export class EuiIconClass extends PureComponent<
   EuiIconProps & WithEuiThemeProps,
   State
 > {
-  isMounted = true;
+  isMounted = false;
   constructor(props: EuiIconProps & WithEuiThemeProps) {
     super(props);
 
@@ -149,6 +149,7 @@ export class EuiIconClass extends PureComponent<
   }
 
   componentDidMount() {
+    this.isMounted = true;
     const { type } = this.props;
 
     if (isEuiIconType(type) && this.state.icon == null) {

--- a/upcoming_changelogs/6166.md
+++ b/upcoming_changelogs/6166.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a bug in some development environments which prevented `EuiIcon` from loading icons asynchronously


### PR DESCRIPTION
### Summary

Fixes #6099 

React.StrictMode, used by Create React App & others, does interesting things around component creation, mounting, and re-use in development mode to enforce lifecycle best practices. **EuiIcon** was setting its `isMounted` property in the wrong place which led to no icons loading in some development environments (I was never able to reproduce the issue in EUI docs), as StrictMode would mount->unmount->mount components, causing **EuiIcon** to throw away the async icon when it loaded.

I tested this by manually changing _node_modules/@elastic/eui_ in a create-react-app, and confirmed the change (also applied manually) resolved this issue in an internal Elastic project.

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
