### PR TITLE
[Euisearchbar] Add option to render hint

### DIFF
--- a/src-docs/src/views/search_bar/props_info.js
+++ b/src-docs/src/views/search_bar/props_info.js
@@ -36,6 +36,11 @@ export const propsInfo = {
           required: false,
           type: { name: '#SearchFilters[]' },
         },
+        hint: {
+          description: 'Renders a hint below the search bar',
+          required: false,
+          type: { name: '#Hint' },
+        },
       },
     },
   },
@@ -500,6 +505,24 @@ export const propsInfo = {
             'An array of additional queries to add as a `must_not` clause to the generated query',
           required: false,
           type: { name: 'ESQuery[]' },
+        },
+      },
+    },
+  },
+
+  Hint: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        content: {
+          description: 'The hint content to render',
+          required: true,
+          type: { name: 'React.ReactNode' },
+        },
+        popOverProps: {
+          description: 'Optional configuration for the hint popover.',
+          required: false,
+          type: { name: 'EuiInputPopoverProps' },
         },
       },
     },

--- a/src-docs/src/views/search_bar/search_bar.js
+++ b/src-docs/src/views/search_bar/search_bar.js
@@ -190,7 +190,7 @@ export const SearchBar = () => {
                     <strong>-dashboard</strong>
                   </span>
                 ),
-                popOverProps: { panelStyle: { backgroundColor: '#f7f8fc' } },
+                popoverProps: { panelStyle: { backgroundColor: '#f7f8fc' } },
               }
             : undefined
         }

--- a/src-docs/src/views/search_bar/search_bar.js
+++ b/src-docs/src/views/search_bar/search_bar.js
@@ -64,6 +64,7 @@ export const SearchBar = () => {
   const [query, setQuery] = useState(initialQuery);
   const [error, setError] = useState(null);
   const [incremental, setIncremental] = useState(false);
+  const [showHint, setShowHint] = useState(false);
 
   const onChange = ({ query, error }) => {
     if (error) {
@@ -75,7 +76,11 @@ export const SearchBar = () => {
   };
 
   const toggleIncremental = () => {
-    setIncremental(!incremental);
+    setIncremental((prev) => !prev);
+  };
+
+  const toggleHint = () => {
+    setShowHint((prev) => !prev);
   };
 
   const renderSearch = () => {
@@ -176,6 +181,19 @@ export const SearchBar = () => {
         }}
         filters={filters}
         onChange={onChange}
+        hint={
+          showHint
+            ? {
+                content: (
+                  <span>
+                    Type search terms, e.g. <strong>visualization</strong> or{' '}
+                    <strong>-dashboard</strong>
+                  </span>
+                ),
+                popOverProps: { panelStyle: { backgroundColor: '#f7f8fc' } },
+              }
+            : undefined
+        }
       />
     );
   };
@@ -292,14 +310,22 @@ export const SearchBar = () => {
 
   return (
     <Fragment>
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem>{renderSearch()}</EuiFlexItem>
-
+      {renderSearch()}
+      <EuiSpacer size="s" />
+      <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiSwitch
             label="Incremental"
             checked={incremental}
             onChange={toggleIncremental}
+          />
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiSwitch
+            label="Show hint"
+            checked={showHint}
+            onChange={toggleHint}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -625,9 +625,10 @@ export class EuiPopover extends Component<Props, State> {
       container,
       focusTrapProps,
       initialFocus: initialFocusProp,
-      tabIndex: tabIndexProp,
+      tabIndex: _tabIndexProp,
       ...rest
     } = this.props;
+    const tabIndexProp = panelProps?.tabIndex ?? _tabIndexProp;
 
     const styles = euiPopoverStyles();
     const popoverStyles = [styles.euiPopover, { display }];

--- a/src/components/search_bar/__snapshots__/search_box.test.tsx.snap
+++ b/src/components/search_bar/__snapshots__/search_box.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`EuiSearchBox render - custom placeholder and incremental 1`] = `
   inputRef={[Function]}
   isClearable={true}
   isLoading={false}
+  onFocus={[Function]}
   onSearch={[Function]}
   placeholder="..."
 />
@@ -29,6 +30,7 @@ exports[`EuiSearchBox render - no config 1`] = `
   inputRef={[Function]}
   isClearable={true}
   isLoading={false}
+  onFocus={[Function]}
   onSearch={[Function]}
   placeholder="Search..."
 />

--- a/src/components/search_bar/search_bar.test.tsx
+++ b/src/components/search_bar/search_bar.test.tsx
@@ -145,7 +145,7 @@ describe('SearchBar', () => {
               box={{ 'data-test-subj': 'searchbar' }}
               hint={{
                 content: <span data-test-subj="myHint">Hello from hint</span>,
-                popOverProps: {
+                popoverProps: {
                   isOpen: isHintVisible,
                 },
               }}

--- a/src/components/search_bar/search_bar.test.tsx
+++ b/src/components/search_bar/search_bar.test.tsx
@@ -7,7 +7,9 @@
  */
 
 /* eslint-disable react/no-multi-comp */
-import React from 'react';
+import React, { useState } from 'react';
+import { act } from 'react-dom/test-utils';
+
 import { requiredProps } from '../../test';
 import { mount, shallow } from 'enzyme';
 import { EuiSearchBar } from './search_bar';
@@ -103,6 +105,83 @@ describe('SearchBar', () => {
       const [[{ query, queryText }]] = onChange.mock.calls;
       expect(query).toBeInstanceOf(Query);
       expect(queryText).toBe('status:inactive');
+    });
+  });
+
+  describe('hint', () => {
+    test('renders a hint below the search bar on focus', () => {
+      const component = mount(
+        <EuiSearchBar
+          query="status:active"
+          box={{ 'data-test-subj': 'searchbar' }}
+          hint={{
+            content: <span data-test-subj="myHint">Hello from hint</span>,
+          }}
+        />
+      );
+
+      const getHint = () => component.find('[data-test-subj="myHint"]');
+
+      let hint = getHint();
+      expect(hint.length).toBe(0);
+
+      act(() => {
+        component.find('input[data-test-subj="searchbar"]').simulate('focus');
+      });
+      component.update();
+
+      hint = getHint();
+      expect(hint.length).toBe(1);
+      expect(hint.text()).toBe('Hello from hint');
+    });
+
+    test('control the visibility of the hint', () => {
+      const TestComp = () => {
+        const [isHintVisible, setIsHintVisible] = useState(false);
+
+        return (
+          <>
+            <EuiSearchBar
+              box={{ 'data-test-subj': 'searchbar' }}
+              hint={{
+                content: <span data-test-subj="myHint">Hello from hint</span>,
+                popOverProps: {
+                  isOpen: isHintVisible,
+                },
+              }}
+            />
+            <button
+              data-test-subj="showHintBtn"
+              onClick={() => setIsHintVisible(true)}
+            >
+              Show hint
+            </button>
+          </>
+        );
+      };
+
+      const component = mount(<TestComp />);
+      const getHint = () => component.find('[data-test-subj="myHint"]');
+
+      let hint = getHint();
+      expect(hint.length).toBe(0);
+
+      act(() => {
+        component.find('input[data-test-subj="searchbar"]').simulate('focus');
+      });
+      component.update();
+
+      hint = getHint();
+      expect(hint.length).toBe(0); // Not visible on focus as it is controlled
+
+      act(() => {
+        component.find('[data-test-subj="showHintBtn"]').simulate('click');
+      });
+      component.update();
+
+      hint = getHint();
+      expect(hint.length).toBe(1);
+      expect(hint.text()).toBe('Hello from hint');
     });
   });
 });

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -36,6 +36,24 @@ interface ArgsWithError {
 
 export type EuiSearchBarOnChangeArgs = ArgsWithQuery | ArgsWithError;
 
+type HintPopOverProps = Partial<
+  Pick<
+    EuiInputPopoverProps,
+    | 'isOpen'
+    | 'closePopover'
+    | 'fullWidth'
+    | 'disableFocusTrap'
+    | 'panelClassName'
+    | 'panelPaddingSize'
+    | 'panelStyle'
+    | 'panelProps'
+    | 'popoverScreenReaderText'
+    | 'repositionOnScroll'
+    | 'zIndex'
+    | 'data-test-subj'
+  >
+>;
+
 export interface EuiSearchBarProps extends CommonProps {
   onChange?: (args: EuiSearchBarOnChangeArgs) => void | boolean;
 
@@ -84,20 +102,7 @@ export interface EuiSearchBarProps extends CommonProps {
    */
   hint?: {
     content: React.ReactNode;
-    popOverProps?: Pick<
-      EuiInputPopoverProps,
-      | 'isOpen'
-      | 'closePopover'
-      | 'fullWidth'
-      | 'disableFocusTrap'
-      | 'panelClassName'
-      | 'panelPaddingSize'
-      | 'panelStyle'
-      | 'panelProps'
-      | 'popoverScreenReaderText'
-      | 'repositionOnScroll'
-      | 'zIndex'
-    >;
+    popOverProps?: HintPopOverProps;
   };
 }
 

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -7,6 +7,8 @@
  */
 
 import React, { Component, ReactElement } from 'react';
+
+import { htmlIdGenerator } from '../../services/accessibility';
 import { isString } from '../../services/predicate';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSearchBox, SchemaType } from './search_box';
@@ -51,6 +53,7 @@ type HintPopOverProps = Partial<
     | 'repositionOnScroll'
     | 'zIndex'
     | 'data-test-subj'
+    | 'id'
   >
 >;
 
@@ -137,6 +140,7 @@ type StateWithOptionalQuery = Omit<State, 'query' | 'isHintVisible'> & {
 
 export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
   static Query = Query;
+  hintId = htmlIdGenerator('__hint')();
 
   constructor(props: EuiSearchBarProps) {
     super(props);
@@ -236,7 +240,12 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
   }
 
   render() {
-    const { query, queryText, error, isHintVisible } = this.state;
+    const {
+      query,
+      queryText,
+      error,
+      isHintVisible: isHintVisibleState,
+    } = this.state;
     const {
       box: { schema, ...box } = { schema: '' }, // strip `schema` out to prevent passing it to EuiSearchBox
       filters,
@@ -259,6 +268,11 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
 
     const toolsRightEl = this.renderTools(toolsRight);
 
+    const popoverProps: HintPopOverProps | undefined = hint
+      ? { id: this.hintId, ...hint.popoverProps }
+      : undefined;
+    const isHintVisible = hint?.popoverProps?.isOpen ?? isHintVisibleState;
+
     return (
       <EuiFlexGroup gutterSize="m" alignItems="center" wrap>
         {toolsLeftEl}
@@ -269,6 +283,7 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
             onSearch={this.onSearch}
             isInvalid={error != null}
             title={error ? error.message : undefined}
+            aria-describedby={isHintVisible ? `${this.hintId}` : undefined}
             hint={
               hint
                 ? {
@@ -277,6 +292,7 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
                       this.setState({ isHintVisible: isVisible });
                     },
                     ...hint,
+                    popoverProps,
                   }
                 : undefined
             }

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -131,10 +131,8 @@ interface State {
   isHintVisible: boolean;
 }
 
-// `state.query` is never null, but can be passed as `null` to `notifyControllingParent`
-// when `error` is not null.
-type StateWithOptionalQuery = Omit<State, 'query' | 'isHintVisible'> & {
-  query: Query | null;
+type NotifyControllingParent = Pick<State, 'queryText' | 'error'> & {
+  query: Query | null; // `state.query` is never null, but can be passed as `null` when an error is present
 };
 
 export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
@@ -175,7 +173,7 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
     return null;
   }
 
-  notifyControllingParent(newState: StateWithOptionalQuery) {
+  notifyControllingParent(newState: NotifyControllingParent) {
     const { onChange } = this.props;
     if (!onChange) {
       return;

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -53,7 +53,6 @@ type HintPopOverProps = Partial<
     | 'repositionOnScroll'
     | 'zIndex'
     | 'data-test-subj'
-    | 'id'
   >
 >;
 
@@ -268,9 +267,6 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
 
     const toolsRightEl = this.renderTools(toolsRight);
 
-    const popoverProps: HintPopOverProps | undefined = hint
-      ? { id: this.hintId, ...hint.popoverProps }
-      : undefined;
     const isHintVisible = hint?.popoverProps?.isOpen ?? isHintVisibleState;
 
     return (
@@ -291,8 +287,8 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
                     setIsVisible: (isVisible: boolean) => {
                       this.setState({ isHintVisible: isVisible });
                     },
+                    id: this.hintId,
                     ...hint,
-                    popoverProps,
                   }
                 : undefined
             }

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -102,7 +102,7 @@ export interface EuiSearchBarProps extends CommonProps {
    */
   hint?: {
     content: React.ReactNode;
-    popOverProps?: HintPopOverProps;
+    popoverProps?: HintPopOverProps;
   };
 }
 

--- a/src/components/search_bar/search_bar.tsx
+++ b/src/components/search_bar/search_bar.tsx
@@ -14,6 +14,7 @@ import { EuiSearchFilters, SearchFilterConfig } from './search_filters';
 import { Query } from './query';
 import { CommonProps } from '../common';
 import { EuiFieldSearchProps } from '../form/field_search';
+import { EuiInputPopoverProps } from '../popover';
 
 export { Query, AST as Ast } from './query';
 
@@ -77,6 +78,27 @@ export interface EuiSearchBarProps extends CommonProps {
    * Date formatter to use when parsing date values
    */
   dateFormat?: object;
+
+  /**
+   * Hint to render below the search bar
+   */
+  hint?: {
+    content: React.ReactNode;
+    popOverProps?: Pick<
+      EuiInputPopoverProps,
+      | 'isOpen'
+      | 'closePopover'
+      | 'fullWidth'
+      | 'disableFocusTrap'
+      | 'panelClassName'
+      | 'panelPaddingSize'
+      | 'panelStyle'
+      | 'panelProps'
+      | 'popoverScreenReaderText'
+      | 'repositionOnScroll'
+      | 'zIndex'
+    >;
+  };
 }
 
 const parseQuery = (
@@ -99,11 +121,14 @@ interface State {
   query: Query;
   queryText: string;
   error: null | Error;
+  isHintVisible: boolean;
 }
 
 // `state.query` is never null, but can be passed as `null` to `notifyControllingParent`
 // when `error` is not null.
-type StateWithOptionalQuery = Omit<State, 'query'> & { query: Query | null };
+type StateWithOptionalQuery = Omit<State, 'query' | 'isHintVisible'> & {
+  query: Query | null;
+};
 
 export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
   static Query = Query;
@@ -115,6 +140,7 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
       query,
       queryText: query.text,
       error: null,
+      isHintVisible: false,
     };
   }
 
@@ -135,6 +161,7 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
         query,
         queryText: query.text,
         error: null,
+        isHintVisible: prevState.isHintVisible,
       };
     }
     return null;
@@ -204,12 +231,13 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
   }
 
   render() {
-    const { query, queryText, error } = this.state;
+    const { query, queryText, error, isHintVisible } = this.state;
     const {
       box: { schema, ...box } = { schema: '' }, // strip `schema` out to prevent passing it to EuiSearchBox
       filters,
       toolsLeft,
       toolsRight,
+      hint,
     } = this.props;
 
     const toolsLeftEl = this.renderTools(toolsLeft);
@@ -236,6 +264,17 @@ export class EuiSearchBar extends Component<EuiSearchBarProps, State> {
             onSearch={this.onSearch}
             isInvalid={error != null}
             title={error ? error.message : undefined}
+            hint={
+              hint
+                ? {
+                    isVisible: isHintVisible,
+                    setIsVisible: (isVisible: boolean) => {
+                      this.setState({ isHintVisible: isVisible });
+                    },
+                    ...hint,
+                  }
+                : undefined
+            }
           />
         </EuiFlexItem>
         {filtersBar}

--- a/src/components/search_bar/search_box.tsx
+++ b/src/components/search_bar/search_box.tsx
@@ -22,6 +22,7 @@ export interface EuiSearchBoxProps extends EuiFieldSearchProps {
   // This is optional in EuiFieldSearchProps
   onSearch: (queryText: string) => void;
   hint?: {
+    id: string;
     isVisible: boolean;
     setIsVisible: (isVisible: boolean) => void;
   } & EuiSearchBarProps['hint'];
@@ -84,6 +85,8 @@ export class EuiSearchBox extends Component<EuiSearchBoxProps> {
             'aria-live': undefined,
             'aria-modal': false,
             role: undefined,
+            tabIndex: -1,
+            id: hint.id,
           }}
           {...hint.popoverProps}
         >

--- a/src/components/search_bar/search_box.tsx
+++ b/src/components/search_bar/search_box.tsx
@@ -85,7 +85,7 @@ export class EuiSearchBox extends Component<EuiSearchBoxProps> {
             'aria-modal': false,
             role: undefined,
           }}
-          {...hint.popOverProps}
+          {...hint.popoverProps}
         >
           {hint.content}
         </EuiInputPopover>

--- a/src/components/search_bar/search_box.tsx
+++ b/src/components/search_bar/search_box.tsx
@@ -83,7 +83,7 @@ export class EuiSearchBox extends Component<EuiSearchBoxProps> {
           }}
           panelProps={{
             'aria-live': undefined,
-            'aria-modal': false,
+            'aria-modal': undefined,
             role: undefined,
             tabIndex: -1,
             id: hint.id,

--- a/src/components/search_bar/search_box.tsx
+++ b/src/components/search_bar/search_box.tsx
@@ -8,6 +8,8 @@
 
 import React, { Component } from 'react';
 import { EuiFieldSearch, EuiFieldSearchProps } from '../form';
+import { EuiInputPopover } from '../popover';
+import { EuiSearchBarProps } from './search_bar';
 
 export interface SchemaType {
   strict?: boolean;
@@ -19,6 +21,10 @@ export interface EuiSearchBoxProps extends EuiFieldSearchProps {
   query: string;
   // This is optional in EuiFieldSearchProps
   onSearch: (queryText: string) => void;
+  hint?: {
+    isVisible: boolean;
+    setIsVisible: (isVisible: boolean) => void;
+  } & EuiSearchBarProps['hint'];
 }
 
 type DefaultProps = Pick<EuiSearchBoxProps, 'placeholder' | 'incremental'>;
@@ -39,7 +45,7 @@ export class EuiSearchBox extends Component<EuiSearchBoxProps> {
   }
 
   render() {
-    const { query, incremental, ...rest } = this.props;
+    const { query, incremental, hint, ...rest } = this.props;
 
     let ariaLabel;
     if (incremental) {
@@ -50,15 +56,42 @@ export class EuiSearchBox extends Component<EuiSearchBoxProps> {
         'This is a search bar. After typing your query, hit enter to filter the results lower in the page.';
     }
 
-    return (
+    const search = (
       <EuiFieldSearch
         inputRef={(input) => (this.inputElement = input)}
         fullWidth
         defaultValue={query}
         incremental={incremental}
         aria-label={ariaLabel}
+        onFocus={() => {
+          hint?.setIsVisible(true);
+        }}
         {...rest}
       />
     );
+
+    if (hint) {
+      return (
+        <EuiInputPopover
+          disableFocusTrap
+          input={search}
+          isOpen={hint.isVisible}
+          fullWidth
+          closePopover={() => {
+            hint.setIsVisible(false);
+          }}
+          panelProps={{
+            'aria-live': undefined,
+            'aria-modal': false,
+            role: undefined,
+          }}
+          {...hint.popOverProps}
+        >
+          {hint.content}
+        </EuiInputPopover>
+      );
+    }
+
+    return search;
   }
 }

--- a/upcoming_changelogs/6319.md
+++ b/upcoming_changelogs/6319.md
@@ -1,0 +1,1 @@
+- Added the `hint` prop to the `<EuiSearchBar />`. This prop lets the consumer render a hint below the search bar that will be displayed on focus.


### PR DESCRIPTION
In this PR I've added an option to the `<EuiSearchBar />` component to render a hint below. By default it displays underneath the bar on focus but its visibility can also be controlled using the `isOpen` prop of the `<EuiInputPopover />` component.

<img width="1243" alt="Screenshot 2022-10-20 at 09 22 16" src="https://user-images.githubusercontent.com/2854616/196882911-884d391e-55b7-4edf-b671-cd5161b31979.png">

<img width="1268" alt="Screenshot 2022-10-20 at 09 22 32" src="https://user-images.githubusercontent.com/2854616/196882921-64690803-23b6-4e05-ad5d-0e0aae27555f.png">


Fixes https://github.com/elastic/eui/issues/6005