### PR TITLE
[EuiModalHeaderTitle] Remove automatic detection of title contents in favor of always wrapping a `h1`, configurable via new `component` prop

### DIFF
--- a/src/components/modal/__snapshots__/modal_header_title.test.tsx.snap
+++ b/src/components/modal/__snapshots__/modal_header_title.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiModalHeaderTitle component 1`] = `
+<div
+  class="euiTitle euiModalHeader__title emotion-euiTitle-m"
+>
+  children
+</div>
+`;
+
 exports[`EuiModalHeaderTitle is rendered 1`] = `
 <h1
   aria-label="aria-label"

--- a/src/components/modal/confirm_modal.test.tsx
+++ b/src/components/modal/confirm_modal.test.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import {
   findTestSubject,
@@ -33,7 +34,10 @@ beforeEach(() => {
 
 describe('EuiConfirmModal', () => {
   shouldRenderCustomStyles(
-    <EuiConfirmModal onCancel={() => {}}>children</EuiConfirmModal>
+    <EuiConfirmModal title="Test" onCancel={() => {}}>
+      children
+    </EuiConfirmModal>,
+    { childProps: ['titleProps'] }
   );
 
   test('renders EuiConfirmModal', () => {
@@ -195,5 +199,17 @@ describe('EuiConfirmModal', () => {
         done();
       });
     });
+  });
+
+  test('titleProps', () => {
+    const { baseElement } = render(
+      <EuiConfirmModal
+        title="A confirmation modal"
+        titleProps={{ component: 'div', className: 'titlePropsTest' }}
+        onCancel={() => {}}
+      />
+    );
+    const title = baseElement.querySelector('.titlePropsTest');
+    expect(title?.tagName.toLowerCase()).toEqual('div');
   });
 });

--- a/src/components/modal/confirm_modal.tsx
+++ b/src/components/modal/confirm_modal.tsx
@@ -8,6 +8,7 @@
 
 import React, {
   FunctionComponent,
+  ComponentProps,
   ReactNode,
   useEffect,
   useState,
@@ -17,7 +18,10 @@ import classnames from 'classnames';
 import { EuiModal, EuiModalProps } from './modal';
 import { EuiModalFooter } from './modal_footer';
 import { EuiModalHeader } from './modal_header';
-import { EuiModalHeaderTitle } from './modal_header_title';
+import {
+  EuiModalHeaderTitle,
+  EuiModalHeaderTitleProps,
+} from './modal_header_title';
 import { EuiModalBody } from './modal_body';
 
 import { useEuiTheme } from '../../services';
@@ -34,6 +38,7 @@ export interface EuiConfirmModalProps
    */
   children?: ReactNode;
   title?: ReactNode;
+  titleProps?: ComponentProps<EuiModalHeaderTitleProps>;
   cancelButtonText?: ReactNode;
   confirmButtonText?: ReactNode;
   onCancel: (
@@ -71,6 +76,7 @@ export const CANCEL_BUTTON = 'cancel';
 export const EuiConfirmModal: FunctionComponent<EuiConfirmModalProps> = ({
   children,
   title,
+  titleProps,
   onCancel,
   onConfirm,
   cancelButtonText,
@@ -118,7 +124,10 @@ export const EuiConfirmModal: FunctionComponent<EuiConfirmModalProps> = ({
   if (title) {
     modalTitle = (
       <EuiModalHeader>
-        <EuiModalHeaderTitle data-test-subj="confirmModalTitleText">
+        <EuiModalHeaderTitle
+          data-test-subj="confirmModalTitleText"
+          {...titleProps}
+        >
           {title}
         </EuiModalHeaderTitle>
       </EuiModalHeader>

--- a/src/components/modal/modal_header_title.test.tsx
+++ b/src/components/modal/modal_header_title.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -17,9 +17,16 @@ describe('EuiModalHeaderTitle', () => {
   shouldRenderCustomStyles(<EuiModalHeaderTitle>children</EuiModalHeaderTitle>);
 
   test('is rendered', () => {
-    const component = (
+    const { container } = render(
       <EuiModalHeaderTitle {...requiredProps}>children</EuiModalHeaderTitle>
     );
-    expect(render(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('component', () => {
+    const { container } = render(
+      <EuiModalHeaderTitle component="div">children</EuiModalHeaderTitle>
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/modal/modal_header_title.tsx
+++ b/src/components/modal/modal_header_title.tsx
@@ -6,26 +6,34 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, ElementType } from 'react';
 import classnames from 'classnames';
 import { CommonProps } from '../common';
 
 import { EuiTitle } from '../title';
 
 export type EuiModalHeaderTitleProps = FunctionComponent<
-  HTMLAttributes<HTMLDivElement> & CommonProps
+  HTMLAttributes<HTMLHeadingElement> &
+    CommonProps & {
+      /**
+       * The tag to render
+       * @default h1
+       */
+      component?: ElementType;
+    }
 >;
 
 export const EuiModalHeaderTitle: EuiModalHeaderTitleProps = ({
   className,
   children,
+  component: Component = 'h1',
   ...rest
 }) => {
   const classes = classnames('euiModalHeader__title', className);
 
   return (
     <EuiTitle size="m" className={classes} {...rest}>
-      {React.isValidElement(children) ? children : <h1>{children}</h1>}
+      <Component>{children}</Component>
     </EuiTitle>
   );
 };

--- a/upcoming_changelogs/6530.md
+++ b/upcoming_changelogs/6530.md
@@ -1,0 +1,6 @@
+- Added the `component` prop to `EuiModalHeaderTitle`, which allows overriding the default `h1` tag
+- Added the `titleProps` prop to `EuiConfirmModal`, which allows overriding the default `h1` tag
+
+**Breaking changes**
+
+- `EuiModalHeaderTitle` now **always** wraps its children in a `h1` tag (vs. attempting to conditionally detect whether its children are raw strings or not). If an h1 tag is not desired, a more generic `div` can be passed via the new `component` prop.

--- a/upcoming_changelogs/6530.md
+++ b/upcoming_changelogs/6530.md
@@ -3,4 +3,4 @@
 
 **Breaking changes**
 
-- `EuiModalHeaderTitle` now **always** wraps its children in a `h1` tag (vs. attempting to conditionally detect whether its children are raw strings or not). If an h1 tag is not desired, a more generic `div` can be passed via the new `component` prop.
+- `EuiModalHeaderTitle` now **always** wraps its children in a `h1` tag (previously attempted to conditionally detect whether its children were raw strings or not). To change this tag type to, e.g. a more generic `div`, use  the new `component` prop.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6531

The [EuiModal conversion](https://github.com/elastic/eui/pull/6321/files#diff-65352da4495c877124ff12f370d4469672232423b8e8b6b78d9a85ed418f53f9) removed the `div` wrapper for `EuiModalHeaderTitle` in favor of `EuiTitle`. In combination with the conditional React child detection check, this broke several instances in Kibana where styles were no longer applying as expected. This is due to devs passing in `<FormattedMessage />` components (which look and smell like a React Element, but in actuality just outputs a raw string that has no valid element to set title styles on).

This PR opinionatedly changes the behavior of `EuiModalTitle` to **always** wrap its contents in a `h1` tag by default, no matter what type of children is passed (string, elements, etc.). For consumers who want to customize the tag wrapper to, e.g. a `h2` or a more generic `div`, they can do so via the `component` prop.

`EuiConfirmModal` also exposes the ability to customize this tag via a new `titleProps` prop.

> ⚠️ NOTE: This change will **almost certainly** require a certain amount of manual inspection/QA once it hits Kibana.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~