### PR TITLE
[EuiIcon] Add legacy/undocumented `alert`->`warning` alias

### DIFF
--- a/src-docs/src/services/playground/iconValidator.js
+++ b/src-docs/src/services/playground/iconValidator.js
@@ -4,6 +4,7 @@ import { mapOptions } from './mapOptions';
 import { PropTypes } from 'react-view';
 
 const iconOptions = mapOptions(iconTypes.concat(logoTypes));
+iconOptions.alert = 'warning'; // Legacy alias for Elastic Charts - primarily here for playground testing
 
 export const iconValidator = (prop = { custom: {} }, value) => {
   const newProp = {

--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -610,6 +610,27 @@ exports[`EuiIcon props type aggregate is rendered 1`] = `
 </svg>
 `;
 
+exports[`EuiIcon props type alert is rendered 1`] = `
+<svg
+  aria-hidden="true"
+  class="euiIcon emotion-euiIcon-m-isLoaded"
+  data-icon-type="alert"
+  data-is-loaded="true"
+  height="16"
+  role="img"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M8.55 9.502l.35-3.507a.905.905 0 10-1.8 0l.35 3.507a.552.552 0 001.1 0zM9 12a1 1 0 11-2 0 1 1 0 012 0z"
+  />
+  <path
+    d="M8.864 1.496a1 1 0 00-1.728 0l-7 12A1 1 0 001 15h14a1 1 0 00.864-1.504l-7-12zM1 14L8 2l7 12H1z"
+  />
+</svg>
+`;
+
 exports[`EuiIcon props type analyzeEvent is rendered 1`] = `
 <svg
   aria-hidden="true"

--- a/src/components/icon/icon_map.ts
+++ b/src/components/icon/icon_map.ts
@@ -415,6 +415,7 @@ export const typeToPathMap = {
   visVisualBuilder: 'vis_visual_builder',
   visualizeApp: 'app_visualize',
   warning: 'warning',
+  alert: 'warning', // NOTE: This is an undocumented alias for `warning`, added for legacy compatability with Elastic Charts
   watchesApp: 'app_watches',
   wordWrap: 'wordWrap',
   wordWrapDisabled: 'wordWrapDisabled',

--- a/upcoming_changelogs/6640.md
+++ b/upcoming_changelogs/6640.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Added a legacy `alert` alias for the `warning` `EuiIcon` type


### PR DESCRIPTION
## Summary

After a conversation with the Elastic Charts team (@dej611 and @stratoula - thank you!) about our rename of the `alert` icon to `warning` (https://github.com/elastic/eui/pull/6608), we've determined that this change unfortunately puts an undue onus on their team due to how their constants, saved objects, and rendering functions are tied together. A quick snippet from our conversations:

> I've run thru the various editors and checked what's the impact of this new alias, and things are a bit more complicated than planned.
> It's not just about rendering, but also configuration in the Lens editor. The ad hoc code has to be deployed into several places for both Annotations and Reference Lines. Also the expression requires both old and new alias to be available for validation.

> An alias on EUI sounds as a better approach here, it will be quite messy to make these changes in kibana side

This PR will need to be included in a backport release to our current Kibana upgrade.

## QA

- Go to https://eui.elastic.co/pr_6640/#/display/icons
- [x] Confirm that the `alert` text is not mentioned or displayed anywhere in our docs, or in any props tables
- Open the icon playground flyout
- Type in `alert` into the `type` input
- [x] Confirm that the `warning` icon shows up as expected

### General checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately