### PR TITLE
Remove overflow: hidden from EuiModal styles that caused a red overla…

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -6,6 +6,9 @@
   flex-direction: column;
   max-height: 75vh; // We overflow the modal body based off this
 
+  // TODO: Consider restoring this once https://bugs.chromium.org/p/chromium/issues/detail?id=1229700 is resolved
+  // overflow: hidden; Ensure long, non-breaking text doesn't expand beyond the modal bounds
+
   position: relative;
   background-color: $euiColorEmptyShade;
   border-radius: $euiBorderRadius;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -5,7 +5,6 @@
   display: flex;
   flex-direction: column;
   max-height: 75vh; // We overflow the modal body based off this
-  overflow: hidden; // Ensure long, non-breaking text doesn't expand beyond the modal bounds
 
   position: relative;
   background-color: $euiColorEmptyShade;

--- a/upcoming_changelogs/6343.md
+++ b/upcoming_changelogs/6343.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed `EuiModal` to not show a red rectangle that blocks content when the modal's content is long enough to scroll
+- Fixed a webkit rendering issue with `EuiModal`s containing tables tall enough to scroll

--- a/upcoming_changelogs/6343.md
+++ b/upcoming_changelogs/6343.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiModal` to not show a red rectangle that blocks content when the modal's content is long enough to scroll

--- a/upcoming_changelogs/6343.md
+++ b/upcoming_changelogs/6343.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed a webkit rendering issue with `EuiModal`s containing tables tall enough to scroll
+- Fixed a webkit rendering issue with `EuiModal`s containing `EuiBasicTable`s tall enough to scroll


### PR DESCRIPTION
## Summary
Fixes #6328 

`EuiModal` contained a bug that would set a red `mask-image` inside of `.euiModalBody__overflow` that appeared on the `EuiModalBody` and covered portions of the modal. This came from a the `overflow: hidden` inside of `EuiModal` that was added to accommodate IE. 

Extra details: https://bugs.chromium.org/p/chromium/issues/detail?id=1229700&q=mask%20image&can=2?

Live CodeSandbox Example w/ Error: https://codesandbox.io/s/sharp-meninsky-v7x6pt?file=/demo.js:41-75

**Before**

https://user-images.githubusercontent.com/40739624/199830027-4414d2e4-f347-41f1-87e9-e57dcba0e59d.mov

**Testing**

To test this, you can update the example in `modal.js` with the example below that contains an `EuiInMemoryTable`. When `overflow: hidden` exists inside of `.euiModal` styles (in `_modal.scss`), you will notice the red block when hovering over and interacting with the table.

<details>
<summary>Modal Example Code</summary>

```
import React, { useState } from 'react';

import {
  EuiButton,
  EuiModal,
  EuiModalBody,
  EuiModalHeader,
  EuiModalHeaderTitle,
  EuiHealth,
  EuiLink,
  EuiInMemoryTable,
} from '../../../../src/components';

import _times from 'lodash/times';

const firstNames = [
  'Very long first name that will wrap or be truncated',
  'Another very long first name which will wrap or be truncated',
  'Clinton',
  'Igor',
  undefined,
  'Drew',
  null,
  'Rashid',
  undefined,
  'John',
];

const lastNames = [
  'Very long last name that will wrap or be truncated',
  'Another very long last name which will wrap or be truncated',
  'Gormley',
  'Motov',
  'Minarik',
  'Raines',
  'Král',
  'Khan',
  'Sissel',
  'Dorlus',
];

const github = [
  'martijnvg',
  'elissaw',
  'clintongormley',
  'imotov',
  'karmi',
  'drewr',
  'HonzaKral',
  'rashidkpc',
  'jordansissel',
  'silne30',
];

const createUsers = (countries) => {
  return _times(20, (index) => {
    return {
      id: index,
      firstName: index < 10 ? firstNames[index] : firstNames[index - 10],
      lastName: index < 10 ? lastNames[index] : lastNames[index - 10],
      github: index < 10 ? github[index] : github[index - 10],
      dateOfBirth: new Date(
        1980,
        Math.floor(Math.random() * 12),
        Math.floor(Math.random() * 27) + 1
      ),
      nationality: 'nationality',
      online: index % 2 === 0,
    };
  });
};

export const Table = () => {
  const columns = [
    {
      field: 'firstName',
      name: 'First Name',
      sortable: true,
      truncateText: true,
    },
    {
      field: 'lastName',
      name: 'Last Name',
      truncateText: true,
    },
    {
      field: 'github',
      name: 'Github',
      render: (username) => (
        <EuiLink href={`https://github.com/${username}`} target="_blank">
          {username}
        </EuiLink>
      ),
    },
    {
      field: 'dateOfBirth',
      name: 'Date of Birth',
      dataType: 'string',
      render: (date) => `hello`,
      sortable: true,
    },
    {
      field: 'nationality',
      name: 'Nationality',
    },
    {
      field: 'online',
      name: 'Online',
      dataType: 'boolean',
      render: (online) => {
        const color = online ? 'success' : 'danger';
        const label = online ? 'Online' : 'Offline';
        return <EuiHealth color={color}>{label}</EuiHealth>;
      },
      sortable: true,
    },
  ];

  const sorting = {
    sort: {
      field: 'dateOfBirth',
      direction: 'desc',
    },
  };

  return (
    <EuiInMemoryTable
      tableCaption="Demo of EuiInMemoryTable"
      items={createUsers()}
      columns={columns}
      pagination={true}
      sorting={sorting}
    />
  );
};

export default () => {
  const [isModalVisible, setIsModalVisible] = useState(false);

  const closeModal = () => setIsModalVisible(false);
  const showModal = () => setIsModalVisible(true);

  let modal;

  if (isModalVisible) {
    modal = (
      <EuiModal onClose={closeModal}>
        <EuiModalHeader>
          <EuiModalHeaderTitle>
            <h1>title</h1>
          </EuiModalHeaderTitle>
        </EuiModalHeader>

        <EuiModalBody>
          <Table />
        </EuiModalBody>
      </EuiModal>
    );
  }

  return (
    <div>
      <EuiButton onClick={showModal}>Show modal</EuiButton>
      {modal}
    </div>
  );
};

```

</details>


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- ~[ ] Checked in both **light and dark** modes~
- ~[ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
- [x] Checked for **breaking changes** and labeled appropriately
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
