### PR TITLE
[EuiFlyout][EuiCollapsibleNav] Fix broken slide in animation for left flyouts

### DIFF
--- a/src/components/flyout/flyout.styles.ts
+++ b/src/components/flyout/flyout.styles.ts
@@ -38,7 +38,7 @@ export const euiFlyoutSlideInLeft = keyframes`
   75% {
     opacity: 1;
     transform: translateX(0%);
-}
+  }
 `;
 
 export const euiFlyoutCloseButtonStyles = (euiThemeContext: UseEuiTheme) => {
@@ -144,7 +144,8 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       clip-path: polygon(0 0, 150% 0, 150% 100%, 0 100%);
 
       ${euiCanAnimate} {
-        animation: ${euiFlyoutSlideInLeft};
+        animation: ${euiFlyoutSlideInLeft} ${euiTheme.animation.normal}
+          ${euiTheme.animation.resistance};
       }
     `,
 

--- a/upcoming_changelogs/6422.md
+++ b/upcoming_changelogs/6422.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed missing slide-in animation on `EuiCollapsibleNav`s and left-side `EuiFlyout`s


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6419 

### Before:

Broken animation missing transform in from left: https://eui.elastic.co/v70.0.0/#/navigation/collapsible-nav

### After:

Original Sass animation: https://eui.elastic.co/v60.0.0/#/navigation/collapsible-nav
Fixed staging link: https://eui.elastic.co/pr_6422/#/navigation/collapsible-nav

## QA

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately