### PR TITLE
More clearly mark `EuiPageSideBarProps` as deprecated

### DIFF
--- a/src/components/page/index.ts
+++ b/src/components/page/index.ts
@@ -39,7 +39,7 @@ export {
 export type { EuiPageSectionProps } from './page_section';
 export { EuiPageSection } from './page_section';
 
-export type { EuiPageSideBarProps } from './page_side_bar';
+export type { EuiPageSideBarProps_Deprecated } from './page_side_bar';
 export { EuiPageSideBar_Deprecated } from './page_side_bar';
 
 export type { EuiPageSidebarProps } from './page_sidebar';

--- a/src/components/page/page_side_bar/index.ts
+++ b/src/components/page/page_side_bar/index.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export type { EuiPageSideBarProps } from './page_side_bar';
+export type { EuiPageSideBarProps_Deprecated } from './page_side_bar';
 export { EuiPageSideBar_Deprecated } from './page_side_bar';

--- a/src/components/page/page_side_bar/page_side_bar.tsx
+++ b/src/components/page/page_side_bar/page_side_bar.tsx
@@ -19,7 +19,10 @@ const paddingSizeToClassNameMap = {
 
 export const PADDING_SIZES = keysOf(paddingSizeToClassNameMap);
 
-export interface EuiPageSideBarProps
+/**
+ * @deprecated Use the new EuiPageSidebarProps in page/page_sidebar instead
+ */
+export interface EuiPageSideBarProps_Deprecated
   extends CommonProps,
     HTMLAttributes<HTMLDivElement> {
   /**
@@ -35,7 +38,7 @@ export interface EuiPageSideBarProps
 /**
  * @deprecated Use the new EuiPageSidebar in page/page_sidebar instead
  */
-export const EuiPageSideBar_Deprecated: FunctionComponent<EuiPageSideBarProps> = ({
+export const EuiPageSideBar_Deprecated: FunctionComponent<EuiPageSideBarProps_Deprecated> = ({
   children,
   className,
   sticky,

--- a/src/components/page/page_template.tsx
+++ b/src/components/page/page_template.tsx
@@ -12,7 +12,7 @@ import { css } from '@emotion/react';
 import { EuiPage, EuiPageProps } from './page';
 import {
   EuiPageSideBar_Deprecated as EuiPageSideBar,
-  EuiPageSideBarProps,
+  EuiPageSideBarProps_Deprecated as EuiPageSideBarProps,
 } from './page_side_bar';
 import { EuiPageBody, EuiPageBodyProps } from './page_body';
 import { EuiPageHeader, EuiPageHeaderProps } from './page_header';

--- a/upcoming_changelogs/6468.md
+++ b/upcoming_changelogs/6468.md
@@ -1,0 +1,3 @@
+**Deprecations**
+
+- Renamed `EuiPageSideBarProps` to `EuiPageSideBarProps_Deprecated`, to reduce usage/confusion with `EuiPageSidebar`


### PR DESCRIPTION
## Summary

@spalger pointed out that we are exporting both `EuiPageSideBarProps` (deprecated) and `EuiPageSidebarProps` (the new one), which is super confusing for consumers and Kibana.

It looks like Caroline missed renaming `EuiPageSideBarProps` to deprecated to match `EuiPageSideBar` (she marked other similar/confusing props as `_Deprecated`), so this PR amends that.

https://github.com/elastic/eui/blob/d549ff0d95969c977f299fbe63a732a0330f83d6/src/components/page/index.ts#L42-L43

https://github.com/elastic/eui/blob/c48afd76b31a6fa645f11626abcce07d653dba86/src/components/page/index.ts#L48-L49

## QA

### General checklist

- [x] Linting/tests pass
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately