### PR TITLE
[EuiCard] Fix bug where layout breaks when `horizontal` and `selectable`

### DIFF
--- a/src-docs/src/views/card/card_example.js
+++ b/src-docs/src/views/card/card_example.js
@@ -106,7 +106,7 @@ export const CardExample = {
       title: 'Layout',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardLayoutSource,
         },
       ],
@@ -148,7 +148,7 @@ export const CardExample = {
       title: 'Images',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardImageSource,
         },
       ],
@@ -194,7 +194,7 @@ export const CardExample = {
       title: 'Footer',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardFooterSource,
         },
       ],
@@ -235,7 +235,7 @@ export const CardExample = {
       title: 'Beta badge',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardBetaSource,
         },
       ],
@@ -269,7 +269,7 @@ export const CardExample = {
       title: 'Selectable',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardSelectableSource,
         },
       ],
@@ -319,7 +319,7 @@ export const CardExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardCheckableCheckboxSource,
         },
       ],
@@ -345,7 +345,7 @@ export const CardExample = {
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardCheckableSource,
         },
       ],
@@ -358,7 +358,7 @@ export const CardExample = {
       title: 'Custom children',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardChildrenSource,
         },
       ],
@@ -395,7 +395,7 @@ export const CardExample = {
       title: 'Plain and other colors',
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: cardDisplaySource,
         },
       ],

--- a/src-docs/src/views/card/card_selectable.tsx
+++ b/src-docs/src/views/card/card_selectable.tsx
@@ -5,7 +5,9 @@ import {
   EuiCard,
   EuiIcon,
   EuiFlexGroup,
+  EuiFlexGrid,
   EuiFlexItem,
+  EuiSpacer,
 } from '../../../../src';
 
 export default () => {
@@ -25,70 +27,189 @@ export default () => {
   };
 
   return (
-    <EuiFlexGroup gutterSize="l">
-      <EuiFlexItem>
-        <EuiCard
-          icon={<EuiIcon size="xxl" type="logoSketch" />}
-          title="Sketch"
-          description="Example of a short card description."
-          footer={
-            <EuiButtonEmpty
-              iconType="iInCircle"
-              size="xs"
-              onClick={detailsClicked}
-              aria-label="See more details about Sketch"
-            >
-              More details
-            </EuiButtonEmpty>
-          }
-          selectable={{
-            onClick: card1Clicked,
-            isSelected: card1Selected,
-          }}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiCard
-          icon={<EuiIcon size="xxl" type="logoGCP" />}
-          title="Google"
-          description="Example of a longer card description. See how the footers stay lined up."
-          footer={
-            <EuiButtonEmpty
-              iconType="iInCircle"
-              size="xs"
-              onClick={detailsClicked}
-              aria-label="See more details about Google"
-            >
-              More details
-            </EuiButtonEmpty>
-          }
-          selectable={{
-            onClick: card2Clicked,
-            isSelected: card2Selected,
-          }}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiCard
-          icon={<EuiIcon size="xxl" type="logoAerospike" />}
-          title="Not Adobe"
-          description="Example of a short card description."
-          footer={
-            <EuiButtonEmpty
-              iconType="iInCircle"
-              size="xs"
-              onClick={detailsClicked}
-              aria-label="See more details about Not Adobe"
-            >
-              More details
-            </EuiButtonEmpty>
-          }
-          selectable={{
-            onClick: () => {},
-            isDisabled: true,
-          }}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <>
+      <EuiFlexGroup gutterSize="l">
+        <EuiFlexItem>
+          <EuiCard
+            icon={<EuiIcon size="xxl" type="logoSketch" />}
+            title="Sketch"
+            description="Example of a short card description."
+            footer={
+              <EuiButtonEmpty
+                iconType="iInCircle"
+                size="xs"
+                onClick={detailsClicked}
+                aria-label="See more details about Sketch"
+              >
+                More details
+              </EuiButtonEmpty>
+            }
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            icon={<EuiIcon size="xxl" type="logoGCP" />}
+            title="Google"
+            description="Example of a longer card description. See how the footers stay lined up."
+            footer={
+              <EuiButtonEmpty
+                iconType="iInCircle"
+                size="xs"
+                onClick={detailsClicked}
+                aria-label="See more details about Google"
+              >
+                More details
+              </EuiButtonEmpty>
+            }
+            selectable={{
+              onClick: card2Clicked,
+              isSelected: card2Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            icon={<EuiIcon size="xxl" type="logoAerospike" />}
+            title="Not Adobe"
+            description="Example of a short card description."
+            footer={
+              <EuiButtonEmpty
+                iconType="iInCircle"
+                size="xs"
+                onClick={detailsClicked}
+                aria-label="See more details about Not Adobe"
+              >
+                More details
+              </EuiButtonEmpty>
+            }
+            selectable={{
+              onClick: () => {},
+              isDisabled: true,
+            }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="xxl" />
+
+      <EuiFlexGrid gutterSize="l" columns={3}>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="xxl" type="search" />}
+            title="Custom query"
+            description="Use KQL or Lucene to detect issues across indices."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="xxl" type="machineLearningApp" />}
+            title="Machine Learning"
+            description="Select ML job to detect anomalous activity."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="xxl" type="search" />}
+            title="Threshold"
+            description="Aggregate query results to detect when number of matches exceeds threshold."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="xxl" type="search" />}
+            title="Event Correlation"
+            description="Use Event Query Language (EQL) to match events, generate sequences, and stack data."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="xxl" type="search" />}
+            title="Indicator Match"
+            description="Use indicators from intelligence sources to detect matching events and alerts."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="xxl" type="search" />}
+            title="New Terms"
+            description="Find documents with values appearing for the first time."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGrid>
+      <EuiSpacer size="xxl" />
+
+      <EuiFlexGroup gutterSize="l">
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="l" type="search" />}
+            title="Custom query"
+            description="Use KQL or Lucene to detect issues across indices."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="l" type="machineLearningApp" />}
+            title="Machine Learning"
+            description="Select ML job to detect anomalous activity."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiCard
+            layout="horizontal"
+            icon={<EuiIcon size="l" type="search" />}
+            title="Threshold"
+            description="Aggregate query results to detect when number of matches exceeds threshold."
+            selectable={{
+              onClick: card1Clicked,
+              isSelected: card1Selected,
+            }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
   );
 };

--- a/src-docs/src/views/card/card_selectable.tsx
+++ b/src-docs/src/views/card/card_selectable.tsx
@@ -5,9 +5,7 @@ import {
   EuiCard,
   EuiIcon,
   EuiFlexGroup,
-  EuiFlexGrid,
   EuiFlexItem,
-  EuiSpacer,
 } from '../../../../src';
 
 export default () => {
@@ -27,189 +25,70 @@ export default () => {
   };
 
   return (
-    <>
-      <EuiFlexGroup gutterSize="l">
-        <EuiFlexItem>
-          <EuiCard
-            icon={<EuiIcon size="xxl" type="logoSketch" />}
-            title="Sketch"
-            description="Example of a short card description."
-            footer={
-              <EuiButtonEmpty
-                iconType="iInCircle"
-                size="xs"
-                onClick={detailsClicked}
-                aria-label="See more details about Sketch"
-              >
-                More details
-              </EuiButtonEmpty>
-            }
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            icon={<EuiIcon size="xxl" type="logoGCP" />}
-            title="Google"
-            description="Example of a longer card description. See how the footers stay lined up."
-            footer={
-              <EuiButtonEmpty
-                iconType="iInCircle"
-                size="xs"
-                onClick={detailsClicked}
-                aria-label="See more details about Google"
-              >
-                More details
-              </EuiButtonEmpty>
-            }
-            selectable={{
-              onClick: card2Clicked,
-              isSelected: card2Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            icon={<EuiIcon size="xxl" type="logoAerospike" />}
-            title="Not Adobe"
-            description="Example of a short card description."
-            footer={
-              <EuiButtonEmpty
-                iconType="iInCircle"
-                size="xs"
-                onClick={detailsClicked}
-                aria-label="See more details about Not Adobe"
-              >
-                More details
-              </EuiButtonEmpty>
-            }
-            selectable={{
-              onClick: () => {},
-              isDisabled: true,
-            }}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-
-      <EuiSpacer size="xxl" />
-
-      <EuiFlexGrid gutterSize="l" columns={3}>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="xxl" type="search" />}
-            title="Custom query"
-            description="Use KQL or Lucene to detect issues across indices."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="xxl" type="machineLearningApp" />}
-            title="Machine Learning"
-            description="Select ML job to detect anomalous activity."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="xxl" type="search" />}
-            title="Threshold"
-            description="Aggregate query results to detect when number of matches exceeds threshold."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="xxl" type="search" />}
-            title="Event Correlation"
-            description="Use Event Query Language (EQL) to match events, generate sequences, and stack data."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="xxl" type="search" />}
-            title="Indicator Match"
-            description="Use indicators from intelligence sources to detect matching events and alerts."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="xxl" type="search" />}
-            title="New Terms"
-            description="Find documents with values appearing for the first time."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-      </EuiFlexGrid>
-      <EuiSpacer size="xxl" />
-
-      <EuiFlexGroup gutterSize="l">
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="l" type="search" />}
-            title="Custom query"
-            description="Use KQL or Lucene to detect issues across indices."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="l" type="machineLearningApp" />}
-            title="Machine Learning"
-            description="Select ML job to detect anomalous activity."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={<EuiIcon size="l" type="search" />}
-            title="Threshold"
-            description="Aggregate query results to detect when number of matches exceeds threshold."
-            selectable={{
-              onClick: card1Clicked,
-              isSelected: card1Selected,
-            }}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup gutterSize="l">
+      <EuiFlexItem>
+        <EuiCard
+          icon={<EuiIcon size="xxl" type="logoSketch" />}
+          title="Sketch"
+          description="Example of a short card description."
+          footer={
+            <EuiButtonEmpty
+              iconType="iInCircle"
+              size="xs"
+              onClick={detailsClicked}
+              aria-label="See more details about Sketch"
+            >
+              More details
+            </EuiButtonEmpty>
+          }
+          selectable={{
+            onClick: card1Clicked,
+            isSelected: card1Selected,
+          }}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiCard
+          icon={<EuiIcon size="xxl" type="logoGCP" />}
+          title="Google"
+          description="Example of a longer card description. See how the footers stay lined up."
+          footer={
+            <EuiButtonEmpty
+              iconType="iInCircle"
+              size="xs"
+              onClick={detailsClicked}
+              aria-label="See more details about Google"
+            >
+              More details
+            </EuiButtonEmpty>
+          }
+          selectable={{
+            onClick: card2Clicked,
+            isSelected: card2Selected,
+          }}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiCard
+          icon={<EuiIcon size="xxl" type="logoAerospike" />}
+          title="Not Adobe"
+          description="Example of a short card description."
+          footer={
+            <EuiButtonEmpty
+              iconType="iInCircle"
+              size="xs"
+              onClick={detailsClicked}
+              aria-label="See more details about Not Adobe"
+            >
+              More details
+            </EuiButtonEmpty>
+          }
+          selectable={{
+            onClick: () => {},
+            isDisabled: true,
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -2,70 +2,78 @@
 
 exports[`EuiCard betaBadgeProps renders href 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical-hasBetaBadge"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-hasBetaBadge"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
-  </div>
-  <span
-    class="emotion-euiCard__betaBadgeAnchor"
-  >
-    <a
-      class="euiBetaBadge emotion-euiBetaBadge-hollow-m-euiCard__betaBadge"
-      href="http://www.elastic.co/"
-      id="generated-idBetaBadge"
-      rel=""
-      title="Link"
+    <span
+      class="emotion-euiCard__betaBadgeAnchor"
     >
-      Link
-    </a>
-  </span>
+      <a
+        class="euiBetaBadge emotion-euiBetaBadge-hollow-m-euiCard__betaBadge"
+        href="http://www.elastic.co/"
+        id="generated-idBetaBadge"
+        rel=""
+        title="Link"
+      >
+        Link
+      </a>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`EuiCard horizontal selectable 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-left-horizontal"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-left"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-horizontal"
+    class="euiCard__main emotion-euiCard__main-horizontal"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-left-interactive"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-horizontal"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-left-interactive"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
   <div
@@ -90,29 +98,33 @@ exports[`EuiCard horizontal selectable 1`] = `
 exports[`EuiCard is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
   data-test-subj="test subject string"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -120,28 +132,32 @@ exports[`EuiCard is rendered 1`] = `
 
 exports[`EuiCard props a null icon 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -149,29 +165,33 @@ exports[`EuiCard props a null icon 1`] = `
 
 exports[`EuiCard props accepts div props like style 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
   style="min-width:0"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -179,44 +199,48 @@ exports[`EuiCard props accepts div props like style 1`] = `
 
 exports[`EuiCard props an avatar icon 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__top emotion-euiCard__top-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
     <div
-      aria-label="test"
-      class="euiAvatar euiAvatar--xl euiAvatar--user euiCard__icon emotion-euiAvatar-xl-user-plain-euiCard__icon-vertical"
-      role="img"
-      title="test"
+      class="euiCard__top emotion-euiCard__top-vertical"
     >
-      <span
-        aria-hidden="true"
+      <div
+        aria-label="test"
+        class="euiAvatar euiAvatar--xl euiAvatar--user euiCard__icon emotion-euiAvatar-xl-user-plain-euiCard__icon-vertical"
+        role="img"
+        title="test"
       >
-        t
-      </span>
+        <span
+          aria-hidden="true"
+        >
+          t
+        </span>
+      </div>
     </div>
-  </div>
-  <div
-    class="euiCard__content emotion-euiCard__content-vertical"
-  >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -224,25 +248,29 @@ exports[`EuiCard props an avatar icon 1`] = `
 
 exports[`EuiCard props children 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="emotion-euiCard__children"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      Child
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
+      </p>
+      <div
+        class="emotion-euiCard__children"
+      >
+        Child
+      </div>
     </div>
   </div>
 </div>
@@ -250,33 +278,37 @@ exports[`EuiCard props children 1`] = `
 
 exports[`EuiCard props children with description 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
+    <div
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <span
-        class="emotion-euiCard__text-center"
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
       >
-        Card title
-      </span>
-    </p>
-    <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
-    >
-      <p>
-        Card description
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
-    </div>
-    <div
-      class="emotion-euiCard__children"
-    >
-      Child
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
+      <div
+        class="emotion-euiCard__children"
+      >
+        Child
+      </div>
     </div>
   </div>
 </div>
@@ -284,28 +316,32 @@ exports[`EuiCard props children with description 1`] = `
 
 exports[`EuiCard props display accent is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--accent euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-accent-euiCard-center-vertical"
+  class="euiPanel euiPanel--accent euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-accent-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -313,28 +349,32 @@ exports[`EuiCard props display accent is rendered 1`] = `
 
 exports[`EuiCard props display danger is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--danger euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-danger-euiCard-center-vertical"
+  class="euiPanel euiPanel--danger euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-danger-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -342,28 +382,32 @@ exports[`EuiCard props display danger is rendered 1`] = `
 
 exports[`EuiCard props display plain is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -371,28 +415,32 @@ exports[`EuiCard props display plain is rendered 1`] = `
 
 exports[`EuiCard props display primary is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--primary euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-primary-euiCard-center-vertical"
+  class="euiPanel euiPanel--primary euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-primary-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -400,28 +448,32 @@ exports[`EuiCard props display primary is rendered 1`] = `
 
 exports[`EuiCard props display subdued is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--subdued euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-subdued-euiCard-center-vertical"
+  class="euiPanel euiPanel--subdued euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-subdued-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -429,28 +481,32 @@ exports[`EuiCard props display subdued is rendered 1`] = `
 
 exports[`EuiCard props display success is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--success euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-success-euiCard-center-vertical"
+  class="euiPanel euiPanel--success euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-success-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -458,28 +514,32 @@ exports[`EuiCard props display success is rendered 1`] = `
 
 exports[`EuiCard props display transparent is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-transparent-euiCard-center-vertical"
+  class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-transparent-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -487,28 +547,32 @@ exports[`EuiCard props display transparent is rendered 1`] = `
 
 exports[`EuiCard props display warning is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--warning euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-warning-euiCard-center-vertical"
+  class="euiPanel euiPanel--warning euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-warning-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -516,64 +580,72 @@ exports[`EuiCard props display warning is rendered 1`] = `
 
 exports[`EuiCard props footer 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
-  </div>
-  <div
-    class="emotion-euiCard__footer"
-  >
-    <span>
-      Footer
-    </span>
+    <div
+      class="emotion-euiCard__footer"
+    >
+      <span>
+        Footer
+      </span>
+    </div>
   </div>
 </div>
 `;
 
 exports[`EuiCard props hasBorder 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasBorder-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasBorder-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -581,28 +653,32 @@ exports[`EuiCard props hasBorder 1`] = `
 
 exports[`EuiCard props horizontal 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-left-horizontal"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-left"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-horizontal"
+    class="euiCard__main emotion-euiCard__main-horizontal"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-left"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-horizontal"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-left"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -610,31 +686,35 @@ exports[`EuiCard props horizontal 1`] = `
 
 exports[`EuiCard props href supports href as a link 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <a
-        aria-describedby="generated-idDescription"
-        class="euiCard__titleAnchor emotion-euiCard__text-center-interactive"
-        href="#"
-        rel="noreferrer"
-      >
-        Hoi
-      </a>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        There
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <a
+          aria-describedby="generated-idDescription"
+          class="euiCard__titleAnchor emotion-euiCard__text-center-interactive"
+          href="#"
+          rel="noreferrer"
+        >
+          Hoi
+        </a>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          There
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -642,36 +722,40 @@ exports[`EuiCard props href supports href as a link 1`] = `
 
 exports[`EuiCard props icon 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__top emotion-euiCard__top-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <span
-      class="myIconClass euiCard__icon emotion-euiCard__icon-vertical"
-      data-euiicon-type="apmApp"
-    />
-  </div>
-  <div
-    class="euiCard__content emotion-euiCard__content-vertical"
-  >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
+    <div
+      class="euiCard__top emotion-euiCard__top-vertical"
     >
       <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
+        class="myIconClass euiCard__icon emotion-euiCard__icon-vertical"
+        data-euiicon-type="apmApp"
+      />
+    </div>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -679,42 +763,46 @@ exports[`EuiCard props icon 1`] = `
 
 exports[`EuiCard props image 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__top emotion-euiCard__top-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
     <div
-      class="euiCard__image emotion-euiCard__image"
+      class="euiCard__top emotion-euiCard__top-vertical"
     >
-      <div>
-        <img
-          alt="Nature"
-          src="https://source.unsplash.com/400x200/?Nature"
-        />
+      <div
+        class="euiCard__image emotion-euiCard__image"
+      >
+        <div>
+          <img
+            alt="Nature"
+            src="https://source.unsplash.com/400x200/?Nature"
+          />
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    class="euiCard__content emotion-euiCard__content-vertical"
-  >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -722,30 +810,34 @@ exports[`EuiCard props image 1`] = `
 
 exports[`EuiCard props isDisabled 1`] = `
 <div
-  class="euiPanel euiPanel--subdued euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-subdued-euiCard-center-vertical-disabled"
+  class="euiPanel euiPanel--subdued euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-subdued-euiCard-center-disabled"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <button
-        aria-describedby=" generated-idDescription"
-        class="euiCard__titleButton emotion-euiCard__text-center-disabled"
-        disabled=""
-      >
-        Card title
-      </button>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <button
+          aria-describedby=" generated-idDescription"
+          class="euiCard__titleButton emotion-euiCard__text-center-disabled"
+          disabled=""
+        >
+          Card title
+        </button>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -753,28 +845,32 @@ exports[`EuiCard props isDisabled 1`] = `
 
 exports[`EuiCard props paddingSize l is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingLarge euiCard emotion-euiPanel-grow-m-l-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingLarge euiCard emotion-euiPanel-grow-m-l-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -782,28 +878,32 @@ exports[`EuiCard props paddingSize l is rendered 1`] = `
 
 exports[`EuiCard props paddingSize m is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -811,28 +911,32 @@ exports[`EuiCard props paddingSize m is rendered 1`] = `
 
 exports[`EuiCard props paddingSize none is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -840,28 +944,32 @@ exports[`EuiCard props paddingSize none is rendered 1`] = `
 
 exports[`EuiCard props paddingSize s is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingSmall euiCard emotion-euiPanel-grow-m-s-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingSmall euiCard emotion-euiPanel-grow-m-s-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -869,28 +977,32 @@ exports[`EuiCard props paddingSize s is rendered 1`] = `
 
 exports[`EuiCard props paddingSize xl is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-xl-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-xl-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -898,28 +1010,32 @@ exports[`EuiCard props paddingSize xl is rendered 1`] = `
 
 exports[`EuiCard props paddingSize xs is rendered 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-xs-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-xs-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -927,28 +1043,32 @@ exports[`EuiCard props paddingSize xs is rendered 1`] = `
 
 exports[`EuiCard props selectable 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center-interactive"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center-interactive"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
   <div
@@ -972,28 +1092,32 @@ exports[`EuiCard props selectable 1`] = `
 
 exports[`EuiCard props textAlign center 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -1001,28 +1125,32 @@ exports[`EuiCard props textAlign center 1`] = `
 
 exports[`EuiCard props textAlign left 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-left-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-left"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-left"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-left"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -1030,28 +1158,32 @@ exports[`EuiCard props textAlign left 1`] = `
 
 exports[`EuiCard props textAlign right 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-right-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-right"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-right"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-right"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -1059,28 +1191,32 @@ exports[`EuiCard props textAlign right 1`] = `
 
 exports[`EuiCard props titleElement 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <h4
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </h4>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
-      </p>
+      <h4
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
+      </h4>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -1088,28 +1224,32 @@ exports[`EuiCard props titleElement 1`] = `
 
 exports[`EuiCard props titleElement with nodes 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <h4
-      class="euiTitle euiCard__title emotion-euiTitle-s"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </h4>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
-      </p>
+      <h4
+        class="euiTitle euiCard__title emotion-euiTitle-s"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
+      </h4>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -1117,28 +1257,32 @@ exports[`EuiCard props titleElement with nodes 1`] = `
 
 exports[`EuiCard props titleSize 1`] = `
 <div
-  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-vertical"
+  class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
 >
   <div
-    class="euiCard__content emotion-euiCard__content-vertical"
+    class="euiCard__main emotion-euiCard__main-vertical"
   >
-    <p
-      class="euiTitle euiCard__title emotion-euiTitle-xs"
-      id="generated-idTitle"
-    >
-      <span
-        class="emotion-euiCard__text-center"
-      >
-        Card title
-      </span>
-    </p>
     <div
-      class="euiText emotion-euiText-s-euiCard__description"
-      id="generated-idDescription"
+      class="euiCard__content emotion-euiCard__content-vertical"
     >
-      <p>
-        Card description
+      <p
+        class="euiTitle euiCard__title emotion-euiTitle-xs"
+        id="generated-idTitle"
+      >
+        <span
+          class="emotion-euiCard__text-center"
+        >
+          Card title
+        </span>
       </p>
+      <div
+        class="euiText emotion-euiText-s-euiCard__description"
+        id="generated-idDescription"
+      >
+        <p>
+          Card description
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -40,13 +40,15 @@ export const euiCardStyles = (
     card: {
       euiCard: css`
         display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        flex-direction: column;
 
         // Apply the outline to the whole card when the internal text button has focus
         &:has([class*='euiCard__text'][class*='-interactive']:focus:focus-visible) {
           outline: ${euiTheme.focus.width} solid currentColor;
         }
       `,
-
       aligned: {
         center: css`
           ${logicalTextAlignCSS('center')};
@@ -61,7 +63,17 @@ export const euiCardStyles = (
           align-items: flex-end;
         `,
       },
+      disabled: css`
+        cursor: not-allowed; // duplicate property due to Chrome bug
+        background-color: ${euiButtonColor(euiThemeContext, 'disabled')};
+        color: ${euiTheme.colors.disabledText};
+      `,
+    },
 
+    main: {
+      euiCard__main: css`
+        display: flex;
+      `,
       layout: {
         vertical: css`
           flex-direction: column;
@@ -69,15 +81,8 @@ export const euiCardStyles = (
         horizontal: css`
           flex-direction: row;
           align-items: flex-start; /* 3 */
-          flex-wrap: wrap;
         `,
       },
-
-      disabled: css`
-        cursor: not-allowed; // duplicate property due to Chrome bug
-        background-color: ${euiButtonColor(euiThemeContext, 'disabled')};
-        color: ${euiTheme.colors.disabledText};
-      `,
     },
 
     content: {

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -69,6 +69,7 @@ export const euiCardStyles = (
         horizontal: css`
           flex-direction: row;
           align-items: flex-start; /* 3 */
+          flex-wrap: wrap;
         `,
       },
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -167,7 +167,6 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
     styles.card.euiCard,
     // Text alignment should always be left when horizontal
     styles.card.aligned[layout === 'horizontal' ? 'left' : textAlign],
-    styles.card.layout[layout],
     isDisabled && styles.card.disabled,
   ];
 
@@ -175,6 +174,8 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
     styles.content.euiCard__content,
     styles.content.layout[layout],
   ];
+
+  const mainStyles = [styles.main.euiCard__main, styles.main.layout[layout]];
 
   const textStyles = euiCardTextStyles(euiThemeContext);
   const textCSS = [
@@ -401,26 +402,28 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
       paddingSize={paddingSize}
       {...rest}
     >
-      {optionalCardTop}
+      <div className="euiCard__main" css={mainStyles}>
+        {optionalCardTop}
 
-      <div className="euiCard__content" css={contentStyles}>
-        <EuiTitle
-          id={`${ariaId}Title`}
-          className="euiCard__title"
-          size={titleSize}
-        >
-          <TitleElement>{theTitle}</TitleElement>
-        </EuiTitle>
+        <div className="euiCard__content" css={contentStyles}>
+          <EuiTitle
+            id={`${ariaId}Title`}
+            className="euiCard__title"
+            size={titleSize}
+          >
+            <TitleElement>{theTitle}</TitleElement>
+          </EuiTitle>
 
-        {optionalDescription}
+          {optionalDescription}
 
-        {optionalChildren}
+          {optionalChildren}
+        </div>
+
+        {/* Beta badge should always be after the title/description but before any footer buttons */}
+        {optionalBetaBadge}
+
+        {optionalFooter}
       </div>
-
-      {/* Beta badge should always be after the title/description but before any footer buttons */}
-      {optionalBetaBadge}
-
-      {optionalFooter}
 
       {optionalSelectButton}
     </EuiPanel>

--- a/src/components/card/card_select/card_select.styles.ts
+++ b/src/components/card/card_select/card_select.styles.ts
@@ -12,6 +12,7 @@ export const euiCardSelectStyles = () => {
   return {
     euiCardSelect: css`
       transform: none !important;
+      align-self: flex-end;
     `,
   };
 };

--- a/upcoming_changelogs/6348.md
+++ b/upcoming_changelogs/6348.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fix bug in `EuiCard` where layout breaks when `horizontal` and `selectable` are both passed


### PR DESCRIPTION
## Summary

This PR fixes a bug in **EuiCard** where the layout breaks when `horizontal` and `selectable` props are passed. It closes #6345.

I decided to wrap the content, beta badge, and footer in a div called `euiCard__main`. Leaving the select button out of this div. 

I first tried just playing with flex without adding a new div, but when the cards were inside a `EuiFlexGrid` the layout wouldn't work as expected. So this led me to create the `euiCard__main`.



### How to test?

Go to the following example: https://eui.elastic.co/pr_6348/#/display/card#selectable. I've put some of the cards inside a `EuiFlexGroup` and others inside a `EuiFlexGrid`. Just for testing purposes. This example then will be **reverted**.

You can compare it with the version that has the bug: https://codesandbox.io/s/leg8ch?file=/demo.js.

<img width="785" alt="cards-layout-issue@2x" src="https://user-images.githubusercontent.com/2750668/200572031-badb4768-6f9b-4017-a837-b2319877322e.png">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~[ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- ~[ ] Checked for **breaking changes** and labeled appropriately~
- ~[ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
- [ ] Revert REVERT ME commit