### PR TITLE
[EuiOverlayMask] Fix broken selector reference in EuiHeader mixin

### DIFF
--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -20,7 +20,7 @@
       }
     }
 
-    &:not(.euiDataGrid__restrictBody) .euiOverlayMask[data-relative-to-header="below"] {
+    &:not(.euiDataGrid__restrictBody) .euiOverlayMask[data-relative-to-header='below'] {
       top: #{$headerHeight};
     }
   }

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -20,7 +20,7 @@
       }
     }
 
-    &:not(.euiDataGrid__restrictBody) .euiOverlayMask[data-relative-to-header=below] {
+    &:not(.euiDataGrid__restrictBody) .euiOverlayMask[data-relative-to-header="below"] {
       top: #{$headerHeight};
     }
   }

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -20,7 +20,7 @@
       }
     }
 
-    &:not(.euiDataGrid__restrictBody) .euiOverlayMask--belowHeader {
+    &:not(.euiDataGrid__restrictBody) .euiOverlayMask[data-relative-to-header=below] {
       top: #{$headerHeight};
     }
   }

--- a/upcoming_changelogs/6293.md
+++ b/upcoming_changelogs/6293.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiHeader` CSS using removed `EuiOverlayMask` class modifiers


### PR DESCRIPTION
### Summary

Missed in https://github.com/elastic/eui/pull/6289 and https://github.com/elastic/eui/pull/6090. Required to not bork Kibana to high heaven

### Checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
