### PR TITLE
EuiFilePicker dropzone style updates

### DIFF
--- a/src/components/form/file_picker/__snapshots__/file_picker.test.tsx.snap
+++ b/src/components/form/file_picker/__snapshots__/file_picker.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`EuiFilePicker is rendered 1`] = `
       <span
         aria-hidden="true"
         class="euiFilePicker__icon"
+        color="primary"
         data-euiicon-type="importAction"
       />
       <div

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -111,7 +111,7 @@
   @include euiTextTruncate;
   line-height: $euiSize;
 
-  // Make normal sized propmpt stand out a bit more - on the large sizez we don't need this as its already identifiable
+  // Make normal sized prompt stand out a bit more - on the large size we don't need this as it's already identifiable
   .euiFilePicker:not(.euiFilePicker--large):not(.euiFilePicker-hasFiles) & {
     color: $euiColorPrimaryText;
   }

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -116,8 +116,7 @@
   // make normal sized prompt look like placeholder
   .euiFilePicker:not(.euiFilePicker--large):not(.euiFilePicker-hasFiles) & {
     color: $euiColorPrimaryText;
-    position: relative;
-    top: -2px;
+    margin-top: calc(#{$euiSizeXS} / -2);
   }
 }
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -75,7 +75,7 @@
   padding-right: $euiFormControlPadding;
   padding-bottom: $euiFormControlPadding;
   pointer-events: none; /* 1 */
-  border: 2px dashed $euiColorLightShade;
+  border: $euiBorderWidthThick dashed $euiColorLightShade;
   border-radius: $euiFormControlBorderRadius;
 
   transition:

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -68,7 +68,6 @@
   * 4. Static height so that it doesn't shift its surrounding contents around
   */
 .euiFilePicker__prompt {
-  // @include euiFormControlDefaultShadow;
   @include euiFormControlWithIcon; /* 2 */
   height: $euiFormControlHeight;
   padding-top: $euiFormControlPadding;

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -153,10 +153,10 @@
 // Focus
 .euiFilePicker__showDrop .euiFilePicker__prompt,
 .euiFilePicker__input:focus + .euiFilePicker__prompt {
-  @include euiFormControlFocusStyle;
+  border-color: $euiColorPrimary;
 
   .euiFilePicker--compressed & {
-    @include euiFormControlFocusStyle($borderOnly: true);
+    border-color: $euiColorPrimary;
   }
 }
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -64,8 +64,7 @@
 /**
   * 1. Don't block the user from dropping files onto the filepicker.
   * 2. Ensure space for import icon, loading spinner, and clear button (only if it has files)
-  * 3. Delay focus gradient or else it will only partially transition while file chooser opens
-  * 4. Static height so that it doesn't shift its surrounding contents around
+  * 3. Static height so that it doesn't shift its surrounding contents around
   */
 .euiFilePicker__prompt {
   @include euiFormControlWithIcon; /* 2 */
@@ -78,10 +77,8 @@
   border-radius: $euiFormControlBorderRadius;
 
   transition:
-    box-shadow $euiAnimSpeedFast ease-in,
-    background-color $euiAnimSpeedFast ease-in,
-    background-image $euiAnimSpeedFast ease-in,
-    background-size $euiAnimSpeedFast ease-in $euiAnimSpeedFast; /* 3 */
+    border-color $euiAnimSpeedFast ease-in,
+    background-color $euiAnimSpeedFast ease-in;
 
   .euiFilePicker--compressed & {
     @include euiFormControlStyleCompressed($includeStates: false);
@@ -114,9 +111,13 @@
   @include euiTextTruncate;
   line-height: $euiSize;
 
-  // make normal sized prompt look like placeholder
+  // Make normal sized propmpt stand out a bit more - on the large sizez we don't need this as its already identifiable
   .euiFilePicker:not(.euiFilePicker--large):not(.euiFilePicker-hasFiles) & {
     color: $euiColorPrimaryText;
+  }
+
+  // Offset/center prompt text for non-large file-pickers
+  .euiFilePicker:not(.euiFilePicker--large) & {
     margin-top: $euiSizeXS / -2;
   }
 }
@@ -153,10 +154,6 @@
 .euiFilePicker__showDrop .euiFilePicker__prompt,
 .euiFilePicker__input:focus + .euiFilePicker__prompt {
   border-color: $euiColorPrimary;
-
-  .euiFilePicker--compressed & {
-    border-color: $euiColorPrimary;
-  }
 }
 
 // Disabled

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -116,7 +116,7 @@
   // make normal sized prompt look like placeholder
   .euiFilePicker:not(.euiFilePicker--large):not(.euiFilePicker-hasFiles) & {
     color: $euiColorPrimaryText;
-    margin-top: calc(#{$euiSizeXS} / -2);
+    margin-top: $euiSizeXS / -2;
   }
 }
 

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -64,7 +64,7 @@
 /**
   * 1. Don't block the user from dropping files onto the filepicker.
   * 2. Ensure space for import icon, loading spinner, and clear button (only if it has files)
-  * 3. Static height so that it doesn't shift its surrounding contents around
+  * 4. Static height so that it doesn't shift its surrounding contents around
   */
 .euiFilePicker__prompt {
   @include euiFormControlWithIcon; /* 2 */

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -88,6 +88,7 @@
     @include euiFormControlWithIcon($compressed: true); /* 2 */
     height: $euiFormControlCompressedHeight;
     border-radius: $euiFormControlCompressedBorderRadius;
+    box-shadow: none;
   }
 
   .euiFilePicker--large & {
@@ -101,10 +102,11 @@
 
   .euiFilePicker--large.euiFilePicker--compressed & {
     height: $euiFilePickerTallHeight - $euiSizeL; /* 4 */
+    box-shadow: none;
   }
 
   .euiFilePicker-isInvalid & {
-    @include euiFormControlInvalidStyle;
+    border: $euiBorderWidthThick dashed $euiColorDanger;
   }
 }
 
@@ -161,6 +163,7 @@
 // Disabled
 .euiFilePicker__input:disabled + .euiFilePicker__prompt {
   @include euiFormControlDisabledStyle;
+  box-shadow: none;
 }
 
 // Make space for the icons on the right

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -68,13 +68,14 @@
   * 4. Static height so that it doesn't shift its surrounding contents around
   */
 .euiFilePicker__prompt {
-  @include euiFormControlDefaultShadow;
+  // @include euiFormControlDefaultShadow;
   @include euiFormControlWithIcon; /* 2 */
   height: $euiFormControlHeight;
   padding-top: $euiFormControlPadding;
   padding-right: $euiFormControlPadding;
   padding-bottom: $euiFormControlPadding;
   pointer-events: none; /* 1 */
+  border: 2px dashed $euiColorLightShade;
   border-radius: $euiFormControlBorderRadius;
 
   transition:
@@ -115,7 +116,9 @@
 
   // make normal sized prompt look like placeholder
   .euiFilePicker:not(.euiFilePicker--large):not(.euiFilePicker-hasFiles) & {
-    color: $euiColorMediumShade;
+    color: $euiColorPrimaryText;
+    position: relative;
+    top: -2px;
   }
 }
 

--- a/src/components/form/file_picker/file_picker.tsx
+++ b/src/components/form/file_picker/file_picker.tsx
@@ -244,6 +244,7 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                 <div className="euiFilePicker__prompt" id={promptId}>
                   <EuiIcon
                     className="euiFilePicker__icon"
+                    color="primary"
                     type="importAction"
                     size={normalFormControl ? 'm' : 'l'}
                     aria-hidden="true"

--- a/src/components/form/file_picker/file_picker.tsx
+++ b/src/components/form/file_picker/file_picker.tsx
@@ -244,7 +244,7 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                 <div className="euiFilePicker__prompt" id={promptId}>
                   <EuiIcon
                     className="euiFilePicker__icon"
-                    color="primary"
+                    color={disabled ? 'subdued' : 'primary'}
                     type="importAction"
                     size={normalFormControl ? 'm' : 'l'}
                     aria-hidden="true"

--- a/upcoming_changelogs/6479.md
+++ b/upcoming_changelogs/6479.md
@@ -1,0 +1,1 @@
+- EuiFilePicker styles have been updated to improve interaction and accessibility.


### PR DESCRIPTION
## Summary

This PR updates `EuiFilePicker` dropzone styles to look more like an interactive element. Text contrast is boosted in the compact variant of the component and it no longer looks like a disabled button or inactive input.

![image](https://user-images.githubusercontent.com/739960/207412489-d5e44301-c840-4b09-98bc-142e79f452f3.png)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
