### PR TITLE
Add docs for using EuiImage with SVGs

### DIFF
--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -38,6 +38,16 @@ const imageZoomSnippet = `<EuiImage
 />
 `;
 
+import ImageSvg from './image_svg';
+const imageSvgSource = require('!!raw-loader!./image_svg');
+const imageSvgSnippet = `<EuiImage
+  allowFullScreen
+  alt={description}
+  url={someUrl}
+  size="l"
+  width={400}
+/>
+`;
 import ImageFloat from './float';
 const imageFloatSource = require('!!raw-loader!./float');
 const imageFloatSnippet = `<EuiImage
@@ -139,6 +149,33 @@ export const ImageExample = {
       ),
       demo: <ImageSizes />,
       snippet: imageSizesSnippet,
+    },
+    {
+      title: 'Supporting SVG images',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: imageSvgSource,
+        },
+      ],
+      text: (
+        <Fragment>
+          <p>
+            If you are using an SVG source within <EuiCode>EuiImage</EuiCode>,
+            the SVG image may not show up! While this is surprising to the user,
+            if your image doesn&apos;t have a width or viewbox set, it is
+            behaving in accordance with the SVG spec.
+          </p>
+          <p>
+            In order to work with an SVG image that lacks a defined size,
+            you&apos;ll want to set a <EuiCode>size</EuiCode> prop. If you are
+            using the <EuiCode>allowFullScreen</EuiCode> prop as well, you will
+            also want to add a <EuiCode>width</EuiCode> prop.
+          </p>
+        </Fragment>
+      ),
+      demo: <ImageSvg />,
+      snippet: imageSvgSnippet,
     },
     {
       title: 'Float images within text',

--- a/src-docs/src/views/image/image_svg.tsx
+++ b/src-docs/src/views/image/image_svg.tsx
@@ -5,7 +5,7 @@ import { EuiImage } from '../../../../src/components';
 export default () => (
   <EuiImage
     size="l"
-    width={400}
+    width={600}
     hasShadow
     caption="Diagram of fishapod timelines"
     alt="Diagram of fishapod timelines"

--- a/src-docs/src/views/image/image_svg.tsx
+++ b/src-docs/src/views/image/image_svg.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { EuiImage } from '../../../../src/components';
+
+export default () => (
+  <EuiImage
+    size="l"
+    width={400}
+    hasShadow
+    caption="Flowchart diagram"
+    alt="Flowchart diagram"
+    src="https://upload.wikimedia.org/wikipedia/commons/c/cf/Clustal_Omega_Algorithm_Flowchart.svg"
+    allowFullScreen
+  />
+);

--- a/src-docs/src/views/image/image_svg.tsx
+++ b/src-docs/src/views/image/image_svg.tsx
@@ -7,8 +7,8 @@ export default () => (
     size="l"
     width={400}
     hasShadow
-    caption="Flowchart diagram"
-    alt="Flowchart diagram"
+    caption="Diagram of fishapod timelines"
+    alt="Diagram of fishapod timelines"
     src="https://upload.wikimedia.org/wikipedia/commons/a/af/Fishapods.svg"
     allowFullScreen
   />

--- a/src-docs/src/views/image/image_svg.tsx
+++ b/src-docs/src/views/image/image_svg.tsx
@@ -9,7 +9,7 @@ export default () => (
     hasShadow
     caption="Flowchart diagram"
     alt="Flowchart diagram"
-    src="https://upload.wikimedia.org/wikipedia/commons/c/cf/Clustal_Omega_Algorithm_Flowchart.svg"
+    src="https://upload.wikimedia.org/wikipedia/commons/a/af/Fishapods.svg"
     allowFullScreen
   />
 );


### PR DESCRIPTION
## Summary

(Second stab at https://github.com/elastic/eui/pull/6591)

I got confused when using auto-generated SVG files with EUI Image because the files were "disappearing". The svgs didn't have defined sizes. I talked with Cee and they proposed a workaround. We're documenting that here so the answer can be there when someone else gets confused!

![image](https://user-images.githubusercontent.com/5943972/218594264-9a1ecb4f-3459-4dc7-9f0e-a7ed91273ba1.png)


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

This just adds docs--let me know if there's a check that you actually want me to go through for this PR that I crossed off.
~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately~

### Emotion conversion checklist

I don't think we need any of this, correct me if I'm wrong! Just commented it all out so I can reference what was there without squiggling out every line

<!--
- **Does it work?**
~- [ ] Output CSS matches the previous CSS / as expected in browsers
- [ ] Rendered className reads as expected in snapshots and in browsers
- [ ] Checked component playground (class components wrapped in `withEuiTheme` need to pass `true` as the second argument to its `propUtilityForPlayground` in `src-docs/src/views/{component}/playground.js`)
&nbsp;
- **Unit tests**
- [ ] [`shouldRenderCustomStyles()`](https://github.com/elastic/eui/blob/6054e9b8310bdb106371c0c9ff8bc48e3e0e594b/src/test/internal/render_custom_styles.tsx) test was added and passes with parent component and any nested `childProps` (e.g. `tooltipProps`)
- [ ] Removed any `mount()`ed snapshots in favor of `render()` or a more specific assertion
&nbsp;
- **Sass/Emotion conversion process**
- [ ] Converted all global Sass vars/mixins to JS (e.g. `$euiSize` to `euiTheme.size.base`)
- [ ] Removed or converted component-specific Sass vars/mixins to exported JS versions, listed removals in changelog, and [manually updated our theme JSON files](https://github.com/elastic/eui/tree/main/src-docs/src/views/theme/_json)
- [ ] Simplified `calc()` to `mathWithUnits` if possible (if mixing different unit types, this may not be possible)
- [ ] Added an `@warn` deprecation message within the `global_styling/mixins/{component}.scss` file
- [ ] Removed component from `src/components/index.scss`
- [ ] Deleted any `src/amsterdam/overrides/{component}.scss` files (styles within should have been converted to the baseline Emotion styles)
&nbsp;
- **CSS tech debt**
- [ ] Reduced specificity where possible (usually by reducing nesting and class name chaining)
- [ ] Wrapped all animations or transitions in `euiCanAnimate`
- [ ] Used `gap` property to add margin between items if using flex
- [ ] Converted side specific padding, margin, and position to `-inline` and `-block` [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) (check inline styles as well as CSS)
&nbsp;
- **DOM cleanup**
- [ ] Did **not** remove any block/element classNames (e.g. `euiComponent`, `euiComponent__child`)
- [ ] Deleted any modifier classNames or maps if not being used in Kibana. **Before doing this step**:
    - [ ] Search/grep through Kibana's codebase for `{euiComponent}-` (case sensitive) to check for source code usage of modifier classes
    - [ ] If usages exist, consider converting to a `data` attribute so that consumers still have something to hook into
&nbsp;
- **Kibana due diligence**
- Pre-emptively check how your conversion will impact the next Kibana upgrade. This entails searching/grepping through Kibana (excluding `**/target, **/*.snap, **/*.storyshot` for less noise) for `eui{Component}` (case sensitive) to find:
- [ ] Any test/query selectors that will need to be updated
- [ ] Any Sass or CSS that will need to be updated, particularly if a component Sass var was deleted
- [ ] Any direct className usages that will need to be refactored (e.g. someone calling the `euiBadge` class on a div instead of simply using the `EuiBadge` component)
&nbsp;
- **Extras/nice-to-have**
- [ ] Documentation pass:
    - [ ] Converted any remaining `.js` docs files to TS
    - [ ] Misc cleanup of docs code (e.g. combine imports to single `from '../src'`, replace `<React.Fragment>` with `<>`)
- [ ] Check for issues in the backlog that could be a quick fix for that component
- [ ] Optional component/code cleanup: consider splitting up the component into multiple children if it's overly verbose or difficult to reason about
-->