### PR TITLE
[EuiImage] Expose full screen state

### DIFF
--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -32,6 +32,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
   caption,
   float,
   margin,
+  onFullScreen,
   ...rest
 }) => {
   const [isFullScreen, setIsFullScreen] = useState(false);
@@ -77,6 +78,7 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
     caption,
     float,
     margin,
+    onFullScreen,
   };
 
   const commonImgProps = {

--- a/src/components/image/image_fullscreen_wrapper.tsx
+++ b/src/components/image/image_fullscreen_wrapper.tsx
@@ -32,7 +32,7 @@ export const EuiImageFullScreenWrapper: FunctionComponent<EuiImageWrapperProps> 
   wrapperProps,
   isFullWidth,
   fullScreenIconColor,
-  onFullScreen
+  onFullScreen,
 }) => {
   const euiTheme = useEuiTheme();
 

--- a/src/components/image/image_fullscreen_wrapper.tsx
+++ b/src/components/image/image_fullscreen_wrapper.tsx
@@ -32,6 +32,7 @@ export const EuiImageFullScreenWrapper: FunctionComponent<EuiImageWrapperProps> 
   wrapperProps,
   isFullWidth,
   fullScreenIconColor,
+  onFullScreen
 }) => {
   const euiTheme = useEuiTheme();
 
@@ -54,6 +55,7 @@ export const EuiImageFullScreenWrapper: FunctionComponent<EuiImageWrapperProps> 
 
   const closeFullScreen = () => {
     setIsFullScreen(false);
+    onFullScreen?.(false);
   };
 
   const [optionalCaptionRef, optionalCaptionText] = useInnerText();

--- a/src/components/image/image_types.ts
+++ b/src/components/image/image_types.ts
@@ -71,6 +71,10 @@ export type EuiImageProps = CommonProps &
      */
     allowFullScreen?: boolean;
     /**
+     * Callback when the image is clicked and `allowFullScreen` is `true`
+     */
+    onFullScreen?: (isFullScreen: boolean) => void;
+    /**
      * Changes the color of the icon that floats above the image when it can be clicked to fullscreen.
      * The default value of `light` is fine unless your image has a white background, in which case you should change it to `dark`.
      */
@@ -91,6 +95,7 @@ export type EuiImageWrapperProps = Pick<
   | 'wrapperProps'
   | 'fullScreenIconColor'
   | 'allowFullScreen'
+  | 'onFullScreen'
 > & {
   isFullWidth: boolean;
   setIsFullScreen: (isFullScreen: boolean) => void;

--- a/src/components/image/image_wrapper.tsx
+++ b/src/components/image/image_wrapper.tsx
@@ -30,7 +30,7 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
   wrapperProps,
   fullScreenIconColor,
   isFullWidth,
-  onFullScreen
+  onFullScreen,
 }) => {
   const openFullScreen = () => {
     setIsFullScreen(true);

--- a/src/components/image/image_wrapper.tsx
+++ b/src/components/image/image_wrapper.tsx
@@ -30,9 +30,11 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
   wrapperProps,
   fullScreenIconColor,
   isFullWidth,
+  onFullScreen
 }) => {
   const openFullScreen = () => {
     setIsFullScreen(true);
+    onFullScreen?.(true);
   };
 
   const classes = classNames(

--- a/upcoming_changelogs/6504.md
+++ b/upcoming_changelogs/6504.md
@@ -1,1 +1,1 @@
-- `EuiPopover` now supports overriding `focusTrapProps.onClickOutside`, which allows customization of auto-close behavior on outside click.
+- Added `onFullScreen` callback to expose the `isFullScreen` state of the `EuiImage`

--- a/upcoming_changelogs/6504.md
+++ b/upcoming_changelogs/6504.md
@@ -1,0 +1,1 @@
+- `EuiPopover` now supports overriding `focusTrapProps.onClickOutside`, which allows customization of auto-close behavior on outside click.


### PR DESCRIPTION
## Summary

We are using EuiImage full screen state and in some case we needed to show caption only when image is in full screen mode. So we need full screen state to determine that. This PR expose the full screen state of the component via callback.



