### PR TITLE
[EuiPopover] Support custom `onClickOutside` overrides

### DIFF
--- a/src-docs/src/views/popover/outside_click.tsx
+++ b/src-docs/src/views/popover/outside_click.tsx
@@ -47,7 +47,6 @@ export default () => {
         focusTrapProps={{
           clickOutsideDisables: false,
           onClickOutside: showModal,
-          onEscapeKey: showModal,
         }}
       >
         <EuiText>

--- a/src-docs/src/views/popover/outside_click.tsx
+++ b/src-docs/src/views/popover/outside_click.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+
+import {
+  EuiPopover,
+  EuiButtonEmpty,
+  EuiText,
+  EuiConfirmModal,
+} from '../../../../src';
+
+export default () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const togglePopover = () =>
+    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
+
+  const button = (
+    <EuiButtonEmpty iconType="help" iconSide="right" onClick={togglePopover}>
+      This popover toggles a confirm modal on close
+    </EuiButtonEmpty>
+  );
+
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
+
+  const modal = isModalVisible ? (
+    <EuiConfirmModal
+      title="You have unsaved work"
+      onCancel={closeModal}
+      onConfirm={() => {
+        closeModal();
+        setIsPopoverOpen(false);
+      }}
+      cancelButtonText="No, don't do it"
+      confirmButtonText="Yes, do it"
+      defaultFocusedButton="cancel"
+    >
+      <p>Are you sure you to close the popover?</p>
+    </EuiConfirmModal>
+  ) : null;
+
+  return (
+    <>
+      <EuiPopover
+        button={button}
+        isOpen={isPopoverOpen}
+        closePopover={() => setIsPopoverOpen(false)}
+        focusTrapProps={{
+          clickOutsideDisables: false,
+          onClickOutside: showModal,
+          onEscapeKey: showModal,
+        }}
+      >
+        <EuiText>
+          <p>
+            Clicking outside this popover toggles a confirm modal.
+            <br />
+            The confirm modal either keeps the popover open or closes the
+            popover.
+          </p>
+        </EuiText>
+      </EuiPopover>
+      {modal}
+    </>
+  );
+};

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -83,7 +83,6 @@ const outsideClickSnippet = `<EuiPopover
   focusTrapProps={{
     clickOutsideDisables: false,
     onClickOutside: doSomething,
-    onEscapeKey: doSomething,
   }}
 >
   <!-- Popover content -->
@@ -430,11 +429,10 @@ export const PopoverExample = {
       text: (
         <>
           <p>
-            If you do not wish the popover to auto-close on outside clicks or
-            escape key presses, you can use{' '}
-            <EuiCode language="ts">focusTrapProps</EuiCode> to customize this
-            behavior. The below example triggers a confirmation modal which can
-            leave the popover open if the user presses &apos;No&apos;.
+            If you do not wish the popover to auto-close on outside clicks, you
+            can use <EuiCode language="ts">focusTrapProps</EuiCode> to customize
+            this behavior. The below example triggers a confirmation modal which
+            can leave the popover open if the user presses &apos;No&apos;.
           </p>
         </>
       ),

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -23,6 +23,9 @@ const initialFocusSource = require('!!raw-loader!./initial_focus');
 import TrapFocus from './trap_focus';
 const trapFocusSource = require('!!raw-loader!./trap_focus');
 
+import OutsideClick from './outside_click';
+const outsideClickSource = require('!!raw-loader!./outside_click');
+
 import PopoverAnchorPosition from './popover_anchor_position';
 const popoverAnchorPositionSource = require('!!raw-loader!./popover_anchor_position');
 
@@ -70,6 +73,19 @@ const initialFocusSnippet = `<EuiPopover
   button={button}
   isOpen={isPopoverOpen}
   closePopover={closePopover}>
+  <!-- Popover content -->
+</EuiPopover>`;
+
+const outsideClickSnippet = `<EuiPopover
+  button={button}
+  isOpen={isPopoverOpen}
+  closePopover={closePopover}
+  focusTrapProps={{
+    clickOutsideDisables: false,
+    onClickOutside: doSomething,
+    onEscapeKey: doSomething,
+  }}
+>
   <!-- Popover content -->
 </EuiPopover>`;
 
@@ -402,6 +418,29 @@ export const PopoverExample = {
       props: { EuiPopover },
       snippet: initialFocusSnippet,
       demo: <InitialFocus />,
+    },
+    {
+      title: 'Custom outside click behavior',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: outsideClickSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            If you do not wish the popover to auto-close on outside clicks or
+            escape key presses, you can use{' '}
+            <EuiCode language="ts">focusTrapProps</EuiCode> to customize this
+            behavior. The below example triggers a confirmation modal which can
+            leave the popover open if the user presses &apos;No&apos;.
+          </p>
+        </>
+      ),
+      props: { EuiPopover },
+      snippet: outsideClickSnippet,
+      demo: <OutsideClick />,
     },
     {
       title: 'Removing the focus trap',

--- a/src/components/popover/popover.spec.tsx
+++ b/src/components/popover/popover.spec.tsx
@@ -95,7 +95,7 @@ describe('EuiPopover', () => {
     });
 
     describe('focusTrapProps', () => {
-      it('allows overriding clickOutsideDisables, onClickOutside, and onEscapeKey', () => {
+      it('allows overriding clickOutsideDisables and onClickOutside', () => {
         const PopoverWithConfirmModal = () => {
           const [isPopoverOpen, setIsPopoverOpen] = useState(false);
           const closePopover = () => setIsPopoverOpen(false);
@@ -129,7 +129,6 @@ describe('EuiPopover', () => {
                 focusTrapProps={{
                   clickOutsideDisables: false,
                   onClickOutside: showModal,
-                  onEscapeKey: showModal,
                 }}
                 closePopover={closePopover}
                 isOpen={isPopoverOpen}
@@ -145,14 +144,11 @@ describe('EuiPopover', () => {
         cy.get('[data-test-subj="togglePopover"]').click();
         cy.focused().should('have.attr', 'data-test-subj', 'popoverPanel'); // Popover exists
 
-        // Trigger the confirm modal via Esc key and then cancel (popover remains)
-        cy.realPress('Escape');
-        cy.focused().should(
-          'have.attr',
-          'data-test-subj',
-          'confirmModalCancelButton'
-        ); // Confirm modal exists
-        cy.realPress('Enter');
+        // Trigger the confirm modal via outside click and then cancel (popover remains)
+        cy.get('body').click('bottomRight');
+        cy.focused()
+          .should('have.attr', 'data-test-subj', 'confirmModalCancelButton')
+          .click();
         cy.focused().should('have.attr', 'data-test-subj', 'popoverPanel'); // Confirm modal should close and popover should still exist and be re-focused
 
         // Trigger the confirm modal via outside click and then confirm (popover closes)

--- a/src/components/popover/popover.spec.tsx
+++ b/src/components/popover/popover.spec.tsx
@@ -10,8 +10,14 @@
 
 import React, { useState } from 'react';
 
-import { EuiButton } from '../button';
+import { EuiButton, EuiConfirmModal } from '../../components';
 import { EuiPopover } from './popover';
+
+const PopoverToggle = ({ onClick }) => (
+  <EuiButton onClick={onClick} data-test-subj="togglePopover">
+    Show popover
+  </EuiButton>
+);
 
 const PopoverComponent = ({ children, ...rest }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -19,16 +25,10 @@ const PopoverComponent = ({ children, ...rest }) => {
   const togglePopover = () =>
     setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
 
-  const button = (
-    <EuiButton onClick={togglePopover} data-test-subj="togglePopover">
-      Show popover
-    </EuiButton>
-  );
-
   return (
     <EuiPopover
       panelProps={{ 'data-test-subj': 'popoverPanel' }}
-      button={button}
+      button={<PopoverToggle onClick={togglePopover} />}
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       {...rest}
@@ -91,6 +91,75 @@ describe('EuiPopover', () => {
           'not.have.attr',
           'data-autofocus'
         );
+      });
+    });
+
+    describe('focusTrapProps', () => {
+      it('allows overriding clickOutsideDisables, onClickOutside, and onEscapeKey', () => {
+        const PopoverWithConfirmModal = () => {
+          const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+          const closePopover = () => setIsPopoverOpen(false);
+          const button = (
+            <PopoverToggle onClick={() => setIsPopoverOpen(true)} />
+          );
+
+          const [isModalVisible, setIsModalVisible] = useState(false);
+          const closeModal = () => setIsModalVisible(false);
+          const showModal = () => setIsModalVisible(true);
+
+          const modal = isModalVisible ? (
+            <EuiConfirmModal
+              title="You have unsaved work"
+              onCancel={closeModal}
+              onConfirm={() => {
+                closeModal();
+                closePopover();
+              }}
+              cancelButtonText="No, don't do it"
+              confirmButtonText="Yes, do it"
+              defaultFocusedButton="cancel"
+            >
+              <p>Are you sure you to close the popover?</p>
+            </EuiConfirmModal>
+          ) : null;
+
+          return (
+            <>
+              <PopoverComponent
+                focusTrapProps={{
+                  clickOutsideDisables: false,
+                  onClickOutside: showModal,
+                  onEscapeKey: showModal,
+                }}
+                closePopover={closePopover}
+                isOpen={isPopoverOpen}
+                button={button}
+              >
+                Test
+              </PopoverComponent>
+              {modal}
+            </>
+          );
+        };
+        cy.mount(<PopoverWithConfirmModal />);
+        cy.get('[data-test-subj="togglePopover"]').click();
+        cy.focused().should('have.attr', 'data-test-subj', 'popoverPanel'); // Popover exists
+
+        // Trigger the confirm modal via Esc key and then cancel (popover remains)
+        cy.realPress('Escape');
+        cy.focused().should(
+          'have.attr',
+          'data-test-subj',
+          'confirmModalCancelButton'
+        ); // Confirm modal exists
+        cy.realPress('Enter');
+        cy.focused().should('have.attr', 'data-test-subj', 'popoverPanel'); // Confirm modal should close and popover should still exist and be re-focused
+
+        // Trigger the confirm modal via outside click and then confirm (popover closes)
+        cy.get('body').click('bottomRight');
+        cy.get('[data-test-subj="confirmModalConfirmButton"]').click();
+        cy.get('[data-test-subj="popoverPanel"]').should('not.exist');
+        cy.focused().should('have.attr', 'data-test-subj', 'togglePopover'); // Popover toggle should be re-focused
       });
     });
   });

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -105,7 +105,12 @@ export interface EuiPopoverProps extends CommonProps {
    */
   focusTrapProps?: Pick<
     EuiFocusTrapProps,
-    'clickOutsideDisables' | 'noIsolation' | 'scrollLock' | 'shards'
+    | 'clickOutsideDisables'
+    | 'onClickOutside'
+    | 'onEscapeKey'
+    | 'noIsolation'
+    | 'scrollLock'
+    | 'shards'
   >;
   /**
    * Show arrow indicating to originating button
@@ -698,12 +703,12 @@ export class EuiPopover extends Component<Props, State> {
         <EuiPortal insert={insert}>
           <EuiFocusTrap
             clickOutsideDisables={true}
+            onClickOutside={this.onClickOutside}
+            onEscapeKey={this.onEscapeKey}
             {...focusTrapProps}
             returnFocus={returnFocus} // Ignore temporary state of indecisive focus
             initialFocus={initialFocus}
             onDeactivation={onTrapDeactivation}
-            onClickOutside={this.onClickOutside}
-            onEscapeKey={this.onEscapeKey}
             disabled={
               !ownFocus || !this.state.isOpenStable || this.state.isClosing
             }

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -107,7 +107,6 @@ export interface EuiPopoverProps extends CommonProps {
     EuiFocusTrapProps,
     | 'clickOutsideDisables'
     | 'onClickOutside'
-    | 'onEscapeKey'
     | 'noIsolation'
     | 'scrollLock'
     | 'shards'
@@ -704,11 +703,11 @@ export class EuiPopover extends Component<Props, State> {
           <EuiFocusTrap
             clickOutsideDisables={true}
             onClickOutside={this.onClickOutside}
-            onEscapeKey={this.onEscapeKey}
             {...focusTrapProps}
             returnFocus={returnFocus} // Ignore temporary state of indecisive focus
             initialFocus={initialFocus}
             onDeactivation={onTrapDeactivation}
+            onEscapeKey={this.onEscapeKey}
             disabled={
               !ownFocus || !this.state.isOpenStable || this.state.isClosing
             }

--- a/upcoming_changelogs/6500.md
+++ b/upcoming_changelogs/6500.md
@@ -1,1 +1,1 @@
-- `EuiPopover` now supports overriding `focusTrapProps.onClickOutside` and `focusTrapProps.onEscapeKey`, which allows customization of auto-close behavior on outside click or Escape keypress.
+- `EuiPopover` now supports overriding `focusTrapProps.onClickOutside`, which allows customization of auto-close behavior on outside click.

--- a/upcoming_changelogs/6500.md
+++ b/upcoming_changelogs/6500.md
@@ -1,0 +1,1 @@
+- `EuiPopover` now supports overriding `focusTrapProps.onClickOutside` and `focusTrapProps.onEscapeKey`, which allows customization of auto-close behavior on outside click or Escape keypress.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6498

It appears the Lens team wants the ability to add a confirmation modal on EuiPopover outside click, in order for consumers to not lose progress or input if they accidentally click away/outside of the popover before finishing their action within the popover.

This is currently not supported by EuiPopover via `closePopover` (and cannot be). Instead, we need to modify `focusTrapProps` to support overriding our internal popover `onOutsideClick` method, which then will allow a consumer to toggle a confirmation modal manually:

![screencap](https://user-images.githubusercontent.com/549407/209212594-8ca11b71-e445-4c5f-94b6-8c448e27542b.gif)


## QA

- Go to https://eui.elastic.co/pr_6500/#/layout/popover#custom-outside-click-behavior
- Click to open the popover, and then click outside the popover
- [ ] Confirm that a confirmation modal appears
- [ ] Confirm that clicking "Yes" causes the confirmation modal **and** the popover to appear
- [ ] Confirm that clicking "No" causes the confirmation modal to disappear, but the popover is still in its open state
- [ ] Confirm that focus is still trapped within the originating popover on modal close, and that attempting to close the modal again re-triggers the confirmation modal

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added ~or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~