### PR TITLE
Updating EuiPopover screen reader text to include mobile cues.

### DIFF
--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -5121,7 +5121,7 @@
   },
   {
     "token": "euiPopover.screenReaderAnnouncement",
-    "defString": "You are in a dialog. To close this dialog, hit escape.",
+    "defString": "You are in a dialog. Press Escape, tap, or click outside this modal to close.",
     "highlighting": "string",
     "loc": {
       "start": {

--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -5121,7 +5121,7 @@
   },
   {
     "token": "euiPopover.screenReaderAnnouncement",
-    "defString": "You are in a dialog. Press Escape, tap, or click outside this modal to close.",
+    "defString": "You are in a dialog. Press Escape, or tap/click outside the dialog to close.",
     "highlighting": "string",
     "loc": {
       "start": {

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
     class="emotion-euiScreenReaderOnly"
     id="generated-id"
   >
-    You are in a dialog. Press Escape, tap, or click outside this modal to close.
+    You are in a dialog. Press Escape, or tap/click outside the dialog to close.
   </p>
   <div>
     <div>

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
     class="emotion-euiScreenReaderOnly"
     id="generated-id"
   >
-    You are in a dialog. To close this dialog, hit escape.
+    You are in a dialog. Press Escape, tap, or click outside this modal to close.
   </p>
   <div>
     <div>

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
     class="emotion-euiScreenReaderOnly"
     id="generated-id"
   >
-    You are in a dialog. To close this dialog, hit escape.
+    You are in a dialog. Press Escape, tap, or click outside this modal to close.
   </p>
   <div>
     <div

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
     class="emotion-euiScreenReaderOnly"
     id="generated-id"
   >
-    You are in a dialog. Press Escape, tap, or click outside this modal to close.
+    You are in a dialog. Press Escape, or tap/click outside the dialog to close.
   </p>
   <div>
     <div

--- a/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div>
           <div

--- a/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div>
           <div

--- a/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`EuiPopover snapshot testing renders with popover contents 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div>
           Hello world

--- a/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`EuiPopover snapshot testing renders with popover contents 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div>
           Hello world

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -175,7 +175,7 @@ exports[`EuiPopover props buffer 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -229,7 +229,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -296,7 +296,7 @@ exports[`EuiPopover props focusTrapProps is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -363,7 +363,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -417,7 +417,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -466,7 +466,7 @@ exports[`EuiPopover props offset without arrow 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -520,7 +520,7 @@ exports[`EuiPopover props ownFocus defaults to true 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -619,7 +619,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -673,7 +673,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>
@@ -728,7 +728,7 @@ exports[`EuiPopover props panelProps is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. Press Escape, tap, or click outside this modal to close.
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div />
       </div>

--- a/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -175,7 +175,7 @@ exports[`EuiPopover props buffer 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -229,7 +229,7 @@ exports[`EuiPopover props buffer for all sides 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -296,7 +296,7 @@ exports[`EuiPopover props focusTrapProps is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -363,7 +363,7 @@ exports[`EuiPopover props isOpen renders true 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -417,7 +417,7 @@ exports[`EuiPopover props offset with arrow 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -466,7 +466,7 @@ exports[`EuiPopover props offset without arrow 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -520,7 +520,7 @@ exports[`EuiPopover props ownFocus defaults to true 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -619,7 +619,7 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -673,7 +673,7 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>
@@ -728,7 +728,7 @@ exports[`EuiPopover props panelProps is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
         >
-          You are in a dialog. To close this dialog, hit escape.
+          You are in a dialog. Press Escape, tap, or click outside this modal to close.
         </p>
         <div />
       </div>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -687,7 +687,7 @@ export class EuiPopover extends Component<Props, State> {
               {ownFocus && (
                 <EuiI18n
                   token="euiPopover.screenReaderAnnouncement"
-                  default="You are in a dialog. Press Escape, tap, or click outside this modal to close."
+                  default="You are in a dialog. Press Escape, or tap/click outside the dialog to close."
                 />
               )}
               {popoverScreenReaderText}

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -687,7 +687,7 @@ export class EuiPopover extends Component<Props, State> {
               {ownFocus && (
                 <EuiI18n
                   token="euiPopover.screenReaderAnnouncement"
-                  default="You are in a dialog. To close this dialog, hit escape."
+                  default="You are in a dialog. Press Escape, tap, or click outside this modal to close."
                 />
               )}
               {popoverScreenReaderText}

--- a/upcoming_changelogs/6567.md
+++ b/upcoming_changelogs/6567.md
@@ -1,0 +1,1 @@
+- Updated `EuiPopover` screen reader instructions for mobile and click behaviors


### PR DESCRIPTION
## Summary
* Updating screen reader help text in EuiPopver and i18nJSON.
* Updating EuiPopover snapshots.

This PR closes #5282 

## QA

<img width="727" alt="Screen Shot 2023-02-01 at 9 03 41 AM" src="https://user-images.githubusercontent.com/934879/216082486-acc8ce7d-5d61-44f0-ba00-9bba8f152e01.png">


---

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in ~~**Chrome**~~, **Safari**, ~~**Edge**~~, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately