### PR TITLE
[eslint] Fix `css` position lint error

### DIFF
--- a/src-docs/src/services/playground/playground.js
+++ b/src-docs/src/services/playground/playground.js
@@ -88,9 +88,9 @@ export default ({
             {...playgroundPanelProps}
           >
             <Compiler
+              css={playgroundCssStyles?.(euiTheme)}
               {...params.compilerProps}
               placeholder={Placeholder}
-              css={playgroundCssStyles?.(euiTheme)}
               className={classNames('playground__demo', playgroundClassName)}
             />
           </EuiPanel>


### PR DESCRIPTION
### Summary

> 12:28:04 /app/src-docs/src/services/playground/playground.js
> 12:28:04   93:15  error  undefined: CSS props must be declared before spread props  local/css_before_spread_props

https://kibana-ci.elastic.co/job/elastic+eui+pull-request-test/8316/console

~### Checklist~
