### PR TITLE
[SearchBar] Add custom_component filter

### DIFF
--- a/src-docs/src/views/search_bar/props_info.js
+++ b/src-docs/src/views/search_bar/props_info.js
@@ -420,6 +420,49 @@ export const propsInfo = {
     },
   },
 
+  CustomComponentFilter: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        type: {
+          description:
+            'Defines the type of the filter. Must be set to `custom_component`',
+          required: true,
+          type: { name: '"custom_component"' },
+        },
+        component: {
+          description: 'The component to render the filter',
+          required: true,
+          type: { name: 'React.ComponentType<#CustomComponentProps>' },
+        },
+        available: {
+          description:
+            'A callback that defines whether this filter is currently available',
+          required: false,
+          type: { name: '() => boolean' },
+        },
+      },
+    },
+  },
+
+  CustomComponentProps: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        query: {
+          description: 'The Query instance to interact with the search bar',
+          required: true,
+          type: { name: 'Query' },
+        },
+        onChange: {
+          description: 'Handler to update the search bar query',
+          required: true,
+          type: { name: '(q:Query) => void' },
+        },
+      },
+    },
+  },
+
   ExecuteQueryOptions: {
     __docgenInfo: {
       _euiObjectType: 'type',

--- a/src-docs/src/views/search_bar/search_bar_filters.js
+++ b/src-docs/src/views/search_bar/search_bar_filters.js
@@ -68,7 +68,8 @@ const initialQuery = EuiSearchBar.Query.MATCH_ALL;
 
 const CustomComponent = ({ query, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [isOnlySales, setIsOnlySales] = useState(false);
+  const tagSalesClause = query.getOrFieldClause('tag', 'sales');
+  const isOnlySales = !!(tagSalesClause && tagClause.value.length === 1);
 
   const closePopover = () => {
     setIsOpen(false);

--- a/src-docs/src/views/search_bar/search_bar_filters.js
+++ b/src-docs/src/views/search_bar/search_bar_filters.js
@@ -11,6 +11,10 @@ import {
   EuiTitle,
   EuiBasicTable,
   EuiSearchBar,
+  EuiFilterButton,
+  EuiPopover,
+  EuiButton,
+  EuiPanel,
 } from '../../../../src/components';
 
 const random = new Random();
@@ -62,6 +66,69 @@ const items = times(10, (id) => {
 
 const initialQuery = EuiSearchBar.Query.MATCH_ALL;
 
+const CustomComponent = ({ query, onChange }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isOnlySales, setIsOnlySales] = useState(false);
+
+  const closePopover = () => {
+    setIsOpen(false);
+  };
+
+  const button = (
+    <EuiFilterButton
+      iconType="arrowDown"
+      iconSide="right"
+      onClick={() => setIsOpen((prev) => !prev)}
+      hasActiveFilters={isOnlySales}
+      numActiveFilters={isOnlySales ? 1 : undefined}
+      grow
+    >
+      Custom
+    </EuiFilterButton>
+  );
+
+  return (
+    <EuiPopover
+      button={button}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downCenter"
+    >
+      <EuiPanel paddingSize="m">
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiButton
+              onClick={() => {
+                const q = query.addOrFieldValue('tag', 'sales', true, 'eq');
+                onChange(q);
+                setIsOnlySales(true);
+                closePopover();
+              }}
+              disabled={isOnlySales}
+            >
+              Only sales
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiButton
+              onClick={() => {
+                const q = query.removeOrFieldValue('tag', 'sales');
+                onChange(q);
+                setIsOnlySales(false);
+                closePopover();
+              }}
+              disabled={isOnlySales === false}
+            >
+              All
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiPanel>
+    </EuiPopover>
+  );
+};
+
 export const SearchBarFilters = () => {
   const [query, setQuery] = useState(initialQuery);
   const [error, setError] = useState(null);
@@ -108,6 +175,10 @@ export const SearchBarFilters = () => {
           value: tag.name,
           view: <EuiHealth color={tag.color}>{tag.name}</EuiHealth>,
         })),
+      },
+      {
+        type: 'custom_component',
+        component: CustomComponent,
       },
     ];
 

--- a/src/components/search_bar/filters/__snapshots__/custom_component_filter.test.tsx.snap
+++ b/src/components/search_bar/filters/__snapshots__/custom_component_filter.test.tsx.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomComponentFilter render 1`] = `
+<CustomComponentFilter
+  aria-label="aria-label"
+  className="testClass1 testClass2"
+  config={
+    Object {
+      "component": [Function],
+      "type": "custom_component",
+    }
+  }
+  data-test-subj="test subject string"
+  index={0}
+  onChange={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Query {
+            "ast": _AST {
+              "_clauses": Array [],
+              "_indexedClauses": Object {
+                "field": Object {},
+                "group": Array [],
+                "is": Object {},
+                "term": Array [],
+              },
+            },
+            "syntax": Object {
+              "parse": [Function],
+              "print": [Function],
+              "printClause": [Function],
+            },
+            "text": "",
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  query={
+    Query {
+      "ast": _AST {
+        "_clauses": Array [],
+        "_indexedClauses": Object {
+          "field": Object {},
+          "group": Array [],
+          "is": Object {},
+          "term": Array [],
+        },
+      },
+      "syntax": Object {
+        "parse": [Function],
+        "print": [Function],
+        "printClause": [Function],
+      },
+      "text": "",
+    }
+  }
+>
+  <CustomComponent
+    onChange={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Query {
+              "ast": _AST {
+                "_clauses": Array [],
+                "_indexedClauses": Object {
+                  "field": Object {},
+                  "group": Array [],
+                  "is": Object {},
+                  "term": Array [],
+                },
+              },
+              "syntax": Object {
+                "parse": [Function],
+                "print": [Function],
+                "printClause": [Function],
+              },
+              "text": "",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    query={
+      Query {
+        "ast": _AST {
+          "_clauses": Array [],
+          "_indexedClauses": Object {
+            "field": Object {},
+            "group": Array [],
+            "is": Object {},
+            "term": Array [],
+          },
+        },
+        "syntax": Object {
+          "parse": [Function],
+          "print": [Function],
+          "printClause": [Function],
+        },
+        "text": "",
+      }
+    }
+  >
+    <div
+      data-test-subj="customComponent"
+    >
+      Custom component
+    </div>
+  </CustomComponent>
+</CustomComponentFilter>
+`;

--- a/src/components/search_bar/filters/custom_component_filter.test.tsx
+++ b/src/components/search_bar/filters/custom_component_filter.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useEffect } from 'react';
+import { requiredProps } from '../../../test';
+import { mount } from 'enzyme';
+import { Query } from '../query';
+import {
+  CustomComponentFilter,
+  CustomComponentFilterProps,
+  CustomComponentProps,
+} from './custom_component_filter';
+
+const CustomComponent: React.FC<CustomComponentProps> = ({
+  query,
+  onChange,
+}) => {
+  useEffect(() => {
+    onChange?.(query);
+  }, [onChange, query]);
+
+  return <div data-test-subj="customComponent">Custom component</div>;
+};
+
+describe('CustomComponentFilter', () => {
+  const props: CustomComponentFilterProps = {
+    ...requiredProps,
+    index: 0,
+    query: Query.parse(''),
+    onChange: jest.fn(),
+    config: {
+      type: 'custom_component',
+      component: CustomComponent,
+    },
+  };
+
+  test('render', () => {
+    const component = mount(<CustomComponentFilter {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('render the provided component', () => {
+    const component = mount(<CustomComponentFilter {...props} />);
+
+    expect(component.find('[data-test-subj="customComponent"]').text()).toEqual(
+      'Custom component'
+    );
+  });
+
+  test('passes down the Query instance and the onChange handler', () => {
+    mount(<CustomComponentFilter {...props} />);
+    expect(props.onChange).toHaveBeenCalled();
+    expect(props.onChange).toHaveBeenCalledWith(props.query);
+  });
+});

--- a/src/components/search_bar/filters/custom_component_filter.tsx
+++ b/src/components/search_bar/filters/custom_component_filter.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FC } from 'react';
+import { Query } from '../query';
+
+/**
+ * The props that are passed down to the custom component
+ */
+export interface CustomComponentProps {
+  query: Query;
+  onChange?: (query: Query) => void;
+}
+
+export interface CustomComponentFilterConfigType<
+  T extends CustomComponentProps = CustomComponentProps
+> {
+  type: 'custom_component';
+  component: React.ComponentType<T>;
+  available?: () => boolean;
+}
+
+export interface CustomComponentFilterProps<
+  T extends CustomComponentProps = CustomComponentProps
+> {
+  index: number;
+  config: CustomComponentFilterConfigType<T>;
+  query: Query;
+  onChange?: (query: Query) => void;
+}
+
+export const CustomComponentFilter: FC<CustomComponentFilterProps> = (
+  props
+) => {
+  const { component: CustomComponent } = props.config;
+  return <CustomComponent query={props.query} onChange={props.onChange} />;
+};

--- a/src/components/search_bar/filters/filters.tsx
+++ b/src/components/search_bar/filters/filters.tsx
@@ -20,6 +20,10 @@ import {
   FieldValueToggleGroupFilter,
   FieldValueToggleGroupFilterConfigType,
 } from './field_value_toggle_group_filter';
+import {
+  CustomComponentFilter,
+  CustomComponentFilterConfigType,
+} from './custom_component_filter';
 import { Query } from '../query';
 
 export const createFilter = (
@@ -48,6 +52,9 @@ export const createFilter = (
     case 'field_value_toggle_group':
       return <FieldValueToggleGroupFilter {...props} config={config} />;
 
+    case 'custom_component':
+      return <CustomComponentFilter {...props} config={config} />;
+
     default:
       // @ts-ignore TS knows that we've checked `config.type` exhaustively
       throw new Error(`Unknown search filter type [${config.type}]`);
@@ -58,4 +65,5 @@ export type SearchFilterConfig =
   | IsFilterConfigType
   | FieldValueSelectionFilterConfigType
   | FieldValueToggleFilterConfigType
-  | FieldValueToggleGroupFilterConfigType;
+  | FieldValueToggleGroupFilterConfigType
+  | CustomComponentFilterConfigType;

--- a/src/components/search_bar/query/ast.ts
+++ b/src/components/search_bar/query/ast.ts
@@ -503,6 +503,14 @@ export class _AST {
     );
   }
 
+  removeIsClauses() {
+    return new _AST(this._clauses.filter((clause) => !Is.isInstance(clause)));
+  }
+
+  removeAllClauses() {
+    return new _AST();
+  }
+
   getGroupClauses() {
     return Object.values(this._indexedClauses.group);
   }

--- a/src/components/search_bar/query/query.ts
+++ b/src/components/search_bar/query/query.ts
@@ -56,6 +56,10 @@ export class Query {
     this.syntax = syntax;
   }
 
+  hasClauses() {
+    return this.ast.clauses.length > 0;
+  }
+
   hasSimpleFieldClause(field: string, value?: string) {
     return this.ast.hasSimpleFieldClause(field, value);
   }
@@ -112,6 +116,11 @@ export class Query {
     return new Query(ast, this.syntax);
   }
 
+  removeAllClauses() {
+    const ast = this.ast.removeAllClauses();
+    return new Query(ast, this.syntax);
+  }
+
   hasIsClause(flag: string) {
     return !isNil(this.ast.getIsClause(flag));
   }
@@ -132,6 +141,11 @@ export class Query {
 
   removeIsClause(flag: string) {
     const ast = this.ast.removeIsClause(flag);
+    return new Query(ast, this.syntax);
+  }
+
+  removeIsClauses() {
+    const ast = this.ast.removeIsClauses();
     return new Query(ast, this.syntax);
   }
 

--- a/upcoming_changelogs/6226.md
+++ b/upcoming_changelogs/6226.md
@@ -1,0 +1,2 @@
+- Added the `custom_component` search filter type for the EuiSearchBar. This new type gives the consumer control to render the search filter dropdown.
+


### PR DESCRIPTION
This PR adds a new filter type to the Search bar: `custom_component`. This filter gives full control to the consumer to render the filter button + the panel.

Fixes https://github.com/elastic/eui/issues/6003

### Example

```js
const CustomComponent = ({ query, onChange }) => {
  // Access to the Query instance and the onChange handler to update the search bar
  const [isOpen, setIsOpen] = useState(false);

  const closePopover = () => {
    setIsOpen(false);
  };

  const button = (
    <EuiFilterButton
      iconType="arrowDown"
      iconSide="right"
      onClick={() => setIsOpen((prev) => !prev)}
      hasActiveFilters={<some-internal-state>}
      numActiveFilters={<some-internal-state>}
      grow
    >
      Filter label
    </EuiFilterButton>
  );

  return (
    <EuiPopover
      button={button}
      isOpen={isOpen}
      closePopover={closePopover}
      panelPaddingSize="none"
      anchorPosition="downCenter"
    >
      <EuiPanel paddingSize="m">
        <div>Custom content</div>
      </EuiPanel>
    </EuiPopover>
  );
};

// And this is the filter configuration

{
  type: 'custom_component',
  component: CustomComponent,
},
```

<img width="905" alt="Screenshot 2022-09-09 at 16 17 06" src="https://user-images.githubusercontent.com/2854616/189385357-d5039b92-fdd4-4d1d-b477-6a7c6530b27c.png">

<img width="1291" alt="Screenshot 2022-09-12 at 16 43 15" src="https://user-images.githubusercontent.com/2854616/189704544-c50f3ec1-5d87-48e0-9fae-70a62f51f25c.png">

