### PR TITLE
[CSS-in-JS] Add `logicalShorthandCSS` util + lint rule

### DIFF
--- a/scripts/eslint-plugin/css_logical_properties.js
+++ b/scripts/eslint-plugin/css_logical_properties.js
@@ -1,5 +1,9 @@
-const logicals = require('../../src/global_styling/functions/logicals.json');
+const {
+  _shorthands,
+  ...logicals
+} = require('../../src/global_styling/functions/logicals.json');
 const logicalProperties = Object.keys(logicals);
+const logicalPropertiesRegex = logicalProperties.join('|');
 
 const logicalValues = {
   'text-align: left': 'text-align: start',
@@ -7,13 +11,26 @@ const logicalValues = {
   // TODO: Consider adding float, clear, & resize as well
   // @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties
 };
-
-const logicalPropertiesRegex = logicalProperties.join('|');
 const logicalValuesRegex = Object.keys(logicalValues).join('|');
+
+// Construct a regex to find shorthands with more than one value
+// Shorthands with only 1 value set (applied to all 4 sides) are fine
+const logicalShorthandsRegexes = _shorthands.map((property) => {
+  const start = `${property}:\\s*`; // e.g. `margin: `
+  const interpolatedVar = '\\${[^}]+}'; // e.g. `${euiTheme.something}`
+  const staticValue = '[^\\s(!};]'; // e.g. `20px` - any value that doesn't have a space, !keyword, } interpolation, or semicolon
+  const value = `(${interpolatedVar}|${staticValue})+`; // Values can be variable or static
+  const end = ';'; // Ensure that the match ends with a semicolon
+
+  return `(${start}(${value}\\s+)+${value}${end})`; // Only match multiple values (spaces between values)
+});
+const logicalShorthandsRegex = logicalShorthandsRegexes.join('|');
+
+// Frankensteining it all together into one horrific regex
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Backreferences
 const regex = new RegExp(
-  `^(?<whitespace>[\\s]*)((?<property>${logicalPropertiesRegex}):)|(?<value>${logicalValuesRegex})`,
+  `^(?<whitespace>[\\s]*)((?<property>${logicalPropertiesRegex}):)|(?<value>${logicalValuesRegex})|(?<shorthand>${logicalShorthandsRegex})`,
   'gm'
 );
 
@@ -30,6 +47,8 @@ module.exports = {
         'Prefer the CSS logical property for {{ property }} - @see src/global_styling/functions/logicals.ts',
       preferLogicalValue:
         'Prefer the CSS logical value for {{ property }} - @see src/global_styling/functions/logicals.ts',
+      preferLogicalShorthand:
+        "Prefer using EUI's `logicalShorthandCSS` utility for shorthands with more than one side - @see src/global_styling/functions/logicals.ts",
     },
     fixable: 'code',
     // NOTE: To disable this lint rule for a single line/property within a css`` block
@@ -42,47 +61,51 @@ module.exports = {
   create: function (context) {
     return {
       TemplateLiteral(node) {
-        const templateContents = node.quasis || [];
-        templateContents.forEach((quasi) => {
-          const stringLiteral = quasi?.value?.raw;
-          if (!stringLiteral) return;
+        const stringLiteral = context.getSourceCode().getText(node);
+        const content = stringLiteral.replace(/^`|`$/g, ''); // Strip starting/ending backtick
 
-          findOccurrences(regex, stringLiteral).forEach(
-            ({ match, lineNumber, column }) => {
-              const property = match.groups.property || match.groups.value;
-              const whitespace = match.groups.whitespace?.length || 0;
+        findOccurrences(regex, content).forEach(
+          ({ match, lineNumber, column }) => {
+            const property =
+              match.groups.property ||
+              match.groups.value ||
+              match.groups.shorthand;
+            const whitespace = match.groups.whitespace?.length || 0;
 
-              const lineStart = quasi.loc.start.line + lineNumber;
-              const columnStart = column + whitespace;
+            const lineStart = node.loc.start.line + lineNumber;
+            const columnStart = column + whitespace;
 
-              context.report({
-                loc: {
-                  start: {
-                    line: lineStart,
-                    column: columnStart,
-                  },
-                  end: {
-                    line: lineStart,
-                    column: columnStart + property.length,
-                  },
+            context.report({
+              loc: {
+                start: {
+                  line: lineStart,
+                  column: columnStart,
                 },
-                messageId: match.groups.value
-                  ? 'preferLogicalValue'
-                  : 'preferLogicalProperty',
-                data: { property },
-                fix: function (fixer) {
-                  const literalStart = quasi.range[0] + 1; // Account for backtick
-                  const indexStart = literalStart + match.index + whitespace;
-
-                  return fixer.replaceTextRange(
-                    [indexStart, indexStart + property.length],
-                    logicalsFixMap[property]
-                  );
+                end: {
+                  line: lineStart,
+                  column: columnStart + property.length,
                 },
-              });
-            }
-          );
-        });
+              },
+              messageId: match.groups.shorthand
+                ? 'preferLogicalShorthand'
+                : match.groups.value
+                ? 'preferLogicalValue'
+                : 'preferLogicalProperty',
+              data: { property },
+              fix: function (fixer) {
+                if (match.groups.shorthand) return false;
+
+                const literalStart = node.range[0] + 1; // Account for stripped backtick
+                const indexStart = literalStart + match.index + whitespace;
+
+                return fixer.replaceTextRange(
+                  [indexStart, indexStart + property.length],
+                  logicalsFixMap[property]
+                );
+              },
+            });
+          }
+        );
       },
     };
   },

--- a/scripts/eslint-plugin/css_logical_properties.test.js
+++ b/scripts/eslint-plugin/css_logical_properties.test.js
@@ -16,6 +16,15 @@ const valid = [
     border-width: 1px;
     scrollbar-width: 30px
   \``,
+  // Allow shorthand properties that set the same value for all sides
+  `\`
+    inset: 0;
+    margin: 10px;
+    padding: \${euiTheme.size.l};
+    border-width: \${euiTheme.base}px;
+  \``,
+  // Ensure we don't accidentally consider !important a shorthand value
+  'css`padding: 0 !important;`',
 ];
 
 const invalid = [
@@ -90,6 +99,26 @@ const invalid = [
       { messageId: 'preferLogicalValue' },
       { messageId: 'preferLogicalProperty' },
     ],
+  },
+  // Shorthand
+  {
+    code: 'css`margin: 10px 50%;`',
+    errors: [{ messageId: 'preferLogicalShorthand' }],
+  },
+  {
+    code:
+      'css`padding: ${euiTheme.size.s} ${euiTheme.size.m} ${euiTheme.size.l};`',
+    errors: [{ messageId: 'preferLogicalShorthand' }],
+  },
+  {
+    code: `css\`
+      inset:
+        \${euiTheme.base}px
+        \${mathWithUnits(euiTheme.size.xl, (x) => x / 3)}
+        \${euiTheme.size.xl}
+        \${euiTheme.base}px;
+    \``,
+    errors: [{ messageId: 'preferLogicalShorthand' }],
   },
 ];
 

--- a/src-docs/src/views/comment/comment_props.tsx
+++ b/src-docs/src/views/comment/comment_props.tsx
@@ -10,6 +10,7 @@ import {
   EuiAvatar,
   useEuiFontSize,
   logicalCSS,
+  logicalBorderRadiusCSS,
   EuiSpacer,
   EuiAccordion,
   EuiCodeBlock,
@@ -65,8 +66,10 @@ export default ({ snippet }: { snippet: ReactNode }) => {
           >
             <div
               css={css`
-                border-radius: ${euiTheme.border.radius.small}
-                  ${euiTheme.border.radius.small} 0 0;
+                ${logicalBorderRadiusCSS(
+                  `${euiTheme.border.radius.small} ${euiTheme.border.radius.small} 0 0`,
+                  true
+                )}
                 padding: ${euiTheme.size.s};
                 background: ${euiTheme.colors.lightestShade};
                 ${logicalCSS('border-bottom', euiTheme.border.thin)}

--- a/src-docs/src/views/theme/borders/_border_sass.tsx
+++ b/src-docs/src/views/theme/borders/_border_sass.tsx
@@ -113,7 +113,7 @@ export const WidthSass: FunctionComponent<ThemeRowType> = ({ description }) => {
         }
         example={
           <div className={'guideSass__border guideSass__border--thickDashed'}>
-            <strong>{`border-width: ${values.euiBorderWidthThick} dashed ${values.euiBorderColor};`}</strong>
+            <strong>{`border: ${values.euiBorderWidthThick} dashed ${values.euiBorderColor};`}</strong>
           </div>
         }
         snippet={'border: $euiBorderWidthThick dashed $euiBorderColor;'}

--- a/src-docs/src/views/theme/sizing/_sizing_js.tsx
+++ b/src-docs/src/views/theme/sizing/_sizing_js.tsx
@@ -9,6 +9,7 @@ import {
   logicalCSS,
   logicalStyle,
   logicals,
+  logicalShorthandCSS,
   EuiText,
   useEuiPaddingSize,
   useEuiBackgroundColor,
@@ -22,6 +23,7 @@ import {
   logicalSizeCSS,
   logicalSizeStyle,
 } from '../../../../../src';
+const { _shorthands, ..._logicals } = logicals;
 
 import { ThemeExample } from '../_components/_theme_example';
 
@@ -243,6 +245,36 @@ export const UtilsJS = () => {
         snippet={"${logicals['padding-left']}: 100px;"}
       />
 
+      <ThemeExample
+        title={<code>{'logicalShorthandCSS(property, value)'}</code>}
+        type="function"
+        description={
+          <p>
+            Until an official W3 spec is available, this utility converts
+            shorthand properties that describe 4-sided boxes/corners such as{' '}
+            <EuiCode language="css">margin</EuiCode>,{' '}
+            <EuiCode language="css">padding</EuiCode>,
+            <EuiCode language="css">inset</EuiCode>, and{' '}
+            <EuiCode language="css">border-radius</EuiCode> to their
+            corresponding logical inline/block properties.
+          </p>
+        }
+        example={
+          <p
+            css={[
+              useEuiBackgroundColorCSS().warning,
+              logicalShorthandCSS('padding', '10px 50px'),
+            ]}
+          >
+            <pre>
+              <code>{logicalShorthandCSS('padding', '10px 50px')}</code>
+            </pre>
+          </p>
+        }
+        snippetLanguage="emotion"
+        snippet={"${logicalShorthandCSS('padding', '10px 50px')};"}
+      />
+
       <EuiPanel color="subdued">
         <EuiAccordion
           id={htmlIdGenerator()()}
@@ -256,7 +288,23 @@ export const UtilsJS = () => {
             `}
             size="s"
           >
-            <code>{Object.keys(logicals).join('\r\n')}</code>
+            <code>{Object.keys(_logicals).join('\r\n')}</code>
+          </EuiText>
+        </EuiAccordion>
+        <EuiSpacer size="s" />
+        <EuiAccordion
+          id={htmlIdGenerator()()}
+          buttonContent={<strong>All supported shorthand properties</strong>}
+          paddingSize="m"
+        >
+          <EuiText
+            css={css`
+              white-space: pre;
+              columns: 3;
+            `}
+            size="s"
+          >
+            <code>{_shorthands.join('\r\n')}</code>
           </EuiText>
         </EuiAccordion>
       </EuiPanel>
@@ -289,7 +337,7 @@ export const UtilsJS = () => {
       />
 
       <ThemeExample
-        title={<code>{'logicalStyle(property, value)'}</code>}
+        title={<code>{'logicalSizeStyle(property, value)'}</code>}
         type="function"
         description={
           <p>

--- a/src/components/badge/badge.styles.ts
+++ b/src/components/badge/badge.styles.ts
@@ -12,6 +12,7 @@ import {
   euiFocusRing,
   euiTextTruncate,
   logicalCSS,
+  logicalShorthandCSS,
   logicalTextAlignCSS,
   mathWithUnits,
 } from '../../global_styling';
@@ -25,7 +26,7 @@ export const euiBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     euiBadge: css`
       display: inline-block;
       vertical-align: middle;
-      padding: 0 ${euiTheme.size.s};
+      ${logicalShorthandCSS('padding', `0 ${euiTheme.size.s}`)}
       ${logicalCSS('max-width', '100%')}
       font-size: ${euiFontSize(euiThemeContext, 'xs').fontSize};
       line-height: ${euiTheme.base + 2}px; // Accounts for the border

--- a/src/components/breadcrumbs/breadcrumb.styles.ts
+++ b/src/components/breadcrumbs/breadcrumb.styles.ts
@@ -14,6 +14,7 @@ import {
   euiTextTruncate,
   euiFocusRing,
   logicalCSS,
+  logicalBorderRadiusCSS,
   mathWithUnits,
 } from '../../global_styling';
 
@@ -126,8 +127,10 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('padding-horizontal', euiTheme.size.m)},
       `,
       firstChild: css`
-        border-radius: ${euiTheme.border.radius.medium} 0 0
-          ${euiTheme.border.radius.medium};
+        ${logicalBorderRadiusCSS(
+          `${euiTheme.border.radius.medium} 0 0 ${euiTheme.border.radius.medium}`,
+          true
+        )}
         clip-path: polygon(
           0 0,
           calc(100% - ${euiTheme.size.s}) 0,
@@ -138,8 +141,10 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('padding-left', euiTheme.size.m)},
       `,
       lastChild: css`
-        border-radius: 0 ${euiTheme.border.radius.medium}
-          ${euiTheme.border.radius.medium} 0;
+        ${logicalBorderRadiusCSS(
+          `0 ${euiTheme.border.radius.medium} ${euiTheme.border.radius.medium} 0`,
+          true
+        )}
         clip-path: polygon(
           0 0,
           100% 0,

--- a/src/components/button/button_display/_button_display.styles.ts
+++ b/src/components/button/button_display/_button_display.styles.ts
@@ -10,6 +10,7 @@ import { UseEuiTheme } from '../../../services';
 import {
   euiFontSize,
   logicalCSS,
+  logicalShorthandCSS,
   logicalTextAlignStyle,
 } from '../../../global_styling';
 
@@ -43,7 +44,7 @@ export const euiButtonDisplayStyles = (euiThemeContext: UseEuiTheme) => {
     euiButtonDisplay: css`
       ${euiButtonBaseCSS()};
       font-weight: ${euiTheme.font.weight.medium};
-      padding: 0 ${euiTheme.size.m};
+      ${logicalShorthandCSS('padding', `0 ${euiTheme.size.m}`)}
 
       &:hover:not(:disabled),
       &:focus {

--- a/src/components/code/code.styles.ts
+++ b/src/components/code/code.styles.ts
@@ -7,6 +7,7 @@
  */
 
 import { css } from '@emotion/react';
+import { logicalShorthandCSS } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 import { euiCodeSyntaxColors, euiCodeSyntaxTokens } from './code_syntax.styles';
 
@@ -21,7 +22,7 @@ export const euiCodeStyles = (euiThemeContext: UseEuiTheme) => {
     euiCode: css`
       font-family: ${euiTheme.font.familyCode};
       font-size: 0.9em; /* 1 */
-      padding: 0.2em 0.5em; /* 1 */
+      ${logicalShorthandCSS('padding', '0.2em 0.5em')} /* 1 */
       background: ${euiCodeSyntax.backgroundColor};
       border-radius: ${euiTheme.border.radius.small};
       font-weight: ${euiTheme.font.weight.bold};

--- a/src/components/expression/expression.styles.ts
+++ b/src/components/expression/expression.styles.ts
@@ -10,6 +10,7 @@ import { css } from '@emotion/react';
 import {
   euiFontSize,
   logicalCSS,
+  logicalShorthandCSS,
   logicalTextAlignCSS,
   euiTextBreakWord,
   euiTextTruncate,
@@ -39,7 +40,10 @@ export const euiExpressionStyles = (euiThemeContext: UseEuiTheme) => {
       )}
       ${euiFontSize(euiThemeContext, 's')};
       ${logicalTextAlignCSS('left')}
-      padding: ${mathWithUnits(euiTheme.size.s, (x) => x / 2)} 0;
+      ${logicalShorthandCSS(
+        'padding',
+        `${mathWithUnits(euiTheme.size.s, (x) => x / 2)} 0`
+      )}
       color: ${euiTheme.colors.text};
 
       &:focus {

--- a/src/components/list_group/list_group_item.styles.ts
+++ b/src/components/list_group/list_group_item.styles.ts
@@ -11,6 +11,7 @@ import {
   euiCanAnimate,
   euiFontSize,
   logicalCSS,
+  logicalShorthandCSS,
   euiBackgroundColor,
   euiTextTruncate,
   euiTextBreakWord,
@@ -96,7 +97,10 @@ export const euiListGroupItemInnerStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     // Base
     euiListGroupItem__inner: css`
-      padding: ${euiTheme.size.xs} ${euiTheme.size.s};
+      ${logicalShorthandCSS(
+        'padding',
+        `${euiTheme.size.xs} ${euiTheme.size.s}`
+      )}
       display: flex;
       align-items: center;
       flex-grow: 1;

--- a/src/components/loading/loading_spinner.styles.ts
+++ b/src/components/loading/loading_spinner.styles.ts
@@ -10,6 +10,7 @@ import {
   _EuiThemeSize,
   euiCanAnimate,
   logicalSizeCSS,
+  logicalShorthandCSS,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 import {
@@ -56,7 +57,10 @@ export const euiLoadingSpinnerStyles = (euiThemeContext: UseEuiTheme) => {
       display: inline-block;
       border-radius: 50%;
       border: ${euiTheme.border.thick};
-      border-color: ${euiSpinnerBorderColorsCSS(euiThemeContext)};
+      ${logicalShorthandCSS(
+        'border-color',
+        euiSpinnerBorderColorsCSS(euiThemeContext)
+      )}
 
       ${euiCanAnimate} {
         animation: ${_loadingSpinner} 0.6s infinite linear;

--- a/src/components/loading/loading_spinner.styles.ts
+++ b/src/components/loading/loading_spinner.styles.ts
@@ -11,6 +11,7 @@ import {
   euiCanAnimate,
   logicalSizeCSS,
   logicalShorthandCSS,
+  mathWithUnits,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 import {
@@ -73,14 +74,20 @@ export const euiLoadingSpinnerStyles = (euiThemeContext: UseEuiTheme) => {
         euiTheme.size[spinnerSizes.s],
         euiTheme.size[spinnerSizes.s]
       )}
-      border-width: calc(${euiTheme.border.width.thin} * 1.5);
+      border-width: ${mathWithUnits(
+        euiTheme.border.width.thin,
+        (x) => x * 1.5
+      )};
     `,
     m: css`
       ${logicalSizeCSS(
         euiTheme.size[spinnerSizes.m],
         euiTheme.size[spinnerSizes.m]
       )}
-      border-width: calc(${euiTheme.border.width.thin} * 1.5);
+      border-width: ${mathWithUnits(
+        euiTheme.border.width.thin,
+        (x) => x * 1.5
+      )};
     `,
     l: css`
       ${logicalSizeCSS(

--- a/src/components/markdown_editor/__snapshots__/markdown_format.styles.test.ts.snap
+++ b/src/components/markdown_editor/__snapshots__/markdown_format.styles.test.ts.snap
@@ -3,7 +3,10 @@
 exports[`euiMarkdownFormat text sizes m 1`] = `
 "
     .euiMarkdownFormat__blockquote {
-      padding: 0 1.1429rem;
+      
+    padding-block: 0;
+    padding-inline: 1.1429rem;
+  
       border-inline-start-width: 0.285725rem;
       margin-block-end: 1.1429rem;
     }
@@ -37,7 +40,10 @@ exports[`euiMarkdownFormat text sizes m 1`] = `
 exports[`euiMarkdownFormat text sizes relative 1`] = `
 "
     .euiMarkdownFormat__blockquote {
-      padding: 0 1em;
+      
+    padding-block: 0;
+    padding-inline: 1em;
+  
       border-inline-start-width: 0.25em;
       margin-block-end: 1em;
     }
@@ -71,7 +77,10 @@ exports[`euiMarkdownFormat text sizes relative 1`] = `
 exports[`euiMarkdownFormat text sizes s 1`] = `
 "
     .euiMarkdownFormat__blockquote {
-      padding: 0 1.0000rem;
+      
+    padding-block: 0;
+    padding-inline: 1.0000rem;
+  
       border-inline-start-width: 0.25rem;
       margin-block-end: 1.0000rem;
     }
@@ -105,7 +114,10 @@ exports[`euiMarkdownFormat text sizes s 1`] = `
 exports[`euiMarkdownFormat text sizes xs 1`] = `
 "
     .euiMarkdownFormat__blockquote {
-      padding: 0 0.8571rem;
+      
+    padding-block: 0;
+    padding-inline: 0.8571rem;
+  
       border-inline-start-width: 0.214275rem;
       margin-block-end: 0.8571rem;
     }

--- a/src/components/markdown_editor/__snapshots__/markdown_format.styles.test.ts.snap
+++ b/src/components/markdown_editor/__snapshots__/markdown_format.styles.test.ts.snap
@@ -6,7 +6,7 @@ exports[`euiMarkdownFormat text sizes m 1`] = `
       
     padding-block: 0;
     padding-inline: 1.1429rem;
-  
+    
       border-inline-start-width: 0.285725rem;
       margin-block-end: 1.1429rem;
     }
@@ -43,7 +43,7 @@ exports[`euiMarkdownFormat text sizes relative 1`] = `
       
     padding-block: 0;
     padding-inline: 1em;
-  
+    
       border-inline-start-width: 0.25em;
       margin-block-end: 1em;
     }
@@ -80,7 +80,7 @@ exports[`euiMarkdownFormat text sizes s 1`] = `
       
     padding-block: 0;
     padding-inline: 1.0000rem;
-  
+    
       border-inline-start-width: 0.25rem;
       margin-block-end: 1.0000rem;
     }
@@ -117,7 +117,7 @@ exports[`euiMarkdownFormat text sizes xs 1`] = `
       
     padding-block: 0;
     padding-inline: 0.8571rem;
-  
+    
       border-inline-start-width: 0.214275rem;
       margin-block-end: 0.8571rem;
     }

--- a/src/components/markdown_editor/markdown_format.styles.ts
+++ b/src/components/markdown_editor/markdown_format.styles.ts
@@ -10,6 +10,7 @@ import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
 import {
   logicalCSS,
+  logicalShorthandCSS,
   euiFontSize,
   _FontScaleOptions,
   mathWithUnits,
@@ -34,7 +35,7 @@ const euiScaleMarkdownFormatText = (
 
   return `
     .euiMarkdownFormat__blockquote {
-      padding: 0 ${fontSize};
+      ${logicalShorthandCSS('padding', `0 ${fontSize}`)}
       ${logicalCSS('border-left-width', blockQuoteBorderWidth)}
       ${logicalCSS('margin-bottom', fontSize)}
     }

--- a/src/components/modal/modal_header.styles.ts
+++ b/src/components/modal/modal_header.styles.ts
@@ -7,6 +7,7 @@
  */
 
 import { css } from '@emotion/react';
+import { logicalShorthandCSS } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
 export const euiModalHeaderStyles = (euiThemeContext: UseEuiTheme) => {
@@ -17,10 +18,12 @@ export const euiModalHeaderStyles = (euiThemeContext: UseEuiTheme) => {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding-inline: ${euiTheme.size.l} ${euiTheme.size.xxl};
-      padding-block: ${euiTheme.size.l} ${euiTheme.size.base};
       flex-grow: 0;
       flex-shrink: 0;
+      ${logicalShorthandCSS(
+        'padding',
+        `${euiTheme.size.l} ${euiTheme.size.xxl} ${euiTheme.size.base} ${euiTheme.size.l}`
+      )}
 
       // If a body doesn't exist, remove some extra padding from footer
       & + .euiModalFooter {

--- a/src/components/popover/popover_footer.styles.ts
+++ b/src/components/popover/popover_footer.styles.ts
@@ -12,6 +12,7 @@ import {
   euiPaddingSize,
   EuiPaddingSize,
   logicalCSS,
+  logicalShorthandCSS,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
@@ -29,8 +30,12 @@ export const euiPopoverFooterStyles = (
     euiPopoverFooter: css`
       ${euiFontSize(euiThemeContext, 's')};
       ${logicalCSS('border-top', euiTheme.border.thin)};
+
       // Negative margins for panel padding
-      margin: ${panelPaddingSize} -${panelPaddingSize} -${panelPaddingSize};
+      ${logicalShorthandCSS(
+        'margin',
+        `${panelPaddingSize} -${panelPaddingSize} -${panelPaddingSize}`
+      )}
     `,
   };
 };

--- a/src/components/popover/popover_title.styles.ts
+++ b/src/components/popover/popover_title.styles.ts
@@ -11,6 +11,7 @@ import {
   EuiPaddingSize,
   euiPaddingSize,
   logicalCSS,
+  logicalShorthandCSS,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 import { euiTitle } from '../title/title.styles';
@@ -53,5 +54,8 @@ const getPaddingOffset = (
 ) => {
   const panelPaddingSize = euiPaddingSize(euiThemeContext, size);
 
-  return `margin: -${panelPaddingSize} -${panelPaddingSize} ${panelPaddingSize};`;
+  return logicalShorthandCSS(
+    'margin',
+    `-${panelPaddingSize} -${panelPaddingSize} ${panelPaddingSize}`
+  );
 };

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -338,7 +338,10 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
         line-height: 1;
         border: ${euiTheme.border.width.thin} solid ${euiTheme.colors.text};
-        border-radius: calc(${euiTheme.border.radius.small} / 2);
+        border-radius: ${mathWithUnits(
+          euiTheme.border.radius.small,
+          (x) => x / 2
+        )};
       }
     `,
     constrainedWidth: css`

--- a/src/components/token/token.styles.ts
+++ b/src/components/token/token.styles.ts
@@ -8,7 +8,11 @@
 
 import { css } from '@emotion/react';
 import chroma from 'chroma-js';
-import { logicalCSS, logicalSizeCSS } from '../../global_styling';
+import {
+  logicalCSS,
+  logicalSizeCSS,
+  mathWithUnits,
+} from '../../global_styling';
 import {
   UseEuiTheme,
   euiPaletteColorBlind,
@@ -103,8 +107,12 @@ export const euiTokenStyles = (
   xs: css`
     ${logicalSizeCSS(euiTheme.size.s, euiTheme.size.s)};
 
-    &[class*='-square'] {
-      border-radius: calc(${euiTheme.border.radius.small} / 2);
+    &[class*='-square'],
+    &[class*='-rectangle'] {
+      border-radius: ${mathWithUnits(
+        euiTheme.border.radius.small,
+        (x) => x / 2
+      )};
     }
 
     &[class*='-rectangle'] {
@@ -113,7 +121,6 @@ export const euiTokenStyles = (
         '1px'
       )}; // adds a small padding so that the icon is not touching the border
       ${logicalCSS('padding-horizontal', euiTheme.size.xs)};
-      border-radius: calc(${euiTheme.border.radius.small} / 2);
     }
   `,
   s: css`

--- a/src/components/tool_tip/tool_tip.styles.ts
+++ b/src/components/tool_tip/tool_tip.styles.ts
@@ -117,7 +117,10 @@ export const euiToolTipStyles = (euiThemeContext: UseEuiTheme) => {
       content: '';
       position: absolute;
       transform-origin: center;
-      border-radius: 2px;
+      border-radius: ${mathWithUnits(
+        euiTheme.border.radius.small,
+        (x) => x / 2
+      )};
       background-color: ${euiToolTipBackgroundColor(euiTheme, colorMode)};
       ${logicalSizeCSS(arrowSize, arrowSize)};
     `,

--- a/src/global_styling/functions/index.ts
+++ b/src/global_styling/functions/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './logicals';
+export * from './logical_shorthands';
 export * from './math';
 export * from './size';
 export * from './typography';

--- a/src/global_styling/functions/logical_shorthands.test.ts
+++ b/src/global_styling/functions/logical_shorthands.test.ts
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { logicalShorthandCSS } from '../functions/logical_shorthands';
+import {
+  logicalShorthandCSS,
+  logicalBorderRadiusCSS,
+} from '../functions/logical_shorthands';
 
 describe('logicalShorthandCSS', () => {
   it('returns the shorthand property as-is if only one value is being set for all 4 sides', () => {
@@ -57,5 +60,138 @@ describe('logicalShorthandCSS', () => {
 
   it('throws an error if the passed property is not a shorthand property', () => {
     expect(() => logicalShorthandCSS('border', 'inherit')).toThrow();
+  });
+});
+
+describe('logicalBorderRadiusCSS', () => {
+  describe('basic non-slash usage', () => {
+    it('returns the shorthand property as-is if only one value is being set for all 4 sides', () => {
+      expect(logicalBorderRadiusCSS('0')).toEqual('border-radius: 0;');
+    });
+
+    it('handles 2 values', () => {
+      expect(logicalBorderRadiusCSS('1px 2px')).toMatchInlineSnapshot(`
+        "border-start-start-radius: 1px;
+        border-start-end-radius: 2px;
+        border-end-end-radius: 1px;
+        border-end-start-radius: 2px;"
+      `);
+    });
+
+    it('handles 3 values', () => {
+      expect(logicalBorderRadiusCSS('1px 2px 3px')).toMatchInlineSnapshot(`
+        "border-start-start-radius: 1px;
+        border-start-end-radius: 2px;
+        border-end-end-radius: 3px;
+        border-end-start-radius: 2px;"
+      `);
+    });
+
+    it('handles 4 values', () => {
+      expect(logicalBorderRadiusCSS('1px 2px 3px 4px')).toMatchInlineSnapshot(`
+        "border-start-start-radius: 1px;
+        border-start-end-radius: 2px;
+        border-end-end-radius: 3px;
+        border-end-start-radius: 4px;"
+      `);
+    });
+
+    describe('ignoreZeroes flag', () => {
+      it('does not remove 0 values by default in case the util is being used to override existing border-radius', () => {
+        expect(logicalBorderRadiusCSS('3px 0 0 5px')).toMatchInlineSnapshot(`
+          "border-start-start-radius: 3px;
+          border-start-end-radius: 0;
+          border-end-end-radius: 0;
+          border-end-start-radius: 5px;"
+        `);
+      });
+
+      it('trims properties that equate to 0 if ignoreZeroes is true', () => {
+        expect(logicalBorderRadiusCSS('0px 10px 0 20px', true))
+          .toMatchInlineSnapshot(`
+          "border-start-end-radius: 10px;
+          border-end-start-radius: 20px;"
+        `);
+      });
+    });
+  });
+
+  describe('slash usage', () => {
+    it('handles 1 set of values', () => {
+      expect(logicalBorderRadiusCSS('10% / 20%')).toMatchInlineSnapshot(`
+        "border-start-start-radius: 10% 20%;
+        border-start-end-radius: 10% 20%;
+        border-end-end-radius: 10% 20%;
+        border-end-start-radius: 10% 20%;"
+      `);
+    });
+
+    it('handles 2 sets of values', () => {
+      expect(logicalBorderRadiusCSS('10% 20% / 30% 40%'))
+        .toMatchInlineSnapshot(`
+        "border-start-start-radius: 10% 30%;
+        border-start-end-radius: 20% 40%;
+        border-end-end-radius: 10% 30%;
+        border-end-start-radius: 20% 40%;"
+      `);
+    });
+
+    it('handles 3 sets of values', () => {
+      expect(logicalBorderRadiusCSS('10% 20% 30% / 40% 50% 60%'))
+        .toMatchInlineSnapshot(`
+        "border-start-start-radius: 10% 40%;
+        border-start-end-radius: 20% 50%;
+        border-end-end-radius: 30% 60%;
+        border-end-start-radius: 20% 50%;"
+      `);
+    });
+
+    it('handles 4 sets of values', () => {
+      expect(logicalBorderRadiusCSS('10% 20% 30% 40% / 50% 60% 70% 80%'))
+        .toMatchInlineSnapshot(`
+        "border-start-start-radius: 10% 50%;
+        border-start-end-radius: 20% 60%;
+        border-end-end-radius: 30% 70%;
+        border-end-start-radius: 40% 80%;"
+      `);
+    });
+
+    it('handles mismatched value amounts', () => {
+      expect(logicalBorderRadiusCSS('10px 20px / 30px')).toMatchInlineSnapshot(`
+        "border-start-start-radius: 10px 30px;
+        border-start-end-radius: 20px 30px;
+        border-end-end-radius: 10px 30px;
+        border-end-start-radius: 20px 30px;"
+      `);
+
+      expect(logicalBorderRadiusCSS('40px / 50px 60px 70px'))
+        .toMatchInlineSnapshot(`
+        "border-start-start-radius: 40px 50px;
+        border-start-end-radius: 40px 60px;
+        border-end-end-radius: 40px 70px;
+        border-end-start-radius: 40px 60px;"
+      `);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('ignores extra spaces between values', () => {
+      expect(logicalBorderRadiusCSS('25px    50px')).toMatchInlineSnapshot(`
+        "border-start-start-radius: 25px;
+        border-start-end-radius: 50px;
+        border-end-end-radius: 25px;
+        border-end-start-radius: 50px;"
+      `);
+    });
+
+    it('ignores more than 4 values', () => {
+      expect(logicalBorderRadiusCSS('1px 2px 3px 4px 5px'))
+        .toMatchInlineSnapshot(`
+        "border-start-start-radius: 1px;
+        border-start-end-radius: 2px;
+        border-end-end-radius: 3px;
+        border-end-start-radius: 4px;"
+      `);
+    });
   });
 });

--- a/src/global_styling/functions/logical_shorthands.test.ts
+++ b/src/global_styling/functions/logical_shorthands.test.ts
@@ -43,6 +43,16 @@ describe('logicalShorthandCSS', () => {
             "
       `);
     });
+
+    it('ignores extra spaces between values', () => {
+      expect(logicalShorthandCSS('border-color', 'red  green   blue    yellow'))
+        .toMatchInlineSnapshot(`
+        "
+            border-block-color: red blue;
+            border-inline-color: yellow green;
+            "
+      `);
+    });
   });
 
   it('throws an error if the passed property is not a shorthand property', () => {

--- a/src/global_styling/functions/logical_shorthands.test.ts
+++ b/src/global_styling/functions/logical_shorthands.test.ts
@@ -20,17 +20,17 @@ describe('logicalShorthandCSS', () => {
         "
             padding-block: 10px;
             padding-inline: 20px;
-          "
+            "
       `);
     });
 
     it('handles 3 values', () => {
-      expect(logicalShorthandCSS('padding', '10px 20px 30px'))
+      expect(logicalShorthandCSS('border-width', '10px 20px 30px'))
         .toMatchInlineSnapshot(`
         "
-            padding-block: 10px 30px;
-            padding-inline: 20px;
-          "
+            border-block-width: 10px 30px;
+            border-inline-width: 20px;
+            "
       `);
     });
 
@@ -40,7 +40,7 @@ describe('logicalShorthandCSS', () => {
         "
             padding-block: 10px 30px;
             padding-inline: 40px 20px;
-          "
+            "
       `);
     });
   });

--- a/src/global_styling/functions/logical_shorthands.test.ts
+++ b/src/global_styling/functions/logical_shorthands.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { logicalShorthandCSS } from '../functions/logical_shorthands';
+
+describe('logicalShorthandCSS', () => {
+  it('returns the shorthand property as-is if only one value is being set for all 4 sides', () => {
+    expect(logicalShorthandCSS('margin', 0)).toEqual('margin: 0;');
+  });
+
+  describe('returns `-block` and `-inline` properties if 2-4 values are passed', () => {
+    it('handles 2 values', () => {
+      expect(logicalShorthandCSS('padding', '10px 20px'))
+        .toMatchInlineSnapshot(`
+        "
+            padding-block: 10px;
+            padding-inline: 20px;
+          "
+      `);
+    });
+
+    it('handles 3 values', () => {
+      expect(logicalShorthandCSS('padding', '10px 20px 30px'))
+        .toMatchInlineSnapshot(`
+        "
+            padding-block: 10px 30px;
+            padding-inline: 20px;
+          "
+      `);
+    });
+
+    it('handles 4 values', () => {
+      expect(logicalShorthandCSS('padding', '10px 20px 30px 40px'))
+        .toMatchInlineSnapshot(`
+        "
+            padding-block: 10px 30px;
+            padding-inline: 40px 20px;
+          "
+      `);
+    });
+  });
+
+  it('throws an error if the passed property is not a shorthand property', () => {
+    expect(() => logicalShorthandCSS('border', 'inherit')).toThrow();
+  });
+});

--- a/src/global_styling/functions/logical_shorthands.ts
+++ b/src/global_styling/functions/logical_shorthands.ts
@@ -34,7 +34,7 @@ export const logicalShorthandCSS = (
   }
 
   // Split all potential values by spaces
-  const values = String(value).split(' ');
+  const values = String(value).split(/\s+/);
 
   let verticalBlockValue;
   let horizontalInlineValue;

--- a/src/global_styling/functions/logical_shorthands.ts
+++ b/src/global_styling/functions/logical_shorthands.ts
@@ -58,8 +58,17 @@ export const logicalShorthandCSS = (
       break;
   }
 
-  return `
+  if (property.includes('border-')) {
+    // Border properties have a different naming syntax than margin/padding/etc
+    const borderProperty = property.split('-')[1];
+    return `
+    border-block-${borderProperty}: ${verticalBlockValue};
+    border-inline-${borderProperty}: ${horizontalInlineValue};
+    `;
+  } else {
+    return `
     ${property}-block: ${verticalBlockValue};
     ${property}-inline: ${horizontalInlineValue};
-  `;
+    `;
+  }
 };

--- a/src/global_styling/functions/logical_shorthands.ts
+++ b/src/global_styling/functions/logical_shorthands.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import LOGICALS from './logicals.json';
+
+export const { _shorthands: LOGICAL_SHORTHANDS } = LOGICALS;
+export type LogicalShorthands = typeof LOGICAL_SHORTHANDS[number];
+
+/**
+ * Unfortunately, shorthand properties that describe boxes
+ * (@see https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box)
+ * do not currently automatically respond to logical changes in display direction
+ * (@see https://github.com/w3c/csswg-drafts/issues/1282)
+ *
+ * This utility is essentially a stop-gap for those shorthand properties,
+ * converting them to corresponding longer logical `-inline` and `-block` properties
+ *
+ * 🗑 NOTE: This file is in a separate util file from logicals.ts due to its relatively
+ * convoluted logic, & to make deleting it easier when an official CSS spec is implemented.
+ */
+export const logicalShorthandCSS = (
+  property: LogicalShorthands,
+  value: string | number
+) => {
+  if (!LOGICAL_SHORTHANDS.includes(property)) {
+    throw new Error(
+      `${property} is not a shorthand property that needs logical CSS`
+    );
+  }
+
+  // Split all potential values by spaces
+  const values = String(value).split(' ');
+
+  let verticalBlockValue;
+  let horizontalInlineValue;
+
+  switch (values.length) {
+    case 1:
+      // If it's the same value all around, no need to use logical properties
+      return `${property}: ${value};`;
+    case 2:
+      verticalBlockValue = values[0];
+      horizontalInlineValue = values[1];
+      break;
+    case 3:
+      verticalBlockValue = `${values[0]} ${values[2]}`;
+      horizontalInlineValue = values[1];
+      break;
+    case 4:
+    default:
+      verticalBlockValue = `${values[0]} ${values[2]}`;
+      horizontalInlineValue = `${values[3]} ${values[1]}`; // Note: left (4th value) comes before right (2nd value)
+      break;
+  }
+
+  return `
+    ${property}-block: ${verticalBlockValue};
+    ${property}-inline: ${horizontalInlineValue};
+  `;
+};

--- a/src/global_styling/functions/logicals.json
+++ b/src/global_styling/functions/logicals.json
@@ -61,6 +61,7 @@
     "inset",
     "border-color",
     "border-width",
-    "border-style"
+    "border-style",
+    "border-radius"
   ]
 }

--- a/src/global_styling/functions/logicals.json
+++ b/src/global_styling/functions/logicals.json
@@ -58,6 +58,9 @@
     "scroll-margin",
     "padding",
     "scroll-padding",
-    "inset"
+    "inset",
+    "border-color",
+    "border-width",
+    "border-style"
   ]
 }

--- a/src/global_styling/functions/logicals.json
+++ b/src/global_styling/functions/logicals.json
@@ -52,5 +52,12 @@
   "border-top-left-radius": "border-start-start-radius",
   "border-top-right-radius": "border-start-end-radius",
   "border-bottom-left-radius": "border-end-start-radius",
-  "border-bottom-right-radius": "border-end-end-radius"
+  "border-bottom-right-radius": "border-end-end-radius",
+  "_shorthands": [
+    "margin",
+    "scroll-margin",
+    "padding",
+    "scroll-padding",
+    "inset"
+  ]
 }

--- a/src/global_styling/functions/logicals.ts
+++ b/src/global_styling/functions/logicals.ts
@@ -28,7 +28,8 @@ export const LOGICAL_SIDES = keysOf(logicalSide);
 export type LogicalSides = typeof LOGICAL_SIDES[number];
 
 export const logicals = LOGICALS;
-export const LOGICAL_PROPERTIES = keysOf(logicals);
+const { _shorthands, ..._logicals } = LOGICALS;
+export const LOGICAL_PROPERTIES = keysOf(_logicals);
 export type LogicalProperties = typeof LOGICAL_PROPERTIES[number];
 
 /**

--- a/upcoming_changelogs/6429.md
+++ b/upcoming_changelogs/6429.md
@@ -1,0 +1,4 @@
+**CSS-in-JS conversions**
+
+- Added a new `logicalShorthandCSS` utility that automatically converts `margin`, `padding`, and other 4-sided shorthands to their corresponding logical properties
+- Added a new `logicalBorderRadiusCSS` utility that automatically converts `border-radius` to corresponding logical properties


### PR DESCRIPTION
## Summary

Unfortunately, [shorthand properties that describe boxes](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) such as `margin` and `padding` do not currently automatically respond to logical changes in display direction (see https://github.com/w3c/csswg-drafts/issues/1282).

Until an official spec is created by W3C, this utility is a stopgap measure to convert (e.g.) `margin` shorthands to `margin-inline` and `margin-block` respectively.

Example usage within Emotion (intentionally similar in usage to `logicalCSS()`):

```js
margin: 0 ${euiTheme.size.s};
```
becomes
```js
${logicalShorthandCSS('margin', `0 ${euiTheme.size.s}`)}
```

I've also added a lint rule for this, which flags shorthand usage with multiple values. Single values (same value applied to all 4 sides) do not need to be converted to a logical property, and both the lint rule and utility intelligently detect this.

Note: there is no `--fix` behavior currently as I deemed it too unnecessarily complex to try and automate a fix - devs will have to manually import and call `logicalShorthandCSS`. Should W3C implement a single-line shorthand keyword or property, this will become much easier to do at that point, so I would strongly suggest waiting for that.

I strongly recommend [following along by commit](https://github.com/elastic/eui/pull/6429/commits) with whitespace changes disabled.

## QA

Checked the following components for CSS output and visual smoke test:

- [x] EuiBadge
- [x] EuiHeaderBreadcrumbs
- [x] EuiButton
- [x] EuiCode
- [x] EuiExpression
- [x] EuiListGroupItem
- [x] EuiLoadingSpinner
- [x] EuiMarkdownFormat
- [x] EuiModalHeader
- [x] EuiPopoverFooter / EuiPopoverTitle
- [x] EuiText
- [x] EuiToken
- [x] EuiTooltip (arrow)

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately