### PR TITLE
[Docs] Fix small screen layout in "other" nav popover

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -1,16 +1,18 @@
 import React, { useState } from 'react';
 
 import {
-  EuiHeaderLogo,
+  EuiBadge,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiHeader,
+  EuiHeaderLogo,
   EuiHeaderSectionItemButton,
-} from '../../../../src/components/header';
-import { EuiBadge } from '../../../../src/components/badge';
-import { EuiIcon } from '../../../../src/components/icon';
-import { EuiToolTip } from '../../../../src/components/tool_tip';
-import { EuiPopover } from '../../../../src/components/popover';
+  EuiIcon,
+  EuiPopover,
+  EuiToolTip,
+} from '../../../../src/components';
 import { useIsWithinBreakpoints } from '../../../../src/services';
-import { EuiButtonEmpty } from '../../../../src/components/button';
 
 // @ts-ignore Not TS
 import { CodeSandboxLink } from '../../components/codesandbox/link';
@@ -101,14 +103,22 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
 
     return (
       <EuiPopover
-        id="guidePageChromeThemePopover"
         button={button}
         isOpen={mobilePopoverIsOpen}
         closePopover={() => setMobilePopoverIsOpen(false)}
       >
-        {renderGithub()}
-        <GuideFigmaLink />
-        {renderCodeSandbox()}
+        <EuiFlexGroup
+          direction="column"
+          alignItems="flexStart"
+          gutterSize="none"
+          responsive={false}
+        >
+          <EuiFlexItem>{renderGithub()}</EuiFlexItem>
+          <EuiFlexItem>
+            <GuideFigmaLink />
+          </EuiFlexItem>
+          <EuiFlexItem>{renderCodeSandbox()}</EuiFlexItem>
+        </EuiFlexGroup>
       </EuiPopover>
     );
   }


### PR DESCRIPTION
### Summary

In the spirit of fixing small screen bugs...

On larger small screens:

**Before:**
<img width="419" alt="Screen Shot 2022-08-25 at 9 32 20 AM" src="https://user-images.githubusercontent.com/2728212/186699603-e1ac59ed-7bed-4235-8e60-dc0cac0b1684.png">

**After:**
<img width="333" alt="Screen Shot 2022-08-25 at 9 56 35 AM" src="https://user-images.githubusercontent.com/2728212/186699626-99f4ae1d-e4f0-41ad-8430-39a8d2da9905.png">


~### Checklist~
