### PR TITLE
[EuiOverlayMask] Restore missing above/below header information

### DIFF
--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -91,7 +91,8 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
   useEffect(() => {
     if (!overlayMaskNode) return;
     overlayMaskNode.className = classNames('euiOverlayMask', className);
-  }, [overlayMaskNode, className]);
+    overlayMaskNode.dataset.relativeToHeader = headerZindexLocation;
+  }, [overlayMaskNode, className, headerZindexLocation]);
 
   return (
     <EuiPortal portalRef={combinedMaskRef}>

--- a/upcoming_changelogs/6289.md
+++ b/upcoming_changelogs/6289.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiOverlayMask` to set a `[data-relative-to-header=above|below]` attribute to replace the `--aboveHeader` and `--belowHeader` classNames removed in its Emotion conversion


### PR DESCRIPTION
### Summary

Several Kibana CSS stylesheets were hooking into the now-removed `euiOverlayMask--aboveHeader` and `euiOverlayMask--belowHeader` classes.

Because of the way EuiOverlayMask's Emotion CSS styles were written, there isn't even a randomly generated Emotion className for those styles to update to. So we need to provide a data attribute instead, and backport this fix.

<img width="1011" alt="" src="https://user-images.githubusercontent.com/549407/193922801-bd623d42-4e11-4913-843f-a465626a73e2.png">

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately