### PR TITLE
[Docs] Fix inconsistent `arrow` usage for expanding and collapsing sections

### DIFF
--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.js
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.js
@@ -170,7 +170,9 @@ export const Table = () => {
         <EuiButtonIcon
           onClick={() => toggleDetails(item)}
           aria-label={itemIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
-          iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}
+          iconType={
+            itemIdToExpandedRowMap[item.id] ? 'arrowDown' : 'arrowRight'
+          }
         />
       ),
     },


### PR DESCRIPTION
## Summary

- The Accordion example shows **down arrow** to indicate expanded sections and **right arrow** for collapsed sections, but the Expanding Table Row example shows **up arrow** to indicate expanded sections and **down arrow** for collapsed sections. This PR fixes these inconsistencies by showing **down arrow** for expanded sections and **right arrow** for collapsed sections in both examples.

- Closes https://github.com/elastic/eui/issues/6362

### General checklist

- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart

