### PR TITLE
Update checklist template to recommend `@default` jsdoc usage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Remove or strikethrough items that do not apply to your PR.
 - [ ] Checked in both **light and dark** modes
 - [ ] Checked in **mobile**
 - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
-- [ ] Props have proper **autodocs** and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
+- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
 - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
 - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
 - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5118

When our props table is unable to intelligently infer default values, we should use the `@default` jsdoc tag to ensure complete documentation.

We've been doing this sporadically in a few places, but adding this to our PR issue template should help us remember to do this more often.

## QA

N/A, dev-only