### PR TITLE
[EuiRange] Fix bug when `showTicks` is `false`

### DIFF
--- a/src/components/form/range/range_track.tsx
+++ b/src/components/form/range/range_track.tsx
@@ -107,7 +107,7 @@ export const EuiRangeTrack: FunctionComponent<EuiRangeTrackProps> = ({
     styles.euiRangeTrack,
     disabled && styles.disabled,
     levels && !!levels.length && styles.hasLevels,
-    (tickSequence || ticks) && styles.hasTicks,
+    showTicks && styles.hasTicks,
   ];
 
   const [trackWidth, setTrackWidth] = useState(0);

--- a/src/components/form/range/range_track.tsx
+++ b/src/components/form/range/range_track.tsx
@@ -107,7 +107,7 @@ export const EuiRangeTrack: FunctionComponent<EuiRangeTrackProps> = ({
     styles.euiRangeTrack,
     disabled && styles.disabled,
     levels && !!levels.length && styles.hasLevels,
-    showTicks && styles.hasTicks,
+    showTicks && (tickSequence || ticks) && styles.hasTicks,
   ];
 
   const [trackWidth, setTrackWidth] = useState(0);

--- a/upcoming_changelogs/6588.md
+++ b/upcoming_changelogs/6588.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed bug in `EuiRange` where styles were applied incorrectly when custom ticks were passed but `showTicks` were false


### PR DESCRIPTION
## Summary

This PR fixes a bug in `EuiRange` where styles were applied incorrectly when custom ticks were passed but `showTicks` were `false`.

Per logic, I think that consumers shouldn't be passing custom ticks if they're not going to show them. But... Just in case they pass, we can improve the design.

So the styles for the ticks **should only** be applied when consumers specifically set the `showTicks` to `true`.

Closes #6578.

![image](https://user-images.githubusercontent.com/2750668/217891844-2d1103c5-59cc-477a-a0ab-14645ed77ff2.png)


## QA

You can test by looking into https://eui.elastic.co/pr_6588/#/elastic-charts/metric-chart#single-value.

### General checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately