### PR TITLE
[EuiSearchBar] Fix `multiSelect: false` filter behavior

### DIFF
--- a/src/components/search_bar/filters/field_value_selection_filter.tsx
+++ b/src/components/search_bar/filters/field_value_selection_filter.tsx
@@ -259,23 +259,23 @@ export class FieldValueSelectionFilter extends Component<
     if (!multiSelect && autoClose) {
       this.closePopover();
       const query = checked
-        ? this.props.query.removeSimpleFieldClauses(field)
-        : this.props.query
+        ? this.props.query
             .removeSimpleFieldClauses(field)
-            .addSimpleFieldValue(field, value, true, operator);
+            .addSimpleFieldValue(field, value, true, operator)
+        : this.props.query.removeSimpleFieldClauses(field);
 
       this.props.onChange(query);
     } else {
       if (multiSelect === 'or') {
         const query = checked
-          ? this.props.query.removeOrFieldValue(field, value)
-          : this.props.query.addOrFieldValue(field, value, true, operator);
+          ? this.props.query.addOrFieldValue(field, value, true, operator)
+          : this.props.query.removeOrFieldValue(field, value);
 
         this.props.onChange(query);
       } else {
         const query = checked
-          ? this.props.query.removeSimpleFieldValue(field, value)
-          : this.props.query.addSimpleFieldValue(field, value, true, operator);
+          ? this.props.query.addSimpleFieldValue(field, value, true, operator)
+          : this.props.query.removeSimpleFieldValue(field, value);
 
         this.props.onChange(query);
       }
@@ -404,15 +404,12 @@ export class FieldValueSelectionFilter extends Component<
           listProps={{
             isVirtualized: isOverSearchThreshold || false,
           }}
-          onChange={(options) => {
-            const diff = items.find(
-              (item, index) => item.checked !== options[index].checked
-            );
-            if (diff) {
+          onChange={(options, event, changedOption) => {
+            if (changedOption.data) {
               this.onOptionClick(
-                diff.data.optionField,
-                diff.data.value,
-                diff.checked
+                changedOption.data.optionField,
+                changedOption.data.value,
+                changedOption.checked
               );
             }
           }}

--- a/upcoming_changelogs/6577.md
+++ b/upcoming_changelogs/6577.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a bug with `EuiSearchBar` where filters with `multiSelect: false` were not able to select a new option when an option was already selected


### PR DESCRIPTION
## Summary

closes #6540
closes #6569

Huge shout out to @robert-seymour-numerated for extremely accurately narrowing down the location in our code in which this bug was occurring, saving me a whole bunch of time 🙌 

And another bonus shout out to @Heenawter for requesting the new `changedOption` parameter/API that we added in #6487, which made this fix extremely easy and require 0 array iteration/comparison 🎉 

I recommend checking the git commit messages for more context & detail as to how the fix works.

### Before
![before](https://user-images.githubusercontent.com/549407/216481121-9b32b929-86a3-4d01-afc5-e0de7de0880e.gif)

### After
![after](https://user-images.githubusercontent.com/549407/216481129-3cbe101b-8cef-4337-981b-d7408225447e.gif)

## QA

The buggy behavior can be reproduced/compared against [production docs](https://elastic.github.io/eui/#/tabular-content/in-memory-tables#in-memory-table-selection).

- Go to https://eui.elastic.co/pr_6577/#/tabular-content/in-memory-tables#in-memory-table-selection, click "Load users"
- Click the "Country" filter button and select any country. Confirm it shows 1 filter badge
- Open the "Country" filter again and select any **other** country
- [x] Confirm that it correctly sets the filter to the new country, and the filter badge count remains at one

### Regression testing

- Go to https://eui.elastic.co/pr_6577/#/tabular-content/in-memory-tables#in-memory-table-with-search-and-external-state
- Click the "Location" filter button
- [x] Confirm that filtering by multiple countries works as expected/as before with no regressions
- Go to https://eui.elastic.co/pr_6577/#/forms/search-bar
- Click the "Tag" filter button
- [x] Confirm that filtering by multiple tags (and removing tags) works as expected/as before

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
