### PR TITLE
[EuiTab] Fix standalone tabs not defaulting to a size

### DIFF
--- a/src/components/tabs/__snapshots__/tab.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tab.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`EuiTab props append is rendered 1`] = `
     Append
   </span>
   <span
-    class="euiTab__content emotion-euiTab__content"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     children
   </span>
@@ -29,7 +29,7 @@ exports[`EuiTab props disabled and selected 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-selected-disabled"
+    class="euiTab__content emotion-euiTab__content-m-selected-disabled"
   >
     Click Me
   </span>
@@ -45,7 +45,7 @@ exports[`EuiTab props disabled is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-disabled"
+    class="euiTab__content emotion-euiTab__content-m-disabled"
   >
     Click Me
   </span>
@@ -63,7 +63,7 @@ exports[`EuiTab props href renders anchor 1`] = `
   role="tab"
 >
   <span
-    class="euiTab__content emotion-euiTab__content"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     children
   </span>
@@ -78,7 +78,7 @@ exports[`EuiTab props isSelected is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-selected"
+    class="euiTab__content emotion-euiTab__content-m-selected"
   >
     children
   </span>
@@ -95,7 +95,7 @@ exports[`EuiTab props onClick renders button 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     children
   </span>
@@ -115,7 +115,7 @@ exports[`EuiTab props prepend is rendered 1`] = `
     Prepend
   </span>
   <span
-    class="euiTab__content emotion-euiTab__content"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     children
   </span>

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -69,7 +69,7 @@ export const EuiTab: FunctionComponent<Props> = ({
   rel,
   prepend,
   append,
-  size,
+  size = 'm',
   expand,
   ...rest
 }) => {

--- a/upcoming_changelogs/6366.md
+++ b/upcoming_changelogs/6366.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiTab` not defaulting to size `m`


### PR DESCRIPTION
## Summary

When we converted `EuiTabs` to Emotion in https://github.com/elastic/eui/pull/6311, we started passing down `size` to child `EuiTab`, but we didn't set a default `size = 'm'` for `<EuiTab>`s used outside of parent `<EuiTabs>` **or** when consumers add, e.g. a wrapper of some kind around `EuiTab`.

This is affecting a Kibana plugin and will need to be backported:

<img width="683" alt="" src="https://user-images.githubusercontent.com/549407/202027850-9aa5a192-1048-4808-9817-bb6a0a1e841c.png">

⚠️ **Note**: Technically this fix does not address scenarios where consumers do something like this:
```
<EuiTabs size="l">
  <SomeIntermediateWrapper>
    <EuiTab> // will be size "m" / will not inherit size "l"
```

For the above scenarios, we need to use React Context instead to share `size`, similar to how EuiDescriptionList behaves, instead of cloning children with props. However, as that's a significantly more involved fix and Kibana needs a working fix sooner rather than later, I'm opting to prefer this fix for the backport and look into a more future-proof context fix later. 

## QA

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) snapshots**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately