### PR TITLE
Changing label in `upgrading-kibana.md`

### DIFF
--- a/wiki/upgrading-kibana.md
+++ b/wiki/upgrading-kibana.md
@@ -16,7 +16,7 @@ If the upgrade includes a large number of commits or has known breaking changes,
 	  * Or run `yarn test:jest` locally
 9. Resolve and commit reported issues (see [Resolving errors](#resolving-errors))
 10. Open a PR or mark existing as "Ready for review" (see [PR template](#pr-template))
-    * Add the `EUI`, `ci:deploy-cloud`, `release_note:skip`, and relevant version tag(s) (the next minor version that has not yet entered feature freeze)
+    * Add the `EUI`, `ci:cloud-deploy`, `release_note:skip`, and relevant version tag(s) (the next minor version that has not yet entered feature freeze)
 	* We typically only merge into the main branch (the next minor version), but if an upgrade is specifically targeting a previous version, you can use the `auto-backport` tag to have Kibana automatically create a backport PR to an existing version branch.
     * Mention/ping any teams that are waiting on features to be available
 


### PR DESCRIPTION
## Summary

Step 10 of [Upgrading EUI in Kibana](https://github.com/elastic/eui/blob/main/wiki/upgrading-kibana.md) **Overview** lists a required tag as `ci:deploy-cloud` but the tag has been renamed to `ci:cloud-deploy` on Kibana. Updating to match.

### General checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
