### PR TITLE
[EuiInlineEdit] (POC Review) Create Component Directory and Base Functionality

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -149,6 +149,8 @@ import { IconExample } from './views/icon/icon_example';
 
 import { ImageExample } from './views/image/image_example';
 
+import { InlineEditExample } from './views/inline_edit/inline_edit_example';
+
 import { InnerTextExample } from './views/inner_text/inner_text_example';
 
 import { KeyPadMenuExample } from './views/key_pad_menu/key_pad_menu_example';
@@ -557,6 +559,7 @@ const navigation = [
       HealthExample,
       IconExample,
       ImageExample,
+      InlineEditExample,
       ListGroupExample,
       LoadingExample,
       NotificationEventExample,

--- a/src-docs/src/views/inline_edit/inline_edit.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+
+import {
+  EuiInlineEdit,
+  EuiFieldText,
+  EuiComboBox,
+  EuiTextArea,
+  EuiComboBoxProps,
+  EuiHorizontalRule,
+  EuiSpacer,
+} from '../../../../src/components';
+
+const optionsStatic = [
+  {
+    label: 'Titan',
+    'data-test-subj': 'titanOption',
+  },
+  {
+    label: 'Enceladus is disabled',
+    disabled: true,
+  },
+  {
+    label: 'Mimas',
+  },
+  {
+    label: 'Dione',
+  },
+  {
+    label: 'Iapetus',
+  },
+  {
+    label: 'Phoebe',
+  },
+  {
+    label: 'Rhea',
+  },
+  {
+    label:
+      "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
+  },
+  {
+    label: 'Tethys',
+  },
+  {
+    label: 'Hyperion',
+  },
+];
+
+export default () => {
+  const [options, setOptions] = useState(optionsStatic);
+  const [selectedOptions, setSelected] = useState([options[2], options[4]]);
+
+  const onChange = (selectedOptions: any) => {
+    setSelected(selectedOptions);
+  };
+
+  return (
+    <>
+      {/* Base components */}
+      <h3>EuiInlineEdit - Text</h3>
+      <EuiInlineEdit
+        editViewType={EuiFieldText}
+        defaultValue="helloWorld"
+        editViewTypeProps={{ id: 'hello' }}
+      />
+      <EuiHorizontalRule />
+
+      <h3>EuiInlineEdit - Textarea</h3>
+      <EuiInlineEdit
+        editViewType={EuiTextArea}
+        defaultValue="Tiramisu jelly beans sweet croissant macaroon topping. Gummies fruitcake sesame snaps lollipop chocolate cake lemon drops icing. Cake cake croissant ice cream jujubes donut toffee. Gummies jelly tiramisu cheesecake brownie icing gummi bears candy canes."
+        editViewTypeProps={{ id: 'hello' }}
+      />
+      <EuiHorizontalRule />
+
+      <h3>EuiInlineEdit - Select</h3>
+      <EuiInlineEdit
+        editViewType={EuiComboBox}
+        editViewTypeProps={{
+          isClearable: true,
+          options: options,
+          placeholder: 'Select or create options',
+          selectedOptions: selectedOptions,
+          onChange: onChange,
+          'data-test-subj': 'demoComboBox',
+          'aria-label': 'Accessible screen reader label',
+          autoFocus: true,
+        }}
+      />
+      <EuiHorizontalRule />
+    </>
+  );
+};

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { GuideSectionTypes } from '../../components';
+
+import { EuiText, EuiInlineEdit } from '../../../../src';
+
+import InlineEdit from './inline_edit';
+const inlineEditSource = require('!!raw-loader!./inline_edit');
+
+export const InlineEditExample = {
+  title: 'Inline edit',
+  intro: (
+    <>
+      <EuiText>
+        Hello! This is where the EuiInlineEdit documentation intro will go!
+      </EuiText>
+    </>
+  ),
+  sections: [
+    {
+      title: 'InlineEdit',
+      text: (
+        <>
+          <p>
+            Description needed: how to use the <strong>EuiInlineEdit</strong>{' '}
+            component.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: inlineEditSource,
+        },
+      ],
+      demo: <InlineEdit />,
+      props: { EuiInlineEdit },
+    },
+  ],
+};

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -18,7 +18,7 @@ export const InlineEditExample = {
   ),
   sections: [
     {
-      title: 'InlineEdit',
+      title: 'Inline edit',
       text: (
         <>
           <p>

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -246,3 +246,18 @@ export type RecursivePartial<T> = {
     : RecursivePartial<T[P]>; // recurse for all non-array and non-primitive values
 };
 type NonAny = number | boolean | string | symbol | null;
+
+// `Defaultize` copied out of @types/react
+type Defaultize<P, D> = P extends any
+  ? string extends keyof P
+    ? P
+    : Pick<P, Exclude<keyof P, keyof D>> &
+        Partial<Pick<P, Extract<keyof P, keyof D>>> &
+        Partial<Pick<D, Exclude<keyof D, keyof P>>>
+  : never;
+
+export type WithDefaultPropsApplied<
+  T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>
+> = T extends { defaultProps: infer D }
+  ? Defaultize<ComponentProps<T>, D>
+  : ComponentProps<T>;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -89,6 +89,8 @@ export * from './icon';
 
 export * from './image';
 
+export * from './inline_edit';
+
 export * from './inner_text';
 
 export * from './i18n';

--- a/src/components/inline_edit/index.ts
+++ b/src/components/inline_edit/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { EuiInlineEdit } from './inline_edit';

--- a/src/components/inline_edit/inline_edit.tsx
+++ b/src/components/inline_edit/inline_edit.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { HTMLAttributes, useState } from 'react';
+import { CommonProps, WithDefaultPropsApplied } from '../common';
+import classNames from 'classnames';
+
+import { EuiButtonEmpty, EuiButtonIcon } from '../button';
+import { EuiFieldText, EuiTextArea, EuiFormRow } from '../form';
+import { EuiComboBox, EuiComboBoxOptionOption } from '../combo_box';
+import { EuiBadge } from '../badge';
+
+import { htmlIdGenerator } from '../../services/accessibility';
+
+type AcceptableComponents =
+  | typeof EuiTextArea
+  | typeof EuiFieldText
+  | typeof EuiComboBox;
+
+export type EuiInlineEditProps<T extends AcceptableComponents> = HTMLAttributes<
+  HTMLDivElement
+> &
+  CommonProps & {
+    /**
+     * The type of form control that will be displayed when EuiInlineEdit
+     * is in editView
+     * @default text
+     */
+    editViewType?: T;
+    /**
+     * Props for the form control created by editViewType
+     */
+    editViewTypeProps?: WithDefaultPropsApplied<T>;
+    /**
+     * Default string value for input in readView
+     */
+    defaultValue?: string;
+    /**
+     * Allow users to pass in a function when the confirm button is clicked
+     *
+     */
+    onConfirm?: () => void;
+    confirmButtonAriaLabel?: string;
+    cancelButtonAriaLabel?: string;
+    /**
+     * Start in editView
+     */
+    startWithEditOpen?: boolean;
+    /**
+     * Form label that appears above the form control
+     */
+    label?: String;
+  };
+
+export const EuiInlineEdit = <T extends AcceptableComponents>({
+  children,
+  className,
+  //@ts-ignore TypeScript sad :(
+  editViewType = EuiFieldText,
+  editViewTypeProps,
+  defaultValue = 'Click me to edit',
+  onConfirm,
+  confirmButtonAriaLabel,
+  cancelButtonAriaLabel,
+  startWithEditOpen,
+  label,
+  ...rest
+}: EuiInlineEditProps<T>) => {
+  const classes = classNames('euiEuiInlineEdit', className);
+
+  const EditViewType = editViewType;
+  const [isInEdit, setIsInEdit] = useState(startWithEditOpen);
+  const inlineTextEditInputId = htmlIdGenerator('__inlineEditInput')();
+
+  /* Text Controls */
+  const [textEditViewValue, setTextEditViewValue] = useState(
+    defaultValue || ''
+  );
+  const [textReadViewValue, setTextReadViewValue] = useState(defaultValue);
+
+  /* ComboBox Control */
+  const [comboBoxSelectedOptions, setComboBoxSelectedOptions] = useState(
+    editViewTypeProps['selectedOptions'] || []
+  );
+
+  /* onConfirm / Save Functions */
+  const saveTextEditValue = () => {
+    const input = (document.getElementById(
+      inlineTextEditInputId
+    ) as HTMLInputElement).value;
+    setTextReadViewValue(input);
+    setIsInEdit(!isInEdit);
+    onConfirm && onConfirm();
+  };
+
+  const saveComboBoxEditValue = () => {
+    // we will need to do a check to see if the array is larger than 0 here.
+    setComboBoxSelectedOptions(editViewTypeProps['selectedOptions']);
+    setIsInEdit(!isInEdit);
+    onConfirm && onConfirm();
+  };
+
+  /* Shared Elements & Functions (Text & ComboBox) */
+  const editViewButtons = (
+    <>
+      <EuiButtonIcon
+        iconType="check"
+        aria-label={confirmButtonAriaLabel || 'confirm'}
+        onClick={
+          EditViewType === EuiComboBox
+            ? saveComboBoxEditValue
+            : saveTextEditValue
+        } // this should be a conditional to switch between text and combobox saves
+      />
+      <EuiButtonIcon
+        iconType="cross"
+        aria-label={cancelButtonAriaLabel || 'cancel'}
+        onClick={() => {
+          setIsInEdit(!isInEdit);
+        }}
+      />
+    </>
+  );
+
+  /* Text Elements & Functions (Textarea and FieldText) */
+  const editTextViewOnChange = (e: any) => {
+    setTextEditViewValue(e.target.value);
+  };
+
+  const textEditViewElement = (
+    <>
+      <EditViewType
+        id={inlineTextEditInputId}
+        value={textEditViewValue}
+        onChange={editTextViewOnChange}
+        {...(rest as any)}
+      />
+
+      {editViewButtons}
+    </>
+  );
+
+  const textReadViewElement = (
+    <EuiButtonEmpty
+      color="text"
+      onClick={() => {
+        setIsInEdit(!isInEdit);
+      }}
+    >
+      {textReadViewValue}
+    </EuiButtonEmpty>
+  );
+
+  /* ComboBox Elements & Functions */
+
+  const comboBoxEditViewElement = (
+    <>
+      <EditViewType
+        id={inlineTextEditInputId}
+        {...editViewTypeProps}
+        {...(rest as any)}
+      />
+
+      {editViewButtons}
+    </>
+  );
+
+  const comboBoxReadViewElement = (
+    <EuiButtonEmpty
+      color="text"
+      onClick={() => {
+        setIsInEdit(!isInEdit);
+      }}
+    >
+      {comboBoxSelectedOptions.map(
+        (option: EuiComboBoxOptionOption<T>, index: number) => {
+          return (
+            <EuiBadge
+              color="hollow"
+              iconType="cross"
+              iconSide="right"
+              key={index}
+            >
+              {option.label}
+            </EuiBadge>
+          );
+        }
+      )}
+    </EuiButtonEmpty>
+  );
+
+  /* Current Form Control in View */
+  const currentFormControlInView =
+    EditViewType === EuiComboBox ? (
+      <EuiFormRow label={label}>
+        {isInEdit ? comboBoxEditViewElement : comboBoxReadViewElement}
+      </EuiFormRow>
+    ) : (
+      <EuiFormRow label={label}>
+        {isInEdit ? textEditViewElement : textReadViewElement}
+      </EuiFormRow>
+    );
+
+  return (
+    <div className={classes} {...rest}>
+      {currentFormControlInView}
+    </div>
+  );
+};

--- a/src/components/inline_edit/inline_edit.tsx
+++ b/src/components/inline_edit/inline_edit.tsx
@@ -112,6 +112,7 @@ export const EuiInlineEdit = <T extends AcceptableComponents>({
       setIsInEdit(!isInEdit);
       onConfirm && onConfirm();
     } else {
+      editViewTypeProps['selectedOptions'] = comboBoxSelectedOptions;
       setIsInEdit(!isInEdit);
     }
   };
@@ -173,6 +174,7 @@ export const EuiInlineEdit = <T extends AcceptableComponents>({
     <>
       <EditViewType
         id={inlineTextEditInputId}
+        selectedOptions={comboBoxSelectedOptions}
         {...editViewTypeProps}
         {...(rest as any)}
       />

--- a/src/components/inline_edit/inline_edit.tsx
+++ b/src/components/inline_edit/inline_edit.tsx
@@ -93,16 +93,27 @@ export const EuiInlineEdit = <T extends AcceptableComponents>({
     const input = (document.getElementById(
       inlineTextEditInputId
     ) as HTMLInputElement).value;
-    setTextReadViewValue(input);
-    setIsInEdit(!isInEdit);
-    onConfirm && onConfirm();
+
+    // If there's no text, cancel the action, reset the input text, and return to readView
+    if (input) {
+      setTextReadViewValue(input);
+      setIsInEdit(!isInEdit);
+      onConfirm && onConfirm();
+    } else {
+      setTextEditViewValue(textReadViewValue);
+      setIsInEdit(!isInEdit);
+    }
   };
 
   const saveComboBoxEditValue = () => {
-    // we will need to do a check to see if the array is larger than 0 here.
-    setComboBoxSelectedOptions(editViewTypeProps['selectedOptions']);
-    setIsInEdit(!isInEdit);
-    onConfirm && onConfirm();
+    // If there are no selections, but the user tries to save, cancel the action and return to readView
+    if (editViewTypeProps['selectedOptions'].length !== 0) {
+      setComboBoxSelectedOptions(editViewTypeProps['selectedOptions']);
+      setIsInEdit(!isInEdit);
+      onConfirm && onConfirm();
+    } else {
+      setIsInEdit(!isInEdit);
+    }
   };
 
   /* Shared Elements & Functions (Text & ComboBox) */


### PR DESCRIPTION
## Note to Reviewer
- Please feel free to fully mark this PR! I'd like to solidify the base of this component before adding in the code for props from my other branch. I'm open to any changes to the code and design for this. I'm purposely leaving this PR in draft for the first round of reviews because there will likely need to be changes before merging this into the feature branch.

- Things I'm looking for:
   - [Code] Does this structure make sense? It's intended to be flexible in case we want to add more `editView` components in the future, but I partially believe it could be a lot cleaner if I just focus on the three intended components 
   - [Design] The original design used he empty buttons for `readView`. Is this still OK? 
   - [Accessibility] Are there any accessibility concerns with this component?

- In your opinion, does a multiple select combo box make sense for this component? Should this be a single select combo box if anything?

## Summary
(Associated with #3928) 

Spec Doc: [EuiInlineEdit Spec Doc](https://docs.google.com/document/d/19Ba2I3iF8W5-XYIdzHH4pBDuXbQ5hyKyv0m2o6Tw70s/edit?usp=sharing)

This is the first PR for the new `EuiInlineEdit` component. This PR creates the required directories for the component and the component docs. The `EuiInlineEdit` component accepts three form controls (`EuiFieldText`, `EuiTextarea`, and `EuiComboBox`) and allows users to toggle between two states to view and edit the controls. 

The base functionality for `EuiInlineEdit` includes:
- Toggling between `readView` and `editView` for the three accepted form controls
  - `readView` should display an `EuiEmptyButton` with text (for `EuiFieldText` and `EuiTextarea`) or badges (for `EuiComboBox`) with the saved or default text and selections
  - `editView` should display the desired form control
- Saving text and selections using a save button when the component is in `editView`
  - Basic validation that does not allow the form controls to be saved when they contain no text / selections. If they are empty and a save is attempted, the component returns to `readView` with the text / selections prior to editing
- Canceling and not saving text and selections using a cancel button when the component is in `editView`


## QA
- [ ] **Saving new text within `EuiInlineEdit` FieldText and TextArea**
Click on the `helloWorld`message or the cupcake ipsum message, change the text inside of the text box, use the submit button to save results. The new message should persist.

https://user-images.githubusercontent.com/40739624/214079053-cdd0d7ae-d793-4a70-9a0f-2678e2e23d99.mov

- [ ] **Saving new text within `EuiInlineEdit` ComboBox**
Click on the badges to open an `EuiComboBox`. Select different options with the dropdown to add them to your list. Use the submit button to save results. A badge for each option selected should appear.

https://user-images.githubusercontent.com/40739624/214079640-5f7d1e00-5d10-40e8-ae7c-61dc38258f29.mov

- [ ] **Cancelling an action within`EuiInlineEdit` FieldText and TextArea**
Click on the `helloWorld`message or the cupcake ipsum message, change the text inside of the text box, use the cancel button. The new message should not persist.

- [ ] **Saving new text within `EuiInlineEdit` ComboBox**
Click on the badges to open an `EuiComboBox`. Select different options with the dropdown to add them to your list. Use the cancel button to save results. The badges and their values should not change.


### General checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
