### PR TITLE
[EuiToolTip] Enforce only one visible tooltip at a time

### DIFF
--- a/src/components/tool_tip/tool_tip.spec.tsx
+++ b/src/components/tool_tip/tool_tip.spec.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+
+import { EuiButton } from '../../components';
+import { EuiToolTip } from './tool_tip';
+
+describe('EuiToolTip', () => {
+  it('shows the tooltip on hover', () => {
+    cy.mount(
+      <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
+        <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
+      </EuiToolTip>
+    );
+    cy.get('[data-test-subj="tooltip"]').should('not.exist');
+    cy.get('[data-test-subj="toggleToolTip"]').trigger('mouseover');
+    cy.get('[data-test-subj="tooltip"]').should('exist');
+  });
+
+  it('shows the tooltip on keyboard focus', () => {
+    cy.mount(
+      <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
+        <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
+      </EuiToolTip>
+    );
+    cy.get('[data-test-subj="tooltip"]').should('not.exist');
+    cy.get('[data-test-subj="toggleToolTip"]').focus();
+    cy.get('[data-test-subj="tooltip"]').should('exist');
+  });
+
+  it('does not show multiple tooltips if one tooltip toggle is focused and another tooltip toggle is hovered', () => {
+    cy.mount(
+      <>
+        <EuiToolTip content="Tooltip A" data-test-subj="tooltipA">
+          <EuiButton data-test-subj="toggleToolTipA">Show tooltip A</EuiButton>
+        </EuiToolTip>
+        <EuiToolTip content="Tooltip B" data-test-subj="tooltipB">
+          <EuiButton data-test-subj="toggleToolTipB">Show tooltip B</EuiButton>
+        </EuiToolTip>
+      </>
+    );
+    cy.get('[data-test-subj="tooltip"]').should('not.exist');
+
+    cy.get('[data-test-subj="toggleToolTipA"]').focus();
+    cy.contains('Tooltip A').should('exist');
+    cy.contains('Tooltip B').should('not.exist');
+
+    cy.get('[data-test-subj="toggleToolTipB"]').trigger('mouseover');
+    cy.contains('Tooltip B').should('exist');
+    cy.contains('Tooltip A').should('not.exist');
+  });
+});

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -24,6 +24,7 @@ import { EuiPortal } from '../portal';
 import { EuiToolTipPopover, ToolTipPositions } from './tool_tip_popover';
 import { EuiToolTipAnchor } from './tool_tip_anchor';
 import { EuiToolTipArrow } from './tool_tip_arrow';
+import { toolTipManager } from './tool_tip_manager';
 
 const positionsToClassNameMap: { [key in ToolTipPositions]: string } = {
   top: 'euiToolTip--top',
@@ -209,7 +210,10 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
   showToolTip = () => {
     if (!this.timeoutId) {
       this.timeoutId = setTimeout(() => {
-        enqueueStateChange(() => this.setState({ visible: true }));
+        enqueueStateChange(() => {
+          this.setState({ visible: true });
+          toolTipManager.registerTooltip(this.hideToolTip);
+        });
       }, delayToMsMap[this.props.delay]);
     }
   };
@@ -267,6 +271,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           toolTipStyles: DEFAULT_TOOLTIP_STYLES,
           arrowStyles: undefined,
         });
+        toolTipManager.deregisterToolTip(this.hideToolTip);
       }
     });
   };

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -16,14 +16,14 @@ import React, {
 import classNames from 'classnames';
 
 import { CommonProps, keysOf } from '../common';
+import { findPopoverPosition, htmlIdGenerator } from '../../services';
+import { enqueueStateChange } from '../../services/react';
+import { EuiResizeObserver } from '../observer/resize_observer';
 import { EuiPortal } from '../portal';
+
+import { EuiToolTipPopover, ToolTipPositions } from './tool_tip_popover';
 import { EuiToolTipAnchor } from './tool_tip_anchor';
 import { EuiToolTipArrow } from './tool_tip_arrow';
-import { EuiToolTipPopover, ToolTipPositions } from './tool_tip_popover';
-import { enqueueStateChange } from '../../services/react';
-import { findPopoverPosition, htmlIdGenerator } from '../../services';
-
-import { EuiResizeObserver } from '../observer/resize_observer';
 
 const positionsToClassNameMap: { [key in ToolTipPositions]: string } = {
   top: 'euiToolTip--top',

--- a/src/components/tool_tip/tool_tip_manager.test.ts
+++ b/src/components/tool_tip/tool_tip_manager.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { toolTipManager } from './tool_tip_manager';
+
+describe('ToolTipManager', () => {
+  describe('registerToolTip', () => {
+    const hideToolTip = jest.fn();
+
+    it('stores the passed hideToolTip callback', () => {
+      toolTipManager.registerTooltip(hideToolTip);
+
+      expect(toolTipManager.toolTipsToHide.has(hideToolTip)).toBeTruthy();
+    });
+
+    it('calls the previously stored hideToolTip callback and removes it from storage', () => {
+      toolTipManager.registerTooltip(() => {});
+
+      expect(hideToolTip).toHaveBeenCalledTimes(1);
+      expect(toolTipManager.toolTipsToHide.has(hideToolTip)).toBeFalsy();
+    });
+  });
+
+  describe('deregisterToolTip', () => {
+    // If the current tooltip is already hidden before the next tooltip is visible,
+    // there's no need to re-hide it, so we deregister the callback
+    const deregisteredHide = jest.fn();
+
+    it('removes the hide callback from storage', () => {
+      toolTipManager.registerTooltip(deregisteredHide);
+      toolTipManager.deregisterToolTip(deregisteredHide);
+      toolTipManager.registerTooltip(() => {});
+
+      expect(deregisteredHide).toHaveBeenCalledTimes(0);
+      expect(toolTipManager.toolTipsToHide.has(deregisteredHide)).toBeFalsy();
+    });
+  });
+});

--- a/src/components/tool_tip/tool_tip_manager.ts
+++ b/src/components/tool_tip/tool_tip_manager.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Manager utility that ensures only one tooltip is visible at a time
+ *
+ * UX rationale (primarily for mouse-only users):
+ * @see https://github.com/elastic/kibana/issues/144482
+ * @see https://github.com/elastic/eui/issues/5883
+ */
+class ToolTipManager {
+  // We use a set instead of a single var just in case
+  // multiple tooltips are registered via async shenanigans
+  toolTipsToHide = new Set<Function>();
+
+  registerTooltip = (hideCallback: Function) => {
+    this.toolTipsToHide.forEach((hide) => hide());
+    this.toolTipsToHide.clear();
+    this.toolTipsToHide.add(hideCallback);
+  };
+
+  deregisterToolTip = (hideCallback: Function) => {
+    this.toolTipsToHide.delete(hideCallback);
+  };
+}
+
+export const toolTipManager = new ToolTipManager();

--- a/upcoming_changelogs/6520.md
+++ b/upcoming_changelogs/6520.md
@@ -1,3 +1,3 @@
 **Breaking changes**
 
-- `EuiToolTip`s now internally enforce only showing **one** tooltip at a time (the most recently triggered tooltip). This primary affects scenarios where users are focused on a tooltip toggle via click, and then hover onto another tooltip toggle.
+- `EuiToolTip`s now internally enforce only showing **one** tooltip at a time (the most recently triggered tooltip). This primarily affects scenarios where users are focused on a tooltip toggle via click, and then hover onto another tooltip toggle.

--- a/upcoming_changelogs/6520.md
+++ b/upcoming_changelogs/6520.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- `EuiToolTip`s now internally enforce only showing **one** tooltip at a time (the most recently triggered tooltip). This primary affects scenarios where users are focused on a tooltip toggle via click, and then hover onto another tooltip toggle.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6423

This PR attempts to address multiple filed issues (https://github.com/elastic/kibana/issues/144482, https://github.com/elastic/eui/issues/5883, etc.) complaining about **focused** tooltip toggles not going away when another tooltip toggle is **hovered**. This behavior primarily affects mouse users (keyboard-only users will not have this issue, as focus is lost when tabbing away).

The solution to this problem should address this point of friction **without impacting the accessibility of keyboard and screenreader users**.

The solution that we think should satisfy the above problem and parameters was to add an internal tooltip manager that only allows **one** tooltip (the most recently triggered tooltip) at a time to be visible. This is typically the desired behavior in 99% of cases for both mouse and keyboard users. Thorough QA testing should be done to ensure that screen reader users experience no significant loss in information. Sighted keyboard-only users should also in theory not experience a UX degradation, since they're not hovering away to another item. Mixed keyboard/mouse users may suffer the most, but can also always hover **back** onto the focused tooltip.

### Before
![before](https://user-images.githubusercontent.com/549407/211932917-dfadfd54-4471-4a15-b245-98c7407d79b1.gif)

### After
![after](https://user-images.githubusercontent.com/549407/211932777-259ca8ad-bd0f-4764-b88f-7752d8935dd0.gif)

## QA

- [x] QA all examples on the [Tooltip docs](http://localhost:8030/#/display/tooltip) and ensure that they still work as expected (fixed scrolling, etc.)
- [x] Ensure tooltips still work in all edge cases for screen readers (this is still the case for me - since the primary behavior this fixes tooltips for is mouse/hovering users, which has no meaningful impact on `aria-describedby` or SRs)

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~