### PR TITLE
[EuiText] Update nested ordered lists styles

### DIFF
--- a/src-docs/src/views/text/text.js
+++ b/src-docs/src/views/text/text.js
@@ -125,6 +125,43 @@ export default () => (
 
       <h6>This is Heading Six</h6>
 
+      <ul>
+        <li>
+          Programming Languages
+          <ul>
+            <li>
+              Backend
+              <ul>
+                <li>Java</li>
+                <li>Python</li>
+                <li>PHP</li>
+              </ul>
+            </li>
+            <li>
+              Frontend
+              <ul>
+                <li>
+                  JavaScript
+                  <ul>
+                    <li>React.js</li>
+                    <li>Angular.js</li>
+                    <li>Vue.js</li>
+                  </ul>
+                </li>
+                <li>
+                  CSS
+                  <ul>
+                    <li>SASS</li>
+                    <li>Less</li>
+                    <li>Stylus</li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+
       <EuiHorizontalRule />
 
       <dl>

--- a/src-docs/src/views/text/text.js
+++ b/src-docs/src/views/text/text.js
@@ -79,10 +79,40 @@ export default () => (
 
       <h4>This is Heading Four</h4>
 
-      <p>
-        So it thought the dog was making a poor life choice by focusing so much
-        on mindfulness. What if its car broke down?
-      </p>
+      <ol>
+        <li>
+          C
+          <ol>
+            <li>Procedural</li>
+            <li>Structured</li>
+            <li>Low-level</li>
+          </ol>
+        </li>
+        <li>
+          Java
+          <ol>
+            <li>Object-oriented</li>
+            <li>Class-based</li>
+            <li>Compiled</li>
+          </ol>
+        </li>
+        <li>
+          Python
+          <ol>
+            <li>Interpreted</li>
+            <li>High-level</li>
+            <li>Scripting</li>
+            <li>
+              Object-oriented
+              <ol>
+                <li>Dynamic typing</li>
+                <li>Garbage collection</li>
+              </ol>
+            </li>
+            <li>Functional</li>
+          </ol>
+        </li>
+      </ol>
 
       <h5>This is Heading Five</h5>
 

--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -92,6 +92,20 @@ exports[`euiTextStyles sizes m 1`] = `
     ol {
       margin-inline-start: 1.7143rem;
     }
+
+    // The styles of the nested ordered lists follow the style of GitHub
+    // which is commonly used in Markdown or MDX formatting.
+    ol ol,
+    ul ol {
+      list-style-type: lower-roman;
+    }
+
+    ul ul ol,
+    ul ol ol,
+    ol ul ol,
+    ol ol ol {
+      list-style-type: lower-alpha;
+    }
   
     blockquote {
       font-size: 1.1429rem;
@@ -240,6 +254,20 @@ exports[`euiTextStyles sizes relative 1`] = `
     ol {
       margin-inline-start: 1.5000em;
     }
+
+    // The styles of the nested ordered lists follow the style of GitHub
+    // which is commonly used in Markdown or MDX formatting.
+    ol ol,
+    ul ol {
+      list-style-type: lower-roman;
+    }
+
+    ul ul ol,
+    ul ol ol,
+    ol ul ol,
+    ol ol ol {
+      list-style-type: lower-alpha;
+    }
   
     blockquote {
       font-size: 1em;
@@ -373,6 +401,20 @@ exports[`euiTextStyles sizes s 1`] = `
     ol {
       margin-inline-start: 1.4286rem;
     }
+
+    // The styles of the nested ordered lists follow the style of GitHub
+    // which is commonly used in Markdown or MDX formatting.
+    ol ol,
+    ul ol {
+      list-style-type: lower-roman;
+    }
+
+    ul ul ol,
+    ul ol ol,
+    ol ul ol,
+    ol ol ol {
+      list-style-type: lower-alpha;
+    }
   
     blockquote {
       font-size: 1.0000rem;
@@ -505,6 +547,20 @@ exports[`euiTextStyles sizes xs 1`] = `
     ul,
     ol {
       margin-inline-start: 1.1429rem;
+    }
+
+    // The styles of the nested ordered lists follow the style of GitHub
+    // which is commonly used in Markdown or MDX formatting.
+    ol ol,
+    ul ol {
+      list-style-type: lower-roman;
+    }
+
+    ul ul ol,
+    ul ol ol,
+    ol ul ol,
+    ol ol ol {
+      list-style-type: lower-alpha;
     }
   
     blockquote {

--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -79,12 +79,12 @@ exports[`euiTextStyles sizes m 1`] = `
     }
 
     p,
-    ul,
-    ol,
     dl,
     blockquote,
     img,
-    pre {
+    pre,
+    > ul,
+    > ol {
       margin-block-end: 1.7143rem;
     }
 
@@ -95,6 +95,7 @@ exports[`euiTextStyles sizes m 1`] = `
 
     // The styles of the nested ordered lists follow the style of GitHub
     // which is commonly used in Markdown or MDX formatting.
+
     ol ol,
     ul ol {
       list-style-type: lower-roman;
@@ -241,12 +242,12 @@ exports[`euiTextStyles sizes relative 1`] = `
     }
 
     p,
-    ul,
-    ol,
     dl,
     blockquote,
     img,
-    pre {
+    pre,
+    > ul,
+    > ol {
       margin-block-end: 1.5000em;
     }
 
@@ -257,6 +258,7 @@ exports[`euiTextStyles sizes relative 1`] = `
 
     // The styles of the nested ordered lists follow the style of GitHub
     // which is commonly used in Markdown or MDX formatting.
+
     ol ol,
     ul ol {
       list-style-type: lower-roman;
@@ -388,12 +390,12 @@ exports[`euiTextStyles sizes s 1`] = `
     }
 
     p,
-    ul,
-    ol,
     dl,
     blockquote,
     img,
-    pre {
+    pre,
+    > ul,
+    > ol {
       margin-block-end: 1.4286rem;
     }
 
@@ -404,6 +406,7 @@ exports[`euiTextStyles sizes s 1`] = `
 
     // The styles of the nested ordered lists follow the style of GitHub
     // which is commonly used in Markdown or MDX formatting.
+
     ol ol,
     ul ol {
       list-style-type: lower-roman;
@@ -535,12 +538,12 @@ exports[`euiTextStyles sizes xs 1`] = `
     }
 
     p,
-    ul,
-    ol,
     dl,
     blockquote,
     img,
-    pre {
+    pre,
+    > ul,
+    > ol {
       margin-block-end: 1.1429rem;
     }
 
@@ -551,6 +554,7 @@ exports[`euiTextStyles sizes xs 1`] = `
 
     // The styles of the nested ordered lists follow the style of GitHub
     // which is commonly used in Markdown or MDX formatting.
+
     ol ol,
     ul ol {
       list-style-type: lower-roman;

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -142,12 +142,12 @@ const euiScaleText = (
     }
 
     p,
-    ul,
-    ol,
     dl,
     blockquote,
     img,
-    pre {
+    pre,
+    > ul,
+    > ol {
       ${logicalCSS('margin-bottom', lineHeightSize)}
     }
 
@@ -158,6 +158,7 @@ const euiScaleText = (
 
     // The styles of the nested ordered lists follow the style of GitHub
     // which is commonly used in Markdown or MDX formatting.
+
     ol ol,
     ul ol {
       list-style-type: lower-roman;

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -155,6 +155,20 @@ const euiScaleText = (
     ol {
       ${logicalCSS('margin-left', lineHeightSize)}
     }
+
+    // The styles of the nested ordered lists follow the style of GitHub
+    // which is commonly used in Markdown or MDX formatting.
+    ol ol,
+    ul ol {
+      list-style-type: lower-roman;
+    }
+
+    ul ul ol,
+    ul ol ol,
+    ol ul ol,
+    ol ol ol {
+      list-style-type: lower-alpha;
+    }
   
     blockquote {
       font-size: ${fontSize};

--- a/upcoming_changelogs/6615.md
+++ b/upcoming_changelogs/6615.md
@@ -1,0 +1,2 @@
+- Updated the styling of nested ordered lists in `EuiText` to align with GitHub's list style, which is a popular format used in Markdown or MDX formatting
+- Added a margin-bottom property exclusively to the direct child `ul` and `ol` elements of the `EuiText` component


### PR DESCRIPTION
## Summary

Updated the styling of nested ordered lists (`ol`) to align with GitHub's list style, which is a popular format used in Markdown or MDX formatting. These changes will enhance the readability and consistency of our content, and ensure that our lists are easily understood by readers.

Added a margin-bottom property exclusively to the direct child `ul` and `ol` elements of the **EuiText** component. This change will ensure that the spacing between nested lists within the **EuiText** component is consistent and visually pleasing. Other child elements of **EuiText** will not be affected by this change.

Closes #6611.

![image](https://user-images.githubusercontent.com/2750668/220916258-aa9b6fa2-4332-48bb-b952-8d4b8c498be9.png)


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
