### PR TITLE
[InMemoryTable] Add `enabled` option to executeQueryOptions

### DIFF
--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -13,6 +13,7 @@ import { requiredProps } from '../../test';
 import { EuiInMemoryTable, EuiInMemoryTableProps } from './in_memory_table';
 import { keys, SortDirection } from '../../services';
 import { SearchFilterConfig } from '../search_bar/filters';
+import { Query } from '../search_bar/query';
 
 interface BasicItem {
   id: number | string;
@@ -1312,6 +1313,54 @@ describe('EuiInMemoryTable', () => {
       expect(component.find('td').at(1).text()).toBe('Index1');
       expect(component.find('td').at(2).text()).toBe('Index2');
       expect(component.find('td').at(3).text()).toBe('Index3');
+    });
+  });
+
+  describe('controlled search query', () => {
+    it('execute the Query and filters the table items', () => {
+      const items = [{ title: 'foo' }, { title: 'bar' }, { title: 'baz' }];
+      const columns = [{ field: 'title', name: 'Title' }];
+      const query = Query.parse('baz');
+
+      const component = mount(
+        <EuiInMemoryTable
+          items={items}
+          search={{ query }}
+          columns={columns}
+          executeQueryOptions={{ defaultFields: ['title'] }}
+        />
+      );
+
+      const tableContent = component.find(
+        '.euiTableRowCell .euiTableCellContent'
+      );
+
+      expect(tableContent.length).toBe(1); // only 1 match
+      expect(tableContent.at(0).text()).toBe('baz');
+    });
+
+    it('does not execute the Query and renders the items passed as is', () => {
+      const items = [{ title: 'foo' }, { title: 'bar' }, { title: 'baz' }];
+      const columns = [{ field: 'title', name: 'Title' }];
+      const query = Query.parse('baz');
+
+      const component = mount(
+        <EuiInMemoryTable
+          items={items}
+          search={{ query }}
+          columns={columns}
+          executeQueryOptions={{ defaultFields: ['title'], enabled: false }}
+        />
+      );
+
+      const tableContent = component.find(
+        '.euiTableRowCell .euiTableCellContent'
+      );
+
+      expect(tableContent.length).toBe(3);
+      expect(tableContent.at(0).text()).toBe('foo');
+      expect(tableContent.at(1).text()).toBe('bar');
+      expect(tableContent.at(2).text()).toBe('baz');
     });
   });
 });

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -86,6 +86,11 @@ type InMemoryTableProps<T> = Omit<
     defaultFields?: string[];
     isClauseMatcher?: (...args: any) => boolean;
     explain?: boolean;
+    /**
+     * When the search bar Query is controlled and passed to the `search` prop it is by default executed against the items passed to the table to filter them out.
+     * If the filtering is already done before passing the `items` to the table we can disable the execution by setting `enabled` to `false`.
+     */
+    enabled?: boolean;
   };
   /**
    * Insert content between the search bar and table components.
@@ -577,9 +582,10 @@ export class EuiInMemoryTable<T> extends Component<
 
     const { query, sortName, pageIndex, pageSize } = this.state;
 
-    const matchingItems = query
-      ? EuiSearchBar.Query.execute(query, items, executeQueryOptions)
-      : items;
+    const matchingItems =
+      query !== null && executeQueryOptions?.enabled !== false
+        ? EuiSearchBar.Query.execute(query, items, executeQueryOptions)
+        : items;
 
     const sortedItems = sortName
       ? matchingItems

--- a/upcoming_changelogs/6284.md
+++ b/upcoming_changelogs/6284.md
@@ -1,0 +1,1 @@
+- Added the `enabled` option to the `<EuiInMemoryTable />` `executeQueryOptions` prop. This option prevents the Query from being executed when controlled by the consumer.


### PR DESCRIPTION
In this PR I've added a new option to `executeQueryOptions` that allows the consumer to disable the execution of the query when it is controlled.

We have the case in Kibana where the `items` are filtered outside of the table and we don't want the query to be executed on the already filtered items.

**Note**

I've also included in this PR a change to the `AST` parser to allow adding and removing items to a specific "must" or "must not" clause. Let me know if this needs to be in a separate PR or if I can leave it here.
The changes was required to make https://github.com/elastic/kibana/pull/142108/files#diff-5de71eb8bb8fd1e9fc5440e218f972239fdb0ff4933f26a180cc45d5950d7143R69 work.

Fixes https://github.com/elastic/eui/issues/6240