### PR TITLE
Allow typography variables in Amsterdam theme to be overridden

### DIFF
--- a/src/themes/amsterdam/global_styling/variables/_typography.scss
+++ b/src/themes/amsterdam/global_styling/variables/_typography.scss
@@ -1,9 +1,9 @@
 // Finally start using the non-beta version of Inter
-$euiFontFamily: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+$euiFontFamily: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 
 // Font sizes -- scale is loosely based on Major Third (1.250) with a base of 14px
 // Base list is an altered scale based on 16px to match the resulted values below
-$euiTextScale:    2.125, 1.6875, 1.375, 1.125, 1, .875, .75;
+$euiTextScale:    2.125, 1.6875, 1.375, 1.125, 1, .875, .75 !default;
 
 $euiFontSize:     $euiSize - 2; // 14px
 
@@ -14,10 +14,10 @@ $euiFontSizeL:     ceil($euiFontSize * 1.57); // 22px // h3
 $euiFontSizeXL:   floor($euiFontSize * 1.93); // 27px // h2
 $euiFontSizeXXL:  floor($euiFontSize * 2.43); // 34px // h1
 
-$euiBodyLineHeight: 1.142857143; // 16px from a 14px base font size to ensure it aligns to our 16px grid
+$euiBodyLineHeight: 1.142857143 !default; // 16px from a 14px base font size to ensure it aligns to our 16px grid
 
-$euiCodeFontWeightRegular: 400;
-$euiCodeFontWeightBold: 700;
+$euiCodeFontWeightRegular: 400 !default;
+$euiCodeFontWeightBold: 700 !default;
 
 // Normally functions are imported before variables in `_index.scss` files
 // But because they need to consume some typography variables they need to live here

--- a/src/themes/amsterdam/global_styling/variables/_typography.scss
+++ b/src/themes/amsterdam/global_styling/variables/_typography.scss
@@ -16,8 +16,8 @@ $euiFontSizeXXL:  floor($euiFontSize * 2.43); // 34px // h1
 
 $euiBodyLineHeight: 1.142857143 !default; // 16px from a 14px base font size to ensure it aligns to our 16px grid
 
-$euiCodeFontWeightRegular: 400 !default;
-$euiCodeFontWeightBold: 700 !default;
+$euiCodeFontWeightRegular: 400;
+$euiCodeFontWeightBold: 700;
 
 // Normally functions are imported before variables in `_index.scss` files
 // But because they need to consume some typography variables they need to live here

--- a/upcoming_changelogs/6665.md
+++ b/upcoming_changelogs/6665.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed user-defined SCSS variables failing to override variables defined in Amsterdam typography overrides.
+


### PR DESCRIPTION
## Summary

At the moment, it's not possible to override `font-family` within the Amsterdam theme via a SCSS variable. This PR adds `!default` to the variables set to hardcoded values in that theme.

Tested locally with the [Typerighter](https://github.com/guardian/typerighter/) project. This allows us to keep our custom typeface consistent across SCSS- and Emotion-themed components.

Aware that eventually these will be deprecated! In the mean time, this will save us vendoring the theme in our codebase.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
