### PR TITLE
Remove unnecessary `known-css-properties` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
   "resolutions": {
     "**/prismjs": "1.27.0",
     "**/trim": "0.0.3",
-    "**/react": "^17.0.0",
-    "**/known-css-properties": "0.24.0"
+    "**/react": "^17.0.0"
   },
   "pre-commit": [
     "test-staged"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10324,10 +10324,10 @@ klona@^2.0.4, klona@^2.0.5:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-known-css-properties@0.24.0, known-css-properties@^0.26.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.24.0.tgz#19aefd85003ae5698a5560d2b55135bf5432155c"
-  integrity sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==
+known-css-properties@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.26.0.tgz#008295115abddc045a9f4ed7e2a84dc8b3a77649"
+  integrity sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==
 
 language-subtag-registry@~0.3.2:
   version "0.3.20"


### PR DESCRIPTION
## Summary

I missed this in #6470 - with `sass-lint` gone, `stylelint` already uses a more modern resolution of `known-css-properties`, so there's no need for us to manually resolve this dependency this any longer.

## QA

### General checklist

N/A, this only affects a single dev dependency, so if sass linting passes on CI everything should be fine