### PR TITLE
Harden release script to check for correct `upstream` remote

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -41,7 +41,8 @@ if (args.dry_run) {
     process.exit(1);
   }
 
-  // ensure git is on the main branch
+  // ensure git is on the correct remote and branch
+  await ensureUpstreamRemote();
   await ensureMainBranch();
 
   // run linting and unit tests
@@ -134,6 +135,30 @@ function parseArguments() {
     ...args,
     steps,
   };
+}
+
+async function ensureUpstreamRemote() {
+  try {
+    const upstreamRemote = execSync('git config --get remote.upstream.url')
+      .toString()
+      .trim();
+    if (
+      !(
+        upstreamRemote.endsWith(':elastic/eui.git') || // : for SSH, / for HTTPS
+        upstreamRemote.endsWith('/elastic/eui.git')
+      )
+    ) {
+      console.error(
+        'Your `upstream` remote must be pointed to https://github.com/elastic/eui.\nPlease run `git remote -v` to ensure you have an `upstream` remote pointed at the correct repo.\n'
+      );
+      process.exit(1);
+    }
+  } catch {
+    console.error(
+      'No `upstream` remote found.\nPlease run: `git remote add upstream git@github.com:elastic/eui.git`\n'
+    );
+    process.exit(1);
+  }
 }
 
 async function ensureMainBranch() {


### PR DESCRIPTION
## Summary

@breehall discovered that our various upstream fetches will cause a lot of failures if `upstream` is pointed at the wrong repo. Rather than assuming devs have `upstream` already set up and pointed correctly, we should catch `upstream` remote issues in our release script automatically.

## QA

- Run `git remote remove upstream` locally
- [x] Run `npm run release` and confirm that it spits out the following error:
    <img width="626" alt="" src="https://user-images.githubusercontent.com/549407/213011884-bd802da4-92ca-44af-9dc2-4da63dd707cf.png">
- Run `git remote add upstream git@github.com:cee-chen/eui.git`
- [x] Run `npm run release` and confirm that it spits out the following error:
    <img width="867" alt="Screen Shot 2023-01-17 at 1 02 16 PM" src="https://user-images.githubusercontent.com/549407/213011902-5400e561-bf11-477f-916e-570fba52adee.png">
- Run `git remote remove upstream && git remote add upstream git@github.com:elastic/eui.git`
- [x] Run `npm run release` and confirm it no longer errors about upstream remotes, but instead throws an error about not being on the `main` branch

### General checklist

N/A, internal dev-only changes
