### PR TITLE
[EuiInlineEdit] Add Dynamic Font Sizing & Truncation Styling

### DIFF
--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiInlineEditText props renders as text 1`] = `
 <div
-  class="euiInlineEdit euiInlineEditText testClass1 testClass2 css-c2vbib-m-m"
+  class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-m-m"
 >
   <button
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"

--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiInlineEditText props renders as text 1`] = `
 <div
-  class="euiInlineEdit euiInlineEditText testClass1 testClass2"
+  class="euiInlineEdit euiInlineEditText testClass1 testClass2 css-c2vbib-m-m"
 >
   <button
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
@@ -20,7 +20,7 @@ exports[`EuiInlineEditText props renders as text 1`] = `
         class="euiButtonEmpty__text"
       >
         <div
-          class="euiText emotion-euiText-m"
+          class="euiText eui-textTruncate emotion-euiText-m"
         >
           hello world
         </div>

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiInlineEditTitle props renders as title 1`] = `
 <div
-  class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 css-1p10it1-m-m"
+  class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-m-m"
 >
   <button
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiInlineEditTitle props renders as title 1`] = `
 <div
-  class="euiInlineEdit euiInlineEditTitle testClass1 testClass2"
+  class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 css-1p10it1-m-m"
 >
   <button
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
@@ -20,7 +20,7 @@ exports[`EuiInlineEditTitle props renders as title 1`] = `
         class="euiButtonEmpty__text"
       >
         <h2
-          class="euiTitle emotion-euiTitle-m"
+          class="euiTitle eui-textTruncate emotion-euiTitle-m"
         >
           hello world
         </h2>

--- a/src/components/inline_edit/inline_edit_text.styles.ts
+++ b/src/components/inline_edit/inline_edit_text.styles.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+import { euiTextStyles } from '../text/text.styles';
+
+export const euiInlineEditTextStyles = (euiThemeContext: UseEuiTheme) => {
+  const textFontStyles = euiTextStyles(euiThemeContext);
+
+  return {
+    euiInlineEditText: css``,
+
+    fontSize: {
+      xs: css`
+        .euiFieldText {
+          ${textFontStyles.xs}
+        }
+      `,
+      s: css`
+        .euiFieldText {
+          ${textFontStyles.s}
+        }
+      `,
+      m: css`
+        .euiFieldText {
+          ${textFontStyles.m}
+        }
+      `,
+    },
+  };
+};

--- a/src/components/inline_edit/inline_edit_text.tsx
+++ b/src/components/inline_edit/inline_edit_text.tsx
@@ -15,6 +15,8 @@ import {
   SMALL_SIZE_FORM,
   MEDIUM_SIZE_FORM,
 } from './inline_edit_form';
+import { useEuiTheme } from '../../services';
+import { euiInlineEditTextStyles } from './inline_edit_text.styles';
 
 export type EuiInlineEditTextSizes = Exclude<EuiTextProps['size'], 'relative'>;
 
@@ -41,6 +43,10 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
 }) => {
   const classes = classNames('euiInlineEditText', className);
 
+  const theme = useEuiTheme();
+  const styles = euiInlineEditTextStyles(theme);
+  const cssStyles = styles.fontSize[size];
+
   const isSmallSize = ['xs', 's'].includes(size);
   const sizes = isSmallSize ? SMALL_SIZE_FORM : MEDIUM_SIZE_FORM;
 
@@ -57,9 +63,16 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   };
 
   return (
-    <EuiInlineEditForm className={classes} {...rest} {...formProps}>
+    <EuiInlineEditForm
+      className={classes}
+      css={cssStyles}
+      {...rest}
+      {...formProps}
+    >
       {(textReadModeValue) => (
-        <EuiText size={size}>{textReadModeValue}</EuiText>
+        <EuiText size={size} className="eui-textTruncate">
+          {textReadModeValue}
+        </EuiText>
       )}
     </EuiInlineEditForm>
   );

--- a/src/components/inline_edit/inline_edit_text.tsx
+++ b/src/components/inline_edit/inline_edit_text.tsx
@@ -45,7 +45,7 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
 
   const theme = useEuiTheme();
   const styles = euiInlineEditTextStyles(theme);
-  const cssStyles = styles.fontSize[size];
+  const cssStyles = [styles.euiInlineEditText, styles.fontSize[size]];
 
   const isSmallSize = ['xs', 's'].includes(size);
   const sizes = isSmallSize ? SMALL_SIZE_FORM : MEDIUM_SIZE_FORM;

--- a/src/components/inline_edit/inline_edit_title.styles.ts
+++ b/src/components/inline_edit/inline_edit_title.styles.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+import { euiTitleStyles } from '../title/title.styles';
+
+export const euiInlineEditTitleStyles = (euiThemeContext: UseEuiTheme) => {
+  const titleFontStyles = euiTitleStyles(euiThemeContext);
+
+  return {
+    euiInlineEditTitle: css``,
+
+    fontSize: {
+      xxxs: css`
+        .euiFieldText {
+          ${titleFontStyles.xxxs}
+        }
+      `,
+      xxs: css`
+        .euiFieldText {
+          ${titleFontStyles.xxs}
+        }
+      `,
+      xs: css`
+        .euiFieldText {
+          ${titleFontStyles.xs}
+        }
+      `,
+      s: css`
+        .euiFieldText {
+          ${titleFontStyles.s}
+        }
+      `,
+      m: css`
+        .euiFieldText {
+          ${titleFontStyles.m}
+        }
+      `,
+      l: css`
+        .euiFieldText {
+          ${titleFontStyles.l}
+        }
+      `,
+    },
+  };
+};

--- a/src/components/inline_edit/inline_edit_title.tsx
+++ b/src/components/inline_edit/inline_edit_title.tsx
@@ -51,7 +51,7 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
 
   const theme = useEuiTheme();
   const styles = euiInlineEditTitleStyles(theme);
-  const cssStyles = styles.fontSize[size];
+  const cssStyles = [styles.euiInlineEditTitle, styles.fontSize[size]];
 
   const H: Heading = heading;
 

--- a/src/components/inline_edit/inline_edit_title.tsx
+++ b/src/components/inline_edit/inline_edit_title.tsx
@@ -15,6 +15,8 @@ import {
   SMALL_SIZE_FORM,
   MEDIUM_SIZE_FORM,
 } from './inline_edit_form';
+import { useEuiTheme } from '../../services';
+import { euiInlineEditTitleStyles } from './inline_edit_title.styles';
 
 export const HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 type Heading = typeof HEADINGS[number];
@@ -47,6 +49,10 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
 }) => {
   const classes = classNames('euiInlineEditTitle', className);
 
+  const theme = useEuiTheme();
+  const styles = euiInlineEditTitleStyles(theme);
+  const cssStyles = styles.fontSize[size];
+
   const H: Heading = heading;
 
   const isSmallSize = ['xxxs', 'xxs', 'xs', 's'].includes(size);
@@ -65,9 +71,14 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   };
 
   return (
-    <EuiInlineEditForm className={classes} {...rest} {...formProps}>
+    <EuiInlineEditForm
+      css={cssStyles}
+      className={classes}
+      {...rest}
+      {...formProps}
+    >
       {(titleReadModeValue) => (
-        <EuiTitle size={size}>
+        <EuiTitle size={size} className="eui-textTruncate">
           <H>{titleReadModeValue}</H>
         </EuiTitle>
       )}


### PR DESCRIPTION
Spec Doc: [EuiInlineEdit Spec Doc](https://docs.google.com/document/d/19Ba2I3iF8W5-XYIdzHH4pBDuXbQ5hyKyv0m2o6Tw70s/edit?usp=sharing)

## Summary
This PR adds styling to both `EuiInlineEdiText` and `EuiInlineEditTitle` components. 

### Dynamic Font Sizing 
When in `editMode` the font size of the text inside of the form control should match the the size of the text in `readMode`. 

![Font Sizing Example](https://user-images.githubusercontent.com/40739624/228612868-6e173211-00c6-4747-ad3b-53f2bb707df1.gif)

### Truncation
When long text is saved, the `EuiEmptyButton` used in `readMode` will truncate the text.

![Truncation Example](https://user-images.githubusercontent.com/40739624/228612895-c153ec14-a7e4-4a61-8acb-53145798d9b4.gif)

## QA

- [ ] **Confirm that `font-size` in `editMode` changes with the `size` prop**
1. Head to the [PR Preview](https://eui.elastic.co/pr_6660/#/display/inline-edit) for `EuiInlineEdit` and click on the `readMode` button to open `editMode`
2. Toggle through the `size` prop button group options and confirm that the font size used in the form control changes as the size is updated. (Note: Forms are compressed in sizes `small` and lower, so you will notice the control getting smaller as you select smaller options).
     
- [ ] **Confirm text is truncated when the length of the text is longer than the button in `readMode`**
1. Update the button text to be a very long string and you should find that the button truncates the new text.

--- 

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
