### PR TITLE
[SearchBar] Use bool query instead of match bool logic

### DIFF
--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
@@ -11,21 +11,37 @@ Object {
   "bool": Object {
     "must": Array [
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "and",
-            "query": "kibana logstash",
-          },
+        "bool": Object {
+          "must": Array [
+            Object {
+              "match": Object {
+                "group": "kibana",
+              },
+            },
+            Object {
+              "match": Object {
+                "group": "logstash",
+              },
+            },
+          ],
         },
       },
     ],
     "must_not": Array [
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "and",
-            "query": "es beats",
-          },
+        "bool": Object {
+          "must": Array [
+            Object {
+              "match": Object {
+                "group": "es",
+              },
+            },
+            Object {
+              "match": Object {
+                "group": "beats",
+              },
+            },
+          ],
         },
       },
     ],
@@ -43,11 +59,14 @@ Object {
         },
       },
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "and",
-            "query": "kibana",
-          },
+        "bool": Object {
+          "must": Array [
+            Object {
+              "match": Object {
+                "group": "kibana",
+              },
+            },
+          ],
         },
       },
       Object {
@@ -70,11 +89,19 @@ Object {
         },
       },
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "and",
-            "query": "eng es",
-          },
+        "bool": Object {
+          "must": Array [
+            Object {
+              "match": Object {
+                "group": "eng",
+              },
+            },
+            Object {
+              "match": Object {
+                "group": "es",
+              },
+            },
+          ],
         },
       },
       Object {
@@ -95,11 +122,14 @@ Object {
         },
       },
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "and",
-            "query": "kibana",
-          },
+        "bool": Object {
+          "must": Array [
+            Object {
+              "match": Object {
+                "group": "kibana",
+              },
+            },
+          ],
         },
       },
     ],
@@ -141,11 +171,14 @@ Object {
         "bool": Object {
           "should": Array [
             Object {
-              "match": Object {
-                "group": Object {
-                  "operator": "or",
-                  "query": "eng",
-                },
+              "bool": Object {
+                "should": Array [
+                  Object {
+                    "match": Object {
+                      "group": "eng",
+                    },
+                  },
+                ],
               },
             },
             Object {
@@ -178,21 +211,32 @@ Object {
         },
       },
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "or",
-            "query": "eng es",
-          },
+        "bool": Object {
+          "should": Array [
+            Object {
+              "match": Object {
+                "group": "eng",
+              },
+            },
+            Object {
+              "match": Object {
+                "group": "es",
+              },
+            },
+          ],
         },
       },
     ],
     "must_not": Array [
       Object {
-        "match": Object {
-          "group": Object {
-            "operator": "and",
-            "query": "kibana",
-          },
+        "bool": Object {
+          "must": Array [
+            Object {
+              "match": Object {
+                "group": "kibana",
+              },
+            },
+          ],
         },
       },
     ],
@@ -211,11 +255,14 @@ Object {
               "bool": Object {
                 "must": Array [
                   Object {
-                    "match": Object {
-                      "name": Object {
-                        "operator": "and",
-                        "query": "john",
-                      },
+                    "bool": Object {
+                      "must": Array [
+                        Object {
+                          "match": Object {
+                            "name": "john",
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
@@ -225,11 +272,14 @@ Object {
               "bool": Object {
                 "must": Array [
                   Object {
-                    "match": Object {
-                      "name": Object {
-                        "operator": "and",
-                        "query": "fred",
-                      },
+                    "bool": Object {
+                      "must": Array [
+                        Object {
+                          "match": Object {
+                            "name": "fred",
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
@@ -254,11 +304,14 @@ Object {
               "bool": Object {
                 "must": Array [
                   Object {
-                    "match": Object {
-                      "name": Object {
-                        "operator": "and",
-                        "query": "john",
-                      },
+                    "bool": Object {
+                      "must": Array [
+                        Object {
+                          "match": Object {
+                            "name": "john",
+                          },
+                        },
+                      ],
                     },
                   },
                 ],
@@ -413,11 +466,14 @@ Object {
         "bool": Object {
           "must": Array [
             Object {
-              "match": Object {
-                "name": Object {
-                  "operator": "and",
-                  "query": "john",
-                },
+              "bool": Object {
+                "must": Array [
+                  Object {
+                    "match": Object {
+                      "name": "john",
+                    },
+                  },
+                ],
               },
             },
           ],

--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
@@ -59,14 +59,8 @@ Object {
         },
       },
       Object {
-        "bool": Object {
-          "must": Array [
-            Object {
-              "match": Object {
-                "group": "kibana",
-              },
-            },
-          ],
+        "match": Object {
+          "group": "kibana",
         },
       },
       Object {
@@ -122,14 +116,8 @@ Object {
         },
       },
       Object {
-        "bool": Object {
-          "must": Array [
-            Object {
-              "match": Object {
-                "group": "kibana",
-              },
-            },
-          ],
+        "match": Object {
+          "group": "kibana",
         },
       },
     ],
@@ -171,14 +159,8 @@ Object {
         "bool": Object {
           "should": Array [
             Object {
-              "bool": Object {
-                "should": Array [
-                  Object {
-                    "match": Object {
-                      "group": "eng",
-                    },
-                  },
-                ],
+              "match": Object {
+                "group": "eng",
               },
             },
             Object {
@@ -229,14 +211,8 @@ Object {
     ],
     "must_not": Array [
       Object {
-        "bool": Object {
-          "must": Array [
-            Object {
-              "match": Object {
-                "group": "kibana",
-              },
-            },
-          ],
+        "match": Object {
+          "group": "kibana",
         },
       },
     ],
@@ -255,14 +231,8 @@ Object {
               "bool": Object {
                 "must": Array [
                   Object {
-                    "bool": Object {
-                      "must": Array [
-                        Object {
-                          "match": Object {
-                            "name": "john",
-                          },
-                        },
-                      ],
+                    "match": Object {
+                      "name": "john",
                     },
                   },
                 ],
@@ -272,14 +242,8 @@ Object {
               "bool": Object {
                 "must": Array [
                   Object {
-                    "bool": Object {
-                      "must": Array [
-                        Object {
-                          "match": Object {
-                            "name": "fred",
-                          },
-                        },
-                      ],
+                    "match": Object {
+                      "name": "fred",
                     },
                   },
                 ],
@@ -304,14 +268,8 @@ Object {
               "bool": Object {
                 "must": Array [
                   Object {
-                    "bool": Object {
-                      "must": Array [
-                        Object {
-                          "match": Object {
-                            "name": "john",
-                          },
-                        },
-                      ],
+                    "match": Object {
+                      "name": "john",
                     },
                   },
                 ],
@@ -466,14 +424,8 @@ Object {
         "bool": Object {
           "must": Array [
             Object {
-              "bool": Object {
-                "must": Array [
-                  Object {
-                    "match": Object {
-                      "name": "john",
-                    },
-                  },
-                ],
+              "match": Object {
+                "name": "john",
               },
             },
           ],

--- a/src/components/search_bar/query/ast_to_es_query_dsl.ts
+++ b/src/components/search_bar/query/ast_to_es_query_dsl.ts
@@ -140,7 +140,7 @@ export const _fieldValuesToQuery = (
           }
         });
 
-        if (terms.length > 0) {
+        if (terms.length > 1) {
           queries.push({
             bool: {
               [andOr === 'and' ? 'must' : 'should']: [
@@ -148,6 +148,8 @@ export const _fieldValuesToQuery = (
               ],
             },
           });
+        } else if (terms.length === 1) {
+          queries.push({ match: { [field]: terms[0] } });
         }
 
         if (phrases.length > 0) {

--- a/src/components/search_bar/query/ast_to_es_query_dsl.ts
+++ b/src/components/search_bar/query/ast_to_es_query_dsl.ts
@@ -6,19 +6,19 @@
  * Side Public License, v 1.
  */
 
-import { printIso8601 } from './date_format';
-import { isDateValue, dateValue, DateValue } from './date_value';
+import { isArray, isDateLike, isString } from '../../../services/predicate';
+import { keysOf } from '../../common';
 import {
-  _AST,
   AST,
   FieldClause,
   IsClause,
   OperatorType,
   TermClause,
   Value,
+  _AST,
 } from './ast';
-import { isArray, isDateLike, isString } from '../../../services/predicate';
-import { keysOf } from '../../common';
+import { printIso8601 } from './date_format';
+import { dateValue, DateValue, isDateValue } from './date_value';
 
 export interface QueryContainer {
   bool?: BoolQuery;
@@ -142,11 +142,10 @@ export const _fieldValuesToQuery = (
 
         if (terms.length > 0) {
           queries.push({
-            match: {
-              [field]: {
-                query: terms.join(' '),
-                operator: andOr,
-              },
+            bool: {
+              [andOr === 'and' ? 'must' : 'should']: [
+                ...terms.map((value) => ({ match: { [field]: value } })),
+              ],
             },
           });
         }

--- a/upcoming_changelogs/6220.md
+++ b/upcoming_changelogs/6220.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `Query.toESQuery()` to generate bool queries instead of relying on match query logic, to work with non-text fields


### PR DESCRIPTION
### Summary

This replaces a single match query with bool `should` or `must` logic in Query.toESQuery().    As a match query, fields with non-text mappings were failing search due to reliance on a text analyzer which doesn't exist in that case.

closes https://github.com/elastic/eui/issues/6217

### Checklist

- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
