### PR TITLE
[EuiPortal docs] Add custom flyout example

### DIFF
--- a/src-docs/src/views/portal/complex/custom_flyout.tsx
+++ b/src-docs/src/views/portal/complex/custom_flyout.tsx
@@ -102,8 +102,21 @@ export default () => {
                 >
                   <EuiSpacer size="s" />
                   <EuiTitle size="m">
-                    <h2>Let’s get started!</h2>
+                    <h2 id={customFlyoutTitleId}>Let&apos;s get started!</h2>
                   </EuiTitle>
+
+                  <EuiButtonIcon
+                    iconType="cross"
+                    aria-label="Close modal"
+                    onClick={closeCustomFlyout}
+                    onKeyDown={onKeyDown}
+                    color="text"
+                    css={css`
+                      position: absolute;
+                      inset-block-start: ${euiTheme.size.base};
+                      inset-inline-end: ${euiTheme.size.base};
+                    `}
+                  />
 
                   <EuiHorizontalRule />
                 </div>
@@ -190,19 +203,6 @@ export default () => {
                   </EuiText>
                 </div>
               </div>
-
-              <EuiButtonIcon
-                iconType="cross"
-                aria-label="Close modal"
-                onClick={closeCustomFlyout}
-                onKeyDown={onKeyDown}
-                color="text"
-                css={css`
-                  position: absolute;
-                  inset-block-start: ${euiTheme.size.base};
-                  inset-inline-end: ${euiTheme.size.base};
-                `}
-              />
             </EuiPanel>
           </EuiFocusTrap>
         </EuiOverlayMask>

--- a/src-docs/src/views/portal/complex/custom_flyout.tsx
+++ b/src-docs/src/views/portal/complex/custom_flyout.tsx
@@ -10,8 +10,6 @@ import {
   EuiButtonIcon,
   EuiText,
   EuiTextColor,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiEmptyPrompt,
   EuiFocusTrap,
   EuiHorizontalRule,
@@ -27,11 +25,17 @@ import {
   useEuiTheme,
 } from '../../../../../src/services';
 
-import { euiCanAnimate } from '../../../../../src/global_styling';
+import {
+  euiCanAnimate,
+  logicalCSS,
+  logicalCSSWithFallback,
+  euiYScrollWithShadows,
+} from '../../../../../src/global_styling';
 
 export default () => {
   const [isCustomFlyoutVisible, setIsCustomFlyoutVisible] = useState(false);
-  const { euiTheme } = useEuiTheme();
+  const euiThemeContext = useEuiTheme();
+  const euiTheme = euiThemeContext.euiTheme;
 
   const toggleCustomFlyout = () => {
     setIsCustomFlyoutVisible(!isCustomFlyoutVisible);
@@ -68,11 +72,12 @@ export default () => {
               role="dialog"
               paddingSize="l"
               css={css`
-                position: absolute;
+                position: fixed;
                 max-inline-size: 480px;
                 max-block-size: auto;
                 inset-inline-end: ${euiTheme.size.l};
                 inset-block-start: ${euiTheme.size.l};
+                block-size: calc(100% - (${euiTheme.size.l} * 2));
 
                 ${euiCanAnimate} {
                   animation: ${euiFlyoutSlideInRight}
@@ -81,71 +86,110 @@ export default () => {
                 }
               `}
             >
-              <EuiFlexGroup justifyContent="spaceBetween" direction="column">
-                <EuiFlexItem>
+              <div
+                css={css`
+                  display: flex;
+                  block-size: 100%;
+                  justify-content: space-between;
+                  flex-direction: column;
+                `}
+              >
+                {/* Flyout Header */}
+                <div
+                  css={css`
+                    flex-grow: 0;
+                  `}
+                >
                   <EuiSpacer size="s" />
                   <EuiTitle size="m">
                     <h2>Let’s get started!</h2>
                   </EuiTitle>
 
                   <EuiHorizontalRule />
+                </div>
 
-                  <EuiText size="s">
-                    <p>
-                      Elastic Observability provides a unified view into the
-                      health and performance of your entire digital ecosystem.
-                      With easy ingest of multiple kinds of data via pre-built
-                      collectors for hundreds of data sources.
-                    </p>
+                {/* Flyout Body */}
+                <div
+                  css={css`
+                    ${logicalCSS('height', '100%')}
+                    ${logicalCSSWithFallback('overflow-y', 'hidden')}
+                    flex-grow: 1;
+                  `}
+                >
+                  <div
+                    css={css`
+                      ${logicalCSS('height', '100%')}
+                      ${euiYScrollWithShadows(euiThemeContext, {
+                        side: 'end',
+                      })}
+                    `}
+                  >
+                    <EuiText size="s">
+                      <p>
+                        Elastic Observability provides a unified view into the
+                        health and performance of your entire digital ecosystem.
+                        With easy ingest of multiple kinds of data via pre-built
+                        collectors for hundreds of data sources.
+                      </p>
 
-                    <EuiHorizontalRule />
+                      <EuiHorizontalRule />
 
-                    <ol
-                      css={css`
-                        > li {
-                          list-style-type: none;
-                        }
+                      <ol
+                        css={css`
+                          > li {
+                            list-style-type: none;
+                          }
 
-                        margin-inline-start: 0 !important;
-                      `}
-                    >
-                      <li>
-                        <h3>Step 1</h3>
-                        <p>Select an ingestion method</p>
-
-                        <EuiHorizontalRule />
-                      </li>
-                      <li>
-                        <EuiTextColor color="subdued">
-                          <h3>Step 2</h3>
+                          margin-inline-start: 0 !important;
+                        `}
+                      >
+                        <li>
+                          <h3>Step 1</h3>
                           <p>Select an ingestion method</p>
-                        </EuiTextColor>
 
-                        <EuiHorizontalRule />
-                      </li>
-                      <li>
-                        <EuiTextColor color="subdued">
-                          <h3>Step 3</h3>
-                          <p>Select an ingestion method</p>
-                        </EuiTextColor>
+                          <EuiHorizontalRule />
+                        </li>
+                        <li>
+                          <EuiTextColor color="subdued">
+                            <h3>Step 2</h3>
+                            <p>Select an ingestion method</p>
+                          </EuiTextColor>
 
-                        <EuiHorizontalRule />
-                      </li>
-                    </ol>
-                  </EuiText>
-                </EuiFlexItem>
-                <EuiFlexItem>
+                          <EuiHorizontalRule />
+                        </li>
+                        <li>
+                          <EuiTextColor color="subdued">
+                            <h3>Step 3</h3>
+                            <p>Select an ingestion method</p>
+                          </EuiTextColor>
+
+                          <EuiHorizontalRule />
+                        </li>
+                      </ol>
+                    </EuiText>
+                  </div>
+                </div>
+
+                {/* Flyout Footer */}
+                <div
+                  css={css`
+                    flex-grow: 0;
+                  `}
+                >
                   <EuiText textAlign="center" color="subdued" size="s">
-                    <EuiButtonEmpty onClick={closeCustomFlyout}>
+                    <EuiButtonEmpty onClick={closeCustomFlyout} size="s">
                       Exit setup guide
                     </EuiButtonEmpty>
+
+                    <EuiSpacer size="s" />
+
                     <p>
                       How’s onboarding? We’d love your{' '}
                       <EuiLink href="#">feedback</EuiLink>.
                     </p>
                   </EuiText>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+                </div>
+              </div>
 
               <EuiButtonIcon
                 iconType="cross"

--- a/src-docs/src/views/portal/complex/custom_flyout.tsx
+++ b/src-docs/src/views/portal/complex/custom_flyout.tsx
@@ -19,15 +19,15 @@ import {
   EuiSpacer,
   EuiButtonEmpty,
   euiFlyoutSlideInRight,
-} from '../../../../src/components';
+} from '../../../../../src/components';
 import {
   keys,
   EuiWindowEvent,
   useGeneratedHtmlId,
   useEuiTheme,
-} from '../../../../src/services';
+} from '../../../../../src/services';
 
-import { euiCanAnimate } from '../../../../src/global_styling';
+import { euiCanAnimate } from '../../../../../src/global_styling';
 
 export default () => {
   const [isCustomFlyoutVisible, setIsCustomFlyoutVisible] = useState(false);
@@ -165,6 +165,7 @@ export default () => {
       </EuiPortal>
     );
   }
+
   return (
     <div>
       <EuiWindowEvent event="keydown" handler={onKeyDown} />

--- a/src-docs/src/views/portal/portal_complex.tsx
+++ b/src-docs/src/views/portal/portal_complex.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { GuideSection } from '../../components/guide_section/guide_section';
+import { GuideSectionTypes } from '../../components/guide_section/guide_section_types';
+
+import CustomFlyout from './complex/custom_flyout';
+const customFlyoutSource = require('!!raw-loader!./complex/custom_flyout');
+
+export default () => {
+  return (
+    <GuideSection
+      demo={<CustomFlyout />}
+      sectionProps={{
+        paddingSize: 'none',
+      }}
+      source={[
+        {
+          type: GuideSectionTypes.JS,
+          code: customFlyoutSource,
+        },
+      ]}
+    />
+  );
+};

--- a/src-docs/src/views/portal/portal_example.js
+++ b/src-docs/src/views/portal/portal_example.js
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiPortal } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiPortal,
+  EuiCallOut,
+  EuiSpacer,
+} from '../../../../src/components';
 
 import Portal from './portal';
 const portalSource = require('!!raw-loader!./portal');
@@ -11,8 +16,7 @@ const portalSource = require('!!raw-loader!./portal');
 import PortalInsert from './portal_insert';
 const portalInsertSource = require('!!raw-loader!./portal_insert');
 
-import PortalFlyout from './portal_flyout';
-const portalFlyoutSource = require('!!raw-loader!./portal_flyout');
+import PortalComplex from './portal_complex';
 
 export const PortalExample = {
   title: 'Portal',
@@ -67,51 +71,47 @@ export const PortalExample = {
     },
     {
       title: 'A custom flyout',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: portalFlyoutSource,
-        },
-      ],
       text: (
-        <React.Fragment>
+        <>
           <p>
-            Custom flyouts should only be created if your design diverges a lot
-            from <Link to="/layout/flyout">EuiFlyout</Link> and you need to
-            apply a lot of CSS overrides. When you create a custom flyout, you
-            need to re-implement the accessibility features, which can be
-            challenging.
+            Custom flyouts should only be implemented if your design diverges a
+            lot from <Link to="/layout/flyout">EuiFlyout</Link>. You need to
+            implement accessibility features, which can be challenging.
           </p>
-          <p>
-            Here are some accessibility considerations you should keep in mind:
-          </p>
-          <ul>
-            <li>
-              Use <Link to="/utilities/focus-trap">EuiFocusTrap</Link> to
-              prevent keyboard-initiated focus from leaving the flyout.
-            </li>
-            <li>
-              If you use a{' '}
-              <Link to="/utilities/overlay-mask">EuiOverlayMask</Link>, it
-              should be dismissed when clicked outside. For that you can pass to
-              your <strong>EuiFocusTrap</strong>{' '}
-              <EuiCode>onClickOutside</EuiCode> prop a method to close the
-              flyout.
-            </li>
-            <li>
-              When pressing the <kbd>ESC</kbd> key your flyout should close. Use
-              a <Link to="/utilities/window-events">EuiWindowEvent</Link> to
-              listen for the key down event.
-            </li>
-            <li>
-              Use <EuiCode>{'aria-labelledby={headingId}'}</EuiCode> to announce
-              the flyout to screen readers.
-            </li>
-          </ul>
-          <p>
-            In addition, you should take into account some design
-            considerations:
-          </p>
+
+          <EuiCallOut
+            title="Here are some accessibility considerations you should keep in mind when implementing a custom flyout."
+            iconType="accessibility"
+          >
+            <ul>
+              <li>
+                Use <Link to="/utilities/focus-trap">EuiFocusTrap</Link> to
+                prevent keyboard-initiated focus from leaving the flyout.
+              </li>
+              <li>
+                If you use a{' '}
+                <Link to="/utilities/overlay-mask">EuiOverlayMask</Link>, it
+                should be dismissed when clicked outside. For that you can pass
+                to your <strong>EuiFocusTrap</strong>{' '}
+                <EuiCode>onClickOutside</EuiCode> prop a method to close the
+                flyout.
+              </li>
+              <li>
+                When pressing the <kbd>ESC</kbd> key your flyout should close.
+                Use a <Link to="/utilities/window-events">EuiWindowEvent</Link>{' '}
+                to listen for the key down event.
+              </li>
+              <li>
+                Use <EuiCode>{'aria-labelledby={headingId}'}</EuiCode> to
+                announce the flyout to screen readers.
+              </li>
+            </ul>
+          </EuiCallOut>
+
+          <EuiSpacer size="l" />
+
+          <p>You should also take into account some design considerations:</p>
+
           <ul>
             <li>
               Use a <Link to="/layout/panel">EuiPanel</Link> for the background.
@@ -122,10 +122,15 @@ export const PortalExample = {
             </li>
             <li>For writing CSS consider using our theme tokens.</li>
           </ul>
-        </React.Fragment>
+
+          <p>
+            In the following demo, you can see how to create your own flyout
+            with all the recommended accessibility and design features:
+          </p>
+
+          <PortalComplex />
+        </>
       ),
-      props: { EuiPortal },
-      demo: <PortalFlyout />,
     },
   ],
 };

--- a/src-docs/src/views/portal/portal_example.js
+++ b/src-docs/src/views/portal/portal_example.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 
@@ -9,6 +10,9 @@ const portalSource = require('!!raw-loader!./portal');
 
 import PortalInsert from './portal_insert';
 const portalInsertSource = require('!!raw-loader!./portal_insert');
+
+import PortalFlyout from './portal_flyout';
+const portalFlyoutSource = require('!!raw-loader!./portal_flyout');
 
 export const PortalExample = {
   title: 'Portal',
@@ -60,6 +64,68 @@ export const PortalExample = {
       ),
       props: { EuiPortal },
       demo: <PortalInsert />,
+    },
+    {
+      title: 'A custom flyout',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: portalFlyoutSource,
+        },
+      ],
+      text: (
+        <React.Fragment>
+          <p>
+            Custom flyouts should only be created if your design diverges a lot
+            from <Link to="/layout/flyout">EuiFlyout</Link> and you need to
+            apply a lot of CSS overrides. When you create a custom flyout, you
+            need to re-implement the accessibility features, which can be
+            challenging.
+          </p>
+          <p>
+            Here are some accessibility considerations you should keep in mind:
+          </p>
+          <ul>
+            <li>
+              Use <Link to="/utilities/focus-trap">EuiFocusTrap</Link> to
+              prevent keyboard-initiated focus from leaving the flyout.
+            </li>
+            <li>
+              If you use a{' '}
+              <Link to="/utilities/overlay-mask">EuiOverlayMask</Link>, it
+              should be dismissed when clicked outside. For that you can pass to
+              your <strong>EuiFocusTrap</strong>{' '}
+              <EuiCode>onClickOutside</EuiCode> prop a method to close the
+              flyout.
+            </li>
+            <li>
+              When pressing the <kbd>ESC</kbd> key your flyout should close. Use
+              a <Link to="/utilities/window-events">EuiWindowEvent</Link> to
+              listen for the key down event.
+            </li>
+            <li>
+              Use <EuiCode>{'aria-labelledby={headingId}'}</EuiCode> to announce
+              the flyout to screen readers.
+            </li>
+          </ul>
+          <p>
+            In addition, you should take into account some design
+            considerations:
+          </p>
+          <ul>
+            <li>
+              Use a <Link to="/layout/panel">EuiPanel</Link> for the background.
+            </li>
+            <li>
+              A flyout should always have a close button on the right top
+              corner. This gives a visual clue that the flyout can be closed.
+            </li>
+            <li>For writing CSS consider using our theme tokens.</li>
+          </ul>
+        </React.Fragment>
+      ),
+      props: { EuiPortal },
+      demo: <PortalFlyout />,
     },
   ],
 };

--- a/src-docs/src/views/portal/portal_example.js
+++ b/src-docs/src/views/portal/portal_example.js
@@ -102,8 +102,13 @@ export const PortalExample = {
                 to listen for the key down event.
               </li>
               <li>
-                Use <EuiCode>{'aria-labelledby={headingId}'}</EuiCode> to
-                announce the flyout to screen readers.
+                Pass an ID to the first heading in the flyout{' '}
+                <EuiCode>{'id={headingId}'}</EuiCode>.
+              </li>
+              <li>
+                Pass to your <strong>EuiPanel</strong>{' '}
+                <EuiCode>{'aria-labelledby={headingId}'}</EuiCode> to announce
+                the flyout to screen readers.
               </li>
             </ul>
           </EuiCallOut>

--- a/src-docs/src/views/portal/portal_flyout.tsx
+++ b/src-docs/src/views/portal/portal_flyout.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+
+import {
+  EuiPortal,
+  EuiButton,
+  EuiPanel,
+  EuiTitle,
+  EuiOverlayMask,
+  EuiButtonIcon,
+  EuiText,
+  EuiTextColor,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiEmptyPrompt,
+  EuiFocusTrap,
+  EuiHorizontalRule,
+  EuiLink,
+  EuiSpacer,
+  EuiButtonEmpty,
+  euiFlyoutSlideInRight,
+} from '../../../../src/components';
+import {
+  keys,
+  EuiWindowEvent,
+  useGeneratedHtmlId,
+  useEuiTheme,
+} from '../../../../src/services';
+
+import { euiCanAnimate } from '../../../../src/global_styling';
+
+export default () => {
+  const [isCustomFlyoutVisible, setIsCustomFlyoutVisible] = useState(false);
+  const { euiTheme } = useEuiTheme();
+
+  const toggleCustomFlyout = () => {
+    setIsCustomFlyoutVisible(!isCustomFlyoutVisible);
+  };
+
+  const closeCustomFlyout = () => {
+    setIsCustomFlyoutVisible(false);
+  };
+
+  const customFlyoutTitleId = useGeneratedHtmlId({
+    prefix: 'customFlyoutTitle',
+  });
+
+  /**
+   * ESC key closes CustomFlyout
+   */
+  const onKeyDown = (event: any) => {
+    if (event.key === keys.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
+      closeCustomFlyout();
+    }
+  };
+
+  let customFlyout;
+
+  if (isCustomFlyoutVisible) {
+    customFlyout = (
+      <EuiPortal>
+        <EuiOverlayMask>
+          <EuiFocusTrap onClickOutside={closeCustomFlyout}>
+            <EuiPanel
+              aria-labelledby={customFlyoutTitleId}
+              role="dialog"
+              paddingSize="l"
+              css={css`
+                position: absolute;
+                max-inline-size: 480px;
+                max-block-size: auto;
+                inset-inline-end: ${euiTheme.size.l};
+                inset-block-start: ${euiTheme.size.l};
+
+                ${euiCanAnimate} {
+                  animation: ${euiFlyoutSlideInRight}
+                    ${euiTheme.animation.normal}
+                    ${euiTheme.animation.resistance};
+                }
+              `}
+            >
+              <EuiFlexGroup justifyContent="spaceBetween" direction="column">
+                <EuiFlexItem>
+                  <EuiSpacer size="s" />
+                  <EuiTitle size="m">
+                    <h2>Let’s get started!</h2>
+                  </EuiTitle>
+
+                  <EuiHorizontalRule />
+
+                  <EuiText size="s">
+                    <p>
+                      Elastic Observability provides a unified view into the
+                      health and performance of your entire digital ecosystem.
+                      With easy ingest of multiple kinds of data via pre-built
+                      collectors for hundreds of data sources.
+                    </p>
+
+                    <EuiHorizontalRule />
+
+                    <ol
+                      css={css`
+                        > li {
+                          list-style-type: none;
+                        }
+
+                        margin-inline-start: 0 !important;
+                      `}
+                    >
+                      <li>
+                        <h3>Step 1</h3>
+                        <p>Select an ingestion method</p>
+
+                        <EuiHorizontalRule />
+                      </li>
+                      <li>
+                        <EuiTextColor color="subdued">
+                          <h3>Step 2</h3>
+                          <p>Select an ingestion method</p>
+                        </EuiTextColor>
+
+                        <EuiHorizontalRule />
+                      </li>
+                      <li>
+                        <EuiTextColor color="subdued">
+                          <h3>Step 3</h3>
+                          <p>Select an ingestion method</p>
+                        </EuiTextColor>
+
+                        <EuiHorizontalRule />
+                      </li>
+                    </ol>
+                  </EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiText textAlign="center" color="subdued" size="s">
+                    <EuiButtonEmpty onClick={closeCustomFlyout}>
+                      Exit setup guide
+                    </EuiButtonEmpty>
+                    <p>
+                      How’s onboarding? We’d love your{' '}
+                      <EuiLink href="#">feedback</EuiLink>.
+                    </p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label="Close modal"
+                onClick={closeCustomFlyout}
+                onKeyDown={onKeyDown}
+                color="text"
+                css={css`
+                  position: absolute;
+                  inset-block-start: ${euiTheme.size.base};
+                  inset-inline-end: ${euiTheme.size.base};
+                `}
+              />
+            </EuiPanel>
+          </EuiFocusTrap>
+        </EuiOverlayMask>
+      </EuiPortal>
+    );
+  }
+  return (
+    <div>
+      <EuiWindowEvent event="keydown" handler={onKeyDown} />
+      <EuiEmptyPrompt
+        color="subdued"
+        iconType="logoObservability"
+        iconColor="default"
+        title={<h2>Observe my data</h2>}
+        titleSize="xs"
+        body={
+          <p>
+            Choose one of our many integrations to bring your data in, and start
+            visualizing it.
+          </p>
+        }
+        actions={<EuiButton onClick={toggleCustomFlyout}>View guide</EuiButton>}
+      />
+      {customFlyout}
+    </div>
+  );
+};

--- a/src/components/flyout/flyout.styles.ts
+++ b/src/components/flyout/flyout.styles.ts
@@ -19,7 +19,7 @@ import { euiShadowXLarge } from '../../themes/amsterdam/global_styling/mixins';
 import { transparentize } from '../../services/color';
 import { euiFormMaxWidth } from '../form/form.styles';
 
-const euiFlyoutSlideInRight = keyframes`
+export const euiFlyoutSlideInRight = keyframes`
   0% {
     opacity: 0;
     transform: translateX(100%);
@@ -30,7 +30,7 @@ const euiFlyoutSlideInRight = keyframes`
   }
 `;
 
-const euiFlyoutSlideInLeft = keyframes`
+export const euiFlyoutSlideInLeft = keyframes`
   0% {
     opacity: 0;
     transform: translateX(-100%);

--- a/src/components/flyout/index.ts
+++ b/src/components/flyout/index.ts
@@ -17,3 +17,5 @@ export { EuiFlyoutFooter } from './flyout_footer';
 
 export type { EuiFlyoutHeaderProps } from './flyout_header';
 export { EuiFlyoutHeader } from './flyout_header';
+
+export { euiFlyoutSlideInRight, euiFlyoutSlideInLeft } from './flyout.styles';


### PR DESCRIPTION
### Summary

Closes #6241.

We normally recommend in our slack to override a `EuiFlyout` or to create one from scratch using a `EuiPortal`. We always point to what should be the right a11y features but we don't have an example in our docs.

So this PR, hopefully, adds an example of what a custom flyout can be with a recommend a11y.    

The example can be found here: https://eui.elastic.co/pr_6247/#/utilities/portal#a-custom-flyout

![Portal-Elastic-UI-Framework](https://user-images.githubusercontent.com/2750668/191554023-1c3da229-53b3-412a-b68c-fcfa2e6cd2ad.png)


### Checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
