### PR TITLE
[EuiResizablePanel] Added tabindex prop to EuiResizablePanel for keyboard accessibility.

### DIFF
--- a/src-docs/src/views/resizable_container/resizable_container_basic.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_basic.tsx
@@ -14,7 +14,7 @@ export default () => (
   <EuiResizableContainer style={{ height: '200px' }}>
     {(EuiResizablePanel, EuiResizableButton) => (
       <>
-        <EuiResizablePanel initialSize={50} minSize="30%" tabindex="0">
+        <EuiResizablePanel initialSize={50} minSize="30%" tabIndex={0}>
           <EuiText>
             <div>{text}</div>
             <a href="">Hello world</a>
@@ -23,7 +23,7 @@ export default () => (
 
         <EuiResizableButton />
 
-        <EuiResizablePanel initialSize={50} minSize="200px" tabindex="0">
+        <EuiResizablePanel initialSize={50} minSize="200px" tabIndex={0}>
           <EuiText>{text}</EuiText>
         </EuiResizablePanel>
       </>

--- a/src-docs/src/views/resizable_container/resizable_container_basic.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_basic.tsx
@@ -14,7 +14,7 @@ export default () => (
   <EuiResizableContainer style={{ height: '200px' }}>
     {(EuiResizablePanel, EuiResizableButton) => (
       <>
-        <EuiResizablePanel initialSize={50} minSize="30%">
+        <EuiResizablePanel initialSize={50} minSize="30%" tabindex="0">
           <EuiText>
             <div>{text}</div>
             <a href="">Hello world</a>
@@ -23,7 +23,7 @@ export default () => (
 
         <EuiResizableButton />
 
-        <EuiResizablePanel initialSize={50} minSize="200px">
+        <EuiResizablePanel initialSize={50} minSize="200px" tabindex="0">
           <EuiText>{text}</EuiText>
         </EuiResizablePanel>
       </>

--- a/src-docs/src/views/resizable_container/resizable_container_callbacks.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_callbacks.tsx
@@ -78,6 +78,7 @@ export default () => {
                 id={firstPanelId}
                 size={sizes[firstPanelId]}
                 minSize="30%"
+                tabindex="0"
               >
                 <EuiText>
                   <div>{text}</div>
@@ -91,6 +92,7 @@ export default () => {
                 id={secondPanelId}
                 size={sizes[secondPanelId]}
                 minSize="200px"
+                tabindex="0"
               >
                 <EuiText>{text}</EuiText>
               </EuiResizablePanel>

--- a/src-docs/src/views/resizable_container/resizable_container_callbacks.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_callbacks.tsx
@@ -78,7 +78,7 @@ export default () => {
                 id={firstPanelId}
                 size={sizes[firstPanelId]}
                 minSize="30%"
-                tabindex="0"
+                tabIndex={0}
               >
                 <EuiText>
                   <div>{text}</div>
@@ -92,7 +92,7 @@ export default () => {
                 id={secondPanelId}
                 size={sizes[secondPanelId]}
                 minSize="200px"
-                tabindex="0"
+                tabIndex={0}
               >
                 <EuiText>{text}</EuiText>
               </EuiResizablePanel>

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -214,7 +214,7 @@ export const ResizableContainerExample = {
       </p>
 
       <>
-        <EuiCallOut title="Consider adding a tabindex for keyboard accessibility">
+        <EuiCallOut title="Consider adding a tabIndex for keyboard accessibility">
           <p>
             Add a prop <EuiCode>tabIndex={0}</EuiCode> to the{' '}
             <strong>EuiResizableContainer</strong> if it is a fixed height or

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -216,7 +216,7 @@ export const ResizableContainerExample = {
       <>
         <EuiCallOut title="Consider adding a tabindex for keyboard accessibility">
           <p>
-            Add a prop <EuiCode>tabindex=&ldquo;0&rdquo;</EuiCode> to the{' '}
+            Add a prop <EuiCode>tabIndex={0}</EuiCode> to the{' '}
             <strong>EuiResizableContainer</strong> if it is a fixed height or
             has a lot of content. This ensures keyboard users can set focus on
             the container and scroll to the bottom using arrow keys.

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -212,6 +212,17 @@ export const ResizableContainerExample = {
         <strong>EuiResizablePanel</strong> component and put the{' '}
         <strong>EuiResizableButton</strong> component between.
       </p>
+
+      <>
+        <EuiCallOut title="Consider adding a tabindex for keyboard accessibility">
+          <p>
+            Add a prop <EuiCode>tabindex=&ldquo;0&rdquo;</EuiCode> to the{' '}
+            <strong>EuiResizableContainer</strong> if it is a fixed height or
+            has a lot of content. This ensures keyboard users can set focus on
+            the container and scroll to the bottom using arrow keys.
+          </p>
+        </EuiCallOut>
+      </>
     </EuiText>
   ),
   sections: [

--- a/src-docs/src/views/resizable_container/resizable_container_reset_values.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_reset_values.tsx
@@ -93,6 +93,7 @@ export default () => {
               id={firstPanelId}
               size={sizes[firstPanelId]}
               minSize="30%"
+              tabindex="0"
             >
               <EuiText>
                 <div>{text}</div>
@@ -105,6 +106,7 @@ export default () => {
               id={secondPanelId}
               size={sizes[secondPanelId]}
               minSize="200px"
+              tabindex="0"
             >
               <EuiText>
                 <div>{text}</div>

--- a/src-docs/src/views/resizable_container/resizable_container_reset_values.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_reset_values.tsx
@@ -93,7 +93,7 @@ export default () => {
               id={firstPanelId}
               size={sizes[firstPanelId]}
               minSize="30%"
-              tabindex="0"
+              tabIndex={0}
             >
               <EuiText>
                 <div>{text}</div>
@@ -106,7 +106,7 @@ export default () => {
               id={secondPanelId}
               size={sizes[secondPanelId]}
               minSize="200px"
-              tabindex="0"
+              tabIndex={0}
             >
               <EuiText>
                 <div>{text}</div>

--- a/src-docs/src/views/resizable_container/resizable_container_vertical.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_vertical.tsx
@@ -13,7 +13,7 @@ export default () => (
   <EuiResizableContainer style={{ height: '400px' }} direction="vertical">
     {(EuiResizablePanel, EuiResizableButton) => (
       <>
-        <EuiResizablePanel initialSize={60} minSize="40%" tabindex="0">
+        <EuiResizablePanel initialSize={60} minSize="40%" tabIndex={0}>
           <EuiText>
             <div>{text}</div>
           </EuiText>
@@ -21,7 +21,7 @@ export default () => (
 
         <EuiResizableButton />
 
-        <EuiResizablePanel initialSize={40} minSize="10%" tabindex="0">
+        <EuiResizablePanel initialSize={40} minSize="10%" tabIndex={0}>
           <EuiText>
             <div>{text}</div>
           </EuiText>

--- a/src-docs/src/views/resizable_container/resizable_container_vertical.tsx
+++ b/src-docs/src/views/resizable_container/resizable_container_vertical.tsx
@@ -13,7 +13,7 @@ export default () => (
   <EuiResizableContainer style={{ height: '400px' }} direction="vertical">
     {(EuiResizablePanel, EuiResizableButton) => (
       <>
-        <EuiResizablePanel initialSize={60} minSize="40%">
+        <EuiResizablePanel initialSize={60} minSize="40%" tabindex="0">
           <EuiText>
             <div>{text}</div>
           </EuiText>
@@ -21,7 +21,7 @@ export default () => (
 
         <EuiResizableButton />
 
-        <EuiResizablePanel initialSize={40} minSize="10%">
+        <EuiResizablePanel initialSize={40} minSize="10%" tabindex="0">
           <EuiText>
             <div>{text}</div>
           </EuiText>

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible.tsx
@@ -104,7 +104,7 @@ export default () => {
                 mode="main"
                 initialSize={60}
                 minSize="50px"
-                tabindex="0"
+                tabIndex={0}
               >
                 <EuiPanel paddingSize="l" style={{ minHeight: '100%' }}>
                   <EuiTitle>

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible.tsx
@@ -100,7 +100,12 @@ export default () => {
 
               <EuiResizableButton />
 
-              <EuiResizablePanel mode="main" initialSize={60} minSize="50px">
+              <EuiResizablePanel
+                mode="main"
+                initialSize={60}
+                minSize="50px"
+                tabindex="0"
+              >
                 <EuiPanel paddingSize="l" style={{ minHeight: '100%' }}>
                   <EuiTitle>
                     <p>{itemSelected.label}</p>

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
@@ -66,7 +66,12 @@ export default () => {
 
             <EuiResizableButton />
 
-            <EuiResizablePanel mode="main" initialSize={60} minSize="20%">
+            <EuiResizablePanel
+              mode="main"
+              initialSize={60}
+              minSize="20%"
+              tabindex="0"
+            >
               <EuiPanel paddingSize="l" style={{ minHeight: '100%' }}>
                 <EuiTitle>
                   <p>{itemSelected.label}</p>

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
@@ -70,7 +70,7 @@ export default () => {
               mode="main"
               initialSize={60}
               minSize="20%"
-              tabindex="0"
+              tabIndex={0}
             >
               <EuiPanel paddingSize="l" style={{ minHeight: '100%' }}>
                 <EuiTitle>

--- a/src-docs/src/views/resizable_container/resizable_panels.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panels.tsx
@@ -29,7 +29,7 @@ export default () => (
           borderRadius="m"
           wrapperPadding="m"
           minSize="20%"
-          tabindex="0"
+          tabIndex={0}
         >
           <EuiText size="s">
             <p>

--- a/src-docs/src/views/resizable_container/resizable_panels.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panels.tsx
@@ -29,6 +29,7 @@ export default () => (
           borderRadius="m"
           wrapperPadding="m"
           minSize="20%"
+          tabindex="0"
         >
           <EuiText size="s">
             <p>

--- a/src/components/resizable_container/__snapshots__/resizable_panel.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_panel.test.tsx.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiResizablePanel props tabindex 1`] = `
+<div>
+  <div
+    class="euiResizablePanel emotion-euiResizablePanel-l"
+    data-position="middle"
+    id="resizable-panel_generated-id"
+    style="inline-size: 100%; block-size: 0%;"
+  >
+    <div
+      aria-label="aria-label"
+      class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content testClass1 testClass2 emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
+      data-test-subj="test subject string"
+      tabindex="0"
+    >
+      Content
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiResizablePanel props wrapperPadding 1`] = `
 <div>
   <div

--- a/src/components/resizable_container/__snapshots__/resizable_panel.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_panel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiResizablePanel props tabindex 1`] = `
+exports[`EuiResizablePanel props tabIndex 1`] = `
 <div>
   <div
     class="euiResizablePanel emotion-euiResizablePanel-l"

--- a/src/components/resizable_container/resizable_panel.test.tsx
+++ b/src/components/resizable_container/resizable_panel.test.tsx
@@ -58,7 +58,7 @@ describe('EuiResizablePanel', () => {
       expect(container).toMatchSnapshot();
     });
 
-    test('tabindex', () => {
+    test('tabIndex', () => {
       const { container } = render(
         <EuiResizableContainerContextProvider registry={mockRegistry}>
           <EuiResizablePanel {...requiredProps} wrapperPadding="l" tabIndex={0}>

--- a/src/components/resizable_container/resizable_panel.test.tsx
+++ b/src/components/resizable_container/resizable_panel.test.tsx
@@ -57,5 +57,17 @@ describe('EuiResizablePanel', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    test('tabindex', () => {
+      const { container } = render(
+        <EuiResizableContainerContextProvider registry={mockRegistry}>
+          <EuiResizablePanel {...requiredProps} wrapperPadding="l" tabIndex={0}>
+            Content
+          </EuiResizablePanel>
+        </EuiResizableContainerContextProvider>
+      );
+
+      expect(container).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/resizable_container/resizable_panel.tsx
+++ b/src/components/resizable_container/resizable_panel.tsx
@@ -129,9 +129,9 @@ export interface EuiResizablePanelProps
    */
   style?: CSSProperties;
   /**
-   * tabindex="0" provides full keyboard access when content overflows `<EuiResizablePanel />`
+   * tabIndex={0} provides full keyboard access when content overflows `<EuiResizablePanel />`
    */
-  tabindex?: string;
+  tabIndex?: number;
   /**
    * Props to add to the wrapping `.euiResizablePanel` div
    */

--- a/src/components/resizable_container/resizable_panel.tsx
+++ b/src/components/resizable_container/resizable_panel.tsx
@@ -129,6 +129,10 @@ export interface EuiResizablePanelProps
    */
   style?: CSSProperties;
   /**
+   * tabindex="0" provides full keyboard access when content overflows `<EuiResizablePanel />`
+   */
+  tabindex?: string;
+  /**
    * Props to add to the wrapping `.euiResizablePanel` div
    */
   wrapperProps?: CommonProps & HTMLAttributes<HTMLDivElement>;

--- a/upcoming_changelogs/6534.md
+++ b/upcoming_changelogs/6534.md
@@ -1,3 +1,0 @@
-**Bug fixes**
-
-- Fixed `EuiResizablePanel` to accept `tabindex` prop so keyboard users can navigate content that overflows its container

--- a/upcoming_changelogs/6534.md
+++ b/upcoming_changelogs/6534.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiResizablePanel` to accept `tabindex` prop so keyboard users can navigate content that overflows its container


### PR DESCRIPTION
## Summary
Added tabindex prop to EuiResizablePanel for keyboard accessibility. Removing a number of axe-core violations for unreachable content and added documentation to help teams know when they need to add `tabindex` prop. Closes #5295.

## QA
<img width="1256" alt="Screen Shot 2023-01-18 at 1 59 11 PM" src="https://user-images.githubusercontent.com/934879/213306492-840a3293-da33-4ada-9d93-f4411b82fd67.png">

---
<img width="1266" alt="Screen Shot 2023-01-18 at 2 00 48 PM" src="https://user-images.githubusercontent.com/934879/213306514-0658686f-ee82-4d1f-a499-2c29e872790f.png">



Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately