### PR TITLE
Fixing toInitials bug that truncates custom initials (Issue #6276)

### DIFF
--- a/src/components/avatar/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__snapshots__/avatar.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`EuiAvatar props initials is rendered 1`] = `
   <span
     aria-hidden="true"
   >
-    l
+    lo
   </span>
 </div>
 `;

--- a/src/services/string/to_initials.ts
+++ b/src/services/string/to_initials.ts
@@ -29,7 +29,7 @@ export function toInitials(
 ): string | null {
   // Calculate the number of initials to show, maxing out at MAX_INITIALS
   let calculatedInitialsLength: number = initials
-    ? initials.split(' ').length
+    ? initials.split('').length
     : name.split(' ').length;
 
   calculatedInitialsLength =

--- a/upcoming_changelogs/6346.md
+++ b/upcoming_changelogs/6346.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed bug in `to_initials` that truncates custom initials


### PR DESCRIPTION
## Summary

This PR fixes the `toInitials` bug mentioned in issue  #6276.

## QA

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately