### PR TITLE
[EuiCard] Fix bug where footer were not getting aligned to the bottom

### DIFF
--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -74,6 +74,7 @@ export const euiCardStyles = (
       euiCard__main: css`
         display: flex;
         inline-size: 100%;
+        flex-grow: 1;
       `,
       layout: {
         vertical: css`

--- a/upcoming_changelogs/6424.md
+++ b/upcoming_changelogs/6424.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fix bug in `EuiCard` where footer were not aligned to the bottom of the card


### PR DESCRIPTION
## Summary

This PR fixes a bug where the **EuiCard** footer was not getting aligned to the bottom. This bug was introduced in #6348, where I added a new container and this new container was not vertically stretching. 

The issue was reported at https://github.com/elastic/kibana/issues/145962.

<img width="2261" alt="cards-footer-alignment@2x" src="https://user-images.githubusercontent.com/2750668/203328607-0f6f8ce5-b662-4752-a021-a68abcdadc7d.png">

### How to test?

The following example should have the footer aligned to the bottom:

- https://eui.elastic.co/pr_6424/#/display/card#footer

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
