### PR TITLE
[Docs] Fix sidenav scroll position resetting on every page change + fix nav on mobile

### DIFF
--- a/src-docs/src/components/guide_page/_guide_page.scss
+++ b/src-docs/src/components/guide_page/_guide_page.scss
@@ -71,6 +71,11 @@
     border-top: $euiBorderThin;
   }
 
+  .euiSideNav-isOpenMobile .euiSideNav__content {
+    max-height: 50vh;
+    overflow: auto;
+  }
+
   .guideSideNav__search {
     padding: $euiSizeS;
   }

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -57,15 +57,7 @@ export class GuidePageChrome extends Component {
         '.euiSideNavItemButton-isSelected'
       );
       if (selectedButton) {
-        let root = selectedButton.parentNode;
-
-        while (
-          !root.classList.contains('euiSideNavItem--root') &&
-          !root.classList.contains('guideSideNav')
-        ) {
-          root = root.parentNode;
-        }
-        root.scrollIntoView();
+        selectedButton.parentElement.scrollIntoView({ block: 'center' });
       }
     });
   };

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -29,7 +29,7 @@ export class GuidePageChrome extends Component {
   componentDidMount = () => {
     this._isMounted = true;
 
-    this.scrollNavSectionIntoViewSync();
+    this.scrollNavSectionIntoView();
   };
 
   componentWillUnmount = () => {
@@ -49,29 +49,25 @@ export class GuidePageChrome extends Component {
     });
   };
 
-  scrollNavSectionIntoViewSync = () => {
+  scrollNavSectionIntoView = () => {
     // wait a bit for react to blow away and re-create the DOM
     // then scroll the selected nav section into view
-    const selectedButton = document.querySelector(
-      '.euiSideNavItemButton-isSelected'
-    );
-    if (selectedButton) {
-      let root = selectedButton.parentNode;
+    requestAnimationFrame(() => {
+      const selectedButton = document.querySelector(
+        '.euiSideNavItemButton-isSelected'
+      );
+      if (selectedButton) {
+        let root = selectedButton.parentNode;
 
-      while (
-        !root.classList.contains('euiSideNavItem--root') &&
-        !root.classList.contains('guideSideNav')
-      ) {
-        root = root.parentNode;
+        while (
+          !root.classList.contains('euiSideNavItem--root') &&
+          !root.classList.contains('guideSideNav')
+        ) {
+          root = root.parentNode;
+        }
+        root.scrollIntoView();
       }
-      root.scrollIntoView();
-    }
-  };
-
-  scrollNavSectionIntoView = () => {
-    setTimeout(() => {
-      this.scrollNavSectionIntoViewSync();
-    }, 250);
+    });
   };
 
   renderSubSections = (href, subSections = [], searchTerm = '') => {

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -215,11 +215,11 @@ export class GuidePageChrome extends Component {
     if (sideNav.length) {
       sideNavContent = (
         <EuiSideNav
-          mobileTitle="Navigate components"
+          mobileTitle="Navigation"
           toggleOpenOnMobile={this.toggleOpenOnMobile}
           isOpenOnMobile={this.state.isSideNavOpenOnMobile}
           items={sideNav}
-          aria-label="EUI"
+          aria-label="EUI navigation"
         />
       );
     } else {

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -45,12 +45,15 @@ export class GuidePageChrome extends Component {
     // wait a bit for react to blow away and re-create the DOM
     // then scroll the selected nav section into view
     requestAnimationFrame(() => {
-      const selectedButton = document.querySelector(
+      const sideNav = document.querySelector('.guideSideNav__content');
+      const isMobile = sideNav?.querySelector('.euiSideNav__mobileToggle');
+
+      const selectedButton = sideNav?.querySelector(
         '.euiSideNavItemButton-isSelected'
       );
-      if (selectedButton) {
-        selectedButton.parentElement.scrollIntoView({ block: 'center' });
-      }
+      selectedButton?.parentElement.scrollIntoView({
+        block: isMobile ? 'start' : 'center',
+      });
     });
   };
 

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -14,8 +14,6 @@ import { EuiBadge } from '../../../../src/components/badge';
 import { slugify } from '../../../../src/services';
 
 export class GuidePageChrome extends Component {
-  _isMounted = false;
-
   constructor(props) {
     super(props);
 
@@ -27,13 +25,7 @@ export class GuidePageChrome extends Component {
   }
 
   componentDidMount = () => {
-    this._isMounted = true;
-
     this.scrollNavSectionIntoView();
-  };
-
-  componentWillUnmount = () => {
-    this._isMounted = false;
   };
 
   toggleOpenOnMobile = () => {

--- a/src-docs/src/services/routing/scroll_to_hash.ts
+++ b/src-docs/src/services/routing/scroll_to_hash.ts
@@ -17,7 +17,9 @@ export const useScrollToHash = () => {
 
   // Scroll back to top of page when going to a completely separate page
   useEffect(() => {
-    window.scrollTo(0, 0);
+    // For some annoying reason, the docs side nav using scrollIntoView() causes
+    // the window to scroll as well, so we need to wrap this in a rAF to supersede it
+    requestAnimationFrame(() => window.scrollTo(0, 0));
   }, [location.pathname]);
 
   useEffect(() => {


### PR DESCRIPTION
### Summary

I recommend [following along by commit](https://github.com/elastic/eui/pull/6177/commits)!

### Previous working(ish) behavior

Note how the tooltip and utility links do not actually stay in view

![screencap](https://user-images.githubusercontent.com/549407/186531866-a091e781-8d9b-4446-ad5a-3111f56f9d44.gif)

### Recent completely broken behavior

Side nav now always resets to the top of the scroll container

![screencap](https://user-images.githubusercontent.com/549407/186532107-f958dfcd-828f-439e-a999-3bd2454ba238.gif)

### New and slightly improved behavior

![screencap](https://user-images.githubusercontent.com/549407/186531668-b387cbd4-fd0e-4df6-9441-f75d0d67e180.gif)

#### Mobile fix (NOTE: requires #6176 to be merged in first or cherry-picked locally)

![screencap](https://user-images.githubusercontent.com/549407/186532572-af0822d5-4ca1-4c09-9ad9-ac05b990b3c5.gif)

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~