### PR TITLE
[EuiDataGrid Docs] Minor update to EuiDataGrid docs code examples

### DIFF
--- a/src-docs/src/views/datagrid/basics/container.js
+++ b/src-docs/src/views/datagrid/basics/container.js
@@ -41,12 +41,17 @@ export default () => {
   );
 
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination(
+        (pagination) => ({ ...pagination, pageSize, pageIndex: 0 }),
+        []
+      ),
+    []
   );
 
   return (

--- a/src-docs/src/views/datagrid/basics/flex.js
+++ b/src-docs/src/views/datagrid/basics/flex.js
@@ -47,12 +47,18 @@ export default () => {
   );
 
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    []
   );
 
   return (

--- a/src-docs/src/views/datagrid/cells_popovers/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/cells_popovers/column_cell_actions.js
@@ -127,12 +127,18 @@ export default () => {
   );
 
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    []
   );
 
   return (

--- a/src-docs/src/views/datagrid/schema_columns/column_actions.js
+++ b/src-docs/src/views/datagrid/schema_columns/column_actions.js
@@ -76,12 +76,18 @@ export default () => {
   );
 
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    []
   );
 
   return (

--- a/src-docs/src/views/datagrid/schema_columns/column_widths.js
+++ b/src-docs/src/views/datagrid/schema_columns/column_widths.js
@@ -53,12 +53,18 @@ export default () => {
   );
 
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    []
   );
 
   return (

--- a/src-docs/src/views/datagrid/schema_columns/control_columns.js
+++ b/src-docs/src/views/datagrid/schema_columns/control_columns.js
@@ -314,12 +314,18 @@ export default function DataGrid() {
     pageSize: 15,
   });
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    [setPagination]
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    [setPagination]
   );
 
   const [visibleColumns, setVisibleColumns] = useState(

--- a/src-docs/src/views/datagrid/schema_columns/control_columns.js
+++ b/src-docs/src/views/datagrid/schema_columns/control_columns.js
@@ -316,7 +316,7 @@ export default function DataGrid() {
   const setPageIndex = useCallback(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
-    [setPagination]
+    []
   );
   const setPageSize = useCallback(
     (pageSize) =>
@@ -325,7 +325,7 @@ export default function DataGrid() {
         pageSize,
         pageIndex: 0,
       })),
-    [setPagination]
+    []
   );
 
   const [visibleColumns, setVisibleColumns] = useState(
@@ -353,7 +353,6 @@ export default function DataGrid() {
     ({ rowIndex, columnId }) => data[rowIndex][columnId],
     []
   );
-
   return (
     <SelectionContext.Provider value={rowSelection}>
       <div>

--- a/src-docs/src/views/datagrid/styling/styling_grid.js
+++ b/src-docs/src/views/datagrid/styling/styling_grid.js
@@ -69,16 +69,20 @@ const DataGridStyle = ({
 
   const setPageIndex = useCallback(
     (pageIndex) => {
-      setPagination({ ...pagination, pageIndex });
+      setPagination((pagination) => ({ ...pagination, pageIndex }));
     },
-    [pagination, setPagination]
+    [setPagination]
   );
 
   const setPageSize = useCallback(
     (pageSize) => {
-      setPagination({ ...pagination, pageSize, pageIndex: 0 });
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      }));
     },
-    [pagination, setPagination]
+    [setPagination]
   );
 
   const handleVisibleColumns = (visibleColumns) =>

--- a/src-docs/src/views/datagrid/styling/styling_grid.js
+++ b/src-docs/src/views/datagrid/styling/styling_grid.js
@@ -67,23 +67,17 @@ const DataGridStyle = ({
     columns.map(({ id }) => id)
   );
 
-  const setPageIndex = useCallback(
-    (pageIndex) => {
-      setPagination((pagination) => ({ ...pagination, pageIndex }));
-    },
-    [setPagination]
-  );
+  const setPageIndex = useCallback((pageIndex) => {
+    setPagination((pagination) => ({ ...pagination, pageIndex }));
+  }, []);
 
-  const setPageSize = useCallback(
-    (pageSize) => {
-      setPagination((pagination) => ({
-        ...pagination,
-        pageSize,
-        pageIndex: 0,
-      }));
-    },
-    [setPagination]
-  );
+  const setPageSize = useCallback((pageSize) => {
+    setPagination((pagination) => ({
+      ...pagination,
+      pageSize,
+      pageIndex: 0,
+    }));
+  }, []);
 
   const handleVisibleColumns = (visibleColumns) =>
     setVisibleColumns(visibleColumns);

--- a/src-docs/src/views/datagrid/toolbar/_grid.js
+++ b/src-docs/src/views/datagrid/toolbar/_grid.js
@@ -65,16 +65,20 @@ const DataGridStyle = ({
 
   const setPageIndex = useCallback(
     (pageIndex) => {
-      setPagination({ ...pagination, pageIndex });
+      setPagination((pagination) => ({ ...pagination, pageIndex }));
     },
-    [pagination, setPagination]
+    [setPagination]
   );
 
   const setPageSize = useCallback(
     (pageSize) => {
-      setPagination({ ...pagination, pageSize, pageIndex: 0 });
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      }));
     },
-    [pagination, setPagination]
+    [setPagination]
   );
 
   const handleVisibleColumns = (visibleColumns) =>

--- a/src-docs/src/views/datagrid/toolbar/_grid.js
+++ b/src-docs/src/views/datagrid/toolbar/_grid.js
@@ -63,23 +63,17 @@ const DataGridStyle = ({
     columns.map(({ id }) => id)
   );
 
-  const setPageIndex = useCallback(
-    (pageIndex) => {
-      setPagination((pagination) => ({ ...pagination, pageIndex }));
-    },
-    [setPagination]
-  );
+  const setPageIndex = useCallback((pageIndex) => {
+    setPagination((pagination) => ({ ...pagination, pageIndex }));
+  }, []);
 
-  const setPageSize = useCallback(
-    (pageSize) => {
-      setPagination((pagination) => ({
-        ...pagination,
-        pageSize,
-        pageIndex: 0,
-      }));
-    },
-    [setPagination]
-  );
+  const setPageSize = useCallback((pageSize) => {
+    setPagination((pagination) => ({
+      ...pagination,
+      pageSize,
+      pageIndex: 0,
+    }));
+  }, []);
 
   const handleVisibleColumns = (visibleColumns) =>
     setVisibleColumns(visibleColumns);

--- a/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
+++ b/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
@@ -95,12 +95,18 @@ export default () => {
   );
 
   const setPageIndex = useCallback(
-    (pageIndex) => setPagination({ ...pagination, pageIndex }),
-    [pagination, setPagination]
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    [setPagination]
   );
   const setPageSize = useCallback(
-    (pageSize) => setPagination({ ...pagination, pageSize, pageIndex: 0 }),
-    [pagination, setPagination]
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    [setPagination]
   );
 
   return (

--- a/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
+++ b/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
@@ -97,7 +97,7 @@ export default () => {
   const setPageIndex = useCallback(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
-    [setPagination]
+    []
   );
   const setPageSize = useCallback(
     (pageSize) =>
@@ -106,7 +106,7 @@ export default () => {
         pageSize,
         pageIndex: 0,
       })),
-    [setPagination]
+    []
   );
 
   return (


### PR DESCRIPTION
## Note
This is my first time attempting to contribute to Eui. I read through the contribution guidelines, but it's very likely I'm still missing something.

## Summary

When using `EuiDataGrid` code snippets from the docs, I noticed `setPagination` updates pagination state by accessing the previous state value directly, rather than by using the previous state value provided by the `setState` callback. The preferred method of accessing previous state when constructing and setting new state is via `setState` callback. In addition accessing the state directly results in an unnecessary `useCallback` dependency.

## QA

### General checklist

No changelog - documentation changes only

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples