### PR TITLE
Fix internal test mocks of `useIsWithin*Breakpoint` hooks

### DIFF
--- a/scripts/jest/setup/mocks.js
+++ b/scripts/jest/setup/mocks.js
@@ -24,12 +24,9 @@ jest.mock('./../../../src/services/accessibility', () => {
   return { ...a11y, htmlIdGenerator, useGeneratedHtmlId };
 });
 
-jest.mock('./../../../src/services/breakpoint', () => {
-  const breakpointServices = jest.requireActual(
-    './../../../src/services/breakpoint'
-  );
+jest.mock('./../../../src/services/breakpoint/current_breakpoint_hook', () => {
   const {
     useCurrentEuiBreakpoint,
   } = require('./../../../src/services/breakpoint/current_breakpoint_hook.testenv');
-  return { ...breakpointServices, useCurrentEuiBreakpoint };
+  return { useCurrentEuiBreakpoint };
 });

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -238,47 +238,33 @@ Array [
 `;
 
 exports[`EuiCollapsibleNav props isDocked 1`] = `
-<div>
+Array [
   <div
     data-focus-guard="true"
     style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
     tabindex="-1"
-  />
+  />,
   <div
     data-focus-guard="true"
     style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
     tabindex="-1"
-  />
+  />,
   <div
     data-focus-lock-disabled="disabled"
   >
     <nav
-      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left"
+      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left"
       id="id"
       style="inline-size:320px"
       tabindex="-1"
-    >
-      <button
-        aria-label="Close this dialog"
-        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
-        data-test-subj="euiFlyoutCloseButton"
-        type="button"
-      >
-        <span
-          aria-hidden="true"
-          class="euiButtonIcon__icon"
-          color="inherit"
-          data-euiicon-type="cross"
-        />
-      </button>
-    </nav>
-  </div>
+    />
+  </div>,
   <div
     data-focus-guard="true"
     style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
     tabindex="-1"
-  />
-</div>
+  />,
+]
 `;
 
 exports[`EuiCollapsibleNav props onClose 1`] = `
@@ -334,47 +320,31 @@ Array [
     aria-expanded="true"
     aria-pressed="true"
   />,
-  <div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
-      <nav
-        class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left"
-        id="id"
-        style="inline-size: 320px;"
-        tabindex="-1"
-      >
-        <button
-          aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1jwwyhx-fill-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-outside-left"
-          data-test-subj="euiFlyoutCloseButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
-      </nav>
-    </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />,
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />,
+  <div
+    data-focus-lock-disabled="disabled"
+  >
+    <nav
+      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left"
+      id="id"
+      style="inline-size: 320px;"
+      tabindex="-1"
     />
   </div>,
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />,
 ]
 `;
 

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -1026,45 +1026,43 @@ Array [
 
 exports[`EuiFlyout props type=push is rendered 1`] = `
 Array [
-  <div>
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />,
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />,
+  <div
+    data-focus-lock-disabled="disabled"
+  >
     <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="1"
-    />
-    <div
-      data-focus-lock-disabled="false"
+      class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-right"
+      role="dialog"
+      tabindex="-1"
     >
-      <div
-        class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-right"
-        role="dialog"
-        tabindex="-1"
+      <button
+        aria-label="Close this dialog"
+        class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
+        data-test-subj="euiFlyoutCloseButton"
+        type="button"
       >
-        <button
-          aria-label="Close this dialog"
-          class="euiButtonIcon euiButtonIcon--xSmall euiFlyout__closeButton css-1830x61-empty-text-hoverStyles-EuiButtonIcon-euiFlyout__closeButton-inside"
-          data-test-subj="euiFlyoutCloseButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
-      </div>
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="cross"
+        />
+      </button>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>,
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="-1"
+  />,
 ]
 `;

--- a/src/components/page/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page/__snapshots__/page_template.test.tsx.snap
@@ -2,19 +2,27 @@
 
 exports[`EuiPageTemplate_Deprecated fullHeight is rendered with noscroll 1`] = `
 <div
-  class="euiPage euiPageTemplate emotion-euiPage-row-grow"
+  class="euiPage euiPageTemplate eui-fullHeight emotion-euiPage-row-grow"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody emotion-euiPageBody"
+    class="euiPageBody eui-fullHeight emotion-euiPageBody"
   >
     <div
-      class="euiPanel euiPanel--plain euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-plain"
+      class="euiPanel euiPanel--plain euiPageContent euiPageContent--borderRadiusNone eui-yScroll emotion-euiPanel-grow-none-plain"
       role="main"
     >
       <div
-        class="euiPageContentBody euiPageContentBody--paddingLarge euiPageContentBody--restrictWidth-default"
-      />
+        class="euiPageContentBody euiPageContentBody--paddingLarge euiPageContentBody--restrictWidth-default eui-fullHeight"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--directionColumn eui-fullHeight"
+        >
+          <div
+            class="euiFlexItem eui-fullHeight"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -22,19 +30,27 @@ exports[`EuiPageTemplate_Deprecated fullHeight is rendered with noscroll 1`] = `
 
 exports[`EuiPageTemplate_Deprecated fullHeight is rendered with true 1`] = `
 <div
-  class="euiPage euiPageTemplate emotion-euiPage-row-grow"
+  class="euiPage euiPageTemplate eui-fullHeight emotion-euiPage-row-grow"
   style="min-height:460px"
 >
   <div
-    class="euiPageBody emotion-euiPageBody"
+    class="euiPageBody eui-fullHeight emotion-euiPageBody"
   >
     <div
-      class="euiPanel euiPanel--plain euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-plain"
+      class="euiPanel euiPanel--plain euiPageContent euiPageContent--borderRadiusNone eui-yScroll emotion-euiPanel-grow-none-plain"
       role="main"
     >
       <div
-        class="euiPageContentBody euiPageContentBody--paddingLarge euiPageContentBody--restrictWidth-default"
-      />
+        class="euiPageContentBody euiPageContentBody--paddingLarge euiPageContentBody--restrictWidth-default eui-fullHeight"
+      >
+        <div
+          class="euiFlexGroup euiFlexGroup--directionColumn eui-fullHeight"
+        >
+          <div
+            class="euiFlexItem eui-yScroll"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/panel/split_panel/__snapshots__/split_panel.test.tsx.snap
+++ b/src/components/panel/split_panel/__snapshots__/split_panel.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`EuiSplitPanel renders as row 1`] = `
 
 exports[`EuiSplitPanel responsive can be changed to different breakpoints 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiSplitPanel emotion-euiPanel-m-plain-hasShadow"
+  class="euiPanel euiPanel--plain euiSplitPanel euiSplitPanel-isResponsive emotion-euiPanel-m-plain-hasShadow"
 />
 `;
 
@@ -50,6 +50,6 @@ exports[`EuiSplitPanel responsive can be false 1`] = `
 
 exports[`EuiSplitPanel responsive is rendered at small screens 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiSplitPanel emotion-euiPanel-m-plain-hasShadow"
+  class="euiPanel euiPanel--plain euiSplitPanel euiSplitPanel-isResponsive emotion-euiPanel-m-plain-hasShadow"
 />
 `;


### PR DESCRIPTION
### Summary

Tests calling `useIsWithinBreakpoints`, `useIsWithinMinBreakpoint`, and `useIsWithinMaxBreakpoint` within EUI were not getting the correct [current_breakpoint_hook.testenv.tsx](https://github.com/elastic/eui/blob/3efa3ee616f3913b7d50197287d09ebb5c71e1a2/src/services/breakpoint/current_breakpoint_hook.testenv.tsx) mock - this is because the mock was pointing at `src/services/breakpoint/index.ts` and not at `src/services/breakpoint/current_breakpoint_hook.ts`, which the `is_within_hooks` file was importing.

- nb: in theory this _shouldn't_ have affected Kibana, since the exported testenv logic is different and replaces the file entirely

### Checklist

N/A, dev-only