### PR TITLE
[EuiBadge] Update named colors to use `EuiTheme` values

### DIFF
--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`EuiBadge is rendered with onClick provided 1`] = `
 exports[`EuiBadge props color accent is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#ee789d;color:#000"
+  style="background-color:#F04E98;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -212,7 +212,7 @@ exports[`EuiBadge props color accepts rgba 1`] = `
 exports[`EuiBadge props color danger is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#ff7e62;color:#000"
+  style="background-color:#BD271E;color:#FFF"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -262,7 +262,7 @@ exports[`EuiBadge props color hollow is rendered 1`] = `
 exports[`EuiBadge props color primary is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#79aad9;color:#000"
+  style="background-color:#07C;color:#FFF"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -279,7 +279,7 @@ exports[`EuiBadge props color primary is rendered 1`] = `
 exports[`EuiBadge props color success is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#6dccb1;color:#000"
+  style="background-color:#00BFB3;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -296,7 +296,7 @@ exports[`EuiBadge props color success is rendered 1`] = `
 exports[`EuiBadge props color warning is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#f1d86f;color:#000"
+  style="background-color:#FEC514;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -396,7 +396,7 @@ exports[`EuiBadge props style is rendered 1`] = `
 exports[`EuiBadge props style is rendered with accent 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#ee789d;color:#000;border:4px solid tomato"
+  style="background-color:#F04E98;color:#000;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -413,7 +413,7 @@ exports[`EuiBadge props style is rendered with accent 1`] = `
 exports[`EuiBadge props style is rendered with danger 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#ff7e62;color:#000;border:4px solid tomato"
+  style="background-color:#BD271E;color:#FFF;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -481,7 +481,7 @@ exports[`EuiBadge props style is rendered with hollow 2`] = `
 exports[`EuiBadge props style is rendered with primary 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#79aad9;color:#000;border:4px solid tomato"
+  style="background-color:#07C;color:#FFF;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -498,7 +498,7 @@ exports[`EuiBadge props style is rendered with primary 1`] = `
 exports[`EuiBadge props style is rendered with success 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#6dccb1;color:#000;border:4px solid tomato"
+  style="background-color:#00BFB3;color:#000;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -515,7 +515,7 @@ exports[`EuiBadge props style is rendered with success 1`] = `
 exports[`EuiBadge props style is rendered with warning 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#f1d86f;color:#000;border:4px solid tomato"
+  style="background-color:#FEC514;color:#000;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`EuiBadge is rendered with onClick provided 1`] = `
 exports[`EuiBadge props color accent is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#F04E98;color:#000"
+  style="background-color:#f583b7;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -279,7 +279,7 @@ exports[`EuiBadge props color primary is rendered 1`] = `
 exports[`EuiBadge props color success is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#00BFB3;color:#000"
+  style="background-color:#4dd2ca;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -396,7 +396,7 @@ exports[`EuiBadge props style is rendered 1`] = `
 exports[`EuiBadge props style is rendered with accent 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#F04E98;color:#000;border:4px solid tomato"
+  style="background-color:#f583b7;color:#000;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -498,7 +498,7 @@ exports[`EuiBadge props style is rendered with primary 1`] = `
 exports[`EuiBadge props style is rendered with success 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#00BFB3;color:#000;border:4px solid tomato"
+  style="background-color:#4dd2ca;color:#000;border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -141,13 +141,10 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     try {
       // Check if a valid color name was provided
       if (COLORS.includes(color as BadgeColor)) {
-        if (color === 'hollow') return style; // hollow uses its own CSS class
-
         // Get the hex equivalent for the provided color name
         switch (color) {
           case 'hollow':
-            colorHex = '';
-            break;
+            return style; // hollow uses its own Emotion class
           case 'default':
             colorHex = euiTheme.euiTheme.colors.lightShade;
             break;

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -31,6 +31,7 @@ import { chromaValid, parseColor } from '../color_picker/utils';
 import { validateHref } from '../../services/security/href_validator';
 
 import { euiBadgeStyles } from './badge.styles';
+import { euiButtonFillColor } from '../../themes/amsterdam/global_styling/mixins';
 
 export const ICON_SIDES = ['left', 'right'] as const;
 type IconSide = typeof ICON_SIDES[number];
@@ -139,11 +140,11 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     const colorToHexMap: { [color in BadgeColor]: string } = {
       default: euiTheme.euiTheme.colors.lightShade, // 11.87:1
       hollow: '', // 11.87:1
-      primary: euiTheme.euiTheme.colors.primary, // 4.65:1
-      success: euiTheme.euiTheme.colors.success, // 9.1:1
-      accent: euiTheme.euiTheme.colors.accent, // 6.24:1
-      warning: euiTheme.euiTheme.colors.warning, // 13.21:1
-      danger: euiTheme.euiTheme.colors.danger, // 6.04:1
+      primary: euiButtonFillColor(euiTheme, 'primary').backgroundColor,
+      success: euiButtonFillColor(euiTheme, 'success').backgroundColor,
+      accent: euiButtonFillColor(euiTheme, 'accent').backgroundColor,
+      warning: euiButtonFillColor(euiTheme, 'warning').backgroundColor,
+      danger: euiButtonFillColor(euiTheme, 'danger').backgroundColor,
     };
 
     let textColor = null;

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -133,20 +133,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   const isHrefValid = !href || validateHref(href);
   const isDisabled = _isDisabled || !isHrefValid;
 
-  // We moved away from euiPaletteColorBlindBehindText() helper so users
-  // could override named colors in custom themes. The minimum color
-  // contrast ratio for each badge (light or dark) is listed inline.
   const optionalCustomStyles = useMemo(() => {
-    const colorToHexMap: { [color in BadgeColor]: string } = {
-      default: euiTheme.euiTheme.colors.lightShade, // 11.87:1
-      hollow: '', // 11.87:1
-      primary: euiButtonFillColor(euiTheme, 'primary').backgroundColor,
-      success: euiButtonFillColor(euiTheme, 'success').backgroundColor,
-      accent: euiButtonFillColor(euiTheme, 'accent').backgroundColor,
-      warning: euiButtonFillColor(euiTheme, 'warning').backgroundColor,
-      danger: euiButtonFillColor(euiTheme, 'danger').backgroundColor,
-    };
-
     let textColor = null;
     let contrastRatio = null;
     let colorHex = null;
@@ -157,7 +144,24 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
         if (color === 'hollow') return style; // hollow uses its own CSS class
 
         // Get the hex equivalent for the provided color name
-        colorHex = colorToHexMap[color as BadgeColor];
+        switch (color) {
+          case 'hollow':
+            colorHex = '';
+            break;
+          case 'default':
+            colorHex = euiTheme.euiTheme.colors.lightShade;
+            break;
+          default:
+            type RemainingColors =
+              | 'primary'
+              | 'success'
+              | 'accent'
+              | 'warning'
+              | 'danger';
+            colorHex = euiButtonFillColor(euiTheme, color as RemainingColors)
+              .backgroundColor;
+            break;
+        }
 
         // Set dark or light text color based upon best contrast
         textColor = setTextColor(euiTheme, colorHex);

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -21,7 +21,6 @@ import { CommonProps, ExclusiveUnion, PropsOf } from '../common';
 import {
   useEuiTheme,
   UseEuiTheme,
-  euiPaletteColorBlindBehindText,
   getSecureRelForTarget,
   isColorDark,
   wcagContrastMin,
@@ -46,11 +45,6 @@ export const COLORS = [
   'danger',
 ] as const;
 type BadgeColor = typeof COLORS[number];
-
-// The color blind palette has some stricter accessibility needs with regards to
-// charts and contrast. We use the euiPaletteColorBlindBehindText variant here since our
-// accessibility concerns pertain to foreground (text) and background contrast
-const visColors = euiPaletteColorBlindBehindText();
 
 type WithButtonProps = {
   /**
@@ -138,15 +132,18 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   const isHrefValid = !href || validateHref(href);
   const isDisabled = _isDisabled || !isHrefValid;
 
+  // We moved away from euiPaletteColorBlindBehindText() helper so users
+  // could override named colors in custom themes. The minimum color
+  // contrast ratio for each badge (light or dark) is listed inline.
   const optionalCustomStyles = useMemo(() => {
     const colorToHexMap: { [color in BadgeColor]: string } = {
-      default: euiTheme.euiTheme.colors.lightShade,
-      hollow: '',
-      primary: visColors[1],
-      success: visColors[0],
-      accent: visColors[2],
-      warning: visColors[5],
-      danger: visColors[9],
+      default: euiTheme.euiTheme.colors.lightShade, // 11.87:1
+      hollow: '', // 11.87:1
+      primary: euiTheme.euiTheme.colors.primary, // 4.65:1
+      success: euiTheme.euiTheme.colors.success, // 9.1:1
+      accent: euiTheme.euiTheme.colors.accent, // 6.24:1
+      warning: euiTheme.euiTheme.colors.warning, // 13.21:1
+      danger: euiTheme.euiTheme.colors.danger, // 6.04:1
     };
 
     let textColor = null;

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`EuiNotificationEvent props badgeColor is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge"
-          style="background-color:#f1d86f;color:#000"
+          style="background-color:#FEC514;color:#000"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`EuiNotificationEventMeta props badgeColor  is rendered 1`] = `
   >
     <span
       class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge"
-      style="background-color:#00BFB3;color:#000"
+      style="background-color:#4dd2ca;color:#000"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`EuiNotificationEventMeta props badgeColor  is rendered 1`] = `
   >
     <span
       class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge"
-      style="background-color:#6dccb1;color:#000"
+      style="background-color:#00BFB3;color:#000"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"

--- a/src/themes/amsterdam/global_styling/mixins/button.ts
+++ b/src/themes/amsterdam/global_styling/mixins/button.ts
@@ -90,6 +90,12 @@ export const euiButtonFillColor = (
 ) => {
   const { euiTheme, colorMode } = euiThemeContext;
 
+  const getForegroundColor = (background: string) => {
+    return isColorDark(...hexToRgb(background))
+      ? euiTheme.colors.ghost
+      : euiTheme.colors.ink;
+  };
+
   let background;
   let foreground;
 
@@ -101,15 +107,22 @@ export const euiButtonFillColor = (
     case 'text':
       background =
         colorMode === 'DARK' ? euiTheme.colors.text : euiTheme.colors.darkShade;
-      foreground = isColorDark(...hexToRgb(background))
-        ? euiTheme.colors.ghost
-        : euiTheme.colors.ink;
+      foreground = getForegroundColor(background);
+      break;
+    case 'success':
+    case 'accent':
+      // Success / accent fills are hard to read on light mode even though they pass color contrast ratios
+      // TODO: If WCAG 3 gets adopted (which would calculates luminosity & would allow us to use white text instead),
+      // we can get rid of this case (https://blog.datawrapper.de/color-contrast-check-data-vis-wcag-apca/)
+      background =
+        colorMode === 'LIGHT'
+          ? tint(euiTheme.colors[color], 0.3)
+          : euiTheme.colors[color];
+      foreground = getForegroundColor(background);
       break;
     default:
       background = euiTheme.colors[color];
-      foreground = isColorDark(...hexToRgb(euiTheme.colors[color]))
-        ? euiTheme.colors.ghost
-        : euiTheme.colors.ink;
+      foreground = getForegroundColor(background);
       break;
   }
 

--- a/upcoming_changelogs/6659.md
+++ b/upcoming_changelogs/6659.md
@@ -1,0 +1,7 @@
+**Bug fixes**
+
+- Fixed `EuiBadge` to use named EuiTheme background colors
+
+**Breaking changes**
+
+- Updated `EuiBadge` snapshots when fixing named background colors in PR #6659

--- a/upcoming_changelogs/6659.md
+++ b/upcoming_changelogs/6659.md
@@ -1,7 +1,7 @@
 **Bug fixes**
 
-- Fixed `EuiBadge` to use named EuiTheme background colors
+- Fixed named `EuiBadge` colors to reflect custom theme overrides
 
 **Breaking changes**
 
-- Updated `EuiBadge` snapshots when fixing named background colors in PR #6659
+- Success- and accent-colored `EuiBadge`s and `EuiButton`s have had their fill colors tinted slightly on light mode to be more readable


### PR DESCRIPTION
## Summary
Issue #6656 identified a case where our `EuiBadge` component was using a helper to generate background colors that wasn't being overridden correctly when users opted for custom themes. This PR removes the helper method and codes badge background colors to match their corresponding filled button.

PR closes #6656

---
### Light theme before

<img width="576" alt="Screen Shot 2023-03-28 at 2 29 21 PM" src="https://user-images.githubusercontent.com/934879/228347008-92badfc6-63eb-4384-a17d-32cc33a2d5e8.png">

### Light theme after

<img width="525" alt="Screen Shot 2023-04-03 at 1 34 50 PM" src="https://user-images.githubusercontent.com/549407/229621659-04ef7bd3-425f-4d05-b8a4-509049d492c4.png">

---
### Dark theme before

<img width="552" alt="Screen Shot 2023-03-28 at 2 29 28 PM" src="https://user-images.githubusercontent.com/934879/228347147-845f901f-2bf1-47c3-8054-6f734fc9be2d.png">


### Dark theme after

<img width="550" alt="Screen Shot 2023-03-29 at 9 25 10 AM" src="https://user-images.githubusercontent.com/934879/228573436-18c012cb-4f02-4cf9-855e-732d0f59bdba.png">

## EuiButton `success`/`accent` color fill changes

As part of this PR, we also tweaked the `success` and `accent` fill buttons to be more readable. Left is before, right is after.

<img src="https://user-images.githubusercontent.com/549407/229632775-f5afc41b-4a58-4134-aa5d-4f8fbacb298b.png" width="300" alt="">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Ran axe scans in light and dark mode to ensure no color contrast ratio regressions
- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
