### PR TITLE
[EuiAccordion] Remove a unnecessary condition statement

### DIFF
--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -354,7 +354,7 @@ export class EuiAccordionClass extends Component<
           />
           <EuiText size="s">
             <p>
-              {isLoadingMessage && isLoadingMessage !== true ? (
+              {isLoadingMessage !== true ? (
                 isLoadingMessage
               ) : (
                 <EuiI18n token="euiAccordion.isLoading" default="Loading" />


### PR DESCRIPTION
## Summary

Condition 'isLoadingMessage' is always true at this point because it has been already checked at line 348. This patch removes the unnecessary condition statement.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

[Cee note] N/A, this is a relatively minor change that doesn't need extensive QA - I would consider current tests passing to be sufficient