### PR TITLE
Fix EuiButtonIcon snapshots

### DIFF
--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
       aria-controls="20"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -65,7 +65,7 @@ exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
       aria-controls="18"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-abgxts-empty-disabled-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiAccordion__iconButton"
       disabled=""
       tabindex="-1"
       type="button"
@@ -121,7 +121,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
       aria-controls="17"
       aria-expanded="true"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen css-mi8usc-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-isOpen"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-isOpen"
       tabindex="-1"
       type="button"
     >
@@ -175,7 +175,7 @@ exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`]
       aria-controls="19"
       aria-expanded="true"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen css-mi8usc-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-isOpen"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-isOpen"
       tabindex="-1"
       type="button"
     >
@@ -231,7 +231,7 @@ exports[`EuiAccordion is rendered 1`] = `
       aria-controls="0"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -281,7 +281,7 @@ exports[`EuiAccordion isDisabled is rendered 1`] = `
       aria-controls="16"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-abgxts-empty-disabled-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiAccordion__iconButton"
       disabled=""
       tabindex="-1"
       type="button"
@@ -379,7 +379,7 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
       aria-controls="8"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton--right css-1t9tlpw-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-arrowRight"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-arrowRight"
       tabindex="-1"
       type="button"
     >
@@ -419,7 +419,7 @@ exports[`EuiAccordion props arrowProps is rendered 1`] = `
       aria-expanded="false"
       aria-label="aria-label"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton testClass1 testClass2 css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton testClass1 testClass2 emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       data-test-subj="test subject string"
       tabindex="-1"
       type="button"
@@ -470,7 +470,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
       aria-controls="3"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -524,7 +524,7 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
       aria-controls="2"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -574,7 +574,7 @@ exports[`EuiAccordion props buttonElement is rendered 1`] = `
       aria-controls="5"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="0"
       type="button"
     >
@@ -623,7 +623,7 @@ exports[`EuiAccordion props buttonProps is rendered 1`] = `
       aria-controls="4"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -675,7 +675,7 @@ exports[`EuiAccordion props element is rendered 1`] = `
       aria-controls="1"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="0"
       type="button"
     >
@@ -724,7 +724,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
       aria-controls="6"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -781,7 +781,7 @@ exports[`EuiAccordion props forceState closed is rendered 1`] = `
       aria-controls="11"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -835,7 +835,7 @@ exports[`EuiAccordion props forceState open is rendered 1`] = `
       aria-controls="12"
       aria-expanded="true"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen css-mi8usc-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-isOpen"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-isOpen"
       tabindex="-1"
       type="button"
     >
@@ -889,7 +889,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
       aria-controls="7"
       aria-expanded="true"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen css-mi8usc-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-isOpen"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-isOpen"
       tabindex="-1"
       type="button"
     >
@@ -943,7 +943,7 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
       aria-controls="14"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >
@@ -1002,7 +1002,7 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
       aria-controls="15"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton css-b10u0p-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton"
       tabindex="-1"
       type="button"
     >

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`CollapsedItemActions render 1`] = `
     >
       <button
         aria-label="All actions"
-        class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+        class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
         data-test-subj="euiCollapsedItemActionsButton"
         type="button"
       >

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           <a
             aria-controls="__table_generated-id"
             aria-label="Previous page"
-            class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+            class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
             data-test-subj="pagination-button-previous"
             href="#__table_generated-id"
             rel="noreferrer"
@@ -225,7 +225,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           </ul>
           <button
             aria-label="Next page"
-            class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+            class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
             data-test-subj="pagination-button-next"
             disabled=""
             type="button"

--- a/src/components/button/button_icon/__snapshots__/button_icon.test.tsx.snap
+++ b/src/components/button/button_icon/__snapshots__/button_icon.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiButtonIcon is rendered 1`] = `
 <button
   aria-label="aria-label"
-  class="euiButtonIcon euiButtonIcon--xSmall testClass1 testClass2 css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall testClass1 testClass2 emotion-euiButtonIcon-empty-primary-hoverStyles"
   data-test-subj="test subject string"
   type="button"
 >
@@ -19,7 +19,7 @@ exports[`EuiButtonIcon is rendered 1`] = `
 exports[`EuiButtonIcon props color accent is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1pk1dsj-empty-accent-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-accent-hoverStyles"
   type="button"
 >
   <span
@@ -34,7 +34,7 @@ exports[`EuiButtonIcon props color accent is rendered 1`] = `
 exports[`EuiButtonIcon props color danger is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-vjplbo-empty-danger-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-danger-hoverStyles"
   type="button"
 >
   <span
@@ -49,7 +49,7 @@ exports[`EuiButtonIcon props color danger is rendered 1`] = `
 exports[`EuiButtonIcon props color ghost is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1riv60-empty-text-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
   type="button"
 >
   <span
@@ -64,7 +64,7 @@ exports[`EuiButtonIcon props color ghost is rendered 1`] = `
 exports[`EuiButtonIcon props color primary is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -79,7 +79,7 @@ exports[`EuiButtonIcon props color primary is rendered 1`] = `
 exports[`EuiButtonIcon props color success is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-33qu1v-empty-success-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-success-hoverStyles"
   type="button"
 >
   <span
