### PR TITLE
[EuiInlineEdit] Create Component Directory and Base Functionality

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -151,6 +151,8 @@ import { ImageExample } from './views/image/image_example';
 
 import { InnerTextExample } from './views/inner_text/inner_text_example';
 
+import { InlineEditExample } from './views/inline_edit/inline_edit_example';
+
 import { KeyPadMenuExample } from './views/key_pad_menu/key_pad_menu_example';
 
 import { LinkExample } from './views/link/link_example';
@@ -561,6 +563,7 @@ const navigation = [
       HealthExample,
       IconExample,
       ImageExample,
+      InlineEditExample,
       ListGroupExample,
       LoadingExample,
       NotificationEventExample,

--- a/src-docs/src/views/inline_edit/inline_edit.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit.tsx
@@ -2,4 +2,9 @@ import React from 'react';
 
 import { EuiInlineEdit } from '../../../../src';
 
-export default () => <EuiInlineEdit></EuiInlineEdit>;
+export default () => (
+  <>
+    <EuiInlineEdit display="text" inputLabel="textControlInput" />
+    <EuiInlineEdit display="title" inputLabel="titleControlInput" />
+  </>
+);

--- a/src-docs/src/views/inline_edit/inline_edit.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 
-import { EuiInlineEdit } from '../../../../src';
+import { EuiInlineEdit, EuiSpacer } from '../../../../src';
 
 export default () => (
   <>
+    <p>EuiInlineEdit - Text</p>
     <EuiInlineEdit display="text" inputLabel="textControlInput" />
+
+    <EuiSpacer />
+
+    <p>EuiInlineEdit - Title</p>
     <EuiInlineEdit display="title" inputLabel="titleControlInput" />
   </>
 );

--- a/src-docs/src/views/inline_edit/inline_edit.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { EuiInlineEdit } from '../../../../src';
+
+export default () => <EuiInlineEdit></EuiInlineEdit>;

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { GuideSectionTypes } from '../../components';
+
+import { EuiText, EuiInlineEdit } from '../../../../src';
+
+import InlineEdit from './inline_edit';
+const inlineEditSource = require('!!raw-loader!./inline_edit');
+
+export const InlineEditExample = {
+  title: 'Inline edit',
+  intro: (
+    <>
+      <EuiText></EuiText>
+    </>
+  ),
+  sections: [
+    {
+      title: 'InlineEdit',
+      text: (
+        <>
+          <p>
+            Description needed: how to use the <strong>EuiInlineEdit</strong>{' '}
+            component.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: inlineEditSource,
+        },
+      ],
+      demo: <InlineEdit />,
+      props: { EuiInlineEdit },
+    },
+  ],
+};

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -11,7 +11,7 @@ export const InlineEditExample = {
   title: 'Inline edit',
   intro: (
     <>
-      <EuiText></EuiText>
+      <EuiText>This is where the description will go</EuiText>
     </>
   ),
   sections: [

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -91,6 +91,8 @@ export * from './image';
 
 export * from './inner_text';
 
+export * from './inline_edit';
+
 export * from './i18n';
 
 export * from './loading';

--- a/src/components/inline_edit/__snapshots__/inline_edit.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit.test.tsx.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiInlineEdit is rendered 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        aria-label="aria-label"
+        class="euiInlineEdit testClass1 testClass2"
+        data-test-subj="test subject string"
+      >
+        <button
+          class="euiButtonEmpty css-wvaqcf-empty-text"
+          type="button"
+        >
+          <span
+            class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+          >
+            <span
+              class="euiButtonContent__icon"
+              color="inherit"
+              data-euiicon-type="pencil"
+            />
+            <span
+              class="euiButtonEmpty__text"
+            >
+              <div
+                class="euiText emotion-euiText-m"
+              >
+                Click me to edit
+              </div>
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      aria-label="aria-label"
+      class="euiInlineEdit testClass1 testClass2"
+      data-test-subj="test subject string"
+    >
+      <button
+        class="euiButtonEmpty css-wvaqcf-empty-text"
+        type="button"
+      >
+        <span
+          class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+        >
+          <span
+            class="euiButtonContent__icon"
+            color="inherit"
+            data-euiicon-type="pencil"
+          />
+          <span
+            class="euiButtonEmpty__text"
+          >
+            <div
+              class="euiText emotion-euiText-m"
+            >
+              Click me to edit
+            </div>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByTestSubject": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByTestSubject": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByTestSubject": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByTestSubject": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByTestSubject": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByTestSubject": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/inline_edit/index.ts
+++ b/src/components/inline_edit/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export {
+  EuiInlineEdit,
+} from './inline_edit';

--- a/src/components/inline_edit/index.ts
+++ b/src/components/inline_edit/index.ts
@@ -6,6 +6,4 @@
  * Side Public License, v 1.
  */
 
-export {
-  EuiInlineEdit,
-} from './inline_edit';
+export { EuiInlineEdit } from './inline_edit';

--- a/src/components/inline_edit/inline_edit.styles.ts
+++ b/src/components/inline_edit/inline_edit.styles.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+
+export const euiInlineEditStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    euiInlineEdit: css`
+      // Always start the object with the first key being the name of the component
+      color: ${euiTheme.colors.primaryText};
+    `,
+  };
+};

--- a/src/components/inline_edit/inline_edit.test.tsx
+++ b/src/components/inline_edit/inline_edit.test.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../test/rtl';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiInlineEdit } from './inline_edit';
+
+describe('EuiInlineEdit', () => {
+  test('is rendered', () => {
+    const component = render(<EuiInlineEdit {...requiredProps} />);
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/inline_edit/inline_edit.test.tsx
+++ b/src/components/inline_edit/inline_edit.test.tsx
@@ -14,7 +14,9 @@ import { EuiInlineEdit } from './inline_edit';
 
 describe('EuiInlineEdit', () => {
   test('is rendered', () => {
-    const component = render(<EuiInlineEdit {...requiredProps} />);
+    const component = render(
+      <EuiInlineEdit display="text" inputLabel="textInput" {...requiredProps} />
+    );
 
     expect(component).toMatchSnapshot();
   });

--- a/src/components/inline_edit/inline_edit.tsx
+++ b/src/components/inline_edit/inline_edit.tsx
@@ -6,18 +6,70 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, FunctionComponent } from 'react';
-import { CommonProps } from '../common';
+import React, { HTMLAttributes, FunctionComponent, useState } from 'react';
+import { CommonProps, ExclusiveUnion } from '../common';
 import classNames from 'classnames';
+import { EuiButtonEmpty, EuiButtonIcon } from '../button';
+import { EuiFieldText, EuiFormRow } from '../form';
+import { EuiTitle, EuiTitleSize } from '../title';
+import { EuiText, TextSize } from '../text';
 import { useEuiTheme } from '../../services';
 import { euiInlineEditStyles } from './inline_edit.styles';
+import { htmlIdGenerator } from '../../services/accessibility';
 
-export type EuiInlineEditProps = HTMLAttributes<HTMLDivElement> &
-  CommonProps & {};
+export const DISPLAY_TYPES = ['title', 'text'] as const;
+export type EuiInlineEditDisplayType = typeof DISPLAY_TYPES[number];
+
+interface TitleDisplayProps {
+  display: 'title';
+  size?: EuiTitleSize;
+}
+
+interface TextDisplayProps {
+  display: 'text';
+  size?: TextSize;
+}
+
+type DisplayProps = TitleDisplayProps | TextDisplayProps;
+
+export type EuiInlineEditProps = CommonProps &
+  ExclusiveUnion<TextDisplayProps, TitleDisplayProps> & {
+    /**
+     * Display type for the text in readView
+     */
+    display: EuiInlineEditDisplayType;
+    /**
+     * Default string value for input in readView
+     */
+    defaultValue?: string;
+    /**
+     * Allow users to pass in a function when the confirm button is clicked
+     */
+    onConfirm?: () => void;
+    confirmButtonAriaLabel?: string;
+    cancelButtonAriaLabel?: string;
+    /**
+     * Start in editView
+     */
+    startWithEditOpen?: boolean;
+    /**
+     * Form label that appears above the form control
+     */
+    inputLabel: String;
+  };
 
 export const EuiInlineEdit: FunctionComponent<EuiInlineEditProps> = ({
   children,
   className,
+  display,
+  // m is the default for both EuiTitle and EuiText
+  size = 'm',
+  defaultValue = 'Click me to edit',
+  onConfirm,
+  confirmButtonAriaLabel,
+  cancelButtonAriaLabel,
+  startWithEditOpen,
+  inputLabel,
   ...rest
 }) => {
   const classes = classNames('euiInlineEdit', className);
@@ -25,9 +77,95 @@ export const EuiInlineEdit: FunctionComponent<EuiInlineEditProps> = ({
   const styles = euiInlineEditStyles(theme);
   const cssStyles = [styles.euiInlineEdit];
 
+  const [isInEdit, setIsInEdit] = useState(startWithEditOpen);
+  const inlineEditInputId = htmlIdGenerator('__inlineEditInput')();
+
+  /* Text Controls */
+  const [editViewValue, setEditViewValue] = useState(defaultValue || '');
+  const [readViewValue, setReadViewValue] = useState(defaultValue);
+
+  const editTextViewOnChange = (e: any) => {
+    setEditViewValue(e.target.value);
+  };
+
+  const saveTextEditValue = () => {
+    const input = (document.getElementById(
+      inlineEditInputId
+    ) as HTMLInputElement).value;
+
+    // If there's no text, cancel the action, reset the input text, and return to readView
+    if (input) {
+      setReadViewValue(input);
+      setIsInEdit(!isInEdit);
+      onConfirm && onConfirm();
+    } else {
+      setEditViewValue(readViewValue);
+      setIsInEdit(!isInEdit);
+    }
+  };
+
+  const editViewButtons = (
+    <>
+      <EuiButtonIcon
+        iconType="check"
+        aria-label={confirmButtonAriaLabel || 'confirm'}
+        onClick={saveTextEditValue}
+      />
+      <EuiButtonIcon
+        iconType="cross"
+        aria-label={cancelButtonAriaLabel || 'cancel'}
+        onClick={() => {
+          setEditViewValue(readViewValue);
+          setIsInEdit(!isInEdit);
+        }}
+      />
+    </>
+  );
+
+  const textEditViewElement = (
+    <EuiFormRow label={inputLabel}>
+      <>
+        <EuiFieldText
+          id={inlineEditInputId}
+          value={editViewValue}
+          onChange={editTextViewOnChange}
+          autoFocus
+          {...(rest as any)}
+        />
+
+        {editViewButtons}
+      </>
+    </EuiFormRow>
+  );
+
+  const textReadViewElement = (
+    <EuiButtonEmpty
+      color="text"
+      iconType="pencil"
+      iconSide="right"
+      autoFocus
+      onClick={() => {
+        setIsInEdit(!isInEdit);
+      }}
+    >
+      {display === 'title' ? (
+        <EuiTitle size={size}>
+          <h2>{readViewValue}</h2>
+        </EuiTitle>
+      ) : (
+        <EuiText size={size}>{readViewValue}</EuiText>
+      )}
+    </EuiButtonEmpty>
+  );
+
+  /* Current Form Control in View */
+  const currentFormControlInView = isInEdit
+    ? textEditViewElement
+    : textReadViewElement;
+
   return (
-    <div className={classes} css={cssStyles} {...rest}>
-      {children}
+    <div className={classes} {...rest}>
+      {currentFormControlInView}
     </div>
   );
 };

--- a/src/components/inline_edit/inline_edit.tsx
+++ b/src/components/inline_edit/inline_edit.tsx
@@ -6,15 +6,16 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { CommonProps, ExclusiveUnion } from '../common';
 import classNames from 'classnames';
-import { EuiButtonEmpty, EuiButtonIcon } from '../button';
-import { EuiFieldText, EuiFormRow } from '../form';
+import { EuiButtonEmpty, EuiButton } from '../button';
+import { EuiFieldText, EuiFormRow, EuiForm } from '../form';
 import { EuiTitle, EuiTitleSize } from '../title';
 import { EuiText, TextSize } from '../text';
-import { useEuiTheme } from '../../services';
-import { euiInlineEditStyles } from './inline_edit.styles';
+import { EuiFlexGroup, EuiFlexItem } from '../flex';
+// import { useEuiTheme } from '../../services';
+// import { euiInlineEditStyles } from './inline_edit.styles';
 import { htmlIdGenerator } from '../../services/accessibility';
 
 export const DISPLAY_TYPES = ['title', 'text'] as const;
@@ -29,8 +30,6 @@ interface TextDisplayProps {
   display: 'text';
   size?: TextSize;
 }
-
-type DisplayProps = TitleDisplayProps | TextDisplayProps;
 
 export type EuiInlineEditProps = CommonProps &
   ExclusiveUnion<TextDisplayProps, TitleDisplayProps> & {
@@ -73,9 +72,11 @@ export const EuiInlineEdit: FunctionComponent<EuiInlineEditProps> = ({
   ...rest
 }) => {
   const classes = classNames('euiInlineEdit', className);
-  const theme = useEuiTheme();
+
+  // Styles to come later
+  /*const theme = useEuiTheme();
   const styles = euiInlineEditStyles(theme);
-  const cssStyles = [styles.euiInlineEdit];
+  const cssStyles = [styles.euiInlineEdit];*/
 
   const [isInEdit, setIsInEdit] = useState(startWithEditOpen);
   const inlineEditInputId = htmlIdGenerator('__inlineEditInput')();
@@ -104,38 +105,54 @@ export const EuiInlineEdit: FunctionComponent<EuiInlineEditProps> = ({
     }
   };
 
-  const editViewButtons = (
-    <>
-      <EuiButtonIcon
-        iconType="check"
-        aria-label={confirmButtonAriaLabel || 'confirm'}
-        onClick={saveTextEditValue}
-      />
-      <EuiButtonIcon
-        iconType="cross"
-        aria-label={cancelButtonAriaLabel || 'cancel'}
-        onClick={() => {
-          setEditViewValue(readViewValue);
-          setIsInEdit(!isInEdit);
-        }}
-      />
-    </>
-  );
-
   const textEditViewElement = (
-    <EuiFormRow label={inputLabel}>
-      <>
-        <EuiFieldText
-          id={inlineEditInputId}
-          value={editViewValue}
-          onChange={editTextViewOnChange}
-          autoFocus
-          {...(rest as any)}
-        />
+    <EuiForm fullWidth>
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiFormRow label={inputLabel}>
+            <>
+              <EuiFieldText
+                id={inlineEditInputId}
+                value={editViewValue}
+                onChange={editTextViewOnChange}
+                autoFocus
+                {...(rest as any)}
+              />
+            </>
+          </EuiFormRow>
+        </EuiFlexItem>
 
-        {editViewButtons}
-      </>
-    </EuiFormRow>
+        <EuiFlexItem grow={false}>
+          <EuiFormRow hasEmptyLabelSpace>
+            <EuiButton
+              iconType="check"
+              aria-label={confirmButtonAriaLabel || 'confirm'}
+              onClick={saveTextEditValue}
+              color="primary"
+              fill
+            >
+              Save
+            </EuiButton>
+          </EuiFormRow>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiFormRow hasEmptyLabelSpace>
+            <EuiButton
+              iconType="cross"
+              aria-label={cancelButtonAriaLabel || 'cancel'}
+              onClick={() => {
+                setEditViewValue(readViewValue);
+                setIsInEdit(!isInEdit);
+              }}
+              color="primary"
+            >
+              Cancel
+            </EuiButton>
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiForm>
   );
 
   const textReadViewElement = (
@@ -149,11 +166,11 @@ export const EuiInlineEdit: FunctionComponent<EuiInlineEditProps> = ({
       }}
     >
       {display === 'title' ? (
-        <EuiTitle size={size}>
+        <EuiTitle size={size as EuiTitleSize}>
           <h2>{readViewValue}</h2>
         </EuiTitle>
       ) : (
-        <EuiText size={size}>{readViewValue}</EuiText>
+        <EuiText size={size as TextSize}>{readViewValue}</EuiText>
       )}
     </EuiButtonEmpty>
   );

--- a/src/components/inline_edit/inline_edit.tsx
+++ b/src/components/inline_edit/inline_edit.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { HTMLAttributes, FunctionComponent } from 'react';
+import { CommonProps } from '../common';
+import classNames from 'classnames';
+import { useEuiTheme } from '../../services';
+import { euiInlineEditStyles } from './inline_edit.styles';
+
+export type EuiInlineEditProps = HTMLAttributes<HTMLDivElement> &
+  CommonProps & {};
+
+export const EuiInlineEdit: FunctionComponent<EuiInlineEditProps> = ({
+  children,
+  className,
+  ...rest
+}) => {
+  const classes = classNames('euiInlineEdit', className);
+  const theme = useEuiTheme();
+  const styles = euiInlineEditStyles(theme);
+  const cssStyles = [styles.euiInlineEdit];
+
+  return (
+    <div className={classes} css={cssStyles} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { EuiTextProps } from './text';
+export type { EuiTextProps, TextSize } from './text';
 export { EuiText } from './text';
 export type { EuiTextColorProps } from './text_color';
 export { EuiTextColor } from './text_color';


### PR DESCRIPTION
## Summary

(Associated with #3928 and #6533)

Spec Doc: [EuiInlineEdit Spec Doc](https://docs.google.com/document/d/19Ba2I3iF8W5-XYIdzHH4pBDuXbQ5hyKyv0m2o6Tw70s/edit?usp=sharing)

This is the first PR for the new `EuiInlineEdit` component. This PR creates the required directories for the component and the component docs. The `EuiInlineEdit` component accepts one of two displays (`text` and `title`) and allows users to edit the copy for a text block or title in place. 

The base functionality for EuiInlineEdit includes:

- Toggling between `readView` and `editView` for the two accepted `display` types
  - `readView` should display an `EuiEmptyButton` with the saved or default text and selections
  - `editView` should display an `EuiFieldText` input and two buttons that allow users to edit their text and save or cancel
- Saving text and selections using a save button when the component is in editView
  - Basic validation that does not allow the form controls to be saved when they contain no text / selections. If they are empty and a save is attempted, the component returns to readView with the text / selections prior to editing
- Canceling and not saving text and selections using a cancel button when the component is in editView


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

