### PR TITLE
Adding a11y specs for three navigation patterns.

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.a11y.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.a11y.tsx
@@ -46,7 +46,8 @@ const breadcrumbs = [
 ];
 
 beforeEach(() => {
-  cy.viewport('ipad-2'); // Displays all breadcrumbs except the single truncated one
+  // Displays all breadcrumbs except the single truncated one
+  cy.viewport(768, 1024); // ipad-2
   cy.mount(
     <EuiBreadcrumbs
       max={4}
@@ -64,8 +65,8 @@ describe('EuiBreadcrumbs', () => {
     });
 
     it('has zero violations when truncated menu is open', () => {
-      cy.get('button.euiBreadcrumb__content').click();
-      cy.get('nav.euiBreadcrumbs').should('exist');
+      cy.get('[aria-label="See collapsed breadcrumbs"]').click();
+      cy.get('[data-popover-open="true"] nav.euiBreadcrumbs').should('exist');
       cy.checkAxe();
     });
   });

--- a/src/components/breadcrumbs/breadcrumbs.a11y.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.a11y.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiBreadcrumbs } from './breadcrumbs';
+
+const breadcrumbs = [
+  {
+    text: 'Animals',
+    href: '#',
+  },
+  {
+    text: 'Metazoans',
+    href: '#',
+  },
+  {
+    text: 'Chordates',
+    href: '#',
+  },
+  {
+    text: 'Vertebrates',
+    href: '#',
+  },
+  {
+    text: 'Tetrapods',
+    href: '#',
+  },
+  {
+    text: 'Reptiles',
+    href: '#',
+  },
+  {
+    text: 'Boa constrictor',
+    href: '#',
+  },
+  {
+    text: 'Nebulosa subspecies',
+  },
+];
+
+beforeEach(() => {
+  cy.viewport('ipad-2'); // Displays all breadcrumbs except the single truncated one
+  cy.mount(
+    <EuiBreadcrumbs
+      max={4}
+      breadcrumbs={breadcrumbs}
+      aria-label="An example of EuiBreadcrumbs with specifying max prop"
+    />
+  );
+  cy.get('ol.euiBreadcrumbs__list').should('exist');
+});
+
+describe('EuiBreadcrumbs', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when truncated menu is open', () => {
+      cy.get('button.euiBreadcrumb__content').click();
+      cy.get('nav.euiBreadcrumbs').should('exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/breadcrumbs/breadcrumbs.a11y.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.a11y.tsx
@@ -47,7 +47,7 @@ const breadcrumbs = [
 
 beforeEach(() => {
   // Displays all breadcrumbs except the single truncated one
-  cy.viewport(768, 1024); // ipad-2
+  cy.viewport(768, 1024); // medium breakpoint
   cy.mount(
     <EuiBreadcrumbs
       max={4}

--- a/src/components/pagination/pagination.a11y.tsx
+++ b/src/components/pagination/pagination.a11y.tsx
@@ -13,12 +13,11 @@ import { EuiPagination } from './pagination';
 
 const Pagination = () => {
   const [activePage, setActivePage] = useState(0);
-  const PAGE_COUNT = 22;
 
   return (
     <EuiPagination
       aria-label="Many pages example"
-      pageCount={PAGE_COUNT}
+      pageCount={22}
       activePage={activePage}
       onPageClick={(activePage) => setActivePage(activePage)}
     />
@@ -28,13 +27,14 @@ const Pagination = () => {
 describe('EuiPagination', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on first mobile render', () => {
+      cy.viewport(375, 667); // iphone-se2
       cy.mount(<Pagination />);
       cy.get('nav.euiPagination').should('exist');
       cy.checkAxe();
     });
 
     it('has zero violations when rendered using non-mobile breakpoint', () => {
-      cy.viewport('macbook-13');
+      cy.viewport(1280, 800); //macbook-13
       cy.mount(<Pagination />);
       cy.get('nav.euiPagination').should('exist');
       cy.checkAxe();

--- a/src/components/pagination/pagination.a11y.tsx
+++ b/src/components/pagination/pagination.a11y.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiPagination } from './pagination';
+
+const Pagination = () => {
+  const [activePage, setActivePage] = useState(0);
+  const PAGE_COUNT = 22;
+
+  return (
+    <EuiPagination
+      aria-label="Many pages example"
+      pageCount={PAGE_COUNT}
+      activePage={activePage}
+      onPageClick={(activePage) => setActivePage(activePage)}
+    />
+  );
+};
+
+describe('EuiPagination', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first mobile render', () => {
+      cy.mount(<Pagination />);
+      cy.get('nav.euiPagination').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations when rendered using non-mobile breakpoint', () => {
+      cy.viewport('macbook-13');
+      cy.mount(<Pagination />);
+      cy.get('nav.euiPagination').should('exist');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/pagination/pagination.a11y.tsx
+++ b/src/components/pagination/pagination.a11y.tsx
@@ -27,7 +27,7 @@ const Pagination = () => {
 describe('EuiPagination', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on first mobile render', () => {
-      cy.viewport(375, 667); // iphone-se2
+      cy.viewport(375, 667); // small breakpoint
       cy.mount(<Pagination />);
       cy.get('nav.euiPagination').should('exist');
       cy.checkAxe();

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -1,0 +1,268 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiSideNav } from './side_nav';
+import { EuiIcon } from '../icon';
+import { htmlIdGenerator } from '../../services';
+
+const SimpleSideNav = () => {
+  const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
+  const toggleOpenOnMobile = () => {
+    setisSideNavOpenOnMobile(!isSideNavOpenOnMobile);
+  };
+  const basicSideNav = [
+    {
+      name: 'Root item',
+      id: htmlIdGenerator('basicExample')(),
+      items: [
+        {
+          name: 'Item with onClick',
+          id: htmlIdGenerator('basicExample')(),
+        },
+        {
+          name: 'Item with href',
+          id: htmlIdGenerator('basicExample')(),
+          href: '/#/navigation/side-nav',
+        },
+        {
+          name: 'Selected item',
+          id: htmlIdGenerator('basicExample')(),
+          isSelected: true,
+        },
+        {
+          name: 'Disabled item',
+          id: htmlIdGenerator('basicExample')(),
+          disabled: true,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <EuiSideNav
+      aria-label="Basic example"
+      mobileTitle="Basic example"
+      toggleOpenOnMobile={() => toggleOpenOnMobile()}
+      isOpenOnMobile={isSideNavOpenOnMobile}
+      style={{ width: 192 }}
+      items={basicSideNav}
+    />
+  );
+};
+
+const ComplexSideNav = () => {
+  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
+  const [selectedItemName, setSelectedItem] = useState('Time stuff');
+
+  const toggleOpenOnMobile = () => {
+    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
+  };
+
+  const selectItem = (name) => {
+    setSelectedItem(name);
+  };
+
+  const createItem = (name, data = {}) => {
+    // NOTE: Duplicate `name` values will cause `id` collisions.
+    return {
+      id: `${name}-id`,
+      name,
+      isSelected: selectedItemName === name,
+      onClick: () => selectItem(name),
+      ...data,
+    };
+  };
+
+  const complexSideNav = [
+    createItem('Elasticsearch', {
+      onClick: undefined,
+      icon: <EuiIcon type="logoElasticsearch" />,
+      items: [
+        createItem('Data sources'),
+        createItem('Users'),
+        createItem('Roles'),
+        createItem('Watches'),
+        createItem(
+          'Extremely long title will become truncated when the browser is narrow enough'
+        ),
+      ],
+    }),
+    createItem('Kibana', {
+      onClick: undefined,
+      icon: <EuiIcon type="logoKibana" />,
+      items: [
+        createItem('Advanced settings', {
+          items: [
+            createItem('General', { disabled: true }),
+            createItem('Timelion', {
+              items: [
+                createItem('Time stuff', {
+                  icon: <EuiIcon type="clock" />,
+                }),
+                createItem('Lion stuff', {
+                  icon: <EuiIcon type="stats" />,
+                }),
+              ],
+            }),
+            createItem('Visualizations'),
+          ],
+        }),
+        createItem('Index Patterns'),
+        createItem('Saved Objects'),
+        createItem('Reporting'),
+      ],
+    }),
+    createItem('Logstash', {
+      onClick: undefined,
+      icon: <EuiIcon type="logoLogstash" />,
+      items: [createItem('Pipeline viewer')],
+    }),
+  ];
+
+  return (
+    <EuiSideNav
+      aria-label="Complex example"
+      mobileTitle="Navigate within $APP_NAME"
+      toggleOpenOnMobile={toggleOpenOnMobile}
+      isOpenOnMobile={isSideNavOpenOnMobile}
+      items={complexSideNav}
+      style={{ width: 192 }}
+    />
+  );
+};
+
+const NestedSideNav = () => {
+  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
+  const [selectedItemName, setSelectedItem] = useState(null);
+
+  const toggleOpenOnMobile = () => {
+    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
+  };
+
+  const selectItem = (name) => {
+    setSelectedItem(name);
+  };
+
+  const createItem = (name, data = {}) => {
+    // NOTE: Duplicate `name` values will cause `id` collisions.
+    return {
+      id: name,
+      name,
+      isSelected: selectedItemName === name,
+      onClick: () => selectItem(name),
+      ...data,
+    };
+  };
+
+  const nestedSideNav = [
+    {
+      name: 'Kibana',
+      id: 'Kibana',
+      icon: <EuiIcon type="logoKibana" />,
+      items: [
+        createItem('Has normal children', {
+          items: [
+            createItem('Without forceOpen', {
+              items: [createItem('Child 1'), createItem('Child 2')],
+            }),
+          ],
+        }),
+        createItem('Normally not open', {
+          items: [
+            createItem('Has forceOpen:true', {
+              forceOpen: true,
+              items: [createItem('Child 3'), createItem('Child 4')],
+            }),
+          ],
+        }),
+        createItem('With forceOpen:true', {
+          forceOpen: true,
+          items: [
+            createItem('Normal child', {
+              items: [createItem('Child 5'), createItem('Child 6')],
+            }),
+          ],
+        }),
+        createItem('Children only, no link', {
+          onClick: undefined,
+          items: [
+            createItem('Another child', {
+              items: [createItem('Child 7'), createItem('Child 8')],
+            }),
+          ],
+        }),
+      ],
+    },
+  ];
+
+  return (
+    <EuiSideNav
+      aria-label="Force-open example"
+      mobileTitle="Navigate within $APP_NAME"
+      toggleOpenOnMobile={toggleOpenOnMobile}
+      isOpenOnMobile={isSideNavOpenOnMobile}
+      items={nestedSideNav}
+      style={{ width: 192 }}
+    />
+  );
+};
+
+describe('Simple EuiSidenav', () => {
+  beforeEach(() => {
+    cy.mount(<SimpleSideNav />);
+  });
+
+  describe('Automated accessibility check', () => {
+    it('has zero violations when mobile side nav is rendered', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when mobile side nav is expanded', () => {
+      cy.get('button').contains('Basic example').click();
+      cy.get('div.euiSideNav__content').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations when rendered using non-mobile breakpoint', () => {
+      cy.viewport('ipad-2');
+      cy.get('nav.euiSideNav').should('exist');
+      cy.checkAxe();
+    });
+  });
+});
+
+describe('Complex EuiSidenav', () => {
+  beforeEach(() => {
+    cy.viewport('ipad-2');
+    cy.mount(<ComplexSideNav />);
+    cy.get('nav.euiSideNav').should('exist');
+  });
+
+  describe('Automated accessibility check', () => {
+    it('has zero violations when complex side nav is rendered', () => {
+      cy.checkAxe();
+    });
+  });
+});
+
+describe('Nested EuiSidenav', () => {
+  beforeEach(() => {
+    cy.viewport('ipad-2');
+    cy.mount(<NestedSideNav />);
+    cy.get('nav.euiSideNav').should('exist');
+  });
+
+  describe('Automated accessibility check', () => {
+    it('has zero violations when complex side nav is rendered', () => {
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -14,7 +14,7 @@ import { EuiIcon } from '../icon';
 import { htmlIdGenerator } from '../../services';
 
 describe('EuiSideNav', () => {
-  describe('Mobile EuiSidenav', () => {
+  describe('Mobile EuiSideNav', () => {
     const MobileSideNav = () => {
       const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
       const toggleOpenOnMobile = () => {
@@ -61,7 +61,7 @@ describe('EuiSideNav', () => {
     };
 
     beforeEach(() => {
-      cy.viewport(375, 667); // iphone-se2
+      cy.viewport(375, 667); // small breakpoint
       cy.mount(<MobileSideNav />);
     });
 
@@ -78,7 +78,7 @@ describe('EuiSideNav', () => {
     });
   });
 
-  describe('Simple EuiSidenav', () => {
+  describe('Simple EuiSideNav', () => {
     const SimpleSideNav = () => {
       const basicSideNav = [
         {
@@ -118,7 +118,7 @@ describe('EuiSideNav', () => {
     };
 
     beforeEach(() => {
-      cy.viewport(768, 1024); // ipad-2
+      cy.viewport(768, 1024); // medium breakpoint
       cy.mount(<SimpleSideNav />);
       cy.get('nav.euiSideNav').should('exist');
     });
@@ -131,7 +131,7 @@ describe('EuiSideNav', () => {
     });
   });
 
-  describe('Nested EuiSidenav', () => {
+  describe('Nested EuiSideNav', () => {
     const NestedSideNav = () => {
       const nestedSideNav = [
         {
@@ -208,7 +208,7 @@ describe('EuiSideNav', () => {
     };
 
     beforeEach(() => {
-      cy.viewport(768, 1024); // ipad-2
+      cy.viewport(768, 1024); // medium breakpoint
       cy.mount(<NestedSideNav />);
       cy.get('nav.euiSideNav').should('exist');
     });
@@ -220,7 +220,7 @@ describe('EuiSideNav', () => {
     });
   });
 
-  describe('Complex EuiSidenav', () => {
+  describe('Complex EuiSideNav', () => {
     const ComplexSideNav = () => {
       const complexSideNav = [
         {
@@ -342,7 +342,7 @@ describe('EuiSideNav', () => {
     };
 
     beforeEach(() => {
-      cy.viewport(768, 1024); // ipad-2
+      cy.viewport(768, 1024); // medium breakpoint
       cy.mount(<ComplexSideNav />);
       cy.get('nav.euiSideNav').should('exist');
     });

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -63,6 +63,7 @@ describe('EuiSideNav', () => {
     beforeEach(() => {
       cy.viewport(375, 667); // iphone-se2
       cy.mount(<MobileSideNav />);
+      cy.get('nav.euiSideNav').should('exist');
     });
 
     describe('Automated accessibility check', () => {

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -13,341 +13,343 @@ import { EuiSideNav } from './side_nav';
 import { EuiIcon } from '../icon';
 import { htmlIdGenerator } from '../../services';
 
-describe('Mobile EuiSidenav', () => {
-  const MobileSideNav = () => {
-    const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
-    const toggleOpenOnMobile = () => {
-      setisSideNavOpenOnMobile(!isSideNavOpenOnMobile);
+describe('EuiSideNav', () => {
+  describe('Mobile EuiSidenav', () => {
+    const MobileSideNav = () => {
+      const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
+      const toggleOpenOnMobile = () => {
+        setisSideNavOpenOnMobile(!isSideNavOpenOnMobile);
+      };
+      const basicSideNav = [
+        {
+          name: 'Root item',
+          id: htmlIdGenerator('basicExample')(),
+          items: [
+            {
+              name: 'Item with onClick',
+              id: htmlIdGenerator('basicExample')(),
+            },
+            {
+              name: 'Item with href',
+              id: htmlIdGenerator('basicExample')(),
+              href: '/#/navigation/side-nav',
+            },
+            {
+              name: 'Selected item',
+              id: htmlIdGenerator('basicExample')(),
+              isSelected: true,
+            },
+            {
+              name: 'Disabled item',
+              id: htmlIdGenerator('basicExample')(),
+              disabled: true,
+            },
+          ],
+        },
+      ];
+
+      return (
+        <EuiSideNav
+          aria-label="Basic example"
+          mobileTitle="Basic example"
+          toggleOpenOnMobile={() => toggleOpenOnMobile()}
+          isOpenOnMobile={isSideNavOpenOnMobile}
+          style={{ width: 192 }}
+          items={basicSideNav}
+        />
+      );
     };
-    const basicSideNav = [
-      {
-        name: 'Root item',
-        id: htmlIdGenerator('basicExample')(),
-        items: [
-          {
-            name: 'Item with onClick',
-            id: htmlIdGenerator('basicExample')(),
-          },
-          {
-            name: 'Item with href',
-            id: htmlIdGenerator('basicExample')(),
-            href: '/#/navigation/side-nav',
-          },
-          {
-            name: 'Selected item',
-            id: htmlIdGenerator('basicExample')(),
-            isSelected: true,
-          },
-          {
-            name: 'Disabled item',
-            id: htmlIdGenerator('basicExample')(),
-            disabled: true,
-          },
-        ],
-      },
-    ];
 
-    return (
-      <EuiSideNav
-        aria-label="Basic example"
-        mobileTitle="Basic example"
-        toggleOpenOnMobile={() => toggleOpenOnMobile()}
-        isOpenOnMobile={isSideNavOpenOnMobile}
-        style={{ width: 192 }}
-        items={basicSideNav}
-      />
-    );
-  };
-
-  beforeEach(() => {
-    cy.viewport(375, 667); // iphone-se2
-    cy.mount(<MobileSideNav />);
-  });
-
-  describe('Automated accessibility check', () => {
-    it('has zero violations when mobile side nav is rendered', () => {
-      cy.checkAxe();
+    beforeEach(() => {
+      cy.viewport(375, 667); // iphone-se2
+      cy.mount(<MobileSideNav />);
     });
 
-    it('has zero violations when mobile side nav is expanded', () => {
-      cy.get('button').contains('Basic example').click();
-      cy.get('div.euiSideNav__content').should('exist');
-      cy.checkAxe();
+    describe('Automated accessibility check', () => {
+      it('has zero violations when mobile side nav is rendered', () => {
+        cy.checkAxe();
+      });
+
+      it('has zero violations when mobile side nav is expanded', () => {
+        cy.get('button').contains('Basic example').click();
+        cy.get('div.euiSideNav__content').should('exist');
+        cy.checkAxe();
+      });
     });
   });
-});
 
-describe('Simple EuiSidenav', () => {
-  const SimpleSideNav = () => {
-    const basicSideNav = [
-      {
-        name: 'Root item',
-        id: htmlIdGenerator('basicExample')(),
-        items: [
-          {
-            name: 'Item with onClick',
-            id: htmlIdGenerator('basicExample')(),
-          },
-          {
-            name: 'Item with href',
-            id: htmlIdGenerator('basicExample')(),
-            href: '/#/navigation/side-nav',
-          },
-          {
-            name: 'Selected item',
-            id: htmlIdGenerator('basicExample')(),
-            isSelected: true,
-          },
-          {
-            name: 'Disabled item',
-            id: htmlIdGenerator('basicExample')(),
-            disabled: true,
-          },
-        ],
-      },
-    ];
+  describe('Simple EuiSidenav', () => {
+    const SimpleSideNav = () => {
+      const basicSideNav = [
+        {
+          name: 'Root item',
+          id: htmlIdGenerator('basicExample')(),
+          items: [
+            {
+              name: 'Item with onClick',
+              id: htmlIdGenerator('basicExample')(),
+            },
+            {
+              name: 'Item with href',
+              id: htmlIdGenerator('basicExample')(),
+              href: '/#/navigation/side-nav',
+            },
+            {
+              name: 'Selected item',
+              id: htmlIdGenerator('basicExample')(),
+              isSelected: true,
+            },
+            {
+              name: 'Disabled item',
+              id: htmlIdGenerator('basicExample')(),
+              disabled: true,
+            },
+          ],
+        },
+      ];
 
-    return (
-      <EuiSideNav
-        aria-label="Basic example"
-        style={{ width: 192 }}
-        items={basicSideNav}
-      />
-    );
-  };
+      return (
+        <EuiSideNav
+          aria-label="Basic example"
+          style={{ width: 192 }}
+          items={basicSideNav}
+        />
+      );
+    };
 
-  beforeEach(() => {
-    cy.viewport(768, 1024); // ipad-2
-    cy.mount(<SimpleSideNav />);
+    beforeEach(() => {
+      cy.viewport(768, 1024); // ipad-2
+      cy.mount(<SimpleSideNav />);
+    });
+
+    describe('Automated accessibility check', () => {
+      it('has zero violations when rendered using non-mobile breakpoint', () => {
+        cy.get('nav.euiSideNav').should('exist');
+        cy.checkAxe();
+      });
+    });
   });
 
-  describe('Automated accessibility check', () => {
-    it('has zero violations when rendered using non-mobile breakpoint', () => {
+  describe('Nested EuiSidenav', () => {
+    const NestedSideNav = () => {
+      const nestedSideNav = [
+        {
+          name: 'Kibana',
+          id: 'kibana-1',
+          icon: <EuiIcon type="logoKibana" />,
+          isSelected: false,
+          items: [
+            {
+              name: 'Has normal children',
+              id: 'has-normal-children-1',
+              isSelected: false,
+            },
+            {
+              name: 'Normally not open',
+              id: 'normally-not-open-1',
+              isSelected: false,
+              items: [
+                {
+                  name: 'Open by override',
+                  id: 'open-by-override-1',
+                  isSelected: false,
+                  forceOpen: true,
+                  items: [
+                    {
+                      name: 'Child 3',
+                      id: 'child-3-1',
+                      isSelected: true,
+                    },
+                    {
+                      name: 'Child 4',
+                      id: 'child-4-1',
+                      isSelected: false,
+                    },
+                    {
+                      name: 'Child 5',
+                      id: 'child-5-1',
+                      isSelected: false,
+                    },
+                    {
+                      name: 'Child 6',
+                      id: 'child-6-1',
+                      isSelected: false,
+                      disabled: true,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              name: 'Has expanded children',
+              id: 'has-expanded-children-1',
+              isSelected: false,
+              forceOpen: true,
+              items: [
+                {
+                  name: 'Child 7',
+                  id: 'child-7-1',
+                  isSelected: false,
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      return (
+        <EuiSideNav
+          aria-label="Force-open example"
+          items={nestedSideNav}
+          style={{ width: 192 }}
+        />
+      );
+    };
+
+    beforeEach(() => {
+      cy.viewport(768, 1024); // ipad-2
+      cy.mount(<NestedSideNav />);
       cy.get('nav.euiSideNav').should('exist');
-      cy.checkAxe();
+    });
+
+    describe('Automated accessibility check', () => {
+      it('has zero violations when complex side nav is rendered', () => {
+        cy.checkAxe();
+      });
     });
   });
-});
 
-describe('Nested EuiSidenav', () => {
-  const NestedSideNav = () => {
-    const nestedSideNav = [
-      {
-        name: 'Kibana',
-        id: 'kibana-1',
-        icon: <EuiIcon type="logoKibana" />,
-        isSelected: false,
-        items: [
-          {
-            name: 'Has normal children',
-            id: 'has-normal-children-1',
-            isSelected: false,
-          },
-          {
-            name: 'Normally not open',
-            id: 'normally-not-open-1',
-            isSelected: false,
-            items: [
-              {
-                name: 'Open by override',
-                id: 'open-by-override-1',
-                isSelected: false,
-                forceOpen: true,
-                items: [
-                  {
-                    name: 'Child 3',
-                    id: 'child-3-1',
-                    isSelected: true,
-                  },
-                  {
-                    name: 'Child 4',
-                    id: 'child-4-1',
-                    isSelected: false,
-                  },
-                  {
-                    name: 'Child 5',
-                    id: 'child-5-1',
-                    isSelected: false,
-                  },
-                  {
-                    name: 'Child 6',
-                    id: 'child-6-1',
-                    isSelected: false,
-                    disabled: true,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            name: 'Has expanded children',
-            id: 'has-expanded-children-1',
-            isSelected: false,
-            forceOpen: true,
-            items: [
-              {
-                name: 'Child 7',
-                id: 'child-7-1',
-                isSelected: false,
-              },
-            ],
-          },
-        ],
-      },
-    ];
+  describe('Complex EuiSidenav', () => {
+    const ComplexSideNav = () => {
+      const complexSideNav = [
+        {
+          name: 'Elasticsearch',
+          id: 'elasticsearch-1',
+          icon: <EuiIcon type="logoElasticsearch" />,
+          isSelected: false,
+          items: [
+            {
+              name: 'Data sources',
+              id: 'data-sources-1',
+              isSelected: false,
+            },
+            {
+              name: 'Users',
+              id: 'users-1',
+              isSelected: false,
+            },
+            {
+              name: 'Roles',
+              id: 'roles-1',
+              isSelected: false,
+            },
+            {
+              name: 'Watches',
+              id: 'watches-1',
+              isSelected: false,
+            },
+            {
+              name:
+                'Extremely long title will become truncated when the browser is narrow enough',
+              id: 'extremely-long-title-1',
+              isSelected: false,
+            },
+          ],
+        },
+        {
+          name: 'Kibana',
+          id: 'kibana-1',
+          icon: <EuiIcon type="logoKibana" />,
+          isSelected: false,
+          items: [
+            {
+              name: 'Advanced settings',
+              id: 'advanced-settings-1',
+              isSelected: false,
+              items: [
+                {
+                  name: 'General',
+                  id: 'general-1',
+                  isSelected: false,
+                  disabled: true,
+                },
+                {
+                  name: 'Timelion',
+                  id: 'timelino-1',
+                  isSelected: false,
+                  items: [
+                    {
+                      name: 'Time stuff',
+                      id: 'time-stuff-1',
+                      icon: <EuiIcon type="clock" />,
+                      isSelected: true,
+                    },
+                    {
+                      name: 'Lion stuff',
+                      id: 'lion-stuff-1',
+                      icon: <EuiIcon type="stats" />,
+                      isSelected: false,
+                    },
+                  ],
+                },
+                {
+                  name: 'Visualizations',
+                  id: 'visualizations-1',
+                  isSelected: false,
+                },
+              ],
+            },
+            {
+              name: 'Index patterns',
+              id: 'index-patterns-1',
+              isSelected: false,
+            },
+            {
+              name: 'Saved objects',
+              id: 'saved-objects-1',
+              isSelected: false,
+            },
+            {
+              name: 'Reporting',
+              id: 'reporting-1',
+              isSelected: false,
+            },
+          ],
+        },
+        {
+          name: 'Logstash',
+          id: 'logstash-1',
+          icon: <EuiIcon type="logoLogstash" />,
+          isSelected: false,
+          items: [
+            {
+              name: 'Pipeline viewer',
+              id: 'data-sources-1',
+              isSelected: false,
+            },
+          ],
+        },
+      ];
 
-    return (
-      <EuiSideNav
-        aria-label="Force-open example"
-        items={nestedSideNav}
-        style={{ width: 192 }}
-      />
-    );
-  };
+      return (
+        <EuiSideNav
+          aria-label="Complex example"
+          items={complexSideNav}
+          style={{ width: 192 }}
+        />
+      );
+    };
 
-  beforeEach(() => {
-    cy.viewport(768, 1024); // ipad-2
-    cy.mount(<NestedSideNav />);
-    cy.get('nav.euiSideNav').should('exist');
-  });
-
-  describe('Automated accessibility check', () => {
-    it('has zero violations when complex side nav is rendered', () => {
-      cy.checkAxe();
+    beforeEach(() => {
+      cy.viewport(768, 1024); // ipad-2
+      cy.mount(<ComplexSideNav />);
+      cy.get('nav.euiSideNav').should('exist');
     });
-  });
-});
 
-describe('Complex EuiSidenav', () => {
-  const ComplexSideNav = () => {
-    const complexSideNav = [
-      {
-        name: 'Elasticsearch',
-        id: 'elasticsearch-1',
-        icon: <EuiIcon type="logoElasticsearch" />,
-        isSelected: false,
-        items: [
-          {
-            name: 'Data sources',
-            id: 'data-sources-1',
-            isSelected: false,
-          },
-          {
-            name: 'Users',
-            id: 'users-1',
-            isSelected: false,
-          },
-          {
-            name: 'Roles',
-            id: 'roles-1',
-            isSelected: false,
-          },
-          {
-            name: 'Watches',
-            id: 'watches-1',
-            isSelected: false,
-          },
-          {
-            name:
-              'Extremely long title will become truncated when the browser is narrow enough',
-            id: 'extremely-long-title-1',
-            isSelected: false,
-          },
-        ],
-      },
-      {
-        name: 'Kibana',
-        id: 'kibana-1',
-        icon: <EuiIcon type="logoKibana" />,
-        isSelected: false,
-        items: [
-          {
-            name: 'Advanced settings',
-            id: 'advanced-settings-1',
-            isSelected: false,
-            items: [
-              {
-                name: 'General',
-                id: 'general-1',
-                isSelected: false,
-                disabled: true,
-              },
-              {
-                name: 'Timelion',
-                id: 'timelino-1',
-                isSelected: false,
-                items: [
-                  {
-                    name: 'Time stuff',
-                    id: 'time-stuff-1',
-                    icon: <EuiIcon type="clock" />,
-                    isSelected: true,
-                  },
-                  {
-                    name: 'Lion stuff',
-                    id: 'lion-stuff-1',
-                    icon: <EuiIcon type="stats" />,
-                    isSelected: false,
-                  },
-                ],
-              },
-              {
-                name: 'Visualizations',
-                id: 'visualizations-1',
-                isSelected: false,
-              },
-            ],
-          },
-          {
-            name: 'Index patterns',
-            id: 'index-patterns-1',
-            isSelected: false,
-          },
-          {
-            name: 'Saved objects',
-            id: 'saved-objects-1',
-            isSelected: false,
-          },
-          {
-            name: 'Reporting',
-            id: 'reporting-1',
-            isSelected: false,
-          },
-        ],
-      },
-      {
-        name: 'Logstash',
-        id: 'logstash-1',
-        icon: <EuiIcon type="logoLogstash" />,
-        isSelected: false,
-        items: [
-          {
-            name: 'Pipeline viewer',
-            id: 'data-sources-1',
-            isSelected: false,
-          },
-        ],
-      },
-    ];
-
-    return (
-      <EuiSideNav
-        aria-label="Complex example"
-        items={complexSideNav}
-        style={{ width: 192 }}
-      />
-    );
-  };
-
-  beforeEach(() => {
-    cy.viewport(768, 1024); // ipad-2
-    cy.mount(<ComplexSideNav />);
-    cy.get('nav.euiSideNav').should('exist');
-  });
-
-  describe('Automated accessibility check', () => {
-    it('has zero violations when complex side nav is rendered', () => {
-      cy.checkAxe();
+    describe('Automated accessibility check', () => {
+      it('has zero violations when complex side nav is rendered', () => {
+        cy.checkAxe();
+      });
     });
   });
 });

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -13,211 +13,55 @@ import { EuiSideNav } from './side_nav';
 import { EuiIcon } from '../icon';
 import { htmlIdGenerator } from '../../services';
 
-const SimpleSideNav = () => {
-  const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
-  const toggleOpenOnMobile = () => {
-    setisSideNavOpenOnMobile(!isSideNavOpenOnMobile);
-  };
-  const basicSideNav = [
-    {
-      name: 'Root item',
-      id: htmlIdGenerator('basicExample')(),
-      items: [
-        {
-          name: 'Item with onClick',
-          id: htmlIdGenerator('basicExample')(),
-        },
-        {
-          name: 'Item with href',
-          id: htmlIdGenerator('basicExample')(),
-          href: '/#/navigation/side-nav',
-        },
-        {
-          name: 'Selected item',
-          id: htmlIdGenerator('basicExample')(),
-          isSelected: true,
-        },
-        {
-          name: 'Disabled item',
-          id: htmlIdGenerator('basicExample')(),
-          disabled: true,
-        },
-      ],
-    },
-  ];
-
-  return (
-    <EuiSideNav
-      aria-label="Basic example"
-      mobileTitle="Basic example"
-      toggleOpenOnMobile={() => toggleOpenOnMobile()}
-      isOpenOnMobile={isSideNavOpenOnMobile}
-      style={{ width: 192 }}
-      items={basicSideNav}
-    />
-  );
-};
-
-const ComplexSideNav = () => {
-  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
-  const [selectedItemName, setSelectedItem] = useState('Time stuff');
-
-  const toggleOpenOnMobile = () => {
-    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
-  };
-
-  const selectItem = (name) => {
-    setSelectedItem(name);
-  };
-
-  const createItem = (name, data = {}) => {
-    // NOTE: Duplicate `name` values will cause `id` collisions.
-    return {
-      id: `${name}-id`,
-      name,
-      isSelected: selectedItemName === name,
-      onClick: () => selectItem(name),
-      ...data,
+describe('Mobile EuiSidenav', () => {
+  const MobileSideNav = () => {
+    const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
+    const toggleOpenOnMobile = () => {
+      setisSideNavOpenOnMobile(!isSideNavOpenOnMobile);
     };
+    const basicSideNav = [
+      {
+        name: 'Root item',
+        id: htmlIdGenerator('basicExample')(),
+        items: [
+          {
+            name: 'Item with onClick',
+            id: htmlIdGenerator('basicExample')(),
+          },
+          {
+            name: 'Item with href',
+            id: htmlIdGenerator('basicExample')(),
+            href: '/#/navigation/side-nav',
+          },
+          {
+            name: 'Selected item',
+            id: htmlIdGenerator('basicExample')(),
+            isSelected: true,
+          },
+          {
+            name: 'Disabled item',
+            id: htmlIdGenerator('basicExample')(),
+            disabled: true,
+          },
+        ],
+      },
+    ];
+
+    return (
+      <EuiSideNav
+        aria-label="Basic example"
+        mobileTitle="Basic example"
+        toggleOpenOnMobile={() => toggleOpenOnMobile()}
+        isOpenOnMobile={isSideNavOpenOnMobile}
+        style={{ width: 192 }}
+        items={basicSideNav}
+      />
+    );
   };
 
-  const complexSideNav = [
-    createItem('Elasticsearch', {
-      onClick: undefined,
-      icon: <EuiIcon type="logoElasticsearch" />,
-      items: [
-        createItem('Data sources'),
-        createItem('Users'),
-        createItem('Roles'),
-        createItem('Watches'),
-        createItem(
-          'Extremely long title will become truncated when the browser is narrow enough'
-        ),
-      ],
-    }),
-    createItem('Kibana', {
-      onClick: undefined,
-      icon: <EuiIcon type="logoKibana" />,
-      items: [
-        createItem('Advanced settings', {
-          items: [
-            createItem('General', { disabled: true }),
-            createItem('Timelion', {
-              items: [
-                createItem('Time stuff', {
-                  icon: <EuiIcon type="clock" />,
-                }),
-                createItem('Lion stuff', {
-                  icon: <EuiIcon type="stats" />,
-                }),
-              ],
-            }),
-            createItem('Visualizations'),
-          ],
-        }),
-        createItem('Index Patterns'),
-        createItem('Saved Objects'),
-        createItem('Reporting'),
-      ],
-    }),
-    createItem('Logstash', {
-      onClick: undefined,
-      icon: <EuiIcon type="logoLogstash" />,
-      items: [createItem('Pipeline viewer')],
-    }),
-  ];
-
-  return (
-    <EuiSideNav
-      aria-label="Complex example"
-      mobileTitle="Navigate within $APP_NAME"
-      toggleOpenOnMobile={toggleOpenOnMobile}
-      isOpenOnMobile={isSideNavOpenOnMobile}
-      items={complexSideNav}
-      style={{ width: 192 }}
-    />
-  );
-};
-
-const NestedSideNav = () => {
-  const [isSideNavOpenOnMobile, setIsSideNavOpenOnMobile] = useState(false);
-  const [selectedItemName, setSelectedItem] = useState(null);
-
-  const toggleOpenOnMobile = () => {
-    setIsSideNavOpenOnMobile(!isSideNavOpenOnMobile);
-  };
-
-  const selectItem = (name) => {
-    setSelectedItem(name);
-  };
-
-  const createItem = (name, data = {}) => {
-    // NOTE: Duplicate `name` values will cause `id` collisions.
-    return {
-      id: name,
-      name,
-      isSelected: selectedItemName === name,
-      onClick: () => selectItem(name),
-      ...data,
-    };
-  };
-
-  const nestedSideNav = [
-    {
-      name: 'Kibana',
-      id: 'Kibana',
-      icon: <EuiIcon type="logoKibana" />,
-      items: [
-        createItem('Has normal children', {
-          items: [
-            createItem('Without forceOpen', {
-              items: [createItem('Child 1'), createItem('Child 2')],
-            }),
-          ],
-        }),
-        createItem('Normally not open', {
-          items: [
-            createItem('Has forceOpen:true', {
-              forceOpen: true,
-              items: [createItem('Child 3'), createItem('Child 4')],
-            }),
-          ],
-        }),
-        createItem('With forceOpen:true', {
-          forceOpen: true,
-          items: [
-            createItem('Normal child', {
-              items: [createItem('Child 5'), createItem('Child 6')],
-            }),
-          ],
-        }),
-        createItem('Children only, no link', {
-          onClick: undefined,
-          items: [
-            createItem('Another child', {
-              items: [createItem('Child 7'), createItem('Child 8')],
-            }),
-          ],
-        }),
-      ],
-    },
-  ];
-
-  return (
-    <EuiSideNav
-      aria-label="Force-open example"
-      mobileTitle="Navigate within $APP_NAME"
-      toggleOpenOnMobile={toggleOpenOnMobile}
-      isOpenOnMobile={isSideNavOpenOnMobile}
-      items={nestedSideNav}
-      style={{ width: 192 }}
-    />
-  );
-};
-
-describe('Simple EuiSidenav', () => {
   beforeEach(() => {
-    cy.mount(<SimpleSideNav />);
+    cy.viewport(375, 667); // iphone-se2
+    cy.mount(<MobileSideNav />);
   });
 
   describe('Automated accessibility check', () => {
@@ -230,19 +74,140 @@ describe('Simple EuiSidenav', () => {
       cy.get('div.euiSideNav__content').should('exist');
       cy.checkAxe();
     });
+  });
+});
 
+describe('Simple EuiSidenav', () => {
+  const SimpleSideNav = () => {
+    const basicSideNav = [
+      {
+        name: 'Root item',
+        id: htmlIdGenerator('basicExample')(),
+        items: [
+          {
+            name: 'Item with onClick',
+            id: htmlIdGenerator('basicExample')(),
+          },
+          {
+            name: 'Item with href',
+            id: htmlIdGenerator('basicExample')(),
+            href: '/#/navigation/side-nav',
+          },
+          {
+            name: 'Selected item',
+            id: htmlIdGenerator('basicExample')(),
+            isSelected: true,
+          },
+          {
+            name: 'Disabled item',
+            id: htmlIdGenerator('basicExample')(),
+            disabled: true,
+          },
+        ],
+      },
+    ];
+
+    return (
+      <EuiSideNav
+        aria-label="Basic example"
+        style={{ width: 192 }}
+        items={basicSideNav}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    cy.viewport(768, 1024); // ipad-2
+    cy.mount(<SimpleSideNav />);
+  });
+
+  describe('Automated accessibility check', () => {
     it('has zero violations when rendered using non-mobile breakpoint', () => {
-      cy.viewport('ipad-2');
       cy.get('nav.euiSideNav').should('exist');
       cy.checkAxe();
     });
   });
 });
 
-describe('Complex EuiSidenav', () => {
+describe('Nested EuiSidenav', () => {
+  const NestedSideNav = () => {
+    const nestedSideNav = [
+      {
+        name: 'Kibana',
+        id: 'kibana-1',
+        icon: <EuiIcon type="logoKibana" />,
+        isSelected: false,
+        items: [
+          {
+            name: 'Has normal children',
+            id: 'has-normal-children-1',
+            isSelected: false,
+          },
+          {
+            name: 'Normally not open',
+            id: 'normally-not-open-1',
+            isSelected: false,
+            items: [
+              {
+                name: 'Open by override',
+                id: 'open-by-override-1',
+                isSelected: false,
+                forceOpen: true,
+                items: [
+                  {
+                    name: 'Child 3',
+                    id: 'child-3-1',
+                    isSelected: true,
+                  },
+                  {
+                    name: 'Child 4',
+                    id: 'child-4-1',
+                    isSelected: false,
+                  },
+                  {
+                    name: 'Child 5',
+                    id: 'child-5-1',
+                    isSelected: false,
+                  },
+                  {
+                    name: 'Child 6',
+                    id: 'child-6-1',
+                    isSelected: false,
+                    disabled: true,
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'Has expanded children',
+            id: 'has-expanded-children-1',
+            isSelected: false,
+            forceOpen: true,
+            items: [
+              {
+                name: 'Child 7',
+                id: 'child-7-1',
+                isSelected: false,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    return (
+      <EuiSideNav
+        aria-label="Force-open example"
+        items={nestedSideNav}
+        style={{ width: 192 }}
+      />
+    );
+  };
+
   beforeEach(() => {
-    cy.viewport('ipad-2');
-    cy.mount(<ComplexSideNav />);
+    cy.viewport(768, 1024); // ipad-2
+    cy.mount(<NestedSideNav />);
     cy.get('nav.euiSideNav').should('exist');
   });
 
@@ -253,10 +218,130 @@ describe('Complex EuiSidenav', () => {
   });
 });
 
-describe('Nested EuiSidenav', () => {
+describe('Complex EuiSidenav', () => {
+  const ComplexSideNav = () => {
+    const complexSideNav = [
+      {
+        name: 'Elasticsearch',
+        id: 'elasticsearch-1',
+        icon: <EuiIcon type="logoElasticsearch" />,
+        isSelected: false,
+        items: [
+          {
+            name: 'Data sources',
+            id: 'data-sources-1',
+            isSelected: false,
+          },
+          {
+            name: 'Users',
+            id: 'users-1',
+            isSelected: false,
+          },
+          {
+            name: 'Roles',
+            id: 'roles-1',
+            isSelected: false,
+          },
+          {
+            name: 'Watches',
+            id: 'watches-1',
+            isSelected: false,
+          },
+          {
+            name:
+              'Extremely long title will become truncated when the browser is narrow enough',
+            id: 'extremely-long-title-1',
+            isSelected: false,
+          },
+        ],
+      },
+      {
+        name: 'Kibana',
+        id: 'kibana-1',
+        icon: <EuiIcon type="logoKibana" />,
+        isSelected: false,
+        items: [
+          {
+            name: 'Advanced settings',
+            id: 'advanced-settings-1',
+            isSelected: false,
+            items: [
+              {
+                name: 'General',
+                id: 'general-1',
+                isSelected: false,
+                disabled: true,
+              },
+              {
+                name: 'Timelion',
+                id: 'timelino-1',
+                isSelected: false,
+                items: [
+                  {
+                    name: 'Time stuff',
+                    id: 'time-stuff-1',
+                    icon: <EuiIcon type="clock" />,
+                    isSelected: true,
+                  },
+                  {
+                    name: 'Lion stuff',
+                    id: 'lion-stuff-1',
+                    icon: <EuiIcon type="stats" />,
+                    isSelected: false,
+                  },
+                ],
+              },
+              {
+                name: 'Visualizations',
+                id: 'visualizations-1',
+                isSelected: false,
+              },
+            ],
+          },
+          {
+            name: 'Index patterns',
+            id: 'index-patterns-1',
+            isSelected: false,
+          },
+          {
+            name: 'Saved objects',
+            id: 'saved-objects-1',
+            isSelected: false,
+          },
+          {
+            name: 'Reporting',
+            id: 'reporting-1',
+            isSelected: false,
+          },
+        ],
+      },
+      {
+        name: 'Logstash',
+        id: 'logstash-1',
+        icon: <EuiIcon type="logoLogstash" />,
+        isSelected: false,
+        items: [
+          {
+            name: 'Pipeline viewer',
+            id: 'data-sources-1',
+            isSelected: false,
+          },
+        ],
+      },
+    ];
+
+    return (
+      <EuiSideNav
+        aria-label="Complex example"
+        items={complexSideNav}
+        style={{ width: 192 }}
+      />
+    );
+  };
+
   beforeEach(() => {
-    cy.viewport('ipad-2');
-    cy.mount(<NestedSideNav />);
+    cy.viewport(768, 1024); // ipad-2
+    cy.mount(<ComplexSideNav />);
     cy.get('nav.euiSideNav').should('exist');
   });
 

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -63,7 +63,6 @@ describe('EuiSideNav', () => {
     beforeEach(() => {
       cy.viewport(375, 667); // iphone-se2
       cy.mount(<MobileSideNav />);
-      cy.get('nav.euiSideNav').should('exist');
     });
 
     describe('Automated accessibility check', () => {
@@ -121,6 +120,7 @@ describe('EuiSideNav', () => {
     beforeEach(() => {
       cy.viewport(768, 1024); // ipad-2
       cy.mount(<SimpleSideNav />);
+      cy.get('nav.euiSideNav').should('exist');
     });
 
     describe('Automated accessibility check', () => {


### PR DESCRIPTION
## Summary
Adding specs to put three navigation patterns through the axe scanner. Experimented further with `beforeEach()` and using the Cypress viewport widths to toggle mobile and desktop layouts.

* Adding EuiBreadcrumb a11y spec.
* Adding EuiSideNav a11y spec.
* Adding EuiPagination a11y spec.

## QA

* Ran Cypress a11y specs on localhost in headless environment

### General checklist

- [x] Checked in **Chrome**, ~~**Safari**,~~ **Edge**, ~~and **Firefox**~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
