### PR TITLE
[EuiSkipLink] Add array support for `fallbackDestination` prop

### DIFF
--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -82,15 +82,40 @@ describe('EuiSkipLink', () => {
           <>
             <EuiSkipLink
               destinationId=""
-              fallbackDestination="main, [role=main]"
+              fallbackDestination="main, [role=main], .appWrapper"
             >
               Skip to content
             </EuiSkipLink>
-            <div role="main">I am content</div>
+            <div className="appWrapper">
+              <div role="main">I am content</div>
+            </div>
           </>
         );
         fireEvent.click(getByText('Skip to content'));
 
+        // Unlike the array behavior, querySelector always picks *the first node in the DOM tree* found
+        // vs. the first item in the selector comma string
+        const expectedFocus = document.querySelector('.appWrapper');
+        expect(document.activeElement).toEqual(expectedFocus);
+      });
+
+      it('supports an array of query selectors', () => {
+        const { getByText } = render(
+          <>
+            <EuiSkipLink
+              destinationId=""
+              fallbackDestination={['main', '[role=main]', '.appWrapper']}
+            >
+              Skip to content
+            </EuiSkipLink>
+            <div className="appWrapper">
+              <div role="main">Test</div>
+            </div>
+          </>
+        );
+        fireEvent.click(getByText('Skip to content'));
+
+        // Array syntax allows us to prioritize preferred selectors
         const expectedFocus = document.querySelector('[role=main]');
         expect(document.activeElement).toEqual(expectedFocus);
       });

--- a/src/components/accessibility/skip_link/skip_link.tsx
+++ b/src/components/accessibility/skip_link/skip_link.tsx
@@ -30,11 +30,15 @@ interface EuiSkipLinkInterface extends EuiButtonProps {
    */
   destinationId: string;
   /**
-   * If no destination ID element exists or can be found, you may provide a string of
-   * query selectors to fall back to (e.g. a `main` or `role="main"` element)
+   * If no destination ID element exists or can be found, you may provide a query selector
+   * string to fall back to.
+   *
+   * For complex applications with potentially variable layouts per page, an array of
+   * query selectors can be passed, e.g. `['main', '[role=main]', '.appWrapper']`, which
+   * prioritizes looking for multiple fallbacks based on array order.
    * @default main
    */
-  fallbackDestination?: string;
+  fallbackDestination?: string | string[];
   /**
    * If default HTML anchor link behavior is not desired (e.g. for SPAs with hash routing),
    * setting this flag to true will manually scroll to and focus the destination element
@@ -83,7 +87,14 @@ export const EuiSkipLink: FunctionComponent<EuiSkipLinkProps> = ({
       const hasValidId = !!destinationEl;
       // Check the fallback destination if not
       if (!destinationEl && fallbackDestination) {
-        destinationEl = document.querySelector(fallbackDestination);
+        if (Array.isArray(fallbackDestination)) {
+          for (let i = 0; i < fallbackDestination.length; i++) {
+            destinationEl = document.querySelector(fallbackDestination[i]);
+            if (destinationEl) break; // Stop once the first fallback has been found
+          }
+        } else {
+          destinationEl = document.querySelector(fallbackDestination);
+        }
       }
 
       if ((overrideLinkBehavior || !hasValidId) && destinationEl) {

--- a/upcoming_changelogs/6646.md
+++ b/upcoming_changelogs/6646.md
@@ -1,0 +1,1 @@
+- Updated `EuiSkipLink`'s `fallbackDestination` prop to support an array of query selector strings


### PR DESCRIPTION
## Summary

Kibana needs nuanced fallback support for skip link behavior. Because it has such a huge variety of individual plugins/apps, we have no guarantee over whether:

1. Apps are using `Eui/KibanaPageTemplate` (which uses the `main` tag)
2. Apps are using the old, deperecated page template components (which does not use the `main` tag but outputs an `.euiPageContent` class we can hook into)
3. Apps are not using any of EUI's page templates whatsoever and we need to target `.kbnAppWrapper` as a last-ditch fallback

Unfortunately, passing `main,.euiPageContent,.kbnAppWrapper` does not work as expected because today I learned I [don't actually know how `document.querySelector` works](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) - I assumed it was targeting the first selector in the comma separated list, but it's actually targeting _the first node_ in the DOM tree that matches any of the selectors in the list. So in Kibana's case, it ended up _always_ targeting `.kbnAppWrapper` (which exists on every page) 😭

The solution to this is that we need to support an array of fallback query selectors which uses array order to determine priority - see the added/modified unit tests for a comparison of behavior.

## QA

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
