### PR TITLE
Adding Cypress a11y tests for five components.

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "css-loader": "^6.7.1",
     "cssnano": "^4.1.10",
     "cypress": "^10.6.0",
-    "cypress-axe": "^0.14.0",
+    "cypress-axe": "^1.0.0",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-real-events": "^1.7.0",
     "dedent": "^0.7.0",

--- a/src/components/date_picker/super_date_picker/super_date_picker.a11y.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.a11y.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import {
+  EuiSuperDatePicker,
+  OnRefreshProps,
+  OnTimeChangeProps,
+} from './super_date_picker';
+
+const SuperDatePicker = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [showUpdateButton] = useState(true);
+  const [start, setStart] = useState('now-30m');
+  const [end, setEnd] = useState('now');
+  const [showFill] = useState(true);
+
+  const onRefresh = ({ start, end, refreshInterval }: OnRefreshProps) => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    }).then(() => {
+      console.log(start, end, refreshInterval);
+    });
+  };
+
+  const onTimeChange = ({ start, end }: OnTimeChangeProps) => {
+    setStart(start);
+    setEnd(end);
+    setIsLoading(true);
+    startLoading();
+  };
+
+  const startLoading = () => {
+    setTimeout(stopLoading, 1000);
+  };
+
+  const stopLoading = () => {
+    setIsLoading(false);
+  };
+
+  const datepickerProps = {
+    isLoading: isLoading,
+    start: start,
+    end: end,
+    onTimeChange: onTimeChange,
+    onRefresh: onRefresh,
+    showUpdateButton: showUpdateButton,
+  };
+
+  return (
+    <EuiSuperDatePicker
+      {...datepickerProps}
+      updateButtonProps={{ fill: showFill }}
+    />
+  );
+};
+
+describe('EuiSuperDatePicker', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on render', () => {
+      cy.mount(<SuperDatePicker />);
+      cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations when quick select menu is open', () => {
+      cy.mount(<SuperDatePicker />);
+      cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
+      cy.get('button.euiFormControlLayout__prepend').click();
+      cy.get('div.euiPanel').contains('Quick select').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations when start / end date menus are open', () => {
+      cy.mount(<SuperDatePicker />);
+      cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
+      cy.get('button.euiSuperDatePicker__prettyFormat').click();
+      cy.get('div.euiDatePopoverContent').should('exist');
+      cy.checkAxe();
+
+      cy.get('button.euiDatePopoverButton--start').click();
+      cy.get('button.euiDatePopoverButton--end').click();
+      cy.get('div.euiDatePopoverContent').should('exist');
+      cy.checkAxe();
+
+      cy.get('button.euiDatePopoverButton--end').click();
+      cy.get('div.euiDatePopoverContent').should('not.exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/date_picker/super_date_picker/super_date_picker.a11y.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.a11y.tsx
@@ -9,11 +9,7 @@
 /// <reference types="../../../../cypress/support"/>
 
 import React, { useState } from 'react';
-import {
-  EuiSuperDatePicker,
-  OnRefreshProps,
-  OnTimeChangeProps,
-} from './super_date_picker';
+import { EuiSuperDatePicker, OnTimeChangeProps } from './super_date_picker';
 
 const SuperDatePicker = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -21,14 +17,6 @@ const SuperDatePicker = () => {
   const [start, setStart] = useState('now-30m');
   const [end, setEnd] = useState('now');
   const [showFill] = useState(true);
-
-  const onRefresh = ({ start, end, refreshInterval }: OnRefreshProps) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, 100);
-    }).then(() => {
-      console.log(start, end, refreshInterval);
-    });
-  };
 
   const onTimeChange = ({ start, end }: OnTimeChangeProps) => {
     setStart(start);
@@ -50,7 +38,6 @@ const SuperDatePicker = () => {
     start: start,
     end: end,
     onTimeChange: onTimeChange,
-    onRefresh: onRefresh,
     showUpdateButton: showUpdateButton,
   };
 
@@ -62,25 +49,24 @@ const SuperDatePicker = () => {
   );
 };
 
+beforeEach(() => {
+  cy.mount(<SuperDatePicker />);
+  cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
+});
+
 describe('EuiSuperDatePicker', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on render', () => {
-      cy.mount(<SuperDatePicker />);
-      cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
       cy.checkAxe();
     });
 
     it('has zero violations when quick select menu is open', () => {
-      cy.mount(<SuperDatePicker />);
-      cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
       cy.get('button.euiFormControlLayout__prepend').click();
       cy.get('div.euiPanel').contains('Quick select').should('exist');
       cy.checkAxe();
     });
 
     it('has zero violations when start / end date menus are open', () => {
-      cy.mount(<SuperDatePicker />);
-      cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
       cy.get('button.euiSuperDatePicker__prettyFormat').click();
       cy.get('div.euiDatePopoverContent').should('exist');
       cy.checkAxe();

--- a/src/components/modal/modal.a11y.tsx
+++ b/src/components/modal/modal.a11y.tsx
@@ -56,14 +56,22 @@ const Modal = () => {
   );
 };
 
+beforeEach(() => {
+  cy.mount(<Modal />);
+  cy.get('div.euiModal').should('not.exist');
+  cy.get('button.euiButton').click();
+  cy.get('div.euiModal').should('exist');
+});
+
 describe('EuiModal', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations when modal is open', () => {
-      cy.mount(<Modal />);
-      cy.get('div.euiModal').should('not.exist');
+      cy.checkAxe();
+    });
 
-      cy.get('button.euiButton').click();
-      cy.get('div.euiModal').should('exist');
+    it('has zero violations when modal is closed', () => {
+      cy.get('div.euiModalFooter button.euiButton').click();
+      cy.get('div.euiModal').should('not.exist');
       cy.checkAxe();
     });
   });

--- a/src/components/modal/modal.a11y.tsx
+++ b/src/components/modal/modal.a11y.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalProps,
+} from './index';
+import { EuiButton } from '../button';
+
+const Modal = () => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
+
+  const modalProps: EuiModalProps = {
+    title: 'Do this thing',
+    onClose: closeModal,
+    children: React,
+  };
+
+  return (
+    <div>
+      <EuiButton onClick={showModal}>Show confirm modal</EuiButton>
+      {isModalVisible && (
+        <EuiModal {...modalProps}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <h1>Title of modal</h1>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            <p>This is a simple modal body</p>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiButton onClick={closeModal} fill>
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+    </div>
+  );
+};
+
+describe('EuiModal', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations when modal is open', () => {
+      cy.mount(<Modal />);
+      cy.get('div.euiModal').should('not.exist');
+
+      cy.get('button.euiButton').click();
+      cy.get('div.euiModal').should('exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/modal/modal.spec.tsx
+++ b/src/components/modal/modal.spec.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import {
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalProps,
+} from './index';
+import { EuiButton } from '../button';
+
+const Modal = () => {
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
+
+  const modalProps: EuiModalProps = {
+    title: 'Do this thing',
+    onClose: closeModal,
+    children: React,
+  };
+
+  return (
+    <div>
+      <EuiButton onClick={showModal}>Show confirm modal</EuiButton>
+      {isModalVisible && (
+        <EuiModal {...modalProps}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <h1>Title of modal</h1>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            <p>This is a simple modal body</p>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiButton onClick={closeModal} fill>
+              Close
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+    </div>
+  );
+};
+
+describe('EuiModal', () => {
+  describe('Basic functionality', () => {
+    it('renders with required props', () => {
+      cy.mount(<Modal />);
+      cy.get('div.euiModal').should('not.exist');
+
+      cy.get('button.euiButton').click();
+      cy.get('div.euiModal').should('exist');
+    });
+
+    it('returns focus correctly when X close button is clicked', () => {
+      cy.mount(<Modal />);
+      cy.get('button.euiButton').click();
+      cy.get('div.euiModal').should('exist');
+      cy.get('button.euiButtonIcon').click();
+      cy.get('div.euiModal').should('not.exist');
+    });
+
+    it('handles focus correctly when Close button is clicked', () => {
+      cy.mount(<Modal />);
+      cy.get('button.euiButton').click();
+      cy.get('div.euiModal').should('exist');
+      cy.get('div.euiModalFooter > button').click();
+      cy.get('div.euiModal').should('not.exist');
+    });
+
+    it('responds to button keypresses', () => {
+      cy.realMount(<Modal />);
+      cy.realPress('Tab');
+      cy.focused().contains('Show confirm modal');
+      cy.realPress('Enter');
+      cy.focused().contains('Title of modal');
+      cy.realPress('Tab');
+      cy.realPress('Enter');
+      cy.focused().contains('Show confirm modal');
+      cy.get('div.euiModal').should('not.exist');
+      cy.realPress('Enter');
+      cy.focused().contains('Title of modal');
+      cy.repeatRealPress('Tab');
+      cy.realPress('Enter');
+      cy.focused().contains('Show confirm modal');
+      cy.get('div.euiModal').should('not.exist');
+    });
+  });
+});

--- a/src/components/popover/popover.a11y.tsx
+++ b/src/components/popover/popover.a11y.tsx
@@ -45,15 +45,28 @@ const Popover = () => {
   );
 };
 
-describe('EuiSuperDatePicker', () => {
+beforeEach(() => {
+  cy.mount(<Popover />);
+  cy.get('div.euiPopover__panel').should('not.exist');
+});
+
+describe('EuiPopover', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on render', () => {
-      cy.mount(<Popover />);
-      cy.get('div.euiPopover__panel').should('not.exist');
       cy.checkAxe();
+    });
 
+    it('has zero violations when popover is opened', () => {
       cy.get('button.euiButtonEmpty').click();
       cy.get('div.euiPopover__panel').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations when popover is closed', () => {
+      cy.get('button.euiButtonEmpty').click();
+      cy.get('div.euiPopover__panel').should('exist');
+      cy.get('button.euiButtonEmpty').click();
+      cy.get('div.euiPopover__panel').should('not.exist');
       cy.checkAxe();
     });
   });

--- a/src/components/popover/popover.a11y.tsx
+++ b/src/components/popover/popover.a11y.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiPopover, EuiPopoverProps } from './popover';
+import { EuiButtonEmpty } from '../button';
+import { EuiText } from '../text';
+
+const Popover = () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const onButtonClick = () =>
+    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
+  const closePopover = () => setIsPopoverOpen(false);
+
+  const button = (
+    <EuiButtonEmpty
+      iconType="documentation"
+      iconSide="right"
+      onClick={onButtonClick}
+    >
+      How it works
+    </EuiButtonEmpty>
+  );
+
+  const popoverProps: EuiPopoverProps = {
+    button: button,
+    isOpen: isPopoverOpen,
+    closePopover: closePopover,
+  };
+
+  return (
+    <EuiPopover {...popoverProps}>
+      <EuiText style={{ width: 300 }}>
+        <p>Popover content that&rsquo;s wider than the default width</p>
+      </EuiText>
+    </EuiPopover>
+  );
+};
+
+describe('EuiSuperDatePicker', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on render', () => {
+      cy.mount(<Popover />);
+      cy.get('div.euiPopover__panel').should('not.exist');
+      cy.checkAxe();
+
+      cy.get('button.euiButtonEmpty').click();
+      cy.get('div.euiPopover__panel').should('exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/tabs/tabs.a11y.tsx
+++ b/src/components/tabs/tabs.a11y.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiTabbedContent, EuiTabbedContentProps } from './tabbed_content';
+import { EuiSpacer } from '../spacer';
+import { EuiText } from '../text';
+
+const tabs = [
+  {
+    id: 'cobalt--id',
+    name: 'Cobalt',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Cobalt is a chemical element with symbol Co and atomic number 27.
+            Like nickel, cobalt is found in the Earth&rsquo;s crust only in
+            chemically combined form, save for small deposits found in alloys of
+            natural meteoric iron. The free element, produced by reductive
+            smelting, is a hard, lustrous, silver-gray metal.
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    id: 'dextrose--id',
+    name: 'Dextrose',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Intravenous sugar solution, also known as dextrose solution, is a
+            mixture of dextrose (glucose) and water. It is used to treat low
+            blood sugar or water loss without electrolyte loss.
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    id: 'hydrogen--id',
+    name: 'Hydrogen',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Hydrogen is a chemical element with symbol H and atomic number 1.
+            With a standard atomic weight of 1.008, hydrogen is the lightest
+            element on the periodic table
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    id: 'monosodium_glutammate--id',
+    name: 'Monosodium Glutamate',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Monosodium glutamate (MSG, also known as sodium glutamate) is the
+            sodium salt of glutamic acid, one of the most abundant naturally
+            occurring non-essential amino acids. Monosodium glutamate is found
+            naturally in tomatoes, cheese and other foods.
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+];
+
+const defaultTabProps: EuiTabbedContentProps = {
+  tabs: tabs,
+  initialSelectedTab: tabs[1],
+  autoFocus: 'selected',
+  onTabClick: () => {},
+};
+
+const TabbedContent = () => {
+  return <EuiTabbedContent {...defaultTabProps} />;
+};
+
+describe('EuiTabs', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations when modal is open', () => {
+      cy.mount(<TabbedContent />);
+      cy.get('div.euiTabs').should('exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/tabs/tabs.a11y.tsx
+++ b/src/components/tabs/tabs.a11y.tsx
@@ -9,11 +9,15 @@
 /// <reference types="../../../cypress/support"/>
 
 import React from 'react';
-import { EuiTabbedContent, EuiTabbedContentProps } from './tabbed_content';
+import {
+  EuiTabbedContent,
+  EuiTabbedContentProps,
+  EuiTabbedContentTab,
+} from './tabbed_content';
 import { EuiSpacer } from '../spacer';
 import { EuiText } from '../text';
 
-const tabs = [
+const tabs: EuiTabbedContentTab[] = [
   {
     id: 'cobalt--id',
     name: 'Cobalt',
@@ -85,19 +89,64 @@ const tabs = [
 
 const defaultTabProps: EuiTabbedContentProps = {
   tabs: tabs,
-  initialSelectedTab: tabs[1],
+  initialSelectedTab: tabs[0],
   autoFocus: 'selected',
   onTabClick: () => {},
 };
 
-const TabbedContent = () => {
-  return <EuiTabbedContent {...defaultTabProps} />;
-};
-
 describe('EuiTabs', () => {
   describe('Automated accessibility check', () => {
-    it('has zero violations when modal is open', () => {
-      cy.mount(<TabbedContent />);
+    it('has zero violations with default props', () => {
+      cy.mount(<EuiTabbedContent {...defaultTabProps} />);
+      cy.get('div.euiTabs').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations with second tab open on render', () => {
+      const secondSelectedTab = {
+        ...defaultTabProps,
+        initialSelectedTab: tabs[1],
+      };
+
+      cy.mount(<EuiTabbedContent {...secondSelectedTab} />);
+      cy.get('div.euiTabs').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations with third tab open on render', () => {
+      const thirdSelectedTab = {
+        ...defaultTabProps,
+        initialSelectedTab: tabs[2],
+      };
+
+      cy.mount(<EuiTabbedContent {...thirdSelectedTab} />);
+      cy.get('div.euiTabs').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations with last tab open on render', () => {
+      const lastSelectedTab = {
+        ...defaultTabProps,
+        initialSelectedTab: tabs[3],
+      };
+
+      cy.mount(<EuiTabbedContent {...lastSelectedTab} />);
+      cy.get('div.euiTabs').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations with all tabs disabled except first', () => {
+      const disabledTabs = tabs.map((tab, i) => {
+        if (i === 0) {
+          return tab;
+        }
+        return { ...tab, disabled: true };
+      });
+      const disabledTabProps = {
+        ...defaultTabProps,
+        tabs: disabledTabs,
+      };
+      cy.mount(<EuiTabbedContent {...disabledTabProps} />);
       cy.get('div.euiTabs').should('exist');
       cy.checkAxe();
     });

--- a/src/components/tabs/tabs.spec.tsx
+++ b/src/components/tabs/tabs.spec.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiTabbedContent, EuiTabbedContentProps } from './tabbed_content';
+import { EuiSpacer } from '../spacer';
+import { EuiText } from '../text';
+
+const tabs = [
+  {
+    id: 'cobalt--id',
+    name: 'Cobalt',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Cobalt is a chemical element with symbol Co and atomic number 27.
+            Like nickel, cobalt is found in the Earth&rsquo;s crust only in
+            chemically combined form, save for small deposits found in alloys of
+            natural meteoric iron. The free element, produced by reductive
+            smelting, is a hard, lustrous, silver-gray metal.
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    id: 'dextrose--id',
+    name: 'Dextrose',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Intravenous sugar solution, also known as dextrose solution, is a
+            mixture of dextrose (glucose) and water. It is used to treat low
+            blood sugar or water loss without electrolyte loss.
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    id: 'hydrogen--id',
+    name: 'Hydrogen',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Hydrogen is a chemical element with symbol H and atomic number 1.
+            With a standard atomic weight of 1.008, hydrogen is the lightest
+            element on the periodic table
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+  {
+    id: 'monosodium_glutammate--id',
+    name: 'Monosodium Glutamate',
+    content: (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            Monosodium glutamate (MSG, also known as sodium glutamate) is the
+            sodium salt of glutamic acid, one of the most abundant naturally
+            occurring non-essential amino acids. Monosodium glutamate is found
+            naturally in tomatoes, cheese and other foods.
+          </p>
+        </EuiText>
+      </>
+    ),
+  },
+];
+
+const TabbedContent = () => {
+  const tabProps: EuiTabbedContentProps = {
+    tabs: tabs,
+    initialSelectedTab: tabs[1],
+    autoFocus: 'selected',
+    onTabClick: () => {},
+  };
+
+  return <EuiTabbedContent {...tabProps} />;
+};
+
+describe('EuiTabs', () => {
+  describe('Basic functionality', () => {
+    it('renders with required props', () => {
+      cy.mount(<TabbedContent />);
+      cy.get('div.euiTabs').should('exist');
+      cy.checkAxe();
+    });
+
+    it('renders tabbed content on click', () => {
+      cy.mount(<TabbedContent />);
+      cy.get('button[role="tab"]').first().realClick();
+      cy.get('div[role="tabpanel"]').first().should('exist');
+      cy.get('div[role="tabpanel"]').should('have.length', 1);
+    });
+
+    it('handles keypress events', () => {
+      cy.realMount(<TabbedContent />);
+      cy.realPress('Tab');
+      cy.realPress(['Shift', 'Tab']);
+      cy.realPress('Enter');
+      cy.get('div[role="tabpanel"]').first().should('exist');
+      cy.get('div[role="tabpanel"]').should('have.length', 1);
+      cy.focused().should('have.text', 'Cobalt');
+      cy.repeatRealPress('Tab', 3);
+      cy.focused().should('have.text', 'Monosodium Glutamate');
+      cy.realPress('Enter');
+      cy.get('div[role="tabpanel"]').last().should('exist');
+      cy.get('div[role="tabpanel"]').should('have.length', 1);
+    });
+  });
+});

--- a/src/components/tree_view/tree_view.a11y.tsx
+++ b/src/components/tree_view/tree_view.a11y.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiTreeView, EuiTreeViewProps } from './tree_view';
+
+const TreeView = () => {
+  const items = [
+    {
+      label: 'Item One',
+      id: 'item_one',
+      isExpanded: true,
+      children: [
+        {
+          label: 'Item A',
+          id: 'item_a',
+        },
+        {
+          label: 'Item B',
+          id: 'item_b',
+          children: [
+            {
+              label: 'A Cloud',
+              id: 'item_cloud',
+            },
+            {
+              label: "I'm a Bug",
+              id: 'item_bug',
+              className: 'classForBug',
+            },
+          ],
+        },
+        {
+          label: 'Item C',
+          id: 'item_c',
+          children: [
+            {
+              label: 'Another Cloud',
+              id: 'item_cloud2',
+            },
+            {
+              label: 'Another Bug',
+              id: 'item_bug2',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: 'Item Two',
+      id: 'item_two',
+    },
+  ];
+
+  const defaultTreeViewProps: EuiTreeViewProps = {
+    items: items,
+    'aria-label': 'Sample folder tree',
+  };
+
+  return (
+    <div style={{ width: '20rem' }}>
+      <EuiTreeView {...defaultTreeViewProps} />
+    </div>
+  );
+};
+
+describe('EuiTreeView', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.mount(<TreeView />);
+      cy.get('div.euiTreeView__wrapper').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations with a nested child expanded', () => {
+      cy.mount(<TreeView />);
+      cy.get('div.euiTreeView__wrapper').should('exist');
+      cy.get('button#item_b').realClick();
+      cy.get('button#item_b').should('have.attr', 'aria-expanded', 'true');
+      cy.get('li.euiTreeView__node').contains('A Cloud').should('exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/tree_view/tree_view.spec.tsx
+++ b/src/components/tree_view/tree_view.spec.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiTreeView, EuiTreeViewProps } from './tree_view';
+
+const TreeView = () => {
+  const items = [
+    {
+      label: 'Item One',
+      id: 'item_one',
+      isExpanded: true,
+      children: [
+        {
+          label: 'Item A',
+          id: 'item_a',
+        },
+        {
+          label: 'Item B',
+          id: 'item_b',
+          children: [
+            {
+              label: 'A Cloud',
+              id: 'item_cloud',
+            },
+            {
+              label: "I'm a Bug",
+              id: 'item_bug',
+              className: 'classForBug',
+            },
+          ],
+        },
+        {
+          label: 'Item C',
+          id: 'item_c',
+          children: [
+            {
+              label: 'Another Cloud',
+              id: 'item_cloud2',
+            },
+            {
+              label: 'Another Bug',
+              id: 'item_bug2',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: 'Item Two',
+      id: 'item_two',
+    },
+  ];
+
+  const defaultTreeViewProps: EuiTreeViewProps = {
+    items: items,
+    'aria-label': 'Sample folder tree',
+  };
+
+  return (
+    <div style={{ width: '20rem' }}>
+      <EuiTreeView {...defaultTreeViewProps} />
+    </div>
+  );
+};
+
+describe('EuiTreeView', () => {
+  describe('Keyboard functionality', () => {
+    it('Expands and collapses children correctly', () => {
+      cy.realMount(<TreeView />);
+      cy.get('div.euiTreeView__wrapper').should('exist');
+      cy.repeatRealPress('Tab', 3);
+      cy.focused().contains('Item B');
+      cy.realPress('Enter');
+      cy.get('li.euiTreeView__node').contains('A Cloud').should('exist');
+      cy.realPress('Enter');
+      cy.get('li.euiTreeView__node').contains('A Cloud').should('not.exist');
+      cy.realPress('Tab');
+      cy.focused().contains('Item C');
+      cy.realPress('Enter');
+      cy.get('li.euiTreeView__node').contains('Another Cloud').should('exist');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5693,10 +5693,10 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-cypress-axe@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.14.0.tgz#5f5e70fb36b8cb3ba73a8ba01e9262ff1268d5e2"
-  integrity sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==
+cypress-axe@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-1.0.0.tgz#ab4e9486eaa3bb956a90a1ae40d52df42827b4f0"
+  integrity sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==
 
 cypress-plugin-tab@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Summary
This PR continues work from #6340. Adding a11y tests for five components, bumping `cypress-axe` to v1.0.0, and adding keyboard navigation tests to three components.

* Adding spec and a11y tests for Modal.
* Adding spec and a11y tests for Tabs.
* Adding spec and a11y tests for TreeView.
* Adding a11y spec for Super Date Picker.
* Adding a11y spec for Popover.

### General checklist

- [x] Checked in **Chrome**, ~~**Safari**,~~ **Edge**, and ~~**Firefox**~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
