### PR TITLE
[EuiSelectable] Fix incorrect `aria-posinset` indices

### DIFF
--- a/src-docs/src/views/selectable/selectable.tsx
+++ b/src-docs/src/views/selectable/selectable.tsx
@@ -20,6 +20,10 @@ export default () => {
       label: 'Dione',
     },
     {
+      label: "I'm a group label",
+      isGroupLabel: true,
+    },
+    {
       label: 'Iapetus',
       checked: 'on',
     },
@@ -38,6 +42,10 @@ export default () => {
     },
     {
       label: 'Hyperion',
+    },
+    {
+      label: "I'm a group label",
+      isGroupLabel: true,
     },
   ]);
 

--- a/src-docs/src/views/selectable/selectable.tsx
+++ b/src-docs/src/views/selectable/selectable.tsx
@@ -20,10 +20,6 @@ export default () => {
       label: 'Dione',
     },
     {
-      label: "I'm a group label",
-      isGroupLabel: true,
-    },
-    {
       label: 'Iapetus',
       checked: 'on',
     },
@@ -42,10 +38,6 @@ export default () => {
     },
     {
       label: 'Hyperion',
-    },
-    {
-      label: "I'm a group label",
-      isGroupLabel: true,
     },
   ]);
 

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -10,10 +10,16 @@ exports[`EuiSelectableListItem is rendered 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -25,7 +31,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -53,7 +59,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -81,7 +87,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -109,7 +115,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -137,7 +143,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -165,7 +171,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -200,10 +206,16 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -215,7 +227,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -243,7 +255,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -271,7 +283,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -318,7 +330,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -346,7 +358,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -374,7 +386,7 @@ exports[`EuiSelectableListItem props activeOptionIndex 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -409,10 +421,16 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -424,7 +442,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -443,7 +461,8 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
               <div
                 class="emotion-euiScreenReaderOnly"
               >
-                 - To select this option, press enter.
+                 - 
+                To select this option, press enter.
               </div>
             </span>
           </span>
@@ -457,7 +476,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -476,7 +495,8 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
               <div
                 class="emotion-euiScreenReaderOnly"
               >
-                 - To select this option, press enter.
+                 - 
+                To select this option, press enter.
               </div>
             </span>
           </span>
@@ -490,7 +510,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -509,7 +529,8 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
               <div
                 class="emotion-euiScreenReaderOnly"
               >
-                 - To select this option, press enter.
+                 - 
+                To select this option, press enter.
               </div>
             </span>
           </span>
@@ -523,7 +544,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -542,7 +563,8 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
               <div
                 class="emotion-euiScreenReaderOnly"
               >
-                 - To select this option, press enter.
+                 - 
+                To select this option, press enter.
               </div>
             </span>
           </span>
@@ -556,7 +578,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -575,7 +597,8 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
               <div
                 class="emotion-euiScreenReaderOnly"
               >
-                 - To select this option, press enter.
+                 - 
+                To select this option, press enter.
               </div>
             </span>
           </span>
@@ -589,7 +612,7 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -608,7 +631,8 @@ exports[`EuiSelectableListItem props allowExclusions 1`] = `
               <div
                 class="emotion-euiScreenReaderOnly"
               >
-                 - To select this option, press enter.
+                 - 
+                To select this option, press enter.
               </div>
             </span>
           </span>
@@ -629,10 +653,16 @@ exports[`EuiSelectableListItem props bordered 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -644,7 +674,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -672,7 +702,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -700,7 +730,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -728,7 +758,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -756,7 +786,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -784,7 +814,7 @@ exports[`EuiSelectableListItem props bordered 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -819,10 +849,16 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:200px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 200px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -834,7 +870,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -862,7 +898,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -890,7 +926,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -918,7 +954,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -946,7 +982,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -974,7 +1010,7 @@ exports[`EuiSelectableListItem props height is forced 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -1009,10 +1045,16 @@ exports[`EuiSelectableListItem props height is full 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:600px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 600px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -1024,7 +1066,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -1052,7 +1094,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -1080,7 +1122,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -1108,7 +1150,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -1136,7 +1178,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -1164,7 +1206,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -1196,8 +1238,15 @@ exports[`EuiSelectableListItem props isVirtualized can be false 1`] = `
 >
   <div
     class="euiSelectableList__list"
+    tabindex="-1"
   >
-    <ul>
+    <ul
+      aria-label="aria-label"
+      aria-multiselectable="true"
+      id="list"
+      role="listbox"
+      tabindex="0"
+    >
       <li
         aria-checked="false"
         aria-posinset="1"
@@ -1376,10 +1425,16 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -1391,7 +1446,7 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -1419,7 +1474,7 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -1447,7 +1502,7 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -1475,7 +1530,7 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -1503,7 +1558,7 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -1531,7 +1586,7 @@ exports[`EuiSelectableListItem props paddingSize none is rendered 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -1566,10 +1621,16 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -1581,7 +1642,7 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -1609,7 +1670,7 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -1637,7 +1698,7 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -1665,7 +1726,7 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -1693,7 +1754,7 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -1721,7 +1782,7 @@ exports[`EuiSelectableListItem props paddingSize s is rendered 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -1756,10 +1817,16 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -1771,7 +1838,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -1785,7 +1852,9 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
-                 =&gt; Titan
+                
+                 =&gt; 
+                Titan
               </span>
             </span>
           </span>
@@ -1799,7 +1868,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -1813,7 +1882,9 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
-                 =&gt; Enceladus
+                
+                 =&gt; 
+                Enceladus
               </span>
             </span>
           </span>
@@ -1827,7 +1898,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -1841,7 +1912,9 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
-                 =&gt; Mimas
+                
+                 =&gt; 
+                Mimas
               </span>
             </span>
           </span>
@@ -1855,7 +1928,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -1869,7 +1942,9 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
-                 =&gt; Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
+                
+                 =&gt; 
+                Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
               </span>
             </span>
           </span>
@@ -1883,7 +1958,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -1897,7 +1972,9 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
-                 =&gt; Tethys
+                
+                 =&gt; 
+                Tethys
               </span>
             </span>
           </span>
@@ -1911,7 +1988,7 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -1925,7 +2002,9 @@ exports[`EuiSelectableListItem props renderOption 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
-                 =&gt; Hyperion
+                
+                 =&gt; 
+                Hyperion
               </span>
             </span>
           </span>
@@ -1946,10 +2025,16 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:120px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 120px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:120px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 120px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -1961,7 +2046,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:20px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 20px; width: 100%;"
           title="Titan"
         >
           <span
@@ -1989,7 +2074,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:20px;height:20px;width:100%"
+          style="position: absolute; left: 0px; top: 20px; height: 20px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -2017,7 +2102,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:40px;height:20px;width:100%"
+          style="position: absolute; left: 0px; top: 40px; height: 20px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -2045,7 +2130,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:60px;height:20px;width:100%"
+          style="position: absolute; left: 0px; top: 60px; height: 20px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -2073,7 +2158,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:80px;height:20px;width:100%"
+          style="position: absolute; left: 0px; top: 80px; height: 20px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -2101,7 +2186,7 @@ exports[`EuiSelectableListItem props rowHeight 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:100px;height:20px;width:100%"
+          style="position: absolute; left: 0px; top: 100px; height: 20px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -2136,10 +2221,16 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -2151,7 +2242,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -2179,7 +2270,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -2207,7 +2298,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -2221,6 +2312,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
+                
                 <mark
                   class="euiMark emotion-euiMarkStyles-EuiMark"
                 >
@@ -2240,7 +2332,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -2268,7 +2360,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -2296,7 +2388,7 @@ exports[`EuiSelectableListItem props searchValue 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -2331,10 +2423,16 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -2346,7 +2444,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -2374,7 +2472,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -2402,7 +2500,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -2416,6 +2514,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
               class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
             >
               <span>
+                
                 <mark
                   class="euiMark emotion-euiMarkStyles-EuiMark"
                 >
@@ -2435,7 +2534,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -2463,7 +2562,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -2491,7 +2590,7 @@ exports[`EuiSelectableListItem props searchValue 2`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -2526,10 +2625,14 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
       >
         <li
           aria-checked="false"
@@ -2541,7 +2644,7 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -2569,7 +2672,7 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -2597,7 +2700,7 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -2625,7 +2728,7 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -2653,7 +2756,7 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -2681,7 +2784,7 @@ exports[`EuiSelectableListItem props searchable enables correct screen reader in
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -2716,10 +2819,16 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -2731,7 +2840,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -2755,7 +2864,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -2779,7 +2888,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -2803,7 +2912,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -2827,7 +2936,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -2851,7 +2960,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -2882,10 +2991,15 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -2897,7 +3011,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -2925,7 +3039,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -2953,7 +3067,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -2981,7 +3095,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -3009,7 +3123,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -3037,7 +3151,7 @@ exports[`EuiSelectableListItem props singleSelection can be forced so that at le
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -3072,10 +3186,15 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -3087,7 +3206,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -3115,7 +3234,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -3143,7 +3262,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -3171,7 +3290,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -3199,7 +3318,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -3227,7 +3346,7 @@ exports[`EuiSelectableListItem props singleSelection can be turned on 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -3262,10 +3381,16 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:192px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 192px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:192px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 192px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -3277,7 +3402,7 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
           data-test-subj="titanOption"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Titan"
         >
           <span
@@ -3305,7 +3430,7 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Enceladus"
         >
           <span
@@ -3333,7 +3458,7 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -3361,7 +3486,7 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -3389,7 +3514,7 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
           data-test-selected="false"
           id="option_4"
           role="option"
-          style="position:absolute;left:0;top:128px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -3417,7 +3542,7 @@ exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
           data-test-selected="false"
           id="option_5"
           role="option"
-          style="position:absolute;left:0;top:160px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span
@@ -3452,10 +3577,16 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
   >
     <div
       class="euiSelectableList__list"
-      style="position:relative;height:128px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; height: 128px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
     >
       <ul
-        style="height:128px;width:100%"
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 128px; width: 100%;"
+        tabindex="0"
       >
         <li
           aria-checked="false"
@@ -3466,7 +3597,7 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
           data-test-selected="false"
           id="option_0"
           role="option"
-          style="position:absolute;left:0;top:0;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
           title="Mimas"
         >
           <span
@@ -3494,7 +3625,7 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
           data-test-selected="false"
           id="option_1"
           role="option"
-          style="position:absolute;left:0;top:32px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
           title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
         >
           <span
@@ -3522,7 +3653,7 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
           data-test-selected="false"
           id="option_2"
           role="option"
-          style="position:absolute;left:0;top:64px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
           title="Tethys"
         >
           <span
@@ -3550,7 +3681,7 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
           data-test-selected="false"
           id="option_3"
           role="option"
-          style="position:absolute;left:0;top:96px;height:32px;width:100%"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
           title="Hyperion"
         >
           <span

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -3705,3 +3705,366 @@ exports[`EuiSelectableListItem props visibleOptions 1`] = `
   </div>
 </div>
 `;
+
+exports[`EuiSelectableListItem group labels handles updating aria attrs correctly when options are changed/updated 1`] = `
+<div
+  class="euiSelectableList testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <div
+    class="euiSelectableList__list"
+    tabindex="-1"
+  >
+    <ul
+      aria-activedescendant="option_undefined"
+      aria-label="aria-label"
+      aria-multiselectable="true"
+      id="list"
+      role="listbox"
+      tabindex="0"
+    >
+      <li
+        class="euiSelectableList__groupLabel"
+        role="presentation"
+      >
+        Moons
+      </li>
+      <li
+        aria-checked="false"
+        aria-posinset="1"
+        aria-selected="false"
+        aria-setsize="5"
+        class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+        data-test-selected="false"
+        id="option_1"
+        role="option"
+        title="Titan"
+      >
+        <span
+          class="euiSelectableListItem__content"
+        >
+          <span
+            class="euiSelectableListItem__icon"
+            data-euiicon-type="empty"
+          />
+          <span
+            class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+          >
+            <span>
+              Titan
+            </span>
+          </span>
+        </span>
+      </li>
+      <li
+        aria-checked="false"
+        aria-posinset="2"
+        aria-selected="false"
+        aria-setsize="5"
+        class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+        data-test-selected="false"
+        id="option_2"
+        role="option"
+        title="Io"
+      >
+        <span
+          class="euiSelectableListItem__content"
+        >
+          <span
+            class="euiSelectableListItem__icon"
+            data-euiicon-type="empty"
+          />
+          <span
+            class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+          >
+            <span>
+              Io
+            </span>
+          </span>
+        </span>
+      </li>
+      <li
+        class="euiSelectableList__groupLabel"
+        role="presentation"
+      >
+        Planets
+      </li>
+      <li
+        aria-checked="false"
+        aria-posinset="3"
+        aria-selected="false"
+        aria-setsize="5"
+        class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+        data-test-selected="false"
+        id="option_4"
+        role="option"
+        title="Mercury"
+      >
+        <span
+          class="euiSelectableListItem__content"
+        >
+          <span
+            class="euiSelectableListItem__icon"
+            data-euiicon-type="empty"
+          />
+          <span
+            class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+          >
+            <span>
+              Mercury
+            </span>
+          </span>
+        </span>
+      </li>
+      <li
+        aria-checked="false"
+        aria-posinset="4"
+        aria-selected="false"
+        aria-setsize="5"
+        class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+        data-test-selected="false"
+        id="option_5"
+        role="option"
+        title="Mars"
+      >
+        <span
+          class="euiSelectableListItem__content"
+        >
+          <span
+            class="euiSelectableListItem__icon"
+            data-euiicon-type="empty"
+          />
+          <span
+            class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+          >
+            <span>
+              Mars
+            </span>
+          </span>
+        </span>
+      </li>
+      <li
+        class="euiSelectableList__groupLabel"
+        role="presentation"
+      >
+        Suns
+      </li>
+      <li
+        aria-checked="false"
+        aria-posinset="5"
+        aria-selected="false"
+        aria-setsize="5"
+        class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+        data-test-selected="false"
+        id="option_7"
+        role="option"
+        title="Sol"
+      >
+        <span
+          class="euiSelectableListItem__content"
+        >
+          <span
+            class="euiSelectableListItem__icon"
+            data-euiicon-type="empty"
+          />
+          <span
+            class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+          >
+            <span>
+              Sol
+            </span>
+          </span>
+        </span>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`EuiSelectableListItem group labels renders with correct aria-setsize and aria-posinset offsets on non-group-labels 1`] = `
+<div
+  class="euiSelectableList testClass1 testClass2"
+  data-test-subj="test subject string"
+>
+  <div
+    data-eui="EuiAutoSizer"
+  >
+    <div
+      class="euiSelectableList__list"
+      style="position: relative; height: 208px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+      tabindex="-1"
+    >
+      <ul
+        aria-label="aria-label"
+        aria-multiselectable="true"
+        id="list"
+        role="listbox"
+        style="height: 256px; width: 100%;"
+        tabindex="0"
+      >
+        <li
+          aria-checked="false"
+          aria-posinset="1"
+          aria-selected="false"
+          aria-setsize="5"
+          class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+          data-test-selected="false"
+          id="option_0"
+          role="option"
+          style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
+          title="Spaaaace"
+        >
+          <span
+            class="euiSelectableListItem__content"
+          >
+            <span
+              class="euiSelectableListItem__icon"
+              data-euiicon-type="empty"
+            />
+            <span
+              class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+            >
+              <span>
+                Spaaaace
+              </span>
+            </span>
+          </span>
+        </li>
+        <li
+          class="euiSelectableList__groupLabel"
+          role="presentation"
+          style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
+        >
+          Moons
+        </li>
+        <li
+          aria-checked="false"
+          aria-posinset="2"
+          aria-selected="false"
+          aria-setsize="5"
+          class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+          data-test-selected="false"
+          id="option_2"
+          role="option"
+          style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
+          title="Titan"
+        >
+          <span
+            class="euiSelectableListItem__content"
+          >
+            <span
+              class="euiSelectableListItem__icon"
+              data-euiicon-type="empty"
+            />
+            <span
+              class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+            >
+              <span>
+                Titan
+              </span>
+            </span>
+          </span>
+        </li>
+        <li
+          aria-checked="false"
+          aria-posinset="3"
+          aria-selected="false"
+          aria-setsize="5"
+          class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+          data-test-selected="false"
+          id="option_3"
+          role="option"
+          style="position: absolute; left: 0px; top: 96px; height: 32px; width: 100%;"
+          title="Io"
+        >
+          <span
+            class="euiSelectableListItem__content"
+          >
+            <span
+              class="euiSelectableListItem__icon"
+              data-euiicon-type="empty"
+            />
+            <span
+              class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+            >
+              <span>
+                Io
+              </span>
+            </span>
+          </span>
+        </li>
+        <li
+          class="euiSelectableList__groupLabel"
+          role="presentation"
+          style="position: absolute; left: 0px; top: 128px; height: 32px; width: 100%;"
+        >
+          Planets
+        </li>
+        <li
+          aria-checked="false"
+          aria-posinset="4"
+          aria-selected="false"
+          aria-setsize="5"
+          class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+          data-test-selected="false"
+          id="option_5"
+          role="option"
+          style="position: absolute; left: 0px; top: 160px; height: 32px; width: 100%;"
+          title="Mercury"
+        >
+          <span
+            class="euiSelectableListItem__content"
+          >
+            <span
+              class="euiSelectableListItem__icon"
+              data-euiicon-type="empty"
+            />
+            <span
+              class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+            >
+              <span>
+                Mercury
+              </span>
+            </span>
+          </span>
+        </li>
+        <li
+          aria-checked="false"
+          aria-posinset="5"
+          aria-selected="false"
+          aria-setsize="5"
+          class="euiSelectableListItem euiSelectableListItem--paddingSmall"
+          data-test-selected="false"
+          id="option_6"
+          role="option"
+          style="position: absolute; left: 0px; top: 192px; height: 32px; width: 100%;"
+          title="Mars"
+        >
+          <span
+            class="euiSelectableListItem__content"
+          >
+            <span
+              class="euiSelectableListItem__icon"
+              data-euiicon-type="empty"
+            />
+            <span
+              class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
+            >
+              <span>
+                Mars
+              </span>
+            </span>
+          </span>
+        </li>
+        <li
+          class="euiSelectableList__groupLabel"
+          role="presentation"
+          style="position: absolute; left: 0px; top: 224px; height: 32px; width: 100%;"
+        >
+          Suns
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiSelectableList } from './selectable_list';
@@ -47,15 +47,16 @@ const selectableListRequiredProps = {
 
 describe('EuiSelectableListItem', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSelectableList options={options} {...selectableListRequiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
+
   describe('props', () => {
     test('visibleOptions', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           visibleOptions={options.slice(2)}
@@ -63,11 +64,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('searchValue', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           searchValue="Mi"
@@ -75,11 +76,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('searchValue', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           searchValue="Mi"
@@ -87,11 +88,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renderOption', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           renderOption={(option: EuiSelectableOption, searchValue?: string) => {
@@ -105,11 +106,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('height is forced', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           height={200}
@@ -117,11 +118,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('height is full', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           height="full"
@@ -129,11 +130,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('allowExclusions', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           allowExclusions
@@ -141,11 +142,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('activeOptionIndex', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           activeOptionIndex={2}
@@ -153,11 +154,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('rowHeight', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           rowHeight={20}
@@ -165,11 +166,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('showIcons can be turned off', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           showIcons={false}
@@ -177,11 +178,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('singleSelection can be turned on', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           singleSelection={true}
@@ -189,11 +190,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('singleSelection can be forced so that at least one must be selected', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           singleSelection="always"
@@ -201,11 +202,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('bordered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           bordered
@@ -213,11 +214,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isVirtualized can be false', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           isVirtualized={false}
@@ -225,11 +226,11 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('searchable enables correct screen reader instructions', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableList
           options={options}
           searchable={true}
@@ -237,13 +238,13 @@ describe('EuiSelectableListItem', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('paddingSize', () => {
       PADDING_SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiSelectableList
               options={options}
               paddingSize={size}
@@ -251,14 +252,14 @@ describe('EuiSelectableListItem', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('textWrap', () => {
       test('can be "wrap"', () => {
-        const component = render(
+        const { container } = render(
           <EuiSelectableList
             options={options}
             textWrap="wrap"
@@ -266,7 +267,7 @@ describe('EuiSelectableListItem', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -271,4 +271,61 @@ describe('EuiSelectableListItem', () => {
       });
     });
   });
+
+  describe('group labels', () => {
+    const optionsWithGroupLabels: EuiSelectableOption[] = [
+      { label: 'Spaaaace' },
+      {
+        label: 'Moons',
+        isGroupLabel: true,
+      },
+      { label: 'Titan' },
+      { label: 'Io' },
+      {
+        label: 'Planets',
+        isGroupLabel: true,
+      },
+      { label: 'Mercury' },
+      { label: 'Mars' },
+      {
+        label: 'Suns',
+        isGroupLabel: true,
+      },
+    ];
+
+    it('renders with correct aria-setsize and aria-posinset offsets on non-group-labels', () => {
+      const { container } = render(
+        <EuiSelectableList
+          options={optionsWithGroupLabels}
+          {...selectableListRequiredProps}
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('handles updating aria attrs correctly when options are changed/updated', () => {
+      const { container, rerender } = render(
+        <EuiSelectableList
+          options={optionsWithGroupLabels}
+          isVirtualized={false}
+          {...selectableListRequiredProps}
+        />
+      );
+
+      const updatedOptions: EuiSelectableOption[] = [
+        ...optionsWithGroupLabels.slice(1),
+        { label: 'Sol' },
+      ];
+      rerender(
+        <EuiSelectableList
+          options={updatedOptions}
+          isVirtualized={false}
+          {...selectableListRequiredProps}
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -221,6 +221,23 @@ export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
     super(props);
   }
 
+  ariaSetSize = 0;
+  ariaPosInSetMap: Record<number, number> = {};
+
+  calculateAriaSetAttrs = (optionArray: Array<EuiSelectableOption<T>>) => {
+    this.ariaPosInSetMap = {};
+    let latestAriaPosIndex = 0;
+
+    optionArray.forEach((option, index) => {
+      if (!option.isGroupLabel) {
+        latestAriaPosIndex++;
+        this.ariaPosInSetMap[index] = latestAriaPosIndex;
+      }
+    });
+
+    this.ariaSetSize = latestAriaPosIndex;
+  };
+
   ListRow = memo(({ data, index, style }: ListChildComponentProps<T>) => {
     const option = data[index];
     const { data: optionData, ..._option } = option;
@@ -268,7 +285,6 @@ export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
       );
     }
 
-    const labelCount = data.filter((option) => option.isGroupLabel).length;
     const id = makeOptionId(index);
 
     return (
@@ -290,8 +306,8 @@ export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
         disabled={disabled}
         prepend={prepend}
         append={append}
-        aria-posinset={index + 1 - labelCount}
-        aria-setsize={data.length - labelCount}
+        aria-posinset={this.ariaPosInSetMap[index]}
+        aria-setsize={this.ariaSetSize}
         onFocusBadge={onFocusBadge}
         allowExclusions={allowExclusions}
         showIcons={showIcons}
@@ -345,6 +361,8 @@ export class EuiSelectableList<T> extends Component<EuiSelectableListProps<T>> {
     } = this.props;
 
     const optionArray = visibleOptions || options;
+
+    this.calculateAriaSetAttrs(optionArray);
 
     const heightIsFull = forcedHeight === 'full';
 

--- a/upcoming_changelogs/6571.md
+++ b/upcoming_changelogs/6571.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSelectable` options with incorrect `aria-posinset` indices when rendered with group labels not at the start of the array


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6565

This bug was occurring whenever group labels existed in the `options` array that were not located at the start of the array.

## QA

- Go to https://eui.elastic.co/pr_6571/#/forms/selectable and inspect the `<li>` items in the first example.
- [x] Confirm they have the correct `aria-posinset` indices before and after the group label(s)
- [x] Confirm axe passes a page scan

### General checklist

- [x] Revert [REVERT ME] commit
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
