### PR TITLE
[EuiPageSection] Add `component` prop, default to `section` tag

### DIFF
--- a/src/components/page/page_section/__snapshots__/page_section.test.tsx.snap
+++ b/src/components/page/page_section/__snapshots__/page_section.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiPageSection is rendered 1`] = `
-<div
+<section
   aria-label="aria-label"
   class="testClass1 testClass2 emotion-euiPageSection-l-top-transparent"
   data-test-subj="test subject string"
@@ -9,127 +9,127 @@ exports[`EuiPageSection is rendered 1`] = `
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props alignment center is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-center-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l-center"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props alignment horizontalCenter is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-horizontalCenter-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l-center"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props alignment top is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props bottomBorder can be true 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l-border"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color accent is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-accent"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color danger is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-danger"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color plain is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-plain"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color primary is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-primary"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color subdued is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-subdued"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color success is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-success"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color transparent is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props color warning is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-warning"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props component 1`] = `
@@ -159,7 +159,7 @@ exports[`EuiPageSection props component 1`] = `
 `;
 
 exports[`EuiPageSection props contentProps are passed down 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
@@ -167,97 +167,97 @@ exports[`EuiPageSection props contentProps are passed down 1`] = `
     class="testClass1 testClass2 emotion-euiPageSection__content-l"
     data-test-subj="test subject string"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props grow can be true 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props paddingSize l is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props paddingSize m is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-m-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-m"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props paddingSize none is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props paddingSize s is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-s-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-s"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props paddingSize xl is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-xl-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-xl"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props paddingSize xs is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-xs-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-xs"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props restrictWidth can be custom 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l-restrictWidth"
     style="max-width:1000px"
   />
-</div>
+</section>
 `;
 
 exports[`EuiPageSection props restrictWidth can be true 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-top-transparent"
 >
   <div
     class="emotion-euiPageSection__content-l-restrictWidth"
     style="max-width:1200px"
   />
-</div>
+</section>
 `;

--- a/src/components/page/page_section/__snapshots__/page_section.test.tsx.snap
+++ b/src/components/page/page_section/__snapshots__/page_section.test.tsx.snap
@@ -132,6 +132,32 @@ exports[`EuiPageSection props color warning is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiPageSection props component 1`] = `
+<main>
+  <section
+    class="emotion-euiPageSection-l-top-transparent"
+  >
+    <div
+      class="emotion-euiPageSection__content-l"
+    />
+  </section>
+  <div
+    class="emotion-euiPageSection-l-top-transparent"
+  >
+    <div
+      class="emotion-euiPageSection__content-l"
+    />
+  </div>
+  <aside
+    class="emotion-euiPageSection-l-top-transparent"
+  >
+    <div
+      class="emotion-euiPageSection__content-l"
+    />
+  </aside>
+</main>
+`;
+
 exports[`EuiPageSection props contentProps are passed down 1`] = `
 <div
   class="emotion-euiPageSection-l-top-transparent"

--- a/src/components/page/page_section/page_section.test.tsx
+++ b/src/components/page/page_section/page_section.test.tsx
@@ -22,6 +22,18 @@ describe('EuiPageSection', () => {
   });
 
   describe('props', () => {
+    test('component', () => {
+      const component = render(
+        <main>
+          <EuiPageSection />
+          <EuiPageSection component="div" />
+          <EuiPageSection component="aside" />
+        </main>
+      );
+
+      expect(component).toMatchSnapshot();
+    });
+
     describe('restrictWidth', () => {
       test('can be true', () => {
         const component = render(<EuiPageSection restrictWidth />);

--- a/src/components/page/page_section/page_section.tsx
+++ b/src/components/page/page_section/page_section.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, ComponentType, HTMLAttributes } from 'react';
 import { CommonProps } from '../../common';
 
 import {
@@ -53,7 +53,11 @@ export type EuiPageSectionProps = CommonProps &
      * Passed down to the div wrapper of the section contents
      */
     contentProps?: HTMLAttributes<HTMLDivElement>;
-  } & Omit<HTMLAttributes<HTMLDivElement>, 'color'>;
+    /**
+     * Sets which HTML element to render.
+     */
+    component?: keyof JSX.IntrinsicElements | ComponentType;
+  } & Omit<HTMLAttributes<Element>, 'color'>;
 
 export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({
   children,
@@ -64,6 +68,7 @@ export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({
   color = 'transparent',
   grow = false,
   contentProps,
+  component: Component = 'section',
   ...rest
 }) => {
   // Set max-width as a style prop
@@ -98,10 +103,10 @@ export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({
   ];
 
   return (
-    <div css={cssStyles} {...rest}>
+    <Component css={cssStyles} {...rest}>
       <div css={cssContentStyles} {...contentProps} style={widthStyles}>
         {children}
       </div>
-    </div>
+    </Component>
   );
 };

--- a/src/components/page_template/bottom_bar/__snapshots__/page_bottom_bar.test.tsx.snap
+++ b/src/components/page_template/bottom_bar/__snapshots__/page_bottom_bar.test.tsx.snap
@@ -13,13 +13,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-l-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-l"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -42,13 +42,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-l-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-l"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -71,13 +71,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-m-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-m"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -100,13 +100,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -129,13 +129,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-s-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-s"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -158,13 +158,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-xl-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-xl"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -187,13 +187,13 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-xs-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-xs"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -216,14 +216,14 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-l-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
         style="max-width:1024px"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -246,14 +246,14 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-l-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
         style="max-width:24rem"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"
@@ -276,14 +276,14 @@ Array [
     >
       Page level controls
     </h2>
-    <div
+    <section
       class="emotion-euiPageSection-l-top-transparent"
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
         style="max-width:1200px"
       />
-    </div>
+    </section>
   </section>,
   <p
     aria-live="assertive"

--- a/src/components/page_template/empty_prompt/__snapshots__/page_empty_prompt.test.tsx.snap
+++ b/src/components/page_template/empty_prompt/__snapshots__/page_empty_prompt.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`_EuiPageEmptyPrompt EuiEmptyPromptProps is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -36,11 +36,11 @@ exports[`_EuiPageEmptyPrompt EuiEmptyPromptProps is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt EuiPageSectionProps is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-l-horizontalCenter-transparent"
 >
   <div
@@ -62,11 +62,11 @@ exports[`_EuiPageEmptyPrompt EuiPageSectionProps is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -90,11 +90,11 @@ exports[`_EuiPageEmptyPrompt is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt paddingSize l is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -116,11 +116,11 @@ exports[`_EuiPageEmptyPrompt paddingSize l is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt paddingSize m is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-m-center-transparent"
 >
   <div
@@ -142,11 +142,11 @@ exports[`_EuiPageEmptyPrompt paddingSize m is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt paddingSize none is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-center-transparent"
 >
   <div
@@ -168,11 +168,11 @@ exports[`_EuiPageEmptyPrompt paddingSize none is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt paddingSize s is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-s-center-transparent"
 >
   <div
@@ -194,11 +194,11 @@ exports[`_EuiPageEmptyPrompt paddingSize s is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt paddingSize xl is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-xl-center-transparent"
 >
   <div
@@ -220,11 +220,11 @@ exports[`_EuiPageEmptyPrompt paddingSize xl is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt paddingSize xs is rendered 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-xs-center-transparent"
 >
   <div
@@ -246,11 +246,11 @@ exports[`_EuiPageEmptyPrompt paddingSize xs is rendered 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt panelled is false and color is defined, then the prompt inherits the color 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -272,11 +272,11 @@ exports[`_EuiPageEmptyPrompt panelled is false and color is defined, then the pr
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt panelled is false and color is not defined, then the prompt is plain 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -298,11 +298,11 @@ exports[`_EuiPageEmptyPrompt panelled is false and color is not defined, then th
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt panelled is true and color is defined, then the prompt inherits the color 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-plain"
 >
   <div
@@ -324,11 +324,11 @@ exports[`_EuiPageEmptyPrompt panelled is true and color is defined, then the pro
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt panelled is true and color is not defined, then the prompt is subdued 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-plain"
 >
   <div
@@ -350,11 +350,11 @@ exports[`_EuiPageEmptyPrompt panelled is true and color is not defined, then the
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt restrict width can be set to a custom number 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -377,11 +377,11 @@ exports[`_EuiPageEmptyPrompt restrict width can be set to a custom number 1`] = 
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt restrict width can be set to a custom value and measurement 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -404,11 +404,11 @@ exports[`_EuiPageEmptyPrompt restrict width can be set to a custom value and mea
       </div>
     </div>
   </div>
-</div>
+</section>
 `;
 
 exports[`_EuiPageEmptyPrompt restrict width can be set to a default 1`] = `
-<div
+<section
   class="emotion-euiPageSection-grow-l-center-transparent"
 >
   <div
@@ -431,5 +431,5 @@ exports[`_EuiPageEmptyPrompt restrict width can be set to a default 1`] = `
       </div>
     </div>
   </div>
-</div>
+</section>
 `;

--- a/upcoming_changelogs/6192.md
+++ b/upcoming_changelogs/6192.md
@@ -1,0 +1,1 @@
+- Added a new `component` prop to `EuiPageSection`, allowing overriding of the default `section` tag


### PR DESCRIPTION
### Summary

It seems incredibly bizarre to have a component named `EuiPageSection` that doesn't actually use the `<section>` tag for semantic meaning.

If for some reason `<section>` is not applicable, we should support overriding the tag via the `component` prop (already used as a paradigm in `EuiPageTemplate` to override `<main>`).

### Checklist

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~