### PR TITLE
[Emotion] Fix/regression test more `css` props

### DIFF
--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -17,10 +17,9 @@ let id = 0;
 const getId = () => `${id++}`;
 
 describe('EuiAccordion', () => {
-  shouldRenderCustomStyles(<EuiAccordion id="styles" />, [
-    'buttonProps',
-    'arrowProps',
-  ]);
+  shouldRenderCustomStyles(<EuiAccordion id="styles" />, {
+    childProps: ['buttonProps', 'arrowProps'],
+  });
 
   test('is rendered', () => {
     const component = render(<EuiAccordion id={getId()} {...requiredProps} />);

--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -14,7 +14,14 @@ import { shouldRenderCustomStyles } from '../../test/internal';
 import { EuiBadge, COLORS, ICON_SIDES } from './badge';
 
 describe('EuiBadge', () => {
-  shouldRenderCustomStyles(<EuiBadge {...requiredProps} />);
+  shouldRenderCustomStyles(
+    <EuiBadge
+      iconType="cross"
+      iconOnClick={() => {}}
+      iconOnClickAriaLabel="Close"
+    />,
+    { childProps: ['closeButtonProps'] }
+  );
 
   test('is rendered', () => {
     const component = render(<EuiBadge {...requiredProps}>Content</EuiBadge>);

--- a/src/components/badge/beta_badge/beta_badge.test.tsx
+++ b/src/components/badge/beta_badge/beta_badge.test.tsx
@@ -9,10 +9,16 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiBetaBadge, COLORS, SIZES } from './beta_badge';
 
 describe('EuiBetaBadge', () => {
+  shouldRenderCustomStyles(
+    <EuiBetaBadge label="Hello" tooltipContent="World" />,
+    { childProps: ['anchorProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(<EuiBetaBadge label="Beta" {...requiredProps} />);
 

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiButton, COLORS, SIZES } from './button';
 
@@ -18,6 +19,10 @@ import {
 } from './button_display/_button_display_content';
 
 describe('EuiButton', () => {
+  shouldRenderCustomStyles(<EuiButton>Content</EuiButton>, {
+    childProps: ['contentProps'],
+  });
+
   test('is rendered', () => {
     const component = render(<EuiButton {...requiredProps}>Content</EuiButton>);
 

--- a/src/components/button/button_display/__snapshots__/_button_display.test.tsx.snap
+++ b/src/components/button/button_display/__snapshots__/_button_display.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiButtonDisplay renders 1`] = `
+<button
+  aria-label="aria-label"
+  class="testClass1 testClass2 emotion-euiButtonDisplay-m-m"
+  data-test-subj="test subject string"
+  type="button"
+>
+  <span
+    class="emotion-euiButtonDisplayContent"
+  >
+    <span
+      class="eui-textTruncate"
+    >
+      Content
+    </span>
+  </span>
+</button>
+`;

--- a/src/components/button/button_display/__snapshots__/_button_display_content.test.tsx.snap
+++ b/src/components/button/button_display/__snapshots__/_button_display_content.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiButtonDisplayContent renders 1`] = `
+<span
+  aria-label="aria-label"
+  class="testClass1 testClass2 emotion-euiButtonDisplayContent"
+  data-test-subj="test subject string"
+>
+  <span
+    class="eui-textTruncate"
+  >
+    Content
+  </span>
+</span>
+`;

--- a/src/components/button/button_display/_button_display.test.tsx
+++ b/src/components/button/button_display/_button_display.test.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+
+import { EuiButtonDisplay } from './_button_display';
+
+describe('EuiButtonDisplay', () => {
+  shouldRenderCustomStyles(<EuiButtonDisplay>Text</EuiButtonDisplay>, {
+    childProps: ['textProps'],
+  });
+
+  it('renders', () => {
+    const { container } = render(
+      <EuiButtonDisplay {...requiredProps}>Content</EuiButtonDisplay>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/button/button_display/_button_display_content.test.tsx
+++ b/src/components/button/button_display/_button_display_content.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+
+import { EuiButtonDisplayContent } from './_button_display_content';
+
+describe('EuiButtonDisplayContent', () => {
+  shouldRenderCustomStyles(
+    <EuiButtonDisplayContent>Text</EuiButtonDisplayContent>,
+    { childProps: ['textProps'] }
+  );
+
+  it('renders', () => {
+    const { container } = render(
+      <EuiButtonDisplayContent {...requiredProps}>
+        Content
+      </EuiButtonDisplayContent>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/button/button_display/_button_display_content.tsx
+++ b/src/components/button/button_display/_button_display_content.tsx
@@ -109,7 +109,7 @@ export const EuiButtonDisplayContent: FunctionComponent<
   const isText = typeof children === 'string';
 
   return (
-    <span {...contentProps} css={cssStyles}>
+    <span css={cssStyles} {...contentProps}>
       {icon}
       {isText ? (
         <span

--- a/src/components/button/button_empty/button_empty.test.tsx
+++ b/src/components/button/button_empty/button_empty.test.tsx
@@ -16,6 +16,10 @@ import { ICON_SIDES } from '../_button_content_deprecated';
 import { BUTTON_COLORS } from '../../../themes/amsterdam/global_styling/mixins';
 
 describe('EuiButtonEmpty', () => {
+  shouldRenderCustomStyles(<EuiButtonEmpty>Content</EuiButtonEmpty>, {
+    childProps: ['contentProps'],
+  });
+
   test('is rendered', () => {
     const component = render(
       <EuiButtonEmpty {...requiredProps}>Content</EuiButtonEmpty>
@@ -23,10 +27,6 @@ describe('EuiButtonEmpty', () => {
 
     expect(component).toMatchSnapshot();
   });
-
-  shouldRenderCustomStyles(
-    <EuiButtonEmpty {...requiredProps}>Content</EuiButtonEmpty>
-  );
 
   describe('props', () => {
     describe('isDisabled', () => {

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -30,7 +30,10 @@ describe('EuiCard', () => {
     expect(component).toMatchSnapshot();
   });
 
-  shouldRenderCustomStyles(<EuiCard title="Card title" />);
+  shouldRenderCustomStyles(
+    <EuiCard title="Card title" betaBadgeProps={{ label: 'beta' }} />,
+    { childProps: ['betaBadgeProps'] }
+  );
 
   describe('props', () => {
     test('icon', () => {

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -9,10 +9,16 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiCollapsibleNavGroup, BACKGROUNDS } from './collapsible_nav_group';
 
 describe('EuiCollapsibleNavGroup', () => {
+  shouldRenderCustomStyles(
+    <EuiCollapsibleNavGroup iconType="logoElastic" title="Test" />,
+    { childProps: ['iconProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiCollapsibleNavGroup id="id" {...requiredProps} />

--- a/src/components/description_list/description_list.test.tsx
+++ b/src/components/description_list/description_list.test.tsx
@@ -19,7 +19,7 @@ describe('EuiDescriptionList', () => {
     <EuiDescriptionList
       listItems={[{ title: 'hello', description: 'world' }]}
     />,
-    ['titleProps', 'descriptionProps']
+    { childProps: ['titleProps', 'descriptionProps'] }
   );
 
   test('is rendered', () => {

--- a/src/components/expression/expression.test.tsx
+++ b/src/components/expression/expression.test.tsx
@@ -16,7 +16,7 @@ import { EuiExpression, COLORS } from './expression';
 describe('EuiExpression', () => {
   shouldRenderCustomStyles(
     <EuiExpression description="the answer is" value="42" />,
-    ['descriptionProps', 'valueProps']
+    { childProps: ['descriptionProps', 'valueProps'] }
   );
 
   test('renders', () => {

--- a/src/components/flyout/flyout.test.tsx
+++ b/src/components/flyout/flyout.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
 import { requiredProps, takeMountedSnapshot } from '../../test';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiFlyout, SIZES, PADDING_SIZES, SIDES } from './flyout';
 
@@ -23,6 +24,11 @@ jest.mock('../portal', () => ({
 }));
 
 describe('EuiFlyout', () => {
+  shouldRenderCustomStyles(
+    <EuiFlyout {...requiredProps} onClose={() => {}} />,
+    { childProps: ['closeButtonProps', 'maskProps'] }
+  );
+
   test('is rendered', () => {
     const component = mount(
       <EuiFlyout {...requiredProps} onClose={() => {}} />

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -351,13 +351,13 @@ export const EuiFlyout = forwardRef(
         {...focusTrapProps}
       >
         <Element
+          css={cssStyles}
           {...(rest as ComponentPropsWithRef<T>)}
           role={role}
           className={classes}
           tabIndex={-1}
           style={newStyle}
           ref={setRef}
-          css={cssStyles}
         >
           {closeButton}
           {children}

--- a/src/components/form/described_form_group/described_form_group.test.tsx
+++ b/src/components/form/described_form_group/described_form_group.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiFormRow } from '../form_row';
 import { EuiDescribedFormGroup } from './described_form_group';
@@ -18,6 +19,10 @@ describe('EuiDescribedFormGroup', () => {
     title: <h3>Title</h3>,
     description: 'Test description',
   };
+
+  shouldRenderCustomStyles(<EuiDescribedFormGroup {...props} />, {
+    childProps: ['descriptionFlexItemProps', 'fieldFlexItemProps'],
+  });
 
   test('is rendered', () => {
     const component = shallow(

--- a/src/components/form/field_password/field_password.test.tsx
+++ b/src/components/form/field_password/field_password.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiFieldPassword, EuiFieldPasswordProps } from './field_password';
 
@@ -23,6 +24,10 @@ const TYPES: Array<EuiFieldPasswordProps['type']> = [
 ];
 
 describe('EuiFieldPassword', () => {
+  shouldRenderCustomStyles(<EuiFieldPassword type="dual" />, {
+    childProps: ['dualToggleProps'],
+  });
+
   test('is rendered', () => {
     const component = render(
       <EuiFieldPassword

--- a/src/components/form/radio/radio.test.tsx
+++ b/src/components/form/radio/radio.test.tsx
@@ -9,10 +9,16 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiRadio } from './radio';
 
 describe('EuiRadio', () => {
+  shouldRenderCustomStyles(
+    <EuiRadio onChange={() => {}} id="id" label="test" />,
+    { childProps: ['labelProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiRadio id="id" onChange={() => {}} {...requiredProps} />

--- a/src/components/form/super_select/super_select.test.tsx
+++ b/src/components/form/super_select/super_select.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
 import { requiredProps, takeMountedSnapshot } from '../../../test';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiSuperSelect } from './super_select';
 
@@ -22,6 +23,11 @@ const options = [
 ];
 
 describe('EuiSuperSelect', () => {
+  shouldRenderCustomStyles(
+    <EuiSuperSelect options={options} onChange={() => {}} />,
+    { childProps: ['popoverProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiSuperSelect

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -22,7 +22,9 @@ describe('EuiImage', () => {
     src: '/cat.jpg',
   };
 
-  shouldRenderCustomStyles(<EuiImage {...requiredProps} />, ['wrapperProps']);
+  shouldRenderCustomStyles(<EuiImage {...requiredProps} />, {
+    childProps: ['wrapperProps'],
+  });
 
   test('is rendered', () => {
     const component = render(<EuiImage {...requiredProps} />);

--- a/src/components/markdown_editor/markdown_editor.test.tsx
+++ b/src/components/markdown_editor/markdown_editor.test.tsx
@@ -9,12 +9,24 @@
 import React from 'react';
 import { render, mount, ReactWrapper } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
+
 import { EuiMarkdownEditor } from './markdown_editor';
 import * as MarkdownTooltip from './plugins/markdown_tooltip';
 import MarkdownActions from './markdown_actions';
 import { getDefaultEuiMarkdownPlugins } from './plugins/markdown_default_plugins';
 
 describe('EuiMarkdownEditor', () => {
+  shouldRenderCustomStyles(
+    <EuiMarkdownEditor
+      {...requiredProps}
+      onChange={() => {}}
+      value="Test"
+      initialViewMode="viewing"
+    />,
+    { childProps: ['markdownFormatProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiMarkdownEditor

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiNotificationEvent is rendered 1`] = `
 <article
   aria-label="aria-label"
   aria-labelledby="generated-id"
-  class="euiNotificationEvent className"
+  class="euiNotificationEvent testClass1 testClass2"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/notification/notification_event.test.tsx
+++ b/src/components/notification/notification_event.test.tsx
@@ -8,25 +8,38 @@
 
 import React from 'react';
 import { mount, render } from 'enzyme';
-import { EuiNotificationEvent } from './notification_event';
-import { EuiContextMenuPanel, EuiContextMenuItem } from '../context_menu';
+
 import {
   findTestSubject,
   takeMountedSnapshot,
   requiredProps,
 } from '../../test';
+import { shouldRenderCustomStyles } from '../../test/internal';
+
+import { EuiNotificationEvent } from './notification_event';
+import { EuiContextMenuPanel, EuiContextMenuItem } from '../context_menu';
 
 describe('EuiNotificationEvent', () => {
+  const props = {
+    id: 'id',
+    type: 'Alert',
+    time: '1 min ago',
+    title: 'title',
+    messages: ['message'],
+  };
+
+  shouldRenderCustomStyles(
+    <EuiNotificationEvent
+      {...props}
+      primaryAction="Test"
+      onClickPrimaryAction={() => {}}
+    />,
+    { childProps: ['primaryActionProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
-      <EuiNotificationEvent
-        id="id"
-        type="Alert"
-        time="1 min ago"
-        title="title"
-        messages={['message']}
-        {...requiredProps}
-      />
+      <EuiNotificationEvent {...props} {...requiredProps} />
     );
 
     expect(component).toMatchSnapshot();
@@ -36,10 +49,7 @@ describe('EuiNotificationEvent', () => {
     test('multiple messages are rendered', () => {
       const component = render(
         <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          title="title"
+          {...props}
           messages={['message 1', 'message 2', 'message 3']}
         />
       );
@@ -49,15 +59,7 @@ describe('EuiNotificationEvent', () => {
 
     test('isRead  is rendered', () => {
       const component = render(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          isRead={true}
-          onRead={() => {}}
-          title="title"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} isRead={true} onRead={() => {}} />
       );
 
       expect(component).toMatchSnapshot();
@@ -65,14 +67,7 @@ describe('EuiNotificationEvent', () => {
 
     test('severity  is rendered', () => {
       const component = render(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          severity="severity"
-          title="title"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} severity="severity" />
       );
 
       expect(component).toMatchSnapshot();
@@ -80,14 +75,7 @@ describe('EuiNotificationEvent', () => {
 
     test('badgeColor is rendered', () => {
       const component = render(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          badgeColor="warning"
-          title="title"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} badgeColor="warning" />
       );
 
       expect(component).toMatchSnapshot();
@@ -95,14 +83,7 @@ describe('EuiNotificationEvent', () => {
 
     test('iconType is rendered', () => {
       const component = render(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          iconType="logoCloud"
-          title="title"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} iconType="logoCloud" />
       );
 
       expect(component).toMatchSnapshot();
@@ -110,14 +91,7 @@ describe('EuiNotificationEvent', () => {
 
     test('headingLevel is rendered', () => {
       const component = render(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          title="title"
-          headingLevel="h4"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} headingLevel="h4" />
       );
 
       expect(component).toMatchSnapshot();
@@ -126,13 +100,9 @@ describe('EuiNotificationEvent', () => {
     test('iconAriaLabel is rendered', () => {
       const component = render(
         <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          title="title"
+          {...props}
           iconType="logoCloud"
           iconAriaLabel="my icon aria label"
-          messages={['message']}
         />
       );
 
@@ -142,13 +112,9 @@ describe('EuiNotificationEvent', () => {
     test('primaryAction is rendered', () => {
       const component = render(
         <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          title="title"
+          {...props}
           primaryAction="primaryAction label"
           onClickPrimaryAction={() => {}}
-          messages={['message']}
         />
       );
 
@@ -158,14 +124,10 @@ describe('EuiNotificationEvent', () => {
     test('primaryActionProps is rendered', () => {
       const component = render(
         <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          title="title"
+          {...props}
           primaryAction="primaryAction"
           primaryActionProps={{ iconType: 'download' }}
           onClickPrimaryAction={() => {}}
-          messages={['message']}
         />
       );
 
@@ -189,11 +151,7 @@ describe('EuiNotificationEvent', () => {
 
       const component = mount(
         <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          title="title"
-          messages={['message']}
+          {...props}
           onOpenContextMenu={onOpenContextMenu}
         />
       );
@@ -215,15 +173,7 @@ describe('EuiNotificationEvent', () => {
       const onRead = jest.fn();
 
       const component = mount(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          isRead={true}
-          onRead={onRead}
-          title="title"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} isRead={true} onRead={onRead} />
       );
 
       findTestSubject(component, 'id-notificationEventReadButton').simulate(
@@ -238,15 +188,11 @@ describe('EuiNotificationEvent', () => {
 
       const component = mount(
         <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
+          {...props}
           isRead={true}
           onRead={() => {}}
           onClickPrimaryAction={onClickPrimaryAction}
           primaryAction="primary action label"
-          title="title"
-          messages={['message']}
         />
       );
 
@@ -261,14 +207,7 @@ describe('EuiNotificationEvent', () => {
       const onClickTitle = jest.fn();
 
       const component = mount(
-        <EuiNotificationEvent
-          id="id"
-          type="Alert"
-          time="1 min ago"
-          onClickTitle={onClickTitle}
-          title="title"
-          messages={['message']}
-        />
+        <EuiNotificationEvent {...props} onClickTitle={onClickTitle} />
       );
 
       findTestSubject(component, 'id-notificationEventTitle').simulate('click');

--- a/src/components/notification/notification_event.tsx
+++ b/src/components/notification/notification_event.tsx
@@ -117,10 +117,11 @@ export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> 
   className,
   ...rest
 }) => {
-  const classes = classNames('euiNotificationEvent', {
-    'euiNotificationEvent--withReadState': typeof isRead === 'boolean',
-    className,
-  });
+  const classes = classNames(
+    'euiNotificationEvent',
+    { 'euiNotificationEvent--withReadState': typeof isRead === 'boolean' },
+    className
+  );
 
   const classesTitle = classNames('euiNotificationEvent__title', {
     'euiNotificationEvent__title--isRead': isRead,

--- a/src/components/page/page_body/page_body.test.tsx
+++ b/src/components/page/page_body/page_body.test.tsx
@@ -15,7 +15,9 @@ import { PADDING_SIZES } from '../../../global_styling';
 import { EuiPageBody } from './page_body';
 
 describe('EuiPageBody', () => {
-  shouldRenderCustomStyles(<EuiPageBody panelled />, ['panelProps']);
+  shouldRenderCustomStyles(<EuiPageBody panelled />, {
+    childProps: ['panelProps'],
+  });
 
   test('is rendered', () => {
     const component = render(<EuiPageBody {...requiredProps} />);

--- a/src/components/page/page_header/page_header_content.test.tsx
+++ b/src/components/page/page_header/page_header_content.test.tsx
@@ -59,13 +59,15 @@ describe('EuiPageHeaderContent', () => {
       breadcrumbs={[{ text: 'breadcrumb' }]}
       tabs={[{ label: 'tab' }]}
     />,
-    [
-      'pageTitleProps',
-      'iconProps',
-      'rightSideGroupProps',
-      'breadcrumbProps',
-      'tabsProps',
-    ]
+    {
+      childProps: [
+        'pageTitleProps',
+        'iconProps',
+        'rightSideGroupProps',
+        'breadcrumbProps',
+        'tabsProps',
+      ],
+    }
   );
 
   test('is rendered', () => {

--- a/src/components/page/page_section/page_section.test.tsx
+++ b/src/components/page/page_section/page_section.test.tsx
@@ -16,7 +16,9 @@ import { ALIGNMENTS } from './page_section.styles';
 import { PADDING_SIZES, BACKGROUND_COLORS } from '../../../global_styling';
 
 describe('EuiPageSection', () => {
-  shouldRenderCustomStyles(<EuiPageSection />, ['contentProps']);
+  shouldRenderCustomStyles(<EuiPageSection />, {
+    childProps: ['contentProps'],
+  });
 
   test('is rendered', () => {
     const component = render(<EuiPageSection {...requiredProps} />);

--- a/src/components/page_template/page_template.test.tsx
+++ b/src/components/page_template/page_template.test.tsx
@@ -15,7 +15,7 @@ import { PADDING_SIZES } from '../../global_styling';
 import { EuiPageTemplate } from './page_template';
 
 describe('EuiPageTemplate', () => {
-  shouldRenderCustomStyles(<EuiPageTemplate />, ['mainProps']);
+  shouldRenderCustomStyles(<EuiPageTemplate />, { childProps: ['mainProps'] });
 
   test('is rendered', () => {
     const component = render(<EuiPageTemplate {...requiredProps} />);

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -9,6 +9,7 @@
 import React, { ReactNode } from 'react';
 import { render, mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
 import { EuiFocusTrap } from '../';
 
 import {
@@ -28,6 +29,14 @@ let id = 0;
 const getId = () => `${id++}`;
 
 describe('EuiPopover', () => {
+  shouldRenderCustomStyles(
+    <EuiPopover button={<button />} closePopover={() => {}} />
+  );
+  shouldRenderCustomStyles(
+    <EuiPopover button={<button />} closePopover={() => {}} isOpen />,
+    { childProps: ['panelProps'], skipStyles: true, skipParentTest: true }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiPopover

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -21,9 +21,10 @@ describe('EuiProgress', () => {
   });
 
   shouldRenderCustomStyles(<EuiProgress />);
-  shouldRenderCustomStyles(<EuiProgress max={100} label="Test" />, [
-    'labelProps',
-  ]);
+  shouldRenderCustomStyles(<EuiProgress max={100} label="Test" />, {
+    childProps: ['labelProps'],
+    skipParentTest: true,
+  });
 
   test('has max', () => {
     const component = render(<EuiProgress max={100} {...requiredProps} />);

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
 import { requiredProps } from '../../test';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiSelectable } from './selectable';
 import { EuiSelectableOption } from './selectable_option';
@@ -28,6 +29,18 @@ const options: EuiSelectableOption[] = [
 ];
 
 describe('EuiSelectable', () => {
+  shouldRenderCustomStyles(
+    <EuiSelectable options={options} searchable>
+      {(list, search) => (
+        <>
+          {search}
+          {list}
+        </>
+      )}
+    </EuiSelectable>,
+    { childProps: ['searchProps', 'listProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiSelectable options={options} {...requiredProps} id="testId" />

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -38,7 +38,7 @@ describe('EuiSelectable', () => {
         </>
       )}
     </EuiSelectable>,
-    { childProps: ['searchProps', 'listProps'] }
+    { childProps: ['searchProps', 'listProps', 'listProps.windowProps'] }
   );
 
   test('is rendered', () => {

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiSelectableTemplateSitewide } from './selectable_template_sitewide';
 import { EuiSelectableTemplateSitewideOption } from './selectable_template_sitewide_option';
@@ -74,6 +75,11 @@ const options: EuiSelectableTemplateSitewideOption[] = [
 ];
 
 describe('EuiSelectableTemplateSitewide', () => {
+  shouldRenderCustomStyles(
+    <EuiSelectableTemplateSitewide options={options} />,
+    { childProps: ['popoverProps'] }
+  );
+
   test('is rendered', () => {
     const component = render(
       <EuiSelectableTemplateSitewide options={options} {...requiredProps} />

--- a/src/components/side_nav/side_nav.test.tsx
+++ b/src/components/side_nav/side_nav.test.tsx
@@ -9,11 +9,16 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiSideNav } from './side_nav';
 import { RenderItem } from './side_nav_item';
 
 describe('EuiSideNav', () => {
+  shouldRenderCustomStyles(<EuiSideNav heading="Test" />, {
+    childProps: ['headingProps'],
+  });
+
   test('is rendered', () => {
     const component = render(<EuiSideNav {...requiredProps} />);
 

--- a/src/test/internal/render_custom_styles.tsx
+++ b/src/test/internal/render_custom_styles.tsx
@@ -9,6 +9,7 @@
 import React, { ReactElement } from 'react';
 import { render } from '@testing-library/react';
 import { css } from '@emotion/react';
+import { get, set } from 'lodash';
 
 const customStyles = {
   className: 'hello',
@@ -81,15 +82,12 @@ export const shouldRenderCustomStyles = (
   if (options.childProps) {
     options.childProps.forEach((childProps) => {
       it(`should render custom ${testCases} on ${childProps}`, () => {
+        const mergedChildProps = set({ ...component.props }, childProps, {
+          ...get(component.props, childProps),
+          ...testProps,
+        });
         const { baseElement } = render(
-          <div>
-            {React.cloneElement(component, {
-              [childProps]: {
-                ...(component.props[childProps] || {}),
-                ...testProps,
-              },
-            })}
-          </div>
+          <div>{React.cloneElement(component, mergedChildProps)}</div>
         );
         assertOutputStyles(baseElement, options);
       });

--- a/src/test/internal/render_custom_styles.tsx
+++ b/src/test/internal/render_custom_styles.tsx
@@ -18,7 +18,10 @@ const customStyles = {
   style: { content: "'world'" },
 };
 
-const assertOutputStyles = (rendered: HTMLElement) => {
+const assertOutputStyles = (
+  rendered: HTMLElement,
+  { skipStyles }: { skipStyles?: boolean }
+) => {
   // className
   const componentNode = rendered.querySelector('.hello');
   expect(componentNode).not.toBeNull();
@@ -27,46 +30,68 @@ const assertOutputStyles = (rendered: HTMLElement) => {
     expect.stringMatching(/css-[\d\w-]{6,}-css/) // should have generated an emotion class ending with -css
   );
   // style
-  expect(componentNode!.getAttribute('style')).toContain("content: 'world';");
+  // skippable as some components explicitly do not accept custom inline styles
+  if (!skipStyles) {
+    expect(componentNode!.getAttribute('style')).toContain("content: 'world';");
+  }
 };
 
 /**
  * Use this test helper to quickly check that the component supports custom
  * `className`, `css`, and `style` properties.
  *
- * Use the second childProps arg to ensure that any child component props
+ * Use options.childProps to ensure that any child component props
  * also correctly accept custom css/classes/styles.
+ *
+ * Use options.skipStyles for components that specifically
+ * do not allow custom inline styles.
  *
  * Example usage:
  *
  * shouldRenderCustomStyles(<EuiMark {...requiredProps} />Marked</EuiMark>);
- * shouldRenderCustomStyles(<EuiPageSection />, ['contentProps']);
+ * shouldRenderCustomStyles(<EuiPageSection />, { childProps: ['contentProps'] });
+ * shouldRenderCustomStyles(<EuiPopover />, { childProps: ['panelProps'], skipStyles: true });
  */
 export const shouldRenderCustomStyles = (
   component: ReactElement,
-  childProps?: string[]
+  options: {
+    childProps?: string[];
+    skipStyles?: boolean;
+    skipParentTest?: boolean;
+  } = {}
 ) => {
-  it('should render custom classNames, css, and styles', () => {
-    const { baseElement } = render(
-      <div>{React.cloneElement(component, customStyles)}</div>
-    );
-    assertOutputStyles(baseElement);
-  });
+  const testCases = options.skipStyles
+    ? 'classNames and css'
+    : 'classNames, css, and styles';
+  const testProps = options.skipStyles
+    ? { className: customStyles.className, css: customStyles.css }
+    : customStyles;
 
-  if (childProps) {
-    childProps.forEach((_childProps) => {
-      it(`should render custom classNames, css, and styles on ${_childProps}`, () => {
+  // Some tests run separate child props tests with different settings & don't need
+  // to run the base parent test multiple times. If so, allow skipping this test
+  if (!(options.skipParentTest === true && options.childProps)) {
+    it(`should render custom ${testCases}`, () => {
+      const { baseElement } = render(
+        <div>{React.cloneElement(component, testProps)}</div>
+      );
+      assertOutputStyles(baseElement, options);
+    });
+  }
+
+  if (options.childProps) {
+    options.childProps.forEach((childProps) => {
+      it(`should render custom ${testCases} on ${childProps}`, () => {
         const { baseElement } = render(
           <div>
             {React.cloneElement(component, {
-              [_childProps]: {
-                ...(component.props[_childProps] || {}),
-                ...customStyles,
+              [childProps]: {
+                ...(component.props[childProps] || {}),
+                ...testProps,
               },
             })}
           </div>
         );
-        assertOutputStyles(baseElement);
+        assertOutputStyles(baseElement, options);
       });
     });
   }

--- a/upcoming_changelogs/6248.md
+++ b/upcoming_changelogs/6248.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiFlyout` not correctly merging passed `css`
+- Fixed `EuiNotificationEvent` not correctly merging passed `className`s


### PR DESCRIPTION
### Summary

Follow up to #6239, closes https://github.com/elastic/eui/issues/6152

This PR:

- Adds tests/fixes more components that have already been converted to Emotion
- Updates the `shouldRenderCustomStyles` API to use a more future-proof `options` obj that allows the following:
  - Skipping the `styles` assertion (since some components explicitly disallow custom `style`s)
  - Skipping the parent component test (since some tests have multiple setups/assertions for child props)
- Adds regression tests for a few more tests that were super quick / did not require any source code changes
- ⚠️ Does **not** fix/regression test all remaining components that have `childProps` - the changelist was getting large, and the tooltip props are slightly tricky, so I'm going to split it into (yet another) follow-up PR

### Checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
