### PR TITLE
[EuAvatar] Avoid mutating the style prop

### DIFF
--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, FunctionComponent, CSSProperties } from 'react';
+import React, { HTMLAttributes, FunctionComponent } from 'react';
 import { CommonProps, ExclusiveUnion } from '../common';
 import classNames from 'classnames';
 
@@ -141,10 +141,7 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
 
   checkValidInitials(initials);
 
-  // copying style into a new object for `avatarStyle` has two purposes:
-  // 1. `avatarStyle` is mutated later and this prevents that mutation from affecting the incoming prop
-  // 2. if `style` is undefined, this "defaults" an empty object
-  const avatarStyle: CSSProperties = { ...style };
+  const avatarStyle = { ...style };
 
   let iconCustomColor = iconColor;
 

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -141,7 +141,11 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
 
   checkValidInitials(initials);
 
-  const avatarStyle: CSSProperties = style || {};
+  // copying style into a new object for `avatarStyle` has two purposes:
+  // 1. `avatarStyle` is mutated later and this prevents that mutation from affecting the incoming prop
+  // 2. if `style` is undefined, this "defaults" an empty object
+  const avatarStyle: CSSProperties = { ...style };
+
   let iconCustomColor = iconColor;
 
   const isNamedColor =

--- a/upcoming_changelogs/6251.md
+++ b/upcoming_changelogs/6251.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiAvatar` to no longer mutate the object passed to its `style` prop


### PR DESCRIPTION
### Summary

Closes #6249 by cloning the incoming `style` prop, if any, instead of keeping a direct reference to the object.

### Checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
