### PR TITLE
[EuiProvider] Change location of fallback Emotion cache

### DIFF
--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -1058,6 +1058,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to all
 <EuiCacheProvider
   cache={
     Object {
+      "compat": true,
       "insert": [Function],
       "inserted": Object {},
       "key": "default",
@@ -1404,6 +1405,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to eac
 <EuiCacheProvider
   cache={
     Object {
+      "compat": true,
       "insert": [Function],
       "inserted": Object {},
       "key": "default",
@@ -1791,7 +1793,30 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to eac
 `;
 
 exports[`EuiProvider providing an @emotion cache config applies the cache to global styles 1`] = `
-<EuiCacheProvider>
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <EuiThemeProvider
     theme={
       Object {
@@ -2137,7 +2162,30 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to glo
 `;
 
 exports[`EuiProvider providing an @emotion cache config applies the cache to utility styles 1`] = `
-<EuiCacheProvider>
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <EuiThemeProvider
     theme={
       Object {

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -1740,6 +1740,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to eac
     <EuiCacheProvider
       cache={
         Object {
+          "compat": true,
           "insert": [Function],
           "inserted": Object {},
           "key": "global",
@@ -1765,6 +1766,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to eac
     <EuiCacheProvider
       cache={
         Object {
+          "compat": true,
           "insert": [Function],
           "inserted": Object {},
           "key": "utility",
@@ -2131,6 +2133,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to glo
     <EuiCacheProvider
       cache={
         Object {
+          "compat": true,
           "insert": [Function],
           "inserted": Object {},
           "key": "global",
@@ -2503,6 +2506,7 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to uti
     <EuiCacheProvider
       cache={
         Object {
+          "compat": true,
           "insert": [Function],
           "inserted": Object {},
           "key": "utility",

--- a/src/components/provider/__snapshots__/provider.test.tsx.snap
+++ b/src/components/provider/__snapshots__/provider.test.tsx.snap
@@ -1,7 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiProvider applying modifications propagates \`modify\` 1`] = `
-<EuiCacheProvider>
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <EuiThemeProvider
     modify={
       Object {
@@ -337,7 +360,30 @@ exports[`EuiProvider applying modifications propagates \`modify\` 1`] = `
 `;
 
 exports[`EuiProvider changing color modes propagates \`colorMode\` 1`] = `
-<EuiCacheProvider>
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <EuiThemeProvider
     colorMode="dark"
     theme={
@@ -662,7 +708,30 @@ exports[`EuiProvider changing color modes propagates \`colorMode\` 1`] = `
 `;
 
 exports[`EuiProvider is rendered 1`] = `
-<EuiCacheProvider>
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <EuiThemeProvider
     theme={
       Object {
@@ -2413,8 +2482,378 @@ exports[`EuiProvider providing an @emotion cache config applies the cache to uti
 </EuiCacheProvider>
 `;
 
+exports[`EuiProvider providing an @emotion cache config provides a default cache from Emotion when configured without a cache 1`] = `
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
+  <EuiThemeProvider
+    theme={
+      Object {
+        "animation": Object {
+          "bounce": "cubic-bezier(.34, 1.61, .7, 1)",
+          "extraFast": "90ms",
+          "extraSlow": "500ms",
+          "fast": "150ms",
+          "normal": "250ms",
+          "resistance": "cubic-bezier(.694, .0482, .335, 1)",
+          "slow": "350ms",
+        },
+        "base": 16,
+        "border": Object {
+          "color": Computed {
+            "computer": [Function],
+            "dependencies": Array [
+              "colors.lightShade",
+            ],
+          },
+          "editable": Computed {
+            "computer": [Function],
+            "dependencies": Array [
+              "border.width",
+              "border.color",
+            ],
+          },
+          "radius": Object {
+            "medium": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "small": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+          },
+          "thick": Computed {
+            "computer": [Function],
+            "dependencies": Array [
+              "border.width",
+              "border.color",
+            ],
+          },
+          "thin": Computed {
+            "computer": [Function],
+            "dependencies": Array [
+              "border.width",
+              "border.color",
+            ],
+          },
+          "width": Object {
+            "thick": "2px",
+            "thin": "1px",
+          },
+        },
+        "breakpoint": Object {
+          "l": 992,
+          "m": 768,
+          "s": 575,
+          "xl": 1200,
+          "xs": 0,
+        },
+        "colors": Object {
+          "DARK": Object {
+            "accent": "#F68FBE",
+            "accentText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "body": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.lightestShade",
+              ],
+            },
+            "danger": "#F86B63",
+            "dangerText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "darkShade": "#98A2B3",
+            "darkestShade": "#D4DAE5",
+            "disabled": "#515761",
+            "disabledText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "emptyShade": "#1D1E24",
+            "fullShade": "#FFF",
+            "highlight": "#2E2D25",
+            "lightShade": "#343741",
+            "lightestShade": "#25262E",
+            "link": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.primaryText",
+              ],
+            },
+            "mediumShade": "#535966",
+            "primary": "#36A2EF",
+            "primaryText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "shadow": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "subduedText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "success": "#7DDED8",
+            "successText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "text": "#DFE5EF",
+            "title": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.text",
+              ],
+            },
+            "warning": "#F3D371",
+            "warningText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+          },
+          "LIGHT": Object {
+            "accent": "#F04E98",
+            "accentText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "body": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.lightestShade",
+              ],
+            },
+            "danger": "#BD271E",
+            "dangerText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "darkShade": "#69707D",
+            "darkestShade": "#343741",
+            "disabled": "#ABB4C4",
+            "disabledText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "emptyShade": "#FFF",
+            "fullShade": "#000",
+            "highlight": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.warning",
+              ],
+            },
+            "lightShade": "#D3DAE6",
+            "lightestShade": "#F1F4FA",
+            "link": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.primaryText",
+              ],
+            },
+            "mediumShade": "#98A2B3",
+            "primary": "#07C",
+            "primaryText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "shadow": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "subduedText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "success": "#00BFB3",
+            "successText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+            "text": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.darkestShade",
+              ],
+            },
+            "title": Computed {
+              "computer": [Function],
+              "dependencies": Array [
+                "colors.text",
+              ],
+            },
+            "warning": "#FEC514",
+            "warningText": Computed {
+              "computer": [Function],
+              "dependencies": Array [],
+            },
+          },
+          "ghost": "#FFF",
+          "ink": "#000",
+        },
+        "focus": Object {
+          "color": "currentColor",
+          "width": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+        },
+        "font": Object {
+          "baseline": Computed {
+            "computer": [Function],
+            "dependencies": Array [
+              "base",
+            ],
+          },
+          "body": Object {
+            "scale": "s",
+            "weight": "regular",
+          },
+          "family": "'Inter', BlinkMacSystemFont, Helvetica, Arial, sans-serif",
+          "familyCode": "'Roboto Mono', Menlo, Courier, monospace",
+          "familySerif": "Georgia, Times, Times New Roman, serif",
+          "featureSettings": "'calt' 1, 'kern' 1, 'liga' 1",
+          "lineHeightMultiplier": 1.5,
+          "scale": Object {
+            "l": 1.375,
+            "m": 1,
+            "s": 0.875,
+            "xl": 1.6875,
+            "xs": 0.75,
+            "xxl": 2.125,
+            "xxs": 0.6875,
+            "xxxs": 0.5625,
+          },
+          "title": Object {
+            "weight": "bold",
+          },
+          "weight": Object {
+            "bold": 700,
+            "light": 300,
+            "medium": 500,
+            "regular": 400,
+            "semiBold": 600,
+          },
+        },
+        "levels": Object {
+          "content": 0,
+          "flyout": 1000,
+          "header": 1000,
+          "mask": 6000,
+          "maskBelowHeader": 1000,
+          "menu": 2000,
+          "modal": 8000,
+          "navigation": 6000,
+          "toast": 9000,
+        },
+        "size": Object {
+          "base": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "l": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "m": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "s": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "xl": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "xs": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "xxl": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "xxs": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "xxxl": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+          "xxxxl": Computed {
+            "computer": [Function],
+            "dependencies": Array [],
+          },
+        },
+      }
+    }
+  >
+    <EuiCacheProvider>
+      <EuiGlobalStyles />
+    </EuiCacheProvider>
+    <EuiCacheProvider>
+      <EuiUtilityClasses />
+    </EuiCacheProvider>
+    <CurrentEuiBreakpointProvider />
+  </EuiThemeProvider>
+</EuiCacheProvider>
+`;
+
 exports[`EuiProvider using \`null\` theme option does not add global styles 1`] = `
-<EuiCacheProvider>
+<EuiCacheProvider
+  cache={
+    Object {
+      "compat": true,
+      "insert": [Function],
+      "inserted": Object {},
+      "key": "css",
+      "nonce": undefined,
+      "registered": Object {},
+      "sheet": StyleSheet {
+        "_insertTag": [Function],
+        "before": null,
+        "container": <head />,
+        "ctr": 0,
+        "insertionPoint": undefined,
+        "isSpeedy": false,
+        "key": "css",
+        "nonce": undefined,
+        "prepend": undefined,
+        "tags": Array [],
+      },
+    }
+  }
+>
   <EuiThemeProvider>
     <CurrentEuiBreakpointProvider />
   </EuiThemeProvider>

--- a/src/components/provider/cache/__snapshots__/cache_provider.test.tsx.snap
+++ b/src/components/provider/cache/__snapshots__/cache_provider.test.tsx.snap
@@ -27,32 +27,3 @@ exports[`EuiProvider customizes CacheProvider when configured with a cache 1`] =
   <div />
 </ContextProvider>
 `;
-
-exports[`EuiProvider provides a default cache from Emotion when configured without a cache 1`] = `
-<ContextProvider
-  value={
-    Object {
-      "compat": true,
-      "insert": [Function],
-      "inserted": Object {},
-      "key": "css",
-      "nonce": undefined,
-      "registered": Object {},
-      "sheet": StyleSheet {
-        "_insertTag": [Function],
-        "before": null,
-        "container": <head />,
-        "ctr": 0,
-        "insertionPoint": undefined,
-        "isSpeedy": false,
-        "key": "css",
-        "nonce": undefined,
-        "prepend": undefined,
-        "tags": Array [],
-      },
-    }
-  }
->
-  <div />
-</ContextProvider>
-`;

--- a/src/components/provider/cache/cache_provider.test.tsx
+++ b/src/components/provider/cache/cache_provider.test.tsx
@@ -27,16 +27,4 @@ describe('EuiProvider', () => {
     expect(component).toMatchSnapshot();
     expect(component.prop('value').key).toEqual('testing');
   });
-
-  it('provides a default cache from Emotion when configured without a cache', () => {
-    const component = shallow(
-      <EuiCacheProvider>
-        <div />
-      </EuiCacheProvider>
-    );
-
-    expect(component).toMatchSnapshot();
-    expect(component.prop('value').key).toEqual('css');
-    expect(component.prop('value').compat).toEqual(true);
-  });
 });

--- a/src/components/provider/cache/cache_provider.tsx
+++ b/src/components/provider/cache/cache_provider.tsx
@@ -7,19 +7,20 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import createCache, { EmotionCache } from '@emotion/cache';
+import { EmotionCache } from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 
-const defaultCache = createCache({ key: 'css' });
-defaultCache.compat = true;
-
 export interface EuiCacheProviderProps {
-  cache?: EmotionCache;
+  cache?: false | EmotionCache;
 }
 
 export const EuiCacheProvider = ({
-  cache = defaultCache,
+  cache,
   children,
-}: PropsWithChildren<EuiCacheProviderProps>) => (
-  <CacheProvider value={cache}>{children}</CacheProvider>
-);
+}: PropsWithChildren<EuiCacheProviderProps>) => {
+  return children && cache ? (
+    <CacheProvider value={cache}>{children}</CacheProvider>
+  ) : (
+    <>{children}</>
+  );
+};

--- a/src/components/provider/provider.test.tsx
+++ b/src/components/provider/provider.test.tsx
@@ -37,6 +37,14 @@ describe('EuiProvider', () => {
     const utilityCache = createCache({
       key: 'utility',
     });
+
+    it('provides a default cache from Emotion when configured without a cache', () => {
+      const component = shallow(<EuiProvider />);
+
+      expect(component).toMatchSnapshot();
+      expect(component.prop('cache').key).toEqual('css');
+      expect(component.prop('cache').compat).toEqual(true);
+    });
     it('applies the cache to all styles', () => {
       const component = shallow(<EuiProvider cache={defaultCache} />);
 

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -88,7 +88,13 @@ export const EuiProvider = <T extends {} = {}>({
         cache.default.compat = true;
       }
       defaultCache = cache.default;
+      if (cache.global) {
+        cache.global.compat = true;
+      }
       globalCache = cache.global;
+      if (cache.utility) {
+        cache.utility.compat = true;
+      }
       utilityCache = cache.utility;
     }
   }

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { PropsWithChildren } from 'react';
+import createCache from '@emotion/cache';
 import { EmotionCache } from '@emotion/react';
 
 import {
@@ -26,6 +27,9 @@ import { EuiCacheProvider } from './cache';
 const isEmotionCacheObject = (
   obj: EmotionCache | Object
 ): obj is EmotionCache => obj.hasOwnProperty('key');
+
+const defaultCache = createCache({ key: 'css' });
+defaultCache.compat = true;
 
 export interface EuiProviderProps<T>
   extends Omit<EuiThemeProviderProps<T>, 'children' | 'theme'>,
@@ -64,7 +68,7 @@ export interface EuiProviderProps<T>
 }
 
 export const EuiProvider = <T extends {} = {}>({
-  cache,
+  cache = defaultCache,
   theme = EuiThemeAmsterdam,
   globalStyles: Globals = EuiGlobalStyles,
   utilityClasses: Utilities = EuiUtilityClasses,

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -28,8 +28,8 @@ const isEmotionCacheObject = (
   obj: EmotionCache | Object
 ): obj is EmotionCache => obj.hasOwnProperty('key');
 
-const defaultCache = createCache({ key: 'css' });
-defaultCache.compat = true;
+const fallbackCache = createCache({ key: 'css' });
+fallbackCache.compat = true;
 
 export interface EuiProviderProps<T>
   extends Omit<EuiThemeProviderProps<T>, 'children' | 'theme'>,
@@ -68,7 +68,7 @@ export interface EuiProviderProps<T>
 }
 
 export const EuiProvider = <T extends {} = {}>({
-  cache = defaultCache,
+  cache = fallbackCache,
   theme = EuiThemeAmsterdam,
   globalStyles: Globals = EuiGlobalStyles,
   utilityClasses: Utilities = EuiUtilityClasses,
@@ -81,15 +81,19 @@ export const EuiProvider = <T extends {} = {}>({
   let utilityCache;
   if (cache) {
     if (isEmotionCacheObject(cache)) {
+      cache.compat = true;
       defaultCache = cache;
     } else {
+      if (cache.default) {
+        cache.default.compat = true;
+      }
       defaultCache = cache.default;
       globalCache = cache.global;
       utilityCache = cache.utility;
     }
   }
   return (
-    <EuiCacheProvider cache={defaultCache}>
+    <EuiCacheProvider cache={defaultCache ?? fallbackCache}>
       <EuiThemeProvider
         theme={theme ?? undefined}
         colorMode={colorMode}

--- a/upcoming_changelogs/6202.md
+++ b/upcoming_changelogs/6202.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed global styles being inserted into the wrong location when a `EuiProvider` cache is not configured.
+


### PR DESCRIPTION
### Summary

Having the fallback cache configured for each `EuiCacheProvider` broke the context "bubbling" fallback assumed by `EuiProvider`, resulting in the `defaultCache` in `EuiProvider` not being the catch-all location for Emotion styles. The net effect is that global styles were being inserted after component styles when not configured with `EuiProvider.cache.global` (such is the case in the docs).

The fix is to move the fallback to be the default prop value in `EuiProvider` rather than `EuiCacheProvider`.
Also, the `defaultCache` will always get `compat=true`, even if consumers forget to add it.

**Before**
<img width="265" alt="Screen Shot 2022-09-01 at 3 11 17 PM" src="https://user-images.githubusercontent.com/2728212/188003349-7bb31293-dd28-4ae2-8574-0bc228bcf748.png">

**After**
<img width="265" alt="Screen Shot 2022-09-01 at 3 11 47 PM" src="https://user-images.githubusercontent.com/2728212/188003434-0f7e399b-70e4-4ce3-bbc6-f4496576910e.png">



### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
