### PR TITLE
[Docs] Update `EuiConfirmModal` examples

### DIFF
--- a/src-docs/src/views/button/guidelines.js
+++ b/src-docs/src/views/button/guidelines.js
@@ -543,14 +543,6 @@ export default () => (
       <EuiTableBody>
         <EuiTableRow>
           <EuiTableRowCell>
-            <EuiButton color="danger">Discard</EuiButton>
-          </EuiTableRowCell>
-
-          <EuiTableRowCell>Remove or Delete</EuiTableRowCell>
-        </EuiTableRow>
-
-        <EuiTableRow>
-          <EuiTableRowCell>
             <EuiButton>New</EuiButton>
           </EuiTableRowCell>
 

--- a/src-docs/src/views/modal/confirm_modal.tsx
+++ b/src-docs/src/views/modal/confirm_modal.tsx
@@ -22,15 +22,19 @@ export default () => {
   if (isModalVisible) {
     modal = (
       <EuiConfirmModal
-        title="Do this thing"
+        title="Update subscription to Platinum?"
         onCancel={closeModal}
         onConfirm={closeModal}
-        cancelButtonText="No, don't do it"
-        confirmButtonText="Yes, do it"
+        cancelButtonText="Cancel"
+        confirmButtonText="Update subscription"
         defaultFocusedButton="confirm"
       >
-        <p>You&rsquo;re about to do something.</p>
-        <p>Are you sure you want to do this?</p>
+        <p>
+          Your subscription and benefits increase immediately. If you change to
+          a lower subscription later, it will not take affect until the next
+          billing cycle.
+        </p>
+        <p>Do you want to continue?</p>
       </EuiConfirmModal>
     );
   }
@@ -40,16 +44,15 @@ export default () => {
   if (isDestroyModalVisible) {
     destroyModal = (
       <EuiConfirmModal
-        title="Do this destructive thing"
+        title="Discard dashboard changes?"
         onCancel={closeDestroyModal}
         onConfirm={closeDestroyModal}
-        cancelButtonText="No, don't do it"
-        confirmButtonText="Yes, do it"
+        cancelButtonText="Keep editing"
+        confirmButtonText="Discard changes"
         buttonColor="danger"
         defaultFocusedButton="confirm"
       >
-        <p>You&rsquo;re about to destroy something.</p>
-        <p>Are you sure you want to do this?</p>
+        <p>You will lose all unsaved changes made to this dashboard.</p>
       </EuiConfirmModal>
     );
   }

--- a/src-docs/src/views/modal/confirm_modal.tsx
+++ b/src-docs/src/views/modal/confirm_modal.tsx
@@ -35,7 +35,6 @@ export default () => {
           a lower subscription later, it will not take affect until the next
           billing cycle.
         </p>
-        <p>Do you want to continue?</p>
       </EuiConfirmModal>
     );
   }

--- a/src-docs/src/views/modal/confirm_modal.tsx
+++ b/src-docs/src/views/modal/confirm_modal.tsx
@@ -22,6 +22,7 @@ export default () => {
   if (isModalVisible) {
     modal = (
       <EuiConfirmModal
+        style={{ width: 600 }}
         title="Update subscription to Platinum?"
         onCancel={closeModal}
         onConfirm={closeModal}


### PR DESCRIPTION
## Summary

This PR updates the confirm modal examples to reflect better writing practices and closes #6506.

It also removes the word "discard" from "Avoid these words in buttons" in: https://eui.elastic.co/#/navigation/button/guidelines.

All the discussions that led to these changes can be found in #6506.



<img width="1153" alt="confirm-modals-b-a@2x" src="https://user-images.githubusercontent.com/2750668/211870511-b30da472-0310-444b-8afc-04e969a1d1fa.png">


## QA

The confirm modals for QA can be found here: https://eui.elastic.co/pr_6519/#/layout/modal#confirm-modal

### General checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
