### PR TITLE
[EuiBasicTable] Remove preventing all mouse/keyboard interactions when `loading`

### DIFF
--- a/src-docs/src/views/tables/basic/basic.tsx
+++ b/src-docs/src/views/tables/basic/basic.tsx
@@ -133,6 +133,7 @@ export default () => {
       columns={columns}
       rowProps={getRowProps}
       cellProps={getCellProps}
+      loading
     />
   );
 };

--- a/src-docs/src/views/tables/basic/basic.tsx
+++ b/src-docs/src/views/tables/basic/basic.tsx
@@ -133,7 +133,6 @@ export default () => {
       columns={columns}
       rowProps={getRowProps}
       cellProps={getCellProps}
-      loading
     />
   );
 };

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -349,10 +349,6 @@ export class EuiBasicTable<T = any> extends Component<
     return null;
   }
 
-  // used for moving in & out of `loading` state
-  private cleanups: Array<() => void> = [];
-  private tbody: HTMLTableSectionElement | null = null;
-
   constructor(props: EuiBasicTableProps<T>) {
     super(props);
     this.state = {
@@ -363,23 +359,11 @@ export class EuiBasicTable<T = any> extends Component<
   }
 
   componentDidMount() {
-    if (this.props.loading && this.tbody) this.addLoadingListeners(this.tbody);
     this.getInitialSelection();
   }
 
-  componentDidUpdate(prevProps: EuiBasicTableProps<T>) {
-    if (prevProps.loading !== this.props.loading) {
-      if (this.props.loading && this.tbody) {
-        this.addLoadingListeners(this.tbody);
-      } else {
-        this.removeLoadingListeners();
-      }
-    }
+  componentDidUpdate() {
     this.getInitialSelection();
-  }
-
-  componentWillUnmount() {
-    this.removeLoadingListeners();
   }
 
   getInitialSelection() {
@@ -397,49 +381,6 @@ export class EuiBasicTable<T = any> extends Component<
   setSelection(newSelection: T[]) {
     this.changeSelection(newSelection);
   }
-
-  private setTbody = (tbody: HTMLTableSectionElement | null) => {
-    // remove listeners from an existing element
-    this.removeLoadingListeners();
-
-    // update the ref
-    this.tbody = tbody;
-
-    // if loading, add listeners
-    if (this.props.loading === true && tbody) {
-      this.addLoadingListeners(tbody);
-    }
-  };
-
-  private addLoadingListeners = (tbody: HTMLTableSectionElement) => {
-    const listener = (event: Event) => {
-      event.stopPropagation();
-      event.preventDefault();
-    };
-    [
-      'mousedown',
-      'mouseup',
-      'mouseover',
-      'mouseout',
-      'mouseenter',
-      'mouseleave',
-      'click',
-      'dblclick',
-      'keydown',
-      'keyup',
-      'keypress',
-    ].forEach((event) => {
-      tbody.addEventListener(event, listener, true);
-      this.cleanups.push(() => {
-        tbody.removeEventListener(event, listener, true);
-      });
-    });
-  };
-
-  private removeLoadingListeners = () => {
-    this.cleanups.forEach((cleanup) => cleanup());
-    this.cleanups.length = 0;
-  };
 
   buildCriteria(props: EuiBasicTableProps<T>): Criteria<T> {
     const criteria: Criteria<T> = {};
@@ -969,10 +910,7 @@ export class EuiBasicTable<T = any> extends Component<
     return (
       <RenderWithEuiTheme>
         {(theme) => (
-          <EuiTableBody
-            bodyRef={this.setTbody}
-            css={loading && euiBasicTableBodyLoading(theme)}
-          >
+          <EuiTableBody css={loading && euiBasicTableBodyLoading(theme)}>
             {content}
           </EuiTableBody>
         )}

--- a/upcoming_changelogs/6543.md
+++ b/upcoming_changelogs/6543.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- `EuiBasicTable` no longer blocks mouse/keyboard interactions while `loading`


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/5014

While converting EuiBasicTable to Emotion, I happened upon this tbody logic/ref added when EuiInMemoryTable was first introduced (https://github.com/elastic/eui/pull/390), although unfortunately, I could not find any context as to why it was introduced/approved.

Unfortunately, I strongly feel that this behavior is problematic at worst (accessibility - keyboard users who tab into a loading table will never be able to tab off) and totally unnecessary at best (we're adding and removing 11 event listeners on loading change, for very little UX benefit).

I'm proposing we remove this, with designer approval and approval of our resident a11y expert.

## QA

- [x] Go to https://eui.elastic.co/pr_6543/#/tabular-content/tables#a-basic-table, confirm that the first loading basic table example can still be interacted with.

### General checklist

- [x] Revert [REVERT ME] commit
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately