### PR TITLE
[Emotion] Fix multiple css props not being properly cascaded/merged to child props

### DIFF
--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiAccordion } from './accordion';
 
@@ -16,6 +17,11 @@ let id = 0;
 const getId = () => `${id++}`;
 
 describe('EuiAccordion', () => {
+  shouldRenderCustomStyles(<EuiAccordion id="styles" />, [
+    'buttonProps',
+    'arrowProps',
+  ]);
+
   test('is rendered', () => {
     const component = render(<EuiAccordion id={getId()} {...requiredProps} />);
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -317,9 +317,9 @@ export class EuiAccordionClass extends Component<
       iconButton = (
         <EuiButtonIcon
           color="text"
+          css={cssIconButtonStyles}
           {...arrowProps}
           className={iconButtonClasses}
-          css={cssIconButtonStyles}
           iconType="arrowRight"
           onClick={this.onToggle}
           aria-controls={id}
@@ -369,10 +369,10 @@ export class EuiAccordionClass extends Component<
 
     const button = (
       <ButtonElement
+        css={cssButtonStyles}
         {...buttonProps}
         id={buttonId}
         className={buttonClasses}
-        css={cssButtonStyles}
         aria-controls={id}
         aria-expanded={isOpen}
         onClick={isDisabled ? undefined : this.onToggle}

--- a/src/components/description_list/description_list.test.tsx
+++ b/src/components/description_list/description_list.test.tsx
@@ -9,13 +9,18 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiDescriptionList } from './description_list';
 import { TYPES, ALIGNMENTS, GUTTER_SIZES } from './description_list_types';
-import { shouldRenderCustomStyles } from '../../test/internal';
 
 describe('EuiDescriptionList', () => {
-  shouldRenderCustomStyles(<EuiDescriptionList />);
+  shouldRenderCustomStyles(
+    <EuiDescriptionList
+      listItems={[{ title: 'hello', description: 'world' }]}
+    />,
+    ['titleProps', 'descriptionProps']
+  );
 
   test('is rendered', () => {
     const component = render(

--- a/src/components/expression/expression.test.tsx
+++ b/src/components/expression/expression.test.tsx
@@ -15,7 +15,8 @@ import { EuiExpression, COLORS } from './expression';
 
 describe('EuiExpression', () => {
   shouldRenderCustomStyles(
-    <EuiExpression description="the answer is" value="42" />
+    <EuiExpression description="the answer is" value="42" />,
+    ['descriptionProps', 'valueProps']
   );
 
   test('renders', () => {

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -22,7 +22,7 @@ describe('EuiImage', () => {
     src: '/cat.jpg',
   };
 
-  shouldRenderCustomStyles(<EuiImage {...requiredProps} />);
+  shouldRenderCustomStyles(<EuiImage {...requiredProps} />, ['wrapperProps']);
 
   test('is rendered', () => {
     const component = render(<EuiImage {...requiredProps} />);

--- a/src/components/image/image_wrapper.tsx
+++ b/src/components/image/image_wrapper.tsx
@@ -56,9 +56,9 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
   return (
     <figure
       aria-label={optionalCaptionText}
+      css={cssFigureStyles}
       {...wrapperProps}
       className={classes}
-      css={cssFigureStyles}
     >
       {allowFullScreen ? (
         <>

--- a/src/components/page/page_body/page_body.test.tsx
+++ b/src/components/page/page_body/page_body.test.tsx
@@ -15,7 +15,7 @@ import { PADDING_SIZES } from '../../../global_styling';
 import { EuiPageBody } from './page_body';
 
 describe('EuiPageBody', () => {
-  shouldRenderCustomStyles(<EuiPageBody />);
+  shouldRenderCustomStyles(<EuiPageBody panelled />, ['panelProps']);
 
   test('is rendered', () => {
     const component = render(<EuiPageBody {...requiredProps} />);

--- a/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiPageHeaderContent is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPageHeaderContent emotion-euiPageHeaderContent"
+  class="euiPageHeaderContent testClass1 testClass2 emotion-euiPageHeaderContent"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/page/page_header/page_header_content.test.tsx
+++ b/src/components/page/page_header/page_header_content.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import {
   ALIGN_ITEMS,
@@ -50,6 +51,23 @@ const breadcrumbs: EuiBreadcrumb[] = [
 ];
 
 describe('EuiPageHeaderContent', () => {
+  shouldRenderCustomStyles(
+    <EuiPageHeaderContent
+      pageTitle="Hello world"
+      iconType="logoElastic"
+      rightSideItems={[<button />]}
+      breadcrumbs={[{ text: 'breadcrumb' }]}
+      tabs={[{ label: 'tab' }]}
+    />,
+    [
+      'pageTitleProps',
+      'iconProps',
+      'rightSideGroupProps',
+      'breadcrumbProps',
+      'tabsProps',
+    ]
+  );
+
   test('is rendered', () => {
     const component = render(<EuiPageHeaderContent {...requiredProps} />);
 

--- a/src/components/page/page_header/page_header_content.tsx
+++ b/src/components/page/page_header/page_header_content.tsx
@@ -169,7 +169,7 @@ export const EuiPageHeaderContent: FunctionComponent<EuiPageHeaderContentProps> 
   );
 
   const useTheme = useEuiTheme();
-  const classes = classNames('euiPageHeaderContent');
+  const classes = classNames('euiPageHeaderContent', className);
   const pageHeaderStyles = euiPageHeaderStyles(useTheme);
   const contentStyles = euiPageHeaderContentStyles(useTheme);
   const styles = setStyleForRestrictedPageWidth(restrictWidth, style);

--- a/src/components/page/page_section/page_section.test.tsx
+++ b/src/components/page/page_section/page_section.test.tsx
@@ -9,12 +9,15 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiPageSection } from './page_section';
 import { ALIGNMENTS } from './page_section.styles';
 import { PADDING_SIZES, BACKGROUND_COLORS } from '../../../global_styling';
 
 describe('EuiPageSection', () => {
+  shouldRenderCustomStyles(<EuiPageSection />, ['contentProps']);
+
   test('is rendered', () => {
     const component = render(<EuiPageSection {...requiredProps} />);
 

--- a/src/components/page/page_section/page_section.tsx
+++ b/src/components/page/page_section/page_section.tsx
@@ -100,11 +100,12 @@ export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({
     bottomBorder === true && styles.border,
     alignment.toLowerCase().includes('center') && contentStyles.center,
     restrictWidth && contentStyles.restrictWidth,
+    contentProps?.css && contentProps.css,
   ];
 
   return (
     <Component css={cssStyles} {...rest}>
-      <div css={cssContentStyles} {...contentProps} style={widthStyles}>
+      <div {...contentProps} css={cssContentStyles} style={widthStyles}>
         {children}
       </div>
     </Component>

--- a/src/components/page_template/page_template.test.tsx
+++ b/src/components/page_template/page_template.test.tsx
@@ -15,7 +15,7 @@ import { PADDING_SIZES } from '../../global_styling';
 import { EuiPageTemplate } from './page_template';
 
 describe('EuiPageTemplate', () => {
-  shouldRenderCustomStyles(<EuiPageTemplate />);
+  shouldRenderCustomStyles(<EuiPageTemplate />, ['mainProps']);
 
   test('is rendered', () => {
     const component = render(<EuiPageTemplate {...requiredProps} />);

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -21,7 +21,9 @@ describe('EuiProgress', () => {
   });
 
   shouldRenderCustomStyles(<EuiProgress />);
-  shouldRenderCustomStyles(<EuiProgress max={100} />);
+  shouldRenderCustomStyles(<EuiProgress max={100} label="Test" />, [
+    'labelProps',
+  ]);
 
   test('has max', () => {
     const component = render(<EuiProgress max={100} {...requiredProps} />);

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -161,8 +161,8 @@ export const EuiProgress: FunctionComponent<ExclusiveUnion<
                   <span
                     title={innerText}
                     ref={ref}
-                    {...labelProps}
                     css={labelCssStyles}
+                    {...labelProps}
                     className={labelClasses}
                   >
                     {label}

--- a/src/test/internal/render_custom_styles.tsx
+++ b/src/test/internal/render_custom_styles.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { ReactElement } from 'react';
-import { render } from 'enzyme';
+import { render } from '@testing-library/react';
 import { css } from '@emotion/react';
 
 /**
@@ -20,26 +20,18 @@ import { css } from '@emotion/react';
  */
 export const shouldRenderCustomStyles = (component: ReactElement) => {
   it('should render custom classNames, css, and styles', () => {
-    const rendered = render(
-      <div>
-        {React.cloneElement(component, {
-          className: 'hello',
-          css: css`
-            color: red;
-          `,
-          style: { content: "'world'" },
-        })}
-      </div>
+    const { baseElement } = render(
+      <div>{React.cloneElement(component, customStyles)}</div>
     );
 
     // className
-    const componentNode = rendered.find('.hello');
-    expect(componentNode).toHaveLength(1);
+    const componentNode = baseElement.querySelector('.hello');
+    expect(componentNode).not.toBeNull();
     // css
-    expect(componentNode.attr('class')).toEqual(
+    expect(componentNode!.getAttribute('class')).toEqual(
       expect.stringMatching(/css-[\d\w-]{6,}-css/) // should have generated an emotion class ending with -css
     );
     // style
-    expect(componentNode.attr('style')).toContain("content:'world'");
+    expect(componentNode!.getAttribute('style')).toContain("content: 'world';");
   });
 };

--- a/src/test/internal/render_custom_styles.tsx
+++ b/src/test/internal/render_custom_styles.tsx
@@ -10,28 +10,64 @@ import React, { ReactElement } from 'react';
 import { render } from '@testing-library/react';
 import { css } from '@emotion/react';
 
+const customStyles = {
+  className: 'hello',
+  css: css`
+    color: red;
+  `,
+  style: { content: "'world'" },
+};
+
+const assertOutputStyles = (rendered: HTMLElement) => {
+  // className
+  const componentNode = rendered.querySelector('.hello');
+  expect(componentNode).not.toBeNull();
+  // css
+  expect(componentNode!.getAttribute('class')).toEqual(
+    expect.stringMatching(/css-[\d\w-]{6,}-css/) // should have generated an emotion class ending with -css
+  );
+  // style
+  expect(componentNode!.getAttribute('style')).toContain("content: 'world';");
+};
+
 /**
  * Use this test helper to quickly check that the component supports custom
  * `className`, `css`, and `style` properties.
  *
+ * Use the second childProps arg to ensure that any child component props
+ * also correctly accept custom css/classes/styles.
+ *
  * Example usage:
  *
  * shouldRenderCustomStyles(<EuiMark {...requiredProps} />Marked</EuiMark>);
+ * shouldRenderCustomStyles(<EuiPageSection />, ['contentProps']);
  */
-export const shouldRenderCustomStyles = (component: ReactElement) => {
+export const shouldRenderCustomStyles = (
+  component: ReactElement,
+  childProps?: string[]
+) => {
   it('should render custom classNames, css, and styles', () => {
     const { baseElement } = render(
       <div>{React.cloneElement(component, customStyles)}</div>
     );
-
-    // className
-    const componentNode = baseElement.querySelector('.hello');
-    expect(componentNode).not.toBeNull();
-    // css
-    expect(componentNode!.getAttribute('class')).toEqual(
-      expect.stringMatching(/css-[\d\w-]{6,}-css/) // should have generated an emotion class ending with -css
-    );
-    // style
-    expect(componentNode!.getAttribute('style')).toContain("content: 'world';");
+    assertOutputStyles(baseElement);
   });
+
+  if (childProps) {
+    childProps.forEach((_childProps) => {
+      it(`should render custom classNames, css, and styles on ${_childProps}`, () => {
+        const { baseElement } = render(
+          <div>
+            {React.cloneElement(component, {
+              [_childProps]: {
+                ...(component.props[_childProps] || {}),
+                ...customStyles,
+              },
+            })}
+          </div>
+        );
+        assertOutputStyles(baseElement);
+      });
+    });
+  }
 };

--- a/upcoming_changelogs/6239.md
+++ b/upcoming_changelogs/6239.md
@@ -1,0 +1,7 @@
+**Bug fixes**
+
+- Fixed `EuiPageSection` not correctly merging `contentProps.css`
+- Fixed `EuiPageHeaderContent` not correctly merging passed `className`s
+- Fixed `EuiAccordion` not correctly merging `buttonProps.css` and `arrowProps.css`
+- Fixed `EuiProgress` not correctly merging `labelProps.css`
+- Fixed `EuiImage` not correctly merging `wrapperProps.css`


### PR DESCRIPTION
### Summary

See https://github.com/elastic/kibana/pull/140706#issuecomment-1247373983

This PR fixes the `css` prop being passed to various child `componentProps` not correctly merging `css`. Apparently Emotion generally requires our `css={}` definition to come before the `{...props}` spread for it to be combined correctly.

Or in the case of `EuiPageSection`, it requires the concatenation to occur in our Emotion styles array declaration (I think because `contentProps` has no classNames on it).

NOTE:

- ⚠️ This PR **does not include components that were converted to Emotion after 64.x** ⚠️ 
  - because this PR needs to be backported to the latest Kibana upgrade, I kept it limited to components converted in 64.0.0 and below
- ⚠️ This PR **does not include components that have not yet been converted to Emotion** ⚠️ 
  - I plan on opening up a follow-up PR to add regression Jest tests for those PR
- ⚠️ This PR **does not include EuiPopover's `panelProps`** ⚠️ 
  -  Because panelProps specifically excludes passing `style`. Still trying to figure out/think on how to ignore that, and it's getting late + I'm about to go on PTO so I figured I'd get this in sooner rather than later.

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
