### PR TITLE
Added a lang attribute to EUI i18n context EN | FR demo.

### DIFF
--- a/src-docs/src/views/i18n/context.js
+++ b/src-docs/src/views/i18n/context.js
@@ -28,12 +28,13 @@ const mappings = {
   },
 };
 
-const ContextConsumer = () => {
+const ContextConsumer = (props) => {
   const [name, setName] = useState('');
+  const { language } = props;
   const placeholderName = useEuiI18n('euiContext.placeholder', 'John Doe');
 
   return (
-    <div>
+    <div lang={language}>
       <strong>
         <EuiI18n
           token="euiContext.greeting"
@@ -96,13 +97,21 @@ export default () => {
     <>
       <EuiFlexGroup gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
-          <EuiButton fill={language === 'en'} onClick={() => setLanguage('en')}>
+          <EuiButton
+            aria-pressed={language === 'en' ? 'true' : 'false'}
+            fill={language === 'en'}
+            onClick={() => setLanguage('en')}
+          >
             <EuiI18n token="euiContext.english" default="English" />
           </EuiButton>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          <EuiButton fill={language === 'fr'} onClick={() => setLanguage('fr')}>
+          <EuiButton
+            aria-pressed={language === 'fr' ? 'true' : 'false'}
+            fill={language === 'fr'}
+            onClick={() => setLanguage('fr')}
+          >
             <EuiI18n token="euiContext.french" default="French" />
           </EuiButton>
         </EuiFlexItem>
@@ -119,7 +128,7 @@ export default () => {
       <EuiSpacer size="m" />
 
       <EuiContext i18n={i18n}>
-        <ContextConsumer />
+        <ContextConsumer language={language} />
       </EuiContext>
     </>
   );

--- a/src-docs/src/views/i18n/context.js
+++ b/src-docs/src/views/i18n/context.js
@@ -28,9 +28,8 @@ const mappings = {
   },
 };
 
-const ContextConsumer = (props) => {
+const ContextConsumer = ({ language }) => {
   const [name, setName] = useState('');
-  const { language } = props;
   const placeholderName = useEuiI18n('euiContext.placeholder', 'John Doe');
 
   return (


### PR DESCRIPTION
## Summary

Added a `lang="en | fr"` attribute to the container in our [i18n Context demo](https://eui.elastic.co/#/utilities/i18n#context). This ensures screen readers will load the correct dictionary for pronunciation and inflection. No axe-core errors detected after the change.

Closes #5368

## QA
<img width="921" alt="Screen Shot 2023-01-24 at 4 49 38 PM" src="https://user-images.githubusercontent.com/934879/214438829-6f3a4d3b-7523-43df-bc2f-9f1ece2f816d.png">

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Checked for **accessibility** including keyboard-only and screenreader modes