### PR TITLE
[EuiDatePicker] Fix accessibility issues in EuiDatePicker and EuiDatePickerRange components 

### DIFF
--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -2384,6 +2384,38 @@
     "filepath": "src/components/date_picker/auto_refresh/refresh_interval.tsx"
   },
   {
+    "token": "euiDatePickerRange.inputsAriaDescribedByEmptyDate",
+    "defString": "Empty date",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 168,
+        "column": 26
+      },
+      "end": {
+        "line": 171,
+        "column": 3
+      }
+    },
+    "filepath": "src/components/date_picker/date_picker_range.tsx"
+  },
+  {
+    "token": "euiDatePickerRange.inputsAriaDescribedBy",
+    "defString": "Selected range: {startDate} to {endDate}",
+    "highlighting": "string",
+    "loc": {
+      "start": {
+        "line": 265,
+        "column": 10
+      },
+      "end": {
+        "line": 273,
+        "column": 12
+      }
+    },
+    "filepath": "src/components/date_picker/date_picker_range.tsx"
+  },
+  {
     "token": "euiAbsoluteTab.dateFormatError",
     "defString": "Expected format: {dateFormat}",
     "highlighting": "string",

--- a/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
@@ -9,11 +9,9 @@ exports[`EuiDatePicker is rendered 1`] = `
     icon="calendar"
     isLoading={false}
   >
-    <EuiValidatableControl>
-      <ContextConsumer>
-        <Component />
-      </ContextConsumer>
-    </EuiValidatableControl>
+    <ContextConsumer>
+      <Component />
+    </ContextConsumer>
   </EuiFormControlLayout>
 </span>
 `;
@@ -59,6 +57,295 @@ exports[`EuiDatePicker is rendered 2`] = `
   withPortal={false}
   yearDropdownItemNumber={7}
 />
+`;
+
+exports[`EuiDatePicker isInvalid is rendered 1`] = `
+<DatePicker
+  accessibleMode={true}
+  adjustDateOnChange={true}
+  allowSameDay={false}
+  aria-invalid={true}
+  aria-label="aria-label"
+  className="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid testClass1 testClass2"
+  data-test-subj="test subject string"
+  dateFormat="MM/DD/YYYY"
+  dateFormatCalendar="MMMM YYYY"
+  disabled={false}
+  disabledKeyboardNavigation={false}
+  dropdownMode="scroll"
+  monthsShown={1}
+  nextMonthButtonLabel="Next month"
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClickOutside={[Function]}
+  onFocus={[Function]}
+  onInputClick={[Function]}
+  onInputError={[Function]}
+  onKeyDown={[Function]}
+  onMonthChange={[Function]}
+  onSelect={[Function]}
+  onYearChange={[Function]}
+  popperPlacement="downLeft"
+  preventOpenOnFocus={false}
+  previousMonthButtonLabel="Previous Month"
+  readOnly={false}
+  renderDayContents={[Function]}
+  shouldCloseOnSelect={true}
+  showMonthDropdown={true}
+  showTimeSelect={false}
+  showYearDropdown={true}
+  strictParsing={false}
+  timeCaption="Time"
+  timeFormat="hh:mm A"
+  timeIntervals={30}
+  withPortal={false}
+  yearDropdownItemNumber={7}
+>
+  <EuiPopover
+    anchorPosition="downLeft"
+    buffer={0}
+    button={
+      <div
+        className="react-datepicker__input-container"
+      >
+        <input
+          aria-invalid={true}
+          aria-label="Press the down key to open a popover containing a calendar."
+          className="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid testClass1 testClass2"
+          disabled={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
+          type="text"
+          value=""
+        />
+      </div>
+    }
+    closePopover={[Function]}
+    display="block"
+    hasArrow={false}
+    isOpen={false}
+    ownFocus={false}
+    panelPaddingSize="none"
+    panelRef={[Function]}
+  >
+    <EuiOutsideClickDetector
+      onOutsideClick={[Function]}
+    >
+      <div
+        css="unknown styles"
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+      >
+        <Insertion
+          cache={
+            Object {
+              "insert": [Function],
+              "inserted": Object {
+                "6tb1tw-euiPopover": true,
+                "hus3oj-euiScreenReaderOnly": true,
+                "zih94u-render": true,
+              },
+              "key": "css",
+              "nonce": undefined,
+              "registered": Object {},
+              "sheet": StyleSheet {
+                "_alreadyInsertedOrderInsensitiveRule": true,
+                "_insertTag": [Function],
+                "before": null,
+                "container": <head>
+                  <style
+                    data-emotion="css"
+                    data-s=""
+                  >
+                    
+                    .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                  </style>
+                  <style
+                    data-emotion="css"
+                    data-s=""
+                  >
+                    
+                    .css-zih94u-render{display:block;}
+                  </style>
+                  <style
+                    data-emotion="css"
+                    data-s=""
+                  >
+                    
+                    .css-hus3oj-euiScreenReaderOnly{position:absolute;inset-block-start:auto;inset-inline-start:-10000px;inline-size:1px;block-size:1px;clip:rect(0 0 0 0);-webkit-clip-path:inset(50%);clip-path:inset(50%);overflow:hidden;margin:-1px;}
+                  </style>
+                </head>,
+                "ctr": 3,
+                "insertionPoint": undefined,
+                "isSpeedy": false,
+                "key": "css",
+                "nonce": undefined,
+                "prepend": undefined,
+                "tags": Array [
+                  <style
+                    data-emotion="css"
+                    data-s=""
+                  >
+                    
+                    .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                  </style>,
+                  <style
+                    data-emotion="css"
+                    data-s=""
+                  >
+                    
+                    .css-zih94u-render{display:block;}
+                  </style>,
+                  <style
+                    data-emotion="css"
+                    data-s=""
+                  >
+                    
+                    .css-hus3oj-euiScreenReaderOnly{position:absolute;inset-block-start:auto;inset-inline-start:-10000px;inline-size:1px;block-size:1px;clip:rect(0 0 0 0);-webkit-clip-path:inset(50%);clip-path:inset(50%);overflow:hidden;margin:-1px;}
+                  </style>,
+                ],
+              },
+            }
+          }
+          isStringTag={true}
+          serialized={
+            Object {
+              "map": undefined,
+              "name": "6tb1tw-euiPopover",
+              "next": undefined,
+              "styles": "position:relative;vertical-align:middle;max-inline-size: 100%;;;label:euiPopover;;;display:block;;",
+              "toString": [Function],
+            }
+          }
+        />
+        <div
+          className="euiPopover emotion-euiPopover"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            css="unknown styles"
+          >
+            <Insertion
+              cache={
+                Object {
+                  "insert": [Function],
+                  "inserted": Object {
+                    "6tb1tw-euiPopover": true,
+                    "hus3oj-euiScreenReaderOnly": true,
+                    "zih94u-render": true,
+                  },
+                  "key": "css",
+                  "nonce": undefined,
+                  "registered": Object {},
+                  "sheet": StyleSheet {
+                    "_alreadyInsertedOrderInsensitiveRule": true,
+                    "_insertTag": [Function],
+                    "before": null,
+                    "container": <head>
+                      <style
+                        data-emotion="css"
+                        data-s=""
+                      >
+                        
+                        .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                      </style>
+                      <style
+                        data-emotion="css"
+                        data-s=""
+                      >
+                        
+                        .css-zih94u-render{display:block;}
+                      </style>
+                      <style
+                        data-emotion="css"
+                        data-s=""
+                      >
+                        
+                        .css-hus3oj-euiScreenReaderOnly{position:absolute;inset-block-start:auto;inset-inline-start:-10000px;inline-size:1px;block-size:1px;clip:rect(0 0 0 0);-webkit-clip-path:inset(50%);clip-path:inset(50%);overflow:hidden;margin:-1px;}
+                      </style>
+                    </head>,
+                    "ctr": 3,
+                    "insertionPoint": undefined,
+                    "isSpeedy": false,
+                    "key": "css",
+                    "nonce": undefined,
+                    "prepend": undefined,
+                    "tags": Array [
+                      <style
+                        data-emotion="css"
+                        data-s=""
+                      >
+                        
+                        .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                      </style>,
+                      <style
+                        data-emotion="css"
+                        data-s=""
+                      >
+                        
+                        .css-zih94u-render{display:block;}
+                      </style>,
+                      <style
+                        data-emotion="css"
+                        data-s=""
+                      >
+                        
+                        .css-hus3oj-euiScreenReaderOnly{position:absolute;inset-block-start:auto;inset-inline-start:-10000px;inline-size:1px;block-size:1px;clip:rect(0 0 0 0);-webkit-clip-path:inset(50%);clip-path:inset(50%);overflow:hidden;margin:-1px;}
+                      </style>,
+                    ],
+                  },
+                }
+              }
+              isStringTag={true}
+              serialized={
+                Object {
+                  "map": undefined,
+                  "name": "zih94u-render",
+                  "next": undefined,
+                  "styles": "display:block;;label:render;",
+                  "toString": [Function],
+                }
+              }
+            />
+            <div
+              className="euiPopover__anchor css-zih94u-render"
+            >
+              <div
+                className="react-datepicker__input-container"
+              >
+                <input
+                  aria-invalid={true}
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  className="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid testClass1 testClass2"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  readOnly={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </EuiOutsideClickDetector>
+  </EuiPopover>
+</DatePicker>
 `;
 
 exports[`EuiDatePicker localization accepts the locale prop 1`] = `

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
               class="react-datepicker__input-container"
             >
               <input
+                aria-invalid="true"
                 aria-label="Press the down key to open a popover containing a calendar."
                 class="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid euiDatePickerRange__start"
                 type="text"
@@ -254,6 +255,7 @@ exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
               class="react-datepicker__input-container"
             >
               <input
+                aria-invalid="true"
                 aria-label="Press the down key to open a popover containing a calendar."
                 class="euiDatePicker euiFieldText euiFieldText-isInvalid euiDatePickerRange__end"
                 type="text"

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -1,451 +1,521 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiDatePickerRange disabled is rendered 1`] = `
-<div
-  class="euiDatePickerRange euiDatePickerRange--isDisabled"
->
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <div
-          class="euiPopover emotion-euiPopover"
-        >
-          <div
-            class="euiPopover__anchor css-zih94u-render"
-          >
-            <div
-              class="react-datepicker__input-container"
-            >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start"
-                disabled=""
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons"
-        >
-          <span
-            class="euiFormControlLayoutCustomIcon"
-          >
-            <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="calendar"
-            />
-          </span>
-        </div>
-      </div>
-    </div>
-  </span>
-  <span
-    class="euiDatePickerRange__delimeter"
+Array [
+  <div
+    class="euiDatePickerRange euiDatePickerRange--isDisabled"
   >
     <span
-      color="subdued"
-      data-euiicon-type="sortRight"
-    />
-  </span>
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
+      class="euiDatePicker euiDatePicker--shadow"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
         <div
-          class="euiPopover emotion-euiPopover"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiPopover__anchor css-zih94u-render"
+            class="euiPopover emotion-euiPopover"
           >
             <div
-              class="react-datepicker__input-container"
+              class="euiPopover__anchor css-zih94u-render"
             >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiDatePickerRange__end"
-                disabled=""
-                type="text"
-                value=""
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start"
+                  disabled=""
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="calendar"
               />
+            </span>
+          </div>
+        </div>
+      </div>
+    </span>
+    <span
+      class="euiDatePickerRange__delimeter"
+    >
+      <span
+        color="subdued"
+        data-euiicon-type="sortRight"
+      />
+    </span>
+    <span
+      class="euiDatePicker euiDatePicker--shadow"
+    >
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiPopover emotion-euiPopover"
+          >
+            <div
+              class="euiPopover__anchor css-zih94u-render"
+            >
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiDatePickerRange__end"
+                  disabled=""
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </span>
-</div>
+    </span>
+  </div>,
+  <p
+    hidden=""
+    id="euiDatePickerRange_generated-id_description"
+  >
+    Selected range: Empty date to Empty date
+  </p>,
+]
 `;
 
 exports[`EuiDatePickerRange is rendered 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiDatePickerRange testClass1 testClass2"
-  data-test-subj="test subject string"
->
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <div
-          class="euiPopover emotion-euiPopover"
-        >
-          <div
-            class="euiPopover__anchor css-zih94u-render"
-          >
-            <div
-              class="react-datepicker__input-container"
-            >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start"
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons"
-        >
-          <span
-            class="euiFormControlLayoutCustomIcon"
-          >
-            <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="calendar"
-            />
-          </span>
-        </div>
-      </div>
-    </div>
-  </span>
-  <span
-    class="euiDatePickerRange__delimeter"
+Array [
+  <div
+    aria-label="aria-label"
+    class="euiDatePickerRange testClass1 testClass2"
+    data-test-subj="test subject string"
   >
     <span
-      color="subdued"
-      data-euiicon-type="sortRight"
-    />
-  </span>
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
+      class="euiDatePicker euiDatePicker--shadow"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
         <div
-          class="euiPopover emotion-euiPopover"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiPopover__anchor css-zih94u-render"
+            class="euiPopover emotion-euiPopover"
           >
             <div
-              class="react-datepicker__input-container"
+              class="euiPopover__anchor css-zih94u-render"
             >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiDatePickerRange__end"
-                type="text"
-                value=""
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="calendar"
               />
+            </span>
+          </div>
+        </div>
+      </div>
+    </span>
+    <span
+      class="euiDatePickerRange__delimeter"
+    >
+      <span
+        color="subdued"
+        data-euiicon-type="sortRight"
+      />
+    </span>
+    <span
+      class="euiDatePicker euiDatePicker--shadow"
+    >
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiPopover emotion-euiPopover"
+          >
+            <div
+              class="euiPopover__anchor css-zih94u-render"
+            >
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiDatePickerRange__end"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </span>
-</div>
+    </span>
+  </div>,
+  <p
+    hidden=""
+    id="euiDatePickerRange_generated-id_description"
+  >
+    Selected range: Empty date to Empty date
+  </p>,
+]
 `;
 
 exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
-<div
-  class="euiDatePickerRange euiDatePickerRange--isInvalid"
->
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <div
-          class="euiPopover emotion-euiPopover"
-        >
-          <div
-            class="euiPopover__anchor css-zih94u-render"
-          >
-            <div
-              class="react-datepicker__input-container"
-            >
-              <input
-                aria-invalid="true"
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid euiDatePickerRange__start"
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons"
-        >
-          <span
-            class="euiFormControlLayoutCustomIcon"
-          >
-            <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="calendar"
-            />
-          </span>
-        </div>
-      </div>
-    </div>
-  </span>
-  <span
-    class="euiDatePickerRange__delimeter"
+Array [
+  <div
+    class="euiDatePickerRange euiDatePickerRange--isInvalid"
   >
     <span
-      color="danger"
-      data-euiicon-type="warning"
-    />
-  </span>
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
+      class="euiDatePicker euiDatePicker--shadow"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
         <div
-          class="euiPopover emotion-euiPopover"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiPopover__anchor css-zih94u-render"
+            class="euiPopover emotion-euiPopover"
           >
             <div
-              class="react-datepicker__input-container"
+              class="euiPopover__anchor css-zih94u-render"
             >
-              <input
-                aria-invalid="true"
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText-isInvalid euiDatePickerRange__end"
-                type="text"
-                value=""
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-invalid="true"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid euiDatePickerRange__start"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="calendar"
               />
+            </span>
+          </div>
+        </div>
+      </div>
+    </span>
+    <span
+      class="euiDatePickerRange__delimeter"
+    >
+      <span
+        color="danger"
+        data-euiicon-type="warning"
+      />
+    </span>
+    <span
+      class="euiDatePicker euiDatePicker--shadow"
+    >
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiPopover emotion-euiPopover"
+          >
+            <div
+              class="euiPopover__anchor css-zih94u-render"
+            >
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-invalid="true"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiFieldText-isInvalid euiDatePickerRange__end"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </span>
-</div>
+    </span>
+  </div>,
+  <p
+    hidden=""
+    id="euiDatePickerRange_generated-id_description"
+  >
+    Selected range: Empty date to Empty date
+  </p>,
+]
 `;
 
 exports[`EuiDatePickerRange readOnly is rendered 1`] = `
-<div
-  class="euiDatePickerRange euiDatePickerRange--readOnly"
->
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <div
-          class="euiPopover emotion-euiPopover"
-        >
-          <div
-            class="euiPopover__anchor css-zih94u-render"
-          >
-            <div
-              class="react-datepicker__input-container"
-            >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start"
-                readonly=""
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons"
-        >
-          <span
-            class="euiFormControlLayoutCustomIcon"
-          >
-            <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="calendar"
-            />
-          </span>
-        </div>
-      </div>
-    </div>
-  </span>
-  <span
-    class="euiDatePickerRange__delimeter"
+Array [
+  <div
+    class="euiDatePickerRange euiDatePickerRange--readOnly"
   >
     <span
-      color="subdued"
-      data-euiicon-type="sortRight"
-    />
-  </span>
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
+      class="euiDatePicker euiDatePicker--shadow"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
         <div
-          class="euiPopover emotion-euiPopover"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiPopover__anchor css-zih94u-render"
+            class="euiPopover emotion-euiPopover"
           >
             <div
-              class="react-datepicker__input-container"
+              class="euiPopover__anchor css-zih94u-render"
             >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiDatePickerRange__end"
-                readonly=""
-                type="text"
-                value=""
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start"
+                  readonly=""
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="calendar"
               />
+            </span>
+          </div>
+        </div>
+      </div>
+    </span>
+    <span
+      class="euiDatePickerRange__delimeter"
+    >
+      <span
+        color="subdued"
+        data-euiicon-type="sortRight"
+      />
+    </span>
+    <span
+      class="euiDatePicker euiDatePicker--shadow"
+    >
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiPopover emotion-euiPopover"
+          >
+            <div
+              class="euiPopover__anchor css-zih94u-render"
+            >
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiDatePickerRange__end"
+                  readonly=""
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </span>
-</div>
+    </span>
+  </div>,
+  <p
+    hidden=""
+    id="euiDatePickerRange_generated-id_description"
+  >
+    Selected range: Empty date to Empty date
+  </p>,
+]
+`;
+
+exports[`EuiDatePickerRange renders the ARIA description element when non-custom controls are used 1`] = `
+<p
+  hidden={true}
+  id="euiDatePickerRange_generated-id_description"
+>
+  <EuiI18n
+    default="Selected range: {startDate} to {endDate}"
+    token="euiDatePickerRange.inputsAriaDescribedBy"
+    values={
+      Object {
+        "endDate": "February 10, 2023 12:00 AM",
+        "startDate": "February 1, 2023 12:00 AM",
+      }
+    }
+  >
+    Selected range: February 1, 2023 12:00 AM to February 10, 2023 12:00 AM
+  </EuiI18n>
+</p>
 `;
 
 exports[`EuiDatePickerRange uses individual EuiDatePicker props 1`] = `
-<div
-  aria-label="aria-label"
-  class="euiDatePickerRange testClass1 testClass2"
-  data-test-subj="test subject string"
->
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <div
-          class="euiPopover emotion-euiPopover"
-        >
-          <div
-            class="euiPopover__anchor css-zih94u-render"
-          >
-            <div
-              class="react-datepicker__input-container"
-            >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start hello"
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFormControlLayoutIcons"
-        >
-          <span
-            class="euiFormControlLayoutCustomIcon"
-          >
-            <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="calendar"
-            />
-          </span>
-        </div>
-      </div>
-    </div>
-  </span>
-  <span
-    class="euiDatePickerRange__delimeter"
+Array [
+  <div
+    aria-label="aria-label"
+    class="euiDatePickerRange testClass1 testClass2"
+    data-test-subj="test subject string"
   >
     <span
-      color="subdued"
-      data-euiicon-type="sortRight"
-    />
-  </span>
-  <span
-    class="euiDatePicker euiDatePicker--shadow"
-  >
-    <div
-      class="euiFormControlLayout"
+      class="euiDatePicker euiDatePicker--shadow"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout"
       >
         <div
-          class="euiPopover emotion-euiPopover"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiPopover__anchor css-zih94u-render"
+            class="euiPopover emotion-euiPopover"
           >
             <div
-              class="react-datepicker__input-container"
+              class="euiPopover__anchor css-zih94u-render"
             >
-              <input
-                aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiDatePickerRange__end world"
-                type="text"
-                value=""
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiFieldText--withIcon euiDatePickerRange__start hello"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormControlLayoutIcons"
+          >
+            <span
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="calendar"
               />
+            </span>
+          </div>
+        </div>
+      </div>
+    </span>
+    <span
+      class="euiDatePickerRange__delimeter"
+    >
+      <span
+        color="subdued"
+        data-euiicon-type="sortRight"
+      />
+    </span>
+    <span
+      class="euiDatePicker euiDatePicker--shadow"
+    >
+      <div
+        class="euiFormControlLayout"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <div
+            class="euiPopover emotion-euiPopover"
+          >
+            <div
+              class="euiPopover__anchor css-zih94u-render"
+            >
+              <div
+                class="react-datepicker__input-container"
+              >
+                <input
+                  aria-describedby="euiDatePickerRange_generated-id_description"
+                  aria-label="Press the down key to open a popover containing a calendar."
+                  class="euiDatePicker euiFieldText euiDatePickerRange__end world"
+                  type="text"
+                  value=""
+                />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </span>
-</div>
+    </span>
+  </div>,
+  <p
+    hidden=""
+    id="euiDatePickerRange_generated-id_description"
+  >
+    Selected range: Empty date to Empty date
+  </p>,
+]
 `;

--- a/src/components/date_picker/date_picker.a11y.tsx
+++ b/src/components/date_picker/date_picker.a11y.tsx
@@ -10,10 +10,10 @@
 
 import React, { useState } from 'react';
 import moment from 'moment';
-import { EuiDatePicker } from './date_picker';
+import { EuiDatePicker, EuiDatePickerProps } from './date_picker';
 import { EuiFormRow } from '../form';
 
-const DatePicker = () => {
+const DatePicker = (extraProps: Partial<EuiDatePickerProps>) => {
   const [startDate, setStartDate] = useState(moment());
 
   const handleChange = (date) => {
@@ -22,18 +22,22 @@ const DatePicker = () => {
 
   return (
     <EuiFormRow label="Select a date">
-      <EuiDatePicker selected={startDate} onChange={handleChange} />
+      <EuiDatePicker
+        {...extraProps}
+        selected={startDate}
+        onChange={handleChange}
+      />
     </EuiFormRow>
   );
 };
 
-beforeEach(() => {
-  cy.realMount(<DatePicker />);
-  cy.get('input.euiDatePicker').should('exist');
-});
-
 describe('EuiDatePicker', () => {
   describe('Automated accessibility check', () => {
+    beforeEach(() => {
+      cy.realMount(<DatePicker />);
+      cy.get('input.euiDatePicker').should('exist');
+    });
+
     it('has zero violations on first render', () => {
       cy.checkAxe();
     });
@@ -66,6 +70,17 @@ describe('EuiDatePicker', () => {
       cy.realPress('Space');
       cy.repeatRealPress('ArrowDown');
       cy.realPress('Enter');
+      cy.checkAxe();
+    });
+  });
+
+  describe('Automated accessibility check - invalid state', () => {
+    beforeEach(() => {
+      cy.realMount(<DatePicker isInvalid />);
+      cy.get('input.euiDatePicker').should('exist');
+    });
+
+    it('has zero violations on first render', () => {
       cy.checkAxe();
     });
   });

--- a/src/components/date_picker/date_picker.test.tsx
+++ b/src/components/date_picker/date_picker.test.tsx
@@ -21,7 +21,11 @@ describe('EuiDatePicker', () => {
     );
 
     expect(component).toMatchSnapshot(); // snapshot of wrapping dom
-    expect(component.find('ContextConsumer').shallow()).toMatchSnapshot(); // snapshot of DatePicker usage
+
+    const contextChildren = component.find('ContextConsumer').dive();
+    const euiValidatableControl = contextChildren.find('EuiValidatableControl');
+
+    expect(euiValidatableControl.find('DatePicker')).toMatchSnapshot(); // snapshot of DatePicker usage
   });
 
   describe('popoverPlacement', () => {
@@ -58,6 +62,16 @@ describe('EuiDatePicker', () => {
       );
 
       expect(takeMountedSnapshot(component)).toMatchSnapshot();
+    });
+  });
+
+  describe('isInvalid', () => {
+    it('is rendered', () => {
+      const component = mount<EuiDatePicker>(
+        <EuiDatePicker {...requiredProps} isInvalid />
+      );
+
+      expect(component.find('DatePicker')).toMatchSnapshot();
     });
   });
 });

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -224,10 +224,10 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
           clear={selected && onClear ? { onClick: onClear } : undefined}
           isLoading={isLoading}
         >
-          <EuiValidatableControl isInvalid={isInvalid}>
-            <EuiI18nConsumer>
-              {({ locale: contextLocale }) => {
-                return (
+          <EuiI18nConsumer>
+            {({ locale: contextLocale }) => {
+              return (
+                <EuiValidatableControl isInvalid={isInvalid}>
                   <ReactDatePicker
                     adjustDateOnChange={adjustDateOnChange}
                     calendarClassName={calendarClassName}
@@ -263,10 +263,10 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
                     popperPlacement={popoverPlacement}
                     {...rest}
                   />
-                );
-              }}
-            </EuiI18nConsumer>
-          </EuiValidatableControl>
+                </EuiValidatableControl>
+              );
+            }}
+          </EuiI18nConsumer>
         </EuiFormControlLayout>
       </span>
     );

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -23,6 +23,11 @@ import { EuiDatePickerProps } from './date_picker';
 
 export type EuiDatePickerRangeProps = CommonProps & {
   /**
+   * Space-separated list of element IDs describing the elements for ARIA purposes.
+   */
+  'aria-describedby'?: string;
+
+  /**
    * Including any children will replace all innards with the provided children
    */
   children?: ReactNode;

--- a/src/components/date_picker/react-datepicker/src/index.d.ts
+++ b/src/components/date_picker/react-datepicker/src/index.d.ts
@@ -25,6 +25,9 @@ import * as moment from 'moment';
 import {PopoverAnchorPosition} from '../../../popover';
 
 export interface ReactDatePickerProps {
+  'aria-describedby'?: string;
+  'aria-invalid'?: string | boolean;
+
   /**
    * Whether changes to Year and Month (via dropdowns) should trigger `onChange`
    */

--- a/src/components/date_picker/react-datepicker/src/index.js
+++ b/src/components/date_picker/react-datepicker/src/index.js
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2018 HackerOne Inc and individual contributors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  */
 
 import Calendar from "./calendar";
@@ -98,6 +98,8 @@ export default class DatePicker extends React.Component {
   static propTypes = {
     adjustDateOnChange: PropTypes.bool,
     allowSameDay: PropTypes.bool,
+    "aria-describedby": PropTypes.string,
+    "aria-invalid": PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     autoComplete: PropTypes.string,
     autoFocus: PropTypes.bool,
     calendarClassName: PropTypes.string,
@@ -344,13 +346,13 @@ export default class DatePicker extends React.Component {
               enableFocusTrap: skipSetBlur ? false : prev.enableFocusTrap
             }),
             () => {
-              // Skip `onBlur` if 
+              // Skip `onBlur` if
               // 1) we are possibly manually moving focus between the input and popover (skipSetBlur) and
-              // 2) the blur event keeps focus on the input 
+              // 2) the blur event keeps focus on the input
               // Focus is also guaranteed to not be inside the popover at this point
               if (!skipSetBlur || (document != null && document.activeElement !== this.input)) {
                 this.setBlur();
-              } 
+              }
 
               this.setState({ inputValue: null });
             }
@@ -548,7 +550,7 @@ export default class DatePicker extends React.Component {
     }
 
     this.props.onSelect(changedDate);
-    
+
     if (this.props.shouldCloseOnSelect) {
       this.setOpen(false, true);
     }
@@ -798,6 +800,8 @@ export default class DatePicker extends React.Component {
       readOnly: this.props.readOnly,
       required: this.props.required,
       tabIndex: this.props.tabIndex,
+      "aria-invalid": this.props["aria-invalid"],
+      "aria-describedby": this.props["aria-describedby"],
       "aria-label": this.state.open ? 'Press the down key to enter a popover containing a calendar. Press the escape key to close the popover.' : 'Press the down key to open a popover containing a calendar.'
     });
   };
@@ -881,7 +885,6 @@ export default class DatePicker extends React.Component {
             {this.renderAccessibleButton()}
           </div>
         }
-        
       >
         {calendar}
       </EuiPopover>


### PR DESCRIPTION
## Summary

This PR improves the date picker components to properly pass `aria-invalid` and `aria-describedby` props to EuiDatePicker.

### EuiDatePicker

- Flip the nesting order of `EuiValidatableControl` and `EuiI18nConsumer` so that `EuiValidatableControl` can properly inject `aria-invalid` and call `setCustomValidity()`
- Pass `aria-invalid` and `aria-describedby` to the underlying react-datepicker input element

### EuiDatePickerRange

- Accept `aria-describedby` prop to be passed to the range controls wrapper element
- Add optional `value` and `onChange` props to allow passing moment dates without the need to explicitly set them in the control elements
- Track the controls value updates in `EuiDatePickerRange` and update the hidden ARIA description element whenever the value changes to allow screen reader software to see the full range description. 

Form validation errors are still supported and will be visible as the `aria-describedby` set on the controls wrapper element. For more validation needs, the `aria-describedby` on the controls can be overridden by explicitly setting `startDateControl` and `endDateControl`.

This PR fixes most of the concerns raised in https://github.com/elastic/eui/issues/6612. The only missing piece is the active range validity ARIA information, but I feel this could be handled by the form validation instead. Definitely something to think about!

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

~- [ ] Checked in both **light and dark** modes~
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

### Emotion conversion checklist

- **Does it work?**
~- [ ] Output CSS matches the previous CSS / as expected in browsers~
~- [ ] Rendered className reads as expected in snapshots and in browsers~
~- [ ] Checked component playground (class components wrapped in `withEuiTheme` need to pass `true` as the second argument to its `propUtilityForPlayground` in `src-docs/src/views/{component}/playground.js`)~
&nbsp;
- **Unit tests**
~- [ ] [`shouldRenderCustomStyles()`](https://github.com/elastic/eui/blob/6054e9b8310bdb106371c0c9ff8bc48e3e0e594b/src/test/internal/render_custom_styles.tsx) test was added and passes with parent component and any nested `childProps` (e.g. `tooltipProps`)~
- [ ] Removed any `mount()`ed snapshots in favor of `render()` or a more specific assertion
&nbsp;
- **Sass/Emotion conversion process**
~- [ ] Converted all global Sass vars/mixins to JS (e.g. `$euiSize` to `euiTheme.size.base`)~
- [ ] Removed or converted component-specific Sass vars/mixins to exported JS versions, listed removals in changelog, and [manually updated our theme JSON files](https://github.com/elastic/eui/tree/main/src-docs/src/views/theme/_json)
~- [ ] Simplified `calc()` to `mathWithUnits` if possible (if mixing different unit types, this may not be possible)~
~- [ ] Added an `@warn` deprecation message within the `global_styling/mixins/{component}.scss` file~
~- [ ] Removed component from `src/components/index.scss`~
~- [ ] Deleted any `src/amsterdam/overrides/{component}.scss` files (styles within should have been converted to the baseline Emotion styles)~
&nbsp;
- **CSS tech debt**
~- [ ] Reduced specificity where possible (usually by reducing nesting and class name chaining)~
~- [ ] Wrapped all animations or transitions in `euiCanAnimate`~
~- [ ] Used `gap` property to add margin between items if using flex~
~- [ ] Converted side specific padding, margin, and position to `-inline` and `-block` [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) (check inline styles as well as CSS)~
&nbsp;
- **DOM cleanup**
- [x] Did **not** remove any block/element classNames (e.g. `euiComponent`, `euiComponent__child`)
~- [ ] Deleted any modifier classNames or maps if not being used in Kibana. **Before doing this step**:~
    ~- [ ] Search/grep through Kibana's codebase for `{euiComponent}-` (case sensitive) to check for source code usage of modifier classes~
    ~- [ ] If usages exist, consider converting to a `data` attribute so that consumers still have something to hook into~
&nbsp;
- **Kibana due diligence**
- Pre-emptively check how your conversion will impact the next Kibana upgrade. This entails searching/grepping through Kibana (excluding `**/target, **/*.snap, **/*.storyshot` for less noise) for `eui{Component}` (case sensitive) to find:
- [ ] Any test/query selectors that will need to be updated
~- [ ] Any Sass or CSS that will need to be updated, particularly if a component Sass var was deleted~
~- [ ] Any direct className usages that will need to be refactored (e.g. someone calling the `euiBadge` class on a div instead of simply using the `EuiBadge` component)~
&nbsp;
- **Extras/nice-to-have**
- [ ] Documentation pass:
    - [ ] Converted any remaining `.js` docs files to TS
    - [ ] Misc cleanup of docs code (e.g. combine imports to single `from '../src'`, replace `<React.Fragment>` with `<>`)
~- [ ] Check for issues in the backlog that could be a quick fix for that component~
~- [ ] Optional component/code cleanup: consider splitting up the component into multiple children if it's overly verbose or difficult to reason about~
