### PR TITLE
[EuiBetaBadge] fix beta badge placement when no tooltip content is specified

### DIFF
--- a/src-docs/src/views/card/card_beta.tsx
+++ b/src-docs/src/views/card/card_beta.tsx
@@ -17,8 +17,8 @@ export default () => (
         onClick={() => {}}
         betaBadgeProps={{
           label: 'Beta',
-          // tooltipContent:
-          //   'This module is not GA. Please help us by reporting any bugs.',
+          tooltipContent:
+            'This module is not GA. Please help us by reporting any bugs.',
         }}
       />
     </EuiFlexItem>
@@ -30,8 +30,8 @@ export default () => (
         betaBadgeProps={{
           label: 'Accent',
           color: 'accent',
-          // tooltipContent:
-          //   'You can change the badge color using betaBadgeProps.color.',
+          tooltipContent:
+            'You can change the badge color using betaBadgeProps.color.',
         }}
         onClick={() => {}}
       />
@@ -46,8 +46,8 @@ export default () => (
           href: 'http://www.elastic.co/subscriptions',
           target: '_blank',
           label: 'Basic',
-          // tooltipContent:
-          //   'Disabled cards with still clickable badges will stay hollow.',
+          tooltipContent:
+            'Disabled cards with still clickable badges will stay hollow.',
         }}
         onClick={() => {}}
       />

--- a/src-docs/src/views/card/card_beta.tsx
+++ b/src-docs/src/views/card/card_beta.tsx
@@ -17,8 +17,8 @@ export default () => (
         onClick={() => {}}
         betaBadgeProps={{
           label: 'Beta',
-          tooltipContent:
-            'This module is not GA. Please help us by reporting any bugs.',
+          // tooltipContent:
+          //   'This module is not GA. Please help us by reporting any bugs.',
         }}
       />
     </EuiFlexItem>
@@ -30,8 +30,8 @@ export default () => (
         betaBadgeProps={{
           label: 'Accent',
           color: 'accent',
-          tooltipContent:
-            'You can change the badge color using betaBadgeProps.color.',
+          // tooltipContent:
+          //   'You can change the badge color using betaBadgeProps.color.',
         }}
         onClick={() => {}}
       />
@@ -46,8 +46,8 @@ export default () => (
           href: 'http://www.elastic.co/subscriptions',
           target: '_blank',
           label: 'Basic',
-          tooltipContent:
-            'Disabled cards with still clickable badges will stay hollow.',
+          // tooltipContent:
+          //   'Disabled cards with still clickable badges will stay hollow.',
         }}
         onClick={() => {}}
       />

--- a/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
+++ b/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
@@ -1,81 +1,97 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiBetaBadge is rendered 1`] = `
-<span
-  aria-label="aria-label"
-  class="euiBetaBadge testClass1 testClass2 emotion-euiBetaBadge-hollow-m"
-  data-test-subj="test subject string"
-  title="Beta"
->
-  Beta
+<span>
+  <span
+    aria-label="aria-label"
+    class="euiBetaBadge testClass1 testClass2 emotion-euiBetaBadge-hollow-m"
+    data-test-subj="test subject string"
+    title="Beta"
+  >
+    Beta
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props color accent is rendered 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-accent-m"
-  title="Beta"
->
-  Beta
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-accent-m"
+    title="Beta"
+  >
+    Beta
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props color hollow is rendered 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
-  title="Beta"
->
-  Beta
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
+    title="Beta"
+  >
+    Beta
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props color subdued is rendered 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-subdued-m"
-  title="Beta"
->
-  Beta
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-subdued-m"
+    title="Beta"
+  >
+    Beta
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props iconType 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
-  title="Beta"
->
+<span>
   <span
-    aria-hidden="true"
-    class="euiBetaBadge__icon emotion-euiBetaBadge__icon"
-    color="inherit"
-    data-euiicon-type="beta"
-  />
+    class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
+    title="Beta"
+  >
+    <span
+      aria-hidden="true"
+      class="euiBetaBadge__icon emotion-euiBetaBadge__icon"
+      color="inherit"
+      data-euiicon-type="beta"
+    />
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props single letter 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
-  title="B"
->
-  B
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
+    title="B"
+  >
+    B
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props size m is rendered 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
-  title="Beta"
->
-  Beta
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-hollow-m"
+    title="Beta"
+  >
+    Beta
+  </span>
 </span>
 `;
 
 exports[`EuiBetaBadge props size s is rendered 1`] = `
-<span
-  class="euiBetaBadge emotion-euiBetaBadge-hollow-s"
-  title="Beta"
->
-  Beta
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-hollow-s"
+    title="Beta"
+  >
+    Beta
+  </span>
 </span>
 `;
 

--- a/src/components/badge/beta_badge/beta_badge.tsx
+++ b/src/components/badge/beta_badge/beta_badge.tsx
@@ -8,7 +8,6 @@
 
 import React, {
   AriaAttributes,
-  Fragment,
   FunctionComponent,
   HTMLAttributes,
   MouseEventHandler,
@@ -215,7 +214,7 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
         </EuiToolTip>
       );
     } else {
-      return <Fragment>{content}</Fragment>;
+      return <span {...anchorProps}>{content}</span>;
     }
   } else {
     if (tooltipContent) {
@@ -245,13 +244,15 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
         );
       }
       return (
-        <span
-          css={cssStyles}
-          className={classes}
-          title={spanTitle as string}
-          {...rest}
-        >
-          {icon || label}
+        <span {...anchorProps}>
+          <span
+            className={classes}
+            title={spanTitle as string}
+            css={cssStyles}
+            {...rest}
+          >
+            {icon || label}
+          </span>
         </span>
       );
     }

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -26,15 +26,19 @@ exports[`EuiCard betaBadgeProps renders href 1`] = `
       </p>
     </div>
   </div>
-  <a
-    class="euiBetaBadge emotion-euiBetaBadge-hollow-m-euiCard__betaBadge"
-    href="http://www.elastic.co/"
-    id="generated-idBetaBadge"
-    rel=""
-    title="Link"
+  <span
+    class="emotion-euiCard__betaBadgeAnchor"
   >
-    Link
-  </a>
+    <a
+      class="euiBetaBadge emotion-euiBetaBadge-hollow-m-euiCard__betaBadge"
+      href="http://www.elastic.co/"
+      id="generated-idBetaBadge"
+      rel=""
+      title="Link"
+    >
+      Link
+    </a>
+  </span>
 </div>
 `;
 

--- a/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
+++ b/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
@@ -104,12 +104,14 @@ exports[`EuiKeyPadMenuItem props betaBadge renders 1`] = `
     <span
       class="euiKeyPadMenuItem__inner"
     >
-      <span
-        aria-hidden="true"
-        class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
-        title="B"
-      >
-        B
+      <span>
+        <span
+          aria-hidden="true"
+          class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
+          title="B"
+        >
+          B
+        </span>
       </span>
       <span
         class="euiKeyPadMenuItem__icon"
@@ -137,12 +139,14 @@ exports[`EuiKeyPadMenuItem props betaBadge renders extra betaBadgeTooltipProps 1
     <span
       class="euiKeyPadMenuItem__inner"
     >
-      <span
-        aria-hidden="true"
-        class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
-        title="B"
-      >
-        B
+      <span>
+        <span
+          aria-hidden="true"
+          class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
+          title="B"
+        >
+          B
+        </span>
       </span>
       <span
         class="euiKeyPadMenuItem__icon"
@@ -170,17 +174,19 @@ exports[`EuiKeyPadMenuItem props betaBadge renders with betaBadgeIconType 1`] = 
     <span
       class="euiKeyPadMenuItem__inner"
     >
-      <span
-        aria-hidden="true"
-        class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
-        title="B"
-      >
+      <span>
         <span
           aria-hidden="true"
-          class="euiBetaBadge__icon emotion-euiBetaBadge__icon"
-          color="inherit"
-          data-euiicon-type="bolt"
-        />
+          class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
+          title="B"
+        >
+          <span
+            aria-hidden="true"
+            class="euiBetaBadge__icon emotion-euiBetaBadge__icon"
+            color="inherit"
+            data-euiicon-type="bolt"
+          />
+        </span>
       </span>
       <span
         class="euiKeyPadMenuItem__icon"
@@ -208,12 +214,14 @@ exports[`EuiKeyPadMenuItem props betaBadge renders with betaBadgeTooltipContent 
     <span
       class="euiKeyPadMenuItem__inner"
     >
-      <span
-        aria-hidden="true"
-        class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
-        title="B"
-      >
-        B
+      <span>
+        <span
+          aria-hidden="true"
+          class="euiBetaBadge euiKeyPadMenuItem__betaBadge emotion-euiBetaBadge-subdued-s"
+          title="B"
+        >
+          B
+        </span>
       </span>
       <span
         class="euiKeyPadMenuItem__icon"

--- a/upcoming_changelogs/6326.md
+++ b/upcoming_changelogs/6326.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiBetaBadge` to always respect its `anchorProps` values, including when there is no tooltip content


### PR DESCRIPTION
## Summary

Fixes #6325

The `anchorProps` value with the positioning css, built by **EuiCard**, was not being used when tooltip content wasn't specified. I've added a wrapping span to the two non-tooltip cases and spread these anchor props onto it.

For testing, I've modified the card + beta badge example, removing their tooltip contents.

### Before

<img width="976" alt="Screen Shot 2022-10-26 at 9 40 08 AM" src="https://user-images.githubusercontent.com/313125/198071894-b113fbdb-5603-43a8-9899-82bc223dc2b1.png">

### After

<img width="971" alt="Screen Shot 2022-10-26 at 9 40 47 AM" src="https://user-images.githubusercontent.com/313125/198072399-188a4c5c-9541-4347-aee7-ae3434d6124a.png">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

~- [ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [x] reverted "REVERT ME" commit
