### PR TITLE
[EuiCodeBlock] Add new `lineNumbers.annotations` API

### DIFF
--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -54,8 +54,18 @@ const codeBlockLinesSnippet = `<EuiCodeBlock language="json" lineNumbers>
 `;
 import CodeBlockLinesHighlight from './line_numbers_highlight';
 const codeBlockLinesHighlightSource = require('!!raw-loader!./line_numbers_highlight');
-const codeBlockLinesHighlightSnippet = `<EuiCodeBlock language="json" lineNumbers={{ start: 32, highlight: '32, 34-37, 40' }}>
-{}
+const codeBlockLinesHighlightSnippet = `<EuiCodeBlock
+  language="json"
+  lineNumbers={{
+    start: 32,
+    highlight: '32, 34-37, 40',
+    annotations: {
+      33: <>A <b>special</b> note about this line</>,
+      45: 'Also accepts quick plaintext notes',
+    }
+  }}
+>
+  {}
 </EuiCodeBlock>
 `;
 
@@ -225,14 +235,30 @@ export const CodeExample = {
     },
     {
       text: (
-        <p>
-          You can also optionally change the starting number and/or visually
-          highlight certain lines by passing a configuration object:{' '}
-          <EuiCode>
-            {'lineNumbers={{ start: 32, highlight: "32, 34-37, 40" }}'}
-          </EuiCode>
-          .
-        </p>
+        <>
+          <p>
+            You can customize line number display further with a configuration
+            object containing the following optional settings:
+          </p>
+          <ul>
+            <li>
+              <EuiCode>start</EuiCode>: Changes the starting number of the first
+              line. Defaults to <EuiCode>1</EuiCode>.
+            </li>
+            <li>
+              <EuiCode>highlight</EuiCode>: Visually highlights certain lines
+              (e.g. <EuiCode>&quot;3</EuiCode>), or ranges of lines (e.g.{' '}
+              <EuiCode>&quot;5-10&quot;</EuiCode>). Accepts a comma-separated
+              string of lines or line ranges.
+            </li>
+            <li>
+              <EuiCode>annotations</EuiCode>: Displays an informational icon
+              next to certain line numbers, that provides more context via a
+              popover. Pass an object of line numbers with corresponding
+              annotations (accepts strings or React nodes).
+            </li>
+          </ul>
+        </>
       ),
       source: [
         {

--- a/src-docs/src/views/code/line_numbers_highlight.tsx
+++ b/src-docs/src/views/code/line_numbers_highlight.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
 
-import { EuiCodeBlock } from '../../../../src/components';
+import { EuiCodeBlock, EuiCode } from '../../../../src/components';
 
 export default () => (
   <EuiCodeBlock
     language="json"
     fontSize="m"
     paddingSize="m"
-    lineNumbers={{ start: 32, highlight: '32, 34-37, 40' }}
+    lineNumbers={{
+      start: 32,
+      highlight: '32, 34-37, 40',
+      annotations: {
+        34: 'Coordinates can be obtained from Elastic Maps',
+        38: (
+          <>
+            Allowed types: <EuiCode>Point</EuiCode>, <EuiCode>Area</EuiCode>
+          </>
+        ),
+      },
+    }}
   >
     {`"OriginLocation": [
   {

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -96,6 +96,86 @@ exports[`EuiCodeBlock fullscreen displays content in fullscreen mode 1`] = `
 </div>
 `;
 
+exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
+<div
+  class="euiCodeBlock testClass1 testClass2 emotion-euiCodeBlock-s"
+>
+  <pre
+    class="euiCodeBlock__pre emotion-euiCodeBlock__pre-preWrap-padding"
+    tabindex="-1"
+  >
+    <code
+      aria-label="aria-label"
+      class="euiCodeBlock__code emotion-euiCodeBlock__code"
+      data-code-language="text"
+      data-test-subj="test subject string"
+    >
+      <span
+        class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
+      >
+        <span
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          data-line-number="1"
+          style="inline-size:8px"
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            1
+          </span>
+          <div
+            class="euiPopover emotion-euiPopover-euiCodeBlockAnnotation"
+          >
+            <div
+              class="euiPopover__anchor css-16vtueo-render"
+            >
+              <button
+                aria-label="Click to view a code annotation for line 1"
+                class="emotion-euiCodeBlockAnnotation__buttonIcon"
+                data-test-subj="euiCodeBlockAnnotationIcon"
+              >
+                <span
+                  color="ghost"
+                  data-euiicon-type="AnnotationInfoIcon"
+                />
+              </button>
+            </div>
+          </div>
+        </span>
+        <span
+          class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
+        >
+          var some = 'code';
+
+        </span>
+      </span>
+      <span
+        class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
+      >
+        <span
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          data-line-number="2"
+          style="inline-size:8px"
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            2
+          </span>
+        </span>
+        <span
+          class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
+        >
+          console.log(some);
+        </span>
+      </span>
+    </code>
+  </pre>
+</div>
+`;
+
 exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
 <div
   class="euiCodeBlock testClass1 testClass2 emotion-euiCodeBlock-s"
@@ -114,11 +194,17 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          aria-hidden="true"
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
           data-line-number="1"
           style="inline-size:8px"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            1
+          </span>
+        </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText-isHighlighted"
         >
@@ -130,11 +216,17 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          aria-hidden="true"
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
           data-line-number="2"
           style="inline-size:8px"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            2
+          </span>
+        </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
         >
@@ -164,11 +256,17 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          aria-hidden="true"
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
           data-line-number="1"
           style="inline-size:8px"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            1
+          </span>
+        </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
         >
@@ -180,11 +278,17 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          aria-hidden="true"
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
           data-line-number="2"
           style="inline-size:8px"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            2
+          </span>
+        </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
         >
@@ -214,11 +318,17 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          aria-hidden="true"
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
           data-line-number="10"
           style="inline-size:16px"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            10
+          </span>
+        </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
         >
@@ -230,11 +340,17 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          aria-hidden="true"
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
+          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
           data-line-number="11"
           style="inline-size:16px"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="emotion-euiCodeBlock__lineNumber"
+          >
+            11
+          </span>
+        </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
         >

--- a/src/components/code/__snapshots__/code_block_annotations.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block_annotations.test.tsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCodeBlockAnnotation renders 1`] = `
+<body>
+  <div>
+    <div
+      class="euiPopover euiPopover-isOpen emotion-euiPopover-euiCodeBlockAnnotation"
+    >
+      <div
+        class="euiPopover__anchor css-16vtueo-render"
+      >
+        <button
+          aria-label="Click to view a code annotation for line 10"
+          class="emotion-euiCodeBlockAnnotation__buttonIcon"
+          data-test-subj="euiCodeBlockAnnotationIcon"
+        >
+          <span
+            color="ghost"
+            data-euiicon-type="AnnotationInfoIcon"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-isOpen-left"
+        data-autofocus="true"
+        data-popover-open="true"
+        data-popover-panel="true"
+        data-test-subj="euiCodeBlockAnnotationPopover"
+        role="dialog"
+        style="top: -22px; left: -16px; z-index: 6001;"
+        tabindex="0"
+      >
+        <div
+          class="euiPopover__arrow emotion-euiPopoverArrow-left"
+          data-popover-arrow="left"
+          style="left: 0px; top: 10px;"
+        />
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
+        </p>
+        <div>
+          <span
+            data-test-subj="popoverContent"
+          >
+            Popover content
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/src/components/code/__snapshots__/utils.test.tsx.snap
+++ b/src/components/code/__snapshots__/utils.test.tsx.snap
@@ -1,27 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`shared utils nodeToHtml recursively converts refactor nodes to React JSX 1`] = `
-<div>
-  <span
-    className="hello-world"
-    key="node-0-0"
-  >
-    Hello world
-  </span>
-</div>
-`;
-
 exports[`line utils highlightByLine with line numbers renders two elements per line: .euiCodeBlock__lineNumber and .euiCodeBlock__lineText 1`] = `
 Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "1",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 1,
           "style": Object {
@@ -64,7 +69,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -83,12 +88,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "2",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 2,
           "style": Object {
@@ -203,7 +224,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -222,12 +243,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "3",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 3,
           "style": Object {
@@ -269,7 +306,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -293,12 +330,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "10",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 10,
           "style": Object {
@@ -341,7 +394,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -360,12 +413,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "11",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 11,
           "style": Object {
@@ -480,7 +549,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -499,12 +568,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "12",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 12,
           "style": Object {
@@ -546,7 +631,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -565,17 +650,38 @@ Array [
 ]
 `;
 
-exports[`line utils highlightByLine with line numbers with highlighted lines adds a class to the specified lines 1`] = `
+exports[`line utils highlightByLine with line numbers with annotations adds a custom annotation object after the lineNumber object 1`] = `
 Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "1",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+          Object {
+            "annotation": "Hello world",
+            "lineNumber": 1,
+            "type": "annotation",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 1,
           "style": Object {
@@ -618,7 +724,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-1k1cwxr-euiCodeBlock__lineText-isHighlighted",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -637,12 +743,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "2",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 2,
           "style": Object {
@@ -757,7 +879,7 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-1k1cwxr-euiCodeBlock__lineText-isHighlighted",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -776,12 +898,28 @@ Array [
   Object {
     "children": Array [
       Object {
-        "children": Array [],
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "3",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
         "properties": Object {
-          "aria-hidden": true,
           "className": Array [
             "euiCodeBlock__lineNumber",
-            "css-13odi3l-euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "data-line-number": 3,
           "style": Object {
@@ -823,7 +961,332 @@ Array [
         "properties": Object {
           "className": Array [
             "euiCodeBlock__lineText",
-            "css-ttqtsf-euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
+          ],
+        },
+        "tagName": "span",
+        "type": "element",
+      },
+    ],
+    "properties": Object {
+      "className": Array [
+        "euiCodeBlock__line",
+        "css-8rt6cm-euiCodeBlock__line-hasLineNumbers",
+      ],
+    },
+    "tagName": "span",
+    "type": "element",
+  },
+]
+`;
+
+exports[`line utils highlightByLine with line numbers with highlighted lines adds a class to the specified lines 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "1",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
+        "properties": Object {
+          "className": Array [
+            "euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
+          ],
+          "data-line-number": 1,
+          "style": Object {
+            "inlineSize": 8,
+          },
+        },
+        "tagName": "span",
+        "type": "element",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "lineEnd": 1,
+                "lineStart": 1,
+                "type": "text",
+                "value": "{",
+              },
+            ],
+            "lineEnd": 1,
+            "lineStart": 1,
+            "properties": Object {
+              "className": Array [
+                "token",
+                "punctuation",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+          Object {
+            "lineEnd": 1,
+            "lineStart": 1,
+            "type": "text",
+            "value": "
+",
+          },
+        ],
+        "properties": Object {
+          "className": Array [
+            "euiCodeBlock__lineText",
+            "css-96t2rh-euiCodeBlock__lineText-isHighlighted",
+          ],
+        },
+        "tagName": "span",
+        "type": "element",
+      },
+    ],
+    "properties": Object {
+      "className": Array [
+        "euiCodeBlock__line",
+        "css-8rt6cm-euiCodeBlock__line-hasLineNumbers",
+      ],
+    },
+    "tagName": "span",
+    "type": "element",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "2",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
+        "properties": Object {
+          "className": Array [
+            "euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
+          ],
+          "data-line-number": 2,
+          "style": Object {
+            "inlineSize": 8,
+          },
+        },
+        "tagName": "span",
+        "type": "element",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "lineEnd": 2,
+            "lineStart": 2,
+            "type": "text",
+            "value": "    ",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "lineEnd": 2,
+                "lineStart": 2,
+                "type": "text",
+                "value": "\\"id\\"",
+              },
+            ],
+            "lineEnd": 2,
+            "lineStart": 2,
+            "properties": Object {
+              "className": Array [
+                "token",
+                "property",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "lineEnd": 2,
+                "lineStart": 2,
+                "type": "text",
+                "value": ":",
+              },
+            ],
+            "lineEnd": 2,
+            "lineStart": 2,
+            "properties": Object {
+              "className": Array [
+                "token",
+                "operator",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+          Object {
+            "lineEnd": 2,
+            "lineStart": 2,
+            "type": "text",
+            "value": " ",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "lineEnd": 2,
+                "lineStart": 2,
+                "type": "text",
+                "value": "\\"1\\"",
+              },
+            ],
+            "lineEnd": 2,
+            "lineStart": 2,
+            "properties": Object {
+              "className": Array [
+                "token",
+                "string",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "lineEnd": 2,
+                "lineStart": 2,
+                "type": "text",
+                "value": ",",
+              },
+            ],
+            "lineEnd": 2,
+            "lineStart": 2,
+            "properties": Object {
+              "className": Array [
+                "token",
+                "punctuation",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+          Object {
+            "lineEnd": 2,
+            "lineStart": 2,
+            "type": "text",
+            "value": "
+",
+          },
+        ],
+        "properties": Object {
+          "className": Array [
+            "euiCodeBlock__lineText",
+            "css-96t2rh-euiCodeBlock__lineText-isHighlighted",
+          ],
+        },
+        "tagName": "span",
+        "type": "element",
+      },
+    ],
+    "properties": Object {
+      "className": Array [
+        "euiCodeBlock__line",
+        "css-8rt6cm-euiCodeBlock__line-hasLineNumbers",
+      ],
+    },
+    "tagName": "span",
+    "type": "element",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "type": "text",
+                "value": "3",
+              },
+            ],
+            "properties": Object {
+              "aria-hidden": true,
+              "className": Array [
+                "css-5u6z3m-euiCodeBlock__lineNumber",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
+        "properties": Object {
+          "className": Array [
+            "euiCodeBlock__lineNumber",
+            "css-wlfghs-euiCodeBlock__lineNumberWrapper",
+          ],
+          "data-line-number": 3,
+          "style": Object {
+            "inlineSize": 8,
+          },
+        },
+        "tagName": "span",
+        "type": "element",
+      },
+      Object {
+        "children": Array [
+          Object {
+            "lineEnd": 3,
+            "lineStart": 3,
+            "type": "text",
+            "value": "  ",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "lineEnd": 3,
+                "lineStart": 3,
+                "type": "text",
+                "value": "}",
+              },
+            ],
+            "lineEnd": 3,
+            "lineStart": 3,
+            "properties": Object {
+              "className": Array [
+                "token",
+                "punctuation",
+              ],
+            },
+            "tagName": "span",
+            "type": "element",
+          },
+        ],
+        "properties": Object {
+          "className": Array [
+            "euiCodeBlock__lineText",
+            "css-rnrc4n-euiCodeBlock__lineText",
           ],
         },
         "tagName": "span",
@@ -1033,4 +1496,31 @@ Array [
     "type": "element",
   },
 ]
+`;
+
+exports[`shared utils nodeToHtml handles rendering custom annotation types 1`] = `
+<div>
+  <span
+    className="hello-world"
+    key="node-0-0"
+  >
+    <EuiCodeBlockAnnotation
+      key="0"
+      lineNumber={3}
+    >
+      Hello world
+    </EuiCodeBlockAnnotation>
+  </span>
+</div>
+`;
+
+exports[`shared utils nodeToHtml recursively converts refactor nodes to React JSX 1`] = `
+<div>
+  <span
+    className="hello-world"
+    key="node-0-0"
+  >
+    Hello world
+  </span>
+</div>
 `;

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -264,5 +264,17 @@ describe('EuiCodeBlock', () => {
       );
       expect(component).toMatchSnapshot();
     });
+
+    it('renders annotated line numbers', () => {
+      const component = render(
+        <EuiCodeBlock
+          lineNumbers={{ annotations: { 1: 'hello world' } }}
+          {...requiredProps}
+        >
+          {code}
+        </EuiCodeBlock>
+      );
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -18,6 +18,7 @@ import {
   getHtmlContent,
   highlightByLine,
 } from './utils';
+import { LineAnnotationMap } from './code_block_annotations';
 import { useOverflow } from './code_block_overflow';
 import { useCopy } from './code_block_copy';
 import {
@@ -62,6 +63,7 @@ type VirtualizedOptionProps = ExclusiveUnion<
 interface LineNumbersConfig {
   start?: number;
   highlight?: string;
+  annotations?: LineAnnotationMap;
 }
 
 export type EuiCodeBlockProps = EuiCodeSharedProps & {
@@ -82,8 +84,9 @@ export type EuiCodeBlockProps = EuiCodeSharedProps & {
 
   /**
    * Displays line numbers.
-   * Optionally accepts a configuration object for setting the starting number and visual highlighting ranges:
-   * `{ start: 100, highlight: '1, 5-10, 20-30, 40' }`
+   * Optionally accepts a configuration object for setting the starting number,
+   * visually highlighting ranges, or annotating specific lines:
+   * `{ start: 100, highlight: '1, 5-10, 20-30, 40', annotations: { 6: 'A special note about this line' } }`
    */
   lineNumbers?: boolean | LineNumbersConfig;
 

--- a/src/components/code/code_block_annotations.spec.tsx
+++ b/src/components/code/code_block_annotations.spec.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="../../../cypress/support"/>
+
+import React from 'react';
+
+import { EuiCodeBlock } from './code_block';
+
+describe('EuiCodeBlock annotations', () => {
+  describe('non-virtualized', () => {
+    const content = `"OriginLocation": [
+  {
+    "coordinates": [
+      -97.43309784,
+      37.64989853
+    ],
+    "type": "Point"
+  }
+],`;
+
+    it('renders a clickable annotation icon that toggles a popover', () => {
+      cy.mount(
+        <EuiCodeBlock
+          language="json"
+          fontSize="m"
+          paddingSize="m"
+          lineNumbers={{
+            annotations: {
+              1: 'Annotation',
+            },
+          }}
+        >
+          {content}
+        </EuiCodeBlock>
+      );
+      cy.get('[data-test-subj="euiCodeBlockAnnotationIcon"]').click();
+      cy.contains(
+        '[data-test-subj="euiCodeBlockAnnotationPopover"]',
+        'Annotation'
+      );
+    });
+  });
+
+  describe('virtualized', () => {
+    const content = `{
+    "id": "1",
+    "rawResponse": {
+      "took": 19,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      }
+    },
+    "id": "2",
+    "rawResponse": {
+      "took": 20,
+      "timed_out": false,
+      "_shards": {
+        "total": 2,
+        "successful": 0,
+        "skipped": 1,
+        "failed": 1
+      }
+    }
+  }`;
+
+    const virtualizedCodeBlock = (
+      <EuiCodeBlock
+        language="json"
+        isVirtualized
+        overflowHeight={200}
+        lineNumbers={{
+          start: 32,
+          highlight: '33-42',
+          annotations: {
+            35: (
+              <span data-test-subj="annotation1">
+                Annotation <a href="#">1</a>
+              </span>
+            ),
+            52: (
+              <span data-test-subj="annotation2">
+                Annotation <strong>2</strong>
+              </span>
+            ),
+          },
+        }}
+      >
+        {content}
+      </EuiCodeBlock>
+    );
+
+    it('renders annotations in virtualized code blocks', () => {
+      cy.mount(virtualizedCodeBlock);
+      cy.get('[data-test-subj="euiCodeBlockAnnotationIcon"]').click();
+      cy.get('[data-test-subj="annotation1"]').should(
+        'have.text',
+        'Annotation 1'
+      );
+      cy.realPress('Escape');
+      cy.get('.euiCodeBlock__pre').scrollTo(0, 500);
+      cy.wait(100);
+      cy.get('.euiCodeBlock__pre').scrollTo(0, 500);
+      cy.get('[data-test-subj="euiCodeBlockAnnotationIcon"]').click();
+      cy.get('[data-test-subj="annotation2"]').should(
+        'have.text',
+        'Annotation 2'
+      );
+    });
+
+    it('renders annotations in fullscreen mode', () => {
+      cy.mount(virtualizedCodeBlock);
+      cy.get('.euiCodeBlock__fullScreenButton').click();
+      cy.get('.euiCodeBlockFullScreen')
+        .find('[data-test-subj="euiCodeBlockAnnotationIcon"]')
+        .first()
+        .focus()
+        .realPress('Enter');
+      cy.get('[data-test-subj="annotation1"]').should(
+        'have.text',
+        'Annotation 1'
+      );
+      cy.realPress('Tab');
+      cy.realPress('Escape');
+      cy.get('.euiCodeBlockFullScreen')
+        .find('[data-test-subj="euiCodeBlockAnnotationIcon"]')
+        .last()
+        .focus()
+        .realPress('Enter');
+      cy.get('[data-test-subj="annotation2"]').should(
+        'have.text',
+        'Annotation 2'
+      );
+    });
+  });
+});

--- a/src/components/code/code_block_annotations.style.ts
+++ b/src/components/code/code_block_annotations.style.ts
@@ -7,23 +7,28 @@
  */
 
 import { css } from '@emotion/react';
-import { logicalCSS, logicalSizeCSS } from '../../global_styling';
+import {
+  logicalCSS,
+  logicalSizeCSS,
+  mathWithUnits,
+} from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
 export const euiCodeBlockAnnotationsStyles = (
   euiTheme: UseEuiTheme['euiTheme']
 ) => {
+  const buttonIconSize = mathWithUnits(euiTheme.size.base, (x) => x - 1.5);
+
   return {
     euiCodeBlockAnnotation: css`
       position: absolute;
       ${logicalCSS('right', 0)}
       ${logicalCSS('top', '50%')}
-      transform: translateY(-50%) translateX(50%);
+      transform: translate(50%, -50%);
       line-height: 1;
     `,
     euiCodeBlockAnnotation__buttonIcon: css`
-      ${logicalSizeCSS(euiTheme.size.base)}
-      transform: scale(0.9);
+      ${logicalSizeCSS(buttonIconSize)}
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/components/code/code_block_annotations.style.ts
+++ b/src/components/code/code_block_annotations.style.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { logicalCSS, logicalSizeCSS } from '../../global_styling';
+import { UseEuiTheme } from '../../services';
+
+export const euiCodeBlockAnnotationsStyles = (
+  euiTheme: UseEuiTheme['euiTheme']
+) => {
+  return {
+    euiCodeBlockAnnotation: css`
+      position: absolute;
+      ${logicalCSS('right', 0)}
+      ${logicalCSS('top', '50%')}
+      transform: translateY(-50%) translateX(50%);
+      line-height: 1;
+    `,
+    euiCodeBlockAnnotation__buttonIcon: css`
+      ${logicalSizeCSS(euiTheme.size.base)}
+      transform: scale(0.9);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: ${euiTheme.colors.primary};
+      border-radius: 50%;
+    `,
+  };
+};

--- a/src/components/code/code_block_annotations.test.tsx
+++ b/src/components/code/code_block_annotations.test.tsx
@@ -29,4 +29,6 @@ describe('EuiCodeBlockAnnotation', () => {
 
     expect(baseElement).toMatchSnapshot();
   });
+
+  // See code_block_annotations.spec.tsx for more in-depth E2E testing
 });

--- a/src/components/code/code_block_annotations.test.tsx
+++ b/src/components/code/code_block_annotations.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import { fireEvent } from '@testing-library/dom';
+import { render, waitForEuiPopoverOpen } from '../../test/rtl';
+
+import { EuiCodeBlockAnnotation } from './code_block_annotations';
+
+describe('EuiCodeBlockAnnotation', () => {
+  // No `requiredProps` or `shouldRenderCustomStyles` - this is not currently meant to be a highly customizable component
+
+  it('renders', async () => {
+    const { baseElement, getByTestSubject } = render(
+      <EuiCodeBlockAnnotation lineNumber={10}>
+        <span data-test-subj="popoverContent">Popover content</span>
+      </EuiCodeBlockAnnotation>
+    );
+
+    fireEvent.click(getByTestSubject('euiCodeBlockAnnotationIcon'));
+    await waitForEuiPopoverOpen();
+    expect(getByTestSubject('popoverContent')).toBeTruthy();
+
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/src/components/code/code_block_annotations.tsx
+++ b/src/components/code/code_block_annotations.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, ReactNode, useState } from 'react';
+
+import { useEuiTheme } from '../../services';
+import { useEuiI18n } from '../i18n';
+import { EuiPopover } from '../popover';
+import { EuiIcon } from '../icon';
+
+import { euiCodeBlockAnnotationsStyles } from './code_block_annotations.style';
+
+export type LineAnnotationMap = Record<number, ReactNode>;
+
+export const EuiCodeBlockAnnotation: FunctionComponent<{
+  lineNumber: number;
+}> = ({ lineNumber, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const ariaLabel = useEuiI18n(
+    'euiCodeBlockAnnotations.ariaLabel',
+    'Click to view a code annotation for line {lineNumber}',
+    { lineNumber }
+  );
+
+  const { euiTheme } = useEuiTheme();
+  const styles = euiCodeBlockAnnotationsStyles(euiTheme);
+
+  return (
+    <EuiPopover
+      isOpen={isOpen}
+      closePopover={() => setIsOpen(false)}
+      button={
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          aria-label={ariaLabel}
+          css={styles.euiCodeBlockAnnotation__buttonIcon}
+          data-test-subj="euiCodeBlockAnnotationIcon"
+        >
+          <EuiIcon type={AnnotationInfoIcon} color="ghost" size="s" />
+        </button>
+      }
+      css={styles.euiCodeBlockAnnotation}
+      zIndex={Number(euiTheme.levels.mask) + 1} // Ensure fullscreen annotation popovers sit above the mask
+      anchorPosition="leftCenter"
+      panelProps={{ 'data-test-subj': 'euiCodeBlockAnnotationPopover' }}
+    >
+      {children}
+    </EuiPopover>
+  );
+};
+
+const AnnotationInfoIcon: FunctionComponent = (props) => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M7.139 14l-.052-6.007H5V6.28h4.111l.052 6.007h1.915V14h-3.94zM6.712 3.38c0-.396.118-.725.354-.987S7.639 2 8.077 2c.438 0 .777.131 1.016.393.24.262.359.591.359.987 0 .39-.12.714-.359.972s-.578.388-1.016.388c-.438 0-.775-.13-1.011-.388-.236-.258-.354-.582-.354-.972z"
+    />
+  </svg>
+);

--- a/src/components/code/code_block_annotations.tsx
+++ b/src/components/code/code_block_annotations.tsx
@@ -12,6 +12,7 @@ import { useEuiTheme } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { EuiPopover } from '../popover';
 import { EuiIcon } from '../icon';
+import { useEuiButtonFocusCSS } from '../../themes/amsterdam/global_styling/mixins/button';
 
 import { euiCodeBlockAnnotationsStyles } from './code_block_annotations.style';
 
@@ -28,8 +29,15 @@ export const EuiCodeBlockAnnotation: FunctionComponent<{
     { lineNumber }
   );
 
-  const { euiTheme } = useEuiTheme();
+  const { euiTheme, colorMode } = useEuiTheme();
   const styles = euiCodeBlockAnnotationsStyles(euiTheme);
+  const buttonIconFocusStyle = useEuiButtonFocusCSS();
+  const cssButtonIconStyles = [
+    styles.euiCodeBlockAnnotation__buttonIcon,
+    buttonIconFocusStyle,
+  ];
+
+  const isDarkMode = colorMode === 'DARK';
 
   return (
     <EuiPopover
@@ -39,10 +47,14 @@ export const EuiCodeBlockAnnotation: FunctionComponent<{
         <button
           onClick={() => setIsOpen(!isOpen)}
           aria-label={ariaLabel}
-          css={styles.euiCodeBlockAnnotation__buttonIcon}
+          css={cssButtonIconStyles}
           data-test-subj="euiCodeBlockAnnotationIcon"
         >
-          <EuiIcon type={AnnotationInfoIcon} color="ghost" size="s" />
+          <EuiIcon
+            type={AnnotationInfoIcon}
+            size="s"
+            color={isDarkMode ? euiTheme.colors.ink : 'ghost'}
+          />
         </button>
       }
       css={styles.euiCodeBlockAnnotation}
@@ -57,8 +69,8 @@ export const EuiCodeBlockAnnotation: FunctionComponent<{
 
 const AnnotationInfoIcon: FunctionComponent = (props) => (
   <svg
-    width={16}
-    height={16}
+    width={11}
+    height={11}
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/code/code_block_full_screen.tsx
+++ b/src/components/code/code_block_full_screen.tsx
@@ -38,9 +38,16 @@ export const useFullScreen = ({
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
     if (event.key === keys.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      setIsFullScreen(false);
+      // We need to make sure annotation Escape keypresses don't also cause fullscreen mode to close
+      const focus = document.activeElement as HTMLElement;
+      const isAnnotationPopover =
+        !!focus?.dataset.popoverOpen || !!focus?.closest('[data-popover-open]');
+
+      if (!isAnnotationPopover) {
+        event.preventDefault();
+        event.stopPropagation();
+        setIsFullScreen(false);
+      }
     }
   }, []);
 

--- a/src/components/code/code_block_line.styles.ts
+++ b/src/components/code/code_block_line.styles.ts
@@ -35,7 +35,7 @@ export const euiCodeBlockLineStyles = (euiThemeContext: UseEuiTheme) => {
       euiCodeBlock__lineText: css`
         flex-grow: 1;
         display: inline-block;
-        padding-inline-start: ${euiTheme.size.s};
+        padding-inline-start: ${euiTheme.size.m};
         border-inline-start: ${euiTheme.border.thin};
         user-select: text;
       `,
@@ -47,10 +47,11 @@ export const euiCodeBlockLineStyles = (euiThemeContext: UseEuiTheme) => {
     },
     lineNumber: {
       euiCodeBlock__lineNumber: css`
+        position: relative;
         flex-grow: 0;
         flex-shrink: 0;
         user-select: none;
-        padding-inline-end: ${euiTheme.size.s};
+        padding-inline-end: ${euiTheme.size.m};
         box-sizing: content-box; // Width is calculated in JS and padding needs to be added on to that value.
 
         &:before {

--- a/src/components/code/code_block_line.styles.ts
+++ b/src/components/code/code_block_line.styles.ts
@@ -46,20 +46,18 @@ export const euiCodeBlockLineStyles = (euiThemeContext: UseEuiTheme) => {
       `,
     },
     lineNumber: {
-      euiCodeBlock__lineNumber: css`
+      euiCodeBlock__lineNumberWrapper: css`
         position: relative;
         flex-grow: 0;
         flex-shrink: 0;
         user-select: none;
         padding-inline-end: ${euiTheme.size.m};
         box-sizing: content-box; // Width is calculated in JS and padding needs to be added on to that value.
-
-        &:before {
-          content: attr(data-line-number);
-          color: ${euiTheme.colors.subduedText};
-          text-align: end;
-          display: block;
-        }
+      `,
+      euiCodeBlock__lineNumber: css`
+        color: ${euiTheme.colors.subduedText};
+        text-align: end;
+        display: block;
       `,
     },
   };

--- a/src/components/code/utils.test.tsx
+++ b/src/components/code/utils.test.tsx
@@ -69,6 +69,28 @@ describe('shared utils', () => {
       const component = shallow(<div>{output}</div>);
       expect(component).toMatchSnapshot();
     });
+
+    it('handles rendering custom annotation types', () => {
+      const output = nodeToHtml(
+        {
+          type: 'element',
+          tagName: 'span',
+          children: [
+            {
+              // @ts-ignore - custom annotation type
+              type: 'annotation',
+              lineNumber: 3,
+              annotation: 'Hello world',
+            },
+          ],
+          properties: { className: ['hello-world'] },
+        },
+        0,
+        []
+      );
+      const component = shallow(<div>{output}</div>);
+      expect(component).toMatchSnapshot();
+    });
   });
 });
 
@@ -136,6 +158,23 @@ describe('line utils', () => {
               'euiCodeBlock__lineText-isHighlighted'
             )
           ).toBe(true);
+        });
+      });
+
+      describe('with annotations', () => {
+        it('adds a custom annotation object after the lineNumber object', () => {
+          const annotation = highlightByLineWithTheme({
+            show: true,
+            start: 1,
+            annotations: { 1: 'Hello world' },
+          });
+          expect(annotation).toMatchSnapshot();
+          // @ts-expect-error RefractorNode
+          expect(annotation[0].children[0].children[1]).toEqual({
+            type: 'annotation',
+            lineNumber: 1,
+            annotation: 'Hello world',
+          });
         });
       });
     });

--- a/upcoming_changelogs/6580.md
+++ b/upcoming_changelogs/6580.md
@@ -1,0 +1,1 @@
+- Added a new `lineNumbers.annotations` API to `EuiCodeBlock`. This new feature displays an informational icon next to the specified line number(s), providing more context via popover


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6564

![screencap](https://user-images.githubusercontent.com/549407/217389263-f95de504-eb05-4c29-b169-8f9ae0b001ce.gif)

This PR implements a new `annotations` API for EuiCodeBlock, with the primary purpose of aiding the @elastic/docs-engineering team and new Elastic docs efforts.

Example usage:

```jsx
<EuiCodeBlock
  lineNumbers={{
    annotations: {
      1: <>A <b>special</b> note about this line</>,
      9: 'Also accepts quick plaintext notes',
    }
  }}
>
  {}
</EuiCodeBlock>
```

## QA

QA link: https://eui.elastic.co/pr_6580/#/editors-syntax/code#line-numbers

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~