### PR TITLE
[Docs] Convert `DisplayToggles` to `*.TS`

### DIFF
--- a/src-docs/src/components/codesandbox/link.js
+++ b/src-docs/src/components/codesandbox/link.js
@@ -198,7 +198,7 @@ ReactDOM.render(
   if (hasDisplayToggles(demoContent)) {
     const cleanedDisplayToggles = cleanEuiImports(displayTogglesRawCode);
 
-    config.files['display_toggles.js'] = {
+    config.files['display_toggles.tsx'] = {
       content: cleanedDisplayToggles,
     };
   }

--- a/src-docs/src/services/string/clean_imports.js
+++ b/src-docs/src/services/string/clean_imports.js
@@ -10,7 +10,18 @@ export const listExtraDeps = (code) => {
   return code
     .match(
       // Match anything not directly calling eui (like lib dirs)
-      /import(?!.*(elastic\/eui|\.))\s.*?'(@[^.]+?\/)?[^.]+?['\/]/g
+      /*
+        flags:
+          g - find all occurances
+          m - multiline, ^ and $ match start and end of lines, not beginning & end of the whole string
+          s - dotall, allow . to match newlines
+        ^import - start matching at any import at the beginning of a line - `m` flag enters multi-line
+        [^;]*? - match anything that isn't the statement-closing semicolon (necessary due to multi-line matching)
+        from\s' - anchor to the from[whitespace]' syntax
+        (?!@elastic\/eui|\.).*? - match anything inside the quotes as long as it doesn't start with @elastic/eui or .
+        '; - end of import source & closing semicolon
+      */
+      /^import[^;]*?from\s'(?!@elastic\/eui|\.).*?';/gms
     )
     .map((match) => match.match(/'(.+)['\/]/)[1])
     .reduce((deps, dep) => {

--- a/src-docs/src/views/date_picker/range.tsx
+++ b/src-docs/src/views/date_picker/range.tsx
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import moment from 'moment';
 
 import { EuiDatePicker, EuiDatePickerRange } from '../../../../src';
-
-// @ts-ignore Importing from JS
 import { DisplayToggles } from '../form_controls/display_toggles';
 
 export default () => {

--- a/src-docs/src/views/form_controls/display_toggles.tsx
+++ b/src-docs/src/views/form_controls/display_toggles.tsx
@@ -1,4 +1,10 @@
-import React, { cloneElement, useState, Fragment } from 'react';
+import React, {
+  cloneElement,
+  useState,
+  Fragment,
+  ReactElement,
+  FunctionComponent,
+} from 'react';
 
 import {
   EuiFlexGroup,
@@ -9,9 +15,39 @@ import {
   EuiButtonEmpty,
   EuiPopover,
   EuiSpacer,
+  EuiSpacerProps,
 } from '../../../../src/components';
 
-export const DisplayToggles = ({
+export type DisplayTogglesProps = {
+  canIsDisabled?: boolean;
+  canDisabled?: boolean;
+  canReadOnly?: boolean;
+  canLoading?: boolean;
+  canCompressed?: boolean;
+  canFullWidth?: boolean;
+  canInvalid?: boolean;
+  canPrepend?: boolean;
+  canAppend?: boolean;
+  canClear?: boolean;
+  children: ReactElement;
+  extras?: ReactElement[];
+  spacerSize?: EuiSpacerProps['size'];
+};
+
+export type CanPropsType = {
+  disabled?: boolean;
+  isDisabled?: boolean;
+  readOnly?: boolean;
+  fullWidth?: boolean;
+  compressed?: boolean;
+  isLoading?: boolean;
+  prepend?: string;
+  append?: string;
+  isInvalid?: boolean;
+  isClearable?: boolean;
+};
+
+export const DisplayToggles: FunctionComponent<DisplayTogglesProps> = ({
   canIsDisabled = false,
   canDisabled = true,
   canReadOnly = true,
@@ -37,7 +73,7 @@ export const DisplayToggles = ({
   const [invalid, setInvalid] = useState(false);
   const [isClearable, setIsClearable] = useState(false);
 
-  const canProps = {};
+  const canProps: CanPropsType = {};
   if (canDisabled) canProps.disabled = disabled;
   if (canIsDisabled) canProps.isDisabled = disabled;
   if (canReadOnly) canProps.readOnly = readOnly;


### PR DESCRIPTION
## Summary

This PR converts the `DisplayToggles` component to Typescript. 

I first converted this component in #6092, then I needed it in #6370. So I converted again. 

So I guess it is better to have its own PR. Both PRs where I converted the component are part of feature branches and they will take a while to be merged. 


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples