### PR TITLE
[EuiSkipLink] Better handling of dynamically rendered content

### DIFF
--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -6,13 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, {
-  FunctionComponent,
-  Ref,
-  useState,
-  useEffect,
-  useCallback,
-} from 'react';
+import React, { FunctionComponent, Ref, useCallback } from 'react';
 import classNames from 'classnames';
 import { isTabbable } from 'tabbable';
 import { useEuiTheme } from '../../../services';
@@ -81,31 +75,17 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
     position !== 'static' ? styles[position] : undefined,
   ];
 
-  const [destinationEl, setDestinationEl] = useState<HTMLElement | null>(null);
-  const [hasValidId, setHasValidId] = useState(true);
-
-  useEffect(() => {
-    const idEl = document.getElementById(destinationId);
-    if (idEl) {
-      setHasValidId(true);
-      setDestinationEl(idEl);
-      return;
-    }
-    setHasValidId(false);
-
-    // If no valid element via ID is available, use the fallback query selectors
-    if (fallbackDestination) {
-      const fallbackEl = document.querySelector<HTMLElement>(
-        fallbackDestination
-      );
-      if (fallbackEl) {
-        setDestinationEl(fallbackEl);
-      }
-    }
-  }, [destinationId, fallbackDestination]);
-
   const onClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
+      let destinationEl: HTMLElement | null = null;
+      // Check if the destination ID is valid
+      destinationEl = document.getElementById(destinationId);
+      const hasValidId = !!destinationEl;
+      // Check the fallback destination if not
+      if (!destinationEl && fallbackDestination) {
+        destinationEl = document.querySelector(fallbackDestination);
+      }
+
       if ((overrideLinkBehavior || !hasValidId) && destinationEl) {
         e.preventDefault();
 
@@ -124,7 +104,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
           destinationEl.tabIndex = -1;
           destinationEl.addEventListener(
             'blur',
-            () => destinationEl.removeAttribute('tabindex'),
+            () => destinationEl?.removeAttribute('tabindex'),
             { once: true }
           );
         }
@@ -134,7 +114,7 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
 
       _onClick?.(e);
     },
-    [overrideLinkBehavior, hasValidId, destinationEl, _onClick]
+    [overrideLinkBehavior, destinationId, fallbackDestination, _onClick]
   );
 
   return (

--- a/upcoming_changelogs/6613.md
+++ b/upcoming_changelogs/6613.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiSkipLink` bug where main content loading in progressively/dynamically after the skip link rendered was not being correctly focused


### PR DESCRIPTION
## Summary

I spiked out adding an `EuiSkipLink` to Kibana in https://github.com/elastic/kibana/pull/150461/commits/5267bc405b60fd7ddc126804f382f637d6f7a10a, but unfortunately ran into multiple issues with the skip link not working as expected.

The problem arises with how Kibana progressively and dynamically renders its layout, and EuiSkipLink storing "valid" IDs/selectors in state. What happens is that the skip link renders on initial load when the header is rendered but the app/content isn't yet loaded. The `destinationalEl` is stored as null and clicks end up doing nothing even after the main content actually loads in.

The fix is to not store valid destination checks in state but instead run them on every click. This is potentially a very minor microperf hit, but not significant by any means (the number of clicks on this link will be relatively trivial/one-time) especially compared to ensuring the component works as intended.

## QA

Regression testing
- [x] https://eui.elastic.co/pr_6613/#/utilities/accessibility#skip-link still works as expected
- [x] Actual EUI skip link still works as expected

### General checklist

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately