### PR TITLE
[EuiSuperDatePicker] Fix incorrect button margins in quick select popover

### DIFF
--- a/src/components/date_picker/super_date_picker/_super_date_picker.scss
+++ b/src/components/date_picker/super_date_picker/_super_date_picker.scss
@@ -1,15 +1,17 @@
 // sass-lint:disable-block function-name-format
 
 .euiSuperDatePicker__flexWrapper {
-  // Need to offset 8px because of negative margins added by small size gutter
-  max-width: calc(100% + #{$euiSizeS});
+  max-width: 100%;
   // Set a sensible min-width for when width is auto
   min-width: MIN(($euiFormMaxWidth / 2) + $euiSuperDatePickerButtonWidth + $euiSizeS, 100%);
   width: $euiSuperDatePickerWidth + $euiSuperDatePickerButtonWidth + $euiSizeS;
 
+  @include euiBreakpoint('xs', 's') {
+    width: 100%;
+  }
+
   &.euiSuperDatePicker__flexWrapper--fullWidth {
-    // Need to offset 8px because of negative margins added by small size gutter
-    width: calc(100% + #{$euiSizeS});
+    width: 100%;
   }
 
   &.euiSuperDatePicker__flexWrapper--isQuickSelectOnly {
@@ -74,11 +76,5 @@
     background-color: $euiFormBackgroundDisabledColor;
     color: $euiColorDarkShade;
     cursor: not-allowed;
-  }
-}
-
-@include euiBreakpoint('xs', 's') {
-  .euiSuperDatePicker__flexWrapper {
-    width: calc(100% + #{$euiSizeS});
   }
 }

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -24,8 +24,4 @@
 .euiQuickSelectPopover__sectionItem {
   font-size: $euiFontSizeS;
   line-height: $euiFontSizeS;
-
-  &:not(:last-of-type) {
-    margin-bottom: $euiSizeS;
-  }
 }

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -24,4 +24,10 @@
 .euiQuickSelectPopover__sectionItem {
   font-size: $euiFontSizeS;
   line-height: $euiFontSizeS;
+
+  &--recentlyUsed {
+    &:not(:last-of-type) {
+      margin-bottom: $euiSizeS;
+    }
+  }
 }

--- a/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/_quick_select_popover.scss
@@ -8,7 +8,7 @@
   max-height: $euiSizeM * 11;
   overflow: hidden;
   overflow-y: auto;
-  padding: $euiSizeS 0 $euiSizeXS; // Offset negative margin from flex items
+  margin: $euiSizeS 0 0;
 }
 
 // sass-lint:disable no-important

--- a/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
@@ -12,7 +12,6 @@ import { EuiButtonEmpty } from '../../../button';
 import { EuiIcon } from '../../../icon';
 import { EuiPopover } from '../../../popover';
 import { EuiTitle } from '../../../title';
-import { EuiSpacer } from '../../../spacer';
 import { EuiHorizontalRule } from '../../../horizontal_rule';
 import { EuiText } from '../../../text';
 
@@ -135,7 +134,6 @@ export class EuiQuickSelectPopover extends Component<
           <EuiTitle size="xxxs">
             <span>{title}</span>
           </EuiTitle>
-          <EuiSpacer size="xs" />
           <EuiText size="s" className="euiQuickSelectPopover__section">
             {React.cloneElement(content, { applyTime: this.applyTime })}
           </EuiText>

--- a/src/components/date_picker/super_date_picker/quick_select_popover/recently_used.tsx
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/recently_used.tsx
@@ -40,7 +40,7 @@ export const EuiRecentlyUsed: FunctionComponent<EuiRecentlyUsedProps> = ({
     };
     return (
       <li
-        className="euiQuickSelectPopover__sectionItem"
+        className="euiQuickSelectPopover__sectionItem euiQuickSelectPopover__sectionItem--recentlyUsed"
         key={`${start}-${end}`}
       >
         <EuiLink onClick={applyRecentlyUsed}>

--- a/upcoming_changelogs/6380.md
+++ b/upcoming_changelogs/6380.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed incorrect button margins in `EuiSuperDatePicker` quick select popover
+- Fixed incorrect margins in `EuiSuperDatePicker` caused by `EuiFlex` CSS gap change

--- a/upcoming_changelogs/6380.md
+++ b/upcoming_changelogs/6380.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed incorrect button margins in `EuiSuperDatePicker` quick select popover


### PR DESCRIPTION
## Summary

This PR fixes incorrect button margins in **EuiSuperDatePicker** quick select popover. This bug was introduced when the **EuiFlexGrid** was converted to Emotion.

<img width="1020" alt="super-date-picker@2x" src="https://user-images.githubusercontent.com/2750668/202512211-0f804082-e473-4514-8ac7-f7528410d28f.png">

### How to test

Compare the example with the bug with the fix:

- Bug: https://eui.elastic.co/v70.2.0/#/templates/super-date-picker
- Fix:  https://eui.elastic.co/pr_6380/#/templates/super-date-picker

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
