### PR TITLE
Fix EuiSideBar with `css` props not being detected by EuiPageTemplate

### DIFF
--- a/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -49,6 +49,76 @@ exports[`EuiPageTemplate bottomBorder is rendered as true 1`] = `
 </div>
 `;
 
+exports[`EuiPageTemplate children detects sidebars and does not place them in the main EuiPageInner 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow"
+  data-test-subj="test subject string"
+  style="min-block-size:max(460px, 100vh)"
+>
+  <div
+    class="emotion-euiPageSidebar-l"
+    style="min-inline-size:248px"
+  />
+  <div
+    class="emotion-euiPageSidebar-l-component"
+    style="min-inline-size:248px"
+  />
+  <main
+    class="emotion-euiPageInner-panelled-left"
+    id="EuiPageTemplateInner_generated-id"
+  />
+</div>
+`;
+
+exports[`EuiPageTemplate children renders all other types within the main EuiPageInner 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow"
+  data-test-subj="test subject string"
+  style="min-block-size:max(460px, 100vh)"
+>
+  <main
+    class="emotion-euiPageInner"
+    id="EuiPageTemplateInner_generated-id"
+  >
+    <header
+      class="euiPageHeader emotion-euiPageHeader-l-border"
+    >
+      <div
+        class="emotion-euiPageHeaderContent-l"
+      >
+        <div
+          class="css-ljpjbj-flex-center"
+        >
+          A
+        </div>
+      </div>
+    </header>
+    <section
+      class="emotion-euiPageSection-grow-l-top-plain"
+    >
+      <div
+        class="emotion-euiPageSection__content-l-restrictWidth"
+        style="max-width:1200px"
+      >
+        B
+      </div>
+    </section>
+    <section
+      class="emotion-euiPageSection-grow-l-top-plain"
+    >
+      <div
+        class="emotion-euiPageSection__content-l-restrictWidth"
+        style="max-width:1200px"
+      >
+        C
+      </div>
+    </section>
+  </main>
+</div>
+`;
+
 exports[`EuiPageTemplate is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -105,15 +105,8 @@ exports[`EuiPageTemplate children renders all other types within the main EuiPag
         B
       </div>
     </section>
-    <section
-      class="emotion-euiPageSection-grow-l-top-plain"
-    >
-      <div
-        class="emotion-euiPageSection__content-l-restrictWidth"
-        style="max-width:1200px"
-      >
-        C
-      </div>
+    <section>
+      C
     </section>
   </main>
 </div>

--- a/src/components/page_template/page_template.test.tsx
+++ b/src/components/page_template/page_template.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
@@ -97,6 +98,35 @@ describe('EuiPageTemplate', () => {
 
         expect(component).toMatchSnapshot();
       });
+    });
+  });
+
+  describe('children', () => {
+    it('detects sidebars and does not place them in the main EuiPageInner', () => {
+      const component = render(
+        <EuiPageTemplate {...requiredProps}>
+          <EuiPageTemplate.Sidebar />
+          <EuiPageTemplate.Sidebar
+            css={css`
+              color: red;
+            `}
+          />
+        </EuiPageTemplate>
+      );
+      expect(component).toMatchSnapshot();
+      expect(component.find('main').children()).toHaveLength(0);
+    });
+
+    it('renders all other types within the main EuiPageInner', () => {
+      const component = render(
+        <EuiPageTemplate {...requiredProps}>
+          <EuiPageTemplate.Header>A</EuiPageTemplate.Header>
+          <EuiPageTemplate.Section>B</EuiPageTemplate.Section>
+          <EuiPageTemplate.Section>C</EuiPageTemplate.Section>
+        </EuiPageTemplate>
+      );
+      expect(component).toMatchSnapshot();
+      expect(component.find('main').children()).toHaveLength(3);
     });
   });
 });

--- a/src/components/page_template/page_template.test.tsx
+++ b/src/components/page_template/page_template.test.tsx
@@ -122,7 +122,7 @@ describe('EuiPageTemplate', () => {
         <EuiPageTemplate {...requiredProps}>
           <EuiPageTemplate.Header>A</EuiPageTemplate.Header>
           <EuiPageTemplate.Section>B</EuiPageTemplate.Section>
-          <EuiPageTemplate.Section>C</EuiPageTemplate.Section>
+          <section>C</section>
         </EuiPageTemplate>
       );
       expect(component).toMatchSnapshot();

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -159,20 +159,20 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   React.Children.toArray(children).forEach((child, index) => {
     if (!React.isValidElement(child)) return; // Skip non-components
 
-    switch (child.type) {
-      case EuiPageSidebar:
-        sidebar.push(
-          React.cloneElement(child, {
-            key: `sidebar${index}`,
-            ...getSideBarProps(),
-            // Allow their props overridden by appending the child props spread at the end
-            ...child.props,
-          })
-        );
-        break;
-
-      default:
-        sections.push(child);
+    if (
+      child.type === EuiPageSidebar ||
+      child.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__ === EuiPageSidebar
+    ) {
+      sidebar.push(
+        React.cloneElement(child, {
+          key: `sidebar${index}`,
+          ...getSideBarProps(),
+          // Allow their props overridden by appending the child props spread at the end
+          ...child.props,
+        })
+      );
+    } else {
+      sections.push(child);
     }
   });
 

--- a/upcoming_changelogs/6324.md
+++ b/upcoming_changelogs/6324.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiPageTemplate` not recognizing child `EuiPageSidebar`s/`EuiPageTemplate.Sidebar`s with `css` props


### PR DESCRIPTION
## Summary

See https://github.com/elastic/kibana/issues/143114#issuecomment-1286856764 for more context. This PR will likely need to be backported to the latest Kibana upgrade to resolve the linked issue.

When the `css` prop is set on a component, Emotion wraps it, changing `.type` EuiPageTemplate is using to detect sidebars. By expanding the conditions for checking for EuiPageSidebar, we can work around this behavior to fix the bug.

## QA

### General checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately