### PR TITLE
[EuiOverlayMask] Do not allow the `css` prop

### DIFF
--- a/src-docs/src/views/overlay_mask/props.tsx
+++ b/src-docs/src/views/overlay_mask/props.tsx
@@ -3,5 +3,5 @@ import { CommonProps } from '../../../../src/components/common';
 import { EuiOverlayMaskInterface } from '../../../../src/components/overlay_mask/overlay_mask';
 
 export const EuiOverlayMaskProps: FunctionComponent<
-  EuiOverlayMaskInterface & CommonProps
+  EuiOverlayMaskInterface & Omit<CommonProps, 'css'>
 > = () => <div />;

--- a/src/components/overlay_mask/overlay_mask.tsx
+++ b/src/components/overlay_mask/overlay_mask.tsx
@@ -43,7 +43,7 @@ export interface EuiOverlayMaskInterface {
   maskRef?: Ref<HTMLDivElement> | MutableRefObject<HTMLDivElement>;
 }
 
-export type EuiOverlayMaskProps = CommonProps &
+export type EuiOverlayMaskProps = Omit<CommonProps, 'css'> &
   Omit<
     Partial<Record<keyof HTMLAttributes<HTMLDivElement>, string>>,
     keyof EuiOverlayMaskInterface
@@ -55,7 +55,6 @@ export const EuiOverlayMask: FunctionComponent<EuiOverlayMaskProps> = ({
   children,
   headerZindexLocation = 'above',
   maskRef,
-  css, // TODO: apply custom CSS-in-JS as a className
   ...rest
 }) => {
   const [overlayMaskNode, setOverlayMaskNode] = useState<HTMLDivElement | null>(


### PR DESCRIPTION
### Summary

Since the overlay mask is essentially a portalled raw DOM node/element, it can't accept an `@emotion/react` `css` prop.

TODO was added in https://github.com/elastic/eui/pull/6118/

### Checklist

- [x] Props have proper **autodocs** ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

Going to skip the changelog on this as this doesn't really affect user functionality, just developer typing and props table documentation.