### PR TITLE
[EuiPage*_Deprecated] Use `@deprecated` flag

### DIFF
--- a/src/components/page/page_content/page_content.tsx
+++ b/src/components/page/page_content/page_content.tsx
@@ -42,8 +42,7 @@ export type EuiPageContentProps = CommonProps &
   };
 
 /**
- * **DEPRECATED**
- * Use EuiPageSection instead
+ * @deprecated Use EuiPageSection instead
  */
 export const EuiPageContent_Deprecated: FunctionComponent<EuiPageContentProps> = ({
   verticalPosition,

--- a/src/components/page/page_content/page_content_body.tsx
+++ b/src/components/page/page_content/page_content_body.tsx
@@ -35,8 +35,7 @@ export interface EuiPageContentBodyProps
 }
 
 /**
- * **DEPRECATED**
- * Use EuiPageSection instead
+ * @deprecated Use EuiPageSection instead
  */
 export const EuiPageContentBody_Deprecated: FunctionComponent<EuiPageContentBodyProps> = ({
   children,

--- a/src/components/page/page_content/page_content_header.tsx
+++ b/src/components/page/page_content/page_content_header.tsx
@@ -21,8 +21,7 @@ export interface EuiPageContentHeaderProps
 }
 
 /**
- * **DEPRECATED**
- * Use EuiPageHeader instead
+ * @deprecated Use EuiPageHeader instead
  */
 export const EuiPageContentHeader_Deprecated: FunctionComponent<EuiPageContentHeaderProps> = ({
   children,

--- a/src/components/page/page_content/page_content_header_section.tsx
+++ b/src/components/page/page_content/page_content_header_section.tsx
@@ -15,8 +15,7 @@ export interface EuiPageContentHeaderSectionProps
     HTMLAttributes<HTMLDivElement> {}
 
 /**
- * **DEPRECATED**
- * Use EuiPageHeader instead
+ * @deprecated Use EuiPageHeader instead
  */
 export const EuiPageContentHeaderSection_Deprecated: FunctionComponent<EuiPageContentHeaderSectionProps> = ({
   children,

--- a/src/components/page/page_side_bar/page_side_bar.tsx
+++ b/src/components/page/page_side_bar/page_side_bar.tsx
@@ -33,8 +33,7 @@ export interface EuiPageSideBarProps
 }
 
 /**
- * **DEPRECATED**
- * Use the new EuiPageSidebar instead
+ * @deprecated Use the new EuiPageSidebar in page/page_sidebar instead
  */
 export const EuiPageSideBar_Deprecated: FunctionComponent<EuiPageSideBarProps> = ({
   children,

--- a/src/components/page/page_template.tsx
+++ b/src/components/page/page_template.tsx
@@ -101,7 +101,9 @@ export type EuiPageTemplateProps_Deprecated = Omit<
 /**
  * This component has been deprecated in favor of the new
  * namespaced version. You can still import this component
- * for a period of time by importing `as EuiPageTemplate`.
+ * until August 2023 by importing `as EuiPageTemplate`.
+ *
+ * @deprecated use EuiPageTemplate from page_template/page_template instead
  */
 export const EuiPageTemplate_Deprecated: FunctionComponent<EuiPageTemplateProps_Deprecated> = ({
   template = 'default',

--- a/upcoming_changelogs/6194.md
+++ b/upcoming_changelogs/6194.md
@@ -1,0 +1,3 @@
+**Deprecations**
+
+- Added `@deprecated` flags to `EuiPageContent_Deprecated`, `EuiPageContentBody_Deprecated`, `EuiPageContentHeader_Deprecated`, `EuiPageContentHeaderSection_Deprecated`, `EuiPageSideBar_Deprecated` and `EuiPageTemplate_Deprecated`, which will provide helpful hints to IDEs that support jsdoc flags. Consumers will have until August 2023 to migrate from these deprecated components.


### PR DESCRIPTION
### Summary

Using the `@deprecated` jsdoc flag will be picked up by supporting IDEs (VSCode, possibly webstorm as well) and add a strikethrough in both import and component usage:

<img width="804" alt="" src="https://user-images.githubusercontent.com/549407/187554952-3f58ffbd-10b4-49cf-8a80-e5e6fb39abee.png">

This will be relatively useful in encouraging Kibana consumers to switch over from deprecated components sooner rather than later.

### Checklist

N/A - technically this is not an actual source-code-affecting change and only affects development 🤔 