### PR TITLE
[EuiTabs] Pass `size` and `expand` to all children using a React context provider

### DIFF
--- a/src/components/tabs/__snapshots__/tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tabs.test.tsx.snap
@@ -4,35 +4,45 @@ exports[`EuiTabs props expand is rendered 1`] = `
 <div
   class="euiTabs emotion-euiTabs-m-bottomBorder"
   role="tablist"
-/>
+>
+  children
+</div>
 `;
 
 exports[`EuiTabs props size l is rendered 1`] = `
 <div
   class="euiTabs emotion-euiTabs-l-bottomBorder"
   role="tablist"
-/>
+>
+  children
+</div>
 `;
 
 exports[`EuiTabs props size m is rendered 1`] = `
 <div
   class="euiTabs emotion-euiTabs-m-bottomBorder"
   role="tablist"
-/>
+>
+  children
+</div>
 `;
 
 exports[`EuiTabs props size s is rendered 1`] = `
 <div
   class="euiTabs emotion-euiTabs-s-bottomBorder"
   role="tablist"
-/>
+>
+  children
+</div>
 `;
 
 exports[`EuiTabs props size xl is rendered 1`] = `
 <div
   class="euiTabs emotion-euiTabs-xl-bottomBorder"
   role="tablist"
-/>
+>
+  children
+</div>
 `;
 
 exports[`EuiTabs renders 1`] = `
@@ -41,5 +51,7 @@ exports[`EuiTabs renders 1`] = `
   class="euiTabs testClass1 testClass2 emotion-euiTabs-m-bottomBorder"
   data-test-subj="test subject string"
   role="tablist"
-/>
+>
+  children
+</div>
 `;

--- a/src/components/tabs/__snapshots__/tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tabs.test.tsx.snap
@@ -1,47 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiTabs props expand is rendered 1`] = `
+exports[`EuiTabs props expand passes down to EuiTab children 1`] = `
 <div
   class="euiTabs emotion-euiTabs-m-bottomBorder"
   role="tablist"
 >
-  children
+  <button
+    aria-selected="false"
+    class="euiTab emotion-euiTab-expanded"
+    role="tab"
+    type="button"
+  >
+    <span
+      class="euiTab__content emotion-euiTab__content-m"
+    >
+      Tab
+    </span>
+  </button>
 </div>
 `;
 
-exports[`EuiTabs props size l is rendered 1`] = `
+exports[`EuiTabs props size l renders and passes down to EuiTab children 1`] = `
 <div
   class="euiTabs emotion-euiTabs-l-bottomBorder"
   role="tablist"
 >
-  children
+  <button
+    aria-selected="false"
+    class="euiTab emotion-euiTab"
+    role="tab"
+    type="button"
+  >
+    <span
+      class="euiTab__content emotion-euiTab__content-l"
+    >
+      Tab
+    </span>
+  </button>
 </div>
 `;
 
-exports[`EuiTabs props size m is rendered 1`] = `
+exports[`EuiTabs props size m renders and passes down to EuiTab children 1`] = `
 <div
   class="euiTabs emotion-euiTabs-m-bottomBorder"
   role="tablist"
 >
-  children
+  <button
+    aria-selected="false"
+    class="euiTab emotion-euiTab"
+    role="tab"
+    type="button"
+  >
+    <span
+      class="euiTab__content emotion-euiTab__content-m"
+    >
+      Tab
+    </span>
+  </button>
 </div>
 `;
 
-exports[`EuiTabs props size s is rendered 1`] = `
+exports[`EuiTabs props size s renders and passes down to EuiTab children 1`] = `
 <div
   class="euiTabs emotion-euiTabs-s-bottomBorder"
   role="tablist"
 >
-  children
+  <button
+    aria-selected="false"
+    class="euiTab emotion-euiTab"
+    role="tab"
+    type="button"
+  >
+    <span
+      class="euiTab__content emotion-euiTab__content-s"
+    >
+      Tab
+    </span>
+  </button>
 </div>
 `;
 
-exports[`EuiTabs props size xl is rendered 1`] = `
+exports[`EuiTabs props size xl renders and passes down to EuiTab children 1`] = `
 <div
   class="euiTabs emotion-euiTabs-xl-bottomBorder"
   role="tablist"
 >
-  children
+  <button
+    aria-selected="false"
+    class="euiTab emotion-euiTab"
+    role="tab"
+    type="button"
+  >
+    <span
+      class="euiTab__content emotion-euiTab__content-xl"
+    >
+      Tab
+    </span>
+  </button>
 </div>
 `;
 

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -12,6 +12,7 @@ import React, {
   ButtonHTMLAttributes,
   FunctionComponent,
   ReactNode,
+  useContext,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../common';
@@ -19,7 +20,7 @@ import { getSecureRelForTarget, useEuiTheme } from '../../services';
 import { validateHref } from '../../services/security/href_validator';
 
 import { euiTabStyles, euiTabContentStyles } from './tab.styles';
-import { EuiTabsProps, EuiTabsSizes } from './tabs';
+import { EuiTabsContext } from './tabs_context';
 
 export interface EuiTabProps extends CommonProps {
   isSelected?: boolean;
@@ -34,16 +35,6 @@ export interface EuiTabProps extends CommonProps {
    * Will be excluded from interactive effects.
    */
   append?: ReactNode;
-  /**
-   * Evenly stretches each tab to fill the
-   * horizontal space
-   */
-  expand?: EuiTabsProps['expand'];
-  /**
-   * Sizes affect both font size and overall size.
-   * Only use the `xl` size when displayed as page titles.
-   */
-  size?: EuiTabsSizes;
 }
 
 type EuiTabPropsForAnchor = EuiTabProps &
@@ -69,10 +60,9 @@ export const EuiTab: FunctionComponent<Props> = ({
   rel,
   prepend,
   append,
-  size = 'm',
-  expand,
   ...rest
 }) => {
+  const { size, expand } = useContext(EuiTabsContext);
   const euiTheme = useEuiTheme();
   const isHrefValid = !href || validateHref(href);
   const disabled = _disabled || !isHrefValid;

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -11,10 +11,13 @@ import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
+import { EuiTab } from './tab';
 import { EuiTabs, SIZES } from './tabs';
 
+const children = <EuiTab>Tab</EuiTab>;
+
 describe('EuiTabs', () => {
-  shouldRenderCustomStyles(<EuiTabs>children</EuiTabs>);
+  shouldRenderCustomStyles(<EuiTabs>{children}</EuiTabs>);
 
   test('renders', () => {
     const component = <EuiTabs {...requiredProps}>children</EuiTabs>;
@@ -25,8 +28,8 @@ describe('EuiTabs', () => {
   describe('props', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
-        it(`${size} is rendered`, () => {
-          const component = render(<EuiTabs size={size}>children</EuiTabs>);
+        it(`${size} renders and passes down to EuiTab children`, () => {
+          const component = render(<EuiTabs size={size}>{children}</EuiTabs>);
 
           expect(component).toMatchSnapshot();
         });
@@ -34,10 +37,22 @@ describe('EuiTabs', () => {
     });
 
     describe('expand', () => {
-      test('is rendered', () => {
-        const component = render(<EuiTabs expand>children</EuiTabs>);
+      it('passes down to EuiTab children', () => {
+        const component = render(<EuiTabs expand>{children}</EuiTabs>);
         expect(component).toMatchSnapshot();
       });
+    });
+  });
+
+  describe('context', () => {
+    it('passes down `size` and `expand` to EuiTab children regardless of nesting', () => {
+      const component = render(
+        <EuiTabs expand size="l">
+          <div>{children}</div>
+        </EuiTabs>
+      );
+      expect(component.find('.euiTab').attr('class')).toContain('-expand');
+      expect(component.find('.euiTab__content').attr('class')).toContain('-l');
     });
   });
 });

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -15,9 +15,8 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { useEuiTheme } from '../../services';
-import { cloneElementWithCss } from '../../services/theme/clone_element';
-
 import { euiTabsStyles } from './tabs.styles';
+import { EuiTabsContext } from './tabs_context';
 
 export const SIZES = ['s', 'm', 'l', 'xl'] as const;
 export type EuiTabsSizes = typeof SIZES[number];
@@ -63,21 +62,12 @@ export const EuiTabs = forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
     const classes = classNames('euiTabs', className);
 
     const styles = euiTabsStyles(euiTheme);
+
     const cssStyles = [
       styles.euiTabs,
       styles[size],
       bottomBorder && styles.bottomBorder,
     ];
-
-    const tabItems = React.Children.map(children, (child) => {
-      if (React.isValidElement(child)) {
-        return cloneElementWithCss(child, {
-          // we're passing the parent `size` and `expand` down to the children
-          size: size,
-          expand: expand,
-        });
-      }
-    });
 
     return (
       <div
@@ -87,7 +77,9 @@ export const EuiTabs = forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
         {...(children && { role: 'tablist' })}
         {...rest}
       >
-        {tabItems}
+        <EuiTabsContext.Provider value={{ expand, size }}>
+          {children}
+        </EuiTabsContext.Provider>
       </div>
     );
   }

--- a/src/components/tabs/tabs_context.tsx
+++ b/src/components/tabs/tabs_context.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { createContext } from 'react';
+import { EuiTabsProps } from './tabs';
+
+export type EuiTabsContextValues = Required<
+  Pick<EuiTabsProps, 'expand' | 'size'>
+>;
+
+export const contextDefaults: EuiTabsContextValues = {
+  expand: false,
+  size: 'm',
+};
+
+export const EuiTabsContext = createContext<EuiTabsContextValues>(
+  contextDefaults
+);

--- a/upcoming_changelogs/6478.md
+++ b/upcoming_changelogs/6478.md
@@ -1,0 +1,8 @@
+**Bug fixes**
+
+- `EuiTabs` now passes `size` and `expand` to all children using a React context provider.
+
+**Breaking changes**
+
+- Removed `size` and `expand` props from `EuiTab`
+


### PR DESCRIPTION
## Summary

- `EuiTabs` component passes `size` and `expand` props only to children (`EuiTab` components) that are direct descendants. The props will not be passed if the children, or one of the children, is wrapped in another element. This PR fixes the issue by using context instead of props to pass `size` and `expand` values to all `EuiTab` children at any level.
- Closes #6367 

### General checklist
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in **mobile**~
~- [ ] Checked in both **light and dark** modes~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~