### PR TITLE
[EuiSkipLink] Allow consumer `onClick`s to be called even if no valid destination or fallback destination exists

### DIFF
--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -120,6 +120,28 @@ describe('EuiSkipLink', () => {
         expect(onClick).toHaveBeenCalled();
       });
 
+      test('is called even when no valid destination exists', () => {
+        const onClick = jest.fn(() =>
+          document.querySelector('button')!.focus()
+        );
+        const { getByText } = render(
+          <>
+            <EuiSkipLink
+              destinationId=""
+              fallbackDestination=""
+              onClick={onClick}
+            >
+              Test
+            </EuiSkipLink>
+            <button />
+          </>
+        );
+        fireEvent.click(getByText('Test'));
+
+        expect(onClick).toHaveBeenCalled();
+        expect(document.activeElement?.tagName.toLowerCase()).toEqual('button');
+      });
+
       test('does not override overrideLinkBehavior', () => {
         const onClick = jest.fn();
         const { getByText } = render(

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -94,16 +94,19 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
     setHasValidId(false);
 
     // If no valid element via ID is available, use the fallback query selectors
-    const fallbackEl = document.querySelector<HTMLElement>(fallbackDestination);
-    if (fallbackEl) {
-      setDestinationEl(fallbackEl);
+    if (fallbackDestination) {
+      const fallbackEl = document.querySelector<HTMLElement>(
+        fallbackDestination
+      );
+      if (fallbackEl) {
+        setDestinationEl(fallbackEl);
+      }
     }
   }, [destinationId, fallbackDestination]);
 
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (overrideLinkBehavior || !hasValidId) {
-        if (!destinationEl) return;
+      if ((overrideLinkBehavior || !hasValidId) && destinationEl) {
         e.preventDefault();
 
         // Scroll to the top of the destination content only if it's ~mostly out of view

--- a/upcoming_changelogs/6355.md
+++ b/upcoming_changelogs/6355.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- `EuiSkipLink` now correctly calls `onClick` even when `fallbackDestination` is invalid


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/549407/201217490-f4318e2b-5c03-4f18-9653-605626ca44b6.png)

I came across this bug in Kibana where Discover had a completely custom EuiSkipLink `onClick` for their legacy data table. They were using the skip link to programmatically scroll the table past hundreds of rows, so the traditional EuiSkipLink behavior did not apply.

This PR allows EuiSkipLink to call totally custom `onClick` behavior (was previously returning early if no target or fallback destination existed) by passing `destinationId="" fallbackDestination=""`.

## QA

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
