### PR TITLE
Adding a Docker script and prompt for Cypress a11y tests in CI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "start": "cross-env BABEL_MODULES=false webpack serve --config=src-docs/webpack.config.js",
     "test-docker": "node ./scripts/test-docker.js",
+    "test-a11y-docker": "node ./scripts/test-a11y-docker.js",
     "sync-docs": "node ./scripts/docs-sync.js",
     "build-docs": "cross-env BABEL_MODULES=false cross-env NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 webpack --config=src-docs/webpack.config.js",
     "build": "yarn extract-i18n-strings && node ./scripts/compile-clean.js && node ./scripts/compile-eui.js && yarn compile-scss",

--- a/scripts/test-a11y-docker.js
+++ b/scripts/test-a11y-docker.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process');
+
+execSync('docker pull docker.elastic.co/eui/ci:3.3', {
+  stdio: 'inherit',
+});
+/* eslint-disable-next-line no-multi-str */
+execSync(
+  'docker run \
+  -i --rm --cap-add=SYS_ADMIN --volume=$(pwd):/app --workdir=/app \
+  -e GIT_COMMITTER_NAME=test -e GIT_COMMITTER_EMAIL=test -e HOME=/tmp \
+  --user=$(id -u):$(id -g) \
+  docker.elastic.co/eui/ci:3.3 \
+  bash -c \'npm config set spin false \
+    && /opt/yarn*/bin/yarn \
+    && yarn cypress install \
+    && NODE_OPTIONS="--max-old-space-size=2048" npm run test-cypress-a11y\'',
+  {
+    stdio: 'inherit',
+  }
+);


### PR DESCRIPTION
## Summary
After [splitting the Cypress a11y tests](https://github.com/elastic/eui/pull/6331) from functional tests, we need a new job to run them in CI. This PR re-uses much of our `test-docker.js` script, but changes up the command to test `NAME.a11y.tsx` files only. It also adds a command to our package.json file that will be used to scrip the Jenkins job.

## QA

* Ran the existing Docker container locally using the new test command

<img width="1020" alt="Screen Shot 2022-11-02 at 3 41 05 PM" src="https://user-images.githubusercontent.com/934879/199601839-9e50fdb9-b9bd-4a76-9d44-9028b0180292.png">


### General checklist

- [x] Checked for **breaking changes** and labeled appropriately