### PR TITLE
[EuiDataGrid] Fix nested interactive controls axe error

### DIFF
--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -87,19 +87,14 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
           data-test-subj="droppable"
         >
           <div
-            aria-describedby="rbd-hidden-text-0-hidden-text-0"
-            class="euiDraggable"
-            data-rbd-drag-handle-context-id="0"
-            data-rbd-drag-handle-draggable-id="columnA"
+            class="euiDraggable euiDraggable--hasCustomDragHandle"
             data-rbd-draggable-context-id="0"
             data-rbd-draggable-id="columnA"
             data-test-subj="draggable"
-            draggable="false"
-            role="button"
-            tabindex="0"
+            role="group"
           >
             <div
-              class="euiDataGridColumnSelector__item false euiDraggable__item"
+              class="euiDataGridColumnSelector__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
               data-test-subj="dataGridColumnSelectorColumnItem-columnA"
             >
               <div
@@ -141,7 +136,14 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
                   </div>
                 </div>
                 <div
+                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                  aria-label="Drag handle"
                   class="euiFlexItem emotion-euiFlexItem-growZero"
+                  data-rbd-drag-handle-context-id="0"
+                  data-rbd-drag-handle-draggable-id="columnA"
+                  draggable="false"
+                  role="button"
+                  tabindex="0"
                 >
                   <span
                     color="subdued"
@@ -152,19 +154,14 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
             </div>
           </div>
           <div
-            aria-describedby="rbd-hidden-text-0-hidden-text-0"
-            class="euiDraggable"
-            data-rbd-drag-handle-context-id="0"
-            data-rbd-drag-handle-draggable-id="columnB"
+            class="euiDraggable euiDraggable--hasCustomDragHandle"
             data-rbd-draggable-context-id="0"
             data-rbd-draggable-id="columnB"
             data-test-subj="draggable"
-            draggable="false"
-            role="button"
-            tabindex="0"
+            role="group"
           >
             <div
-              class="euiDataGridColumnSelector__item false euiDraggable__item"
+              class="euiDataGridColumnSelector__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
               data-test-subj="dataGridColumnSelectorColumnItem-columnB"
             >
               <div
@@ -206,7 +203,14 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
                   </div>
                 </div>
                 <div
+                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                  aria-label="Drag handle"
                   class="euiFlexItem emotion-euiFlexItem-growZero"
+                  data-rbd-drag-handle-context-id="0"
+                  data-rbd-drag-handle-draggable-id="columnB"
+                  draggable="false"
+                  role="button"
+                  tabindex="0"
                 >
                   <span
                     color="subdued"

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -98,17 +98,17 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
               data-test-subj="dataGridColumnSelectorColumnItem-columnA"
             >
               <div
-                class="euiFlexGroup emotion-euiFlexGroup-m-flexStart-center-row"
+                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
                   <div
                     class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
                   >
                     <button
                       aria-checked="true"
-                      aria-labelledby="generated-id"
+                      aria-label="columnA"
                       class="euiSwitch__button"
                       data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
                       id="generated-id"
@@ -127,13 +127,23 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
                         />
                       </span>
                     </button>
-                    <span
-                      class="euiSwitch__label"
-                      id="generated-id"
-                    >
-                      columnA
-                    </span>
                   </div>
+                </div>
+                <div
+                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                  aria-hidden="true"
+                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  data-rbd-drag-handle-context-id="0"
+                  data-rbd-drag-handle-draggable-id="columnA"
+                  draggable="false"
+                  role="button"
+                  tabindex="-1"
+                >
+                  <span
+                    class="euiDataGridColumnSelector__itemLabel"
+                  >
+                    columnA
+                  </span>
                 </div>
                 <div
                   aria-describedby="rbd-hidden-text-0-hidden-text-0"
@@ -165,17 +175,17 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
               data-test-subj="dataGridColumnSelectorColumnItem-columnB"
             >
               <div
-                class="euiFlexGroup emotion-euiFlexGroup-m-flexStart-center-row"
+                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
               >
                 <div
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
                   <div
                     class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
                   >
                     <button
                       aria-checked="true"
-                      aria-labelledby="generated-id"
+                      aria-label="columnB"
                       class="euiSwitch__button"
                       data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
                       id="generated-id"
@@ -194,13 +204,23 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
                         />
                       </span>
                     </button>
-                    <span
-                      class="euiSwitch__label"
-                      id="generated-id"
-                    >
-                      columnB
-                    </span>
                   </div>
+                </div>
+                <div
+                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                  aria-hidden="true"
+                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  data-rbd-drag-handle-context-id="0"
+                  data-rbd-drag-handle-draggable-id="columnB"
+                  draggable="false"
+                  role="button"
+                  tabindex="-1"
+                >
+                  <span
+                    class="euiDataGridColumnSelector__itemLabel"
+                  >
+                    columnB
+                  </span>
                 </div>
                 <div
                   aria-describedby="rbd-hidden-text-0-hidden-text-0"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -68,19 +68,14 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
         data-test-subj="droppable"
       >
         <div
-          aria-describedby="rbd-hidden-text-0-hidden-text-0"
-          class="euiDraggable"
-          data-rbd-drag-handle-context-id="0"
-          data-rbd-drag-handle-draggable-id="columnA"
+          class="euiDraggable euiDraggable--hasCustomDragHandle"
           data-rbd-draggable-context-id="0"
           data-rbd-draggable-id="columnA"
           data-test-subj="draggable"
-          draggable="false"
-          role="button"
-          tabindex="0"
+          role="group"
         >
           <div
-            class="euiDataGridColumnSorting__item false euiDraggable__item"
+            class="euiDataGridColumnSorting__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
           >
             <p
               class="emotion-euiScreenReaderOnly"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -103,30 +103,44 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
                 </button>
               </div>
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <span
-                  class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
-                >
-                  <span
-                    data-euiicon-type="tokenNumber"
-                  />
-                </span>
-              </div>
-              <div
+                aria-describedby="rbd-hidden-text-0-hidden-text-0"
                 aria-hidden="true"
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
+                data-rbd-drag-handle-context-id="0"
+                data-rbd-drag-handle-draggable-id="columnA"
+                draggable="false"
+                role="button"
+                tabindex="-1"
               >
                 <div
-                  class="euiText emotion-euiText-xs"
+                  class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
                 >
-                  <p>
-                    Column A
-                  </p>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                  >
+                    <span
+                      class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
+                    >
+                      <span
+                        data-euiicon-type="tokenNumber"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                  >
+                    <div
+                      class="euiText emotion-euiText-xs"
+                    >
+                      <p>
+                        Column A
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
               <div
-                class="euiFlexItem euiDataGridColumnSorting__orderButtons emotion-euiFlexItem-grow-1"
+                class="euiFlexItem emotion-euiFlexItem-grow-1"
               >
                 <fieldset
                   class="euiButtonGroup euiButtonGroup--compressed euiButtonGroup--text euiButtonGroup--fullWidth euiDataGridColumnSorting__order"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
