### PR TITLE
[EuiFlexItem] Revert flex-basis unitless 0 CSS change

### DIFF
--- a/src/components/flex/_flex_group.scss
+++ b/src/components/flex/_flex_group.scss
@@ -5,7 +5,7 @@
 
   .euiFlexItem {
     flex-grow: 1;
-    flex-basis: 0;
+    flex-basis: 0%;
   }
 }
 


### PR DESCRIPTION
### Summary

💀 Turns out this affects modern browsers, not just IE: 

![screencap](https://user-images.githubusercontent.com/549407/186523886-5d5a382c-2baf-4aa8-ad4d-c30c00243cc8.gif)

No changelog as #6161 has not yet been released

### Checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~
