### PR TITLE
[EuiPopover docs] Update examples to align with product assistance guidelines

### DIFF
--- a/src-docs/src/views/popover/initial_focus.tsx
+++ b/src-docs/src/views/popover/initial_focus.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import {
+  EuiButtonEmpty,
   EuiButton,
   EuiFormRow,
   EuiPopover,
@@ -16,9 +17,9 @@ export default () => {
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+    <EuiButtonEmpty iconType="help" iconSide="right" onClick={onButtonClick}>
       Show popover
-    </EuiButton>
+    </EuiButtonEmpty>
   );
 
   return (

--- a/src-docs/src/views/popover/popover.tsx
+++ b/src-docs/src/views/popover/popover.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { EuiPopover, EuiButton, EuiText } from '../../../../src';
+import { EuiPopover, EuiButtonEmpty, EuiText } from '../../../../src';
 
 export default () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -10,9 +10,13 @@ export default () => {
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
-      Show popover
-    </EuiButton>
+    <EuiButtonEmpty
+      iconType="documentation"
+      iconSide="right"
+      onClick={onButtonClick}
+    >
+      How it works
+    </EuiButtonEmpty>
   );
 
   return (

--- a/src-docs/src/views/popover/popover_anchor_position.tsx
+++ b/src-docs/src/views/popover/popover_anchor_position.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import {
   EuiPopover,
-  EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -87,13 +87,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick1}
               >
                 downLeft
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen1}
             closePopover={closePopover1}
@@ -106,13 +106,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick2}
               >
                 downCenter
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen2}
             closePopover={closePopover2}
@@ -125,13 +125,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick3}
               >
                 downRight
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen3}
             closePopover={closePopover3}
@@ -148,13 +148,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick4}
               >
                 upLeft
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen4}
             closePopover={closePopover4}
@@ -167,13 +167,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick5}
               >
                 upCenter
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen5}
             closePopover={closePopover5}
@@ -186,13 +186,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick6}
               >
                 upRight
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen6}
             closePopover={closePopover6}
@@ -209,13 +209,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick7}
               >
                 leftUp
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen7}
             closePopover={closePopover7}
@@ -228,13 +228,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick8}
               >
                 leftCenter
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen8}
             closePopover={closePopover8}
@@ -247,13 +247,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick9}
               >
                 leftDown
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen9}
             closePopover={closePopover9}
@@ -270,13 +270,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick10}
               >
                 rightUp
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen10}
             closePopover={closePopover10}
@@ -289,13 +289,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick11}
               >
                 rightCenter
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen11}
             closePopover={closePopover11}
@@ -308,13 +308,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick12}
               >
                 rightDown
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen12}
             closePopover={closePopover12}

