### PR TITLE
[CSS-in-JS] Add utility for converting `style` to logical properties

### DIFF
--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -642,7 +642,7 @@ exports[`EuiCodeBlock virtualization renders a virtualized code block 1`] = `
   >
     <pre
       class="euiCodeBlock__pre emotion-euiCodeBlock__pre-pre-padding-controlsOffset"
-      style="position:relative;height:600px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position:relative;block-size:600px;inline-size:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
       tabindex="0"
     >
       <code
@@ -650,18 +650,18 @@ exports[`EuiCodeBlock virtualization renders a virtualized code block 1`] = `
         class="euiCodeBlock__code emotion-euiCodeBlock__code-isVirtualized"
         data-code-language="text"
         data-test-subj="test subject string"
-        style="height:36px;width:100%"
+        style="block-size:36px;inline-size:100%"
       >
         <span
           class="euiCodeBlock__line emotion-euiCodeBlock__line"
-          style="position:absolute;left:0;top:0;height:18px;width:100%"
+          style="position:absolute;inset-inline-start:0;inset-block-start:0;block-size:18px;inline-size:100%"
         >
           var some = 'code';
 
         </span>
         <span
           class="euiCodeBlock__line emotion-euiCodeBlock__line"
-          style="position:absolute;left:0;top:18px;height:18px;width:100%"
+          style="position:absolute;inset-inline-start:0;inset-block-start:18px;block-size:18px;inline-size:100%"
         >
           console.log(some);
         </span>

--- a/src/components/code/code_block_virtualized.tsx
+++ b/src/components/code/code_block_virtualized.tsx
@@ -9,6 +9,7 @@
 import React, { HTMLAttributes, forwardRef, useMemo } from 'react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { RefractorNode } from 'refractor';
+import { logicalStyles } from '../../global_styling';
 import { EuiAutoSizer } from '../auto_sizer';
 import { nodeToHtml } from './utils';
 
@@ -27,16 +28,21 @@ export const EuiCodeBlockVirtualized = ({
 }) => {
   const VirtualizedOuterElement = useMemo(
     () =>
-      forwardRef<any, any>((props, ref) => (
-        <pre {...props} ref={ref} {...preProps} />
+      forwardRef<any, any>(({ style, ...props }, ref) => (
+        <pre style={logicalStyles(style)} {...props} ref={ref} {...preProps} />
       )),
     [preProps]
   );
 
   const VirtualizedInnerElement = useMemo(
     () =>
-      forwardRef<any, any>((props, ref) => (
-        <code {...props} ref={ref} {...codeProps} />
+      forwardRef<any, any>(({ style, ...props }, ref) => (
+        <code
+          style={logicalStyles(style)}
+          {...props}
+          ref={ref}
+          {...codeProps}
+        />
       )),
     [codeProps]
   );
@@ -62,6 +68,6 @@ export const EuiCodeBlockVirtualized = ({
 
 const ListRow = ({ data, index, style }: ListChildComponentProps) => {
   const row = data[index];
-  row.properties.style = style;
+  row.properties.style = logicalStyles(style);
   return nodeToHtml(row, index, data, 0);
 };

--- a/src/global_styling/functions/__snapshots__/logicals.test.ts.snap
+++ b/src/global_styling/functions/__snapshots__/logicals.test.ts.snap
@@ -108,7 +108,7 @@ exports[`logicalCSS mixin returns a string property for each directional propert
 
 exports[`logicalCSS mixin returns a string property for each directional property: width 1`] = `"inline-size: 8px;"`;
 
-exports[`logicalCSSWithFallback  returns both the original property and the logical property 1`] = `
+exports[`logicalCSSWithFallback returns both the original property and the logical property 1`] = `
 "
   overflow-x: auto;
   overflow-inline: auto;

--- a/src/global_styling/functions/logicals.test.ts
+++ b/src/global_styling/functions/logicals.test.ts
@@ -12,6 +12,7 @@ import {
   logicalCSS,
   logicalCSSWithFallback,
   logicalStyle,
+  logicalStyles,
   logicalTextAlignCSS,
   logicalTextAlignStyle,
 } from '../functions/logicals';
@@ -38,6 +39,25 @@ describe('logicalStyle mixin returns an object property', () => {
       it(prop, () => {
         expect(logicalStyle(prop, '8px')).toMatchSnapshot();
       });
+    });
+  });
+});
+
+describe('logicalStyles returns an object property', () => {
+  it('converts all properties in an object to their logical equivalent', () => {
+    expect(
+      logicalStyles({ width: '100%', top: 30, marginRight: '20px' })
+    ).toEqual({
+      inlineSize: '100%',
+      insetBlockStart: 30,
+      marginInlineEnd: '20px',
+    });
+  });
+
+  it('does nothing if no convertible logical CSS properties exist', () => {
+    expect(logicalStyles({ color: 'red', backgroundColor: 'blue' })).toEqual({
+      color: 'red',
+      backgroundColor: 'blue',
     });
   });
 });

--- a/src/global_styling/functions/logicals.test.ts
+++ b/src/global_styling/functions/logicals.test.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { testCustomHook } from '../../test/internal';
 import {
   LOGICAL_PROPERTIES,
   LOGICAL_TEXT_ALIGNMENT,
@@ -21,19 +20,15 @@ describe('logicalCSS mixin returns a string property', () => {
   describe('for each directional property:', () => {
     LOGICAL_PROPERTIES.forEach((prop) => {
       it(prop, () => {
-        expect(
-          testCustomHook(() => logicalCSS(prop, '8px')).return
-        ).toMatchSnapshot();
+        expect(logicalCSS(prop, '8px')).toMatchSnapshot();
       });
     });
   });
 });
 
-describe('logicalCSSWithFallback ', () => {
+describe('logicalCSSWithFallback', () => {
   it('returns both the original property and the logical property', () => {
-    expect(
-      testCustomHook(() => logicalCSSWithFallback('overflow-x', 'auto')).return
-    ).toMatchSnapshot();
+    expect(logicalCSSWithFallback('overflow-x', 'auto')).toMatchSnapshot();
   });
 });
 
@@ -41,9 +36,7 @@ describe('logicalStyle mixin returns an object property', () => {
   describe('for each directional property:', () => {
     LOGICAL_PROPERTIES.forEach((prop) => {
       it(prop, () => {
-        expect(
-          testCustomHook(() => logicalStyle(prop, '8px')).return
-        ).toMatchSnapshot();
+        expect(logicalStyle(prop, '8px')).toMatchSnapshot();
       });
     });
   });
@@ -53,9 +46,7 @@ describe('logicalTextAlignCSS mixin returns a string property', () => {
   describe('for each text align value:', () => {
     LOGICAL_TEXT_ALIGNMENT.forEach((align) => {
       it(align, () => {
-        expect(
-          testCustomHook(() => logicalTextAlignCSS(align)).return
-        ).toMatchSnapshot();
+        expect(logicalTextAlignCSS(align)).toMatchSnapshot();
       });
     });
   });
@@ -65,9 +56,7 @@ describe('logicalTextAlignStyle mixin returns a string property', () => {
   describe('for each text align value:', () => {
     LOGICAL_TEXT_ALIGNMENT.forEach((align) => {
       it(align, () => {
-        expect(
-          testCustomHook(() => logicalTextAlignStyle(align)).return
-        ).toMatchSnapshot();
+        expect(logicalTextAlignStyle(align)).toMatchSnapshot();
       });
     });
   });

--- a/src/global_styling/functions/logicals.ts
+++ b/src/global_styling/functions/logicals.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { CSSProperties } from 'react';
 import { keysOf } from '../../components/common';
 import LOGICALS from './logicals.json';
 
@@ -60,17 +61,44 @@ export const logicalCSSWithFallback = (
 `;
 
 /**
+ * Casing utils for swapping between camel case (style objs) and kebab case (CSS)
+ */
+const camelCase = (kebabCasedString: string): string =>
+  kebabCasedString.replace(/-\w/g, (str) => str.charAt(1).toUpperCase());
+const kebabCase = (camelCasedString: string): string =>
+  camelCasedString.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+
+/**
  *
  * @param property A string that is a valid CSS logical property
  * @param value String to output as the property value
  * @returns `object` Returns the logical CSS property version for the given `property: value` pair
  */
 export const logicalStyle = (property: LogicalProperties, value?: any) => {
-  // Strip hyphens and camelCase the CSS logical property so React doesn't throw errors
-  const camelCasedProperty = logicals[property].replace(/-\w/g, (str) =>
-    str.charAt(1).toUpperCase()
-  );
-  return { [camelCasedProperty]: value };
+  return { [camelCase(logicals[property])]: value };
+};
+
+/**
+ * Given a style object with any amount of unknown CSS properties,
+ * find ones that can be converted to logical properties and convert them
+ *
+ * @param styleObject - A React object of camelCased styles
+ * @returns `object`
+ */
+export const logicalStyles = (styleObject: CSSProperties) => {
+  const logicalStyleObject: Record<string, string | number | undefined> = {};
+
+  Object.entries(styleObject).forEach(([key, value]) => {
+    const cssProperty = kebabCase(key);
+    if (logicals.hasOwnProperty(cssProperty)) {
+      const logicalKey = camelCase(logicals[cssProperty as LogicalProperties]);
+      logicalStyleObject[logicalKey] = value;
+    } else {
+      logicalStyleObject[key] = value;
+    }
+  });
+
+  return logicalStyleObject;
 };
 
 /**

--- a/upcoming_changelogs/6426.md
+++ b/upcoming_changelogs/6426.md
@@ -1,0 +1,3 @@
+**CSS-in-JS conversions**
+
+- Added a new `logicalStyles` utility that automatically converts all non-logical properties in a `style` object to their corresponding logical properties


### PR DESCRIPTION
## Summary

This utility allows us to convert any `style` object to use corresponding logical properties instead of, e.g. `width`, `height`, etc. It checks the entire style obj for keys that have corresponding logical properties and converts them if so. It's particular desired for anywhere we use a virtualization library.

The example/snapshot change for `EuiCodeBlock` most clearly illustrates what this utility accomplishes.

This is very much a "nice to have" util and doesn't necessarily exactly work 100% as expected in `react-window` in actual `direction: rtl` or `writing-mode: vertical-rl` prod behavior (although it's hard to tell if this is because EUI as a whole is not fully converted to logical properties yet).

It also contains an incidental test cleanup commit.

## QA

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately