### PR TITLE
[EuiSkeletonLoading] Improve loading accessibility and bake in `isLoading` API handling

### DIFF
--- a/src-docs/src/views/skeleton/skeleton_circle.tsx
+++ b/src-docs/src/views/skeleton/skeleton_circle.tsx
@@ -22,35 +22,43 @@ export default () => {
       <EuiSpacer />
       <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
         <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonCircle size="s" />
-          ) : (
+          <EuiSkeletonCircle
+            size="s"
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton avatar"
+          >
             <EuiAvatar size="s" name="Raphael" />
-          )}
+          </EuiSkeletonCircle>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonCircle size="m" />
-          ) : (
+          <EuiSkeletonCircle
+            size="m"
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton avatar"
+          >
             <EuiAvatar size="m" name="Donatello" />
-          )}
+          </EuiSkeletonCircle>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonCircle size="l" />
-          ) : (
+          <EuiSkeletonCircle
+            size="l"
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton avatar"
+          >
             <EuiAvatar size="l" name="Leonardo" />
-          )}
+          </EuiSkeletonCircle>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonCircle size="xl" />
-          ) : (
+          <EuiSkeletonCircle
+            size="xl"
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton avatar"
+          >
             <EuiAvatar size="xl" name="Michelangelo" />
-          )}
+          </EuiSkeletonCircle>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -22,6 +22,9 @@ const skeletonCircleSource = require('!!raw-loader!./skeleton_circle');
 
 import SkeletonText from './skeleton_text';
 const skeletonTextSource = require('!!raw-loader!./skeleton_text');
+const skeletonTextSnippet = `<EuiSkeletonText lines={3} size="m" isLoading={isLoading} contentAriaLabel="Example text">
+  <EuiText size="m"><p>Example text</p></EuiText>
+</EuiSkeletonText>`;
 
 import SkeletonTitle from './skeleton_title';
 const skeletonTitleSource = require('!!raw-loader!./skeleton_title');
@@ -30,7 +33,6 @@ import SkeletonRectangle from './skeleton_rectangle';
 const skeletonRectangleSource = require('!!raw-loader!./skeleton_rectangle');
 
 const skeletonCircleSnippet = '<EuiSkeletonCircle size="m" />';
-const skeletonTextSnippet = '<EuiSkeletonText lines={3} size="m" />';
 const skeletonTitleSnippet = '<EuiSkeletonTitle size="l" />';
 const skeletonRectangleSnippet =
   '<EuiSkeletonRectangle width="200px" height="20px" borderRadius="m" />';

--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -2,12 +2,15 @@ import React from 'react';
 
 import { GuideSectionTypes } from '../../components';
 import {
-  EuiCode,
-  EuiText,
   EuiSkeletonTitle,
   EuiSkeletonText,
   EuiSkeletonRectangle,
   EuiSkeletonCircle,
+  EuiSkeletonLoading,
+  EuiText,
+  EuiSpacer,
+  EuiCallOut,
+  EuiCode,
 } from '../../../../src/components';
 
 import {
@@ -47,16 +50,57 @@ const skeletonRectangleSnippet = `<EuiSkeletonRectangle
   <EuiPanel />
 </EuiSkeletonRectangle>`;
 
+import SkeletonLoading from './skeleton_loading';
+const skeletonLoadingSource = require('!!raw-loader!./skeleton_loading');
+const skeletonLoadingSnippet = `<EuiSkeletonLoading
+  isLoading={isLoading}
+  contentAriaLabel="User data"
+  loadingContent={
+    <>
+      <EuiSkeletonTitle />
+      <EuiSkeletonText />
+      <EuiSkeletonCircle />
+      <EuiSkeletonRectangle />
+    </>
+  }
+  loadedContent={
+    <>
+      {/* Equivalent loaded content */}
+    </>
+  }
+/>`;
+
 export const SkeletonExample = {
   title: 'Skeleton',
   intro: (
-    <EuiText>
-      <p>
-        The <strong>EuiSkeleton</strong> components are placeholder components
-        for content which haven&apos;t yet loaded. They provide a meaningful
-        preview and avoid layout content shifts.
-      </p>
-    </EuiText>
+    <>
+      <EuiText>
+        <p>
+          The <strong>EuiSkeleton</strong> components are placeholder components
+          for content which has yet to load. They provide meaningful previews,
+          avoid layout content shifts, and add accessible announcements to
+          screen readers when content is done loading.
+        </p>
+      </EuiText>
+      <EuiSpacer />
+      <EuiCallOut
+        iconType="accessibility"
+        title={
+          <>
+            Using the <EuiCode>contentAriaLabel</EuiCode> prop
+          </>
+        }
+      >
+        <p>
+          The <EuiCode>contentAriaLabel</EuiCode> prop should be used to help
+          describe the type of content that is loading to screen reader users.
+          If you do not provide a descriptive label and have have multiple
+          loading skeletons on the page, screen reader users may hear a
+          multitude of &ldquo;Loaded&rdquo; messages in a row, with no
+          meaningful indication of what actually loaded.
+        </p>
+      </EuiCallOut>
+    </>
   ),
   sections: [
     {
@@ -144,6 +188,39 @@ export const SkeletonExample = {
       snippet: skeletonRectangleSnippet,
       demo: <SkeletonRectangle />,
       playground: skeletonRectangleConfig,
+    },
+    {
+      title: 'Combining multiple skeletons',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: skeletonLoadingSource,
+        },
+      ],
+      text: (
+        <EuiText>
+          <p>
+            <strong>EuiSkeletonLoading</strong> is a light wrapper around the{' '}
+            <strong>EuiSkeleton</strong> components that handles loading
+            accessibility and flipping between skeleton and loaded content.
+          </p>
+          <p>
+            As you may have noticed in the previous demos, toggling multiple
+            skeletons to their loaded state all at once triggers multiple queued
+            screen reader announcements, which can be annoying to SR users.
+          </p>
+          <p>
+            To circumvent this, use <strong>EuiSkeletonLoading</strong> to
+            handle a single parent-level <EuiCode>isLoading</EuiCode> state.{' '}
+            <strong>EuiSkeleton</strong> children passed to the{' '}
+            <EuiCode>loadingContent</EuiCode> should not have their own{' '}
+            <EuiCode>isLoading</EuiCode> props or children.
+          </p>
+        </EuiText>
+      ),
+      props: { EuiSkeletonLoading },
+      snippet: skeletonLoadingSnippet,
+      demo: <SkeletonLoading />,
     },
   ],
 };

--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -19,6 +19,9 @@ import {
 
 import SkeletonCircle from './skeleton_circle';
 const skeletonCircleSource = require('!!raw-loader!./skeleton_circle');
+const skeletonCircleSnippet = `<EuiSkeletonCircle size="m" isLoading={isLoading} contentAriaLabel="Avatar">
+  <EuiAvatar size="s" name="Sally" />
+</EuiSkeletonCircle>`;
 
 import SkeletonText from './skeleton_text';
 const skeletonTextSource = require('!!raw-loader!./skeleton_text');
@@ -35,7 +38,6 @@ const skeletonTitleSnippet = `<EuiSkeletonTitle size="l" isLoading={isLoading} c
 import SkeletonRectangle from './skeleton_rectangle';
 const skeletonRectangleSource = require('!!raw-loader!./skeleton_rectangle');
 
-const skeletonCircleSnippet = '<EuiSkeletonCircle size="m" />';
 const skeletonRectangleSnippet =
   '<EuiSkeletonRectangle width="200px" height="20px" borderRadius="m" />';
 

--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -28,12 +28,14 @@ const skeletonTextSnippet = `<EuiSkeletonText lines={3} size="m" isLoading={isLo
 
 import SkeletonTitle from './skeleton_title';
 const skeletonTitleSource = require('!!raw-loader!./skeleton_title');
+const skeletonTitleSnippet = `<EuiSkeletonTitle size="l" isLoading={isLoading} contentAriaLabel="Example title">
+  <EuiTitle><h1>Example title</h1></EuiTitle>
+</EuiSkeletonTitle>`;
 
 import SkeletonRectangle from './skeleton_rectangle';
 const skeletonRectangleSource = require('!!raw-loader!./skeleton_rectangle');
 
 const skeletonCircleSnippet = '<EuiSkeletonCircle size="m" />';
-const skeletonTitleSnippet = '<EuiSkeletonTitle size="l" />';
 const skeletonRectangleSnippet =
   '<EuiSkeletonRectangle width="200px" height="20px" borderRadius="m" />';
 

--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -37,9 +37,15 @@ const skeletonTitleSnippet = `<EuiSkeletonTitle size="l" isLoading={isLoading} c
 
 import SkeletonRectangle from './skeleton_rectangle';
 const skeletonRectangleSource = require('!!raw-loader!./skeleton_rectangle');
-
-const skeletonRectangleSnippet =
-  '<EuiSkeletonRectangle width="200px" height="20px" borderRadius="m" />';
+const skeletonRectangleSnippet = `<EuiSkeletonRectangle
+  width="100%"
+  height={500}
+  borderRadius="m"
+  isLoading={isLoading}
+  contentAriaLabel="Example description"
+>
+  <EuiPanel />
+</EuiSkeletonRectangle>`;
 
 export const SkeletonExample = {
   title: 'Skeleton',

--- a/src-docs/src/views/skeleton/skeleton_loading.tsx
+++ b/src-docs/src/views/skeleton/skeleton_loading.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+
+import {
+  EuiSkeletonLoading,
+  EuiSkeletonTitle,
+  EuiTitle,
+  EuiSkeletonText,
+  EuiText,
+  EuiSkeletonRectangle,
+  EuiCard,
+  EuiSkeletonCircle,
+  EuiAvatar,
+  EuiSwitch,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiCode,
+} from '../../../../src/components';
+
+export default () => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  return (
+    <>
+      <EuiSwitch
+        label="Toggle loaded state"
+        checked={isLoading}
+        onChange={() => setIsLoading(!isLoading)}
+      />
+      <EuiSpacer />
+      <EuiSkeletonLoading
+        isLoading={isLoading}
+        contentAriaLabel="Demo loading section"
+        loadingContent={
+          <section>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiSkeletonCircle size="s" />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiSkeletonTitle size="l" />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiSkeletonText lines={5} />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiSkeletonRectangle width="100%" height={148} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </section>
+        }
+        loadedContent={
+          <section>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiAvatar size="s" name="Avatar" />
+              <EuiTitle size="l">
+                <span>Example section title</span>
+              </EuiTitle>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <EuiText>
+                  <p>
+                    This demo groups multiple skeleton types into a single
+                    loading section by using{' '}
+                    <EuiCode>EuiSkeletonLoading</EuiCode>.
+                  </p>
+                  <p>
+                    This is a significant usability improvement for screen
+                    readers as only one loaded message is announced, as opposed
+                    to four.
+                  </p>
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiCard
+                  icon={<EuiIcon size="xxl" type="logoElastic" />}
+                  title="Elastic Cloud"
+                  description="Example card description."
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </section>
+        }
+      />
+    </>
+  );
+};

--- a/src-docs/src/views/skeleton/skeleton_loading.tsx
+++ b/src-docs/src/views/skeleton/skeleton_loading.tsx
@@ -12,6 +12,7 @@ import {
   EuiAvatar,
   EuiSwitch,
   EuiSpacer,
+  EuiPanel,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -33,7 +34,7 @@ export default () => {
         isLoading={isLoading}
         contentAriaLabel="Demo loading section"
         loadingContent={
-          <section>
+          <EuiPanel>
             <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
               <EuiFlexItem grow={false}>
                 <EuiSkeletonCircle size="s" />
@@ -51,10 +52,10 @@ export default () => {
                 <EuiSkeletonRectangle width="100%" height={148} />
               </EuiFlexItem>
             </EuiFlexGroup>
-          </section>
+          </EuiPanel>
         }
         loadedContent={
-          <section>
+          <EuiPanel>
             <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
               <EuiAvatar size="s" name="Avatar" />
               <EuiTitle size="l">
@@ -79,13 +80,14 @@ export default () => {
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiCard
+                  display="subdued"
                   icon={<EuiIcon size="xxl" type="logoElastic" />}
                   title="Elastic Cloud"
                   description="Example card description."
                 />
               </EuiFlexItem>
             </EuiFlexGroup>
-          </section>
+          </EuiPanel>
         }
       />
     </>

--- a/src-docs/src/views/skeleton/skeleton_rectangle.tsx
+++ b/src-docs/src/views/skeleton/skeleton_rectangle.tsx
@@ -8,6 +8,7 @@ import {
   EuiSpacer,
   EuiImage,
   EuiBadge,
+  EuiCard,
   EuiIcon,
 } from '../../../../src/components';
 
@@ -24,40 +25,49 @@ export default () => {
       <EuiSpacer />
       <EuiFlexGroup responsive={false} wrap>
         <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonRectangle width="16px" height="16px" borderRadius="s" />
-          ) : (
-            <EuiIcon type="cheer" />
-          )}
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonRectangle
-              width="54.16px"
-              height="20px"
-              borderRadius="m"
-            />
-          ) : (
+          <EuiSkeletonRectangle
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton badge"
+            width="54.16px"
+            height="20px"
+            borderRadius="s"
+          >
             <EuiBadge color="success">Active</EuiBadge>
-          )}
+          </EuiSkeletonRectangle>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false}>
-          {isLoading ? (
-            <EuiSkeletonRectangle
-              width={100}
-              height={100}
-              borderRadius="none"
-            />
-          ) : (
+          <EuiSkeletonRectangle
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton image"
+            width={100}
+            height={100}
+            borderRadius="none"
+          >
             <EuiImage
               width={100}
               height={100}
               src="https://picsum.photos/300/300"
               alt="A randomized image"
             />
-          )}
+          </EuiSkeletonRectangle>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiSkeletonRectangle
+            isLoading={isLoading}
+            contentAriaLabel="Demo skeleton card"
+            width={203}
+            height={148}
+            borderRadius="m"
+          >
+            <EuiCard
+              icon={<EuiIcon size="xxl" type="logoCloud" />}
+              title="Elastic Cloud"
+              description="Example card description."
+              onClick={() => {}}
+            />
+          </EuiSkeletonRectangle>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/src-docs/src/views/skeleton/skeleton_text.tsx
+++ b/src-docs/src/views/skeleton/skeleton_text.tsx
@@ -8,7 +8,6 @@ import {
   EuiButtonGroup,
   EuiSpacer,
   EuiFlexGroup,
-  EuiFlexItem,
 } from '../../../../src/components';
 
 type TextSizes = 'm' | 's' | 'xs' | 'relative';
@@ -40,35 +39,34 @@ export default () => {
         />
       </EuiFlexGroup>
       <EuiSpacer />
-      <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonText lines={3} size={size} />
-          ) : (
-            <EuiText
-              // Trim text to 3 lines to visually match the skeleton lines
-              css={css`
-                text-overflow: ellipsis;
-                overflow: hidden;
-                line-clamp: 3;
-                display: -webkit-box;
-                -webkit-line-clamp: 3;
-                -webkit-box-orient: vertical;
-              `}
-              size={size}
-            >
-              <p>
-                Far out in the uncharted backwaters of the unfashionable end of
-                the western spiral arm of the Galaxy lies a small unregarded
-                yellow sun. Orbiting this at a distance of roughly ninety-two
-                million miles is an utterly insignificant little blue green
-                planet whose ape-descended life forms are so amazingly primitive
-                that they still think digital watches are a pretty neat idea.
-              </p>
-            </EuiText>
-          )}
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiSkeletonText
+        lines={3}
+        size={size}
+        isLoading={isLoading}
+        contentAriaLabel="Demo skeleton text"
+      >
+        <EuiText
+          // Trim text to 3 lines to visually match the skeleton lines
+          css={css`
+            text-overflow: ellipsis;
+            overflow: hidden;
+            line-clamp: 3;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+          `}
+          size={size}
+        >
+          <p>
+            Far out in the uncharted backwaters of the unfashionable end of the
+            western spiral arm of the Galaxy lies a small unregarded yellow sun.
+            Orbiting this at a distance of roughly ninety-two million miles is
+            an utterly insignificant little blue green planet whose
+            ape-descended life forms are so amazingly primitive that they still
+            think digital watches are a pretty neat idea.
+          </p>
+        </EuiText>
+      </EuiSkeletonText>
     </>
   );
 };

--- a/src-docs/src/views/skeleton/skeleton_title.tsx
+++ b/src-docs/src/views/skeleton/skeleton_title.tsx
@@ -6,7 +6,6 @@ import {
   EuiSwitch,
   EuiSpacer,
   EuiFlexGroup,
-  EuiFlexItem,
 } from '../../../../src/components';
 
 export default () => {
@@ -21,65 +20,65 @@ export default () => {
       />
       <EuiSpacer />
       <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonTitle size="xxxs" />
-          ) : (
-            <EuiTitle size="xxxs">
-              <span>This is an extra extra extra small title</span>
-            </EuiTitle>
-          )}
-        </EuiFlexItem>
+        <EuiSkeletonTitle
+          size="xxxs"
+          isLoading={isLoading}
+          contentAriaLabel="Demo skeleton title"
+        >
+          <EuiTitle size="xxxs">
+            <span>This is an extra extra extra small title</span>
+          </EuiTitle>
+        </EuiSkeletonTitle>
 
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonTitle size="xxs" />
-          ) : (
-            <EuiTitle size="xxs">
-              <span>This is an extra extra small title</span>
-            </EuiTitle>
-          )}
-        </EuiFlexItem>
+        <EuiSkeletonTitle
+          size="xxs"
+          isLoading={isLoading}
+          contentAriaLabel="Demo skeleton title"
+        >
+          <EuiTitle size="xxs">
+            <span>This is an extra extra small title</span>
+          </EuiTitle>
+        </EuiSkeletonTitle>
 
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonTitle size="xs" />
-          ) : (
-            <EuiTitle size="xs">
-              <span>This is an extra small title</span>
-            </EuiTitle>
-          )}
-        </EuiFlexItem>
+        <EuiSkeletonTitle
+          size="xs"
+          isLoading={isLoading}
+          contentAriaLabel="Demo skeleton title"
+        >
+          <EuiTitle size="xs">
+            <span>This is an extra small title</span>
+          </EuiTitle>
+        </EuiSkeletonTitle>
 
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonTitle size="s" />
-          ) : (
-            <EuiTitle size="s">
-              <span>This is a small title</span>
-            </EuiTitle>
-          )}
-        </EuiFlexItem>
+        <EuiSkeletonTitle
+          size="s"
+          isLoading={isLoading}
+          contentAriaLabel="Demo skeleton title"
+        >
+          <EuiTitle size="s">
+            <span>This is a small title</span>
+          </EuiTitle>
+        </EuiSkeletonTitle>
 
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonTitle size="m" />
-          ) : (
-            <EuiTitle size="m">
-              <span>This is a medium title</span>
-            </EuiTitle>
-          )}
-        </EuiFlexItem>
+        <EuiSkeletonTitle
+          size="m"
+          isLoading={isLoading}
+          contentAriaLabel="Demo skeleton title"
+        >
+          <EuiTitle size="m">
+            <span>This is a medium title</span>
+          </EuiTitle>
+        </EuiSkeletonTitle>
 
-        <EuiFlexItem>
-          {isLoading ? (
-            <EuiSkeletonTitle size="l" />
-          ) : (
-            <EuiTitle size="l">
-              <span>This is a large title</span>
-            </EuiTitle>
-          )}
-        </EuiFlexItem>
+        <EuiSkeletonTitle
+          size="l"
+          isLoading={isLoading}
+          contentAriaLabel="Demo skeleton title"
+        >
+          <EuiTitle size="l">
+            <span>This is a large title</span>
+          </EuiTitle>
+        </EuiSkeletonTitle>
       </EuiFlexGroup>
     </>
   );

--- a/src/components/loading/__snapshots__/loading_content.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_content.test.tsx.snap
@@ -1,21 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiLoadingContent is rendered 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="aria-label"
-  class="euiSkeletonText testClass1 testClass2"
-  data-test-subj="test subject string"
-  role="progressbar"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
 >
   <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-</span>
+    aria-label="Loading "
+    class="euiSkeletonText testClass1 testClass2"
+    data-test-subj="test subject string"
+    role="progressbar"
+  >
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+  </span>
+</div>
 `;

--- a/src/components/skeleton/__snapshots__/skeleton_circle.test.tsx.snap
+++ b/src/components/skeleton/__snapshots__/skeleton_circle.test.tsx.snap
@@ -3,45 +3,65 @@
 exports[`EuiSkeletonCircle is rendered 1`] = `
 <div
   aria-busy="true"
-  aria-label="aria-label"
-  class="euiSkeletonCircle testClass1 testClass2 emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-l"
-  data-test-subj="test subject string"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonCircle testClass1 testClass2 emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-l"
+    data-test-subj="test subject string"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonCircle size l 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-l"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-l"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonCircle size m 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-m"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-m"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonCircle size s 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-s"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-s"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonCircle size xl 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-xl"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonCircle emotion-euiSkeletonGradientAnimation-euiSkeletonCircle-xl"
+    role="progressbar"
+  />
+</div>
 `;

--- a/src/components/skeleton/__snapshots__/skeleton_loading.test.tsx.snap
+++ b/src/components/skeleton/__snapshots__/skeleton_loading.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiSkeletonLoading renders \`loadedContent\` when \`isLoading\` is false 1`] = `
+<div
+  aria-busy="false"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    class="emotion-euiScreenReaderOnly"
+  >
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      role="status"
+    >
+      Loaded Sample user data
+    </div>
+    <div
+      aria-atomic="true"
+      aria-hidden="true"
+      aria-live="off"
+      role="status"
+    />
+  </div>
+  <span
+    data-test-subj="loaded"
+  />
+</div>
+`;
+
+exports[`EuiSkeletonLoading renders \`loadingContent\` when \`isLoading\` is true 1`] = `
+<div
+  aria-busy="true"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading Sample user data"
+    data-test-subj="loading"
+    role="progressbar"
+  />
+</div>
+`;

--- a/src/components/skeleton/__snapshots__/skeleton_rectangle.test.tsx.snap
+++ b/src/components/skeleton/__snapshots__/skeleton_rectangle.test.tsx.snap
@@ -3,60 +3,84 @@
 exports[`EuiSkeletonRectangle borderRadius m 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
-  role="progressbar"
-  style="inline-size: 24px; block-size: 24px;"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
+    role="progressbar"
+    style="inline-size: 24px; block-size: 24px;"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonRectangle borderRadius none 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-none"
-  role="progressbar"
-  style="inline-size: 24px; block-size: 24px;"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-none"
+    role="progressbar"
+    style="inline-size: 24px; block-size: 24px;"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonRectangle borderRadius s 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
-  role="progressbar"
-  style="inline-size: 24px; block-size: 24px;"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
+    role="progressbar"
+    style="inline-size: 24px; block-size: 24px;"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonRectangle correctly renders passed styles 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
-  role="progressbar"
-  style="background-color: red; inline-size: 24px; block-size: 24px;"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
+    role="progressbar"
+    style="background-color: red; inline-size: 24px; block-size: 24px;"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonRectangle is rendered 1`] = `
 <div
   aria-busy="true"
-  aria-label="aria-label"
-  class="euiSkeletonRectangle testClass1 testClass2 emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
-  data-test-subj="test subject string"
-  role="progressbar"
-  style="inline-size: 24px; block-size: 24px;"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonRectangle testClass1 testClass2 emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
+    data-test-subj="test subject string"
+    role="progressbar"
+    style="inline-size: 24px; block-size: 24px;"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonRectangle width and height 1`] = `
 <div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
-  role="progressbar"
-  style="inline-size: 100%; block-size: 33vh;"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    aria-label="Loading "
+    class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-s"
+    role="progressbar"
+    style="inline-size: 100%; block-size: 33vh;"
+  />
+</div>
 `;

--- a/src/components/skeleton/__snapshots__/skeleton_text.test.tsx.snap
+++ b/src/components/skeleton/__snapshots__/skeleton_text.test.tsx.snap
@@ -1,97 +1,117 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSkeletonText is rendered 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="aria-label"
-  class="euiSkeletonText testClass1 testClass2"
-  data-test-subj="test subject string"
-  role="progressbar"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
 >
   <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-</span>
+    aria-label="Loading "
+    class="euiSkeletonText testClass1 testClass2"
+    data-test-subj="test subject string"
+    role="progressbar"
+  >
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+  </span>
+</div>
 `;
 
 exports[`EuiSkeletonText size m 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonText"
-  role="progressbar"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
 >
   <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
-  />
-</span>
+    aria-label="Loading "
+    class="euiSkeletonText"
+    role="progressbar"
+  >
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-m"
+    />
+  </span>
+</div>
 `;
 
 exports[`EuiSkeletonText size relative 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonText"
-  role="progressbar"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
 >
   <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-relative"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-relative"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-relative"
-  />
-</span>
+    aria-label="Loading "
+    class="euiSkeletonText"
+    role="progressbar"
+  >
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-relative"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-relative"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-relative"
+    />
+  </span>
+</div>
 `;
 
 exports[`EuiSkeletonText size s 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonText"
-  role="progressbar"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
 >
   <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-s"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-s"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-s"
-  />
-</span>
+    aria-label="Loading "
+    class="euiSkeletonText"
+    role="progressbar"
+  >
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-s"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-s"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-s"
+    />
+  </span>
+</div>
 `;
 
 exports[`EuiSkeletonText size xs 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonText"
-  role="progressbar"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
 >
   <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-xs"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-xs"
-  />
-  <span
-    class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-xs"
-  />
-</span>
+    aria-label="Loading "
+    class="euiSkeletonText"
+    role="progressbar"
+  >
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-xs"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-xs"
+    />
+    <span
+      class="emotion-euiSkeletonGradientAnimation-euiSkeletonText-xs"
+    />
+  </span>
+</div>
 `;

--- a/src/components/skeleton/__snapshots__/skeleton_title.test.tsx.snap
+++ b/src/components/skeleton/__snapshots__/skeleton_title.test.tsx.snap
@@ -1,65 +1,93 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSkeletonTitle is rendered 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="aria-label"
-  class="euiSkeletonTitle testClass1 testClass2 emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-m"
-  data-test-subj="test subject string"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle testClass1 testClass2 emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-m"
+    data-test-subj="test subject string"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonTitle size l 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-l"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-l"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonTitle size m 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-m"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-m"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonTitle size s 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-s"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-s"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonTitle size xs 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-xs"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-xs"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonTitle size xxs 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-xxs"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-xxs"
+    role="progressbar"
+  />
+</div>
 `;
 
 exports[`EuiSkeletonTitle size xxxs 1`] = `
-<span
+<div
   aria-busy="true"
-  aria-label="Loading"
-  class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-xxxs"
-  role="progressbar"
-/>
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    aria-label="Loading "
+    class="euiSkeletonTitle emotion-euiSkeletonGradientAnimation-euiSkeletonTitle-xxxs"
+    role="progressbar"
+  />
+</div>
 `;

--- a/src/components/skeleton/index.ts
+++ b/src/components/skeleton/index.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+export type { EuiSkeletonLoadingProps } from './skeleton_loading';
+export { EuiSkeletonLoading } from './skeleton_loading';
 export type { EuiSkeletonCircleProps } from './skeleton_circle';
 export { EuiSkeletonCircle } from './skeleton_circle';
 export type { EuiSkeletonTextProps } from './skeleton_text';

--- a/src/components/skeleton/skeleton_circle.test.tsx
+++ b/src/components/skeleton/skeleton_circle.test.tsx
@@ -14,7 +14,9 @@ import { shouldRenderCustomStyles } from '../../test/internal';
 import { EuiSkeletonCircle, SIZES } from './skeleton_circle';
 
 describe('EuiSkeletonCircle', () => {
-  shouldRenderCustomStyles(<EuiSkeletonCircle />);
+  shouldRenderCustomStyles(<EuiSkeletonCircle />, {
+    childProps: ['ariaWrapperProps'],
+  });
 
   test('is rendered', () => {
     const { container } = render(<EuiSkeletonCircle {...requiredProps} />);
@@ -30,5 +32,16 @@ describe('EuiSkeletonCircle', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
     });
+  });
+
+  it('renders its children when `isLoading=false`', () => {
+    const { queryByRole, queryByTestSubject } = render(
+      <EuiSkeletonCircle isLoading={false}>
+        <span data-test-subj="loaded" />
+      </EuiSkeletonCircle>
+    );
+
+    expect(queryByRole('progressbar')).toBeFalsy();
+    expect(queryByTestSubject('loaded')).toBeTruthy();
   });
 });

--- a/src/components/skeleton/skeleton_circle.tsx
+++ b/src/components/skeleton/skeleton_circle.tsx
@@ -12,20 +12,25 @@ import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { useEuiTheme } from '../../services';
 
-import { useLoadingAriaAttributes } from './utils';
+import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
 import { euiSkeletonCircleStyles } from './skeleton_circle.styles';
 
 export const SIZES = ['s', 'm', 'l', 'xl'] as const;
 export type SkeletonCircleSize = typeof SIZES[number];
 
 export type EuiSkeletonCircleProps = HTMLAttributes<HTMLDivElement> &
-  CommonProps & {
+  CommonProps &
+  _EuiSkeletonAriaProps & {
     size?: SkeletonCircleSize;
   };
 
 export const EuiSkeletonCircle: FunctionComponent<EuiSkeletonCircleProps> = ({
-  className,
+  isLoading = true,
   size = 'l',
+  className,
+  contentAriaLabel,
+  ariaWrapperProps,
+  children,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -33,11 +38,18 @@ export const EuiSkeletonCircle: FunctionComponent<EuiSkeletonCircleProps> = ({
   const cssStyles = [styles.euiSkeletonCircle, styles[size]];
 
   return (
-    <div
-      className={classNames('euiSkeletonCircle', className)}
-      css={cssStyles}
-      {...useLoadingAriaAttributes()}
-      {...rest}
+    <EuiSkeletonLoading
+      isLoading={isLoading}
+      loadingContent={
+        <div
+          className={classNames('euiSkeletonCircle', className)}
+          css={cssStyles}
+          {...rest}
+        />
+      }
+      loadedContent={children || ''}
+      contentAriaLabel={contentAriaLabel}
+      {...ariaWrapperProps}
     />
   );
 };

--- a/src/components/skeleton/skeleton_loading.test.tsx
+++ b/src/components/skeleton/skeleton_loading.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../test/rtl';
+import { shouldRenderCustomStyles } from '../../test/internal';
+
+import { EuiSkeletonLoading } from './skeleton_loading';
+
+describe('EuiSkeletonLoading', () => {
+  const loadingContent = <span data-test-subj="loading" />;
+  const loadedContent = <span data-test-subj="loaded" />;
+
+  const contentProps = {
+    loadingContent,
+    loadedContent,
+    contentAriaLabel: 'Sample user data',
+  };
+
+  shouldRenderCustomStyles(<EuiSkeletonLoading {...contentProps} />);
+
+  it('renders `loadingContent` when `isLoading` is true', () => {
+    const { container, queryByTestSubject } = render(
+      <EuiSkeletonLoading {...contentProps} isLoading={true} />
+    );
+
+    expect(queryByTestSubject('loading')).toBeTruthy();
+    expect(queryByTestSubject('loaded')).toBeFalsy();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders `loadedContent` when `isLoading` is false', () => {
+    const { container, queryByTestSubject } = render(
+      <EuiSkeletonLoading {...contentProps} isLoading={false} />
+    );
+
+    expect(queryByTestSubject('loading')).toBeFalsy();
+    expect(queryByTestSubject('loaded')).toBeTruthy();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/skeleton/skeleton_loading.tsx
+++ b/src/components/skeleton/skeleton_loading.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, HTMLAttributes, ReactElement } from 'react';
+
+import { CommonProps } from '../common';
+import { EuiScreenReaderLive } from '../accessibility/screen_reader_live';
+import { useEuiI18n } from '../i18n';
+
+export type _EuiSkeletonAriaProps = {
+  /**
+   * When true, shows the loading skeleton component.
+   * When false, shows any `children` and announces to screen readers that your content has loaded.
+   */
+  isLoading?: boolean;
+  /**
+   * Label your loading sections to provide more helpful context to screen readers.
+   * For example, pass "API keys" to have screen readers read "Loading API keys" and "Loaded API keys".
+   */
+  contentAriaLabel?: string;
+  /**
+   * Any optional props to pass to the `aria-busy` wrapper around the skeleton content
+   */
+  ariaWrapperProps?: HTMLAttributes<HTMLDivElement>;
+};
+
+export type EuiSkeletonLoadingProps = CommonProps &
+  _EuiSkeletonAriaProps['ariaWrapperProps'] &
+  Pick<_EuiSkeletonAriaProps, 'isLoading' | 'contentAriaLabel'> & {
+    /**
+     * Content to display when loading
+     */
+    loadingContent: ReactElement;
+    /**
+     * Content to display when loaded
+     */
+    loadedContent: any;
+  };
+
+export const EuiSkeletonLoading: FunctionComponent<EuiSkeletonLoadingProps> = ({
+  isLoading = true,
+  contentAriaLabel,
+  loadingContent,
+  loadedContent,
+  ...rest
+}) => {
+  const loadingAriaLabel = useEuiI18n(
+    'euiSkeletonLoading.loadingAriaText',
+    'Loading {contentAriaLabel}',
+    { contentAriaLabel }
+  );
+  const loadedAriaLive = useEuiI18n(
+    'euiSkeletonLoading.loadedAriaText',
+    'Loaded {contentAriaLabel}',
+    { contentAriaLabel }
+  );
+  const loadingProps = {
+    'aria-label': loadingAriaLabel,
+    role: 'progressbar',
+  };
+
+  return (
+    <div
+      aria-busy={isLoading}
+      data-test-subj="euiSkeletonLoadingAriaWrapper"
+      {...rest}
+    >
+      {isLoading ? (
+        React.cloneElement(loadingContent, loadingProps)
+      ) : (
+        <>
+          <EuiScreenReaderLive>{loadedAriaLive}</EuiScreenReaderLive>
+          {loadedContent}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/skeleton/skeleton_rectangle.test.tsx
+++ b/src/components/skeleton/skeleton_rectangle.test.tsx
@@ -14,7 +14,9 @@ import { shouldRenderCustomStyles } from '../../test/internal';
 import { EuiSkeletonRectangle, RADIUS } from './skeleton_rectangle';
 
 describe('EuiSkeletonRectangle', () => {
-  shouldRenderCustomStyles(<EuiSkeletonRectangle />);
+  shouldRenderCustomStyles(<EuiSkeletonRectangle />, {
+    childProps: ['ariaWrapperProps'],
+  });
 
   test('is rendered', () => {
     const { container } = render(<EuiSkeletonRectangle {...requiredProps} />);
@@ -48,5 +50,16 @@ describe('EuiSkeletonRectangle', () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders its children when `isLoading=false`', () => {
+    const { queryByRole, queryByTestSubject } = render(
+      <EuiSkeletonRectangle isLoading={false}>
+        <span data-test-subj="loaded" />
+      </EuiSkeletonRectangle>
+    );
+
+    expect(queryByRole('progressbar')).toBeFalsy();
+    expect(queryByTestSubject('loaded')).toBeTruthy();
   });
 });

--- a/src/components/skeleton/skeleton_rectangle.tsx
+++ b/src/components/skeleton/skeleton_rectangle.tsx
@@ -13,25 +13,30 @@ import { CommonProps } from '../common';
 import { useEuiTheme } from '../../services';
 import { logicalStyles } from '../../global_styling';
 
-import { useLoadingAriaAttributes } from './utils';
+import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
 import { euiSkeletonRectangleStyles } from './skeleton_rectangle.styles';
 
 export const RADIUS = ['s', 'm', 'none'] as const;
 export type SkeletonRectangleBorderRadius = typeof RADIUS[number];
 
 export type EuiSkeletonRectangleProps = HTMLAttributes<HTMLDivElement> &
-  CommonProps & {
+  CommonProps &
+  _EuiSkeletonAriaProps & {
     width?: string | number;
     height?: string | number;
     borderRadius?: SkeletonRectangleBorderRadius;
   };
 
 export const EuiSkeletonRectangle: FunctionComponent<EuiSkeletonRectangleProps> = ({
-  className,
+  isLoading = true,
   borderRadius = 's',
   width = '24px',
   height = '24px',
   style,
+  className,
+  contentAriaLabel,
+  ariaWrapperProps,
+  children,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -39,12 +44,19 @@ export const EuiSkeletonRectangle: FunctionComponent<EuiSkeletonRectangleProps> 
   const cssStyles = [styles.euiSkeletonRectangle, styles[borderRadius]];
 
   return (
-    <div
-      className={classNames('euiSkeletonRectangle', className)}
-      css={cssStyles}
-      style={logicalStyles({ ...style, width, height })}
-      {...useLoadingAriaAttributes()}
-      {...rest}
+    <EuiSkeletonLoading
+      isLoading={isLoading}
+      loadingContent={
+        <div
+          className={classNames('euiSkeletonRectangle', className)}
+          css={cssStyles}
+          style={logicalStyles({ ...style, width, height })}
+          {...rest}
+        />
+      }
+      loadedContent={children || ''}
+      contentAriaLabel={contentAriaLabel}
+      {...ariaWrapperProps}
     />
   );
 };

--- a/src/components/skeleton/skeleton_text.test.tsx
+++ b/src/components/skeleton/skeleton_text.test.tsx
@@ -15,7 +15,9 @@ import { TEXT_SIZES } from '../text/text';
 import { EuiSkeletonText, LINES } from './skeleton_text';
 
 describe('EuiSkeletonText', () => {
-  shouldRenderCustomStyles(<EuiSkeletonText />);
+  shouldRenderCustomStyles(<EuiSkeletonText />, {
+    childProps: ['ariaWrapperProps'],
+  });
 
   test('is rendered', () => {
     const { container } = render(<EuiSkeletonText {...requiredProps} />);
@@ -42,5 +44,16 @@ describe('EuiSkeletonText', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
     });
+  });
+
+  it('renders its children when `isLoading=false`', () => {
+    const { queryByRole, queryByTestSubject } = render(
+      <EuiSkeletonText isLoading={false}>
+        <span data-test-subj="loaded" />
+      </EuiSkeletonText>
+    );
+
+    expect(queryByRole('progressbar')).toBeFalsy();
+    expect(queryByTestSubject('loaded')).toBeTruthy();
   });
 });

--- a/src/components/skeleton/skeleton_text.tsx
+++ b/src/components/skeleton/skeleton_text.tsx
@@ -13,22 +13,33 @@ import { CommonProps } from '../common';
 import { useEuiTheme } from '../../services';
 import { TextSize } from '../text/text';
 
-import { useLoadingAriaAttributes } from './utils';
+import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
 import { euiSkeletonTextStyles } from './skeleton_text.styles';
 
 export const LINES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 export type LineRange = typeof LINES[number];
 
 export type EuiSkeletonTextProps = CommonProps &
-  HTMLAttributes<HTMLDivElement> & {
+  HTMLAttributes<HTMLDivElement> &
+  _EuiSkeletonAriaProps & {
+    /**
+     * Number of lines to display (between 1 to 10)
+     */
     lines?: LineRange;
+    /**
+     * EuiText size to render
+     */
     size?: TextSize;
   };
 
 export const EuiSkeletonText: FunctionComponent<EuiSkeletonTextProps> = ({
+  isLoading = true,
   lines = 3,
   size = 'm',
   className,
+  contentAriaLabel,
+  ariaWrapperProps,
+  children,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -41,12 +52,16 @@ export const EuiSkeletonText: FunctionComponent<EuiSkeletonTextProps> = ({
   }
 
   return (
-    <span
-      className={classNames('euiSkeletonText', className)}
-      {...useLoadingAriaAttributes()}
-      {...rest}
-    >
-      {lineElements}
-    </span>
+    <EuiSkeletonLoading
+      isLoading={isLoading}
+      loadingContent={
+        <span className={classNames('euiSkeletonText', className)} {...rest}>
+          {lineElements}
+        </span>
+      }
+      loadedContent={children || ''}
+      contentAriaLabel={contentAriaLabel}
+      {...ariaWrapperProps}
+    />
   );
 };

--- a/src/components/skeleton/skeleton_title.test.tsx
+++ b/src/components/skeleton/skeleton_title.test.tsx
@@ -15,7 +15,9 @@ import { TITLE_SIZES } from '../title/title';
 import { EuiSkeletonTitle } from './skeleton_title';
 
 describe('EuiSkeletonTitle', () => {
-  shouldRenderCustomStyles(<EuiSkeletonTitle />);
+  shouldRenderCustomStyles(<EuiSkeletonTitle />, {
+    childProps: ['ariaWrapperProps'],
+  });
 
   test('is rendered', () => {
     const { container } = render(<EuiSkeletonTitle {...requiredProps} />);
@@ -31,5 +33,16 @@ describe('EuiSkeletonTitle', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
     });
+  });
+
+  it('renders its children when `isLoading=false`', () => {
+    const { queryByRole, queryByTestSubject } = render(
+      <EuiSkeletonTitle isLoading={false}>
+        <span data-test-subj="loaded" />
+      </EuiSkeletonTitle>
+    );
+
+    expect(queryByRole('progressbar')).toBeFalsy();
+    expect(queryByTestSubject('loaded')).toBeTruthy();
   });
 });

--- a/src/components/skeleton/skeleton_title.tsx
+++ b/src/components/skeleton/skeleton_title.tsx
@@ -13,17 +13,25 @@ import { CommonProps } from '../common';
 import { useEuiTheme } from '../../services';
 import { EuiTitleSize } from '../title';
 
-import { useLoadingAriaAttributes } from './utils';
+import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
 import { euiSkeletonTitleStyles } from './skeleton_title.styles';
 
 export type EuiSkeletonTitleProps = HTMLAttributes<HTMLDivElement> &
-  CommonProps & {
+  CommonProps &
+  _EuiSkeletonAriaProps & {
+    /**
+     * EuiTitle size to render
+     */
     size?: EuiTitleSize;
   };
 
 export const EuiSkeletonTitle: FunctionComponent<EuiSkeletonTitleProps> = ({
-  className,
+  isLoading = true,
   size = 'm',
+  className,
+  contentAriaLabel,
+  ariaWrapperProps,
+  children,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -31,11 +39,18 @@ export const EuiSkeletonTitle: FunctionComponent<EuiSkeletonTitleProps> = ({
   const cssStyles = [styles.euiSkeletonTitle, styles[size]];
 
   return (
-    <span
-      className={classNames('euiSkeletonTitle', className)}
-      css={cssStyles}
-      {...useLoadingAriaAttributes()}
-      {...rest}
+    <EuiSkeletonLoading
+      isLoading={isLoading}
+      loadingContent={
+        <span
+          className={classNames('euiSkeletonTitle', className)}
+          css={cssStyles}
+          {...rest}
+        />
+      }
+      loadedContent={children || ''}
+      contentAriaLabel={contentAriaLabel}
+      {...ariaWrapperProps}
     />
   );
 };

--- a/src/components/skeleton/utils.ts
+++ b/src/components/skeleton/utils.ts
@@ -11,17 +11,6 @@ import { css } from '@emotion/react';
 import { UseEuiTheme, shade, tint } from '../../services';
 import { euiCanAnimate, logicalCSS } from '../../global_styling';
 import { euiAnimSlideX } from '../../global_styling/utility/animations';
-import { useLoadingAriaLabel } from '../loading/_loading_strings';
-
-export const useLoadingAriaAttributes = () => {
-  const defaultLabel = useLoadingAriaLabel();
-
-  return {
-    'aria-busy': true,
-    'aria-label': defaultLabel,
-    role: 'progressbar',
-  };
-};
 
 type AnimationOptions = {
   slideSize?: string;

--- a/src/components/skeleton/utils.ts
+++ b/src/components/skeleton/utils.ts
@@ -35,7 +35,7 @@ export const euiSkeletonGradientAnimation = (
 
     ${euiCanAnimate} {
       overflow: hidden;
-      z-index: 1; // This is unfortunately necessary workaround that forces Safari to correctly respect border-radius
+      isolation: isolate; // This is unfortunately necessary workaround that forces Safari to correctly respect border-radius
 
       &::after {
         content: '';

--- a/upcoming_changelogs/6562.md
+++ b/upcoming_changelogs/6562.md
@@ -1,0 +1,2 @@
+- All `EuiSkeleton` components now accept an `isLoading` flag and `children`, which automatically handles conditionally rendering loading skeletons vs.  loaded content (`children`)
+- All `EuiSkeleton` components now accept a `contentAriaLabel` prop, which more meaningfully describes the loaded content to screen readers


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/4814

This adds the loading accessibility detailed in #4814. I recommend following along by commit if possible.

- All `EuiSkeleton` components now accept `isLoading` and `children` props, which automatically handles conditionally rendering the skeleton components vs. the loaded content (`children`) for consumers.
- A `Loaded {contentAriaLabel}` announcement is now made whenever `isLoading` flips to false.

<img width="1096" alt="" src="https://user-images.githubusercontent.com/549407/215649218-1a815c2b-525f-474a-85d9-a3bb904efa60.png">

![screencap](https://user-images.githubusercontent.com/549407/215649240-03311ee7-26d6-4e71-8d15-5c333031e54a.gif)


## QA

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~