### PR TITLE
Error & warning guides

### DIFF
--- a/src-docs/src/views/call_out/call_out_example.js
+++ b/src-docs/src/views/call_out/call_out_example.js
@@ -132,7 +132,8 @@ export const CallOutExample = {
           Use this callout to warn the user against decisions they might regret.
           You should receive a warning message when the program detects that{' '}
           <b>
-            something is not behaving right, but it didn't cause any termination
+            something is not behaving right, but it didn&apos;t cause any
+            termination
           </b>
           .
         </p>
@@ -154,7 +155,7 @@ export const CallOutExample = {
           example if you want to communicate an error. You should receive an
           error message when the issue is{' '}
           <b>
-            terminal, this doesn't always mean that the operation stops
+            terminal, this doesn&apos;t always mean that the operation stops
             completely, but the task is not complete
           </b>
           .

--- a/src-docs/src/views/call_out/call_out_example.js
+++ b/src-docs/src/views/call_out/call_out_example.js
@@ -130,6 +130,11 @@ export const CallOutExample = {
       text: (
         <p>
           Use this callout to warn the user against decisions they might regret.
+          You should receive a warning message when the program detects that{' '}
+          <b>
+            something is not behaving right, but it didn't cause any termination
+          </b>
+          .
         </p>
       ),
       snippet: warningSnippet,
@@ -144,7 +149,16 @@ export const CallOutExample = {
         },
       ],
       text: (
-        <p>Use this callout to let the user know that something went wrong.</p>
+        <p>
+          Use this callout to let the user know that something went wrong. For
+          example if you want to communicate an error. You should receive an
+          error message when the issue is{' '}
+          <b>
+            terminal, this doesn't always mean that the operation stops
+            completely, but the task is not complete
+          </b>
+          .
+        </p>
       ),
       snippet: dangerSnippet,
       demo: <Danger />,

--- a/src-docs/src/views/call_out/danger.tsx
+++ b/src-docs/src/views/call_out/danger.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { EuiCallOut, EuiLink } from '../../../../src';
 
 export default () => (
-  <EuiCallOut title="Sorry, there was an error" color="danger" iconType="alert">
+  <EuiCallOut title="Sorry, there was an error" color="danger" iconType="error">
     <p>
       Now you have to fix it, but maybe{' '}
       <EuiLink href="#">this link can help</EuiLink>.

--- a/src-docs/src/views/call_out/warning.tsx
+++ b/src-docs/src/views/call_out/warning.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { EuiCallOut, EuiLink, EuiButton } from '../../../../src';
 
 export default () => (
-  <EuiCallOut title="Proceed with caution!" color="warning" iconType="help">
+  <EuiCallOut title="Proceed with caution!" color="warning" iconType="alert">
     <p>
       Here be dragons. Don&rsquo;t wanna mess with no dragons. And{' '}
       <EuiLink href="#">here&rsquo;s a link</EuiLink>.

--- a/src-docs/src/views/toast/danger.js
+++ b/src-docs/src/views/toast/danger.js
@@ -11,7 +11,7 @@ export default () => (
   <EuiToast
     title="Couldn't complete the search"
     color="danger"
-    iconType="alert"
+    iconType="error"
   >
     <p>{esError}</p>
   </EuiToast>

--- a/src-docs/src/views/toast/guidelines.js
+++ b/src-docs/src/views/toast/guidelines.js
@@ -114,8 +114,9 @@ and space to read it properly. Alternatively just link to a full page.
                 Warning toasts direct user attention to a potential problem
               </dt>
               <dd>
-                These toasts work well in monitoring apps when something
-                significant requires action.
+                You should receive a warning message when the program detects
+                that something is not behaving right, but it didn't cause any
+                termination.
               </dd>
             </EuiText>
           </EuiFlexItem>
@@ -136,8 +137,9 @@ and space to read it properly. Alternatively just link to a full page.
             <EuiText>
               <dt>Error toasts report a problem</dt>
               <dd>
-                An error toast might let users know an action didn&apos;t
-                complete or that a form has errors.
+                You should receive an error message when the issue is terminal,
+                this doesn't always mean that the operation stops completely,
+                but the task is not complete
               </dd>
             </EuiText>
           </EuiFlexItem>

--- a/src-docs/src/views/toast/guidelines.js
+++ b/src-docs/src/views/toast/guidelines.js
@@ -115,8 +115,8 @@ and space to read it properly. Alternatively just link to a full page.
               </dt>
               <dd>
                 You should receive a warning message when the program detects
-                that something is not behaving right, but it didn't cause any
-                termination.
+                that something is not behaving right, but it didn&apos;t cause
+                any termination.
               </dd>
             </EuiText>
           </EuiFlexItem>
@@ -138,8 +138,8 @@ and space to read it properly. Alternatively just link to a full page.
               <dt>Error toasts report a problem</dt>
               <dd>
                 You should receive an error message when the issue is terminal,
-                this doesn't always mean that the operation stops completely,
-                but the task is not complete
+                this doesn&apos;t always mean that the operation stops
+                completely, but the task is not complete
               </dd>
             </EuiText>
           </EuiFlexItem>

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -201,8 +201,9 @@ export const ToastExample = {
         <p>
           Use this callout to warn the user against decisions they might regret.
           You should receive a warning message when the program detects that
-          something is not behaving right, but it didn't cause any termination.
-          Setting <EuiCode language="js">color=&quot;warning&quot;</EuiCode>.
+          something is not behaving right, but it didn&apos;t cause any
+          termination. Setting{' '}
+          <EuiCode language="js">color=&quot;warning&quot;</EuiCode>.
         </p>
       ),
       demo: (
@@ -224,9 +225,10 @@ export const ToastExample = {
         <p>
           Use this callout to let the user know that something went wrong. For
           example if you want to communicate an error. You should receive an
-          error message when the issue is terminal, this doesn't always mean
-          that the operation stops completely, but the task is not complete.
-          Setting <EuiCode language="js">color=&quot;danger&quot;</EuiCode>.
+          error message when the issue is terminal, this doesn&apos;t always
+          mean that the operation stops completely, but the task is not
+          complete. Setting{' '}
+          <EuiCode language="js">color=&quot;danger&quot;</EuiCode>.
         </p>
       ),
       demo: (

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -202,7 +202,7 @@ export const ToastExample = {
       text: (
         <p>
           Use this callout to warn the user against decisions they might regret.
-          You should receive a warning message when the program detects that
+          Show a warning message when the program detects that {' '}
           <b>
             something is not behaving right, but it didn&apos;t cause any
             termination.

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -199,6 +199,9 @@ export const ToastExample = {
       ],
       text: (
         <p>
+          Use this callout to warn the user against decisions they might regret.
+          You should receive a warning message when the program detects that
+          something is not behaving right, but it didn't cause any termination.
           Setting <EuiCode language="js">color=&quot;warning&quot;</EuiCode>.
         </p>
       ),
@@ -219,6 +222,10 @@ export const ToastExample = {
       ],
       text: (
         <p>
+          Use this callout to let the user know that something went wrong. For
+          example if you want to communicate an error. You should receive an
+          error message when the issue is terminal, this doesn't always mean
+          that the operation stops completely, but the task is not complete.
           Setting <EuiCode language="js">color=&quot;danger&quot;</EuiCode>.
         </p>
       ),

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -159,7 +159,8 @@ export const ToastExample = {
       ],
       text: (
         <p>
-          Setting <EuiCode language="js">type=&quot;info&quot;</EuiCode>.
+          For informative messages use{' '}
+          <EuiCode language="js">type=&quot;info&quot;</EuiCode>.
         </p>
       ),
       demo: (
@@ -179,7 +180,8 @@ export const ToastExample = {
       ],
       text: (
         <p>
-          Setting <EuiCode language="js">color=&quot;success&quot;</EuiCode>.
+          For success messages use{' '}
+          <EuiCode language="js">color=&quot;success&quot;</EuiCode>.
         </p>
       ),
       demo: (
@@ -201,8 +203,11 @@ export const ToastExample = {
         <p>
           Use this callout to warn the user against decisions they might regret.
           You should receive a warning message when the program detects that
-          something is not behaving right, but it didn&apos;t cause any
-          termination. Setting{' '}
+          <b>
+            something is not behaving right, but it didn&apos;t cause any
+            termination.
+          </b>{' '}
+          For warning messages use{' '}
           <EuiCode language="js">color=&quot;warning&quot;</EuiCode>.
         </p>
       ),
@@ -225,9 +230,12 @@ export const ToastExample = {
         <p>
           Use this callout to let the user know that something went wrong. For
           example if you want to communicate an error. You should receive an
-          error message when the issue is terminal, this doesn&apos;t always
-          mean that the operation stops completely, but the task is not
-          complete. Setting{' '}
+          error message when the issue is{' '}
+          <b>
+            terminal, this doesn&apos;t always mean that the operation stops
+            completely, but the task is not complete
+          </b>
+          . For errors messages use{' '}
           <EuiCode language="js">color=&quot;danger&quot;</EuiCode>.
         </p>
       ),

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -202,7 +202,7 @@ export const ToastExample = {
       text: (
         <p>
           Use this callout to warn the user against decisions they might regret.
-          Show a warning message when the program detects that {' '}
+          Show a warning message when the program detects that{' '}
           <b>
             something is not behaving right, but it didn&apos;t cause any
             termination.
@@ -229,8 +229,8 @@ export const ToastExample = {
       text: (
         <p>
           Use this callout to let the user know that something went wrong. For
-          example if you want to communicate an error. You should show an
-          error message when the issue is{' '}
+          example if you want to communicate an error. You should show an error
+          message when the issue is{' '}
           <b>
             terminal, this doesn&apos;t always mean that the operation stops
             completely, but the task is not complete

--- a/src-docs/src/views/toast/toast_example.js
+++ b/src-docs/src/views/toast/toast_example.js
@@ -229,7 +229,7 @@ export const ToastExample = {
       text: (
         <p>
           Use this callout to let the user know that something went wrong. For
-          example if you want to communicate an error. You should receive an
+          example if you want to communicate an error. You should show an
           error message when the issue is{' '}
           <b>
             terminal, this doesn&apos;t always mean that the operation stops

--- a/src-docs/src/views/toast/warning.js
+++ b/src-docs/src/views/toast/warning.js
@@ -6,6 +6,6 @@ export default () => (
   <EuiToast
     title="Sometimes a title is enough!"
     color="warning"
-    iconType="help"
+    iconType="alert"
   />
 );


### PR DESCRIPTION
## Summary

Recently we worked on a new error icon, which should be used when different error patterns are displayed in the UI. For example when using `EuiToast` or `EuiCallOut`. We know that the difference between an error and a warning might be slight, but it's also essential when we want to have a recognized and easy-to-understand patter and product. In this PR, I'm updating some small pieces of documentation here and there to communicate this difference clearly. 

Toast Guidelines
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/13353203/220083261-1556798a-597e-4b5d-b8b5-7cc7add2b511.png">

Toast examples
<img width="1273" alt="image" src="https://user-images.githubusercontent.com/13353203/220084589-4b5d826d-471d-4ca6-bd22-8b85ad011dfd.png">

Callout examples
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/13353203/220083578-03f3e994-31f1-4e15-8127-0fa24244d8cf.png">

Related to: 
https://github.com/elastic/eui/issues/6554
https://github.com/elastic/kibana/pull/151413
