### PR TITLE
Replace `remark-parse` with `remark-parse-no-trim`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "resolutions": {
     "**/prismjs": "1.27.0",
-    "**/trim": "0.0.3",
     "**/react": "^17.0.0",
     "**/known-css-properties": "0.24.0"
   },
@@ -90,7 +89,7 @@
     "rehype-stringify": "^8.0.0",
     "remark-breaks": "^2.0.2",
     "remark-emoji": "^2.1.0",
-    "remark-parse": "^8.0.3",
+    "remark-parse-no-trim": "^8.0.4",
     "remark-rehype": "^8.0.0",
     "tabbable": "^5.2.1",
     "text-diff": "^1.0.1",

--- a/src-docs/src/services/props/markdown_format/plugin_list.js
+++ b/src-docs/src/services/props/markdown_format/plugin_list.js
@@ -1,4 +1,4 @@
-import markdown from 'remark-parse';
+import markdown from 'remark-parse-no-trim';
 import highlight from '../../../../../src/components/markdown_editor/plugins/remark/remark_prismjs';
 import { getDefaultEuiMarkdownProcessingPlugins } from '../../../../../src/components';
 

--- a/src/components/markdown_editor/markdown_types.ts
+++ b/src/components/markdown_editor/markdown_types.ts
@@ -10,7 +10,7 @@ import { ComponentType, ReactNode } from 'react';
 import { VFile } from 'vfile';
 // eslint-disable-next-line import/no-unresolved
 import { Node as UnistNode, Position as UnistPosition } from 'unist';
-import { Parser } from 'remark-parse';
+import { Parser } from 'remark-parse-no-trim';
 import { VFileMessage } from 'vfile-message';
 import { IconType } from '../icon';
 

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/parsing_plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/parsing_plugins.ts
@@ -22,7 +22,7 @@ import {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   Settings,
 } from 'unified';
-import markdown from 'remark-parse';
+import markdown from 'remark-parse-no-trim';
 import emoji from 'remark-emoji';
 import breaks from 'remark-breaks';
 import highlight from '../remark/remark_prismjs';

--- a/upcoming_changelogs/6482.md
+++ b/upcoming_changelogs/6482.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed security warnings caused by `trim@0.0.1` sub-dependency

--- a/yarn.lock
+++ b/yarn.lock
@@ -13931,10 +13931,10 @@ remark-math@1.0.4:
   dependencies:
     trim-trailing-lines "^1.1.0"
 
-remark-parse@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"
-  integrity sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==
+remark-parse-no-trim@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/remark-parse-no-trim/-/remark-parse-no-trim-8.0.4.tgz#f5c9531644284071d4a57a49e19a42ad4e8040bd"
+  integrity sha512-WtqeHNTZ0LSdyemmY1/G6y9WoEFblTtgckfKF5/NUnri919/0/dEu8RCDfvXtJvu96soMvT+mLWWgYVUaiHoag==
   dependencies:
     ccount "^1.0.0"
     collapse-white-space "^1.0.2"
@@ -13946,7 +13946,6 @@ remark-parse@^8.0.3:
     parse-entities "^2.0.0"
     repeat-string "^1.5.4"
     state-toggle "^1.0.0"
-    trim "0.0.1"
     trim-trailing-lines "^1.0.0"
     unherit "^1.0.4"
     unist-util-remove-position "^2.0.0"
@@ -15959,11 +15958,6 @@ trim-trailing-lines@^1.0.0, trim-trailing-lines@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz#7f0739881ff76657b7776e10874128004b625a94"
   integrity sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==
-
-trim@0.0.1, trim@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.3.tgz#05243a47a3a4113e6b49367880a9cca59697a20b"
-  integrity sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## Summary

This PR does **not** fully address https://github.com/elastic/eui/issues/5543, but resolves the underlying issue being described (security issues caused by `remark-parse`'s use of `trim@0.0.1`).

Simply upgrading `remark-parse` is non-trivial due to all the reasons outlined in https://github.com/elastic/eui/issues/5543#issuecomment-1352060546, but it looks like GitHub's docs team at some point released a fork of `remark-parse@8.0.3` without the trim dependency/security warnings, which is exactly what we need for an interim solution.

## QA

- [x] Go to https://eui.elastic.co/pr_6482/#/editors-syntax/markdown-format and confirm everything still renders/works as before
- [x] Go to https://eui.elastic.co/pr_6482/#/editors-syntax/markdown-editor and confirm everything still renders/works as before

### General checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately