### PR TITLE
[EuiInMemoryTable] Update state.prevProps.sortName & sortDirection

### DIFF
--- a/src-docs/src/views/tables/data_store.js
+++ b/src-docs/src/views/tables/data_store.js
@@ -70,8 +70,6 @@ const github = [
   'silne30',
 ];
 
-const dob = new Date(1980, 1, 1);
-
 const createUsers = (countries) => {
   return times(20, (index) => {
     return {
@@ -79,7 +77,11 @@ const createUsers = (countries) => {
       firstName: index < 10 ? firstNames[index] : firstNames[index - 10],
       lastName: index < 10 ? lastNames[index] : lastNames[index - 10],
       github: index < 10 ? github[index] : github[index - 10],
-      dateOfBirth: dob,
+      dateOfBirth: new Date(
+        1980,
+        Math.floor(Math.random() * 12),
+        Math.floor(Math.random() * 27) + 1
+      ),
       nationality: random.oneToOne(
         countries.map((country) => country.code),
         index

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -453,6 +453,85 @@ describe('EuiInMemoryTable', () => {
         mount(<EuiInMemoryTable {...props} />);
       }).not.toThrow();
     });
+
+    test('changing the sort field and direction via sorting prop', () => {
+      // regression for https://github.com/elastic/eui/issues/6032
+      const props: EuiInMemoryTableProps<BasicItem> = {
+        ...requiredProps,
+        items: [
+          { id: '3', name: 'name3' },
+          { id: '1', name: 'name1' },
+          { id: '2', name: 'name2' },
+        ],
+        columns: [
+          {
+            field: 'id',
+            name: 'Id',
+            sortable: true,
+          },
+          {
+            field: 'name',
+            name: 'Name',
+            sortable: true,
+          },
+        ],
+        sorting: {
+          sort: {
+            field: 'id',
+            direction: SortDirection.ASC,
+          },
+        },
+      };
+
+      const component = mount(<EuiInMemoryTable {...props} />);
+
+      // initial sorting: id asc
+      expect(
+        component
+          .find('tbody .euiTableCellContent__text')
+          .map((cell) => cell.text())
+      ).toEqual(['1', 'name1', '2', 'name2', '3', 'name3']);
+
+      // sorting: id desc
+      component.setProps({
+        sorting: { sort: { field: 'id', direction: SortDirection.DESC } },
+      });
+      expect(
+        component
+          .find('tbody .euiTableCellContent__text')
+          .map((cell) => cell.text())
+      ).toEqual(['3', 'name3', '2', 'name2', '1', 'name1']);
+
+      // sorting: name asc
+      component.setProps({
+        sorting: { sort: { field: 'name', direction: SortDirection.ASC } },
+      });
+      expect(
+        component
+          .find('tbody .euiTableCellContent__text')
+          .map((cell) => cell.text())
+      ).toEqual(['1', 'name1', '2', 'name2', '3', 'name3']);
+
+      // sorting: name desc
+      component.setProps({
+        sorting: { sort: { field: 'name', direction: SortDirection.DESC } },
+      });
+      expect(
+        component
+          .find('tbody .euiTableCellContent__text')
+          .map((cell) => cell.text())
+      ).toEqual(['3', 'name3', '2', 'name2', '1', 'name1']);
+
+      // can return to initial sorting: id asc
+      component.setProps({
+        sorting: { sort: { field: 'id', direction: SortDirection.ASC } },
+      });
+      expect(
+        component
+          .find('tbody .euiTableCellContent__text')
+          .map((cell) => cell.text())
+      ).toEqual(['1', 'name1', '2', 'name2', '3', 'name3']);
+    });
   });
 
   test('with initial sorting', () => {

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -319,6 +319,11 @@ export class EuiInMemoryTable<T> extends Component<
     ) {
       updatedPrevState = {
         ...updatedPrevState,
+        prevProps: {
+          ...updatedPrevState.prevProps,
+          sortName,
+          sortDirection,
+        },
         sortName,
         sortDirection,
       };

--- a/upcoming_changelogs/6228.md
+++ b/upcoming_changelogs/6228.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed **EuiInMemoryTable**'s internal state tracking to include changes of `sorting.sort` values 
+- Fixed `EuiInMemoryTable`'s internal state tracking to include changes of `sorting.sort` values 

--- a/upcoming_changelogs/6228.md
+++ b/upcoming_changelogs/6228.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed **EuiInMemoryTable**'s internal state tracking to include changes of `sorting.sort` values 


### PR DESCRIPTION
### Summary

Fixes #6032 by updating **EuiInMemoryTable**'s `getDerivedStateFromProps` to update the sort details in prevProps as necessary.

~To be honest, I'm not sure how to write a meaningful test for this. @sebelga can you extract your use case to a simple test scenario? (just describing it should be fine, I can put the test together)~

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
