### PR TITLE
[EuiTour] Add extra spacing between the `title` and `subtitle`

### DIFF
--- a/src/components/tour/tour.styles.ts
+++ b/src/components/tour/tour.styles.ts
@@ -89,6 +89,7 @@ export const euiTourHeaderStyles = ({ euiTheme }: UseEuiTheme) => ({
   `,
   euiTourHeader__subtitle: css`
     color: ${euiTheme.colors.subduedText};
+    padding-block-end: ${euiTheme.size.xs};
   `,
 });
 

--- a/upcoming_changelogs/6512.md
+++ b/upcoming_changelogs/6512.md
@@ -1,0 +1,1 @@
+- Added an extra spacing between the title and subtitle to `EuiTour`


### PR DESCRIPTION
## Summary

This PR adds an extra spacing of 4px (`euiTheme.size.xs`) between the `title` and `subtitle` in **EuiTour** and closes #5848.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
