### PR TITLE
[EuiSuperSelect] Updated i18n default instructions string

### DIFF
--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -4241,7 +4241,7 @@
   },
   {
     "token": "euiSuperSelect.screenReaderAnnouncement",
-    "defString": "You are in a form selector and must select a single option.\n              Use the up and down keys to navigate or escape to close.",
+    "defString": "You are in a form selector and must select a single option.\n              Use the Up and Down arrow keys to navigate or Escape to close.",
     "highlighting": "string",
     "loc": {
       "start": {

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
               class="emotion-euiScreenReaderOnly"
               id="euiSuperSelect__generated-id__screenreaderDescribeId"
             >
-              You are in a form selector and must select a single option. Use the up and down keys to navigate or escape to close.
+              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
             </p>
             <div
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
@@ -442,7 +442,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
               class="emotion-euiScreenReaderOnly"
               id="euiSuperSelect__generated-id__screenreaderDescribeId"
             >
-              You are in a form selector and must select a single option. Use the up and down keys to navigate or escape to close.
+              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
             </p>
             <div
               aria-activedescendant="1"
@@ -594,7 +594,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
               class="emotion-euiScreenReaderOnly"
               id="euiSuperSelect__generated-id__screenreaderDescribeId"
             >
-              You are in a form selector and must select a single option. Use the up and down keys to navigate or escape to close.
+              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
             </p>
             <div
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
@@ -745,7 +745,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
               class="emotion-euiScreenReaderOnly"
               id="euiSuperSelect__generated-id__screenreaderDescribeId"
             >
-              You are in a form selector and must select a single option. Use the up and down keys to navigate or escape to close.
+              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
             </p>
             <div
               aria-activedescendant="2"

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -339,7 +339,7 @@ export class EuiSuperSelect<T extends string> extends Component<
             <EuiI18n
               token="euiSuperSelect.screenReaderAnnouncement"
               default="You are in a form selector and must select a single option.
-              Use the up and down keys to navigate or escape to close."
+              Use the Up and Down arrow keys to navigate or Escape to close."
             />
           </p>
         </EuiScreenReaderOnly>

--- a/upcoming_changelogs/6549.md
+++ b/upcoming_changelogs/6549.md
@@ -1,3 +1,1 @@
-**Bug fixes**
-
-- Fixed `EuiSuperSelect` screen reader instructions to be more specific
+- Updated `EuiSuperSelect` screen reader instructions to be more specific

--- a/upcoming_changelogs/6549.md
+++ b/upcoming_changelogs/6549.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSuperSelect` screen reader instructions to be more specific


### PR DESCRIPTION
## Summary

Updated the `EuiSuperSelect` screen reader instructions to more explicitly say "Up and Down arrow keys" and capitalize "Escape". Tested with VoiceOver on Safari + Firefox. Screenshot below.

Closes #5363.

<img width="806" alt="Screen Shot 2023-01-25 at 9 29 26 AM" src="https://user-images.githubusercontent.com/934879/214607753-fb2e9669-3c63-4a80-b694-dd5f99deb172.png">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately