### PR TITLE
[EuiSkipLink] Add `fallbackDestination` support, defaulting to `main` tag

### DIFF
--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -215,8 +215,9 @@ export const AccessibilityExample = {
             navigation, or ornamental elements, and quickly reach the main
             content of the page. It requires a <EuiCode>destinationId</EuiCode>{' '}
             which should match the <EuiCode>id</EuiCode> of your main content.
-            You can also change the <EuiCode>position</EuiCode> to{' '}
-            <EuiCode>fixed</EuiCode>.
+            If your ID does not correspond to a valid element, the skip link
+            will fall back to focusing the <EuiCode>{'<main>'}</EuiCode> tag on
+            your page, if it exists.
           </p>
           <p>
             <em>

--- a/src-docs/src/views/accessibility/skip_link.tsx
+++ b/src-docs/src/views/accessibility/skip_link.tsx
@@ -1,39 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import {
-  EuiSkipLink,
-  EuiCallOut,
-  EuiSpacer,
-  EuiSwitch,
-} from '../../../../src/components';
+import { EuiSkipLink, EuiText } from '../../../../src/components';
 
 export default () => {
-  const [isFixed, setFixed] = useState(false);
-
   return (
-    <>
-      <EuiSwitch
-        label="Fix link to top of screen"
-        checked={isFixed}
-        onChange={(e) => setFixed(e.target.checked)}
-      />
-      <EuiSpacer />
-      <EuiSkipLink
-        destinationId="/utilities/accessibility"
-        position={isFixed ? 'fixed' : 'static'}
-        data-test-subj="skip-link-demo-subj"
-      >
-        Skip to {isFixed && 'main '}content
+    <EuiText id="skip-link-example">
+      <p>The following skip links are only visible on focus:</p>
+      <EuiSkipLink destinationId="skip-link-example" overrideLinkBehavior>
+        Skips to this example container
       </EuiSkipLink>
-      {isFixed && (
-        <>
-          <EuiCallOut
-            size="s"
-            title="A functional &lsquo;Skip to main content&rsquo; link will be added to the EUI docs site once our URL format is updated."
-            iconType="iInCircle"
-          />
-        </>
-      )}
-    </>
+      <EuiSkipLink destinationId="" overrideLinkBehavior>
+        Falls back to main container
+      </EuiSkipLink>
+    </EuiText>
   );
 };

--- a/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
@@ -20,18 +20,6 @@ exports[`EuiSkipLink is rendered 1`] = `
 </a>
 `;
 
-exports[`EuiSkipLink props onClick is rendered 1`] = `
-<a
-  class="euiSkipLink emotion-euiButtonDisplay-s-s-fill-primary-euiSkipLink-euiScreenReaderOnly"
-  href="#somewhere"
-  rel="noreferrer"
->
-  <span
-    class="emotion-euiButtonDisplayContent"
-  />
-</a>
-`;
-
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
 <a
   class="euiSkipLink emotion-euiButtonDisplay-s-s-fill-primary-euiSkipLink-absolute-euiScreenReaderOnly"

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -7,20 +7,21 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
+import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test';
 
 import { EuiSkipLink, POSITIONS } from './skip_link';
 
 describe('EuiSkipLink', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSkipLink destinationId="somewhere" {...requiredProps}>
         Skip
       </EuiSkipLink>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
@@ -60,29 +61,29 @@ describe('EuiSkipLink', () => {
     });
 
     test('tabIndex is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSkipLink destinationId="somewhere" tabIndex={-1} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('onClick is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSkipLink destinationId="somewhere" onClick={() => {}} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('position', () => {
       POSITIONS.forEach((position) => {
         test(`${position} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiSkipLink destinationId="somewhere" position={position} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -104,12 +104,24 @@ describe('EuiSkipLink', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    test('onClick is rendered', () => {
-      const { container } = render(
-        <EuiSkipLink destinationId="somewhere" onClick={() => {}} />
+    test('onClick is called without overriding overrideLinkBehavior', () => {
+      const onClick = jest.fn();
+      const { getByText } = render(
+        <>
+          <EuiSkipLink
+            destinationId="somewhere"
+            overrideLinkBehavior
+            onClick={onClick}
+          >
+            Test
+          </EuiSkipLink>
+          <div id="somewhere" />
+        </>
       );
+      fireEvent.click(getByText('Test'));
 
-      expect(container.firstChild).toMatchSnapshot();
+      expect(document.activeElement?.id).toEqual('somewhere');
+      expect(onClick).toHaveBeenCalled();
     });
 
     describe('position', () => {

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { fireEvent } from '@testing-library/dom';
 import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test';
 
@@ -57,6 +58,41 @@ describe('EuiSkipLink', () => {
         mockElement.getBoundingClientRect = () => ({ top: 1000 } as any);
         component.find('a').simulate('click');
         expect(scrollSpy).toHaveBeenCalled();
+      });
+
+      afterAll(() => jest.restoreAllMocks());
+    });
+
+    describe('fallbackDestination', () => {
+      it('falls back to focusing the main tag if destinationId is invalid', () => {
+        const { getByText } = render(
+          <>
+            <EuiSkipLink destinationId="">Skip to content</EuiSkipLink>
+            <main>I am content</main>
+          </>
+        );
+        fireEvent.click(getByText('Skip to content'));
+
+        const expectedFocus = document.querySelector('main');
+        expect(document.activeElement).toEqual(expectedFocus);
+      });
+
+      it('supports multiple query selectors', () => {
+        const { getByText } = render(
+          <>
+            <EuiSkipLink
+              destinationId=""
+              fallbackDestination="main, [role=main]"
+            >
+              Skip to content
+            </EuiSkipLink>
+            <div role="main">I am content</div>
+          </>
+        );
+        fireEvent.click(getByText('Skip to content'));
+
+        const expectedFocus = document.querySelector('[role=main]');
+        expect(document.activeElement).toEqual(expectedFocus);
       });
     });
 

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -30,7 +30,7 @@ interface EuiSkipLinkInterface extends EuiButtonProps {
    */
   destinationId: string;
   /**
-   * If no destination ID element exists or can be found, you may provide a set of
+   * If no destination ID element exists or can be found, you may provide a string of
    * query selectors to fall back to (e.g. a `main` or `role="main"` element)
    * @default main
    */

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -62,6 +62,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
   position = 'static',
   children,
   className,
+  onClick: _onClick,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -95,7 +96,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
 
   let onClick = undefined;
   if (overrideLinkBehavior || !hasValidId) {
-    onClick = (e: React.MouseEvent) => {
+    onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
       if (!destinationEl) return;
       e.preventDefault();
 
@@ -120,6 +121,8 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
       }
 
       destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus autoscroll behaves oddly on Chrome around fixed headers
+
+      _onClick?.(e);
     };
   }
 

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { isTabbable } from 'tabbable';
 import { useEuiTheme } from '../../../services';
 import { EuiButton, EuiButtonProps } from '../../button/button';
-import { PropsForAnchor, PropsForButton, ExclusiveUnion } from '../../common';
+import { PropsForAnchor } from '../../common';
 import { EuiScreenReaderOnly } from '../screen_reader_only';
 import { euiSkipLinkStyles } from './skip_link.styles';
 
@@ -41,21 +41,12 @@ interface EuiSkipLinkInterface extends EuiButtonProps {
   tabIndex?: number;
 }
 
-type propsForAnchor = PropsForAnchor<
+export type EuiSkipLinkProps = PropsForAnchor<
   EuiSkipLinkInterface,
   {
     buttonRef?: Ref<HTMLAnchorElement>;
   }
 >;
-
-type propsForButton = PropsForButton<
-  EuiSkipLinkInterface,
-  {
-    buttonRef?: Ref<HTMLButtonElement>;
-  }
->;
-
-export type EuiSkipLinkProps = ExclusiveUnion<propsForAnchor, propsForButton>;
 
 export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
   destinationId,
@@ -76,44 +67,35 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
     position !== 'static' ? styles[position] : undefined,
   ];
 
-  // Create the `href` from `destinationId`
-  let optionalProps = {};
-  if (destinationId) {
-    optionalProps = {
-      href: `#${destinationId}`,
-    };
-  }
+  let onClick = undefined;
   if (overrideLinkBehavior) {
-    optionalProps = {
-      ...optionalProps,
-      onClick: (e: React.MouseEvent) => {
-        e.preventDefault();
+    onClick = (e: React.MouseEvent) => {
+      e.preventDefault();
 
-        const destinationEl = document.getElementById(destinationId);
-        if (!destinationEl) return;
+      const destinationEl = document.getElementById(destinationId);
+      if (!destinationEl) return;
 
-        // Scroll to the top of the destination content only if it's ~mostly out of view
-        const destinationY = destinationEl.getBoundingClientRect().top;
-        const halfOfViewportHeight = window.innerHeight / 2;
-        if (
-          destinationY >= halfOfViewportHeight ||
-          window.scrollY >= destinationY + halfOfViewportHeight
-        ) {
-          destinationEl.scrollIntoView();
-        }
+      // Scroll to the top of the destination content only if it's ~mostly out of view
+      const destinationY = destinationEl.getBoundingClientRect().top;
+      const halfOfViewportHeight = window.innerHeight / 2;
+      if (
+        destinationY >= halfOfViewportHeight ||
+        window.scrollY >= destinationY + halfOfViewportHeight
+      ) {
+        destinationEl.scrollIntoView();
+      }
 
-        // Ensure the destination content is focusable
-        if (!isTabbable(destinationEl)) {
-          destinationEl.tabIndex = -1;
-          destinationEl.addEventListener(
-            'blur',
-            () => destinationEl.removeAttribute('tabindex'),
-            { once: true }
-          );
-        }
+      // Ensure the destination content is focusable
+      if (!isTabbable(destinationEl)) {
+        destinationEl.tabIndex = -1;
+        destinationEl.addEventListener(
+          'blur',
+          () => destinationEl.removeAttribute('tabindex'),
+          { once: true }
+        );
+      }
 
-        destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus autoscroll behaves oddly on Chrome around fixed headers
-      },
+      destinationEl.focus({ preventScroll: true }); // Scrolling is already handled above, and focus autoscroll behaves oddly on Chrome around fixed headers
     };
   }
 
@@ -125,7 +107,8 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
         tabIndex={position === 'fixed' ? 0 : tabIndex}
         size="s"
         fill
-        {...optionalProps}
+        href={`#${destinationId}`}
+        onClick={onClick}
         {...rest}
       >
         {children}


### PR DESCRIPTION
### Summary

This PR adds built-in EUI support for the skip link fallback mechanism I described in https://github.com/elastic/kibana/issues/135760#issuecomment-1247006238. A quick tl;dr summary of changes

- EuiSkipLink is now always an `a` tag and never a `button`
- EuiSkipLink now supports a new `fallbackDestination` prop which accepts any query selector. For the purposes of the above PR, this means Kibana can pass in `fallbackDestination="main, role=[main], div[app-fixed-viewport]"` and simply have things work across almost all plugins
- EuiSkipLink has been incidentally fixed to not completely override our own `onClick` behavior if a consumer passes their own `onClick`
- EuiSkipLink docs/examples have been updated & improved
- EuiSkipLink unit tests have been updated & improved

I recommend following along by commit if possible, although I was a little sloppier on my last few commits.

### Checklist

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] Checked for **breaking changes** and labeled appropriately~