### PR TITLE
[EuiAccordion] Remove `will-change` CSS

### DIFF
--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -12,7 +12,6 @@ import { Link } from 'react-router-dom';
 import { fake } from 'faker';
 
 import {
-  EuiAccordion,
   EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -412,27 +411,25 @@ export default () => {
   });
 
   return (
-    <EuiAccordion id="fdsfasdf" buttonContent="fullscreen testing">
-      <DataContext.Provider value={raw_data}>
-        <EuiDataGrid
-          aria-label="Data grid demo"
-          columns={columns}
-          columnVisibility={{ visibleColumns, setVisibleColumns }}
-          trailingControlColumns={trailingControlColumns}
-          rowCount={raw_data.length}
-          renderCellValue={RenderCellValue}
-          inMemory={{ level: 'sorting' }}
-          sorting={{ columns: sortingColumns, onSort }}
-          pagination={{
-            ...pagination,
-            pageSizeOptions: [10, 50, 100],
-            onChangeItemsPerPage: onChangeItemsPerPage,
-            onChangePage: onChangePage,
-          }}
-          onColumnResize={onColumnResize.current}
-          ref={gridRef}
-        />
-      </DataContext.Provider>
-    </EuiAccordion>
+    <DataContext.Provider value={raw_data}>
+      <EuiDataGrid
+        aria-label="Data grid demo"
+        columns={columns}
+        columnVisibility={{ visibleColumns, setVisibleColumns }}
+        trailingControlColumns={trailingControlColumns}
+        rowCount={raw_data.length}
+        renderCellValue={RenderCellValue}
+        inMemory={{ level: 'sorting' }}
+        sorting={{ columns: sortingColumns, onSort }}
+        pagination={{
+          ...pagination,
+          pageSizeOptions: [10, 50, 100],
+          onChangeItemsPerPage: onChangeItemsPerPage,
+          onChangePage: onChangePage,
+        }}
+        onColumnResize={onColumnResize.current}
+        ref={gridRef}
+      />
+    </DataContext.Provider>
   );
 };

--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -12,6 +12,7 @@ import { Link } from 'react-router-dom';
 import { fake } from 'faker';
 
 import {
+  EuiAccordion,
   EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -411,25 +412,27 @@ export default () => {
   });
 
   return (
-    <DataContext.Provider value={raw_data}>
-      <EuiDataGrid
-        aria-label="Data grid demo"
-        columns={columns}
-        columnVisibility={{ visibleColumns, setVisibleColumns }}
-        trailingControlColumns={trailingControlColumns}
-        rowCount={raw_data.length}
-        renderCellValue={RenderCellValue}
-        inMemory={{ level: 'sorting' }}
-        sorting={{ columns: sortingColumns, onSort }}
-        pagination={{
-          ...pagination,
-          pageSizeOptions: [10, 50, 100],
-          onChangeItemsPerPage: onChangeItemsPerPage,
-          onChangePage: onChangePage,
-        }}
-        onColumnResize={onColumnResize.current}
-        ref={gridRef}
-      />
-    </DataContext.Provider>
+    <EuiAccordion id="fdsfasdf" buttonContent="fullscreen testing">
+      <DataContext.Provider value={raw_data}>
+        <EuiDataGrid
+          aria-label="Data grid demo"
+          columns={columns}
+          columnVisibility={{ visibleColumns, setVisibleColumns }}
+          trailingControlColumns={trailingControlColumns}
+          rowCount={raw_data.length}
+          renderCellValue={RenderCellValue}
+          inMemory={{ level: 'sorting' }}
+          sorting={{ columns: sortingColumns, onSort }}
+          pagination={{
+            ...pagination,
+            pageSizeOptions: [10, 50, 100],
+            onChangeItemsPerPage: onChangeItemsPerPage,
+            onChangePage: onChangePage,
+          }}
+          onColumnResize={onColumnResize.current}
+          ref={gridRef}
+        />
+      </DataContext.Provider>
+    </EuiAccordion>
   );
 };

--- a/src/components/accordion/accordion.styles.ts
+++ b/src/components/accordion/accordion.styles.ts
@@ -79,7 +79,6 @@ export const euiAccordionChildWrapperStyles = ({ euiTheme }: UseEuiTheme) => ({
         ${euiTheme.animation.resistance},
       opacity ${euiTheme.animation.normal} ${euiTheme.animation.resistance};
     visibility: hidden;
-    will-change: opacity, visibility, ${logicals.height};
 
     &:focus {
       outline: none; // Hide focus ring because of tabindex=-1 on Safari

--- a/upcoming_changelogs/6235.md
+++ b/upcoming_changelogs/6235.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed `EuiDataGrid`'s broken fullscreen mode when ensted within an `EuiAccordion`
+- Fixed `EuiDataGrid`'s broken fullscreen mode when nested within an `EuiAccordion`

--- a/upcoming_changelogs/6235.md
+++ b/upcoming_changelogs/6235.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid`'s broken fullscreen mode when ensted within an `EuiAccordion`


### PR DESCRIPTION
## Summary

EuiAccordion's `will-change` CSS creates a [stacking context](https://www.joshwcomeau.com/css/stacking-contexts/) which causes nested positioned components to behave unexpectedly, e.g. fullscreen mode in EuiDataGrid:

<img width="1427" alt="" src="https://user-images.githubusercontent.com/549407/190001999-dc0a9034-e152-4378-82b4-8d0134b2924e.png">

We're opting removing this CSS for several reasons:

- https://github.com/elastic/eui/pull/5806:
  - "It's also very possible that we don't need to engage the GPU at all and even `transform: translatez(0);` was a preoptimization. In that case, we can remove `will-change`, too"
- It looks like `translateZ` was first added by [5 years ago in a relatively unrelated component PR](https://github.com/elastic/kibana/pull/14003), so we're guessing the addition this was an unnecessary pre-optimization that was popular in the frontend world at the time
- Mozilla/MDN has since [recommended against](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) using will-change:
  - "**Warning**: `will-change` is intended to be used as a last resort, in order to try to deal with existing performance problems. It should not be used to anticipate performance problems"

## QA

- [x] Confirm that https://eui.elastic.co/pr_6235/#/tabular-content/data-grid full screen mode works correctly and does not look broken
- [x] Test https://eui.elastic.co/pr_6235/#/layout/accordion performance in Chrome, Safari, Edge, and Firefox, and confirm no significant degradation of performance

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] Revert [REVERT ME] commit