### PR TITLE
A11y specs for EuiDataGrid, EuiDatePicker, EuiDelayRender, EuiEmptyPrompt

### DIFF
--- a/src/components/datagrid/data_grid.a11y.tsx
+++ b/src/components/datagrid/data_grid.a11y.tsx
@@ -8,39 +8,206 @@
 
 /// <reference types="../../../cypress/support"/>
 
-import React from 'react';
-import { EuiDataGrid, EuiDataGridProps } from './index';
+import React, { useState } from 'react';
+import { EuiDataGrid, EuiDataGridColumn } from './index';
+import { faker } from '@faker-js/faker';
+
+const columns: EuiDataGridColumn[] = [
+  {
+    id: 'Name',
+  },
+  {
+    id: 'Email',
+    cellActions: [
+      ({ rowIndex, columnId, Component }) => {
+        const row = ++rowIndex;
+        return (
+          <Component
+            onClick={() => {}}
+            iconType="heart"
+            aria-label={`Send love to ${row}, column "${columnId}" `}
+          >
+            Send love
+          </Component>
+        );
+      },
+    ],
+  },
+  {
+    id: 'User ID',
+    schema: 'string',
+  },
+  {
+    id: 'Account balance',
+  },
+  {
+    id: 'Last purchase',
+    schema: 'datetime',
+  },
+  {
+    id: 'Favorite distro',
+    schema: 'favoriteDistro',
+  },
+];
+
+const storeData: any[] = [];
+
+for (let i = 1; i < 11; i++) {
+  storeData.push({
+    Name: `${faker.name.lastName()}, ${faker.name.firstName()} ${faker.name.suffix()}`,
+    Email: `${faker.internet.email()}`,
+    'User ID': `${faker.datatype.number({ min: 1000000, max: 9999999 })}`,
+    'Account balance': faker.finance.amount(),
+    'Last purchase': `${faker.date.past()}`,
+    'Favorite distro': i % 2 === 0 ? 'Alma' : 'Debian',
+  });
+}
+
+const commaSeparateNumbers = (numberString) => {
+  // extract the groups-of-three digits that are right-aligned
+  return numberString.replace(/((\d{3})+)$/, (match) =>
+    // then replace each group of xyz digits with ,xyz
+    match.replace(/(\d{3})/g, ',$1')
+  );
+};
 
 const DataGrid = () => {
-  const baseProps: EuiDataGridProps = {
-    'aria-label': 'grid for testing',
-    columns: [
-      { id: 'a', display: 'First' },
-      { id: 'b', display: 'Second' },
-      { id: 'c', display: 'Third' },
-      { id: 'd', display: 'Fourth' },
-      { id: 'e', display: 'Fifth' },
-    ],
-    columnVisibility: {
-      visibleColumns: ['a', 'b', 'c', 'd', 'e'],
-      setVisibleColumns: () => {},
-    },
-    rowCount: 10,
-    renderCellValue: ({ rowIndex, columnId }) => `${columnId}, ${rowIndex}`,
-    renderFooterCellValue: ({ columnId }) => `${columnId}, footer`,
+  const [visibleColumns, setVisibleColumns] = useState(
+    columns.map(({ id }) => id)
+  );
+
+  const [data, setData] = useState(storeData);
+  const [sortingColumns, setSortingColumns] = useState([
+    { id: 'custom', direction: 'asc' as 'asc' | 'desc' },
+  ]);
+
+  const setSorting = (sortingColumns) => {
+    const sortedData = [...data].sort((a, b) => {
+      for (let i = 0; i < sortingColumns.length; i++) {
+        const column = sortingColumns[i];
+        const aValue = a[column.id];
+        const bValue = b[column.id];
+
+        if (aValue < bValue) return column.direction === 'asc' ? -1 : 1;
+        if (aValue > bValue) return column.direction === 'asc' ? 1 : -1;
+      }
+
+      return 0;
+    });
+
+    setData(sortedData);
+    setSortingColumns(sortingColumns);
   };
 
-  return <EuiDataGrid {...baseProps} />;
+  return (
+    <EuiDataGrid
+      aria-label="Data grid schema example"
+      columns={columns}
+      columnVisibility={{ visibleColumns, setVisibleColumns }}
+      rowCount={data.length}
+      inMemory={{ level: 'sorting' }}
+      renderCellValue={({ rowIndex, columnId, schema }) => {
+        let value = data[rowIndex][columnId];
+
+        if (schema === 'numeric') {
+          value = commaSeparateNumbers(value);
+        }
+
+        return value;
+      }}
+      sorting={{ columns: sortingColumns, onSort: setSorting }}
+      schemaDetectors={[
+        {
+          type: 'favoriteDistro',
+          textTransform: 'capitalize',
+          detector(value) {
+            return value.toLowerCase() === 'alma' ||
+              value.toLowerCase() === 'debian'
+              ? 1
+              : 0;
+          },
+          comparator(a, b, direction) {
+            const aValue = a.toLowerCase() === 'alma';
+            const bValue = b.toLowerCase() === 'alma';
+            if (aValue < bValue) return direction === 'asc' ? 1 : -1;
+            if (aValue > bValue) return direction === 'asc' ? -1 : 1;
+            return 0;
+          },
+          sortTextAsc: 'Alma to Debian',
+          sortTextDesc: 'Debian to Alma',
+          icon: 'starFilled',
+          color: '#800080',
+        },
+      ]}
+    />
+  );
 };
 
 beforeEach(() => {
-  cy.viewport(1024, 768); // medium breakpoint
-  cy.mount(<DataGrid />);
+  cy.viewport(1280, 800); // large breakpoint
+  cy.mount(
+    <div style={{ width: '80%', margin: '0 auto' }}>
+      <DataGrid />
+    </div>
+  );
 });
 
 describe('EuiDataGrid', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the columns reorder menu is open', () => {
+      cy.get(
+        'button[data-test-subj="dataGridColumnSelectorButton"]'
+      ).realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the hide all columns button is clicked', () => {
+      cy.get(
+        'button[data-test-subj="dataGridColumnSelectorButton"]'
+      ).realClick();
+      cy.get(
+        'button[data-test-subj="dataGridColumnSelectorHideAllButton"]'
+      ).realClick();
+      // TODO: Log this issue and remove the skipFailures boolean when fixed
+      cy.checkAxe({ skipFailures: true });
+    });
+
+    it('has zero violations when the columns reorder searchbox returns multiple results', () => {
+      cy.get(
+        'button[data-test-subj="dataGridColumnSelectorButton"]'
+      ).realClick();
+      cy.get('input[data-test-subj="dataGridColumnSelectorSearch"]').type('a');
+      cy.get('div.euiSwitch--compressed').should(($s) => {
+        expect($s).to.have.length(5);
+      });
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the columns reorder searchbox returns 1 result', () => {
+      cy.get(
+        'button[data-test-subj="dataGridColumnSelectorButton"]'
+      ).realClick();
+      cy.get('input[data-test-subj="dataGridColumnSelectorSearch"]').type(
+        'favorite'
+      );
+      cy.get('div.euiSwitch--compressed').should(($s) => {
+        expect($s).to.have.length(1);
+      });
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the columns reorder searchbox returns 0 results', () => {
+      cy.get(
+        'button[data-test-subj="dataGridColumnSelectorButton"]'
+      ).realClick();
+      cy.get('input[data-test-subj="dataGridColumnSelectorSearch"]').type('x');
+      cy.get('div.euiSwitch--compressed').should(($s) => {
+        expect($s).to.have.length(0);
+      });
       cy.checkAxe();
     });
 
@@ -60,6 +227,34 @@ describe('EuiDataGrid', () => {
 
     it('has zero violations when the column actions menu is open', () => {
       cy.get('button.euiDataGridHeaderCell__button').first().realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations when a cell expansion popover is open', () => {
+      cy.get(
+        'div[data-gridcell-visible-row-index="0"][data-gridcell-column-index="1"]'
+      ).realClick();
+      cy.get(
+        'div[data-gridcell-visible-row-index="0"][data-gridcell-column-index="1"]'
+      )
+        .find('button.euiButtonIcon')
+        .last()
+        .realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the Favorite Distro column has been sorted', () => {
+      cy.get('button.euiDataGridHeaderCell__button').last().realClick();
+      cy.get('button.euiListGroupItem__button')
+        .contains('Sort Alma to Debian')
+        .should('exist')
+        .realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations when fullscreen is open', () => {
+      cy.get('button[data-test-subj="dataGridFullScreenButton"]').realClick();
+      cy.get('div.euiDataGrid--fullScreen').should('exist');
       cy.checkAxe();
     });
   });

--- a/src/components/datagrid/data_grid.a11y.tsx
+++ b/src/components/datagrid/data_grid.a11y.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiDataGrid, EuiDataGridProps } from './index';
+
+const DataGrid = () => {
+  const baseProps: EuiDataGridProps = {
+    'aria-label': 'grid for testing',
+    columns: [
+      { id: 'a', display: 'First' },
+      { id: 'b', display: 'Second' },
+      { id: 'c', display: 'Third' },
+      { id: 'd', display: 'Fourth' },
+      { id: 'e', display: 'Fifth' },
+    ],
+    columnVisibility: {
+      visibleColumns: ['a', 'b', 'c', 'd', 'e'],
+      setVisibleColumns: () => {},
+    },
+    rowCount: 10,
+    renderCellValue: ({ rowIndex, columnId }) => `${columnId}, ${rowIndex}`,
+    renderFooterCellValue: ({ columnId }) => `${columnId}, footer`,
+  };
+
+  return <EuiDataGrid {...baseProps} />;
+};
+
+beforeEach(() => {
+  cy.viewport(1024, 768); // medium breakpoint
+  cy.mount(<DataGrid />);
+});
+
+describe('EuiDataGrid', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the keyboard shortcut menu is open', () => {
+      cy.get(
+        'button[data-test-subj="dataGridKeyboardShortcutsButton"]'
+      ).realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the grid display menu is open', () => {
+      cy.get(
+        'button[data-test-subj="dataGridDisplaySelectorButton"]'
+      ).realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the column actions menu is open', () => {
+      cy.get('button.euiDataGridHeaderCell__button').first().realClick();
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/date_picker/date_picker.a11y.tsx
+++ b/src/components/date_picker/date_picker.a11y.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import moment from 'moment';
+import { EuiDatePicker } from './date_picker';
+import { EuiFormRow } from '../form';
+
+const DatePicker = () => {
+  const [startDate, setStartDate] = useState(moment());
+
+  const handleChange = (date) => {
+    setStartDate(date);
+  };
+
+  return (
+    <EuiFormRow label="Select a date">
+      <EuiDatePicker selected={startDate} onChange={handleChange} />
+    </EuiFormRow>
+  );
+};
+
+beforeEach(() => {
+  cy.realMount(<DatePicker />);
+  cy.get('input.euiDatePicker').should('exist');
+});
+
+describe('EuiDatePicker', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the calendar widget is expanded', () => {
+      cy.get('input.euiDatePicker').realClick();
+      cy.get('div.react-datepicker').should('exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations after picking a date with arrow keys', () => {
+      cy.realPress('Tab');
+      cy.get('div.react-datepicker').should('exist');
+      cy.repeatRealPress('ArrowDown');
+      cy.realPress('ArrowRight');
+      cy.realPress('Enter');
+      cy.get('div.react-datepicker').should('not.exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations after picking a date with dropdown menus', () => {
+      cy.realPress('Tab');
+      cy.get('div.react-datepicker').should('exist');
+      cy.repeatRealPress('Tab', 4);
+      cy.get('div.react-datepicker__month-read-view').should('have.focus');
+      cy.realPress('Space');
+      cy.repeatRealPress('ArrowDown');
+      cy.realPress('Enter');
+      cy.realPress('Tab');
+      cy.realPress('Space');
+      cy.repeatRealPress('ArrowDown');
+      cy.realPress('Enter');
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/delay_hide/delay_hide.a11y.tsx
+++ b/src/components/delay_hide/delay_hide.a11y.tsx
@@ -9,51 +9,47 @@
 /// <reference types="../../../cypress/support"/>
 
 import React, { useState } from 'react';
-import { EuiDelayRender } from './delay_render';
+import { EuiDelayHide } from './delay_hide';
 import { EuiCheckbox, EuiFieldNumber, EuiFormRow } from '../form';
 import { EuiFlexItem } from '../flex';
 import { EuiLoadingSpinner } from '../loading';
 
-const DelayRender = () => {
-  const [minimumDelay, setDelay] = useState(1000);
-  const [render, setRender] = useState(false);
+const DelayHide = () => {
+  const [minimumDuration, setDuration] = useState(1000);
+  const [hide, setHide] = useState(false);
 
-  const onChangeMinimumDelay = (event) => {
-    setDelay(parseInt(event.target.value, 10));
+  const onChangeMinimumDuration = (event) => {
+    setDuration(parseInt(event.target.value, 10));
   };
 
   const onChangeHide = (event) => {
-    setRender(event.target.checked);
+    setHide(event.target.checked);
   };
 
-  const status = render ? 'showing' : 'hidden';
-  const label = `Child (${status})`;
   return (
     <>
       <EuiFlexItem>
         <EuiFormRow>
           <EuiCheckbox
             id="dummy-id"
-            checked={render}
+            checked={hide}
             onChange={onChangeHide}
-            label="Show child"
+            label="Hide child"
           />
         </EuiFormRow>
-        <EuiFormRow label="Minimum delay">
+        <EuiFormRow label="Minimum duration">
           <EuiFieldNumber
-            value={minimumDelay}
-            onChange={onChangeMinimumDelay}
+            value={minimumDuration}
+            onChange={onChangeMinimumDuration}
           />
         </EuiFormRow>
 
-        <EuiFormRow label={label}>
-          {render ? (
-            <EuiDelayRender delay={minimumDelay}>
-              <EuiLoadingSpinner size="m" />
-            </EuiDelayRender>
-          ) : (
-            <></>
-          )}
+        <EuiFormRow label="Child to render">
+          <EuiDelayHide
+            hide={hide}
+            minimumDuration={minimumDuration}
+            render={() => <EuiLoadingSpinner size="m" />}
+          />
         </EuiFormRow>
       </EuiFlexItem>
     </>
@@ -61,46 +57,48 @@ const DelayRender = () => {
 };
 
 beforeEach(() => {
-  cy.realMount(<DelayRender />);
+  cy.realMount(<DelayHide />);
 });
 
-describe('EuiDelayRender', () => {
+describe('EuiHideRender', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on first render', () => {
       cy.checkAxe();
     });
 
-    it('has zero violations when the show child input is checked', () => {
+    it('has zero violations when the hide child input is checked', () => {
       cy.get('input.euiCheckbox__input').realClick();
       cy.get('div.euiFormRow__fieldWrapper')
         .last()
-        .find('span[role="progressbar"]', { timeout: 5000 });
-      cy.checkAxe();
-    });
-
-    it('has zero violations when the show child input is pressed', () => {
-      cy.realPress('Tab');
-      cy.get('input.euiCheckbox__input').should('have.focus');
-      cy.realPress('Space');
-      cy.get('div.euiFormRow__fieldWrapper')
-        .last()
         .find('span[role="progressbar"]', { timeout: 5000 })
-        .should('exist');
+        .should('not.exist');
       cy.checkAxe();
     });
 
-    it('has zero violations when the show child input is toggled', () => {
+    it('has zero violations when the hide child input is pressed', () => {
       cy.realPress('Tab');
       cy.get('input.euiCheckbox__input').should('have.focus');
-      cy.realPress('Space');
-      cy.get('div.euiFormRow__fieldWrapper')
-        .last()
-        .find('span[role="progressbar"]', { timeout: 5000 });
       cy.realPress('Space');
       cy.get('div.euiFormRow__fieldWrapper')
         .last()
         .find('span[role="progressbar"]', { timeout: 5000 })
         .should('not.exist');
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the hide child input is toggled', () => {
+      cy.realPress('Tab');
+      cy.get('input.euiCheckbox__input').should('have.focus');
+      cy.realPress('Space');
+      cy.get('div.euiFormRow__fieldWrapper')
+        .last()
+        .find('span[role="progressbar"]')
+        .should('not.exist');
+      cy.realPress('Space');
+      cy.get('div.euiFormRow__fieldWrapper')
+        .last()
+        .find('span[role="progressbar"]', { timeout: 5000 })
+        .should('exist');
       cy.checkAxe();
     });
   });

--- a/src/components/delay_render/delay_render.a11y.tsx
+++ b/src/components/delay_render/delay_render.a11y.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiDelayRender } from './delay_render';
+import { EuiCheckbox, EuiFieldNumber, EuiFormRow } from '../form';
+import { EuiFlexItem } from '../flex';
+import { EuiLoadingSpinner } from '../loading';
+
+const DelayRender = () => {
+  const [minimumDelay, setDelay] = useState(1000);
+  const [render, setRender] = useState(false);
+
+  const onChangeMinimumDelay = (event) => {
+    setDelay(parseInt(event.target.value, 10));
+  };
+
+  const onChangeHide = (event) => {
+    setRender(event.target.checked);
+  };
+
+  const status = render ? 'showing' : 'hidden';
+  const label = `Child (${status})`;
+  return (
+    <>
+      <EuiFlexItem>
+        <EuiFormRow>
+          <EuiCheckbox
+            id="dummy-id"
+            checked={render}
+            onChange={onChangeHide}
+            label="Show child"
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Minimum delay">
+          <EuiFieldNumber
+            value={minimumDelay}
+            onChange={onChangeMinimumDelay}
+          />
+        </EuiFormRow>
+
+        <EuiFormRow label={label}>
+          {render ? (
+            <EuiDelayRender delay={minimumDelay}>
+              <EuiLoadingSpinner size="m" />
+            </EuiDelayRender>
+          ) : (
+            <></>
+          )}
+        </EuiFormRow>
+      </EuiFlexItem>
+    </>
+  );
+};
+
+beforeEach(() => {
+  cy.realMount(<DelayRender />);
+});
+
+describe('EuiDelayRender', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the delay input is checked', () => {
+      cy.get('input.euiCheckbox__input').realClick();
+      cy.get('div.euiFormRow__fieldWrapper')
+        .last()
+        .find('span[role="progressbar"]', { timeout: 5000 });
+      cy.checkAxe();
+    });
+
+    it('has zero violations when the delay input is pressed', () => {
+      cy.realPress('Tab');
+      cy.get('input.euiCheckbox__input').should('have.focus');
+      cy.realPress('Space');
+      cy.get('div.euiFormRow__fieldWrapper')
+        .last()
+        .find('span[role="progressbar"]', { timeout: 5000 });
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/delay_render/delay_render.a11y.tsx
+++ b/src/components/delay_render/delay_render.a11y.tsx
@@ -74,7 +74,8 @@ describe('EuiDelayRender', () => {
       cy.get('input.euiCheckbox__input').realClick();
       cy.get('div.euiFormRow__fieldWrapper')
         .last()
-        .find('span[role="progressbar"]', { timeout: 5000 });
+        .find('span[role="progressbar"]', { timeout: 5000 })
+        .should('exist');
       cy.checkAxe();
     });
 

--- a/src/components/empty_prompt/empty_prompt.a11y.tsx
+++ b/src/components/empty_prompt/empty_prompt.a11y.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiButton } from '../button';
+import { EuiEmptyPrompt } from './empty_prompt';
+import { EuiLink } from '../link';
+import { EuiTitle } from '../title';
+
+const EmptyPrompt = ({ addCaseSpy, addLinkSpy }) => {
+  return (
+    <EuiEmptyPrompt
+      iconType="logoSecurity"
+      title={<h2>Start adding cases</h2>}
+      body={<p>Add a new case or change your filter settings.</p>}
+      actions={
+        <EuiButton color="primary" onClick={addCaseSpy} fill>
+          Add a case
+        </EuiButton>
+      }
+      footer={
+        <>
+          <EuiTitle size="xxs">
+            <h3>Want to learn more?</h3>
+          </EuiTitle>
+          <EuiLink href="#" onClick={addLinkSpy}>
+            Read the docs
+          </EuiLink>
+        </>
+      }
+    />
+  );
+};
+
+beforeEach(() => {
+  const addCaseSpy = cy.spy().as('addCaseSpy');
+  const addLinkSpy = cy.spy().as('addLinkSpy');
+  cy.viewport(1024, 768); // medium breakpoint
+  cy.realMount(<EmptyPrompt addCaseSpy={addCaseSpy} addLinkSpy={addLinkSpy} />);
+});
+
+describe('EuiEmptyPrompt', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations after clicking Add a case button', () => {
+      cy.get('button.euiButton').contains('Add a case').realClick();
+      cy.get('@addCaseSpy').should('have.been.called');
+      cy.checkAxe();
+    });
+
+    it('has zero violations after clicking Read the docs link', () => {
+      cy.get('a.euiLink').contains('Read the docs').realClick();
+      cy.get('@addLinkSpy').should('have.been.called');
+      cy.checkAxe();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
* Added EuiDataGrid a11y spec.
* Added a11y and keyboard spec for EuiDatePicker.
* Added a11y and keyboard spec for EuiDelayRender.
* Added a11y and keyboard spec for EuiEmptyPrompt.

Mocked two tests using `cy.spy()` to confirm no a11y side effects on `EuiEmptyPrompt`. Probably over-engineered, but it's a pattern I want to establish for future Cypress component tests where we do need to capture and evaluate side effects.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in **Chrome**, ~~**Safari**~~, **Edge**, ~~and **Firefox**~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
