### PR TITLE
[EuiCard] Harden Click Event Criteria to Prevent Duplicate `onClick` Events

### DIFF
--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -138,6 +138,19 @@ describe('EuiCard', () => {
         component.find('button').simulate('click');
         expect(handler.mock.calls.length).toEqual(1);
       });
+
+      it('should only call onClick once when title is a React node', () => {
+        const handler = jest.fn();
+        const component = mount(
+          <EuiCard
+            title={<span>Hoi</span>}
+            description="There"
+            onClick={handler}
+          />
+        );
+        component.find('button').simulate('click');
+        expect(handler.mock.calls.length).toEqual(1);
+      });
     });
 
     test('titleElement', () => {

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -143,12 +143,12 @@ describe('EuiCard', () => {
         const handler = jest.fn();
         const component = mount(
           <EuiCard
-            title={<span>Hoi</span>}
+            title={<span data-test-subj="click">Hoi</span>}
             description="There"
             onClick={handler}
           />
         );
-        component.find('button').simulate('click');
+        component.find('[data-test-subj="click"]').simulate('click');
         expect(handler.mock.calls.length).toEqual(1);
       });
     });

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -193,7 +193,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
    */
   let link: HTMLAnchorElement | HTMLButtonElement | null = null;
   const outerOnClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (link && link !== e.target) {
+    if (link && link !== e.target && !link.contains(e.target as Node)) {
       link.click();
     }
   };

--- a/upcoming_changelogs/6551.md
+++ b/upcoming_changelogs/6551.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiCard` to ensure `onClick` method only runs once when `title` contains a React node


### PR DESCRIPTION
Fixes #6545 

## Summary

Resolved a bug that causes the `onClick` method to be triggered twice when clicking on a card title by creating a condition inside of `outerOnClick` to ensure the link does not contain a duplicate click event. Updated tests accordingly

## QA

**Testing:**

1. Pull branch and open `src-docs/src/views/card/card_beta.tsx`. Update the first `EuiCard` instance (line 13) to: 
```
<EuiCard
        icon={<EuiIcon size="xxl" type="dashboardApp" />}
        title={<span>Dashboards</span>}
        description="Example of a card's description. Stick to one or two sentences."
        onClick={() => {
          console.log('Dashboards Clicked');
        }}
        betaBadgeProps={{
          label: 'Beta',
          tooltipContent:
            'This module is not GA. Please help us by reporting any bugs.',
        }}
      />
```

2. Spin up EUI and navigate the the EuiCard Beta Badge example. When clicking on the title (`Dashboards`), you should find that the click event has only fired once, not twice.

### General checklist

- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
