### PR TITLE
Fix HTMLAttributes type incorrectly coming from `enzyme`

### DIFF
--- a/src/components/page/page_content/page_content.tsx
+++ b/src/components/page/page_content/page_content.tsx
@@ -6,12 +6,11 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
 
 import { EuiPanel, _EuiPanelProps, _EuiPanelDivlike } from '../../panel/panel';
-import { HTMLAttributes } from 'enzyme';
 
 export type EuiPageContentVerticalPositions = 'center';
 export type EuiPageContentHorizontalPositions = 'center';

--- a/src/components/page/page_content/page_content.tsx
+++ b/src/components/page/page_content/page_content.tsx
@@ -37,7 +37,7 @@ export type EuiPageContentProps = CommonProps &
      * There should only be one EuiPageContent per page and should contain the main contents.
      * If this is untrue, set role = `null`, or change it to match your needed aria role
      */
-    role?: HTMLAttributes['role'] | null;
+    role?: HTMLAttributes<HTMLElement>['role'] | null;
   };
 
 /**

--- a/upcoming_changelogs/6643.md
+++ b/upcoming_changelogs/6643.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a type definition incorrectly coming from a dev dependency, which was causing issues for some consuming projects


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6642

The `HTMLAttributes` type should be coming from `react`, not `enzyme`.

## QA

- [x] Run `yarn build-pack` and check `eui.d.ts` and confirm that `import { HTMLAttributes } from 'enzyme'` is not present

### General checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately