### PR TITLE
[Emotion] Remove misc unnecessary args from Emotion style functions

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -135,7 +135,6 @@ EuiButton.displayName = 'EuiButton';
 
 // Use defaultProps for simple pass-through props
 EuiButton.defaultProps = {
-  minWidth: 112,
   size: 'm',
   color: 'primary',
 };

--- a/src/components/button/button_display/_button_display.styles.ts
+++ b/src/components/button/button_display/_button_display.styles.ts
@@ -35,17 +35,14 @@ const _buttonSize = (size: string) => {
   `;
 };
 
-export const euiButtonDisplayStyles = (
-  euiThemeContext: UseEuiTheme,
-  minWidth: string
-) => {
+export const euiButtonDisplayStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
   return {
     // Base
     euiButtonDisplay: css`
       ${euiButtonBaseCSS()};
-      ${minWidth && logicalCSS('min-width', minWidth)};
+      ${logicalCSS('min-width', `${euiTheme.base * 7}px`)}
       font-weight: ${euiTheme.font.weight.medium};
       padding: 0 ${euiTheme.size.m};
 

--- a/src/components/button/button_display/_button_display.tsx
+++ b/src/components/button/button_display/_button_display.tsx
@@ -125,6 +125,7 @@ export const EuiButtonDisplay = forwardRef<HTMLElement, EuiButtonDisplayProps>(
       target,
       rel,
       type = 'button',
+      style,
       ...rest
     },
     ref
@@ -135,12 +136,9 @@ export const EuiButtonDisplay = forwardRef<HTMLElement, EuiButtonDisplayProps>(
       isLoading,
     });
 
-    const minWidthPx: string =
-      typeof minWidth === 'number' ? `${minWidth}px` : (minWidth as string);
-
     const theme = useEuiTheme();
 
-    const styles = euiButtonDisplayStyles(theme, minWidthPx);
+    const styles = euiButtonDisplayStyles(theme);
     const buttonRadiusStyle = useEuiButtonRadiusCSS()[size];
     const cssStyles = [
       styles.euiButtonDisplay,
@@ -193,6 +191,7 @@ export const EuiButtonDisplay = forwardRef<HTMLElement, EuiButtonDisplayProps>(
       element,
       {
         css: cssStyles,
+        style: minWidth ? { ...style, minWidth } : style,
         ref,
         ...elementProps,
         ...relObj,

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -29,8 +29,7 @@ const halfPaddingKey = 's';
 
 export const euiCardStyles = (
   euiThemeContext: UseEuiTheme,
-  paddingSize: EuiCardProps['paddingSize'],
-  color: EuiCardProps['display']
+  paddingSize: EuiCardProps['paddingSize']
 ) => {
   const { euiTheme } = euiThemeContext;
   const paddingAmount = euiPaddingSize(euiThemeContext, paddingSize!);
@@ -137,33 +136,34 @@ export const euiCardStyles = (
       `,
     },
 
-    euiCard__image: css`
-      position: relative;
-      overflow: hidden;
+    image: {
+      euiCard__image: css`
+        position: relative;
+        overflow: hidden;
 
-      // Padding based sizing & negative margins
-      ${logicalCSS('width', `calc(100% + (${paddingAmount} * 2))`)};
-      ${logicalCSS('left', `-${paddingAmount}`)};
-      ${logicalCSS('top', `-${paddingAmount}`)};
-      // ensure the parent is only as tall as the image
-      ${logicalCSS('margin-bottom', `-${paddingAmount}`)};
+        // Padding based sizing & negative margins
+        ${logicalCSS('width', `calc(100% + (${paddingAmount} * 2))`)};
+        ${logicalCSS('left', `-${paddingAmount}`)};
+        ${logicalCSS('top', `-${paddingAmount}`)};
+        // ensure the parent is only as tall as the image
+        ${logicalCSS('margin-bottom', `-${paddingAmount}`)};
 
-      // match border radius, minus border width
-      ${logicalCSS(
-        'border-top-left-radius',
-        `calc(${euiTheme.border.radius.medium} - ${euiTheme.border.width.thin})`
-      )}
-      ${logicals['border-top-right-radius']}: calc(${euiTheme.border.radius
-        .medium} - ${euiTheme.border.width.thin});
+        // match border radius, minus border width
+        ${logicalCSS(
+          'border-top-left-radius',
+          `calc(${euiTheme.border.radius.medium} - ${euiTheme.border.width.thin})`
+        )}
+        ${logicals['border-top-right-radius']}: calc(${euiTheme.border.radius
+          .medium} - ${euiTheme.border.width.thin});
 
-      ${color === 'transparent'
-        ? `border-radius: ${euiTheme.border.radius.medium};`
-        : undefined}
-
-      img {
-        ${logicalCSS('width', '100%')}; /* 4 */
-      }
-    `,
+        img {
+          ${logicalCSS('width', '100%')}; /* 4 */
+        }
+      `,
+      transparent: css`
+        border-radius: ${euiTheme.border.radius.medium};
+      `,
+    },
 
     icon: {
       euiCard__icon: css``,

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -181,7 +181,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
     !isDisabled && (onClick || href || (selectable && !selectable.isDisabled));
 
   const euiThemeContext = useEuiTheme();
-  const styles = euiCardStyles(euiThemeContext, paddingSize, display);
+  const styles = euiCardStyles(euiThemeContext, paddingSize);
   const cardStyles = [
     styles.card.euiCard,
     // Text alignment should always be left when horizontal
@@ -257,7 +257,10 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   let imageNode;
   if (image && layout === 'vertical') {
     if (isValidElement(image) || typeof image === 'string') {
-      const imageStyles = [styles.euiCard__image];
+      const imageStyles = [
+        styles.image.euiCard__image,
+        display === 'transparent' && styles.image.transparent,
+      ];
       imageNode = (
         <div className="euiCard__image" css={imageStyles}>
           {isValidElement(image) ? image : <img src={image} alt="" />}

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
   <div>
     <div>
       <div
-        class="euiPopoverTitle emotion-euiPopoverTitle-s"
+        class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
       >
         <div
           class="euiFormControlLayout euiFormControlLayout--compressed"

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`EuiQuickSelect is rendered 1`] = `
         className="euiQuickSelect__applyButton"
         color="primary"
         disabled={false}
-        minWidth={112}
         onClick={[Function]}
         size="s"
       >
@@ -219,7 +218,6 @@ exports[`EuiQuickSelect prevQuickSelect 1`] = `
         className="euiQuickSelect__applyButton"
         color="primary"
         disabled={false}
-        minWidth={112}
         onClick={[Function]}
         size="s"
       >

--- a/src/components/popover/__snapshots__/popover_title.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover_title.test.tsx.snap
@@ -3,43 +3,43 @@
 exports[`EuiPopoverTitle is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPopoverTitle testClass1 testClass2 emotion-euiPopoverTitle-l"
+  class="euiPopoverTitle testClass1 testClass2 emotion-euiPopoverTitle-l-l"
   data-test-subj="test subject string"
 />
 `;
 
 exports[`EuiPopoverTitle props paddingSize l is rendered 1`] = `
 <div
-  class="euiPopoverTitle emotion-euiPopoverTitle-l"
+  class="euiPopoverTitle emotion-euiPopoverTitle-l-l"
 />
 `;
 
 exports[`EuiPopoverTitle props paddingSize m is rendered 1`] = `
 <div
-  class="euiPopoverTitle emotion-euiPopoverTitle-m"
+  class="euiPopoverTitle emotion-euiPopoverTitle-l-m"
 />
 `;
 
 exports[`EuiPopoverTitle props paddingSize none is rendered 1`] = `
 <div
-  class="euiPopoverTitle emotion-euiPopoverTitle"
+  class="euiPopoverTitle emotion-euiPopoverTitle-l"
 />
 `;
 
 exports[`EuiPopoverTitle props paddingSize s is rendered 1`] = `
 <div
-  class="euiPopoverTitle emotion-euiPopoverTitle-s"
+  class="euiPopoverTitle emotion-euiPopoverTitle-l-s"
 />
 `;
 
 exports[`EuiPopoverTitle props paddingSize xl is rendered 1`] = `
 <div
-  class="euiPopoverTitle emotion-euiPopoverTitle-xl"
+  class="euiPopoverTitle emotion-euiPopoverTitle-l-xl"
 />
 `;
 
 exports[`EuiPopoverTitle props paddingSize xs is rendered 1`] = `
 <div
-  class="euiPopoverTitle emotion-euiPopoverTitle-xs"
+  class="euiPopoverTitle emotion-euiPopoverTitle-l-xs"
 />
 `;

--- a/src/components/popover/popover_title.styles.ts
+++ b/src/components/popover/popover_title.styles.ts
@@ -15,22 +15,43 @@ import {
 import { UseEuiTheme } from '../../services';
 import { euiTitle } from '../title/title.styles';
 
-export const euiPopoverTitleStyles = (
-  euiThemeContext: UseEuiTheme,
-  panelPadding: EuiPaddingSize
-) => {
+export const euiPopoverTitleStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
-  // If the popover's containing panel has padding applied,
-  // ensure the title expands to cover that padding and
-  const panelPaddingSize = euiPaddingSize(euiThemeContext, panelPadding);
 
   return {
     // Base
     euiPopoverTitle: css`
       ${euiTitle(euiThemeContext, 'xxs')};
       ${logicalCSS('border-bottom', euiTheme.border.thin)};
-      // Negative margins for panel padding
-      margin: -${panelPaddingSize} -${panelPaddingSize} ${panelPaddingSize};
     `,
+    // If the popover's containing panel has padding applied,
+    // ensure the title expands to cover that padding via negative margins
+    panelPaddingSizes: {
+      none: css``,
+      xs: css`
+        ${getPaddingOffset(euiThemeContext, 'xs')}
+      `,
+      s: css`
+        ${getPaddingOffset(euiThemeContext, 's')}
+      `,
+      m: css`
+        ${getPaddingOffset(euiThemeContext, 'm')}
+      `,
+      l: css`
+        ${getPaddingOffset(euiThemeContext, 'l')}
+      `,
+      xl: css`
+        ${getPaddingOffset(euiThemeContext, 'xl')}
+      `,
+    },
   };
+};
+
+const getPaddingOffset = (
+  euiThemeContext: UseEuiTheme,
+  size: EuiPaddingSize
+) => {
+  const panelPaddingSize = euiPaddingSize(euiThemeContext, size);
+
+  return `margin: -${panelPaddingSize} -${panelPaddingSize} ${panelPaddingSize};`;
 };

--- a/src/components/popover/popover_title.tsx
+++ b/src/components/popover/popover_title.tsx
@@ -33,10 +33,11 @@ export const EuiPopoverTitle: EuiPopoverTitleProps = ({
 }) => {
   const { paddingSize: panelPadding } = useContext(EuiPopoverPanelContext);
   const euiTheme = useEuiTheme();
-  const styles = euiPopoverTitleStyles(euiTheme, panelPadding);
+  const styles = euiPopoverTitleStyles(euiTheme);
   const paddingStyles = useEuiPaddingCSS();
   const cssStyles = [
     styles.euiPopoverTitle,
+    styles.panelPaddingSizes[panelPadding],
     // If a paddingSize is not directly provided, inherit from the EuiPopoverPanel
     paddingStyles[paddingSize || panelPadding],
   ];

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
           style="min-width: 240px; max-width: 420px;"
         >
           <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-euiTourHeader"
+            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
             id="generated-id"
           >
             <h2
@@ -169,7 +169,7 @@ exports[`EuiTourStep can have subtitle 1`] = `
           style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-euiTourHeader"
+            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
             id="generated-id"
           >
             <h2
@@ -277,7 +277,7 @@ exports[`EuiTourStep can override the footer action 1`] = `
           style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-euiTourHeader"
+            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
             id="generated-id"
           >
             <h2
@@ -364,7 +364,7 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
           style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-euiTourHeader"
+            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
             id="generated-id"
           >
             <h2
@@ -467,7 +467,7 @@ exports[`EuiTourStep is rendered 1`] = `
           style="min-width: 300px; max-width: 600px;"
         >
           <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-euiTourHeader"
+            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
             id="generated-id"
           >
             <h2


### PR DESCRIPTION
### Summary

See https://github.com/elastic/eui/pull/6213#discussion_r965200619 for more context

- **EuiButton**: custom `minWidth`s should be a `style` tag and not an Emotion class, for the same reason we inline custom `color`s on components (we're otherwise generating a potentially infinite number of classes)
- **EuiPopoverTitle**: the `paddingSize` on this can be easily be converted into a static list of keys without sacrificing readability
- **EuiCard**: the `display` arg can be easily removed in favor of an array conditional instead, but the `paddingSize` cannot (this instance is a good example of when dev readability trumps Emotion performance, especially since paddingSize can only be one of 7 options and is not as wildcard as, e.g. minWidth or color)

### Checklist

- [x] QA EuiButton, EuiPopover, and EuiCard and confirm they work the same as previously
- Skipping changelog on this one as this is primarily tech debt and no user-facing changes should have occurred
