### PR TITLE
[Docs] Remove arrow key page/route navigation

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -697,20 +697,4 @@ export default {
   getAppRoutes: function getAppRoutes() {
     return allRoutes;
   },
-
-  getPreviousRoute: function getPreviousRoute(routeName) {
-    const index = allRoutes.findIndex((item) => {
-      return item.name === routeName;
-    });
-
-    return index >= 0 ? allRoutes[index - 1] : undefined;
-  },
-
-  getNextRoute: function getNextRoute(routeName) {
-    const index = allRoutes.findIndex((item) => {
-      return item.name === routeName;
-    });
-
-    return index < allRoutes.length - 1 ? allRoutes[index + 1] : undefined;
-  },
 };

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { toggleLocale as _toggleLocale } from '../actions';
@@ -17,49 +17,12 @@ import {
   EuiScreenReaderLive,
 } from '../../../src/components';
 
-import { keys } from '../../../src/services';
-
 export const AppView = ({ children, currentRoute }) => {
   const dispatch = useDispatch();
   const toggleLocale = (locale) => dispatch(_toggleLocale(locale));
   const locale = useSelector((state) => getLocale(state));
   const routes = useSelector((state) => getRoutes(state));
   const { theme } = useContext(ThemeContext);
-
-  useEffect(() => {
-    const onKeydown = (event) => {
-      if (event.target !== document.body) {
-        return;
-      }
-
-      if (event.metaKey) {
-        return;
-      }
-
-      if (event.key === keys.ARROW_LEFT) {
-        pushRoute(routes.getPreviousRoute);
-        return;
-      }
-
-      if (event.key === keys.ARROW_RIGHT) {
-        pushRoute(routes.getNextRoute);
-      }
-
-      function pushRoute(getRoute) {
-        const route = getRoute(currentRoute.name);
-
-        if (route) {
-          routes.history.push(`/${route.path}`);
-        }
-      }
-    };
-
-    document.addEventListener('keydown', onKeydown);
-
-    return () => {
-      document.removeEventListener('keydown', onKeydown);
-    };
-  }, []); // eslint-disable-line
 
   const portalledHeadingAnchorLinks = useHeadingAnchorLinks();
 


### PR DESCRIPTION
## Summary

closes #4762

EUI as a team has decided to remove the left/right arrow key press behavior that would cause the user to go to the "next" or "previous" page in the side nav list. We made this decision for several reasons:

1. It's an accessibility issue - the fact that SR/keyboard users have no idea that it's there and that it behaves unpredictably is problematic
2. It's a dev point of friction - particularly with data grid etc., it's easy (when live-coding) to end up with stranded focus while using arrow keys to navigate the grid and end up on a totally different page than you wanted to be
3. It's no longer used by anyone on the team. If we're getting to the point of far-reaching changes where _every page_ in our docs need to be tested/QA'd, we should be writing automated testing or visual screenshotting tests instead of attempting to do it manually.

## QA

- Go to the staging link for this PR
- Confirm the left/right arrow keys no longer cause pagination between the 