### PR TITLE
[EuiBasicTable] Fix row heights jumping when actions are disabled

### DIFF
--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -1723,6 +1723,7 @@ exports[`EuiBasicTable with multiple record actions with custom availability 1`]
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_1_1"
             showOnHover={true}
@@ -1784,6 +1785,7 @@ exports[`EuiBasicTable with multiple record actions with custom availability 1`]
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_2_1"
             showOnHover={true}
@@ -1846,6 +1848,7 @@ exports[`EuiBasicTable with multiple record actions with custom availability 1`]
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_3_1"
             showOnHover={true}
@@ -1903,6 +1906,7 @@ exports[`EuiBasicTable with multiple record actions with custom availability 1`]
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_4_1"
             showOnHover={true}
@@ -3023,6 +3027,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_1_1"
             showOnHover={true}
@@ -3081,6 +3086,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_2_1"
             showOnHover={true}
@@ -3139,6 +3145,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and a single record a
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_3_1"
             showOnHover={true}
@@ -3707,6 +3714,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_1_1"
             showOnHover={true}
@@ -3771,6 +3779,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_2_1"
             showOnHover={true}
@@ -3835,6 +3844,7 @@ exports[`EuiBasicTable with pagination, selection, sorting and multiple record a
           </EuiTableRowCell>
           <EuiTableRowCell
             align="right"
+            css="unknown styles"
             hasActions={true}
             key="record_actions_3_1"
             showOnHover={true}

--- a/src/components/basic_table/basic_table.styles.ts
+++ b/src/components/basic_table/basic_table.styles.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+// Unsets the extra height caused by tooltip/popover wrappers around table action buttons
+// Without this, the row height jumps whenever actions are disabled
+export const euiBasicTableActionsWrapper = css`
+  line-height: 1;
+`;

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -66,6 +66,8 @@ import {
 } from './table_types';
 import { EuiTableSortMobileProps } from '../table/mobile/table_sort_mobile';
 
+import { euiBasicTableActionsWrapper } from './basic_table.styles';
+
 type DataTypeProfiles = Record<
   EuiTableDataType,
   {
@@ -1214,6 +1216,7 @@ export class EuiBasicTable<T = any> extends Component<
         align="right"
         textOnly={false}
         hasActions={true}
+        css={euiBasicTableActionsWrapper}
       >
         {tools}
       </EuiTableRowCell>

--- a/upcoming_changelogs/6538.md
+++ b/upcoming_changelogs/6538.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed slight row height jumping in `EuiBasicTable`s when actions with tooltips became disabled


### PR DESCRIPTION
## Summary
For whatever arcane CSS reason, the `EuiToolTip` and `EuiPopover` anchor wrappers around tables' action buttons were causing a slight 1-2px increase in height.

Resetting the entire action cell's `line-height` appears to fix the issue and ensures that all actions remain at 24px high regardless of whether they're enabled or disabled.

I also started a `basic_table.styles.ts` file while here, we'll end up using it at some point.

### Before
![before](https://user-images.githubusercontent.com/549407/213535131-23f46049-44d7-40bd-bf80-615c8f621efa.gif)

### After
![after](https://user-images.githubusercontent.com/549407/213535145-9bc293ad-4d9a-4f58-a2d0-1f5168b8bbc5.gif)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately