### PR TITLE
[EuiCode] Fix bold tokens

### DIFF
--- a/src/components/code/code_syntax.styles.ts
+++ b/src/components/code/code_syntax.styles.ts
@@ -171,7 +171,7 @@ export const euiCodeSyntaxTokens = (euiThemeContext: UseEuiTheme) => {
   
     .token.important,
     .token.bold {
-      font-weight: $euiCodeFontWeightBold;
+      font-weight: ${euiTheme.font.weight.bold};
     }
   
     .token.url-reference,

--- a/upcoming_changelogs/6666.md
+++ b/upcoming_changelogs/6666.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed bold `EuiCode` tokens to actually be bold


### PR DESCRIPTION
## Summary

This was previously a Sass variable that was likely missed in EuiCode's Emotion conversion. It should be pointing at an `euiTheme` JS var instead.

## QA

To be honest, I have no idea where we even print bold code tokens so I'm not sure where to produce a before/after - this change is fairly straightforward however so I don't know if it needs thorough testing.

### General checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
