### PR TITLE
[Range sliders docs] Add non linear intervals example

### DIFF
--- a/src-docs/src/views/form_controls/display_toggles.tsx
+++ b/src-docs/src/views/form_controls/display_toggles.tsx
@@ -1,4 +1,10 @@
-import React, { cloneElement, useState, Fragment } from 'react';
+import React, {
+  cloneElement,
+  useState,
+  Fragment,
+  ReactElement,
+  FunctionComponent,
+} from 'react';
 
 import {
   EuiFlexGroup,
@@ -9,9 +15,39 @@ import {
   EuiButtonEmpty,
   EuiPopover,
   EuiSpacer,
+  EuiSpacerProps,
 } from '../../../../src/components';
 
-export const DisplayToggles = ({
+export type DisplayTogglesProps = {
+  canIsDisabled?: boolean;
+  canDisabled?: boolean;
+  canReadOnly?: boolean;
+  canLoading?: boolean;
+  canCompressed?: boolean;
+  canFullWidth?: boolean;
+  canInvalid?: boolean;
+  canPrepend?: boolean;
+  canAppend?: boolean;
+  canClear?: boolean;
+  children: ReactElement;
+  extras?: ReactElement[];
+  spacerSize?: EuiSpacerProps['size'];
+};
+
+export type canPropsType = {
+  disabled?: boolean;
+  isDisabled?: boolean;
+  readOnly?: boolean;
+  fullWidth?: boolean;
+  compressed?: boolean;
+  isLoading?: boolean;
+  prepend?: string;
+  append?: string;
+  isInvalid?: boolean;
+  isClearable?: boolean;
+};
+
+export const DisplayToggles: FunctionComponent<DisplayTogglesProps> = ({
   canIsDisabled = false,
   canDisabled = true,
   canReadOnly = true,
@@ -37,7 +73,7 @@ export const DisplayToggles = ({
   const [invalid, setInvalid] = useState(false);
   const [isClearable, setIsClearable] = useState(false);
 
-  const canProps = {};
+  const canProps: canPropsType = {};
   if (canDisabled) canProps.disabled = disabled;
   if (canIsDisabled) canProps.isDisabled = disabled;
   if (canReadOnly) canProps.readOnly = readOnly;

--- a/src-docs/src/views/range/dual_range.tsx
+++ b/src-docs/src/views/range/dual_range.tsx
@@ -1,17 +1,31 @@
 import React, { useState } from 'react';
 
-import { EuiDualRange, EuiSpacer, EuiTitle } from '../../../../src/components';
-
-import { useGeneratedHtmlId } from '../../../../src/services';
+import {
+  EuiDualRange,
+  EuiDualRangeProps,
+  EuiSpacer,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '../../../../src';
 
 export default () => {
-  const [value, setValue] = useState(['100', '150']);
-  const [value2, setValue2] = useState(['40', '60']);
+  const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
+    '100',
+    '150',
+  ]);
+  const [dualValue2, setDualValue2] = useState<EuiDualRangeProps['value']>([
+    '40',
+    '60',
+  ]);
 
   const basicRangeSliderId = useGeneratedHtmlId({ prefix: 'basicRangeSlider' });
   const draggableRangeSliderId = useGeneratedHtmlId({
     prefix: 'draggableRangeSlider',
   });
+
+  const onDualChange = (value: EuiDualRangeProps['value']) => {
+    setDualValue(value);
+  };
 
   return (
     <>
@@ -20,8 +34,8 @@ export default () => {
         min={0}
         max={300}
         step={10}
-        value={value}
-        onChange={setValue}
+        value={dualValue}
+        onChange={onDualChange}
         showLabels
         aria-label="An example of EuiDualRange"
       />
@@ -39,8 +53,8 @@ export default () => {
         min={0}
         max={100}
         step={1}
-        value={value2}
-        onChange={setValue2}
+        value={dualValue2}
+        onChange={setDualValue2}
         showLabels
         aria-label="An example of EuiDualRange with isDraggable='true'"
         isDraggable

--- a/src-docs/src/views/range/input.tsx
+++ b/src-docs/src/views/range/input.tsx
@@ -1,23 +1,30 @@
 import React, { useState, Fragment } from 'react';
 
-import { EuiRange, EuiSpacer, EuiDualRange } from '../../../../src/components';
-
-import { useGeneratedHtmlId } from '../../../../src/services';
+import {
+  EuiRange,
+  EuiSpacer,
+  EuiDualRange,
+  EuiDualRangeProps,
+  useGeneratedHtmlId,
+} from '../../../../src';
 
 export default () => {
   const [value, setValue] = useState('20');
-  const [dualValue, setDualValue] = useState([20, 100]);
+  const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
+    20,
+    100,
+  ]);
 
   const inputRangeSliderId = useGeneratedHtmlId({ prefix: 'inputRangeSlider' });
   const dualInputRangeSliderId = useGeneratedHtmlId({
     prefix: 'dualInputRangeSlider',
   });
 
-  const onChange = (e) => {
+  const onChange = (e: any) => {
     setValue(e.target.value);
   };
 
-  const onDualChange = (value) => {
+  const onDualChange = (value: EuiDualRangeProps['value']) => {
     setDualValue(value);
   };
 
@@ -27,6 +34,8 @@ export default () => {
         id={inputRangeSliderId}
         value={value}
         onChange={onChange}
+        min={0}
+        max={100}
         showInput
         aria-label="An example of EuiRange"
       />

--- a/src-docs/src/views/range/input.tsx
+++ b/src-docs/src/views/range/input.tsx
@@ -20,20 +20,12 @@ export default () => {
     prefix: 'dualInputRangeSlider',
   });
 
-  const onChange = (e: any) => {
-    setValue(e.target.value);
-  };
-
-  const onDualChange = (value: EuiDualRangeProps['value']) => {
-    setDualValue(value);
-  };
-
   return (
     <Fragment>
       <EuiRange
         id={inputRangeSliderId}
         value={value}
-        onChange={onChange}
+        onChange={(e) => setValue(e.currentTarget.value)}
         min={0}
         max={100}
         showInput
@@ -45,7 +37,7 @@ export default () => {
       <EuiDualRange
         id={dualInputRangeSliderId}
         value={dualValue}
-        onChange={onDualChange}
+        onChange={(value) => setDualValue(value)}
         showInput
         minInputProps={{ 'aria-label': 'Min value' }}
         maxInputProps={{ 'aria-label': 'Max value' }}

--- a/src-docs/src/views/range/input_only.tsx
+++ b/src-docs/src/views/range/input_only.tsx
@@ -23,15 +23,6 @@ export default () => {
     prefix: 'dualInputRangeSlider',
   });
 
-  // TODO EuiRangeProps['value'] doesn't work
-  const onChange = (e: any) => {
-    setValue(e.target.value);
-  };
-
-  const onDualChange = (value: EuiDualRangeProps['value']) => {
-    setDualValue(value);
-  };
-
   const levels = [
     {
       min: 0,
@@ -51,7 +42,7 @@ export default () => {
         <EuiRange
           id={inputRangeSliderId}
           value={value}
-          onChange={onChange}
+          onChange={(e) => setValue(e.currentTarget.value)}
           min={0}
           max={100}
           showInput="inputWithPopover"
@@ -66,7 +57,7 @@ export default () => {
         <EuiDualRange
           id={dualInputRangeSliderId}
           value={dualValue}
-          onChange={onDualChange}
+          onChange={(value) => setDualValue(value)}
           showInput="inputWithPopover"
           showLabels
           levels={levels}

--- a/src-docs/src/views/range/input_only.tsx
+++ b/src-docs/src/views/range/input_only.tsx
@@ -1,24 +1,34 @@
 import React, { useState, Fragment } from 'react';
 
-import { EuiRange, EuiSpacer, EuiDualRange } from '../../../../src/components';
+import {
+  EuiRange,
+  EuiRangeProps,
+  EuiSpacer,
+  EuiDualRange,
+  EuiDualRangeProps,
+  useGeneratedHtmlId,
+} from '../../../../src';
 
 import { DisplayToggles } from '../form_controls/display_toggles';
-import { useGeneratedHtmlId } from '../../../../src/services';
 
 export default () => {
-  const [value, setValue] = useState('20');
-  const [dualValue, setDualValue] = useState([20, 100]);
+  const [value, setValue] = useState<EuiRangeProps['value']>('20');
+  const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
+    20,
+    100,
+  ]);
 
   const inputRangeSliderId = useGeneratedHtmlId({ prefix: 'inputRangeSlider' });
   const dualInputRangeSliderId = useGeneratedHtmlId({
     prefix: 'dualInputRangeSlider',
   });
 
-  const onChange = (e) => {
+  // TODO EuiRangeProps['value'] doesn't work
+  const onChange = (e: any) => {
     setValue(e.target.value);
   };
 
-  const onDualChange = (value) => {
+  const onDualChange = (value: EuiDualRangeProps['value']) => {
     setDualValue(value);
   };
 
@@ -42,6 +52,8 @@ export default () => {
           id={inputRangeSliderId}
           value={value}
           onChange={onChange}
+          min={0}
+          max={100}
           showInput="inputWithPopover"
           showLabels
           aria-label="An example of EuiRange with showInput prop"

--- a/src-docs/src/views/range/levels.tsx
+++ b/src-docs/src/views/range/levels.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../src';
 
 export default () => {
-  const [value, setvalue] = useState('20');
+  const [value, setValue] = useState('20');
   const [customColorsValue, setCustomColorsValue] = useState('15');
   const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
     20,
@@ -85,24 +85,12 @@ export default () => {
     prefix: 'dualRangeWithLevelsHelp',
   });
 
-  const onChange = (e: any) => {
-    setvalue(e.target.value);
-  };
-
-  const onCustomColorsChange = (e: any) => {
-    setCustomColorsValue(e.target.value);
-  };
-
-  const onDualChange = (value: EuiDualRangeProps['value']) => {
-    setDualValue(value);
-  };
-
   return (
     <Fragment>
       <EuiRange
         id={rangeWithLevelsId}
         value={value}
-        onChange={(e) => onChange(e)}
+        onChange={(e) => setValue(e.currentTarget.value)}
         showTicks
         min={0}
         max={100}
@@ -120,7 +108,7 @@ export default () => {
       <EuiRange
         id={rangeWithCustomColorsId}
         value={customColorsValue}
-        onChange={(e) => onCustomColorsChange(e)}
+        onChange={(e) => setCustomColorsValue(e.currentTarget.value)}
         showTicks
         min={0}
         max={100}
@@ -138,7 +126,7 @@ export default () => {
       <EuiDualRange
         id={dualRangeWithLevelsId}
         value={dualValue}
-        onChange={(value) => onDualChange(value)}
+        onChange={(value) => setDualValue(value)}
         showTicks
         ticks={[
           { label: '20kb', value: 20 },

--- a/src-docs/src/views/range/levels.tsx
+++ b/src-docs/src/views/range/levels.tsx
@@ -5,14 +5,17 @@ import {
   EuiSpacer,
   EuiFormHelpText,
   EuiDualRange,
-} from '../../../../src/components';
-
-import { useGeneratedHtmlId } from '../../../../src/services';
+  EuiDualRangeProps,
+  useGeneratedHtmlId,
+} from '../../../../src';
 
 export default () => {
   const [value, setvalue] = useState('20');
   const [customColorsValue, setCustomColorsValue] = useState('15');
-  const [dualValue, setDualValue] = useState([20, 100]);
+  const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
+    20,
+    100,
+  ]);
 
   const levels = [
     {
@@ -82,15 +85,15 @@ export default () => {
     prefix: 'dualRangeWithLevelsHelp',
   });
 
-  const onChange = (e) => {
+  const onChange = (e: any) => {
     setvalue(e.target.value);
   };
 
-  const onCustomColorsChange = (e) => {
+  const onCustomColorsChange = (e: any) => {
     setCustomColorsValue(e.target.value);
   };
 
-  const onDualChange = (value) => {
+  const onDualChange = (value: EuiDualRangeProps['value']) => {
     setDualValue(value);
   };
 
@@ -101,6 +104,8 @@ export default () => {
         value={value}
         onChange={(e) => onChange(e)}
         showTicks
+        min={0}
+        max={100}
         tickInterval={20}
         levels={levels}
         aria-label="An example of EuiRange with levels prop"
@@ -117,6 +122,8 @@ export default () => {
         value={customColorsValue}
         onChange={(e) => onCustomColorsChange(e)}
         showTicks
+        min={0}
+        max={100}
         ticks={customTicks}
         levels={customColorsLevels}
         aria-label="An example of EuiRange with custom colored indicators"

--- a/src-docs/src/views/range/range.tsx
+++ b/src-docs/src/views/range/range.tsx
@@ -15,7 +15,7 @@ export default () => {
     prefix: 'rangeWithValuePrepend',
   });
 
-  const onChange = (e) => {
+  const onChange = (e: any) => {
     setValue(e.target.value);
   };
 

--- a/src-docs/src/views/range/range.tsx
+++ b/src-docs/src/views/range/range.tsx
@@ -1,6 +1,6 @@
 import React, { useState, Fragment } from 'react';
 
-import { EuiRange, EuiSpacer } from '../../../../src/components';
+import { EuiRange, EuiRangeProps, EuiSpacer } from '../../../../src/components';
 
 import { useGeneratedHtmlId } from '../../../../src/services';
 
@@ -15,8 +15,8 @@ export default () => {
     prefix: 'rangeWithValuePrepend',
   });
 
-  const onChange = (e: any) => {
-    setValue(e.target.value);
+  const onChange: EuiRangeProps['onChange'] = (e) => {
+    setValue(e.currentTarget.value);
   };
 
   return (

--- a/src-docs/src/views/range/range_example.js
+++ b/src-docs/src/views/range/range_example.js
@@ -94,7 +94,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: rangeSource,
         },
       ],
@@ -168,7 +168,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: dualRangeSource,
         },
       ],
@@ -214,7 +214,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: inputSource,
         },
       ],
@@ -249,7 +249,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: ticksSource,
         },
       ],
@@ -291,7 +291,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: levelsSource,
         },
       ],
@@ -331,7 +331,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: inputOnlySource,
         },
       ],
@@ -363,7 +363,7 @@ export const RangeControlExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: statesSource,
         },
       ],

--- a/src-docs/src/views/range/states.tsx
+++ b/src-docs/src/views/range/states.tsx
@@ -35,21 +35,13 @@ export default () => {
     prefix: 'inputRangeWithOptions',
   });
 
-  const onChange = (e: any) => {
-    setValue(e.target.value);
-  };
-
-  const onDualChange = (value: EuiDualRangeProps['value']) => {
-    setDualValue(value);
-  };
-
   return (
     <Fragment>
       <DisplayToggles canAppend canPrepend canLoading={false}>
         <EuiRange
           id={rangeWithOptionsId}
           value={value}
-          onChange={onChange}
+          onChange={(e) => setValue(e.currentTarget.value)}
           min={0}
           max={100}
           showTicks
@@ -69,7 +61,7 @@ export default () => {
         <EuiDualRange
           id={inputRangeWithOptionsId}
           value={dualValue}
-          onChange={onDualChange}
+          onChange={(value) => setDualValue(value)}
           showLabels
           showInput
           showTicks

--- a/src-docs/src/views/range/states.tsx
+++ b/src-docs/src/views/range/states.tsx
@@ -1,13 +1,22 @@
 import React, { useState, Fragment } from 'react';
 
-import { EuiRange, EuiSpacer, EuiDualRange } from '../../../../src/components';
+import {
+  EuiRange,
+  EuiSpacer,
+  EuiDualRange,
+  EuiDualRangeProps,
+} from '../../../../src/components';
 import { DisplayToggles } from '../form_controls/display_toggles';
 
 import { useGeneratedHtmlId } from '../../../../src/services';
 
 export default () => {
   const [value, setValue] = useState('20');
-  const [dualValue, setDualValue] = useState([20, 100]);
+  const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
+    20,
+    100,
+  ]);
+
   const levels = [
     {
       min: 0,
@@ -26,11 +35,11 @@ export default () => {
     prefix: 'inputRangeWithOptions',
   });
 
-  const onChange = (e) => {
+  const onChange = (e: any) => {
     setValue(e.target.value);
   };
 
-  const onDualChange = (value) => {
+  const onDualChange = (value: EuiDualRangeProps['value']) => {
     setDualValue(value);
   };
 
@@ -41,6 +50,8 @@ export default () => {
           id={rangeWithOptionsId}
           value={value}
           onChange={onChange}
+          min={0}
+          max={100}
           showTicks
           showInput
           showLabels

--- a/src-docs/src/views/range/ticks.tsx
+++ b/src-docs/src/views/range/ticks.tsx
@@ -18,16 +18,14 @@ export default () => {
   ]);
   const [noLinearValue, setNoLinearValue] = useState('28');
 
-  const onChange = (e: any) => {
-    setValue(e.target.value);
+  const onChange: EuiRangeProps['onChange'] = (e) => {
+    setValue(e.currentTarget.value);
   };
-
-  const onDualChange = (value: EuiDualRangeProps['value']) => {
+  const onDualChange: EuiDualRangeProps['onChange'] = (value) => {
     setDualValue(value);
   };
-
-  const onChangeNoLinearValue = (e: any) => {
-    setNoLinearValue(e.target.value);
+  const onChangeNoLinearValue: EuiRangeProps['onChange'] = (e) => {
+    setNoLinearValue(e.currentTarget.value);
   };
 
   const rangeBasicTicksId = useGeneratedHtmlId({ prefix: 'rangeBasicTicks' });

--- a/src-docs/src/views/range/ticks.tsx
+++ b/src-docs/src/views/range/ticks.tsx
@@ -2,23 +2,32 @@ import React, { useState, Fragment } from 'react';
 
 import {
   EuiRange,
+  EuiRangeProps,
   EuiSpacer,
   EuiTitle,
   EuiDualRange,
-} from '../../../../src/components';
-
-import { useGeneratedHtmlId } from '../../../../src/services';
+  EuiDualRangeProps,
+  useGeneratedHtmlId,
+} from '../../../../src';
 
 export default () => {
-  const [value, setValue] = useState('20');
-  const [dualValue, setDualValue] = useState([20, 100]);
+  const [value, setValue] = useState<EuiRangeProps['value']>('20');
+  const [dualValue, setDualValue] = useState<EuiDualRangeProps['value']>([
+    20,
+    100,
+  ]);
+  const [noLinearValue, setNoLinearValue] = useState('28');
 
-  const onChange = (e) => {
+  const onChange = (e: any) => {
     setValue(e.target.value);
   };
 
-  const onDualChange = (value) => {
+  const onDualChange = (value: EuiDualRangeProps['value']) => {
     setDualValue(value);
+  };
+
+  const onChangeNoLinearValue = (e: any) => {
+    setNoLinearValue(e.target.value);
   };
 
   const rangeBasicTicksId = useGeneratedHtmlId({ prefix: 'rangeBasicTicks' });
@@ -32,6 +41,8 @@ export default () => {
     prefix: 'dualRangeLongLabels',
   });
 
+  const rangeNoLinearId = useGeneratedHtmlId({ prefix: 'rangeNoLinaerId' });
+
   return (
     <Fragment>
       <EuiRange
@@ -39,6 +50,8 @@ export default () => {
         step={10}
         value={value}
         onChange={onChange}
+        min={0}
+        max={100}
         showTicks
         aria-label="An example of EuiRange with ticks"
       />
@@ -55,6 +68,8 @@ export default () => {
         id={rangeCustomTickIntervalId}
         value={value}
         onChange={onChange}
+        min={0}
+        max={100}
         showInput
         showRange
         showTicks
@@ -102,6 +117,33 @@ export default () => {
           { label: '100 kilobytes', value: 100 },
         ]}
         aria-label="An example of EuiDualRange with long tick labels"
+      />
+
+      <EuiSpacer size="xl" />
+
+      <EuiTitle size="xxs">
+        <h3>No linear intervals</h3>
+      </EuiTitle>
+
+      <EuiSpacer size="l" />
+
+      <EuiRange
+        id={rangeNoLinearId}
+        value={noLinearValue}
+        onChange={onChangeNoLinearValue}
+        showTicks
+        min={0}
+        max={84}
+        ticks={[
+          { label: '1 GB', value: 0 },
+          { label: '2GB', value: 14 },
+          { label: '4GB', value: 28 },
+          { label: '8GB', value: 42 },
+          { label: '16GB', value: 56 },
+          { label: '32GB', value: 70 },
+          { label: '64GB', value: 84 },
+        ]}
+        aria-label="An example of EuiDualRange with no linear intervals"
       />
     </Fragment>
   );


### PR DESCRIPTION
## Summary

This PR is open against [[Feature Branch] Convert EuiRange sliders to Emotion and more enhancements](https://github.com/elastic/eui/pull/6092/)  and it fixes https://github.com/elastic/eui/issues/6307.:

- It adds a new coding example called "No linear intervals"  in the tick marks section.
- It also converts all the range slider demos to **typescript**.
- It also converts the `DisplayToggles` component to TS.

<img width="446" alt="Screenshot 2022-10-27 at 19 19 10" src="https://user-images.githubusercontent.com/2750668/198368106-851ca05f-e97e-41f3-87c9-2e2e10c2aeb5.png">


### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
