### PR TITLE
Fix rule to override `margin-inline-start` for badges inside a `EuiBadgeGroup`

### DIFF
--- a/src/components/badge/badge_group/badge_group.styles.ts
+++ b/src/components/badge/badge_group/badge_group.styles.ts
@@ -18,7 +18,7 @@ export const euiBadgeGroupStyles = ({ euiTheme }: UseEuiTheme) => {
       ${logicalCSS('max-width', '100%')}
 
       // Override the .euiBadge + .euiBadge CSS in badge.styles.ts
-      .euiBadge {
+      .euiBadge + .euiBadge {
         ${logicalCSS('margin-left', 0)}
       }
     `,

--- a/upcoming_changelogs/6618.md
+++ b/upcoming_changelogs/6618.md
@@ -1,0 +1,1 @@
+- Fix issue with badges appearing within an `EuiBadgeGroup`, where the CSS rule to override the `margin-inline-start` was not being applied correctly due to the order of appearance in the CSS rules


### PR DESCRIPTION
## Summary

This PR closes #6617.

Fix the issue with badges appearing within an `EuiBadgeGroup`, where the CSS rule to override the `margin-inline-start` was not being applied correctly due to the order of appearance in the CSS rules. 

With the fix, the correct order of appearance is now enforced, allowing the margin to be properly overridden and ensuring that badges are displayed in the desired position within the `EuiBadgeGroup`.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
