### PR TITLE
[EuiPageSidebar] Fix inline styles not updating if `sticky` is not set

### DIFF
--- a/src/components/page/page_sidebar/page_sidebar.test.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render, mount } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 import { PADDING_SIZES } from '../../../global_styling';
@@ -41,6 +41,49 @@ describe('EuiPageSidebar', () => {
         const component = render(<EuiPageSidebar paddingSize={size} />);
 
         expect(component).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('inline styles', () => {
+    it('updates correctly when `sticky` is not set', () => {
+      const component = mount(<EuiPageSidebar data-test-subj="sidebar" />);
+
+      expect(
+        component.find('[data-test-subj="sidebar"]').last().prop('style')
+      ).toEqual({ minInlineSize: 248 });
+
+      component.setProps({ minWidth: 100 });
+      component.update();
+
+      expect(
+        component.find('[data-test-subj="sidebar"]').last().prop('style')
+      ).toEqual({ minInlineSize: 100 });
+    });
+
+    it('updates correctly when `sticky` is set', () => {
+      const component = mount(
+        <EuiPageSidebar sticky data-test-subj="sidebar" />
+      );
+
+      expect(
+        component.find('[data-test-subj="sidebar"]').last().prop('style')
+      ).toEqual({
+        insetBlockStart: 0,
+        maxBlockSize: 'calc(100vh - 0px)',
+        minInlineSize: 248,
+      });
+
+      component.setProps({ style: { color: 'red' } });
+      component.update();
+
+      expect(
+        component.find('[data-test-subj="sidebar"]').last().prop('style')
+      ).toEqual({
+        color: 'red',
+        insetBlockStart: 0,
+        maxBlockSize: 'calc(100vh - 0px)',
+        minInlineSize: 248,
       });
     });
   });

--- a/src/components/page/page_sidebar/page_sidebar.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.tsx
@@ -81,6 +81,11 @@ export const EuiPageSidebar: FunctionComponent<EuiPageSidebarProps> = ({
   });
 
   useEffect(() => {
+    let updatedStyles = {
+      ...style,
+      ...logicalStyle('min-width', isResponding ? '100%' : minWidth),
+    };
+
     if (sticky) {
       const euiHeaderFixedCounter = Number(
         document.body.dataset.fixedHeaders ?? 0
@@ -91,13 +96,14 @@ export const EuiPageSidebar: FunctionComponent<EuiPageSidebarProps> = ({
           ? sticky?.offset
           : themeContext.euiTheme.base * 3 * euiHeaderFixedCounter;
 
-      setInlineStyles({
-        ...style,
-        ...logicalStyle('min-width', isResponding ? '100%' : minWidth),
+      updatedStyles = {
+        ...updatedStyles,
         ...logicalStyle('top', offset),
         ...logicalStyle('max-height', `calc(100vh - ${offset}px)`),
-      });
+      };
     }
+
+    setInlineStyles(updatedStyles);
   }, [style, sticky, themeContext.euiTheme.base, isResponding, minWidth]);
 
   return (

--- a/upcoming_changelogs/6191.md
+++ b/upcoming_changelogs/6191.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiPageSidebar` bug where inline styles were not correctly updating


### PR DESCRIPTION
### Summary

This PR fixes an issue that Caroline was running into in her EuiPageTemplate Kibana upgrade PR (https://github.com/elastic/kibana/pull/138546):

<img width="801" alt="" src="https://user-images.githubusercontent.com/549407/187308755-a4695f68-87ab-410f-81ad-9dbc69716478.png">

The reason why `minWidth` isn't updating downstream in Kibana is because `sticky` is not set in Kibana, and `EuiPageSidebar` has buggy logic causing inline styles not to be correctly updated if `sticky` is not set.

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
