### PR TITLE
Fixing EuiCodeBlock regex for Safari regex support.

### DIFF
--- a/src-docs/src/components/guide_section/_utils.js
+++ b/src-docs/src/components/guide_section/_utils.js
@@ -76,12 +76,12 @@ export const renderJsSourceCode = (code) => {
   const remainingImports = [];
 
   renderedCode = renderedCode.replace(
+    // (?<!(`[\s\S]*))               - negative lookbehind ensuring that import statements aren't part of a template literal
     // (\/\/.+\n)?                   - optional preceding comments that must be above specific imports, e.g. // @ts-ignore
     // import                        - import + whitespace
     // ([^]+?)                       - capture any characters (including newlines)
     //  from ('[A-Za-z0-9 -_.@/]*';) - ` from 'someLibrary';` - alphanumeric and certain special characters only
-    // (?!(`))                       - negative lookahead ensuring that import statements aren't part of a template literal
-    /(\/\/.+\n)?import ([^]+?) from ('[A-Za-z0-9 -_.@/]*';)(?!(`))/g,
+    /(?<!(`[\s\S]*))(\/\/.+\n)?import ([^]+?) from ('[A-Za-z0-9 -_.@/]*';)/g,
     (match) => {
       remainingImports.push(match);
       return '';

--- a/src-docs/src/components/guide_section/_utils.js
+++ b/src-docs/src/components/guide_section/_utils.js
@@ -76,12 +76,12 @@ export const renderJsSourceCode = (code) => {
   const remainingImports = [];
 
   renderedCode = renderedCode.replace(
-    // (?<!(`[\s\S]*))               - negative lookbehind ensuring that import statements aren't part of a template literal
     // (\/\/.+\n)?                   - optional preceding comments that must be above specific imports, e.g. // @ts-ignore
     // import                        - import + whitespace
     // ([^]+?)                       - capture any characters (including newlines)
     //  from ('[A-Za-z0-9 -_.@/]*';) - ` from 'someLibrary';` - alphanumeric and certain special characters only
-    /(?<!(`[\s\S]*))(\/\/.+\n)?import ([^]+?) from ('[A-Za-z0-9 -_.@/]*';)/g,
+    // (?!(`))                       - negative lookahead ensuring that import statements aren't part of a template literal
+    /(\/\/.+\n)?import ([^]+?) from ('[A-Za-z0-9 -_.@/]*';)(?!(`))/g,
     (match) => {
       remainingImports.push(match);
       return '';

--- a/src-docs/src/components/guide_section/_utils.js
+++ b/src-docs/src/components/guide_section/_utils.js
@@ -110,6 +110,8 @@ export const renderJsSourceCode = (code) => {
   ]
     .filter((stripEmptyImports) => stripEmptyImports)
     .join('\n');
+  // Trim starting/ending newlines (but not spaces) in the remaining code
+  renderedCode = renderedCode.replace(/^[\r\n]+|[\r\n]+$/g, '');
 
-  return `${renderedImports}\n\n${renderedCode.trim()}${remainingCode}`;
+  return `${renderedImports}\n\n${renderedCode}${remainingCode}`;
 };

--- a/src-docs/src/components/guide_section/_utils.js
+++ b/src-docs/src/components/guide_section/_utils.js
@@ -76,12 +76,11 @@ export const renderJsSourceCode = (code) => {
   const remainingImports = [];
 
   renderedCode = renderedCode.replace(
-    // (?<!(`[\s\S]*))               - negative lookbehind ensuring that import statements aren't part of a template literal
     // (\/\/.+\n)?                   - optional preceding comments that must be above specific imports, e.g. // @ts-ignore
     // import                        - import + whitespace
     // ([^]+?)                       - capture any characters (including newlines)
     //  from ('[A-Za-z0-9 -_.@/]*';) - ` from 'someLibrary';` - alphanumeric and certain special characters only
-    /(?<!(`[\s\S]*))(\/\/.+\n)?import ([^]+?) from ('[A-Za-z0-9 -_.@/]*';)/g,
+    /(\/\/.+\n)?import ([^]+?) from ('[A-Za-z0-9 -_.@/]*';)/g,
     (match) => {
       remainingImports.push(match);
       return '';

--- a/src-docs/src/components/guide_section/_utils.test.js
+++ b/src-docs/src/components/guide_section/_utils.test.js
@@ -321,8 +321,6 @@ describe('renderJsSourceCode', () => {
           default: dedent(`
             import React from 'react';
 
-            import foo from 'bar';
-
             import { v4 } from '@uuid/v4';
 
             const jsCode = \`/* I'm an example of JS */
@@ -333,7 +331,6 @@ describe('renderJsSourceCode', () => {
       ).toEqual(
         dedent(`
             import React from 'react';
-            import foo from 'bar';
             import { v4 } from '@uuid/v4';
 
             const jsCode = \`/* I'm an example of JS */

--- a/src-docs/src/components/guide_section/_utils.test.js
+++ b/src-docs/src/components/guide_section/_utils.test.js
@@ -324,7 +324,8 @@ describe('renderJsSourceCode', () => {
             import { v4 } from '@uuid/v4';
 
             const jsCode = \`/* I'm an example of JS */
-            import React from 'react';\`;
+            import React from 'react';
+            const hello = 'world';\`;
   
             export default () => 'Hello world!';`),
         })
@@ -334,7 +335,8 @@ describe('renderJsSourceCode', () => {
             import { v4 } from '@uuid/v4';
 
             const jsCode = \`/* I'm an example of JS */
-            import React from 'react';\`;
+            import React from 'react';
+            const hello = 'world';\`;
   
             export default () => 'Hello world!';`)
       );

--- a/src-docs/src/components/guide_section/_utils.test.js
+++ b/src-docs/src/components/guide_section/_utils.test.js
@@ -321,6 +321,8 @@ describe('renderJsSourceCode', () => {
           default: dedent(`
             import React from 'react';
 
+            import foo from 'bar';
+
             import { v4 } from '@uuid/v4';
 
             const jsCode = \`/* I'm an example of JS */
@@ -331,6 +333,7 @@ describe('renderJsSourceCode', () => {
       ).toEqual(
         dedent(`
             import React from 'react';
+            import foo from 'bar';
             import { v4 } from '@uuid/v4';
 
             const jsCode = \`/* I'm an example of JS */

--- a/upcoming_changelogs/6603.md
+++ b/upcoming_changelogs/6603.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- (Documentation only) Fixed a negative lookbehind regex causing our docs to crash when viewed in Safari


### PR DESCRIPTION
## Summary
Yesterday I merged #6595 to update `EuiCodeBlock` regex to ignore template literal comments. This change caused a bug in Safari because it used the currently unsupported [negative lookbehind](https://caniuse.com/js-regexp-lookbehind). I've updated the regex to use negative lookahead and keyed off the end of the template literal string instead of the beginning.

Retested with Chrome, Safari, Edge, and Firefox locally as well as opened CodeSandbox from playground links in each browser. Expanded unit test for this case.

### Changeset
* Updated EuiCodeBlock regex to support Safari using negative lookahead.
* Changed regex comment to explain negative lookahead.

### Screenshot from Safari

<img width="868" alt="safari-lookahead" src="https://user-images.githubusercontent.com/934879/219074933-bc2daa11-2533-440f-914f-87210f46e133.png">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
