### PR TITLE
[EuiSearchBar docs] Updated placeholder example to align with forms guidelines

### DIFF
--- a/src-docs/src/views/search_bar/controlled_search_bar.js
+++ b/src-docs/src/views/search_bar/controlled_search_bar.js
@@ -189,7 +189,7 @@ export const ControlledSearchBar = () => {
       <EuiSearchBar
         query={query}
         box={{
-          placeholder: 'e.g. type:visualization -is:active joe',
+          placeholder: 'type:visualization -is:active joe',
           incremental,
           schema,
         }}

--- a/src-docs/src/views/search_bar/search_bar.js
+++ b/src-docs/src/views/search_bar/search_bar.js
@@ -170,7 +170,7 @@ export const SearchBar = () => {
       <EuiSearchBar
         defaultQuery={initialQuery}
         box={{
-          placeholder: 'e.g. type:visualization -is:active joe',
+          placeholder: 'type:visualization -is:active joe',
           incremental,
           schema,
         }}

--- a/src-docs/src/views/search_bar/search_bar_filters.js
+++ b/src-docs/src/views/search_bar/search_bar_filters.js
@@ -260,7 +260,7 @@ export const SearchBarFilters = () => {
       <EuiSearchBar
         defaultQuery={initialQuery}
         box={{
-          placeholder: 'e.g. type:visualization -is:active joe',
+          placeholder: 'type:visualization -is:active joe',
           incremental: true,
           schema,
         }}


### PR DESCRIPTION
### Summary

One of the examples in https://eui.elastic.co/#/forms/search-bar#search-bar-filters doesn't align with the form controls guidelines: https://eui.elastic.co/#/forms/form-controls/guidelines.


<img width="1242" alt="Screenshot 2022-09-15 at 17 25 52" src="https://user-images.githubusercontent.com/2750668/190457655-28f7b977-2ea2-42c0-b8ce-e72290adaaa1.png">

So this PR fixes that. 

### Checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
