### PR TITLE
[EuiCard] Fix bug with vertical cards not growing 100% in width

### DIFF
--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -73,6 +73,7 @@ export const euiCardStyles = (
     main: {
       euiCard__main: css`
         display: flex;
+        inline-size: 100%;
       `,
       layout: {
         vertical: css`

--- a/upcoming_changelogs/6377.md
+++ b/upcoming_changelogs/6377.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed bug in `EuiCard` where inner content in vertical cards were not growing 100% in width
+- Fixed bug in `EuiCard` where the inner content in vertical cards was not growing 100% in width

--- a/upcoming_changelogs/6377.md
+++ b/upcoming_changelogs/6377.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed bug in `EuiCard` where inner content in vertical cards were not growing 100% in width


### PR DESCRIPTION
## Summary

This PR fixes a bug where the inner content in vertical cards was not growing 100% in width. This issue was introduced in #6348. **The bug is only visible if the card has inner background**. 

<img width="1538" alt="cards-vertical-width-grow@2x" src="https://user-images.githubusercontent.com/2750668/202475129-90995f55-b81d-4f94-af77-1cd8bfa31bb9.png">

The best way to test is by comparing the cards in the button page EUI version 70.2.0 (where the bug exists) with the fix:
- **Bug:** https://eui.elastic.co/v70.2.0/#/navigation/button
- **Fix:** https://eui.elastic.co/pr_6377/#/navigation/button

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in mobile
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
