### PR TITLE
Expands the guideline for hint text

### DIFF
--- a/src-docs/src/views/form_controls/guidelines.js
+++ b/src-docs/src/views/form_controls/guidelines.js
@@ -68,7 +68,8 @@ export default () => {
         description={
           <p>
             Place hints and instructions outside a text field so it is always
-            visible to the user. Use hint text to:
+            visible to the user. Keep the hint text short, maximum two 
+            sentences long. Use hint text to:
             <EuiSpacer />
             <ul>
               <li>

--- a/src-docs/src/views/form_controls/guidelines.js
+++ b/src-docs/src/views/form_controls/guidelines.js
@@ -68,8 +68,8 @@ export default () => {
         description={
           <p>
             Place hints and instructions outside a text field so it is always
-            visible to the user. Keep the hint text short, maximum two 
-            sentences long. Use hint text to:
+            visible to the user. Keep the hint text short, maximum two sentences
+            long. Use hint text to:
             <EuiSpacer />
             <ul>
               <li>


### PR DESCRIPTION
### Summary

This PR expands the guidelines for hint text. Provides a recommendation for text length. 

![Screenshot 2022-08-29 at 14 06 11](https://user-images.githubusercontent.com/22324794/187197387-d744951f-6483-46f6-8101-d7e7caf052d2.png)

### Checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