@@ -94,7 +94,7 @@ exports[`EuiButtonIcon props color success is rendered 1`] = `
 exports[`EuiButtonIcon props color text is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
   type="button"
 >
   <span
@@ -109,7 +109,7 @@ exports[`EuiButtonIcon props color text is rendered 1`] = `
 exports[`EuiButtonIcon props color warning is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-t4mk3t-empty-warning-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-warning-hoverStyles"
   type="button"
 >
   <span
@@ -124,7 +124,7 @@ exports[`EuiButtonIcon props color warning is rendered 1`] = `
 exports[`EuiButtonIcon props display base is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-t06pf1-base-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-base-primary"
   type="button"
 >
   <span
@@ -139,7 +139,7 @@ exports[`EuiButtonIcon props display base is rendered 1`] = `
 exports[`EuiButtonIcon props display empty is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -154,7 +154,7 @@ exports[`EuiButtonIcon props display empty is rendered 1`] = `
 exports[`EuiButtonIcon props display fill is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1nhcb79-fill-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-fill-primary"
   type="button"
 >
   <span
@@ -169,7 +169,7 @@ exports[`EuiButtonIcon props display fill is rendered 1`] = `
 exports[`EuiButtonIcon props href secures the rel attribute when the target is _blank 1`] = `
 <a
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   href="#"
   rel="noopener noreferrer"
   target="_blank"
@@ -186,7 +186,7 @@ exports[`EuiButtonIcon props href secures the rel attribute when the target is _
 exports[`EuiButtonIcon props iconType is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -201,7 +201,7 @@ exports[`EuiButtonIcon props iconType is rendered 1`] = `
 exports[`EuiButtonIcon props isDisabled is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
   disabled=""
   type="button"
 >
@@ -217,7 +217,7 @@ exports[`EuiButtonIcon props isDisabled is rendered 1`] = `
 exports[`EuiButtonIcon props isDisabled or disabled is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
   disabled=""
   type="button"
 >
@@ -233,7 +233,7 @@ exports[`EuiButtonIcon props isDisabled or disabled is rendered 1`] = `
 exports[`EuiButtonIcon props isDisabled renders a button even when href is defined 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
   disabled=""
   type="button"
 >
@@ -249,7 +249,7 @@ exports[`EuiButtonIcon props isDisabled renders a button even when href is defin
 exports[`EuiButtonIcon props isLoading is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
   disabled=""
   type="button"
 >
@@ -265,7 +265,7 @@ exports[`EuiButtonIcon props isSelected is rendered as false 1`] = `
 <button
   aria-label="button"
   aria-pressed="false"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -281,7 +281,7 @@ exports[`EuiButtonIcon props isSelected is rendered as true 1`] = `
 <button
   aria-label="button"
   aria-pressed="true"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -296,7 +296,7 @@ exports[`EuiButtonIcon props isSelected is rendered as true 1`] = `
 exports[`EuiButtonIcon props size m is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--medium css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -311,7 +311,7 @@ exports[`EuiButtonIcon props size m is rendered 1`] = `
 exports[`EuiButtonIcon props size s is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--small css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--small emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span
@@ -326,7 +326,7 @@ exports[`EuiButtonIcon props size s is rendered 1`] = `
 exports[`EuiButtonIcon props size xs is rendered 1`] = `
 <button
   aria-label="button"
-  class="euiButtonIcon euiButtonIcon--xSmall css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-primary-hoverStyles"
   type="button"
 >
   <span

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -158,20 +158,23 @@ export const EuiButtonIcon: FunctionComponent<Props> = (props) => {
 
   // eslint-disable-next-line no-nested-ternary
   const color = isDisabled ? 'disabled' : _color === 'ghost' ? 'text' : _color;
-  const buttonColorStyles = useEuiButtonColorCSS({
-    display,
-  })[color];
 
-  // Temporary extra style for empty `:hover` state until we decide how to handle universally
-  const hoverStyles =
-    display === 'empty'
-      ? css`
-          &:hover {
-            background-color: ${euiButtonEmptyColor(euiThemeContext, color)
-              .backgroundColor};
-          }
-        `
-      : css``;
+  const styles = {
+    euiButtonIcon: css``,
+    colors: useEuiButtonColorCSS({ display }),
+    // Temporary extra style for empty `:hover` state until we decide how to handle universally
+    hoverStyles: css`
+      &:hover {
+        background-color: ${euiButtonEmptyColor(euiThemeContext, color)
+          .backgroundColor};
+      }
+    `,
+  };
+  const cssStyles = [
+    styles.euiButtonIcon,
+    styles.colors[color],
+    display === 'empty' && styles.hoverStyles,
+  ];
 
   const classes = classNames(
     'euiButtonIcon',
@@ -219,7 +222,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = (props) => {
 
     return (
       <a
-        css={[buttonColorStyles, hoverStyles]}
+        css={cssStyles}
         tabIndex={isAriaHidden ? -1 : undefined}
         className={classes}
         href={href}
@@ -236,7 +239,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = (props) => {
   let buttonType: ButtonHTMLAttributes<HTMLButtonElement>['type'];
   return (
     <button
-      css={[buttonColorStyles, hoverStyles]}
+      css={cssStyles}
       tabIndex={isAriaHidden ? -1 : undefined}
       disabled={isDisabled}
       className={classes}

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -109,8 +109,8 @@ exports[`EuiCodeBlock fullscreen displays content in fullscreen mode 1`] = `
                 "insert": [Function],
                 "inserted": Object {
                   "animation-ox4vyo": true,
-                  "dsw53p-empty-text-hoverStyles-EuiButtonIcon": true,
                   "jcaat8-euiToolTipAnchor-inlineBlock": true,
+                  "o2mzw-euiButtonIcon-empty-text-hoverStyles": true,
                 },
                 "key": "css",
                 "nonce": undefined,
@@ -160,21 +160,21 @@ exports[`EuiCodeBlock fullscreen displays content in fullscreen mode 1`] = `
                       data-s=""
                     >
                       
-                      .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon{color:#343741;}
+                      .emotion-euiButtonIcon-empty-text-hoverStyles{color:#343741;}
                     </style>
                     <style
                       data-emotion="css"
                       data-s=""
                     >
                       
-                      .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:focus,.css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:active{background-color:rgba(211,218,230,0.2);}
+                      .emotion-euiButtonIcon-empty-text-hoverStyles:focus,.emotion-euiButtonIcon-empty-text-hoverStyles:active{background-color:rgba(211,218,230,0.2);}
                     </style>
                     <style
                       data-emotion="css"
                       data-s=""
                     >
                       
-                      .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:hover{background-color:rgba(211,218,230,0.2);}
+                      .emotion-euiButtonIcon-empty-text-hoverStyles:hover{background-color:rgba(211,218,230,0.2);}
                     </style>
                     <style
                       data-emotion="css"
@@ -233,21 +233,21 @@ exports[`EuiCodeBlock fullscreen displays content in fullscreen mode 1`] = `
                       data-s=""
                     >
                       
-                      .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon{color:#343741;}
+                      .emotion-euiButtonIcon-empty-text-hoverStyles{color:#343741;}
                     </style>,
                     <style
                       data-emotion="css"
                       data-s=""
                     >
                       
-                      .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:focus,.css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:active{background-color:rgba(211,218,230,0.2);}
+                      .emotion-euiButtonIcon-empty-text-hoverStyles:focus,.emotion-euiButtonIcon-empty-text-hoverStyles:active{background-color:rgba(211,218,230,0.2);}
                     </style>,
                     <style
                       data-emotion="css"
                       data-s=""
                     >
                       
-                      .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:hover{background-color:rgba(211,218,230,0.2);}
+                      .emotion-euiButtonIcon-empty-text-hoverStyles:hover{background-color:rgba(211,218,230,0.2);}
                     </style>,
                     <style
                       data-emotion="css"
@@ -278,16 +278,16 @@ exports[`EuiCodeBlock fullscreen displays content in fullscreen mode 1`] = `
             serialized={
               Object {
                 "map": undefined,
-                "name": "dsw53p-empty-text-hoverStyles-EuiButtonIcon",
+                "name": "o2mzw-euiButtonIcon-empty-text-hoverStyles",
                 "next": undefined,
-                "styles": "color:#343741;&:focus,&:active{background-color:rgba(211,218,230,0.2);};label:empty;;;label:text;;;&:hover{background-color:rgba(211,218,230,0.2);};label:hoverStyles;;;;label:EuiButtonIcon;;",
+                "styles": ";label:euiButtonIcon;;;color:#343741;&:focus,&:active{background-color:rgba(211,218,230,0.2);};label:empty;;;label:text;;;&:hover{background-color:rgba(211,218,230,0.2);};label:hoverStyles;;;",
                 "toString": [Function],
               }
             }
           />
           <button
             aria-label="Collapse"
-            className="euiButtonIcon euiButtonIcon--xSmall euiCodeBlock__fullScreenButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+            className="euiButtonIcon euiButtonIcon--xSmall euiCodeBlock__fullScreenButton emotion-euiButtonIcon-empty-text-hoverStyles"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -627,8 +627,8 @@ console.log(some);"
                       Object {
                         "insert": [Function],
                         "inserted": Object {
-                          "dsw53p-empty-text-hoverStyles-EuiButtonIcon": true,
                           "jcaat8-euiToolTipAnchor-inlineBlock": true,
+                          "o2mzw-euiButtonIcon-empty-text-hoverStyles": true,
                         },
                         "key": "css",
                         "nonce": undefined,
@@ -657,21 +657,21 @@ console.log(some);"
                               data-s=""
                             >
                               
-                              .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon{color:#343741;}
+                              .emotion-euiButtonIcon-empty-text-hoverStyles{color:#343741;}
                             </style>
                             <style
                               data-emotion="css"
                               data-s=""
                             >
                               
-                              .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:focus,.css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:active{background-color:rgba(211,218,230,0.2);}
+                              .emotion-euiButtonIcon-empty-text-hoverStyles:focus,.emotion-euiButtonIcon-empty-text-hoverStyles:active{background-color:rgba(211,218,230,0.2);}
                             </style>
                             <style
                               data-emotion="css"
                               data-s=""
                             >
                               
-                              .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:hover{background-color:rgba(211,218,230,0.2);}
+                              .emotion-euiButtonIcon-empty-text-hoverStyles:hover{background-color:rgba(211,218,230,0.2);}
                             </style>
                           </head>,
                           "ctr": 5,
@@ -700,21 +700,21 @@ console.log(some);"
                               data-s=""
                             >
                               
-                              .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon{color:#343741;}
+                              .emotion-euiButtonIcon-empty-text-hoverStyles{color:#343741;}
                             </style>,
                             <style
                               data-emotion="css"
                               data-s=""
                             >
                               
-                              .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:focus,.css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:active{background-color:rgba(211,218,230,0.2);}
+                              .emotion-euiButtonIcon-empty-text-hoverStyles:focus,.emotion-euiButtonIcon-empty-text-hoverStyles:active{background-color:rgba(211,218,230,0.2);}
                             </style>,
                             <style
                               data-emotion="css"
                               data-s=""
                             >
                               
-                              .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:hover{background-color:rgba(211,218,230,0.2);}
+                              .emotion-euiButtonIcon-empty-text-hoverStyles:hover{background-color:rgba(211,218,230,0.2);}
                             </style>,
                           ],
                         },
@@ -758,8 +758,8 @@ console.log(some);"
                             Object {
                               "insert": [Function],
                               "inserted": Object {
-                                "dsw53p-empty-text-hoverStyles-EuiButtonIcon": true,
                                 "jcaat8-euiToolTipAnchor-inlineBlock": true,
+                                "o2mzw-euiButtonIcon-empty-text-hoverStyles": true,
                               },
                               "key": "css",
                               "nonce": undefined,
@@ -788,21 +788,21 @@ console.log(some);"
                                     data-s=""
                                   >
                                     
-                                    .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon{color:#343741;}
+                                    .emotion-euiButtonIcon-empty-text-hoverStyles{color:#343741;}
                                   </style>
                                   <style
                                     data-emotion="css"
                                     data-s=""
                                   >
                                     
-                                    .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:focus,.css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:active{background-color:rgba(211,218,230,0.2);}
+                                    .emotion-euiButtonIcon-empty-text-hoverStyles:focus,.emotion-euiButtonIcon-empty-text-hoverStyles:active{background-color:rgba(211,218,230,0.2);}
                                   </style>
                                   <style
                                     data-emotion="css"
                                     data-s=""
                                   >
                                     
-                                    .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:hover{background-color:rgba(211,218,230,0.2);}
+                                    .emotion-euiButtonIcon-empty-text-hoverStyles:hover{background-color:rgba(211,218,230,0.2);}
                                   </style>
                                 </head>,
                                 "ctr": 5,
@@ -831,21 +831,21 @@ console.log(some);"
                                     data-s=""
                                   >
                                     
-                                    .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon{color:#343741;}
+                                    .emotion-euiButtonIcon-empty-text-hoverStyles{color:#343741;}
                                   </style>,
                                   <style
                                     data-emotion="css"
                                     data-s=""
                                   >
                                     
-                                    .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:focus,.css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:active{background-color:rgba(211,218,230,0.2);}
+                                    .emotion-euiButtonIcon-empty-text-hoverStyles:focus,.emotion-euiButtonIcon-empty-text-hoverStyles:active{background-color:rgba(211,218,230,0.2);}
                                   </style>,
                                   <style
                                     data-emotion="css"
                                     data-s=""
                                   >
                                     
-                                    .css-dsw53p-empty-text-hoverStyles-EuiButtonIcon:hover{background-color:rgba(211,218,230,0.2);}
+                                    .emotion-euiButtonIcon-empty-text-hoverStyles:hover{background-color:rgba(211,218,230,0.2);}
                                   </style>,
                                 ],
                               },
@@ -855,16 +855,16 @@ console.log(some);"
                           serialized={
                             Object {
                               "map": undefined,
-                              "name": "dsw53p-empty-text-hoverStyles-EuiButtonIcon",
+                              "name": "o2mzw-euiButtonIcon-empty-text-hoverStyles",
                               "next": undefined,
-                              "styles": "color:#343741;&:focus,&:active{background-color:rgba(211,218,230,0.2);};label:empty;;;label:text;;;&:hover{background-color:rgba(211,218,230,0.2);};label:hoverStyles;;;;label:EuiButtonIcon;;",
+                              "styles": ";label:euiButtonIcon;;;color:#343741;&:focus,&:active{background-color:rgba(211,218,230,0.2);};label:empty;;;label:text;;;&:hover{background-color:rgba(211,218,230,0.2);};label:hoverStyles;;;",
                               "toString": [Function],
                             }
                           }
                         />
                         <button
                           aria-label="Copy"
-                          className="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+                          className="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
                           disabled={false}
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -961,7 +961,7 @@ exports[`EuiCodeBlock props overflowHeight is rendered 1`] = `
   >
     <button
       aria-label="Expand"
-      class="euiButtonIcon euiButtonIcon--xSmall euiCodeBlock__fullScreenButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiCodeBlock__fullScreenButton emotion-euiButtonIcon-empty-text-hoverStyles"
       type="button"
     >
       <span
@@ -1216,7 +1216,7 @@ exports[`EuiCodeBlock virtualization renders a virtualized code block 1`] = `
   >
     <button
       aria-label="Expand"
-      class="euiButtonIcon euiButtonIcon--xSmall euiCodeBlock__fullScreenButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiCodeBlock__fullScreenButton emotion-euiButtonIcon-empty-text-hoverStyles"
       type="button"
     >
       <span

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -24,7 +24,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -74,7 +74,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -119,7 +119,7 @@ Array [
     >
       <button
         aria-label="Close this dialog"
-        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
       >
@@ -169,7 +169,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -215,7 +215,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -260,7 +260,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
     >
       <button
         aria-label="Close this dialog"
-        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
       >
@@ -305,7 +305,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -356,7 +356,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -402,7 +402,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-left"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -237,7 +237,7 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true accepts accordion pro
       aria-controls="id"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton--right css-1t9tlpw-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-arrowRight"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-arrowRight"
       tabindex="-1"
       type="button"
     >
@@ -302,7 +302,7 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accord
       aria-controls="id"
       aria-expanded="false"
       aria-labelledby="generated-id"
-      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton--right css-1t9tlpw-empty-text-hoverStyles-EuiButtonIcon-euiAccordion__iconButton-arrowRight"
+      class="euiButtonIcon euiButtonIcon--xSmall euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-empty-text-hoverStyles-euiAccordion__iconButton-arrowRight"
       tabindex="-1"
       type="button"
     >

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
       <a
         aria-controls="generated-id"
         aria-label="Previous page"
-        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
         data-test-subj="pagination-button-previous"
         href="#generated-id"
         rel="noreferrer"
@@ -119,7 +119,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
       </ul>
       <button
         aria-label="Next page"
-        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
         data-test-subj="pagination-button-next"
         disabled=""
         type="button"
@@ -994,7 +994,7 @@ Array [
               >
                 <button
                   aria-label="Display options"
-                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
                   data-test-subj="dataGridDisplaySelectorButton"
                   type="button"
                 >
@@ -1013,7 +1013,7 @@ Array [
           >
             <button
               aria-label="Enter fullscreen"
-              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
               data-test-subj="dataGridFullScreenButton"
               type="button"
             >
@@ -1439,7 +1439,7 @@ Array [
               >
                 <button
                   aria-label="Display options"
-                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
                   data-test-subj="dataGridDisplaySelectorButton"
                   type="button"
                 >
@@ -1458,7 +1458,7 @@ Array [
           >
             <button
               aria-label="Enter fullscreen"
-              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
               data-test-subj="dataGridFullScreenButton"
               type="button"
             >
@@ -2225,7 +2225,7 @@ Array [
               >
                 <button
                   aria-label="Display options"
-                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
                   data-test-subj="dataGridDisplaySelectorButton"
                   type="button"
                 >
@@ -2244,7 +2244,7 @@ Array [
           >
             <button
               aria-label="Enter fullscreen"
-              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
               data-test-subj="dataGridFullScreenButton"
               type="button"
             >
@@ -2669,7 +2669,7 @@ Array [
               >
                 <button
                   aria-label="Display options"
-                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
                   data-test-subj="dataGridDisplaySelectorButton"
                   type="button"
                 >
@@ -2688,7 +2688,7 @@ Array [
           >
             <button
               aria-label="Enter fullscreen"
-              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+              class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
               data-test-subj="dataGridFullScreenButton"
               type="button"
             >

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
               >
                 <button
                   aria-label="Remove Column A from data grid sort"
-                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGridColumnSorting__button css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+                  class="euiButtonIcon euiButtonIcon--xSmall euiDataGridColumnSorting__button emotion-euiButtonIcon-empty-text-hoverStyles"
                   type="button"
                 >
                   <span

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -25,7 +25,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -71,7 +71,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -116,7 +116,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-s7z86u-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-right"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-fill-text-euiFlyout__closeButton-outside-right"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -161,7 +161,7 @@ Array [
       >
         <button
           aria-label="aria-label"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton testClass1 testClass2 css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton testClass1 testClass2 emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="test subject string"
           type="button"
         >
@@ -237,7 +237,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -283,7 +283,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -329,7 +329,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -374,7 +374,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -419,7 +419,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -464,7 +464,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -508,7 +508,7 @@ Array [
     >
       <button
         aria-label="Close this dialog"
-        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
         data-test-subj="euiFlyoutCloseButton"
         type="button"
       >
@@ -552,7 +552,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -597,7 +597,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -642,7 +642,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -687,7 +687,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -731,7 +731,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -776,7 +776,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -821,7 +821,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -867,7 +867,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -912,7 +912,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -957,7 +957,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -1002,7 +1002,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >
@@ -1047,7 +1047,7 @@ Array [
       >
         <button
           aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton emotion-euiButtonIcon-empty-text-hoverStyles-euiFlyout__closeButton-inside"
           data-test-subj="euiFlyoutCloseButton"
           type="button"
         >

--- a/src/components/form/field_password/__snapshots__/field_password.test.tsx.snap
+++ b/src/components/form/field_password/__snapshots__/field_password.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`EuiFieldPassword props dual dual type also renders append 1`] = `
   </span>
   <button
     aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
-    class="euiButtonIcon euiButtonIcon--xSmall euiFormControlLayout__append css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+    class="euiButtonIcon euiButtonIcon--xSmall euiFormControlLayout__append emotion-euiButtonIcon-empty-primary-hoverStyles"
     title="Show password as plain text. Note: this will visually expose your password on the screen."
     type="button"
   >
@@ -148,7 +148,7 @@ exports[`EuiFieldPassword props dual dualToggleProps is rendered 1`] = `
   </div>
   <button
     aria-label="aria-label"
-    class="euiButtonIcon euiButtonIcon--xSmall euiFormControlLayout__append testClass1 testClass2 css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+    class="euiButtonIcon euiButtonIcon--xSmall euiFormControlLayout__append testClass1 testClass2 emotion-euiButtonIcon-empty-primary-hoverStyles"
     data-test-subj="test subject string"
     title="Show password as plain text. Note: this will visually expose your password on the screen."
     type="button"
@@ -341,7 +341,7 @@ exports[`EuiFieldPassword props type dual is rendered 1`] = `
   </div>
   <button
     aria-label="Show password as plain text. Note: this will visually expose your password on the screen."
-    class="euiButtonIcon euiButtonIcon--xSmall euiFormControlLayout__append css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+    class="euiButtonIcon euiButtonIcon--xSmall euiFormControlLayout__append emotion-euiButtonIcon-empty-primary-hoverStyles"
     title="Show password as plain text. Note: this will visually expose your password on the screen."
     type="button"
   >

--- a/src/components/list_group/__snapshots__/list_group.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`EuiListGroup listItems is rendered 1`] = `
     </span>
     <button
       aria-label="bell"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow emotion-euiButtonIcon-empty-primary-hoverStyles"
       type="button"
     >
       <span
@@ -145,7 +145,7 @@ exports[`EuiListGroup listItems is rendered with color 1`] = `
     </span>
     <button
       aria-label="bell"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow emotion-euiButtonIcon-empty-primary-hoverStyles"
       type="button"
     >
       <span

--- a/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`EuiListGroupItem props extraAction can be disabled 1`] = `
     </span>
   </span>
   <button
-    class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+    class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction emotion-euiButtonIcon-empty-disabled-hoverStyles"
     disabled=""
     type="button"
   >
@@ -147,7 +147,7 @@ exports[`EuiListGroupItem props extraAction is rendered 1`] = `
   </span>
   <button
     aria-label="label"
-    class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+    class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow emotion-euiButtonIcon-empty-primary-hoverStyles"
     type="button"
   >
     <span

--- a/src/components/list_group/pinnable_list_group/__snapshots__/pinnable_list_group.test.tsx.snap
+++ b/src/components/list_group/pinnable_list_group/__snapshots__/pinnable_list_group.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
     </span>
     <button
       aria-label="Pin Label with iconType to the top"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Pin Label with iconType to the top"
       type="button"
     >
@@ -53,7 +53,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
     </span>
     <button
       aria-label="bell"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow emotion-euiButtonIcon-empty-primary-hoverStyles"
       type="button"
     >
       <span
@@ -81,7 +81,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
     </a>
     <button
       aria-label="Pin Active link to the top"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Pin Active link to the top"
       type="button"
     >
@@ -109,7 +109,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
     </button>
     <button
       aria-label="Unpin Button with onClick to the top"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow euiPinnableListGroup__itemExtraAction euiPinnableListGroup__itemExtraAction-pinned css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow euiPinnableListGroup__itemExtraAction euiPinnableListGroup__itemExtraAction-pinned emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Unpin Button with onClick to the top"
       type="button"
     >
@@ -138,7 +138,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
     </a>
     <button
       aria-label="Pin Link with href to the top"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Pin Link with href to the top"
       type="button"
     >
@@ -195,7 +195,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
     </span>
     <button
       aria-label="Pin item"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Pin item"
       type="button"
     >
@@ -222,7 +222,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
     </span>
     <button
       aria-label="bell"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow emotion-euiButtonIcon-empty-primary-hoverStyles"
       type="button"
     >
       <span
@@ -250,7 +250,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
     </a>
     <button
       aria-label="Pin item"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Pin item"
       type="button"
     >
@@ -278,7 +278,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
     </button>
     <button
       aria-label="Unpin item"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow euiPinnableListGroup__itemExtraAction euiPinnableListGroup__itemExtraAction-pinned css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiListGroupItem__extraAction-alwaysShow euiPinnableListGroup__itemExtraAction euiPinnableListGroup__itemExtraAction-pinned emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Unpin item"
       type="button"
     >
@@ -307,7 +307,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
     </a>
     <button
       aria-label="Pin item"
-      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiListGroupItem__extraAction euiPinnableListGroup__itemExtraAction emotion-euiButtonIcon-empty-primary-hoverStyles"
       title="Pin item"
       type="button"
     >

--- a/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
+++ b/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -34,7 +34,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -54,7 +54,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -71,7 +71,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -88,7 +88,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -108,7 +108,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -125,7 +125,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -142,7 +142,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -204,7 +204,7 @@ exports[`EuiMarkdownEditor custom plugins are excluded and popover is rendered 1
           >
             <button
               aria-label="Show markdown help"
-              class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+              class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-text-hoverStyles"
               title="Syntax help"
               type="button"
             >
@@ -247,7 +247,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -264,7 +264,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -284,7 +284,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -301,7 +301,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -318,7 +318,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -338,7 +338,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -355,7 +355,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -372,7 +372,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -392,7 +392,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       >
         <button
           aria-label="Tooltip"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -453,7 +453,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
         >
           <button
             aria-label="Show markdown help"
-            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-text-hoverStyles"
             type="button"
           >
             <span
@@ -494,7 +494,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -511,7 +511,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -531,7 +531,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -548,7 +548,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -565,7 +565,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -585,7 +585,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -602,7 +602,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -619,7 +619,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -639,7 +639,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       >
         <button
           aria-label="Tooltip"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -699,7 +699,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
         >
           <button
             aria-label="Show markdown help"
-            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-text-hoverStyles"
             type="button"
           >
             <span
@@ -740,7 +740,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -757,7 +757,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -777,7 +777,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -794,7 +794,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -811,7 +811,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -831,7 +831,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -848,7 +848,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -865,7 +865,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -885,7 +885,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       >
         <button
           aria-label="Tooltip"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -945,7 +945,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
         >
           <button
             aria-label="Show markdown help"
-            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-text-hoverStyles"
             type="button"
           >
             <span
@@ -986,7 +986,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1003,7 +1003,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1023,7 +1023,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1040,7 +1040,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1057,7 +1057,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1077,7 +1077,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1094,7 +1094,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1111,7 +1111,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1131,7 +1131,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       >
         <button
           aria-label="Tooltip"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1191,7 +1191,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
         >
           <button
             aria-label="Show markdown help"
-            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-text-hoverStyles"
             type="button"
           >
             <span
@@ -1232,7 +1232,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1249,7 +1249,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1269,7 +1269,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1286,7 +1286,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1303,7 +1303,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1323,7 +1323,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1340,7 +1340,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1357,7 +1357,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1377,7 +1377,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       >
         <button
           aria-label="Tooltip"
-          class="euiButtonIcon euiButtonIcon--xSmall css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           type="button"
         >
@@ -1437,7 +1437,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
         >
           <button
             aria-label="Show markdown help"
-            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-text-hoverStyles"
             type="button"
           >
             <span
@@ -1478,7 +1478,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Bold"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1496,7 +1496,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Italic"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1517,7 +1517,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Unordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1535,7 +1535,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Ordered list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1553,7 +1553,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Task list"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1574,7 +1574,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Quote"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1592,7 +1592,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Code"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1610,7 +1610,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Link"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1631,7 +1631,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       >
         <button
           aria-label="Tooltip"
-          class="euiButtonIcon euiButtonIcon--xSmall css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+          class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-disabled-hoverStyles"
           data-test-subj="euiMarkdownEditorToolbarButton"
           disabled=""
           type="button"
@@ -1694,7 +1694,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
         >
           <button
             aria-label="Show markdown help"
-            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton css-1pivaxp-empty-disabled-hoverStyles-EuiButtonIcon"
+            class="euiButtonIcon euiButtonIcon--small euiMarkdownEditorFooter__helpButton emotion-euiButtonIcon-empty-disabled-hoverStyles"
             disabled=""
             type="button"
           >

--- a/src/components/modal/__snapshots__/confirm_modal.test.tsx.snap
+++ b/src/components/modal/__snapshots__/confirm_modal.test.tsx.snap
@@ -27,7 +27,7 @@ Array [
     >
       <button
         aria-label="Closes this modal window"
-        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon emotion-euiButtonIcon-empty-text-hoverStyles"
         type="button"
       >
         <span
@@ -138,7 +138,7 @@ Array [
     >
       <button
         aria-label="Closes this modal window"
-        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon emotion-euiButtonIcon-empty-text-hoverStyles"
         type="button"
       >
         <span

--- a/src/components/modal/__snapshots__/modal.test.tsx.snap
+++ b/src/components/modal/__snapshots__/modal.test.tsx.snap
@@ -27,7 +27,7 @@ Array [
     >
       <button
         aria-label="Closes this modal window"
-        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon css-dsw53p-empty-text-hoverStyles-EuiButtonIcon"
+        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon emotion-euiButtonIcon-empty-text-hoverStyles"
         type="button"
       >
         <span

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -376,7 +376,7 @@ exports[`EuiNotificationEvent props isRead  is rendered 1`] = `
   >
     <button
       aria-label="Mark title as unread"
-      class="euiButtonIcon euiButtonIcon--xSmall euiNotificationEventReadButton euiNotificationEventReadButton--isRead css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+      class="euiButtonIcon euiButtonIcon--xSmall euiNotificationEventReadButton euiNotificationEventReadButton--isRead emotion-euiButtonIcon-empty-primary-hoverStyles"
       data-test-subj="id-notificationEventReadButton"
       title="Mark as unread"
       type="button"

--- a/src/components/notification/__snapshots__/notification_event_read_button.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_read_button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiNotificationEventReadButton is rendered 1`] = `
 <button
   aria-label="Mark eventName as unread"
-  class="euiButtonIcon euiButtonIcon--xSmall euiNotificationEventReadButton euiNotificationEventReadButton--isRead css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall euiNotificationEventReadButton euiNotificationEventReadButton--isRead emotion-euiButtonIcon-empty-primary-hoverStyles"
   data-test-subj="id-notificationEventReadButton"
   title="Mark as unread"
   type="button"
@@ -20,7 +20,7 @@ exports[`EuiNotificationEventReadButton is rendered 1`] = `
 exports[`EuiNotificationEventReadButton renders isRead to false 1`] = `
 <button
   aria-label="Mark eventName as read"
-  class="euiButtonIcon euiButtonIcon--xSmall euiNotificationEventReadButton css-l12df3-empty-primary-hoverStyles-EuiButtonIcon"
+  class="euiButtonIcon euiButtonIcon--xSmall euiNotificationEventReadButton emotion-euiButtonIcon-empty-primary-hoverStyles"
   data-test-subj="id-notificationEventReadButton"
   title="Mark as read"
   type="button"

--- a/src/components/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/src/components/pagination/__snapshots__/pagination.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`EuiPagination is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -57,7 +57,7 @@ exports[`EuiPagination is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -86,7 +86,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </span>
   <button
     aria-label="First page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-first"
     title="First page"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </button>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     title="Previous page"
     type="button"
@@ -114,7 +114,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </button>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -128,7 +128,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </button>
   <button
     aria-label="Last page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-last"
     disabled=""
     type="button"
@@ -157,7 +157,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     title="Previous page"
     type="button"
@@ -343,7 +343,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     title="Next page"
     type="button"
@@ -372,7 +372,7 @@ exports[`EuiPagination props aria-controls is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -413,7 +413,7 @@ exports[`EuiPagination props aria-controls is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -442,7 +442,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </span>
   <button
     aria-label="First page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-first"
     disabled=""
     type="button"
@@ -456,7 +456,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </button>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -481,7 +481,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </div>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -495,7 +495,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </button>
   <button
     aria-label="Last page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-last"
     disabled=""
     type="button"
@@ -524,7 +524,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </span>
   <button
     aria-label="First page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-first"
     disabled=""
     type="button"
@@ -538,7 +538,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </button>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -552,7 +552,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </button>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     title="Next page"
     type="button"
@@ -566,7 +566,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </button>
   <button
     aria-label="Last page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-last"
     title="Last page"
     type="button"
@@ -595,7 +595,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -741,7 +741,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     title="Next page"
     type="button"
@@ -770,7 +770,7 @@ exports[`EuiPagination props responsive can be customized 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -810,7 +810,7 @@ exports[`EuiPagination props responsive can be customized 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -839,7 +839,7 @@ exports[`EuiPagination props responsive can be false 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -879,7 +879,7 @@ exports[`EuiPagination props responsive can be false 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-1qa11t0-empty-disabled-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+    class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-disabled-hoverStyles-euiPaginationArrowButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       </span>
       <button
         aria-label="Previous page"
-        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
         data-test-subj="pagination-button-previous"
         title="Previous page"
         type="button"
@@ -175,7 +175,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       </ul>
       <button
         aria-label="Next page"
-        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
         data-test-subj="pagination-button-next"
         title="Next page"
         type="button"
@@ -217,7 +217,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
       </span>
       <button
         aria-label="Previous page"
-        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
         data-test-subj="pagination-button-previous"
         title="Previous page"
         type="button"
@@ -338,7 +338,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
       </ul>
       <button
         aria-label="Next page"
-        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton css-oedqdf-empty-text-hoverStyles-EuiButtonIcon-euiPaginationArrowButton"
+        class="euiButtonIcon euiButtonIcon--xSmall euiPaginationArrowButton emotion-euiButtonIcon-empty-text-hoverStyles-euiPaginationArrowButton"
         data-test-subj="pagination-button-next"
         title="Next page"
         type="button"

--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`EuiGlobalToastList props side can be changed to left 1`] = `
     </div>
     <button
       aria-label="Dismiss toast"
-      class="euiButtonIcon euiButtonIcon--xSmall css-17zm7r8-empty-text-hoverStyles-EuiButtonIcon-euiToast__closeButton"
+      class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles-euiToast__closeButton"
       data-test-subj="toastCloseButton"
       type="button"
     >
@@ -92,7 +92,7 @@ exports[`EuiGlobalToastList props side can be changed to left 1`] = `
     </div>
     <button
       aria-label="Dismiss toast"
-      class="euiButtonIcon euiButtonIcon--xSmall css-17zm7r8-empty-text-hoverStyles-EuiButtonIcon-euiToast__closeButton"
+      class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles-euiToast__closeButton"
       data-test-subj="toastCloseButton"
       type="button"
     >
@@ -148,7 +148,7 @@ exports[`EuiGlobalToastList props toasts is rendered 1`] = `
     </div>
     <button
       aria-label="Dismiss toast"
-      class="euiButtonIcon euiButtonIcon--xSmall css-17zm7r8-empty-text-hoverStyles-EuiButtonIcon-euiToast__closeButton"
+      class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles-euiToast__closeButton"
       data-test-subj="toastCloseButton"
       type="button"
     >
@@ -195,7 +195,7 @@ exports[`EuiGlobalToastList props toasts is rendered 1`] = `
     </div>
     <button
       aria-label="Dismiss toast"
-      class="euiButtonIcon euiButtonIcon--xSmall css-17zm7r8-empty-text-hoverStyles-EuiButtonIcon-euiToast__closeButton"
+      class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles-euiToast__closeButton"
       data-test-subj="toastCloseButton"
       type="button"
     >


### PR DESCRIPTION
### Summary

EuiButtonIcon's changes were merged in with randomized `css-` IDs in their snapshots, generating an annoying amount of snapshot churn. Adding an initial `euiButtonIcon: css` fixes this and makes working with downstream changes less of a headache

### Checklist

- [x] Confirm colors/hover styles are still working correctly
- [x] Skipping changelog on this as this is primarily dev-facing
