### PR TITLE
[EuiResizableContainer] Add resizable container callbacks

### DIFF
--- a/src-docs/src/views/resizable_container/resizable_container_callbacks.js
+++ b/src-docs/src/views/resizable_container/resizable_container_callbacks.js
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import {
+  EuiText,
+  EuiResizableContainer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiStat,
+  EuiPanel,
+} from '../../../../src/components';
+import { fake } from 'faker';
+import { useGeneratedHtmlId } from '../../../../src/services';
+
+const text = (
+  <>
+    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{fake('{{lorem.paragraphs}}')}</p>
+    <p>{fake('{{lorem.paragraphs}}')}</p>
+  </>
+);
+
+export default () => {
+  const firstPanelId = useGeneratedHtmlId({ prefix: 'firstPanel' });
+  const secondPanelId = useGeneratedHtmlId({ prefix: 'secondPanel' });
+  const [resizeTrigger, setResizeTrigger] = useState();
+  const [sizes, setSizes] = useState({
+    [firstPanelId]: 50,
+    [secondPanelId]: 50,
+  });
+
+  return (
+    <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiPanel>
+              <EuiStat
+                title={resizeTrigger ?? ''}
+                titleSize="m"
+                description="Trigger"
+                isLoading={!resizeTrigger}
+              />
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiPanel>
+              <EuiStat
+                title={`${Math.round(sizes[firstPanelId])}%`}
+                titleSize="m"
+                description="First panel"
+                isLoading={!resizeTrigger}
+              />
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiPanel>
+              <EuiStat
+                title={`${Math.round(sizes[secondPanelId])}%`}
+                titleSize="m"
+                description="Second panel"
+                isLoading={!resizeTrigger}
+              />
+            </EuiPanel>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiResizableContainer
+          style={{ height: '200px' }}
+          onPanelWidthChange={(newSizes) => {
+            setSizes((prevSizes) => ({ ...prevSizes, ...newSizes }));
+          }}
+          onResizeStart={(trigger) => setResizeTrigger(trigger)}
+          onResizeEnd={() => setResizeTrigger(undefined)}
+        >
+          {(EuiResizablePanel, EuiResizableButton) => (
+            <>
+              <EuiResizablePanel
+                id={firstPanelId}
+                size={sizes[firstPanelId]}
+                minSize="30%"
+              >
+                <EuiText>
+                  <div>{text}</div>
+                  <a href="">Hello world</a>
+                </EuiText>
+              </EuiResizablePanel>
+
+              <EuiResizableButton />
+
+              <EuiResizablePanel
+                id={secondPanelId}
+                size={sizes[secondPanelId]}
+                minSize="200px"
+              >
+                <EuiText>{text}</EuiText>
+              </EuiResizablePanel>
+            </>
+          )}
+        </EuiResizableContainer>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/src-docs/src/views/resizable_container/resizable_container_callbacks.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_callbacks.tsx
@@ -7,6 +7,7 @@ import {
   EuiStat,
   EuiPanel,
 } from '../../../../src/components';
+// @ts-ignore - faker does not have type declarations
 import { fake } from 'faker';
 import { useGeneratedHtmlId } from '../../../../src/services';
 
@@ -21,7 +22,7 @@ const text = (
 export default () => {
   const firstPanelId = useGeneratedHtmlId({ prefix: 'firstPanel' });
   const secondPanelId = useGeneratedHtmlId({ prefix: 'secondPanel' });
-  const [resizeTrigger, setResizeTrigger] = useState();
+  const [resizeTrigger, setResizeTrigger] = useState<'pointer' | 'key'>();
   const [sizes, setSizes] = useState({
     [firstPanelId]: 50,
     [secondPanelId]: 50,

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -341,7 +341,7 @@ export const ResizableContainerExample = {
     {
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: ResizableContainerCallbacksSource,
         },
       ],

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -82,6 +82,29 @@ const verticalSnippet = `<EuiResizableContainer direction="vertical">
   )}
 </EuiResizableContainer>`;
 
+const callbacksSnippet = `<EuiResizableContainer
+  onResizeStart={(trigger) => console.log('onResizeStart', trigger)}
+  onResizeEnd={() => console.log('onResizeEnd')}
+>
+  {(EuiResizablePanel, EuiResizableButton) => (
+    <>
+      <EuiResizablePanel initialSize={50} minSize="20%">
+        <EuiText>
+          <p>{text}</p>
+        </EuiText>
+      </EuiResizablePanel>
+
+      <EuiResizableButton />
+
+      <EuiResizablePanel initialSize={50} minSize="20%">
+        <EuiText>
+          <p>{text}</p>
+        </EuiText>
+      </EuiResizablePanel>
+    </>
+  )}
+</EuiResizableContainer>`;
+
 const collapsibleSnippet = `<EuiResizableContainer>
   {(EuiResizablePanel, EuiResizableButton) => (
     <>
@@ -326,15 +349,18 @@ export const ResizableContainerExample = {
       text: (
         <>
           <p>
-            <strong>EuiResizableContainer</strong> also provides action hooks
-            for parent components to access internal methods, such as{' '}
-            <strong>EuiResizablePanel</strong> collapse toggling. The actions
-            are accessible via the third parameter of the render prop function.
+            <strong>EuiResizableContainer</strong> supports{' '}
+            <EuiCode>onResizeStart</EuiCode> and <EuiCode>onResizeEnd</EuiCode>{' '}
+            callback props to listen for when resizing starts and ends. The{' '}
+            <EuiCode>onResizeStart</EuiCode> callback is passed a{' '}
+            <EuiCode>{"trigger: 'pointer' | 'key'"}</EuiCode> parameter to
+            determine which user action triggered the resize.
           </p>
         </>
       ),
+      props: { EuiResizableContainer, EuiResizablePanel, EuiResizableButton },
       demo: <ResizableContainerCallbacks />,
-      snippet: collapsibleExtSnippet,
+      snippet: callbacksSnippet,
     },
     {
       source: [

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -23,6 +23,7 @@ import { PanelModeType } from '!!prop-loader!../../../../src/components/resizabl
 import ResizableContainerBasic from './resizable_container_basic';
 import ResizableContainerVertical from './resizable_container_vertical';
 import ResizableContainerResetValues from './resizable_container_reset_values';
+import ResizableContainerCallbacks from './resizable_container_callbacks';
 import ResizablePanels from './resizable_panels';
 import ResizablePanelCollapsible from './resizable_panel_collapsible';
 import ResizablePanelCollapsibleResponsive from './resizable_panel_collapsible_responsive';
@@ -32,6 +33,7 @@ import ResizablePanelCollapsibleExt from './resizable_panel_collapsible_external
 const ResizableContainerSource = require('!!raw-loader!./resizable_container_basic');
 const ResizableContainerVerticalSource = require('!!raw-loader!./resizable_container_vertical');
 const ResizableContainerResetValuesSource = require('!!raw-loader!./resizable_container_reset_values');
+const ResizableContainerCallbacksSource = require('!!raw-loader!./resizable_container_callbacks');
 const ResizablePanelsSource = require('!!raw-loader!./resizable_panels');
 const ResizablePanelCollapsibleSource = require('!!raw-loader!./resizable_panel_collapsible');
 const ResizablePanelCollapsibleResponsiveSource = require('!!raw-loader!./resizable_panel_collapsible_responsive');
@@ -312,6 +314,27 @@ export const ResizableContainerExample = {
       props: { EuiResizableContainer, EuiResizablePanel, EuiResizableButton },
       demo: <ResizableContainerVertical />,
       snippet: verticalSnippet,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: ResizableContainerCallbacksSource,
+        },
+      ],
+      title: 'Resizable container callbacks',
+      text: (
+        <>
+          <p>
+            <strong>EuiResizableContainer</strong> also provides action hooks
+            for parent components to access internal methods, such as{' '}
+            <strong>EuiResizablePanel</strong> collapse toggling. The actions
+            are accessible via the third parameter of the render prop function.
+          </p>
+        </>
+      ),
+      demo: <ResizableContainerCallbacks />,
+      snippet: collapsibleExtSnippet,
     },
     {
       source: [

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -23,11 +23,12 @@ import { useEuiResizableContainerContext } from './context';
 import {
   EuiResizableButtonController,
   EuiResizableButtonMouseEvent,
-  EuiResizableButtonKeyDownEvent,
+  EuiResizableButtonKeyEvent,
 } from './types';
 
 interface EuiResizableButtonControls {
-  onKeyDown: (eve: EuiResizableButtonKeyDownEvent) => void;
+  onKeyDown: (eve: EuiResizableButtonKeyEvent) => void;
+  onKeyUp: (eve: EuiResizableButtonKeyEvent) => void;
   onMouseDown: (eve: EuiResizableButtonMouseEvent) => void;
   onTouchStart: (eve: EuiResizableButtonMouseEvent) => void;
   onFocus: (id: string) => void;

--- a/src/components/resizable_container/resizable_container.test.tsx
+++ b/src/components/resizable_container/resizable_container.test.tsx
@@ -172,165 +172,167 @@ describe('EuiResizableContainer', () => {
     expect(component).toMatchSnapshot();
   });
 
-  const mountWithCallbacks = ({
-    direction,
-  }: {
-    direction?: 'vertical' | 'horizontal';
-  } = {}) => {
-    const onResizeStart = jest.fn();
-    const onResizeEnd = jest.fn();
-    const component = mount(
-      <EuiResizableContainer
-        {...requiredProps}
-        onResizeStart={onResizeStart}
-        onResizeEnd={onResizeEnd}
-        direction={direction}
-        data-test-subj="euiResizableContainer"
-      >
-        {(EuiResizablePanel, EuiResizableButton) => (
-          <>
-            <EuiResizablePanel initialSize={50}>Testing</EuiResizablePanel>
-            <EuiResizableButton data-test-subj="euiResizableButton" />
-            <EuiResizablePanel initialSize={50}>123</EuiResizablePanel>
-          </>
-        )}
-      </EuiResizableContainer>
-    );
-    const container = findTestSubject(component, 'euiResizableContainer');
-    const button = findTestSubject(component, 'euiResizableButton');
-    return { container, button, onResizeStart, onResizeEnd };
-  };
+  describe('on resize callbacks', () => {
+    const mountWithCallbacks = ({
+      direction,
+    }: {
+      direction?: 'vertical' | 'horizontal';
+    } = {}) => {
+      const onResizeStart = jest.fn();
+      const onResizeEnd = jest.fn();
+      const component = mount(
+        <EuiResizableContainer
+          {...requiredProps}
+          onResizeStart={onResizeStart}
+          onResizeEnd={onResizeEnd}
+          direction={direction}
+          data-test-subj="euiResizableContainer"
+        >
+          {(EuiResizablePanel, EuiResizableButton) => (
+            <>
+              <EuiResizablePanel initialSize={50}>Testing</EuiResizablePanel>
+              <EuiResizableButton data-test-subj="euiResizableButton" />
+              <EuiResizablePanel initialSize={50}>123</EuiResizablePanel>
+            </>
+          )}
+        </EuiResizableContainer>
+      );
+      const container = findTestSubject(component, 'euiResizableContainer');
+      const button = findTestSubject(component, 'euiResizableButton');
+      return { container, button, onResizeStart, onResizeEnd };
+    };
 
-  test('onResizeStart and onResizeEnd are called for pointer events', () => {
-    const {
-      container,
-      button,
-      onResizeStart,
-      onResizeEnd,
-    } = mountWithCallbacks();
-    button.simulate('mousedown', {
-      pageX: 0,
-      pageY: 0,
-      clientX: 0,
-      clientY: 0,
+    test('onResizeStart and onResizeEnd are called for pointer events', () => {
+      const {
+        container,
+        button,
+        onResizeStart,
+        onResizeEnd,
+      } = mountWithCallbacks();
+      button.simulate('mousedown', {
+        pageX: 0,
+        pageY: 0,
+        clientX: 0,
+        clientY: 0,
+      });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
+      container.simulate('mouseup');
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      button.simulate('mousedown', {
+        pageX: 0,
+        pageY: 0,
+        clientX: 0,
+        clientY: 0,
+      });
+      expect(onResizeStart).toHaveBeenCalledTimes(2);
+      expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
+      container.simulate('mouseleave');
+      expect(onResizeEnd).toHaveBeenCalledTimes(2);
+      button.simulate('touchstart', {
+        touches: [
+          {
+            clientX: 0,
+            clientY: 0,
+          },
+        ],
+      });
+      expect(onResizeStart).toHaveBeenCalledTimes(3);
+      expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
+      container.simulate('touchend');
+      expect(onResizeEnd).toHaveBeenCalledTimes(3);
     });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-    container.simulate('mouseup');
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    button.simulate('mousedown', {
-      pageX: 0,
-      pageY: 0,
-      clientX: 0,
-      clientY: 0,
+
+    test('onResizeStart and onResizeEnd are called for left/right keyboard events', () => {
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
+      button.simulate('keydown', { key: keys.ARROW_RIGHT });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keyup', { key: keys.ARROW_RIGHT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      button.simulate('keydown', { key: keys.ARROW_LEFT });
+      expect(onResizeStart).toHaveBeenCalledTimes(2);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keyup', { key: keys.ARROW_LEFT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(2);
     });
-    expect(onResizeStart).toHaveBeenCalledTimes(2);
-    expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-    container.simulate('mouseleave');
-    expect(onResizeEnd).toHaveBeenCalledTimes(2);
-    button.simulate('touchstart', {
-      touches: [
-        {
-          clientX: 0,
-          clientY: 0,
-        },
-      ],
+
+    test('onResizeStart and onResizeEnd are called for up/down keyboard events', () => {
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks({
+        direction: 'vertical',
+      });
+      button.simulate('keydown', { key: keys.ARROW_UP });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keyup', { key: keys.ARROW_UP });
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      button.simulate('keydown', { key: keys.ARROW_DOWN });
+      expect(onResizeStart).toHaveBeenCalledTimes(2);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keyup', { key: keys.ARROW_DOWN });
+      expect(onResizeEnd).toHaveBeenCalledTimes(2);
     });
-    expect(onResizeStart).toHaveBeenCalledTimes(3);
-    expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-    container.simulate('touchend');
-    expect(onResizeEnd).toHaveBeenCalledTimes(3);
-  });
 
-  test('onResizeStart and onResizeEnd are called for left/right keyboard events', () => {
-    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
-    button.simulate('keydown', { key: keys.ARROW_RIGHT });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keyup', { key: keys.ARROW_RIGHT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    button.simulate('keydown', { key: keys.ARROW_LEFT });
-    expect(onResizeStart).toHaveBeenCalledTimes(2);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keyup', { key: keys.ARROW_LEFT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(2);
-  });
-
-  test('onResizeStart and onResizeEnd are called for up/down keyboard events', () => {
-    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks({
-      direction: 'vertical',
+    test('onResizeStart and onResizeEnd are called only for the correct keyboard events', () => {
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
+      button.simulate('keydown', { key: keys.ARROW_DOWN });
+      expect(onResizeStart).toHaveBeenCalledTimes(0);
+      button.simulate('keydown', { key: keys.ARROW_RIGHT });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keyup', { key: keys.ARROW_DOWN });
+      expect(onResizeEnd).toHaveBeenCalledTimes(0);
+      button.simulate('keyup', { key: keys.ARROW_RIGHT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
     });
-    button.simulate('keydown', { key: keys.ARROW_UP });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keyup', { key: keys.ARROW_UP });
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    button.simulate('keydown', { key: keys.ARROW_DOWN });
-    expect(onResizeStart).toHaveBeenCalledTimes(2);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keyup', { key: keys.ARROW_DOWN });
-    expect(onResizeEnd).toHaveBeenCalledTimes(2);
-  });
 
-  test('onResizeStart and onResizeEnd are called only for the correct keyboard events', () => {
-    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
-    button.simulate('keydown', { key: keys.ARROW_DOWN });
-    expect(onResizeStart).toHaveBeenCalledTimes(0);
-    button.simulate('keydown', { key: keys.ARROW_RIGHT });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keyup', { key: keys.ARROW_DOWN });
-    expect(onResizeEnd).toHaveBeenCalledTimes(0);
-    button.simulate('keyup', { key: keys.ARROW_RIGHT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-  });
-
-  test('onResizeStart and onResizeEnd are called correctly when switching resize direction with the keyboard', () => {
-    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
-    button.simulate('keydown', { key: keys.ARROW_RIGHT });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keydown', { key: keys.ARROW_LEFT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenCalledTimes(2);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('keyup', { key: keys.ARROW_RIGHT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    button.simulate('keyup', { key: keys.ARROW_LEFT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(2);
-  });
-
-  test('onResizeEnd is called before starting a new resize if a keyboard resize is triggered while a pointer resize is in progress', () => {
-    const {
-      container,
-      button,
-      onResizeStart,
-      onResizeEnd,
-    } = mountWithCallbacks();
-    button.simulate('mousedown', {
-      pageX: 0,
-      pageY: 0,
-      clientX: 0,
-      clientY: 0,
+    test('onResizeStart and onResizeEnd are called correctly when switching resize direction with the keyboard', () => {
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
+      button.simulate('keydown', { key: keys.ARROW_RIGHT });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keydown', { key: keys.ARROW_LEFT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenCalledTimes(2);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('keyup', { key: keys.ARROW_RIGHT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      button.simulate('keyup', { key: keys.ARROW_LEFT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(2);
     });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-    button.simulate('keydown', { key: keys.ARROW_RIGHT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenCalledTimes(2);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    container.simulate('mouseup');
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
-    button.simulate('keyup', { key: keys.ARROW_RIGHT });
-    expect(onResizeEnd).toHaveBeenCalledTimes(2);
-  });
 
-  test('onResizeEnd is called for keyboard resizes when the button is blurred', () => {
-    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
-    button.simulate('keydown', { key: keys.ARROW_RIGHT });
-    expect(onResizeStart).toHaveBeenCalledTimes(1);
-    expect(onResizeStart).toHaveBeenLastCalledWith('key');
-    button.simulate('blur');
-    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    test('onResizeEnd is called before starting a new resize if a keyboard resize is triggered while a pointer resize is in progress', () => {
+      const {
+        container,
+        button,
+        onResizeStart,
+        onResizeEnd,
+      } = mountWithCallbacks();
+      button.simulate('mousedown', {
+        pageX: 0,
+        pageY: 0,
+        clientX: 0,
+        clientY: 0,
+      });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
+      button.simulate('keydown', { key: keys.ARROW_RIGHT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenCalledTimes(2);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      container.simulate('mouseup');
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      button.simulate('keyup', { key: keys.ARROW_RIGHT });
+      expect(onResizeEnd).toHaveBeenCalledTimes(2);
+    });
+
+    test('onResizeEnd is called for keyboard resizes when the button is blurred', () => {
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
+      button.simulate('keydown', { key: keys.ARROW_RIGHT });
+      expect(onResizeStart).toHaveBeenCalledTimes(1);
+      expect(onResizeStart).toHaveBeenLastCalledWith('key');
+      button.simulate('blur');
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/components/resizable_container/resizable_container.test.tsx
+++ b/src/components/resizable_container/resizable_container.test.tsx
@@ -324,4 +324,13 @@ describe('EuiResizableContainer', () => {
     button.simulate('keyup', { key: keys.ARROW_RIGHT });
     expect(onResizeEnd).toHaveBeenCalledTimes(2);
   });
+
+  test('onResizeEnd is called for keyboard resizes when the button is blurred', () => {
+    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
+    button.simulate('keydown', { key: keys.ARROW_RIGHT });
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenLastCalledWith('key');
+    button.simulate('blur');
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/resizable_container/resizable_container.test.tsx
+++ b/src/components/resizable_container/resizable_container.test.tsx
@@ -272,7 +272,7 @@ describe('EuiResizableContainer', () => {
     expect(onResizeEnd).toHaveBeenCalledTimes(2);
   });
 
-  test('onResizeStart and onResizeEnd are only called for the correct keyboard events', () => {
+  test('onResizeStart and onResizeEnd are called only for the correct keyboard events', () => {
     const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
     button.simulate('keydown', { key: keys.ARROW_DOWN });
     expect(onResizeStart).toHaveBeenCalledTimes(0);
@@ -283,5 +283,45 @@ describe('EuiResizableContainer', () => {
     expect(onResizeEnd).toHaveBeenCalledTimes(0);
     button.simulate('keyup', { key: keys.ARROW_RIGHT });
     expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test('onResizeStart and onResizeEnd are called correctly when switching resize direction with the keyboard', () => {
+    const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
+    button.simulate('keydown', { key: keys.ARROW_RIGHT });
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenLastCalledWith('key');
+    button.simulate('keydown', { key: keys.ARROW_LEFT });
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenCalledTimes(2);
+    expect(onResizeStart).toHaveBeenLastCalledWith('key');
+    button.simulate('keyup', { key: keys.ARROW_RIGHT });
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    button.simulate('keyup', { key: keys.ARROW_LEFT });
+    expect(onResizeEnd).toHaveBeenCalledTimes(2);
+  });
+
+  test('onResizeEnd is called before starting a new resize if a keyboard resize is triggered while a pointer resize is in progress', () => {
+    const {
+      container,
+      button,
+      onResizeStart,
+      onResizeEnd,
+    } = mountWithCallbacks();
+    button.simulate('mousedown', {
+      pageX: 0,
+      pageY: 0,
+      clientX: 0,
+      clientY: 0,
+    });
+    expect(onResizeStart).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
+    button.simulate('keydown', { key: keys.ARROW_RIGHT });
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeStart).toHaveBeenCalledTimes(2);
+    expect(onResizeStart).toHaveBeenLastCalledWith('key');
+    container.simulate('mouseup');
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    button.simulate('keyup', { key: keys.ARROW_RIGHT });
+    expect(onResizeEnd).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -135,19 +135,26 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
   }, [initialize, containerSize]);
 
   const resizeTrigger = useRef<ResizeTrigger>();
-  const resizeStart = useCallback(
-    (trigger: ResizeTrigger) => {
-      onResizeStart?.(trigger);
-      resizeTrigger.current = trigger;
-    },
-    [onResizeStart]
-  );
   const resizeEnd = useCallback(
     (trigger: ResizeTrigger) => {
       onResizeEnd?.(trigger);
       resizeTrigger.current = undefined;
     },
     [onResizeEnd]
+  );
+  const resizeStart = useCallback(
+    (trigger: ResizeTrigger) => {
+      // If another resize starts while the previous one is still in progress
+      // (e.g. user presses opposite arrow to change direction while the first
+      // is still held down, or user presses an arrow while dragging with the
+      // mouse), we want to signal the end of the previous resize first.
+      if (resizeTrigger.current) {
+        resizeEnd(resizeTrigger.current);
+      }
+      onResizeStart?.(trigger);
+      resizeTrigger.current = trigger;
+    },
+    [onResizeStart, resizeEnd]
   );
 
   const onMouseDown = useCallback(

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -47,8 +47,6 @@ const containerDirections = {
   horizontal: 'horizontal',
 };
 
-type ResizeTrigger = 'pointer' | 'key';
-
 export interface EuiResizableContainerProps
   extends HTMLAttributes<HTMLDivElement>,
     CommonProps {
@@ -74,13 +72,17 @@ export interface EuiResizableContainerProps
   /**
    * Called when resizing starts
    */
-  onResizeStart?: (trigger: ResizeTrigger) => any;
+  onResizeStart?: (trigger: 'pointer' | 'key') => any;
   /**
    * Called when resizing ends
    */
   onResizeEnd?: () => any;
   style?: CSSProperties;
 }
+
+type ResizeTrigger = Parameters<
+  NonNullable<EuiResizableContainerProps['onResizeStart']>
+>[0];
 
 const initialState: EuiResizableContainerState = {
   isDragging: false,

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -78,7 +78,7 @@ export interface EuiResizableContainerProps
   /**
    * Called when resizing ends
    */
-  onResizeEnd?: (trigger: ResizeTrigger) => any;
+  onResizeEnd?: () => any;
   style?: CSSProperties;
 }
 
@@ -140,13 +140,10 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
     keyMoveDirection?: KeyMoveDirection;
   }>({});
 
-  const resizeEnd = useCallback(
-    (trigger: ResizeTrigger) => {
-      onResizeEnd?.(trigger);
-      resizeContext.current = {};
-    },
-    [onResizeEnd]
-  );
+  const resizeEnd = useCallback(() => {
+    onResizeEnd?.();
+    resizeContext.current = {};
+  }, [onResizeEnd]);
 
   const resizeStart = useCallback(
     (trigger: ResizeTrigger, keyMoveDirection?: KeyMoveDirection) => {
@@ -155,7 +152,7 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
       // is still held down, or user presses an arrow while dragging with the
       // mouse), we want to signal the end of the previous resize first.
       if (resizeContext.current.trigger) {
-        resizeEnd(resizeContext.current.trigger);
+        resizeEnd();
       }
       onResizeStart?.(trigger);
       resizeContext.current = { trigger, keyMoveDirection };
@@ -249,7 +246,7 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
         resizeContext.current.trigger === 'key' &&
         resizeContext.current.keyMoveDirection === getKeyMoveDirection(key)
       ) {
-        resizeEnd('key');
+        resizeEnd();
       }
     },
     [getKeyMoveDirection, resizeEnd]
@@ -257,7 +254,7 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
 
   const onMouseUp = useCallback(() => {
     if (resizeContext.current.trigger === 'pointer') {
-      resizeEnd('pointer');
+      resizeEnd();
     }
     actions.reset();
   }, [actions, resizeEnd]);

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -40,6 +40,7 @@ import {
   EuiResizableContainerState,
   EuiResizableContainerActions,
   KeyMoveDirection,
+  ResizeTrigger,
 } from './types';
 
 const containerDirections = {
@@ -67,22 +68,18 @@ export interface EuiResizableContainerProps
    * Pure function which accepts an object where keys are IDs of panels, which sizes were changed,
    * and values are actual sizes in percents
    */
-  onPanelWidthChange?: ({}: { [key: string]: number }) => any;
+  onPanelWidthChange?: ({}: { [key: string]: number }) => void;
   onToggleCollapsed?: ToggleCollapseCallback;
   /**
    * Called when resizing starts
    */
-  onResizeStart?: (trigger: 'pointer' | 'key') => any;
+  onResizeStart?: (trigger: ResizeTrigger) => void;
   /**
    * Called when resizing ends
    */
-  onResizeEnd?: () => any;
+  onResizeEnd?: () => void;
   style?: CSSProperties;
 }
-
-type ResizeTrigger = Parameters<
-  NonNullable<EuiResizableContainerProps['onResizeStart']>
->[0];
 
 const initialState: EuiResizableContainerState = {
   isDragging: false,

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -261,6 +261,13 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
     actions.reset();
   }, [actions, resizeEnd]);
 
+  const onBlur = useCallback(() => {
+    if (resizeContext.current.trigger === 'key') {
+      resizeEnd();
+    }
+    actions.resizerBlur();
+  }, [actions, resizeEnd]);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const EuiResizableButton = useCallback(
     euiResizableButtonWithControls({
@@ -269,7 +276,7 @@ export const EuiResizableContainer: FunctionComponent<EuiResizableContainerProps
       onMouseDown,
       onTouchStart: onMouseDown,
       onFocus: actions.resizerFocus,
-      onBlur: actions.resizerBlur,
+      onBlur,
       isHorizontal,
       registration: {
         register: actions.registerResizer,

--- a/src/components/resizable_container/types.ts
+++ b/src/components/resizable_container/types.ts
@@ -14,6 +14,8 @@ export type PanelPosition = 'first' | 'middle' | 'last';
 
 export type PanelDirection = 'left' | 'right';
 
+export type KeyMoveDirection = 'forward' | 'backward';
+
 export interface EuiResizablePanelController {
   id: string;
   size: number;
@@ -82,7 +84,7 @@ export interface ActionKeyMove {
   payload: {
     prevPanelId: string;
     nextPanelId: string;
-    direction: 'forward' | 'backward';
+    direction: KeyMoveDirection;
   };
 }
 

--- a/src/components/resizable_container/types.ts
+++ b/src/components/resizable_container/types.ts
@@ -16,6 +16,9 @@ export type PanelDirection = 'left' | 'right';
 
 export type KeyMoveDirection = 'forward' | 'backward';
 
+type ResizeTriggerTuple = ['pointer', 'key'];
+export type ResizeTrigger = ResizeTriggerTuple[number];
+
 export interface EuiResizablePanelController {
   id: string;
   size: number;

--- a/src/components/resizable_container/types.ts
+++ b/src/components/resizable_container/types.ts
@@ -41,7 +41,7 @@ export type EuiResizableButtonMouseEvent =
   | MouseEvent<HTMLButtonElement>
   | TouchEvent<HTMLButtonElement>;
 
-export type EuiResizableButtonKeyDownEvent = KeyboardEvent<HTMLButtonElement>;
+export type EuiResizableButtonKeyEvent = KeyboardEvent<HTMLButtonElement>;
 
 export interface EuiResizableContainerState {
   isDragging: boolean;

--- a/src/components/resizable_container/types.ts
+++ b/src/components/resizable_container/types.ts
@@ -16,8 +16,7 @@ export type PanelDirection = 'left' | 'right';
 
 export type KeyMoveDirection = 'forward' | 'backward';
 
-type ResizeTriggerTuple = ['pointer', 'key'];
-export type ResizeTrigger = ResizeTriggerTuple[number];
+export type ResizeTrigger = 'pointer' | 'key';
 
 export interface EuiResizablePanelController {
   id: string;

--- a/upcoming_changelogs/6236.md
+++ b/upcoming_changelogs/6236.md
@@ -1,0 +1,1 @@
+- Added support for `onResizeStart` and `onResizeEnd` callbacks to `EuiResizableContainer`


### PR DESCRIPTION
### Summary

This PR adds support for `onResizeStart` and `onResizeEnd` callback props to `EuiResizableContainer`. The callbacks support resizing with a pointer or a keyboard, and a `trigger: 'pointer' | 'key'` parameter is passed to `onResizeStart` indicating which action triggered the resize.

Notes:
- For pointers, `onResizeStart` is called on `mousedown`, and `onResizeEnd` is called on `mouseup` or `mouseleave`.
- For keyboards, `onResizeStart` is called only on the first `keydown` event while the key remains pressed, and `onResizeEnd` is called on `keyup`. Tapping an arrow key repeatedly will called `onResizeStart` and `onResizeEnd` once for each tap.
- If an arrow key is pressed while a pointer resize is in progress, `onResizeEnd` is called to signal the end of the pointer resize before `onResizeStart('key')` is called to signal the start of the keyboard resize.
- If the opposite arrow key is pressed while a keyboard resize is in progress, `onResizeEnd` is called to signal the end of the previous keyboard resize before `onResizeStart('key')` is called to signal the start of the current keyboard resize. After changing resize directions, releasing the previous key will not call `onResizeEnd` again since it would signal the end of the current keyboard resize.
- The related issue mentions potentially adding support for similar events to `EuiResizablePanel`, but I didn't get around to that in this PR.

(The GIF makes it look like some taps are missed due to the frame rate, but this should not actually happen)
![resizable_container_callbacks](https://user-images.githubusercontent.com/25592674/190297320-6cd4f35c-43d4-4e4f-a6f2-755e2c48b62f.gif)

Resolves #6225.

### Checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
