### PR TITLE
[Wiki] Remove `main` changelog update step from Kibana patch/backports docs

### DIFF
--- a/wiki/releasing-versions.md
+++ b/wiki/releasing-versions.md
@@ -90,11 +90,5 @@ This provides a walkthrough of the patching & backport release process; examples
   * Publish the new version to npm
     * Get your npm One Time Password (OTP) from Google Authenticator, Authy, etc
     * Publish with your OPT and the new version as the tag - `npm publish --tag=backport --otp=your-one-time-password`
-* Update `main`'s changelog to include this release
-  * On the branch you used to build & release, copy the relevant changelog section - e.g. contents of ```## [`22.3.1`](https://github.com/elastic/eui/tree/v22.3.1)```
-  * Checkout `main` - `git checkout main`
-  * Paste the changelog section at the correct location in _CHANGELOG.md_
-    * Include an extra line at the top of this section describing it as a backport, e.g. **Note: this release is a backport containing changes originally made in `23.0.0`, `23.1.0`, and `23.2.0`**
-  * Commit the changelog entry to main and push - `git commit -anm "changelog" && git push`
 * Let people know the backport is released
 * Celebrate profusely


### PR DESCRIPTION
## Summary

Updates our wiki documentation to remove the step where we add backports/patch releases made only for Kibana from the `main` CHANGELOG. Since we're not doing GH releases for the backport/patches, it doesn't make sense to list them in the main CHANGELOG.