### PR TITLE
Specify the operator option when generating term queries.

### DIFF
--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
@@ -15,12 +15,18 @@ Object {
           "must": Array [
             Object {
               "match": Object {
-                "group": "kibana",
+                "group": Object {
+                  "operator": "and",
+                  "query": "kibana",
+                },
               },
             },
             Object {
               "match": Object {
-                "group": "logstash",
+                "group": Object {
+                  "operator": "and",
+                  "query": "logstash",
+                },
               },
             },
           ],
@@ -33,12 +39,18 @@ Object {
           "must": Array [
             Object {
               "match": Object {
-                "group": "es",
+                "group": Object {
+                  "operator": "and",
+                  "query": "es",
+                },
               },
             },
             Object {
               "match": Object {
-                "group": "beats",
+                "group": Object {
+                  "operator": "and",
+                  "query": "beats",
+                },
               },
             },
           ],
@@ -60,7 +72,10 @@ Object {
       },
       Object {
         "match": Object {
-          "group": "kibana",
+          "group": Object {
+            "operator": "and",
+            "query": "kibana",
+          },
         },
       },
       Object {
@@ -87,12 +102,18 @@ Object {
           "must": Array [
             Object {
               "match": Object {
-                "group": "eng",
+                "group": Object {
+                  "operator": "and",
+                  "query": "eng",
+                },
               },
             },
             Object {
               "match": Object {
-                "group": "es",
+                "group": Object {
+                  "operator": "and",
+                  "query": "es",
+                },
               },
             },
           ],
@@ -117,7 +138,10 @@ Object {
       },
       Object {
         "match": Object {
-          "group": "kibana",
+          "group": Object {
+            "operator": "and",
+            "query": "kibana",
+          },
         },
       },
     ],
@@ -160,7 +184,10 @@ Object {
           "should": Array [
             Object {
               "match": Object {
-                "group": "eng",
+                "group": Object {
+                  "operator": "or",
+                  "query": "eng",
+                },
               },
             },
             Object {
@@ -197,12 +224,18 @@ Object {
           "should": Array [
             Object {
               "match": Object {
-                "group": "eng",
+                "group": Object {
+                  "operator": "or",
+                  "query": "eng",
+                },
               },
             },
             Object {
               "match": Object {
-                "group": "es",
+                "group": Object {
+                  "operator": "or",
+                  "query": "es",
+                },
               },
             },
           ],
@@ -212,7 +245,10 @@ Object {
     "must_not": Array [
       Object {
         "match": Object {
-          "group": "kibana",
+          "group": Object {
+            "operator": "and",
+            "query": "kibana",
+          },
         },
       },
     ],
@@ -232,7 +268,10 @@ Object {
                 "must": Array [
                   Object {
                     "match": Object {
-                      "name": "john",
+                      "name": Object {
+                        "operator": "and",
+                        "query": "john",
+                      },
                     },
                   },
                 ],
@@ -243,7 +282,10 @@ Object {
                 "must": Array [
                   Object {
                     "match": Object {
-                      "name": "fred",
+                      "name": Object {
+                        "operator": "and",
+                        "query": "fred",
+                      },
                     },
                   },
                 ],
@@ -269,7 +311,10 @@ Object {
                 "must": Array [
                   Object {
                     "match": Object {
-                      "name": "john",
+                      "name": Object {
+                        "operator": "and",
+                        "query": "john",
+                      },
                     },
                   },
                 ],
@@ -425,7 +470,10 @@ Object {
           "must": Array [
             Object {
               "match": Object {
-                "name": "john",
+                "name": Object {
+                  "operator": "and",
+                  "query": "john",
+                },
               },
             },
           ],

--- a/src/components/search_bar/query/ast_to_es_query_dsl.ts
+++ b/src/components/search_bar/query/ast_to_es_query_dsl.ts
@@ -144,12 +144,21 @@ export const _fieldValuesToQuery = (
           queries.push({
             bool: {
               [andOr === 'and' ? 'must' : 'should']: [
-                ...terms.map((value) => ({ match: { [field]: value } })),
+                ...terms.map((value) => ({
+                  match: {
+                    [field]: {
+                      query: value,
+                      operator: andOr,
+                    },
+                  },
+                })),
               ],
             },
           });
         } else if (terms.length === 1) {
-          queries.push({ match: { [field]: terms[0] } });
+          queries.push({
+            match: { [field]: { query: terms[0], operator: andOr } },
+          });
         }
 
         if (phrases.length > 0) {

--- a/upcoming_changelogs/6409.md
+++ b/upcoming_changelogs/6409.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Restores the previous match operator behaviour when the query value is split into multiple terms after analysis.


### PR DESCRIPTION
This restores previous functionality when querying for multi-term values in analysed fields

Fixes https://github.com/elastic/eui/issues/6399

## Summary

Restores the previous match operator behaviour when the query value is split into multiple terms after analysis. 

## QA

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress]
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