--- a/src-docs/src/views/popover/popover_container.js
+++ b/src-docs/src/views/popover/popover_container.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import {
-  EuiButton,
+  EuiButtonEmpty,
   EuiCode,
   EuiPanel,
   EuiPopover,
@@ -17,14 +17,14 @@ export default () => {
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButton
-      iconType="arrowDown"
+    <EuiButtonEmpty
+      iconType="help"
       iconSide="right"
       onClick={onButtonClick}
       style={{ position: 'relative', left: 50 }}
     >
       Show constrained popover
-    </EuiButton>
+    </EuiButtonEmpty>
   );
 
   return (

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -223,7 +223,7 @@ export const PopoverExample = {
       text: (
         <>
           <p>
-            Popovers often need titling. Use the
+            Popovers often need titling. Use the{' '}
             <strong>EuiPopoverTitle</strong> component nested somewhere inside
             the popover contents.
           </p>

--- a/src-docs/src/views/popover/popover_fixed.tsx
+++ b/src-docs/src/views/popover/popover_fixed.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { EuiButton, EuiPopover } from '../../../../src';
+import { EuiButtonEmpty, EuiPopover, EuiButton } from '../../../../src';
 
 export default () => {
   const [isExampleShown, setIsExampleShown] = useState(false);
@@ -14,14 +14,9 @@ export default () => {
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButton
-      iconType="arrowDown"
-      iconSide="right"
-      onClick={onButtonClick}
-      fill
-    >
+    <EuiButtonEmpty iconType="help" iconSide="right" onClick={onButtonClick}>
       Show fixed popover
-    </EuiButton>
+    </EuiButtonEmpty>
   );
 
   return (

--- a/src-docs/src/views/popover/popover_htmlelement_anchor.js
+++ b/src-docs/src/views/popover/popover_htmlelement_anchor.js
@@ -46,8 +46,8 @@ export default () => {
     <div
       dangerouslySetInnerHTML={{
         __html: `
-  <button id="popoverAnchorButton" class="euiButton euiButton--primary">
-    <span class="euiButton__content">This is an HTML button</span>
+  <button id="popoverAnchorButton" class="EuiButtonEmpty EuiButtonEmpty--primary">
+    <span class="EuiButtonEmpty__content">This is an HTML button</span>
   </button>
         `,
       }}

--- a/src-docs/src/views/popover/popover_panel_class_name.tsx
+++ b/src-docs/src/views/popover/popover_panel_class_name.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { EuiPopover, EuiButton, EuiText } from '../../../../src';
+import { EuiPopover, EuiButtonEmpty, EuiText } from '../../../../src';
 
 export default () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -12,13 +12,13 @@ export default () => {
   return (
     <EuiPopover
       button={
-        <EuiButton
-          iconType="arrowDown"
+        <EuiButtonEmpty
+          iconType="help"
           iconSide="right"
           onClick={onButtonClick}
         >
           Text scaling
-        </EuiButton>
+        </EuiButtonEmpty>
       }
       isOpen={isPopoverOpen}
       closePopover={closePopover}

--- a/src-docs/src/views/popover/popover_with_title.tsx
+++ b/src-docs/src/views/popover/popover_with_title.tsx
@@ -5,6 +5,7 @@ import {
   EuiPopoverTitle,
   EuiPopoverFooter,
   EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -33,13 +34,13 @@ export default () => {
       <EuiFlexItem grow={false}>
         <EuiPopover
           button={
-            <EuiButton
-              iconType="arrowDown"
+            <EuiButtonEmpty
+              iconType="questionInCircle"
               iconSide="right"
               onClick={onButtonClick1}
             >
               With title
-            </EuiButton>
+            </EuiButtonEmpty>
           }
           isOpen={isPopoverOpen1}
           closePopover={closePopover1}
@@ -60,13 +61,13 @@ export default () => {
       <EuiFlexItem grow={false}>
         <EuiPopover
           button={
-            <EuiButton
-              iconType="arrowDown"
+            <EuiButtonEmpty
+              iconType="questionInCircle"
               iconSide="right"
               onClick={onButtonClick2}
             >
               With footer
-            </EuiButton>
+            </EuiButtonEmpty>
           }
           isOpen={isPopoverOpen2}
           closePopover={closePopover2}
@@ -91,13 +92,13 @@ export default () => {
       <EuiFlexItem grow={false}>
         <EuiPopover
           button={
-            <EuiButton
-              iconType="arrowDown"
+            <EuiButtonEmpty
+              iconType="questionInCircle"
               iconSide="right"
               onClick={onButtonClick3}
             >
               With title and footer button
-            </EuiButton>
+            </EuiButtonEmpty>
           }
           isOpen={isPopoverOpen3}
           closePopover={closePopover3}

--- a/src-docs/src/views/popover/popover_with_title_padding.tsx
+++ b/src-docs/src/views/popover/popover_with_title_padding.tsx
@@ -5,6 +5,7 @@ import {
   EuiPopoverTitle,
   EuiPopoverFooter,
   EuiButton,
+  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -50,13 +51,13 @@ export default () => {
           <EuiPopover
             panelPaddingSize="s"
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick2}
               >
                 Small panel padding
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen2}
             closePopover={closePopover2}
@@ -80,13 +81,13 @@ export default () => {
           <EuiPopover
             panelPaddingSize="none"
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick1}
               >
                 No panel padding (none)
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen1}
             closePopover={closePopover1}
@@ -111,13 +112,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick4}
               >
                 No title padding (none)
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen4}
             closePopover={closePopover4}
@@ -144,13 +145,13 @@ export default () => {
           <EuiPopover
             panelPaddingSize="none"
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick3}
               >
                 No panel padding with small title padding
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen3}
             closePopover={closePopover3}
@@ -177,13 +178,13 @@ export default () => {
         <EuiFlexItem grow={false}>
           <EuiPopover
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick5}
               >
                 No footer padding (none)
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen5}
             closePopover={closePopover5}
@@ -208,13 +209,13 @@ export default () => {
           <EuiPopover
             panelPaddingSize="none"
             button={
-              <EuiButton
-                iconType="arrowDown"
+              <EuiButtonEmpty
+                iconType="questionInCircle"
                 iconSide="right"
                 onClick={onButtonClick6}
               >
                 Set each padding individually
-              </EuiButton>
+              </EuiButtonEmpty>
             }
             isOpen={isPopoverOpen6}
             closePopover={closePopover6}

--- a/src-docs/src/views/popover/trap_focus.tsx
+++ b/src-docs/src/views/popover/trap_focus.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import {
+  EuiButtonEmpty,
   EuiButton,
   EuiFormRow,
   EuiPopover,
@@ -18,9 +19,9 @@ export default () => {
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
+    <EuiButtonEmpty iconType="help" iconSide="right" onClick={onButtonClick}>
       Show popover
-    </EuiButton>
+    </EuiButtonEmpty>
   );
 
   // Since `hasFocus={false}` disables popover auto focus, we need to manually set it ourselves


### PR DESCRIPTION

### Summary

This PR updates a few examples for the EuiPopover to better align with product assistance guidelines (https://github.com/elastic/tech-writing-guidelines/pull/54/):

- Most of the **EuiButtons** were updated to use **EuiButtonEmptys**. In our products, the trigger to open popovers typically comes from a **EuiButtonEmpty** and this align with the guidelines.
- I replaced all icons. All examples were using an `arrowDown`, and it should be avoided. It seems that indicates that the popover will open down. And this is not always true. Like in the following example:

<img width="421" alt="Screenshot 2022-09-23 at 15 05 01" src="https://user-images.githubusercontent.com/2750668/191995928-3adf47e0-4231-4ddd-8692-d4d70673cd63.png">

- The `arrowDown` icons were replaced with `help`, `questionInCircle` and `documentation` icons. To better align with the guidelines.

<img width="474" alt="popover-trigger@2x" src="https://user-images.githubusercontent.com/2750668/191997043-c06029de-9b21-45e5-b352-1c368a77a224.png">


### Checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**

