### PR TITLE
[EuiSkeleton] Design review

### DIFF
--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -121,7 +121,7 @@ export const SkeletonExample = {
       text: (
         <EuiText>
           <p>
-            <strong>EuiSkeletonCircle</strong> allows you define a large and
+            <strong>EuiSkeletonRectangle</strong> allows you define a large and
             customizable shape via its <EuiCode>width</EuiCode>,{' '}
             <EuiCode>height</EuiCode>, and <EuiCode>borderRadius</EuiCode>{' '}
             props.

--- a/src/components/skeleton/skeleton_text.styles.ts
+++ b/src/components/skeleton/skeleton_text.styles.ts
@@ -36,7 +36,7 @@ export const euiSkeletonCommonStyles = (euiThemeContext: UseEuiTheme) => {
     euiSkeletonText: css`
       display: block;
       ${logicalCSS('width', '100%')}
-      border-radius: ${euiTheme.border.radius.medium};
+      border-radius: ${euiTheme.border.radius.small};
       ${euiSkeletonGradientAnimation(euiThemeContext)}
 
       // Offset via transform to more closely match placement of text

--- a/src/components/skeleton/skeleton_title.styles.ts
+++ b/src/components/skeleton/skeleton_title.styles.ts
@@ -41,6 +41,7 @@ export const euiSkeletonTitleStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     xxxs: css`
       ${logicalCSS('height', euiTitle(euiThemeContext, 'xxxs').lineHeight)};
+      border-radius: ${euiTheme.border.radius.small};
     `,
   };
 };


### PR DESCRIPTION
## Summary

This PR makes the **EuiSkeletonText** and **EuiSkeletonTitle** have a more rectangular `border-radius`.

## Design changes

<img width="1458" alt="skeleton@2x" src="https://user-images.githubusercontent.com/2750668/215182379-5b167e86-9071-4d84-9f4a-845e8a1707b2.png">


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**