### PR TITLE
[EuiSelectable] Fix focus ring on non-searchable listboxes

### DIFF
--- a/src/components/selectable/selectable_list/_selectable_list.scss
+++ b/src/components/selectable/selectable_list/_selectable_list.scss
@@ -18,6 +18,11 @@
 .euiSelectableList__list {
   @include euiOverflowShadow;
   @include euiScrollBar;
+
+  &:focus,
+  & > ul:focus {
+    outline: none;
+  }
 }
 
 .euiSelectableList__groupLabel {

--- a/src/components/selectable/selectable_list/_selectable_list.scss
+++ b/src/components/selectable/selectable_list/_selectable_list.scss
@@ -1,10 +1,12 @@
-// Expand height of list via flex box
 .euiSelectableList {
-  &:focus-within {
-    @include euiFocusRing;
+  // NOTE: This is currently only visible on supported browsers (all except FF)
+  // which is (unfortunately) better than always displaying the focus ring to mouse users
+  &:has(:focus-visible) {
+    @include euiFocusRing(null, $euiFocusRingSize / 2, false);
   }
 }
 
+// Expand height of list via flex box
 .euiSelectableList-fullHeight {
   flex-grow: 1;
 }
@@ -21,7 +23,7 @@
 
   &:focus,
   & > ul:focus {
-    outline: none;
+    outline: none; // Focus outline handled by parent .euiSelectableList
   }
 }
 

--- a/src/themes/amsterdam/global_styling/mixins/_states.scss
+++ b/src/themes/amsterdam/global_styling/mixins/_states.scss
@@ -3,22 +3,31 @@
 // This re-uses the same faux focus ring mixin, but adjusts the outline instead
 // @param {size} Old param from default theme that won't be used, so it should always be `null`
 // @param {offset} Accepts a specific number or 'inner' or 'outer' to adjust outline position
-@mixin euiFocusRing($size: null, $offset: false) {
+// @param {includeFocusVisible} Allows turning off :not:focus-visible selector (which can interfere with some manual usages)
+@mixin euiFocusRing($size: null, $offset: false, $focusVisibleSelectors: true) {
   // Safari & Firefox
   outline: $euiFocusRingSize solid currentColor;
 
-  // Chrome
-  &:focus-visible {
-    outline-style: auto;
-  }
+  @if ($focusVisibleSelectors) {
+    // Chrome
+    &:focus-visible {
+      outline-style: auto;
+    }
 
-  &:not(:focus-visible) {
-    outline: none;
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  } @else {
+    outline-style: auto;
   }
 
   // Adjusting position with offset
   @if (type-of($offset) == number) {
-    outline-offset: #{$offset}px;
+    @if (unitless($offset)) {
+      outline-offset: #{$offset}px;
+    } @else {
+      outline-offset: #{$offset};
+    }
   } @else if ($offset == 'inner') {
     outline-offset: -$euiFocusRingSize;
   } @else if ($offset == 'outer') {

--- a/upcoming_changelogs/6637.md
+++ b/upcoming_changelogs/6637.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed visual listbox focus ring bug on non-searchable `EuiSelectable`s


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6633

This PR attempts to fix the odd focus ring behavior for `EuiSelectable`s that are listboxes only (i.e., do not have the `searchable` prop).

Unfortunately, due to limitations of `:focus-within` and `:focus-visible` (https://github.com/WICG/focus-visible/issues/151), we can only support clear focus rings for for browsers that support the `:has` selector (i.e. all browsers except FF, which is working on `:has` support).

### Before (Chrome)

<img width="546" alt="" src="https://user-images.githubusercontent.com/2750668/223189678-7368bcc6-7f4d-4978-b7fb-ab7ea52527a2.png">

### After (Chrome) - keyboard focus only

<img width="731" alt="" src="https://user-images.githubusercontent.com/549407/223572714-8353677b-7cc2-4c1f-ad1d-091acefffded.png">

### Before (FF)

<img width="583" alt="" src="https://user-images.githubusercontent.com/549407/222609914-fc3602bc-ee8f-4d55-8f82-b01c0757a944.png">

### After (FF) - both keyboard & mouse focus

<img width="730" alt="" src="https://user-images.githubusercontent.com/549407/223573077-1b4a8fb6-02fb-4f47-b5b0-efefcdd6ce82.png">

## QA

- Go to https://eui.elastic.co/pr_6637/#/forms/selectable#the-basics
- [x] In Chrome/Safari/Edge, confirm that keyboard tabbing to the listbox shows a non-wonky-looking focus ring and allows all normal navigation/selection key behavior
- [x] In Chrome/Safari/Edge, confirm that **clicking** on options still works as before and does not show a focus ring

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
