### PR TITLE
[EuiPageSection] Fix `contentProps` not correctly concatenating `css`

### DIFF
--- a/src/components/page/page_section/page_section.test.tsx
+++ b/src/components/page/page_section/page_section.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { css } from '@emotion/react';
 import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
@@ -108,5 +109,28 @@ describe('EuiPageSection', () => {
         expect(component).toMatchSnapshot();
       });
     });
+  });
+
+  // Regression test for recurring bug / unintuitive Emotion behavior
+  it('correctly merges `css` passed to `contentProps`', () => {
+    const component = render(
+      <EuiPageSection
+        contentProps={{
+          css: css`
+            color: red;
+          `,
+          'data-test-subj': 'content',
+        }}
+      />
+    );
+    const content = component.find('[data-test-subj="content"]');
+    expect(content).toMatchInlineSnapshot(`
+      <div
+        class="emotion-euiPageSection__content-l-css"
+        data-test-subj="content"
+      />
+    `);
+    expect(content.attr('class')).toContain('euiPageSection__content'); // Preserves our CSS
+    expect(content.attr('class').endsWith('-css')).toBeTruthy(); // Concatenates custom CSS
   });
 });

--- a/src/components/page/page_section/page_section.tsx
+++ b/src/components/page/page_section/page_section.tsx
@@ -100,11 +100,15 @@ export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({
     bottomBorder === true && styles.border,
     alignment.toLowerCase().includes('center') && contentStyles.center,
     restrictWidth && contentStyles.restrictWidth,
+    contentProps?.css && contentProps.css,
   ];
 
   return (
     <Component css={cssStyles} {...rest}>
-      <div css={cssContentStyles} {...contentProps} style={widthStyles}>
+      {/* `css` must be merged manually after props spread on the content wrapper -
+      Emotion does not automatically correctly merge `css` on non-component JSX */}
+      {/* eslint-disable-next-line local/css_before_spread_props */}
+      <div {...contentProps} css={cssContentStyles} style={widthStyles}>
         {children}
       </div>
     </Component>

--- a/upcoming_changelogs/6365.md
+++ b/upcoming_changelogs/6365.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Re-fixed `EuiPageSection` not correctly merging `contentProps.css`


### PR DESCRIPTION
## Summary

- This was originally fixed in https://github.com/elastic/eui/pull/6239 
  - (although my guess as to why it needed to be that way was not quite correct)
- This was broken in https://github.com/elastic/eui/pull/6257 (released in v69.x)
  - I assumed it was working because tests were passing, but tests were only checking that passed CSS existed and not for our CSS being overriden
- This PR re-fixes the bug **(will need to be backported for Kibana)** and adds clearer comments and a regression unit test.

## QA

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately