### PR TITLE
[EuiSuperSelect] Add new `placeholder` API; clean up screen reader accessibility

### DIFF
--- a/src-docs/src/views/super_select/super_select_complex.js
+++ b/src-docs/src/views/super_select/super_select_complex.js
@@ -42,7 +42,7 @@ export default () => {
     },
   ];
 
-  const [value, setValue] = useState('option_one');
+  const [value, setValue] = useState();
 
   const onChange = (value) => {
     setValue(value);
@@ -52,6 +52,7 @@ export default () => {
     <EuiSuperSelect
       options={options}
       valueOfSelected={value}
+      placeholder="Select an option"
       onChange={(value) => onChange(value)}
       itemLayoutAlign="top"
       hasDividers

--- a/src-docs/src/views/super_select/super_select_example.js
+++ b/src-docs/src/views/super_select/super_select_example.js
@@ -102,13 +102,21 @@ export const SuperSelectExample = {
         },
       ],
       text: (
-        <p>
-          Both <EuiCode>inputDisplay</EuiCode> and{' '}
-          <EuiCode>dropdownDisplay</EuiCode> accept React nodes. Therefore you
-          can pass some descriptions with each option to show in the dropdown.
-          If your options will most likely be multi-line, add the{' '}
-          <EuiCode>hasDividers</EuiCode> prop to show borders between options.
-        </p>
+        <>
+          <p>
+            Both <EuiCode>inputDisplay</EuiCode> and{' '}
+            <EuiCode>dropdownDisplay</EuiCode> accept React nodes. Therefore you
+            can pass some descriptions with each option to show in the dropdown.
+            If your options will most likely be multi-line, add the{' '}
+            <EuiCode>hasDividers</EuiCode> prop to show borders between options.
+          </p>
+          <p>
+            A <EuiCode>placeholder</EuiCode> prop may also be passed that
+            accepts string as well as React nodes (to match your{' '}
+            <EuiCode>inputDisplay</EuiCode> if necessary). This placeholder will
+            only show when <EuiCode>valueOfSelected</EuiCode> is empty.
+          </p>
+        </>
       ),
       props: {},
       snippet: superSelectComplexSnippet,

--- a/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
+++ b/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
@@ -18,12 +18,6 @@ exports[`EuiColorPalettePicker is rendered 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -69,12 +63,6 @@ exports[`EuiColorPalettePicker is rendered with a selected custom text 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: Plain text as a custom option, is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -122,42 +110,6 @@ exports[`EuiColorPalettePicker is rendered with a selected fixed palette 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: 
-            <span
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-            >
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                Palette 1
-              </span>
-              <span
-                aria-hidden="true"
-                class="euiColorPaletteDisplayFixed__bleedArea"
-              >
-                <span
-                  style="background-color:#1fb0b2;width:20%"
-                />
-                <span
-                  style="background-color:#ffdb6d;width:20%"
-                />
-                <span
-                  style="background-color:#ee9191;width:20%"
-                />
-                <span
-                  style="background-color:#ffffff;width:20%"
-                />
-                <span
-                  style="background-color:#888094;width:20%"
-                />
-              </span>
-            </span>
-            , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -233,23 +185,6 @@ exports[`EuiColorPalettePicker is rendered with a selected gradient palette 1`] 
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: 
-            <span
-              class="emotion-euiScreenReaderOnly"
-            >
-              Linear Gradient
-            </span>
-            <span
-              aria-hidden="true"
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-              style="background:linear-gradient(to right, #1fb0b2 0%, #ffdb6d 25%, #ee9191 50%, #ffffff 75%, #888094 100%)"
-            />
-            , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -306,23 +241,6 @@ exports[`EuiColorPalettePicker is rendered with a selected gradient palette with
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: 
-            <span
-              class="emotion-euiScreenReaderOnly"
-            >
-              Linear Gradient with stops
-            </span>
-            <span
-              aria-hidden="true"
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-              style="background:linear-gradient(to right, #54B399 0%, #D36086 53%, #9170B8 74%, #F5A700 100%)"
-            />
-            , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -379,12 +297,6 @@ exports[`EuiColorPalettePicker is rendered with the prop selectionDisplay set as
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: Palette 1, is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -432,42 +344,6 @@ exports[`EuiColorPalettePicker more props are propagated to each option 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: 
-            <span
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
-            >
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                Palette 1
-              </span>
-              <span
-                aria-hidden="true"
-                class="euiColorPaletteDisplayFixed__bleedArea"
-              >
-                <span
-                  style="background-color: rgb(31, 176, 178); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(255, 219, 109); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(238, 145, 145); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(255, 255, 255); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(136, 128, 148); width: 20%;"
-                />
-              </span>
-            </span>
-            , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -165,6 +165,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
             </p>
             <div
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+              aria-label="Select listbox"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -410,6 +411,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
             <div
               aria-activedescendant="1"
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+              aria-label="Select listbox"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -554,6 +556,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
             </p>
             <div
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+              aria-label="Select listbox"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -699,6 +702,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
             <div
               aria-activedescendant="2"
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+              aria-label="Select listbox"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -18,12 +18,6 @@ exports[`EuiSuperSelect is rendered 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -69,12 +63,6 @@ exports[`EuiSuperSelect props compressed is rendered 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -120,12 +108,6 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
@@ -183,7 +165,6 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
             </p>
             <div
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-labelledby="euiSuperSelect__generated-id__screenreaderLabelId"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -269,12 +250,6 @@ exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -325,12 +300,6 @@ exports[`EuiSuperSelect props is rendered with a prepend and append 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             aria-label="aria-label"
@@ -381,12 +350,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: Option #1, is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
@@ -447,7 +410,6 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
             <div
               aria-activedescendant="1"
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-labelledby="euiSuperSelect__generated-id__screenreaderLabelId"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -535,12 +497,6 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
@@ -598,7 +554,6 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
             </p>
             <div
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-labelledby="euiSuperSelect__generated-id__screenreaderLabelId"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -684,12 +639,6 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: Option #2, is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
@@ -750,7 +699,6 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
             <div
               aria-activedescendant="2"
               aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-labelledby="euiSuperSelect__generated-id__screenreaderLabelId"
               class="euiSuperSelect__listbox"
               role="listbox"
               tabindex="0"
@@ -836,12 +784,6 @@ exports[`EuiSuperSelect props select component is rendered 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: , is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons"
@@ -885,12 +827,6 @@ exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
-          <span
-            class="emotion-euiScreenReaderOnly"
-            id="euiSuperSelect__generated-id__screenreaderLabelId"
-          >
-            Select an option: Option #2, is selected
-          </span>
           <button
             aria-haspopup="listbox"
             class="euiSuperSelectControl euiFormControlLayout--1icons"

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.tsx.snap
@@ -12,11 +12,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         aria-label="aria-label"
@@ -54,11 +49,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--compressed"
@@ -94,11 +84,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--1icons"
@@ -134,11 +119,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--1icons"
@@ -174,11 +154,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--fullWidth"
@@ -214,11 +189,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--2icons euiSuperSelectControl-isInvalid"
@@ -258,11 +228,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: , is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--2icons euiSuperSelectControl-isLoading"
@@ -344,11 +309,6 @@ Array [
     <div
       class="euiFormControlLayout__childrenWrapper"
     >
-      <span
-        class="emotion-euiScreenReaderOnly"
-      >
-        Select an option: Option #1, is selected
-      </span>
       <button
         aria-haspopup="listbox"
         class="euiSuperSelectControl euiFormControlLayout--1icons"

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.tsx.snap
@@ -291,6 +291,47 @@ Array [
 ]
 `;
 
+exports[`EuiSuperSelectControl props placeholder is rendered 1`] = `
+Array [
+  <input
+    type="hidden"
+    value=""
+  />,
+  <div
+    class="euiFormControlLayout"
+  >
+    <div
+      class="euiFormControlLayout__childrenWrapper"
+    >
+      <button
+        aria-haspopup="listbox"
+        class="euiSuperSelectControl euiFormControlLayout--1icons"
+        type="button"
+      >
+        <span
+          class="euiSuperSelectControl__placeholder"
+        >
+          Select an option
+        </span>
+      </button>
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+      >
+        <span
+          class="euiFormControlLayoutCustomIcon"
+        >
+          <span
+            aria-hidden="true"
+            class="euiFormControlLayoutCustomIcon__icon"
+            data-euiicon-type="arrowDown"
+          />
+        </span>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`EuiSuperSelectControl props value option is rendered 1`] = `
 Array [
   <input

--- a/src/components/form/super_select/_super_select_control.scss
+++ b/src/components/form/super_select/_super_select_control.scss
@@ -26,6 +26,10 @@
     padding-bottom: 0; /* 1 */
   }
 
+  &__placeholder {
+    @include euiFormControlDisabledTextStyle;
+  }
+
   &.euiSuperSelect--isOpen__button { // since this is a button, we also want the visual indicator of active when options are shown
     @include euiFormControlFocusStyle;
   }

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, FocusEvent } from 'react';
+import React, { Component, FocusEvent, ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { CommonProps } from '../../common';
@@ -45,6 +45,11 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
     options: Array<EuiSuperSelectOption<T>>;
 
     valueOfSelected?: T;
+
+    /**
+     * Placeholder to display when the current selected value is empty.
+     */
+    placeholder?: ReactNode;
 
     /**
      * Classes for the context menu item
@@ -253,6 +258,7 @@ export class EuiSuperSelect<T extends string> extends Component<
       className,
       options,
       valueOfSelected,
+      placeholder,
       onChange,
       isOpen,
       isInvalid,
@@ -290,6 +296,7 @@ export class EuiSuperSelect<T extends string> extends Component<
         screenReaderId={this.labelledById}
         options={options}
         value={valueOfSelected}
+        placeholder={placeholder}
         onClick={
           this.state.isPopoverOpen ? this.closePopover : this.openPopover
         }

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -106,7 +106,6 @@ export class EuiSuperSelect<T extends string> extends Component<
   private _isMounted: boolean = false;
 
   describedById = htmlIdGenerator('euiSuperSelect_')('_screenreaderDescribeId');
-  labelledById = htmlIdGenerator('euiSuperSelect_')('_screenreaderLabelId');
 
   state = {
     isPopoverOpen: this.props.isOpen || false,
@@ -293,7 +292,6 @@ export class EuiSuperSelect<T extends string> extends Component<
 
     const button = (
       <EuiSuperSelectControl
-        screenReaderId={this.labelledById}
         options={options}
         value={valueOfSelected}
         placeholder={placeholder}
@@ -351,7 +349,6 @@ export class EuiSuperSelect<T extends string> extends Component<
           </p>
         </EuiScreenReaderOnly>
         <div
-          aria-labelledby={this.labelledById}
           aria-describedby={this.describedById}
           className="euiSuperSelect__listbox"
           role="listbox"

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -348,15 +348,20 @@ export class EuiSuperSelect<T extends string> extends Component<
             />
           </p>
         </EuiScreenReaderOnly>
-        <div
-          aria-describedby={this.describedById}
-          className="euiSuperSelect__listbox"
-          role="listbox"
-          aria-activedescendant={valueOfSelected}
-          tabIndex={0}
-        >
-          {items}
-        </div>
+        <EuiI18n token="euiSuperSelect.ariaLabel" default="Select listbox">
+          {(ariaLabel: string) => (
+            <div
+              aria-label={ariaLabel}
+              aria-describedby={this.describedById}
+              className="euiSuperSelect__listbox"
+              role="listbox"
+              aria-activedescendant={valueOfSelected}
+              tabIndex={0}
+            >
+              {items}
+            </div>
+          )}
+        </EuiI18n>
       </EuiInputPopover>
     );
   }

--- a/src/components/form/super_select/super_select_control.test.tsx
+++ b/src/components/form/super_select/super_select_control.test.tsx
@@ -88,6 +88,24 @@ describe('EuiSuperSelectControl', () => {
 
       expect(component).toMatchSnapshot();
     });
+
+    test('placeholder is rendered', () => {
+      const component = render(
+        <EuiSuperSelectControl
+          options={[
+            { value: '1', inputDisplay: 'Option #1' },
+            { value: '2', inputDisplay: 'Option #2' },
+          ]}
+          placeholder="Select an option"
+          onChange={() => {}}
+        />
+      );
+
+      expect(component).toMatchSnapshot();
+      expect(
+        component.find('.euiSuperSelectControl__placeholder')
+      ).toBeTruthy();
+    });
   });
 
   describe('inherits', () => {

--- a/src/components/form/super_select/super_select_control.tsx
+++ b/src/components/form/super_select/super_select_control.tsx
@@ -71,11 +71,6 @@ export interface EuiSuperSelectControlProps<T>
    * `string` | `ReactElement` or an array of these
    */
   append?: EuiFormControlLayoutProps['append'];
-  /**
-   * Creates a semantic label ID for the `div[role="listbox"]` that's opened on click or keypress.
-   * __Generated and passed down by `EuiSuperSelect`.__
-   */
-  screenReaderId?: string;
 }
 
 export const EuiSuperSelectControl: <T extends string>(
@@ -97,7 +92,6 @@ export const EuiSuperSelectControl: <T extends string>(
     placeholder,
     prepend,
     append,
-    screenReaderId,
     disabled,
     ...rest
   } = props;

--- a/src/components/form/super_select/super_select_control.tsx
+++ b/src/components/form/super_select/super_select_control.tsx
@@ -16,12 +16,10 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../../common';
 
-import { EuiScreenReaderOnly } from '../../accessibility';
 import {
   EuiFormControlLayout,
   EuiFormControlLayoutProps,
 } from '../form_control_layout';
-import { EuiI18n } from '../../i18n';
 import { getFormControlClassNameForIconCount } from '../form_control_layout/_num_icons';
 import { useFormContext } from '../eui_form_context';
 
@@ -161,19 +159,6 @@ export const EuiSuperSelectControl: <T extends string>(
         prepend={prepend}
         append={append}
       >
-        {/*
-          This is read when the user tabs in. The comma is important,
-          otherwise the screen reader often combines the text.
-        */}
-        <EuiScreenReaderOnly>
-          <span id={screenReaderId}>
-            <EuiI18n
-              token="euiSuperSelectControl.selectAnOption"
-              default="Select an option: {selectedValue}, is selected"
-              values={{ selectedValue }}
-            />
-          </span>
-        </EuiScreenReaderOnly>
         <button
           type="button"
           className={classes}

--- a/src/components/form/super_select/super_select_control.tsx
+++ b/src/components/form/super_select/super_select_control.tsx
@@ -35,7 +35,7 @@ export interface EuiSuperSelectOption<T> {
 
 export interface EuiSuperSelectControlProps<T>
   extends CommonProps,
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value'> {
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'placeholder'> {
   /**
    * @default false
    */
@@ -57,6 +57,7 @@ export interface EuiSuperSelectControlProps<T>
   readOnly?: boolean;
 
   name?: string;
+  placeholder?: ReactNode;
   value?: T;
 
   options?: Array<EuiSuperSelectOption<T>>;
@@ -95,6 +96,7 @@ export const EuiSuperSelectControl: <T extends string>(
     defaultValue,
     compressed = false,
     value,
+    placeholder,
     prepend,
     append,
     screenReaderId,
@@ -134,6 +136,8 @@ export const EuiSuperSelectControl: <T extends string>(
       ? selectedOption.inputDisplay
       : selectedValue;
   }
+
+  const showPlaceholder = !!placeholder && !selectedValue;
 
   return (
     <Fragment>
@@ -179,7 +183,13 @@ export const EuiSuperSelectControl: <T extends string>(
           readOnly={readOnly}
           {...rest}
         >
-          {selectedValue}
+          {showPlaceholder ? (
+            <span className="euiSuperSelectControl__placeholder">
+              {placeholder}
+            </span>
+          ) : (
+            selectedValue
+          )}
         </button>
       </EuiFormControlLayout>
     </Fragment>

--- a/upcoming_changelogs/6630.md
+++ b/upcoming_changelogs/6630.md
@@ -1,0 +1,1 @@
+- Added new `placeholder` prop to `EuiSuperSelect`


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6189

This PR adds a working `placeholder` prop that accepts either a string or ReactNode (to potentially match `inputDisplay`, which can also be a ReactNode).

![screencap](https://user-images.githubusercontent.com/549407/222542034-2a2b9654-33db-430a-9eb1-a5f9247c995e.gif)

This PR also incidentally cleans up and removes some unnecessary screen reader accessibility that was not quite working as intended. Rationales are in commit messages/code comments.

## QA

- Go to http://localhost:8030/#/forms/super-select#more-complex
- [x] Confirm placeholder renders as expected, and does not render when a value is selected

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~