### PR TITLE
[EuiBasicTable] Fix incorrect props documentation

### DIFF
--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -65,7 +65,7 @@ type Sorting = boolean | SortingOptions;
 
 type InMemoryTableProps<T> = Omit<
   EuiBasicTableProps<T>,
-  'pagination' | 'sorting' | 'noItemsMessage'
+  'pagination' | 'sorting' | 'noItemsMessage' | 'onChange'
 > & {
   message?: ReactNode;
   /**
@@ -78,6 +78,12 @@ type InMemoryTableProps<T> = Omit<
    * Set `allowNeutralSort` to false to force column sorting. Defaults to true.
    */
   allowNeutralSort?: boolean;
+  /**
+   * `onChange` is not required when `pagination` and/or `sorting` are configured,
+   * but if `onChange` is present it is responsible for handling state for each/both.
+   * See #Criteria or #CriteriaWithPagination
+   */
+  onChange?: EuiBasicTableProps<T>['onChange'];
   /**
    * Callback for when table pagination or sorting is changed. This is meant to be informational only, and not used to set any state as the in-memory table already manages this state. See #Criteria or #CriteriaWithPagination.
    */


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5928

The above issue auto-stale-closed, but I thought updating the docs would be a super quick fix and I wanted to address it really quickly [with Greg's comments](https://github.com/elastic/eui/issues/5928#issuecomment-1138633747) since a docs change is much simpler than a props change.

### Before
<img width="854" alt="" src="https://user-images.githubusercontent.com/549407/205729794-7c1b34e4-aeaa-42e2-a41b-4cd03f80b6cd.png">

### After
<img width="859" alt="" src="https://user-images.githubusercontent.com/549407/205729813-94e64482-6d8e-4fe7-a411-da7cacfa985f.png">

## QA

### General checklist

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**