### PR TITLE
[EuiFlyout] Preserve scrollbar width on `body` when EuiFlyout is open

### DIFF
--- a/src/components/code/code_block_full_screen.tsx
+++ b/src/components/code/code_block_full_screen.tsx
@@ -101,7 +101,7 @@ export const EuiCodeBlockFullScreenWrapper: FunctionComponent = ({
 
   return (
     <EuiOverlayMask>
-      <EuiFocusTrap clickOutsideDisables={true}>
+      <EuiFocusTrap scrollLock preventScrollOnFocus clickOutsideDisables={true}>
         <div className="euiCodeBlockFullScreen" css={cssStyles}>
           {children}
         </div>

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -405,6 +405,7 @@ export const EuiFlyout = forwardRef(
     let flyout = (
       <EuiFocusTrap
         disabled={isPushed}
+        scrollLock={ownFocus}
         clickOutsideDisables={!ownFocus}
         onClickOutside={onClickOutside}
         {...focusTrapProps}

--- a/src/components/image/image_fullscreen_wrapper.tsx
+++ b/src/components/image/image_fullscreen_wrapper.tsx
@@ -68,7 +68,11 @@ export const EuiImageFullScreenWrapper: FunctionComponent<EuiImageWrapperProps> 
 
   return (
     <EuiOverlayMask data-test-subj="fullScreenOverlayMask">
-      <EuiFocusTrap onClickOutside={closeFullScreen}>
+      <EuiFocusTrap
+        scrollLock
+        preventScrollOnFocus
+        onClickOutside={closeFullScreen}
+      >
         <>
           <figure
             aria-label={optionalCaptionText}

--- a/upcoming_changelogs/6645.md
+++ b/upcoming_changelogs/6645.md
@@ -1,0 +1,5 @@
+**Bug fixes**
+
+- Fixed `EuiFlyout` to preserve body scrollbar width on open
+- Fixed `EuiImage`'s full screen mode to not scroll jump & to preserve body scrollbar width on open
+- Fixed `EuiCodeBlock`'s full screen mode to not scroll jump & to preserve body scrollbar width on open


### PR DESCRIPTION
## Summary

The `scrollLock` property on `EuiFocusTrap` (actually an underlying 3rd party library, `react-focus-on`) allows preventing scrolling on the background and additionally "freezes" the width of the of the body so that the removal/addition of the scrollbar doesn't cause the page width to change slightly whenever the focus trap opens:

<img width="992" alt="" src="https://user-images.githubusercontent.com/549407/225389249-0fc53d41-afa7-4513-b63a-0a7e3e54583c.png">

This property was added for `EuiModal` in https://github.com/elastic/eui/pull/6327/commits/daf6a73fd34696630e234a44da06b84949595d89. This PR adds this functionality & behavior as well to all other components with focus traps with full-screen behavior, i.e. `EuiFlyout`, `EuiImage`, and `EuiCodeBlock`.

Note that `EuiDataGrid`'s fullscreen mode is not handled here, as page jumping is going to happen no matter what in EuiDataGrid (the entire grid is taken out of its normal page flow and becomes fullscreen/fixed), so it's not super relevant or useful to add `scrollLock` to it.

## QA

- Go to https://eui.elastic.co/pr_6645/#/layout/flyout
- Open any flyout, and then find `.euiFlyout` and add a custom temporary CSS of `opacity: 0;`
- [x] Confirm that the background body content/width has space to account for the missing scrollbar
- Go to https://eui.elastic.co/pr_6645/#/display/image#click-an-image-for-a-fullscreen-version
- [x] Click fullscreen mode on any image, and confirm the background body content/width does not jump when toggling between modes

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~ N/A - not added since this is a third party library
