### PR TITLE
[EuiModal] Temporary workaround for scroll-jumping behavior

### DIFF
--- a/src/components/modal/__snapshots__/modal.test.tsx.snap
+++ b/src/components/modal/__snapshots__/modal.test.tsx.snap
@@ -1,51 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders EuiModal 1`] = `
-Array [
+exports[`EuiModal renders 1`] = `
+<body>
   <div
     aria-hidden="true"
     data-aria-hidden="true"
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />,
+  />
   <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="1"
-  />,
-  <div
-    data-focus-lock-disabled="false"
+    class="euiOverlayMask emotion-euiOverlayMask-aboveHeader"
+    data-euiportal="true"
+    data-relative-to-header="above"
   >
     <div
-      aria-label="aria-label"
-      class="euiModal euiModal--maxWidth-default testClass1 testClass2"
-      data-test-subj="test subject string"
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
       tabindex="0"
+    />
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="1"
+    />
+    <div
+      data-focus-lock-disabled="false"
     >
-      <button
-        aria-label="Closes this modal window"
-        class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon emotion-euiButtonIcon-empty-text-hoverStyles"
-        type="button"
+      <div
+        aria-label="aria-label"
+        class="euiModal euiModal--maxWidth-default testClass1 testClass2"
+        data-test-subj="test subject string"
+        tabindex="0"
       >
-        <span
-          aria-hidden="true"
-          class="euiButtonIcon__icon"
-          color="inherit"
-          data-euiicon-type="cross"
-        />
-      </button>
-      children
+        <button
+          aria-label="Closes this modal window"
+          class="euiButtonIcon euiButtonIcon--xSmall euiModal__closeIcon emotion-euiButtonIcon-empty-text-hoverStyles"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
+        children
+      </div>
     </div>
-  </div>,
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />,
-]
+    <div
+      aria-hidden="true"
+      data-aria-hidden="true"
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
 `;

--- a/src/components/modal/modal.test.tsx
+++ b/src/components/modal/modal.test.tsx
@@ -7,19 +7,44 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
-import { requiredProps, takeMountedSnapshot } from '../../test';
+import { fireEvent } from '@testing-library/dom';
+import { render } from '../../test/rtl';
+import { requiredProps } from '../../test';
 
 import { EuiModal } from './modal';
 
-test('renders EuiModal', () => {
-  const component = (
-    <EuiModal onClose={() => {}} {...requiredProps}>
-      children
-    </EuiModal>
-  );
+describe('EuiModal', () => {
+  it('renders', () => {
+    const { baseElement } = render(
+      <EuiModal onClose={() => {}} {...requiredProps}>
+        children
+      </EuiModal>
+    );
 
-  expect(
-    takeMountedSnapshot(mount(component), { hasArrayOutput: true })
-  ).toMatchSnapshot();
+    // NOTE: Using baseElement instead of container is required for components that use portals
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  // TODO: Remove this onFocus scroll workaround after react-focus-on supports focusOptions
+  // @see https://github.com/elastic/eui/issues/6304
+  describe('focus/scroll workaround', () => {
+    it('scrolls back to the original window position on initial modal focus', () => {
+      window.scrollTo = jest.fn();
+
+      const { getByTestSubject } = render(
+        <EuiModal data-test-subj="modal" onClose={() => {}}>
+          children
+        </EuiModal>
+      );
+
+      // For whatever reason, react-focus-lock doesn't appear to trigger focus in RTL so we'll do it manually
+      fireEvent.focusIn(getByTestSubject('modal'));
+      // Confirm that scrolling does not occur more than once
+      fireEvent.focusIn(getByTestSubject('modal'));
+      fireEvent.focusIn(getByTestSubject('modal'));
+
+      expect(window.scrollTo).toHaveBeenCalledTimes(1);
+      jest.restoreAllMocks();
+    });
+  });
 });

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -6,7 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, ReactNode, HTMLAttributes } from 'react';
+import React, {
+  FunctionComponent,
+  ReactNode,
+  HTMLAttributes,
+  useRef,
+  useCallback,
+} from 'react';
 import classnames from 'classnames';
 
 import { keys } from '../../services';
@@ -52,6 +58,18 @@ export const EuiModal: FunctionComponent<EuiModalProps> = ({
   style,
   ...rest
 }) => {
+  // TODO: Remove this onFocus scroll workaround after react-focus-on supports focusOptions
+  // @see https://github.com/elastic/eui/issues/6304
+  const bodyScrollTop = useRef<undefined | number>(
+    typeof window === 'undefined' ? undefined : window.scrollY // Account for SSR
+  );
+  const onFocus = useCallback(() => {
+    if (bodyScrollTop.current != null) {
+      window.scrollTo({ top: bodyScrollTop.current });
+      bodyScrollTop.current = undefined; // Unset after first auto focus
+    }
+  }, []);
+
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === keys.ESCAPE) {
       event.preventDefault();
@@ -82,6 +100,7 @@ export const EuiModal: FunctionComponent<EuiModalProps> = ({
           className={classes}
           onKeyDown={onKeyDown}
           tabIndex={0}
+          onFocus={onFocus}
           style={newStyle || style}
           {...rest}
         >

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -91,7 +91,7 @@ export const EuiModal: FunctionComponent<EuiModalProps> = ({
 
   return (
     <EuiOverlayMask>
-      <EuiFocusTrap initialFocus={initialFocus}>
+      <EuiFocusTrap initialFocus={initialFocus} scrollLock>
         {
           // Create a child div instead of applying these props directly to FocusTrap, or else
           // fallbackFocus won't work.

--- a/upcoming_changelogs/6327.md
+++ b/upcoming_changelogs/6327.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Temporarily patched `EuiModal` to not cause scroll-jumping issues on modal open


### PR DESCRIPTION
## Summary

This temporarily addresses https://github.com/elastic/eui/issues/6304 but is not the intended long-term solution. Ideally once https://github.com/theKashey/react-focus-on/pull/63 is merged and released, we would upgrade `react-focus-on` and switch to using `focusOptions={{ preventScroll: true }}` instead.

I recommend following along by commit, the first commit has the primary workaround (intended to be easily removable/deletable in the future).

## QA

- [x] Go to https://eui.elastic.co/pr_6327/#/layout/modal and confirm that clicking any modal does not cause jumping. Ensure you scroll down to lower examples to make sure those scroll positions are preserved as well

### General checklist

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately