### PR TITLE
[EuiModalHeaderTitle] Fix type errors when passed EuiTitle props

### DIFF
--- a/src/components/modal/__snapshots__/modal_header_title.test.tsx.snap
+++ b/src/components/modal/__snapshots__/modal_header_title.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiModalHeaderTitle allows passing any props that EuiTitle accepts 1`] = `
+<h1
+  class="euiTitle euiModalHeader__title emotion-euiTitle-uppercase-s"
+>
+  children
+</h1>
+`;
+
 exports[`EuiModalHeaderTitle component 1`] = `
 <div
   class="euiTitle euiModalHeader__title emotion-euiTitle-m"

--- a/src/components/modal/modal_header_title.test.tsx
+++ b/src/components/modal/modal_header_title.test.tsx
@@ -29,4 +29,13 @@ describe('EuiModalHeaderTitle', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('allows passing any props that EuiTitle accepts', () => {
+    const { container } = render(
+      <EuiModalHeaderTitle size="s" textTransform="uppercase">
+        children
+      </EuiModalHeaderTitle>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/components/modal/modal_header_title.tsx
+++ b/src/components/modal/modal_header_title.tsx
@@ -8,13 +8,12 @@
 
 import React, { FunctionComponent, HTMLAttributes, ElementType } from 'react';
 import classnames from 'classnames';
-import { CommonProps } from '../common';
 
-import { EuiTitle } from '../title';
+import { EuiTitle, EuiTitleProps } from '../title';
 
 export type EuiModalHeaderTitleProps = FunctionComponent<
-  HTMLAttributes<HTMLHeadingElement> &
-    CommonProps & {
+  Omit<EuiTitleProps, 'children'> &
+    HTMLAttributes<HTMLHeadingElement> & {
       /**
        * The tag to render. Can be changed to a lower heading
        * level like `h2` or a container `div`.

--- a/upcoming_changelogs/6547.md
+++ b/upcoming_changelogs/6547.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiModalHeaderTitle` type errors when passed `EuiTitle` props


### PR DESCRIPTION
## Summary

There are several Kibana instances of devs doing things like `<EuiModalHeaderTitle><EuiTitle size="s"><h3>`, which we can boil down to `<EuiModalHeaderTitle size="s" component="h3">`, but Typescript is complaining about it.

These props are currently already being passed via `...rest`, so this is primarily just a type change with a changelog so we can do a patch release for the Kibana upgrade.

## QA

### General checklist


- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
