### PR TITLE
[Docs] fixed EuiThemeProvider links in EuiProvider documentation

### DIFF
--- a/src-docs/src/views/provider/provider_example.js
+++ b/src-docs/src/views/provider/provider_example.js
@@ -44,7 +44,7 @@ export const ProviderExample = {
 
           <p>
             See{' '}
-            <EuiLink href="/#/theming/theme-provider">
+            <EuiLink href="#/theming/theme-provider">
               <strong>EuiThemeProvider</strong>
             </EuiLink>{' '}
             for full documentation as all relevant props will pass through. For
@@ -63,7 +63,7 @@ export const ProviderExample = {
             <strong>EuiProvider</strong> by composing its constituent parts.
             More context, functionality, and configurations will be added to{' '}
             <strong>EuiProvider</strong> in future releases. Nested instances of{' '}
-            <EuiLink href="/#/theming/theme-provider">
+            <EuiLink href="#/theming/theme-provider">
               <strong>EuiThemeProvider</strong>
             </EuiLink>
             , however, are valid.


### PR DESCRIPTION
### Summary

Documentation hyperlink fix. Links were referring to `https://elastic.github.io/#/theming/theme-provider` instead of `https://elastic.github.io/eui/#/theming/theme-provider`

### Checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
