### PR TITLE
[CI] Skip a11y testing to stop CI from hanging

### DIFF
--- a/scripts/test-docker.js
+++ b/scripts/test-docker.js
@@ -13,7 +13,6 @@ execSync("docker run \
     && /opt/yarn*/bin/yarn \
     && yarn cypress install \
     && NODE_OPTIONS=\"--max-old-space-size=2048\" npm run test-ci \
-    && npm run start-test-server-and-a11y-test \
     && npm run build'", {
   stdio: 'inherit',
 });


### PR DESCRIPTION
### Summary

We're seeing multiple hanging CI issues on the a11y testing step:

- https://kibana-ci.elastic.co/job/elastic+eui+pull-request-test/8235/console
- https://kibana-ci.elastic.co/job/elastic+eui+pull-request/8510/

It's not totally clear why, but this only started happening recently (Sept 21st/22nd). This PR skips said step in order to unblock multiple PRs from being merged. Long term, we should potentially consider moving our a11y tests to using Cypress/cypress-axe instead of building our docs and running axe against docs.

Note: I accidentally pushed this commit directly up to main and had to reverted it on main 💀 please disregard that oopsie

### Checklist

- [x] CI passes
