### PR TITLE
[EuiPopover] Add `hasDragDrop` prop for popovers with draggable contexts

### DIFF
--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
   aria-describedby="generated-id"
   aria-live="off"
   aria-modal="true"
-  class="euiPanel euiPanel--plain euiPanel--paddingSmall euiPopover__panel euiDataGrid__controlPopoverWithDragDrop emotion-euiPanel-grow-m-s-plain-euiPopover__panel"
+  class="euiPanel euiPanel--plain euiPanel--paddingSmall euiPopover__panel emotion-euiPanel-grow-m-s-plain-euiPopover__panel-hasDragDrop-bottom"
   data-autofocus="true"
   data-popover-panel="true"
   role="dialog"

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
   tabindex="0"
 >
   <div
-    class="emotion-euiPopoverArrow-bottom"
+    class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
     data-popover-arrow="bottom"
     style="left: 10px; top: 0px;"
   />

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
   aria-describedby="generated-id"
   aria-live="off"
   aria-modal="true"
-  class="euiPanel euiPanel--plain euiPanel--paddingSmall euiPopover__panel euiDataGrid__controlPopoverWithDragDrop emotion-euiPanel-grow-m-s-plain-euiPopover__panel"
+  class="euiPanel euiPanel--plain euiPanel--paddingSmall euiPopover__panel emotion-euiPanel-grow-m-s-plain-euiPopover__panel-hasDragDrop-bottom"
   data-autofocus="true"
   data-popover-panel="true"
   role="dialog"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
   tabindex="0"
 >
   <div
-    class="emotion-euiPopoverArrow-bottom"
+    class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
     data-popover-arrow="bottom"
     style="left: 10px; top: 0px;"
   />

--- a/src/components/datagrid/controls/_data_grid_toolbar.scss
+++ b/src/components/datagrid/controls/_data_grid_toolbar.scss
@@ -52,14 +52,6 @@
   }
 }
 
-.euiDataGrid__controlPopoverWithDragDrop {
-  // Hack because the fixed positions of drag and drop don't work inside of transformed elements
-  // sass-lint:disable-block no-important
-  transform: none !important;
-  transition: none !important;
-  margin-top: -$euiSizeS;
-}
-
 .euiDataGrid__controlScroll {
   @include euiYScrollWithShadows;
   max-height: $euiDataGridPopoverMaxHeight;

--- a/src/components/datagrid/controls/column_selector.tsx
+++ b/src/components/datagrid/controls/column_selector.tsx
@@ -147,7 +147,7 @@ export const useDataGridColumnSelector = (
         closePopover={() => setIsOpen(false)}
         anchorPosition="downLeft"
         panelPaddingSize="s"
-        panelClassName="euiDataGrid__controlPopoverWithDragDrop"
+        hasDragDrop
         button={
           <EuiButtonEmpty
             size="xs"

--- a/src/components/datagrid/controls/column_sorting.tsx
+++ b/src/components/datagrid/controls/column_sorting.tsx
@@ -141,7 +141,7 @@ export const useDataGridColumnSorting = (
       closePopover={() => setIsOpen(false)}
       anchorPosition="downLeft"
       panelPaddingSize="s"
-      panelClassName="euiDataGrid__controlPopoverWithDragDrop"
+      hasDragDrop
       button={
         <EuiButtonEmpty
           size="xs"

--- a/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`EuiPopover snapshot testing renders with popover contents 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         >
@@ -177,7 +177,7 @@ exports[`EuiPopover props buffer 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -236,7 +236,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -308,7 +308,7 @@ exports[`EuiPopover props focusTrapProps is rendered 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -380,7 +380,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -439,7 +439,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -552,7 +552,7 @@ exports[`EuiPopover props ownFocus defaults to true 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -608,7 +608,7 @@ exports[`EuiPopover props ownFocus renders false 1`] = `
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -661,7 +661,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -720,7 +720,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -780,7 +780,7 @@ exports[`EuiPopover props panelProps is rendered 1`] = `
         tabindex="0"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />
@@ -837,7 +837,7 @@ exports[`EuiPopover props popoverScreenReaderText 1`] = `
         style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
-          class="emotion-euiPopoverArrow-bottom"
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
           data-popover-arrow="bottom"
           style="left: 10px; top: 0px;"
         />

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -168,6 +168,11 @@ export interface EuiPopoverProps extends CommonProps {
    */
   repositionOnScroll?: boolean;
   /**
+   * Must be set to true if using `EuiDragDropContext` within a popover,
+   * otherwise your nested drag & drop will have incorrect positioning
+   */
+  hasDragDrop?: boolean;
+  /**
    * By default, popover content inherits the z-index of the anchor
    * component; pass `zIndex` to override
    */
@@ -613,6 +618,7 @@ export class EuiPopover extends Component<Props, State> {
       hasArrow,
       arrowChildren,
       repositionOnScroll,
+      hasDragDrop,
       zIndex,
       attachToAnchor,
       display,
@@ -708,6 +714,7 @@ export class EuiPopover extends Component<Props, State> {
               position={this.state.arrowPosition}
               isAttached={attachToAnchor}
               className={classNames(panelClassName, panelProps?.className)}
+              hasDragDrop={hasDragDrop}
               hasShadow={false}
               paddingSize={panelPaddingSize}
               tabIndex={tabIndex}

--- a/src/components/popover/popover_arrow/_popover_arrow.tsx
+++ b/src/components/popover/popover_arrow/_popover_arrow.tsx
@@ -29,7 +29,12 @@ export const EuiPopoverArrow: FunctionComponent<EuiPopoverArrowProps> = ({
   const cssStyles = [styles.euiPopoverArrow, styles[position]];
 
   return (
-    <div data-popover-arrow={position} css={cssStyles} {...rest}>
+    <div
+      className="euiPopover__arrow"
+      data-popover-arrow={position}
+      css={cssStyles}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/components/popover/popover_panel/__snapshots__/_popover_panel.test.tsx.snap
+++ b/src/components/popover/popover_panel/__snapshots__/_popover_panel.test.tsx.snap
@@ -9,6 +9,13 @@ exports[`EuiPopoverPanel is rendered 1`] = `
 />
 `;
 
+exports[`EuiPopoverPanel props hasDragDrop is rendered 1`] = `
+<div
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-hasShadow-euiPopover__panel-hasDragDrop"
+  data-popover-panel="true"
+/>
+`;
+
 exports[`EuiPopoverPanel props isAttached is rendered 1`] = `
 <div
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-hasShadow-euiPopover__panel-isOpen"

--- a/src/components/popover/popover_panel/_popover_panel.styles.ts
+++ b/src/components/popover/popover_panel/_popover_panel.styles.ts
@@ -91,5 +91,30 @@ export const euiPopoverPanelStyles = (euiThemeContext: UseEuiTheme) => {
       left: css``,
       right: css``,
     },
+
+    // Overrides for drag & drop contexts within popovers. This is required because
+    // the fixed positions of drag and drop don't work inside of transformed elements
+    hasDragDrop: {
+      hasDragDrop: css`
+        transform: none;
+        // Filter also causes a stacking context that interferes with the positioned children,
+        // so we disable it and recreate the shadow via box-shadow instead
+        filter: none;
+        ${euiShadowMedium(euiThemeContext, { property: 'box-shadow' })};
+      `,
+      // The offset transforms must be recreated in margins
+      top: css`
+        margin-block-start: ${euiTheme.size[translateDistance]};
+      `,
+      bottom: css`
+        margin-block-start: -${euiTheme.size[translateDistance]};
+      `,
+      left: css`
+        margin-inline-start: ${euiTheme.size[translateDistance]};
+      `,
+      right: css`
+        margin-inline-start: -${euiTheme.size[translateDistance]};
+      `,
+    },
   };
 };

--- a/src/components/popover/popover_panel/_popover_panel.styles.ts
+++ b/src/components/popover/popover_panel/_popover_panel.styles.ts
@@ -12,6 +12,7 @@ import {
   euiShadowFlat,
   euiShadowMedium,
 } from '../../../themes/amsterdam/global_styling/mixins';
+import { getShadowColor } from '../../../themes/amsterdam/global_styling/functions';
 import { UseEuiTheme } from '../../../services';
 import { euiCanAnimate, logicalCSS } from '../../../global_styling';
 
@@ -25,7 +26,7 @@ const translateDistance = 's';
  */
 
 export const euiPopoverPanelStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
+  const { euiTheme, colorMode } = euiThemeContext;
 
   return {
     // Base
@@ -105,15 +106,34 @@ export const euiPopoverPanelStyles = (euiThemeContext: UseEuiTheme) => {
       // The offset transforms must be recreated in margins
       top: css`
         margin-block-start: ${euiTheme.size[translateDistance]};
+        // Existing box-shadow of the popover is sufficient to see the arrow
       `,
       bottom: css`
         margin-block-start: -${euiTheme.size[translateDistance]};
+
+        .euiPopover__arrow {
+          filter: drop-shadow(
+            0 -6px 6px ${getShadowColor(euiTheme.colors.shadow, 0.12, colorMode)}
+          );
+        }
       `,
       left: css`
         margin-inline-start: ${euiTheme.size[translateDistance]};
+
+        .euiPopover__arrow {
+          filter: drop-shadow(
+            6px 0 6px ${getShadowColor(euiTheme.colors.shadow, 0.12, colorMode)}
+          );
+        }
       `,
       right: css`
         margin-inline-start: -${euiTheme.size[translateDistance]};
+
+        .euiPopover__arrow {
+          filter: drop-shadow(
+            -6px 0 6px ${getShadowColor(euiTheme.colors.shadow, 0.12, colorMode)}
+          );
+        }
       `,
     },
   };

--- a/src/components/popover/popover_panel/_popover_panel.test.tsx
+++ b/src/components/popover/popover_panel/_popover_panel.test.tsx
@@ -36,6 +36,12 @@ describe('EuiPopoverPanel', () => {
       expect(component).toMatchSnapshot();
     });
 
+    test('hasDragDrop is rendered', () => {
+      const component = render(<EuiPopoverPanel hasDragDrop />);
+
+      expect(component).toMatchSnapshot();
+    });
+
     describe('position', () => {
       POSITIONS.forEach((position) => {
         test(`${position} is rendered`, () => {

--- a/src/components/popover/popover_panel/_popover_panel.tsx
+++ b/src/components/popover/popover_panel/_popover_panel.tsx
@@ -28,6 +28,7 @@ type EuiPopoverPanelInternalProps = {
   isOpen?: boolean;
   isAttached?: boolean;
   position?: EuiPopoverArrowPositions | null;
+  hasDragDrop?: boolean;
 };
 
 /**
@@ -36,7 +37,15 @@ type EuiPopoverPanelInternalProps = {
  */
 export const EuiPopoverPanel: FunctionComponent<
   EuiPopoverPanelProps & EuiPopoverPanelInternalProps
-> = ({ children, className, isOpen, isAttached, position, ...rest }) => {
+> = ({
+  children,
+  className,
+  isOpen,
+  isAttached,
+  hasDragDrop,
+  position,
+  ...rest
+}) => {
   const panelContext = useContext(EuiPopoverPanelContext);
   if (rest.paddingSize) panelContext.paddingSize = rest.paddingSize;
 
@@ -56,6 +65,14 @@ export const EuiPopoverPanel: FunctionComponent<
       ...panelCSS,
       isOpen && styles.attached.isOpen,
       position && styles.attached[position],
+    ];
+  }
+
+  if (hasDragDrop) {
+    panelCSS = [
+      ...panelCSS,
+      styles.hasDragDrop.hasDragDrop,
+      position && styles.hasDragDrop[position],
     ];
   }
 

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
       style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
-        class="emotion-euiPopoverArrow-left"
+        class="euiPopover__arrow emotion-euiPopoverArrow-left"
         data-popover-arrow="left"
         style="left: 0px; top: 10px;"
       >
@@ -155,7 +155,7 @@ exports[`EuiTourStep can have subtitle 1`] = `
       style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
-        class="emotion-euiPopoverArrow-left"
+        class="euiPopover__arrow emotion-euiPopoverArrow-left"
         data-popover-arrow="left"
         style="left: 0px; top: 10px;"
       >
@@ -263,7 +263,7 @@ exports[`EuiTourStep can override the footer action 1`] = `
       style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
-        class="emotion-euiPopoverArrow-left"
+        class="euiPopover__arrow emotion-euiPopoverArrow-left"
         data-popover-arrow="left"
         style="left: 0px; top: 10px;"
       >
@@ -355,7 +355,7 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
       style="top: -22px; left: -16px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
-        class="emotion-euiPopoverArrow-left"
+        class="euiPopover__arrow emotion-euiPopoverArrow-left"
         data-popover-arrow="left"
         style="left: 0px; top: 10px;"
       />
@@ -453,7 +453,7 @@ exports[`EuiTourStep is rendered 1`] = `
       style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
     >
       <div
-        class="emotion-euiPopoverArrow-left"
+        class="euiPopover__arrow emotion-euiPopoverArrow-left"
         data-popover-arrow="left"
         style="left: 0px; top: 10px;"
       >

--- a/upcoming_changelogs/6329.md
+++ b/upcoming_changelogs/6329.md
@@ -1,0 +1,5 @@
+- Added the `hasDragDrop` prop to `EuiPopover`. Use this prop if your popover contains `EuiDragDropContext`.
+
+**Bug fixes**
+
+- Fixed buggy drag & drop behavior within `EuiDataGrid`'s columns & sorting toolbar popovers


### PR DESCRIPTION
## Summary

I recommend following along by commit.

closes https://github.com/elastic/eui/issues/6314

Paraphrasing my comment from the above issue as to why this prop/fix is needed:

> you always need to set `transform: none !important;` on any popover panels that contain drag & drop. This is because drag & drop does not work inside transformed elements. There is an example of our own EuiDataGrid using this workaround here:
https://github.com/elastic/eui/blob/7412e4f74d2b56bc151889f6784c6e0d3ffab4af/src/components/datagrid/controls/_data_grid_toolbar.scss#L55-L61
> When `EuiPopover` was converted to Emotion, it started to use `filter` to create a drop shadow effect instead of `box-shadow`, causing our EuiDataGrid popover drag & drop to stop working. Unfortunately `filter` appears to create a [stacking context](https://www.joshwcomeau.com/css/stacking-contexts/) that causes drag & drop to misbehave 💀

I went with adding a `hasDragDrop` prop to EuiPopover to solve this issue. Almost all the workarounds/unsets are very specific to EuiPopover (we don't appear to use filter for any other components, and the reason why we use filter is to to get a drop shadow that encompasses the popover arrow) - EuiModal for example does not use either transforms or filter for its shadow. So I didn't think the workaround should be something exported by EuiDragDrop.

Footnote for tracking: Another issue where `filter` has caused shenanigans: https://github.com/elastic/eui/pull/6163

### Before
![before](https://user-images.githubusercontent.com/549407/198359452-1d22fcf9-c7ba-4d0b-95ce-c58f78c40a96.gif)

### After
![after](https://user-images.githubusercontent.com/549407/198359332-fd78e906-4bf4-4c99-88fb-580430222310.gif)

## QA

- [x] Go to https://eui.elastic.co/pr_6329/#/tabular-content/data-grid and confirm dragging and dropping in the columns and sort fields toolbar popovers works correctly

### General checklist

~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately