### PR TITLE
Add renovate bot to jenkins white-list

### DIFF
--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -10,6 +10,8 @@
       - github-pull-request:
           org-list:
             - elastic
+          white-list:
+            - renovate
           allow-whitelist-orgs-as-admins: true
           trigger-phrase: '(.*(?:jenkins\W+)?test\W+(?:this|it)(?:\W+please)?.*)|^retest$'
           github-hooks: true


### PR DESCRIPTION
## Summary

This PR adds `renovate` bot user to the permitted users for building pull requests. See JJB [options](https://jenkins-job-builder.readthedocs.io/en/latest/triggers.html?highlight=white-list#triggers.github-pull-request).

This will prevent messages like [this](https://github.com/elastic/eui/pull/6350#issuecomment-1307505603), shown below and automatically run the CI build treating `renovate` as a trusted user.

<img width="922" alt="image" src="https://user-images.githubusercontent.com/19007109/205722263-e550d74b-7347-4e4e-9e8e-be4604fee356.png">
