### PR TITLE
[EuiDatePicker] Fix CodeSandbox locale examples and add dev note for explicit imports

### DIFF
--- a/src-docs/src/views/date_picker/date_picker_example.js
+++ b/src-docs/src/views/date_picker/date_picker_example.js
@@ -268,8 +268,8 @@ export const DatePickerExample = {
           </p>
           <EuiCallOut color="warning">
             Moment will try to load the locale on demand when it is used.
-            Bundlers that do not support dynamic imports will need to explicitly
-            import the locale, e.g.{' '}
+            Bundlers that do not support dynamic require statements will need to
+            explicitly import the locale, e.g.{' '}
             <EuiCode>{"import 'moment/locale/zh-cn'"}</EuiCode>. See the below
             demo JS for examples.
           </EuiCallOut>

--- a/src-docs/src/views/date_picker/date_picker_example.js
+++ b/src-docs/src/views/date_picker/date_picker_example.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { GuideSectionTypes } from '../../components';
 
 import {
+  EuiCallOut,
   EuiCode,
   EuiLink,
   EuiDatePicker,
@@ -254,16 +255,25 @@ export const DatePickerExample = {
         },
       ],
       text: (
-        <p>
-          Locale formatting is achieved by using the <EuiCode>locale</EuiCode>,
-          <EuiCode>timeFormat</EuiCode>, and <EuiCode>dateFormat</EuiCode>{' '}
-          props. The latter will take any <EuiCode>moment()</EuiCode> notation.
-          Check{' '}
-          <a href="https://en.wikipedia.org/wiki/Date_format_by_country">
-            Date format by country
-          </a>{' '}
-          for formatting examples.
-        </p>
+        <>
+          <p>
+            Locale formatting is achieved by using the <EuiCode>locale</EuiCode>
+            ,<EuiCode>timeFormat</EuiCode>, and <EuiCode>dateFormat</EuiCode>{' '}
+            props. The latter will take any <EuiCode>moment()</EuiCode>{' '}
+            notation. Check{' '}
+            <a href="https://en.wikipedia.org/wiki/Date_format_by_country">
+              Date format by country
+            </a>{' '}
+            for formatting examples.
+          </p>
+          <EuiCallOut color="warning">
+            Moment will try to load the locale on demand when it is used.
+            Bundlers that do not support dynamic imports will need to explicitly
+            import the locale, e.g.{' '}
+            <EuiCode>{"import 'moment/locale/zh-cn'"}</EuiCode>. See the below
+            demo JS for examples.
+          </EuiCallOut>
+        </>
       ),
       snippet: localeSnippet,
       demo: <Locale />,

--- a/src-docs/src/views/date_picker/locale.js
+++ b/src-docs/src/views/date_picker/locale.js
@@ -2,6 +2,12 @@ import React, { useState } from 'react';
 
 import moment from 'moment';
 
+// NOTE: These explicit imports are required for CodeSandbox and any
+// bundler that does not support Moment dynamically loading locales
+import 'moment/locale/zh-cn';
+import 'moment/locale/ko';
+import 'moment/locale/de';
+
 import {
   EuiDatePicker,
   EuiFormRow,
@@ -59,7 +65,7 @@ export default () => {
           onChange={handleChange}
           dateFormat="DD-MM-YYYY HH:mm"
           timeFormat="HH:mm"
-          locale="de-de"
+          locale="de"
         />
       </EuiFormRow>
     </div>


### PR DESCRIPTION
### Summary

- see https://github.com/elastic/eui/issues/6233
- see https://github.com/elastic/eui/issues/2383

### Checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~ N/A, docs only