### PR TITLE
[EuiFlex] Fix responsive selector missed in Emotion conversion

### DIFF
--- a/src/components/flex/flex_group.styles.ts
+++ b/src/components/flex/flex_group.styles.ts
@@ -22,7 +22,7 @@ export const euiFlexGroupStyles = (euiThemeContext: UseEuiTheme) => {
       ${euiBreakpoint(euiThemeContext, ['xs', 's'])} {
         flex-wrap: wrap;
 
-        .euiFlexItem {
+        & > .euiFlexItem {
           ${logicalCSS('width', '100%')}
           flex-basis: 100%;
         }

--- a/upcoming_changelogs/6381.md
+++ b/upcoming_changelogs/6381.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed visual bug in nested `EuiFlexGroup`s, where the parent `EuiFlexGroup` is responsive but a child `EuiFlexGroup` is not


### PR DESCRIPTION
## Summary

Prior Sass had a `>` selector that I missed in my conversion:
https://github.com/elastic/eui/blob/c85913bef931f2eb7df754c48eca7fdf6481ebc4/src/components/flex/_flex_item.scss#L30-L36

This primarily affects nested nested EuiFlexGroups where the parent is responsive but a child EuiFlexGroup within is not responsive. This is affecting Kibana and will need to be backported to the latest upgrade.

### Before
<img width="508" alt="" src="https://user-images.githubusercontent.com/549407/202564051-a78228c7-e36c-44dd-85be-a1ee08f9803d.png">

### After
<img width="514" alt="" src="https://user-images.githubusercontent.com/549407/202564062-d904a8ab-afed-488e-babd-53bf2966c680.png">

## QA

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately