### PR TITLE
Adding a11y tests for EuiColorPicker, EuiComboBox, and EuiCopy

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.a11y.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.a11y.tsx
@@ -65,7 +65,7 @@ describe('EuiBreadcrumbs', () => {
     });
 
     it('has zero violations when truncated menu is open', () => {
-      cy.get('[aria-label="See collapsed breadcrumbs"]').click();
+      cy.get('[aria-label="See collapsed breadcrumbs"]').realClick();
       cy.get('[data-popover-open="true"] nav.euiBreadcrumbs').should('exist');
       cy.checkAxe();
     });

--- a/src/components/color_picker/color_picker.a11y.tsx
+++ b/src/components/color_picker/color_picker.a11y.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiColorPicker } from './color_picker';
+import { EuiFormRow } from '../form';
+import { useColorPickerState } from '../../services';
+
+const ColorPicker = () => {
+  const [color, setColor, errors] = useColorPickerState('#D36086');
+  return (
+    <EuiFormRow label="Pick a color" isInvalid={!!errors} error={errors}>
+      <EuiColorPicker onChange={setColor} color={color} isInvalid={!!errors} />
+    </EuiFormRow>
+  );
+};
+
+beforeEach(() => {
+  cy.realMount(<ColorPicker />);
+});
+
+describe('EuiColorPicker', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the picker is opened', () => {
+      cy.get('input[data-test-subj="euiColorPickerAnchor"]').realClick();
+      cy.get('div[data-test-subj="euiColorPickerPopover"]').should('exist');
+      cy.checkAxe();
+      cy.realPress('Escape');
+      cy.get('div[data-test-subj="euiColorPickerPopover"]').should('not.exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations after keyboard interaction', () => {
+      cy.realPress('Tab');
+      cy.get('input[data-test-subj="euiColorPickerAnchor"]').should(
+        'have.focus'
+      );
+      cy.realPress('Enter');
+      cy.repeatRealPress('ArrowDown', 5);
+      cy.repeatRealPress('ArrowRight', 3);
+      cy.realPress('Escape');
+      cy.get('input[data-test-subj="euiColorPickerAnchor"]').should(
+        'have.focus'
+      );
+      cy.get('input[data-test-subj="euiColorPickerAnchor"]').should(
+        'have.attr',
+        'value',
+        '#C9557B'
+      );
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/combo_box/combo_box.a11y.tsx
+++ b/src/components/combo_box/combo_box.a11y.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiComboBox } from './index';
+
+const ComboBox = () => {
+  const [options] = useState([
+    {
+      label: 'Titan',
+      'data-test-subj': 'titanOption',
+    },
+    {
+      label: 'Enceladus',
+      'data-test-subj': 'enceladusOption',
+    },
+    {
+      label: 'Mimas',
+      'data-test-subj': 'mimasOption',
+    },
+    {
+      label: 'Dione',
+      'data-test-subj': 'dioneOption',
+    },
+    {
+      label: 'Iapetus',
+      'data-test-subj': 'iapetusOption',
+    },
+    {
+      label: 'Phoebe',
+      'data-test-subj': 'phoebeOption',
+    },
+    {
+      label: 'Rhea',
+      'data-test-subj': 'rheaOption',
+    },
+    {
+      label: 'Tethys',
+      'data-test-subj': 'tethysOption',
+    },
+    {
+      label: 'Hyperion',
+      'data-test-subj': 'hyperionOption',
+    },
+  ]);
+
+  const [selectedOptions, setSelected] = useState([]);
+
+  const onChange = (selectedOptions) => {
+    setSelected(selectedOptions);
+  };
+
+  return (
+    <EuiComboBox
+      aria-label="Accessible screen reader label"
+      placeholder="Select options"
+      options={options}
+      selectedOptions={selectedOptions}
+      onChange={onChange}
+      isClearable={true}
+      isCaseSensitive
+    />
+  );
+};
+
+beforeEach(() => {
+  cy.realMount(<ComboBox />);
+  cy.get('input[data-test-subj="comboBoxSearchInput"]').should('exist');
+});
+
+describe('EuiComboBox', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the combobox is expanded', () => {
+      cy.get('input[data-test-subj="comboBoxSearchInput"]').realClick();
+      cy.get('button[data-test-subj="titanOption"]').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations after keyboard interaction', () => {
+      cy.realPress('Tab');
+      cy.get('input[data-test-subj="comboBoxSearchInput"]').should(
+        'have.focus'
+      );
+      cy.get('button[data-test-subj="titanOption"]').should('exist');
+      cy.repeatRealPress('ArrowDown');
+      cy.realPress('Enter');
+      cy.repeatRealPress('ArrowDown');
+      cy.realPress('Enter');
+      cy.repeatRealPress('ArrowDown');
+      cy.realPress('Enter');
+      cy.get('div[data-test-subj="comboBoxInput"]')
+        .find('span.euiBadge')
+        .should('have.length', 3);
+      cy.checkAxe();
+
+      // Close the listbox and interact with the Clear button
+      cy.realPress('Escape');
+      cy.realPress('Tab');
+      cy.get('button[data-test-subj="comboBoxClearButton"]').should(
+        'have.focus'
+      );
+      cy.realPress('Space');
+      cy.get('div[data-test-subj="comboBoxInput"]')
+        .find('span.euiBadge')
+        .should('have.length', 0);
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/control_bar/control_bar.a11y.tsx
+++ b/src/components/control_bar/control_bar.a11y.tsx
@@ -171,15 +171,15 @@ describe('EuiControlBar', () => {
     });
 
     it('has zero violations when control bar is shown', () => {
-      cy.get('button.euiButton').contains('Toggle example').click();
+      cy.get('button.euiButton').contains('Toggle example').realClick();
       cy.get('section[aria-label="Page level controls"]').should('exist');
       cy.checkAxe({ context: 'section[aria-label="Page level controls"]' });
     });
 
     it('has zero violations when control bar is hidden', () => {
-      cy.get('button.euiButton').contains('Toggle example').click();
+      cy.get('button.euiButton').contains('Toggle example').realClick();
       cy.get('section[aria-label="Page level controls"]').should('exist');
-      cy.get('button.euiButton').contains('Toggle example').click();
+      cy.get('button.euiButton').contains('Toggle example').realClick();
       cy.get('section[aria-label="Page level controls"]').should('not.exist');
       cy.checkAxe();
     });

--- a/src/components/copy/copy.a11y.tsx
+++ b/src/components/copy/copy.a11y.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiButton } from '../button';
+import { EuiCopy } from './copy';
+import { EuiFormRow, EuiFieldText } from '../form';
+import { EuiSpacer } from '../spacer';
+
+const Copy = () => {
+  const [copyText, setCopyText] = useState('I am the text that will be copied');
+
+  const onChange = (e) => {
+    setCopyText(e.target.value);
+  };
+
+  return (
+    <div>
+      <EuiFormRow label="Enter text that will be copied to clipboard">
+        <EuiFieldText value={copyText} onChange={onChange} />
+      </EuiFormRow>
+
+      <EuiSpacer size="m" />
+
+      <EuiCopy textToCopy={copyText}>
+        {(copy) => (
+          <EuiButton onClick={copy} data-test-subj="cy-copy-button">
+            Click to copy input text
+          </EuiButton>
+        )}
+      </EuiCopy>
+    </div>
+  );
+};
+
+beforeEach(() => {
+  cy.realMount(<Copy />);
+});
+
+describe('EuiCopy', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations after the copy button is clicked', () => {
+      cy.get('button[data-test-subj="cy-copy-button"]').realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations after keyboard interaction', () => {
+      cy.repeatRealPress('Tab');
+      cy.realPress('Enter');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/modal/modal.a11y.tsx
+++ b/src/components/modal/modal.a11y.tsx
@@ -70,7 +70,7 @@ describe('EuiModal', () => {
     });
 
     it('has zero violations when modal is closed', () => {
-      cy.get('div.euiModalFooter button.euiButton').realClick();
+      cy.get('div.euiModalFooter button.euiButton').click();
       cy.get('div.euiModal').should('not.exist');
       cy.checkAxe();
     });

--- a/src/components/modal/modal.a11y.tsx
+++ b/src/components/modal/modal.a11y.tsx
@@ -59,7 +59,7 @@ const Modal = () => {
 beforeEach(() => {
   cy.mount(<Modal />);
   cy.get('div.euiModal').should('not.exist');
-  cy.get('button.euiButton').click();
+  cy.get('button.euiButton').realClick();
   cy.get('div.euiModal').should('exist');
 });
 
@@ -70,7 +70,7 @@ describe('EuiModal', () => {
     });
 
     it('has zero violations when modal is closed', () => {
-      cy.get('div.euiModalFooter button.euiButton').click();
+      cy.get('div.euiModalFooter button.euiButton').realClick();
       cy.get('div.euiModal').should('not.exist');
       cy.checkAxe();
     });

--- a/src/components/side_nav/side_nav.a11y.tsx
+++ b/src/components/side_nav/side_nav.a11y.tsx
@@ -71,7 +71,7 @@ describe('EuiSideNav', () => {
       });
 
       it('has zero violations when mobile side nav is expanded', () => {
-        cy.get('button').contains('Basic example').click();
+        cy.get('button').contains('Basic example').realClick();
         cy.get('div.euiSideNav__content').should('exist');
         cy.checkAxe();
       });


### PR DESCRIPTION
## Summary
* Added color picker Cypress a11y spec. Updating some specs to use `cy.realClick()`
* Added EuiComboBox a11y and keyboard specs.
* Adding EuiCopy a11y and keyboard specs.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in **Chrome**, ~~**Safari**~~, **Edge**, ~~and **Firefox**~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
