### PR TITLE
[EuiIcon Docs] Add callout with considerations for when importing SVGs as Components

### DIFF
--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -255,7 +255,7 @@ export const IconExample = {
           <EuiCallOut
             iconType="accessibility"
             title={
-              <>Important considerations when importing SVGs as Components</>
+              <>Important considerations when importing SVGs as components</>
             }
             color="warning"
           >

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -252,11 +252,34 @@ export const IconExample = {
             the CSS helpers if you have complex logos that need to work with
             theming.
           </p>
+          <EuiCallOut
+            iconType="accessibility"
+            title={
+              <>Important considerations when importing SVGs as Components</>
+            }
+            color="warning"
+          >
+            <p>
+              When importing an SVG as a component like{' '}
+              <EuiCode language="js">
+                {"import {ReactComponent as ReactLogo} from './logo.svg';"}
+              </EuiCode>
+              , keep in mind that the component will not support the{' '}
+              <EuiCode language="js">title</EuiCode> prop. The{' '}
+              <EuiCode language="js">title</EuiCode> prop is designed to only
+              work with our icons or SVGs imported as images or passed as a Data
+              URL. So, if you&apos;re importing your SVG as a component, be sure
+              to use an
+              <EuiCode language="js">aria-label</EuiCode> instead of a{' '}
+              <EuiCode language="js">title</EuiCode> prop to enhance
+              accessibility and avoid potential issues.
+            </p>
+          </EuiCallOut>
         </>
       ),
       source: [
         {
-          type: GuideSectionTypes.JS,
+          type: GuideSectionTypes.TSX,
           code: iconTypesSource,
         },
       ],

--- a/src-docs/src/views/icon/icon_example.js
+++ b/src-docs/src/views/icon/icon_example.js
@@ -262,7 +262,7 @@ export const IconExample = {
             <p>
               When importing an SVG as a component like{' '}
               <EuiCode language="js">
-                {"import {ReactComponent as ReactLogo} from './logo.svg';"}
+                {"import { ReactComponent as ReactLogo } from './logo.svg';"}
               </EuiCode>
               , keep in mind that the component will not support the{' '}
               <EuiCode language="js">title</EuiCode> prop. The{' '}


### PR DESCRIPTION
## Summary

Closes #3961. 

This PR adds a callout with considerations for when importing SVGs as Components. As it can be seen on the following screenshot:

<img width="1167" alt="Screenshot 2023-03-21 at 13 55 39" src="https://user-images.githubusercontent.com/2750668/226628069-640550f0-21fd-42d9-87e7-d99a4aa5f756.png">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
