### PR TITLE
Allow header height to be overridden in theme

### DIFF
--- a/src/themes/amsterdam/global_styling/variables/_header.scss
+++ b/src/themes/amsterdam/global_styling/variables/_header.scss
@@ -2,6 +2,6 @@
 // It adds separation between the header and flyout
 $euiHeaderBorderColor: lightOrDarkTheme(shade($euiBorderColor, 3%), shade($euiColorEmptyShade, 35%));
 
-$euiHeaderHeight: $euiSizeXXL + $euiSizeS;
+$euiHeaderHeight: $euiSizeXXL + $euiSizeS !default;
 $euiHeaderChildSize: $euiSizeXXL;
 $euiHeaderHeightCompensation: $euiHeaderHeight;


### PR DESCRIPTION
Adding `default!` to the $euiHeaderHeight variable allows for the header to be an arbitrary size by setting the value before importing the Amsterdam theme. Is there a better way to go about this?

```
$euiHeaderHeight: 75px;
@import "@elastic/eui/src/themes/amsterdam/theme_light";
```

If I am on the right track, I will further clean up and adhere to the list below. 

## Summary

Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

### Emotion conversion checklist

- **Does it work?**
- [ ] Output CSS matches the previous CSS / as expected in browsers
- [ ] Rendered className reads as expected in snapshots and in browsers


- **Sass/Emotion conversion process**
- [ ] Converted all global Sass vars/mixins to JS (e.g. `$euiSize` to `euiTheme.size.base`)
- [ ] Removed or converted component-specific Sass vars/mixins to exported JS versions, listed removals in changelog, and [manually updated our theme JSON files](https://github.com/elastic/eui/tree/main/src-docs/src/views/theme/_json)

&nbsp;
- **CSS tech debt**
- [ ] Reduced specificity where possible (usually by reducing nesting and class name chaining)

- **DOM cleanup**
- [ ] Did **not** remove any block/element classNames (e.g. `euiComponent`, `euiComponent__child`)
- [ ] Deleted any modifier classNames or maps if not being used in Kibana. **Before doing this step**:
    - [ ] Search/grep through Kibana's codebase for `{euiComponent}-` (case sensitive) to check for source code usage of modifier classes
    - [ ] If usages exist, consider converting to a `data` attribute so that consumers still have something to hook into
&nbsp;
- **Kibana due diligence**
- Pre-emptively check how your conversion will impact the next Kibana upgrade. This entails searching/grepping through Kibana (excluding `**/target, **/*.snap, **/*.storyshot` for less noise) for `eui{Component}` (case sensitive) to find:
- [ ] Any test/query selectors that will need to be updated
- [ ] Any Sass or CSS that will need to be updated, particularly if a component Sass var was deleted
- [ ] Any direct className usages that will need to be refactored (e.g. someone calling the `euiBadge` class on a div instead of simply using the `EuiBadge` component)
&nbsp;
- **Extras/nice-to-have**
- [ ] Documentation pass:
    - [ ] Converted any remaining `.js` docs files to TS
    - [ ] Misc cleanup of docs code (e.g. combine imports to single `from '../src'`, replace `<React.Fragment>` with `<>`)
- [ ] Check for issues in the backlog that could be a quick fix for that component
- [ ] Optional component/code cleanup: consider splitting up the component into multiple children if it's overly verbose or difficult to reason about