@@ -109,26 +109,34 @@ exports[`EuiDataGridColumnSortingDraggable renders an EuiDraggable component of 
       </EuiI18n>
     </EuiFlexItem>
     <EuiFlexItem
-      grow={false}
-    >
-      <EuiToken
-        iconType="tokenNumber"
-      />
-    </EuiFlexItem>
-    <EuiFlexItem
       aria-hidden={true}
+      className="euiDataGridColumnSorting__name"
+      tabIndex={-1}
     >
-      <EuiText
-        size="xs"
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
       >
-        <p>
-          Column A
-        </p>
-      </EuiText>
+        <EuiFlexItem
+          grow={false}
+        >
+          <EuiToken
+            iconType="tokenNumber"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiText
+            size="xs"
+          >
+            <p>
+              Column A
+            </p>
+          </EuiText>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiFlexItem>
-    <EuiFlexItem
-      className="euiDataGridColumnSorting__orderButtons"
-    >
+    <EuiFlexItem>
       <EuiI18n
         default="Select sorting method for {display}"
         token="euiColumnSortingDraggable.toggleLegend"

--- a/src/components/datagrid/controls/_data_grid_column_sorting.scss
+++ b/src/components/datagrid/controls/_data_grid_column_sorting.scss
@@ -32,11 +32,12 @@
     min-width: unset;
   }
   min-width: 200px;
-  border: none;
 
-  // Hack to overwrite some nested, unreachable component code with button groups
-  button {
-    // stylelint-disable-next-line declaration-no-important
-    font-size: $euiFontSizeXS !important;
+  .euiButtonGroup__buttons {
+    border: none;
+  }
+
+  .euiButtonGroupButton {
+    font-size: $euiFontSizeXS;
   }
 }

--- a/src/components/datagrid/controls/_data_grid_column_sorting.scss
+++ b/src/components/datagrid/controls/_data_grid_column_sorting.scss
@@ -20,23 +20,23 @@
   outline-offset: -$euiFocusRingSize;
 }
 
-.euiDataGridColumnSorting__orderButtons {
+.euiDataGridColumnSorting__name {
   @include euiBreakpoint('xs', 's') {
-    padding-left: $euiSizeXS;
+    padding-right: $euiSizeXS;
   }
-  padding-left: $euiSizeL;
+  padding-right: $euiSizeL;
+}
 
-  .euiDataGridColumnSorting__order {
-    @include euiBreakpoint('xs', 's') {
-      min-width: unset;
-    }
-    min-width: 200px;
-    border: none;
+.euiDataGridColumnSorting__order {
+  @include euiBreakpoint('xs', 's') {
+    min-width: unset;
+  }
+  min-width: 200px;
+  border: none;
 
-    // Hack to overwrite some nested, unreachable component code with button groups
-    button {
-      // stylelint-disable-next-line declaration-no-important
-      font-size: $euiFontSizeXS !important;
-    }
+  // Hack to overwrite some nested, unreachable component code with button groups
+  button {
+    // stylelint-disable-next-line declaration-no-important
+    font-size: $euiFontSizeXS !important;
   }
 }

--- a/src/components/datagrid/controls/column_selector.tsx
+++ b/src/components/datagrid/controls/column_selector.tsx
@@ -16,7 +16,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { EuiPopover, EuiPopoverFooter, EuiPopoverTitle } from '../../popover';
-import { EuiI18n } from '../../i18n';
+import { EuiI18n, useEuiI18n } from '../../i18n';
 import { EuiButtonEmpty } from '../../button';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiSwitch, EuiFieldText } from '../../form';
@@ -116,6 +116,10 @@ export const useDataGridColumnSelector = (
   );
 
   const isDragEnabled = allowColumnReorder && columnSearchText.length === 0; // only allow drag-and-drop when not filtering columns
+  const dragHandleAriaLabel = useEuiI18n(
+    'euiColumnSelector.dragHandleAriaLabel',
+    'Drag handle'
+  );
 
   let buttonText = (
     <EuiI18n token="euiColumnSelector.button" default="Columns" />
@@ -199,6 +203,8 @@ export const useDataGridColumnSelector = (
                       draggableId={id}
                       index={index}
                       isDragDisabled={!isDragEnabled}
+                      hasInteractiveChildren
+                      customDragHandle
                     >
                       {(provided, state) => (
                         <div
@@ -244,7 +250,11 @@ export const useDataGridColumnSelector = (
                               )}
                             </EuiFlexItem>
                             {isDragEnabled && (
-                              <EuiFlexItem grow={false}>
+                              <EuiFlexItem
+                                grow={false}
+                                {...provided.dragHandleProps}
+                                aria-label={dragHandleAriaLabel}
+                              >
                                 <EuiIcon type="grab" color="subdued" />
                               </EuiFlexItem>
                             )}

--- a/src/components/datagrid/controls/column_selector.tsx
+++ b/src/components/datagrid/controls/column_selector.tsx
@@ -216,14 +216,15 @@ export const useDataGridColumnSelector = (
                         >
                           <EuiFlexGroup
                             responsive={false}
-                            gutterSize="m"
+                            gutterSize="s"
                             alignItems="center"
                           >
-                            <EuiFlexItem>
-                              {allowColumnHiding ? (
+                            {allowColumnHiding && (
+                              <EuiFlexItem grow={false}>
                                 <EuiSwitch
                                   name={id}
                                   label={displayValues[id] || id}
+                                  showLabel={false}
                                   checked={visibleColumnIds.has(id)}
                                   compressed
                                   className="euiSwitch--mini"
@@ -243,11 +244,18 @@ export const useDataGridColumnSelector = (
                                   }}
                                   data-test-subj={`dataGridColumnSelectorToggleColumnVisibility-${id}`}
                                 />
-                              ) : (
-                                <span className="euiDataGridColumnSelector__itemLabel">
-                                  {id}
-                                </span>
-                              )}
+                              </EuiFlexItem>
+                            )}
+                            <EuiFlexItem
+                              // This extra column name flex item affords the column more grabbable real estate
+                              // for mouse users, while hiding repetition for keyboard/screen reader users
+                              {...provided.dragHandleProps}
+                              aria-hidden
+                              tabIndex={-1}
+                            >
+                              <span className="euiDataGridColumnSelector__itemLabel">
+                                {displayValues[id] || id}
+                              </span>
                             </EuiFlexItem>
                             {isDragEnabled && (
                               <EuiFlexItem

--- a/src/components/datagrid/controls/column_sorting_draggable.tsx
+++ b/src/components/datagrid/controls/column_sorting_draggable.tsx
@@ -67,7 +67,13 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
   );
 
   return (
-    <EuiDraggable draggableId={id} index={index} {...rest}>
+    <EuiDraggable
+      draggableId={id}
+      index={index}
+      hasInteractiveChildren
+      customDragHandle
+      {...rest}
+    >
       {(provided, state) => (
         <div
           className={`euiDataGridColumnSorting__item ${

--- a/src/components/datagrid/controls/column_sorting_draggable.tsx
+++ b/src/components/datagrid/controls/column_sorting_draggable.tsx
@@ -122,20 +122,38 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
               </EuiI18n>
             </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiToken
-                color={schemaDetails != null ? schemaDetails.color : undefined}
-                iconType={
-                  schemaDetails != null ? schemaDetails.icon : 'tokenString'
-                }
-              />
+            <EuiFlexItem
+              className="euiDataGridColumnSorting__name"
+              // This extra column name flex item affords the column more grabbable real estate
+              // for mouse users, while hiding repetition for keyboard/screen reader users
+              {...provided.dragHandleProps}
+              tabIndex={-1}
+              aria-hidden
+            >
+              <EuiFlexGroup
+                gutterSize="xs"
+                alignItems="center"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiToken
+                    color={
+                      schemaDetails != null ? schemaDetails.color : undefined
+                    }
+                    iconType={
+                      schemaDetails != null ? schemaDetails.icon : 'tokenString'
+                    }
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiText size="xs">
+                    <p>{display}</p>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
-            <EuiFlexItem aria-hidden>
-              <EuiText size="xs">
-                <p>{display}</p>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem className="euiDataGridColumnSorting__orderButtons">
+
+            <EuiFlexItem>
               <EuiI18n
                 token="euiColumnSortingDraggable.toggleLegend"
                 default="Select sorting method for {display}"
@@ -165,6 +183,7 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<EuiDataGridCol
                 )}
               </EuiI18n>
             </EuiFlexItem>
