### PR TITLE
[Emotion] Fix overly large scroll shadow gradients

### DIFF
--- a/src/components/flyout/__snapshots__/flyout_body.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout_body.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiFlyoutBody is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <div
-    class="euiFlyoutBody__overflow css-1fk8opf-noBanner"
+    class="euiFlyoutBody__overflow css-18yrfj9-noBanner"
     tabindex="0"
   >
     <div

--- a/src/global_styling/mixins/_helpers.ts
+++ b/src/global_styling/mixins/_helpers.ts
@@ -93,7 +93,7 @@ const euiOverflowShadowStyles = (
 ) => {
   const direction = _direction || 'y';
   const side = _side || 'both';
-  const hideHeight = `calc(${size.base} * 0.75 * 1.25)`;
+  const hideHeight = size.s;
   const gradientStart = `
   ${transparentize('red', 0.1)} 0%,
   ${transparentize('red', 1)} ${hideHeight}

--- a/src/global_styling/utility/__snapshots__/utility.test.tsx.snap
+++ b/src/global_styling/utility/__snapshots__/utility.test.tsx.snap
@@ -178,9 +178,9 @@ exports[`global utility styles generates static global styles 1`] = `
 
   mask-image: linear-gradient(to bottom, 
   rgba(255,0,0,0.1) 0%,
-  rgb(255,0,0) calc(16px * 0.75 * 1.25)
+  rgb(255,0,0) 8px
   , 
-  rgb(255,0,0) calc(100% - calc(16px * 0.75 * 1.25)),
+  rgb(255,0,0) calc(100% - 8px),
   rgba(255,0,0,0.1) 100%
   );
 ;}
@@ -217,9 +217,9 @@ exports[`global utility styles generates static global styles 1`] = `
 
   mask-image: linear-gradient(to right, 
   rgba(255,0,0,0.1) 0%,
-  rgb(255,0,0) calc(16px * 0.75 * 1.25)
+  rgb(255,0,0) 8px
   , 
-  rgb(255,0,0) calc(100% - calc(16px * 0.75 * 1.25)),
+  rgb(255,0,0) calc(100% - 8px),
   rgba(255,0,0,0.1) 100%
   );
 ;}[class*='eui-showFor']{display:none!important;}

--- a/upcoming_changelogs/6374.md
+++ b/upcoming_changelogs/6374.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed the shadow sizes of `.eui-yScrollWithShadows` and `.eui-xScrollWithShadows`


### PR DESCRIPTION
## Summary

Elizabet noticed this first in https://github.com/elastic/eui/pull/6321#discussion_r1006780946, I'm copying her fix here so we can get it into Kibana 8.6FF.

> I noticed that the previous value `calc(${size.base} * 0.75 * 1.25)` was not corresponding to the Sass mixin (before converted to Emotion). So I fixed to use a similar value:
>
> <img width="721" alt="" src="https://user-images.githubusercontent.com/2750668/198277233-cdc7d172-5cf2-46ab-93b5-bfc6f240d24d.png">
>
> The problem of using the ``calc(${size.base} * 0.75 * 1.25)`` could be noticed here:
>
> <img width="846" alt="" src="https://user-images.githubusercontent.com/2750668/198278858-e1c31a02-eb6a-4786-9bec-ec21832958b6.png">

In production, this primarily affects `EuiFlyout` and consumers directly using `.eui-yScrollWithShadows` and `.eui-xScrollWithShadows`. It currently affects the Maps plugin in prod:

<img src="https://user-images.githubusercontent.com/373691/202289281-8855d58c-a80c-419e-a1b4-7fbd7f3e0235.png">

## QA

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
