### PR TITLE
[Docs] Add EUI error messaging to playground errors

### DIFF
--- a/src-docs/src/services/playground/playground.js
+++ b/src-docs/src/services/playground/playground.js
@@ -5,12 +5,15 @@ import format from 'html-format';
 import { useView, Compiler, Placeholder } from 'react-view';
 import {
   EuiCodeBlock,
-  EuiErrorBoundary,
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiPanel,
   useEuiTheme,
 } from '../../../../src';
+import {
+  EuiErrorMessage,
+  EuiErrorBoundary,
+} from '../../../../src/components/error_boundary/error_boundary';
 import Knobs from './knobs';
 import { GuideSectionPropsDescription } from '../../components/guide_section/guide_section_parts/guide_section_props_description';
 
@@ -68,6 +71,10 @@ export default ({
       }
     }, [params.knobProps]);
 
+    // react-view swallows errors thrown in the Compiler, so we need to grab
+    // them via errorProps and pass them to our own EUI component
+    const thrownError = params.errorProps.msg; // string or null
+
     return (
       <>
         <EuiFlyoutHeader hasBorder>
@@ -86,6 +93,9 @@ export default ({
               guideDemo__ghostBackground: isGhost,
             })}
             {...playgroundPanelProps}
+            paddingSize={
+              thrownError ? 'none' : playgroundPanelProps?.paddingSize
+            }
           >
             <Compiler
               css={playgroundCssStyles?.(euiTheme)}
@@ -93,6 +103,7 @@ export default ({
               placeholder={Placeholder}
               className={classNames('playground__demo', playgroundClassName)}
             />
+            {thrownError && <EuiErrorMessage errorMessage={thrownError} />}
           </EuiPanel>
         </EuiFlyoutHeader>
         <EuiFlyoutHeader className="playground__codeWrapper" hasBorder>

--- a/src/components/error_boundary/error_boundary.tsx
+++ b/src/components/error_boundary/error_boundary.tsx
@@ -6,14 +6,19 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, HTMLAttributes, ReactNode } from 'react';
+import React, {
+  Component,
+  FunctionComponent,
+  HTMLAttributes,
+  ReactNode,
+} from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 
 import { EuiTitle } from '../title';
 import { EuiCodeBlock } from '../code';
 import { EuiI18n } from '../i18n';
-import { withEuiTheme, WithEuiThemeProps } from '../../services';
+import { useEuiTheme } from '../../services';
 
 import { euiErrorBoundaryStyles } from './error_boundary.styles';
 
@@ -30,13 +35,11 @@ export type EuiErrorBoundaryProps = CommonProps &
     children: ReactNode;
   };
 
-type EuiErrorBoundaryExtendedProps = EuiErrorBoundaryProps & WithEuiThemeProps;
-
-export class _EuiErrorBoundary extends Component<
-  EuiErrorBoundaryExtendedProps,
+export class EuiErrorBoundary extends Component<
+  EuiErrorBoundaryProps,
   EuiErrorBoundaryState
 > {
-  constructor(props: EuiErrorBoundaryExtendedProps) {
+  constructor(props: EuiErrorBoundaryProps) {
     super(props);
 
     const errorState: EuiErrorBoundaryState = {
@@ -62,41 +65,42 @@ ${stackStr}`;
   }
 
   render() {
-    const {
-      className,
-      children,
-      'data-test-subj': _dataTestSubj,
-      theme,
-      ...rest
-    } = this.props;
-    const dataTestSubj = classNames('euiErrorBoundary', _dataTestSubj);
-    const styles = euiErrorBoundaryStyles(theme);
+    const { children, ...rest } = this.props;
 
     if (this.state.hasError) {
       // You can render any custom fallback UI
-      return (
-        <div
-          css={styles.euiErrorBoundary}
-          className={classNames('euiErrorBoundary', className)}
-          data-test-subj={dataTestSubj}
-          {...rest}
-        >
-          <EuiCodeBlock>
-            <EuiTitle size="xs">
-              <p>
-                <EuiI18n token="euiErrorBoundary.error" default="Error" />
-              </p>
-            </EuiTitle>
-            {this.state.error}
-          </EuiCodeBlock>
-        </div>
-      );
+      return <EuiErrorMessage {...rest} errorMessage={this.state.error} />;
     }
 
     return children;
   }
 }
 
-export const EuiErrorBoundary = withEuiTheme<EuiErrorBoundaryProps>(
-  _EuiErrorBoundary
-);
+/**
+ * Split out into a separate styling-only component for easier use of hooks,
+ * and also for internal re-use by EUI's docs/playgrounds
+ */
+export const EuiErrorMessage: FunctionComponent<
+  CommonProps & { errorMessage?: string }
+> = ({ errorMessage, className, 'data-test-subj': dataTestSubj, ...rest }) => {
+  const euiTheme = useEuiTheme();
+  const styles = euiErrorBoundaryStyles(euiTheme);
+
+  return (
+    <div
+      css={styles.euiErrorBoundary}
+      className={classNames('euiErrorBoundary', className)}
+      data-test-subj={classNames('euiErrorBoundary', dataTestSubj)}
+      {...rest}
+    >
+      <EuiCodeBlock>
+        <EuiTitle size="xs">
+          <p>
+            <EuiI18n token="euiErrorBoundary.error" default="Error" />
+          </p>
+        </EuiTitle>
+        {errorMessage}
+      </EuiCodeBlock>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Previously when components threw errors in playgrounds, there would just be an empty blank and a console message:

<img width="1042" alt="" src="https://user-images.githubusercontent.com/549407/205974249-d9aaadc7-2979-4309-87dd-99cd5e1bc9dc.png">

I initially attempted wrapping the playground in an `EuiErrorBoundary`, but nothing was happening. After looking at [react-view's documentation](https://github.com/uber/react-view#error), I realized they were swallowing/capturing errors and passing them via an `errorProps`.

I didn't want to use react-view's default `Error` component as they styling was super different than anything else we had in EUI, and we already had error styling via `EuiErrorBoundary`. My solution to this was to extract react-view's `errorProps.message`, and pass that manually to a styled internal component (a view-only internal version of `EuiErrorBoundary` pulled out separately). The end result:

<img width="1063" alt="" src="https://user-images.githubusercontent.com/549407/206021304-08315059-0078-4602-9b20-6a9fc8b0f01a.png">

## QA

Repro steps:

1. Go to https://eui.elastic.co/pr_6464/#/forms/range-sliders#single-range's playground
2. Change `step` value to `3`
3. Confirm you actually see a visible error message in the playground

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**