+
             <EuiFlexItem
               grow={false}
               {...provided.dragHandleProps}

--- a/src/components/datagrid/data_grid.a11y.tsx
+++ b/src/components/datagrid/data_grid.a11y.tsx
@@ -243,12 +243,15 @@ describe('EuiDataGrid', () => {
       cy.checkAxe();
     });
 
-    it('has zero violations when the Favorite Distro column has been sorted', () => {
+    it('has zero violations on sort and when the columns sorting menu is open', () => {
       cy.get('button.euiDataGridHeaderCell__button').last().realClick();
       cy.get('button.euiListGroupItem__button')
         .contains('Sort Alma to Debian')
         .should('exist')
         .realClick();
+      cy.get(
+        'button[data-test-subj="dataGridColumnSortingPopover"]'
+      ).realClick();
       cy.checkAxe();
     });
 

--- a/src/components/datagrid/data_grid.a11y.tsx
+++ b/src/components/datagrid/data_grid.a11y.tsx
@@ -158,7 +158,7 @@ describe('EuiDataGrid', () => {
       cy.checkAxe();
     });
 
-    it('has zero violations when the columns reorder menu is open', () => {
+    it('has zero violations when the columns visibility menu is open', () => {
       cy.get(
         'button[data-test-subj="dataGridColumnSelectorButton"]'
       ).realClick();

--- a/upcoming_changelogs/6517.md
+++ b/upcoming_changelogs/6517.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid` a11y errors within toolbar popovers containing draggable elements with interactive children
+- Fixed several styling bugs within `EuiDataGrid`'s sorting toolbar popover


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6516

This was actually a more trivial than I thought, since our [EuiDraggable component already has affordance built in](https://elastic.github.io/eui/#/display/drag-and-drop#interactive-elements) for interactive children via `hasInteractiveChildren` and `customDragHandle` :)

axe should no longer be complaining about nested interactive controls when any EuiDataGrid popover with draggable columns is open. Said draggable columns should remain draggable by drag handles and column names, but not by any interactive elements.

## QA

- Go to http://localhost:8030/#/tabular-content/data-grid
- Open the "Columns" visibliity popover in the data grid toolbar
    - [x] Open axe, scan the page, and confirm it does not show a Serious "Interactive controls must not be nested" error
    - [x] With a mouse, confirm that dragging both by column name and drag handle works
    - [x] With a mouse, confirm that dragging by the switch does **not** work
    - [x] With a keyboard/screen reader, confirm that interacting with both the switch and the drag handle works and is easy to understand
- Open the "Sort fields" visibliity popover in the data grid toolbar
- In the bottom left hand corner of the popover, click "Pick fields to sort by". Pick at least 2 fields
    - [x] Open axe, scan the page, and confirm it does not show a Serious "Interactive controls must not be nested" error
    - [x] With a mouse, confirm that dragging by either column name or drag handle both work
    - [x] With a mouse, confirm that dragging by  either the X button or the sort order button group does **not** work
    - [x] With a keyboard/screen reader, confirm that interacting with every item in each row (especially the drag handle) works and is easy to understand

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~