### PR TITLE
[EuiButton] Remove pointer-events:none on disabled buttons

### DIFF
--- a/src/components/button/button_display/_button_display.styles.ts
+++ b/src/components/button/button_display/_button_display.styles.ts
@@ -54,7 +54,6 @@ export const euiButtonDisplayStyles = (euiThemeContext: UseEuiTheme) => {
 
     // States
     isDisabled: css`
-      pointer-events: none;
       cursor: not-allowed;
     `,
     fullWidth: css`

--- a/upcoming_changelogs/6323.md
+++ b/upcoming_changelogs/6323.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiButton`'s cursor style when the button is disabled  


### PR DESCRIPTION
## Summary

We added `pointer-events: none` to disabled buttons as part of their conversion to Emotion. The internet is full of opinions (e.g. a [material-ui issue](https://github.com/mui/material-ui/issues/14455) and a [ux stack exchange](https://ux.stackexchange.com/questions/77163/should-disabled-elements-ever-have-pointer-events)) on this, but we've found it created some jest and functional test errors in Kibana, and it also prevents the `cursor: not-allowed` style from taking effect. This unsets the pointer-events property.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately