### PR TITLE
[EuiSelectable] Disable arrow key navigation on non-search/listbox children

### DIFF
--- a/src-docs/src/views/selectable/selectable_custom_render.tsx
+++ b/src-docs/src/views/selectable/selectable_custom_render.tsx
@@ -8,6 +8,8 @@ import {
   EuiSwitch,
   EuiSelectable,
   EuiSelectableOption,
+  EuiFilterGroup,
+  EuiFilterButton,
 } from '../../../../src';
 
 const countryData = [
@@ -80,6 +82,8 @@ export default () => {
     );
   };
 
+  const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
+
   const [useCustomContent, setUseCustomContent] = useState(true);
   const [isVirtualized, setIsVirtualized] = useState(true);
 
@@ -107,12 +111,27 @@ export default () => {
           rowHeight: useCustomContent ? 50 : undefined,
           showIcons: false,
         }}
+        searchProps={{ inputRef: setInputRef }}
         renderOption={useCustomContent ? renderCountryOption : undefined}
         height={240}
       >
         {(list, search) => (
           <>
             {search}
+            <EuiSpacer size="s" />
+            <EuiFilterGroup>
+              <EuiFilterButton
+                iconType="arrowDown"
+                onClick={() => {
+                  inputRef?.focus();
+                }}
+                numFilters={10}
+                hasActiveFilters={true}
+                numActiveFilters={2}
+              >
+                Filters
+              </EuiFilterButton>
+            </EuiFilterGroup>
             {list}
           </>
         )}

--- a/src-docs/src/views/selectable/selectable_custom_render.tsx
+++ b/src-docs/src/views/selectable/selectable_custom_render.tsx
@@ -8,8 +8,6 @@ import {
   EuiSwitch,
   EuiSelectable,
   EuiSelectableOption,
-  EuiFilterGroup,
-  EuiFilterButton,
 } from '../../../../src';
 
 const countryData = [
@@ -82,8 +80,6 @@ export default () => {
     );
   };
 
-  const [inputRef, setInputRef] = useState<HTMLInputElement | null>(null);
-
   const [useCustomContent, setUseCustomContent] = useState(true);
   const [isVirtualized, setIsVirtualized] = useState(true);
 
@@ -111,27 +107,12 @@ export default () => {
           rowHeight: useCustomContent ? 50 : undefined,
           showIcons: false,
         }}
-        searchProps={{ inputRef: setInputRef }}
         renderOption={useCustomContent ? renderCountryOption : undefined}
         height={240}
       >
         {(list, search) => (
           <>
             {search}
-            <EuiSpacer size="s" />
-            <EuiFilterGroup>
-              <EuiFilterButton
-                iconType="arrowDown"
-                onClick={() => {
-                  inputRef?.focus();
-                }}
-                numFilters={10}
-                hasActiveFilters={true}
-                numActiveFilters={2}
-              >
-                Filters
-              </EuiFilterButton>
-            </EuiFilterGroup>
             {list}
           </>
         )}

--- a/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -425,7 +425,7 @@ exports[`EuiSelectable search value supports inheriting initialSearchValue from 
 </div>
 `;
 
-exports[`EuiSelectable should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its popover 1`] = `
+exports[`EuiSelectable should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its search/listbox 1`] = `
 Object {
   "activeOptionIndex": 0,
   "isFocused": true,
@@ -445,7 +445,7 @@ Object {
 }
 `;
 
-exports[`EuiSelectable should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its popover 2`] = `
+exports[`EuiSelectable should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its search/listbox 2`] = `
 Object {
   "activeOptionIndex": 0,
   "isFocused": true,

--- a/src/components/selectable/selectable.spec.tsx
+++ b/src/components/selectable/selectable.spec.tsx
@@ -93,7 +93,7 @@ describe('EuiSelectable', () => {
     it('can clear the input', () => {
       cy.realMount(<EuiSelectableWithSearchInput />);
 
-      // Focus the second option
+      // Search/filter down to the second option
       cy.get('input')
         .realClick()
         .realType('enc')
@@ -103,7 +103,7 @@ describe('EuiSelectable', () => {
             .should('have.attr', 'title', 'Enceladus');
         });
 
-      // Using ENTER
+      // Clear search using ENTER
       cy.get('[data-test-subj="clearSearchButton"]')
         .focus()
         .realPress('{enter}')
@@ -113,7 +113,7 @@ describe('EuiSelectable', () => {
             .should('have.attr', 'title', 'Titan');
         });
 
-      // Focus the second option
+      // Search/filter again
       cy.get('input')
         .realClick()
         .realType('enc')
@@ -123,10 +123,34 @@ describe('EuiSelectable', () => {
             .should('have.attr', 'title', 'Enceladus');
         });
 
-      // Using SPACE
+      // Clear search using SPACE
       cy.get('[data-test-subj="clearSearchButton"]')
         .focus()
         .realPress('Space')
+        .then(() => {
+          cy.get('li[role=option]')
+            .first()
+            .should('have.attr', 'title', 'Titan');
+        });
+
+      // Ensure the clear button does not respond to up/down arrow keys
+      cy.get('input')
+        .realClick()
+        .realType('titan')
+        .then(() => {
+          cy.get('li[role=option]')
+            .first()
+            .should('have.attr', 'title', 'Titan');
+        });
+      cy.get('[data-test-subj="clearSearchButton"]')
+        .focus()
+        .realPress('ArrowDown')
+        .then(() => {
+          cy.get('li[role=option]')
+            .first()
+            .should('have.attr', 'title', 'Titan');
+        })
+        .realPress('ArrowUp')
         .then(() => {
           cy.get('li[role=option]')
             .first()

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -383,6 +383,7 @@ describe('EuiSelectable', () => {
           {(list) => list}
         </EuiSelectable>
       );
+      const target = component.find('div.euiSelectableList__list').getDOMNode();
 
       component.find('[role="option"]').first().simulate('click');
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -393,7 +394,7 @@ describe('EuiSelectable', () => {
         checked: 'on',
       });
 
-      component.simulate('keydown', { key: 'Enter', shiftKey: true });
+      component.simulate('keydown', { key: 'Enter', target });
       expect(onChange).toHaveBeenCalledTimes(2);
       expect(onChange.mock.calls[1][0][0].checked).toEqual('on');
       expect(onChange.mock.calls[1][1].type).toEqual('keydown');
@@ -401,6 +402,24 @@ describe('EuiSelectable', () => {
         ...options[0],
         checked: 'on',
       });
+    });
+
+    it('does not call onChange on keydown when focus is not on the search/listbox', () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <EuiSelectable options={options} onChange={onChange}>
+          {(list) => (
+            <>
+              <button id="test">test</button>
+              {list}
+            </>
+          )}
+        </EuiSelectable>
+      );
+      const target = component.find('#test').getDOMNode();
+
+      component.simulate('keydown', { key: 'Enter', target });
+      expect(onChange).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -412,12 +431,32 @@ describe('EuiSelectable', () => {
           {(list) => list}
         </EuiSelectable>
       );
+      const target = component.find('div.euiSelectableList__list').getDOMNode();
 
-      component.simulate('keydown', { key: 'ArrowDown' });
+      component.simulate('keydown', { key: 'ArrowDown', target });
       expect(callback).toHaveBeenCalledWith(options[0]);
 
-      component.simulate('keydown', { key: 'ArrowUp' });
+      component.simulate('keydown', { key: 'ArrowUp', target });
       expect(callback).toHaveBeenCalledWith(options[2]);
+    });
+
+    it('does not change internal activeOptionIndex state on keydown when focus is not on the search/listbox', () => {
+      const callback = jest.fn();
+      const component = mount(
+        <EuiSelectable options={options} onActiveOptionChange={callback}>
+          {(list) => (
+            <>
+              <button id="test">test</button>
+              {list}
+            </>
+          )}
+        </EuiSelectable>
+      );
+      const target = component.find('#test').getDOMNode();
+
+      component.simulate('keydown', { key: 'ArrowDown', target });
+      component.simulate('keydown', { key: 'ArrowUp', target });
+      expect(callback).toHaveBeenCalledTimes(0);
     });
 
     it('handles the active option changing due to searching', () => {
@@ -437,8 +476,9 @@ describe('EuiSelectable', () => {
           )}
         </EuiSelectable>
       );
+      const target = component.find('input[type="search"]').getDOMNode();
 
-      component.simulate('keydown', { key: 'ArrowDown' });
+      component.simulate('keydown', { key: 'ArrowDown', target });
       expect(callback).toHaveBeenCalledWith(options[2]); // Pandora
     });
   });

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -49,7 +49,7 @@ describe('EuiSelectable', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its popover', () => {
+  test('should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its search/listbox', () => {
     const component = mount(
       <EuiSelectable options={options} searchable>
         {(list, search) => (
@@ -67,9 +67,10 @@ describe('EuiSelectable', () => {
     });
     expect(component.state()).toMatchSnapshot();
 
-    component.find('.euiSelectable').simulate('blur', {
-      relatedTarget: { firstChild: { id: 'generated-id_listbox' } },
-    });
+    const listBox = component.find('div.euiSelectableList__list').getDOMNode();
+    component
+      .find('.euiSelectable')
+      .simulate('blur', { relatedTarget: listBox });
     component.update();
     expect(component.state()).toMatchSnapshot();
   });

--- a/src/components/selectable/selectable.tsx
+++ b/src/components/selectable/selectable.tsx
@@ -14,6 +14,7 @@ import React, {
   ReactElement,
   KeyboardEvent,
   MouseEvent,
+  FocusEvent,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../common';
@@ -298,7 +299,7 @@ export class EuiSelectable<T = {}> extends Component<
     this.preventOnFocus = true;
   };
 
-  onFocus = () => {
+  onFocus = (event?: FocusEvent) => {
     if (this.preventOnFocus) {
       this.preventOnFocus = false;
       return;
@@ -308,6 +309,10 @@ export class EuiSelectable<T = {}> extends Component<
       !this.state.visibleOptions.length ||
       this.state.activeOptionIndex != null
     ) {
+      return;
+    }
+
+    if (event && !this.isFocusOnSearchOrListBox(event.target)) {
       return;
     }
 
@@ -450,9 +455,7 @@ export class EuiSelectable<T = {}> extends Component<
 
   onContainerBlur = (e: React.FocusEvent) => {
     // Ignore blur events when moving from search to option to avoid activeOptionIndex conflicts
-    if (
-      ((e.relatedTarget as Node)?.firstChild as HTMLElement)?.id === this.listId
-    ) {
+    if (this.isFocusOnSearchOrListBox(e.relatedTarget)) {
       return;
     }
 

--- a/upcoming_changelogs/6631.md
+++ b/upcoming_changelogs/6631.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSelectable` to no longer show active selection state or respond to the Up/Down arrow keys when focus is inside the selectable container, but not on the searchbox or listbox.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6627

In #5613 and [#5693](https://github.com/elastic/eui/pull/5693/commits/6bccb75a37b8132f0b6395471d06bc4c4eaa4f77#diff-2bc165a0bf23c9a90824394f5072dc0b25e65056dcac4c148cb465d149fcd6ac), an early return was added to the space/enter keydown listeners to ensure the search clear button still worked without accidentally selecting an option.

It turns out we should have been more aggressive about this early return and put it in front of the entire listener so that the up/down arrow keys also did not function when on the clear button (or any other wildcard interactive content passed by consumers). The arrow keys and enter/space keys should only function when consumers are focused either on the searchbox, or on the listbox.

### Before

![before](https://user-images.githubusercontent.com/549407/222608758-afea80ff-ca7c-4a34-908b-f1d516c4b88c.gif)

### After

![after](https://user-images.githubusercontent.com/549407/222608768-1962f447-da2e-4c55-bee6-0f6773f8839e.gif)

Custom interactive child content within `<EuiSelectable>` (should remove focus/active state):

![screencap](https://user-images.githubusercontent.com/549407/222609004-5084de95-d7b7-4870-b4ee-ca28d824921f.gif)

## QA

- Go to https://eui.elastic.co/pr_6631/#/forms/selectable#rendering-the-options (scroll all the way down)
- Tab into the search box, arrow up/down, confirm active option selection works
- Tab to the fake "Filters" button
- [x] Confirm that the active selection goes away
- [x] Confirm that using the up/down arrow keys does nothing on the button
- [x] Tab backwards to the search box and confirm active option selection/navigation works as expected

### General checklist

- [x] Revert [REVERT ME] commit
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~