### PR TITLE
A11y specs for EuiImage, EuiTable, EuiKeyPadMenu.

### DIFF
--- a/src/components/basic_table/table.a11y.tsx
+++ b/src/components/basic_table/table.a11y.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiInMemoryTable } from './in_memory_table';
+import { EuiHealth } from '../health';
+import { EuiLink } from '../link';
+import { formatDate, PropertySort } from '../../services';
+import { createDataStore } from '../../../src-docs/src/views/tables/data_store';
+
+interface SortingOptions {
+  sort: PropertySort;
+}
+
+const store = createDataStore();
+
+const InMemoryTable = () => {
+  const columns: any[] = [
+    {
+      field: 'firstName',
+      name: 'First Name',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'lastName',
+      name: 'Last Name',
+      truncateText: true,
+    },
+    {
+      field: 'github',
+      name: 'Github',
+      render: (username) => (
+        <EuiLink href={`https://github.com/${username}`} target="_blank">
+          {username}
+        </EuiLink>
+      ),
+    },
+    {
+      field: 'dateOfBirth',
+      name: 'Date of Birth',
+      dataType: 'date',
+      render: (date) => formatDate(date, 'dobLong'),
+      sortable: true,
+    },
+    {
+      field: 'nationality',
+      name: 'Nationality',
+      render: (countryCode) => {
+        const country = store.getCountry(countryCode);
+        return `${country!.flag} ${country!.name}`;
+      },
+    },
+    {
+      field: 'online',
+      name: 'Online',
+      dataType: 'boolean',
+      render: (online) => {
+        const color = online ? 'success' : 'danger';
+        const label = online ? 'Online' : 'Offline';
+        return <EuiHealth color={color}>{label}</EuiHealth>;
+      },
+      sortable: true,
+    },
+  ];
+
+  const sorting: SortingOptions = {
+    sort: {
+      field: 'dateOfBirth',
+      direction: 'desc',
+    },
+  };
+
+  return (
+    <EuiInMemoryTable
+      data-test-subj="cy-in-memory-table"
+      tableCaption="Demo of EuiInMemoryTable"
+      items={store.users}
+      columns={columns}
+      pagination={true}
+      sorting={sorting}
+    />
+  );
+};
+
+beforeEach(() => {
+  cy.viewport(1024, 768); // medium breakpoint
+  cy.realMount(<InMemoryTable />);
+  cy.get('div[data-test-subj="cy-in-memory-table"]').should('exist');
+});
+
+describe('EuiInMemoryTable', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations on pagination click', () => {
+      cy.get('a[data-test-subj="pagination-button-1"]').realClick();
+      cy.get('button[data-test-subj="pagination-button-1"]').should(
+        'be.disabled'
+      );
+      cy.checkAxe();
+    });
+
+    it('has zero violations after number of rows is increased', () => {
+      cy.get(
+        'button[data-test-subj="tablePaginationPopoverButton"]'
+      ).realClick();
+      cy.get('div[data-popover-open="true"]').should('exist');
+      cy.get('button[data-test-subj="tablePagination-25-rows"]').realClick();
+      cy.get('table.euiTable').find('tr.euiTableRow').should('have.length', 20);
+      cy.checkAxe();
+    });
+
+    it('has zero violations after sorting on a column', () => {
+      cy.realPress('Tab');
+      cy.get('button[data-test-subj="tableHeaderSortButton"]')
+        .first()
+        .should('have.focus');
+      cy.realPress('Enter');
+      cy.get('tbody tr.euiTableRow span.euiTableCellContent__text')
+        .first()
+        .contains(
+          'Another very long first name which will wrap or be truncated'
+        );
+    });
+
+    it('has zero violations when number of rows is increased by keyboard', () => {
+      cy.repeatRealPress('Tab', 14);
+      cy.get('button[data-test-subj="tablePaginationPopoverButton"]')
+        .should('have.focus')
+        .realPress('Space');
+      cy.get('div[data-popover-open="true"]').should('exist');
+      cy.get('div[data-popover-open="true"]').should('have.focus');
+      cy.repeatRealPress('Tab'); // Switched to Tab from ArrowDown because of flaky test runs
+      cy.get('button[data-test-subj="tablePagination-25-rows"]').realPress(
+        'Space'
+      );
+      cy.get('table.euiTable').find('tr.euiTableRow').should('have.length', 20);
+      cy.checkAxe();
+    });
+
+    it('has zero violations when pagination is pressed', () => {
+      cy.repeatRealPress('Tab', 15);
+      cy.get('a[data-test-subj="pagination-button-1"]')
+        .should('have.focus')
+        .realPress('Enter');
+      cy.get('button[data-test-subj="pagination-button-1"]').should(
+        'be.disabled'
+      );
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/image/image.a11y.tsx
+++ b/src/components/image/image.a11y.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+import { EuiImage } from './image';
+
+const Image = () => (
+  <EuiImage
+    size="m"
+    hasShadow
+    allowFullScreen
+    caption="Albert Einstein, theoretical physicist"
+    alt="" // Because this image is sufficiently described by its caption, there is no need to repeat it via alt text
+    src="https://upload.wikimedia.org/wikipedia/commons/d/d3/Albert_Einstein_Head.jpg"
+  />
+);
+
+beforeEach(() => {
+  cy.viewport(1024, 768); // medium breakpoint
+  cy.realMount(<Image />);
+  cy.get('figure[aria-label="Albert Einstein, theoretical physicist"]').should(
+    'exist'
+  );
+});
+
+describe('EuiImage', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations on fullscreen render', () => {
+      cy.get('button[data-test-subj="activateFullScreenButton"]').realClick();
+      cy.get('button[data-test-subj="deactivateFullScreenButton"]').should(
+        'exist'
+      );
+      cy.checkAxe();
+      cy.get('div[data-test-subj="fullScreenOverlayMask"]').realClick();
+      cy.checkAxe();
+    });
+
+    it('has zero violations on keyboard interaction', () => {
+      cy.realPress('Tab');
+      cy.get('button[data-test-subj="activateFullScreenButton"]').should(
+        'have.focus'
+      );
+      cy.realPress('Enter');
+      cy.get('button[data-test-subj="deactivateFullScreenButton"]').should(
+        'exist'
+      );
+      cy.get('button[data-test-subj="deactivateFullScreenButton"]').should(
+        'have.focus'
+      );
+      cy.checkAxe();
+      cy.realPress('Escape');
+      cy.get('button[data-test-subj="activateFullScreenButton"]').should(
+        'have.focus'
+      );
+      cy.checkAxe();
+    });
+  });
+});

--- a/src/components/key_pad_menu/key_pad_menu.a11y.tsx
+++ b/src/components/key_pad_menu/key_pad_menu.a11y.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React, { useState } from 'react';
+import { EuiKeyPadMenu } from './key_pad_menu';
+import { EuiKeyPadMenuItem } from './key_pad_menu_item';
+import { EuiIcon } from '../icon';
+import { useGeneratedHtmlId } from '../../services';
+
+const KeyPadMenu = () => {
+  const keypadButtonId__1 = useGeneratedHtmlId({
+    prefix: 'keypadButton',
+    suffix: 'first',
+  });
+  const keypadButtonId__2 = useGeneratedHtmlId({
+    prefix: 'keypadButton',
+    suffix: 'second',
+  });
+  const keypadButtonId__3 = useGeneratedHtmlId({
+    prefix: 'keypadButton',
+    suffix: 'third',
+  });
+  const keypadButtonId__4 = useGeneratedHtmlId({
+    prefix: 'keypadButton',
+    suffix: 'fourth',
+  });
+  const keypadButtonId__5 = useGeneratedHtmlId({
+    prefix: 'keypadButton',
+    suffix: 'fifth',
+  });
+  const keypadButtonId__6 = useGeneratedHtmlId({
+    prefix: 'keypadButton',
+    suffix: 'sixth',
+  });
+
+  const [selectedID, setSelectedID] = useState(keypadButtonId__6);
+
+  return (
+    <div aria-label="Menu keypad">
+      <EuiKeyPadMenu>
+        <EuiKeyPadMenuItem
+          data-test-subj="cy-keypad-button-1"
+          id={keypadButtonId__1}
+          label="Button 1"
+          isSelected={selectedID === keypadButtonId__1}
+          onClick={() => setSelectedID(keypadButtonId__1)}
+        >
+          <EuiIcon type="grid" size="l" />
+        </EuiKeyPadMenuItem>
+        <EuiKeyPadMenuItem
+          data-test-subj="cy-keypad-button-2"
+          id={keypadButtonId__2}
+          label="Button 2"
+          isSelected={selectedID === keypadButtonId__2}
+          onClick={() => setSelectedID(keypadButtonId__2)}
+        >
+          <EuiIcon type="grid" size="l" />
+        </EuiKeyPadMenuItem>
+        <EuiKeyPadMenuItem
+          data-test-subj="cy-keypad-button-3"
+          id={keypadButtonId__3}
+          label="Button 3"
+          isSelected={selectedID === keypadButtonId__3}
+          onClick={() => setSelectedID(keypadButtonId__3)}
+        >
+          <EuiIcon type="grid" size="l" />
+        </EuiKeyPadMenuItem>
+        <EuiKeyPadMenuItem
+          data-test-subj="cy-keypad-link-1"
+          id={keypadButtonId__4}
+          label="Link 1"
+          href="#/navigation/key-pad-menu"
+          isSelected={selectedID === keypadButtonId__4}
+          onClick={() => setSelectedID(keypadButtonId__4)}
+        >
+          <EuiIcon type="link" size="l" />
+        </EuiKeyPadMenuItem>
+        <EuiKeyPadMenuItem
+          data-test-subj="cy-keypad-link-2"
+          id={keypadButtonId__5}
+          label="Link 2"
+          href="#/navigation/key-pad-menu"
+          isSelected={selectedID === keypadButtonId__5}
+          onClick={() => setSelectedID(keypadButtonId__5)}
+        >
+          <EuiIcon type="link" size="l" />
+        </EuiKeyPadMenuItem>
+        <EuiKeyPadMenuItem
+          data-test-subj="cy-keypad-link-3"
+          id={keypadButtonId__6}
+          label="Disabled Link 3"
+          isDisabled
+          isSelected={selectedID === keypadButtonId__6}
+        >
+          <EuiIcon type="link" size="l" />
+        </EuiKeyPadMenuItem>
+      </EuiKeyPadMenu>
+    </div>
+  );
+};
+
+beforeEach(() => {
+  cy.realMount(<KeyPadMenu />);
+  cy.get('div[aria-label="Menu keypad"]').should('exist');
+});
+
+describe('EuiKeyPadMenu', () => {
+  describe('Automated accessibility check', () => {
+    it('has zero violations on first render', () => {
+      cy.checkAxe();
+    });
+
+    it('has zero violations on item click', () => {
+      cy.get('a[data-test-subj="cy-keypad-link-2"]').realClick();
+      cy.get('a[data-test-subj="cy-keypad-link-2"]').should(
+        'have.class',
+        'euiKeyPadMenuItem-isSelected'
+      );
+      cy.checkAxe();
+    });
+
+    it('has zero violations on item keypress', () => {
+      cy.repeatRealPress('Tab', 3);
+      cy.get('button[data-test-subj="cy-keypad-button-3"]').should(
+        'have.focus'
+      );
+      cy.realPress('Space');
+      cy.get('button[data-test-subj="cy-keypad-button-3"]').should(
+        'have.class',
+        'euiKeyPadMenuItem-isSelected'
+      );
+      cy.checkAxe();
+      cy.realPress(['Shift', 'Tab']);
+      cy.get('button[data-test-subj="cy-keypad-button-2"]').should(
+        'have.focus'
+      );
+      cy.realPress('Space');
+      cy.get('button[data-test-subj="cy-keypad-button-2"]').should(
+        'have.class',
+        'euiKeyPadMenuItem-isSelected'
+      );
+      cy.get('button[data-test-subj="cy-keypad-button-3"]').should(
+        'not.have.class',
+        'euiKeyPadMenuItem-isSelected'
+      );
+      cy.checkAxe();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

* Added a11y and keyboard specs for EuiImage.
* Added a11y and keyboard specs for EuiInMemoryTable.
* Added a11y and keyboard specs for EuiKeyPadMenu.

## QA

<img width="997" alt="Screen Shot 2022-12-20 at 10 45 58 AM" src="https://user-images.githubusercontent.com/934879/208720718-d5c6f39b-006f-4ef4-8497-c279a690f54e.png">


### General checklist

- [x] Checked in **Chrome**, ~~**Safari**~~, **Edge**, ~~and **Firefox**~~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes