### PR TITLE
[EuiDataGrid] Add new `setCellPopoverProps` API to `renderCellPopover`

### DIFF
--- a/src-docs/src/views/datagrid/cells_popovers/cell_popover_rendercellpopover.tsx
+++ b/src-docs/src/views/datagrid/cells_popovers/cell_popover_rendercellpopover.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import { faker } from '@faker-js/faker';
 
 import {
@@ -73,11 +73,17 @@ const RenderCellPopover = (props: EuiDataGridCellPopoverElementProps) => {
     cellActions,
     cellContentsElement,
     DefaultCellPopover,
+    setCellPopoverProps,
   } = props;
 
   let title: ReactNode = 'Custom popover';
   let content: ReactNode = <EuiText size="s">{children}</EuiText>;
   let footer: ReactNode = cellActions;
+
+  // Set custom cell expansion popover props
+  useEffect(() => {
+    setCellPopoverProps({ panelClassName: 'customCellPopover' });
+  }, [setCellPopoverProps]);
 
   // An example of custom popover content
   if (schema === 'favoriteFranchise') {

--- a/src-docs/src/views/datagrid/cells_popovers/datagrid_cell_popover_example.js
+++ b/src-docs/src/views/datagrid/cells_popovers/datagrid_cell_popover_example.js
@@ -112,6 +112,15 @@ export const DataGridCellPopoverExample = {
                 rendering for other cells.
               </p>
             </li>
+            <li>
+              <p>
+                <EuiCode>setCellPopoverProps</EuiCode> - this callback is passed
+                to allow customizing the cell expansion popover. Accepts any
+                prop that <EuiCode>EuiPopover</EuiCode> accepts, except for{' '}
+                <EuiCode>button</EuiCode> & <EuiCode>closePopover</EuiCode>,
+                which is controlled by the data grid.
+              </p>
+            </li>
           </ul>
           <p>
             Take a look at the below example&apos;s demo code to see the above

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -30,6 +30,7 @@ describe('EuiDataGridCell', () => {
     openCellPopover: jest.fn(),
     setPopoverAnchor: jest.fn(),
     setPopoverContent: jest.fn(),
+    setCellPopoverProps: () => {},
   };
   const requiredProps = {
     rowIndex: 0,

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -478,7 +478,11 @@ export class EuiDataGridCell extends Component<
 
   handleCellPopover = () => {
     if (this.isPopoverOpen()) {
-      const { setPopoverAnchor, setPopoverContent } = this.props.popoverContext;
+      const {
+        setPopoverAnchor,
+        setPopoverContent,
+        setCellPopoverProps,
+      } = this.props.popoverContext;
 
       // Set popover anchor
       const cellAnchorEl = this.popoverAnchorRef.current!;
@@ -515,6 +519,7 @@ export class EuiDataGridCell extends Component<
             <EuiDataGridCellPopoverActions {...sharedProps} column={column} />
           }
           DefaultCellPopover={DefaultCellPopover}
+          setCellPopoverProps={setCellPopoverProps}
         >
           <CellElement
             {...sharedProps}

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -8,7 +8,7 @@
 
 /// <reference types="../../../../cypress/support"/>
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { EuiDataGrid, EuiDataGridProps } from '../';
 
 const baseProps: EuiDataGridProps = {
@@ -99,5 +99,32 @@ describe('EuiDataGridCellPopover', () => {
     cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
       'not.exist'
     );
+  });
+
+  it('allows consumers to use setCellPopoverProps, passed from renderCellPopover, to customize popover props', () => {
+    const RenderCellPopover = ({
+      DefaultCellPopover,
+      setCellPopoverProps,
+      ...props
+    }) => {
+      useEffect(() => {
+        setCellPopoverProps({
+          panelClassName: 'hello',
+          panelProps: { className: 'world' },
+        });
+      }, [setCellPopoverProps]);
+
+      return <DefaultCellPopover {...props} />;
+    };
+
+    cy.realMount(
+      <EuiDataGrid {...baseProps} renderCellPopover={RenderCellPopover} />
+    );
+    cy.get(
+      '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+    ).realClick();
+    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
+
+    cy.get('.euiDataGridRowCell__popover.hello.world').should('exist');
   });
 });

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { renderHook, act } from '@testing-library/react-hooks';
 import { shallow } from 'enzyme';
+
 import { keys } from '../../../services';
-import { testCustomHook } from '../../../test/internal';
 
 import { DataGridCellPopoverContextShape } from '../data_grid_types';
 import { useCellPopover, DefaultCellPopover } from './data_grid_cell_popover';
@@ -18,55 +18,57 @@ import { useCellPopover, DefaultCellPopover } from './data_grid_cell_popover';
 describe('useCellPopover', () => {
   describe('openCellPopover', () => {
     it('sets popoverIsOpen state to true', () => {
-      const {
-        return: { cellPopoverContext },
-        getUpdatedState,
-      } = testCustomHook(() => useCellPopover());
-      expect(cellPopoverContext.popoverIsOpen).toEqual(false);
+      const { result } = renderHook(useCellPopover);
+      expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(false);
 
       act(() =>
-        cellPopoverContext.openCellPopover({ rowIndex: 0, colIndex: 0 })
+        result.current.cellPopoverContext.openCellPopover({
+          rowIndex: 0,
+          colIndex: 0,
+        })
       );
-      expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(true);
+      expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(true);
     });
 
     it('does nothing if called again on a popover that is already open', () => {
-      const {
-        return: { cellPopoverContext, cellPopover },
-        getUpdatedState,
-      } = testCustomHook(() => useCellPopover());
-      expect(cellPopover).toBeFalsy();
+      const { result } = renderHook(useCellPopover);
+      expect(result.current.cellPopover).toBeFalsy();
 
       act(() => {
-        cellPopoverContext.openCellPopover({ rowIndex: 0, colIndex: 0 });
-        cellPopoverContext.setPopoverAnchor(document.createElement('div'));
+        result.current.cellPopoverContext.openCellPopover({
+          rowIndex: 0,
+          colIndex: 0,
+        });
+        result.current.cellPopoverContext.setPopoverAnchor(
+          document.createElement('div')
+        );
       });
-      expect(getUpdatedState().cellPopover).not.toBeFalsy();
+      expect(result.current.cellPopover).not.toBeFalsy();
 
       act(() => {
-        getUpdatedState().cellPopoverContext.openCellPopover({
+        result.current.cellPopoverContext.openCellPopover({
           rowIndex: 0,
           colIndex: 0,
         });
       });
-      expect(getUpdatedState().cellPopover).not.toBeFalsy();
+      expect(result.current.cellPopover).not.toBeFalsy();
     });
   });
 
   describe('closeCellPopover', () => {
     it('sets popoverIsOpen state to false', () => {
-      const {
-        return: { cellPopoverContext },
-        getUpdatedState,
-      } = testCustomHook(() => useCellPopover());
+      const { result } = renderHook(useCellPopover);
 
       act(() =>
-        cellPopoverContext.openCellPopover({ rowIndex: 0, colIndex: 0 })
+        result.current.cellPopoverContext.openCellPopover({
+          rowIndex: 0,
+          colIndex: 0,
+        })
       );
-      expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(true);
+      expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(true);
 
-      act(() => cellPopoverContext.closeCellPopover());
-      expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(false);
+      act(() => result.current.cellPopoverContext.closeCellPopover());
+      expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(false);
     });
   });
 
@@ -86,14 +88,11 @@ describe('useCellPopover', () => {
     };
 
     it('renders', () => {
-      const {
-        return: { cellPopoverContext, cellPopover },
-        getUpdatedState,
-      } = testCustomHook(() => useCellPopover());
-      expect(cellPopover).toBeFalsy(); // Should be empty on init
+      const { result } = renderHook(useCellPopover);
+      expect(result.current.cellPopover).toBeFalsy(); // Should be empty on init
 
-      populateCellPopover(cellPopoverContext);
-      expect(getUpdatedState().cellPopover).toMatchInlineSnapshot(`
+      populateCellPopover(result.current.cellPopoverContext);
+      expect(result.current.cellPopover).toMatchInlineSnapshot(`
         <EuiWrappingPopover
           button={<div />}
           closePopover={[Function]}
@@ -134,25 +133,16 @@ describe('useCellPopover', () => {
       mockCell.appendChild(mockPopoverAnchor);
 
       const renderCellPopover = () => {
-        const {
-          return: { cellPopoverContext },
-          getUpdatedState,
-        } = testCustomHook<ReturnType<typeof useCellPopover>>(() =>
-          useCellPopover()
-        );
-        populateCellPopover(cellPopoverContext);
+        const { result } = renderHook(useCellPopover);
+        populateCellPopover(result.current.cellPopoverContext);
+        const component = shallow(<div>{result.current.cellPopover}</div>);
 
-        const { cellPopover } = getUpdatedState();
-        const component = shallow(<div>{cellPopover}</div>);
-
-        return { component, getUpdatedState };
+        return { result, component };
       };
 
       it('closes the popover and refocuses the cell when the Escape key is pressed', () => {
-        const { component, getUpdatedState } = renderCellPopover();
-        expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
-          true
-        );
+        const { result, component } = renderCellPopover();
+        expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(true);
 
         const event = {
           key: keys.ESCAPE,
@@ -165,17 +155,13 @@ describe('useCellPopover', () => {
         expect(event.preventDefault).toHaveBeenCalled();
         expect(event.stopPropagation).toHaveBeenCalled();
 
-        expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
-          false
-        );
+        expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(false);
         expect(document.activeElement).toEqual(mockCell);
       });
 
       it('closes the popover when the F2 key is pressed', () => {
-        const { component, getUpdatedState } = renderCellPopover();
-        expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
-          true
-        );
+        const { result, component } = renderCellPopover();
+        expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(true);
 
         const event = {
           key: keys.F2,
@@ -188,17 +174,13 @@ describe('useCellPopover', () => {
         expect(event.preventDefault).toHaveBeenCalled();
         expect(event.stopPropagation).toHaveBeenCalled();
 
-        expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
-          false
-        );
+        expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(false);
         expect(document.activeElement).toEqual(mockCell);
       });
 
       it('does nothing when other keys are pressed', () => {
-        const { component, getUpdatedState } = renderCellPopover();
-        expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
-          true
-        );
+        const { result, component } = renderCellPopover();
+        expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(true);
 
         const event = {
           key: keys.ENTER,
@@ -212,9 +194,7 @@ describe('useCellPopover', () => {
         expect(event.stopPropagation).not.toHaveBeenCalled();
         expect(rafSpy).not.toHaveBeenCalled();
 
-        expect(getUpdatedState().cellPopoverContext.popoverIsOpen).toEqual(
-          true
-        );
+        expect(result.current.cellPopoverContext.popoverIsOpen).toEqual(true);
       });
     });
   });

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -234,6 +234,7 @@ describe('popover content renderers', () => {
     cellActions: <div data-test-subj="mockCellActions">Action</div>,
     cellContentsElement,
     DefaultCellPopover,
+    setCellPopoverProps: () => {},
   };
 
   test('default cell popover', () => {

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -218,6 +218,8 @@ describe('useCellPopover', () => {
       });
     });
   });
+
+  // setCellPopoverProps is tested in the Cypress .spec file
 });
 
 describe('popover content renderers', () => {

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -7,9 +7,10 @@
  */
 
 import React, { createContext, useState, useCallback, ReactNode } from 'react';
+import classNames from 'classnames';
 
 import { keys } from '../../../services';
-import { EuiWrappingPopover } from '../../popover';
+import { EuiWrappingPopover, EuiPopoverProps } from '../../popover';
 import {
   DataGridCellPopoverContextShape,
   EuiDataGridCellPopoverElementProps,
@@ -24,6 +25,7 @@ export const DataGridCellPopoverContext = createContext<
   closeCellPopover: () => {},
   setPopoverAnchor: () => {},
   setPopoverContent: () => {},
+  setCellPopoverProps: () => {},
 });
 
 export const useCellPopover = (): {
@@ -39,6 +41,10 @@ export const useCellPopover = (): {
   // Popover anchor & content are passed by individual `EuiDataGridCell`s
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
   const [popoverContent, setPopoverContent] = useState<ReactNode>();
+  // Allow customization of most (not all) popover props by consumers
+  const [cellPopoverProps, setCellPopoverProps] = useState<
+    Partial<EuiPopoverProps>
+  >({});
 
   const closeCellPopover = useCallback(() => setPopoverIsOpen(false), []);
   const openCellPopover = useCallback(
@@ -68,21 +74,26 @@ export const useCellPopover = (): {
     cellLocation,
     setPopoverAnchor,
     setPopoverContent,
+    setCellPopoverProps,
   };
 
   // Note that this popover is rendered once at the top grid level, rather than one popover per cell
   const cellPopover = popoverIsOpen && popoverAnchor && (
     <EuiWrappingPopover
       isOpen={popoverIsOpen}
-      button={popoverAnchor}
       display="block"
       hasArrow={false}
       panelPaddingSize="s"
-      panelClassName="euiDataGridRowCell__popover"
+      {...cellPopoverProps}
       panelProps={{
         'data-test-subj': 'euiDataGridExpansionPopover',
+        ...(cellPopoverProps.panelProps || {}),
       }}
-      closePopover={closeCellPopover}
+      panelClassName={classNames(
+        'euiDataGridRowCell__popover',
+        cellPopoverProps.panelClassName,
+        cellPopoverProps.panelProps?.className
+      )}
       onKeyDown={(event) => {
         if (event.key === keys.F2 || event.key === keys.ESCAPE) {
           event.preventDefault();
@@ -92,6 +103,8 @@ export const useCellPopover = (): {
           requestAnimationFrame(() => popoverAnchor.parentElement!.focus());
         }
       }}
+      button={popoverAnchor}
+      closePopover={closeCellPopover}
     >
       {popoverContent}
     </EuiWrappingPopover>

--- a/src/components/datagrid/body/footer/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/footer/data_grid_footer_row.test.tsx
@@ -49,6 +49,7 @@ describe('EuiDataGridFooterRow', () => {
               "closeCellPopover": [Function],
               "openCellPopover": [Function],
               "popoverIsOpen": false,
+              "setCellPopoverProps": [Function],
               "setPopoverAnchor": [Function],
               "setPopoverContent": [Function],
             }
@@ -75,6 +76,7 @@ describe('EuiDataGridFooterRow', () => {
               "closeCellPopover": [Function],
               "openCellPopover": [Function],
               "popoverIsOpen": false,
+              "setCellPopoverProps": [Function],
               "setPopoverAnchor": [Function],
               "setPopoverContent": [Function],
             }
@@ -127,6 +129,7 @@ describe('EuiDataGridFooterRow', () => {
                 "closeCellPopover": [Function],
                 "openCellPopover": [Function],
                 "popoverIsOpen": false,
+                "setCellPopoverProps": [Function],
                 "setPopoverAnchor": [Function],
                 "setPopoverContent": [Function],
               }
@@ -178,6 +181,7 @@ describe('EuiDataGridFooterRow', () => {
                 "closeCellPopover": [Function],
                 "openCellPopover": [Function],
                 "popoverIsOpen": false,
+                "setCellPopoverProps": [Function],
                 "setPopoverAnchor": [Function],
                 "setPopoverContent": [Function],
               }

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -28,6 +28,7 @@ import { ExclusiveUnion, CommonProps, OneOf } from '../common';
 import { RowHeightUtils } from './utils/row_heights';
 import { IconType } from '../icon';
 import { EuiTokenProps } from '../token';
+import { EuiPopoverProps } from '../popover';
 
 // since react-window doesn't export a type with the imperative api only we can
 // use this to omit the react-specific class component methods
@@ -206,6 +207,7 @@ export interface DataGridCellPopoverContextShape {
   closeCellPopover(): void;
   setPopoverAnchor(anchor: HTMLElement): void;
   setPopoverContent(content: ReactNode): void;
+  setCellPopoverProps: EuiDataGridCellPopoverElementProps['setCellPopoverProps'];
 }
 
 export type CommonGridProps = CommonProps &
@@ -501,6 +503,13 @@ export interface EuiDataGridCellPopoverElementProps
    * If so, that component is provided here as a passed React function component for your usage.
    */
   DefaultCellPopover: JSXElementConstructor<EuiDataGridCellPopoverElementProps>;
+  /**
+   * Allows passing props to the wrapping cell expansion popover and panel.
+   * Accepts any props that `EuiPopover` accepts, except for `button` and `closePopover`.
+   */
+  setCellPopoverProps: (
+    props: Omit<EuiPopoverProps, 'button' | 'closePopover'>
+  ) => void;
 }
 
 export interface EuiDataGridCellProps {

--- a/upcoming_changelogs/6632.md
+++ b/upcoming_changelogs/6632.md
@@ -1,0 +1,1 @@
+- Added new `setCellPopoverProps` parameter callback to `EuiDataGrid`'s `renderCellPopover` prop


### PR DESCRIPTION
## Summary

The Discover team requested an API in https://github.com/elastic/kibana/pull/152480 to allow setting props on the cell popover. This prop will enable them to, e.g. set custom `resize` CSS on the cell popover panel, making their cell popovers resizable, and additionally set custom min/max height/widths.

The new `setCellPopoverProps` API behaves exactly the same as `setCellProps` does for the cell, and allows customizing (almost) any prop that `EuiPopover` takes, except for the `button` and `closePopover` props.

Example usage:

```jsx
<EuiDataGrid
  renderCellPopover={({ setCellPopoverProps, DefaultCellPopover, ...props }) => {
    // Set a custom className on each cell popover panel
    useEffect(() => {
      setCellPopoverProps({ panelClassName: 'customCellPopover' });
    }, [setCellPopoverProps]);

    // Render popover as-is
    return <DefaultCellPopover {...props} />
  }}
/>
```

I strongly recommend [following along by commit](https://github.com/elastic/eui/pull/6632/commits) for code review.

## QA

- Go to https://eui.elastic.co/pr_6632/#/tabular-content/data-grid-cells-popovers#completely-customizing-cell-popover-rendering
- Open any cell popover in the demo
- [x] Inspect the cell popover panel when open and confirm it has the `customCellPopover` class

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~