### PR TITLE
Adding a release step to docs

### DIFF
--- a/wiki/releasing-versions.md
+++ b/wiki/releasing-versions.md
@@ -11,6 +11,14 @@ _**Before you get started**_
   - if you have 2FA enabled, you may be prompted for an [OTP or other token](https://github.com/settings/tokens)
 
 ### Releasing `@elastic/eui`
+Check for latest code and dependencies. Run the following commands in a new terminal window:
+
+```shell
+git checkout main && git pull
+
+# Run after the git pull completes
+yarn
+```
 
 The release process is started by running the following command.
 


### PR DESCRIPTION
## Summary

Adding a step to check for latest code and dependencies on `main` branch.

---
<img width="1304" alt="Screen Shot 2022-12-13 at 1 35 14 PM" src="https://user-images.githubusercontent.com/934879/207428180-fabc364d-b104-4c86-a150-f97540fcaefd.png">


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
