### PR TITLE
[EuiDatePicker] Add alert icon when `isInvalid`

### DIFF
--- a/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`EuiDatePicker is rendered 1`] = `
   <EuiFormControlLayout
     fullWidth={false}
     icon="calendar"
-    isLoading={false}
   >
     <EuiValidatableControl>
       <ContextConsumer>
@@ -869,20 +868,10 @@ exports[`EuiDatePicker localization inherits locale from context 1`] = `
 
 exports[`EuiDatePicker popoverPlacement upRight is rendered 1`] = `
 <EuiDatePicker
-  adjustDateOnChange={true}
   aria-label="aria-label"
   className="testClass1 testClass2"
   data-test-subj="test subject string"
-  dateFormat="MM/DD/YYYY"
-  fullWidth={false}
-  inputRef={[Function]}
-  isLoading={false}
   popoverPlacement="upRight"
-  shadow={true}
-  shouldCloseOnSelect={true}
-  showIcon={true}
-  showTimeSelect={false}
-  timeFormat="hh:mm A"
 >
   <span
     className="euiDatePicker euiDatePicker--shadow"
@@ -890,7 +879,6 @@ exports[`EuiDatePicker popoverPlacement upRight is rendered 1`] = `
     <EuiFormControlLayout
       fullWidth={false}
       icon="calendar"
-      isLoading={false}
     >
       <div
         className="euiFormControlLayout"
@@ -1155,7 +1143,6 @@ exports[`EuiDatePicker popoverPlacement upRight is rendered 1`] = `
           </EuiValidatableControl>
           <EuiFormControlLayoutIcons
             icon="calendar"
-            isLoading={false}
           >
             <div
               className="euiFormControlLayoutIcons"

--- a/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker.test.tsx.snap
@@ -8,11 +8,9 @@ exports[`EuiDatePicker is rendered 1`] = `
     fullWidth={false}
     icon="calendar"
   >
-    <EuiValidatableControl>
-      <ContextConsumer>
-        <Component />
-      </ContextConsumer>
-    </EuiValidatableControl>
+    <ContextConsumer>
+      <Component />
+    </ContextConsumer>
   </EuiFormControlLayout>
 </span>
 `;
@@ -886,261 +884,259 @@ exports[`EuiDatePicker popoverPlacement upRight is rendered 1`] = `
         <div
           className="euiFormControlLayout__childrenWrapper"
         >
-          <EuiValidatableControl>
-            <DatePicker
-              accessibleMode={true}
-              adjustDateOnChange={true}
-              allowSameDay={false}
-              aria-label="aria-label"
-              className="euiDatePicker euiFieldText euiFieldText--withIcon testClass1 testClass2"
-              data-test-subj="test subject string"
-              dateFormat="MM/DD/YYYY"
-              dateFormatCalendar="MMMM YYYY"
-              disabled={false}
-              disabledKeyboardNavigation={false}
-              dropdownMode="scroll"
-              monthsShown={1}
-              nextMonthButtonLabel="Next month"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onClickOutside={[Function]}
-              onFocus={[Function]}
-              onInputClick={[Function]}
-              onInputError={[Function]}
-              onKeyDown={[Function]}
-              onMonthChange={[Function]}
-              onSelect={[Function]}
-              onYearChange={[Function]}
-              popperPlacement="upRight"
-              preventOpenOnFocus={false}
-              previousMonthButtonLabel="Previous Month"
-              readOnly={false}
-              renderDayContents={[Function]}
-              shouldCloseOnSelect={true}
-              showMonthDropdown={true}
-              showTimeSelect={false}
-              showYearDropdown={true}
-              strictParsing={false}
-              timeCaption="Time"
-              timeFormat="hh:mm A"
-              timeIntervals={30}
-              withPortal={false}
-              yearDropdownItemNumber={7}
-            >
-              <EuiPopover
-                anchorPosition="upRight"
-                buffer={0}
-                button={
-                  <div
-                    className="react-datepicker__input-container"
-                  >
-                    <input
-                      aria-label="Press the down key to open a popover containing a calendar."
-                      className="euiDatePicker euiFieldText euiFieldText--withIcon testClass1 testClass2"
-                      disabled={false}
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      readOnly={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                }
-                closePopover={[Function]}
-                display="block"
-                hasArrow={false}
-                isOpen={false}
-                ownFocus={false}
-                panelPaddingSize="none"
-                panelRef={[Function]}
-              >
-                <EuiOutsideClickDetector
-                  onOutsideClick={[Function]}
+          <DatePicker
+            accessibleMode={true}
+            adjustDateOnChange={true}
+            allowSameDay={false}
+            aria-label="aria-label"
+            className="euiDatePicker euiFieldText euiFieldText--withIcon testClass1 testClass2"
+            data-test-subj="test subject string"
+            dateFormat="MM/DD/YYYY"
+            dateFormatCalendar="MMMM YYYY"
+            disabled={false}
+            disabledKeyboardNavigation={false}
+            dropdownMode="scroll"
+            monthsShown={1}
+            nextMonthButtonLabel="Next month"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClickOutside={[Function]}
+            onFocus={[Function]}
+            onInputClick={[Function]}
+            onInputError={[Function]}
+            onKeyDown={[Function]}
+            onMonthChange={[Function]}
+            onSelect={[Function]}
+            onYearChange={[Function]}
+            popperPlacement="upRight"
+            preventOpenOnFocus={false}
+            previousMonthButtonLabel="Previous Month"
+            readOnly={false}
+            renderDayContents={[Function]}
+            shouldCloseOnSelect={true}
+            showMonthDropdown={true}
+            showTimeSelect={false}
+            showYearDropdown={true}
+            strictParsing={false}
+            timeCaption="Time"
+            timeFormat="hh:mm A"
+            timeIntervals={30}
+            withPortal={false}
+            yearDropdownItemNumber={7}
+          >
+            <EuiPopover
+              anchorPosition="upRight"
+              buffer={0}
+              button={
+                <div
+                  className="react-datepicker__input-container"
                 >
+                  <input
+                    aria-label="Press the down key to open a popover containing a calendar."
+                    className="euiDatePicker euiFieldText euiFieldText--withIcon testClass1 testClass2"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    readOnly={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              }
+              closePopover={[Function]}
+              display="block"
+              hasArrow={false}
+              isOpen={false}
+              ownFocus={false}
+              panelPaddingSize="none"
+              panelRef={[Function]}
+            >
+              <EuiOutsideClickDetector
+                onOutsideClick={[Function]}
+              >
+                <div
+                  css="unknown styles"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchStart={[Function]}
+                >
+                  <Insertion
+                    cache={
+                      Object {
+                        "insert": [Function],
+                        "inserted": Object {
+                          "6tb1tw-euiPopover": true,
+                          "zih94u-render": true,
+                        },
+                        "key": "css",
+                        "nonce": undefined,
+                        "registered": Object {},
+                        "sheet": StyleSheet {
+                          "_alreadyInsertedOrderInsensitiveRule": true,
+                          "_insertTag": [Function],
+                          "before": null,
+                          "container": <head>
+                            <style
+                              data-emotion="css"
+                              data-s=""
+                            >
+                              
+                              .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                            </style>
+                            <style
+                              data-emotion="css"
+                              data-s=""
+                            >
+                              
+                              .css-zih94u-render{display:block;}
+                            </style>
+                          </head>,
+                          "ctr": 2,
+                          "insertionPoint": undefined,
+                          "isSpeedy": false,
+                          "key": "css",
+                          "nonce": undefined,
+                          "prepend": undefined,
+                          "tags": Array [
+                            <style
+                              data-emotion="css"
+                              data-s=""
+                            >
+                              
+                              .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                            </style>,
+                            <style
+                              data-emotion="css"
+                              data-s=""
+                            >
+                              
+                              .css-zih94u-render{display:block;}
+                            </style>,
+                          ],
+                        },
+                      }
+                    }
+                    isStringTag={true}
+                    serialized={
+                      Object {
+                        "map": undefined,
+                        "name": "6tb1tw-euiPopover",
+                        "next": undefined,
+                        "styles": "position:relative;vertical-align:middle;max-inline-size: 100%;;;label:euiPopover;;;display:block;;",
+                        "toString": [Function],
+                      }
+                    }
+                  />
                   <div
-                    css="unknown styles"
+                    className="euiPopover emotion-euiPopover"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
                     onTouchEnd={[Function]}
                     onTouchStart={[Function]}
                   >
-                    <Insertion
-                      cache={
-                        Object {
-                          "insert": [Function],
-                          "inserted": Object {
-                            "6tb1tw-euiPopover": true,
-                            "zih94u-render": true,
-                          },
-                          "key": "css",
-                          "nonce": undefined,
-                          "registered": Object {},
-                          "sheet": StyleSheet {
-                            "_alreadyInsertedOrderInsensitiveRule": true,
-                            "_insertTag": [Function],
-                            "before": null,
-                            "container": <head>
-                              <style
-                                data-emotion="css"
-                                data-s=""
-                              >
-                                
-                                .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
-                              </style>
-                              <style
-                                data-emotion="css"
-                                data-s=""
-                              >
-                                
-                                .css-zih94u-render{display:block;}
-                              </style>
-                            </head>,
-                            "ctr": 2,
-                            "insertionPoint": undefined,
-                            "isSpeedy": false,
+                    <div
+                      css="unknown styles"
+                    >
+                      <Insertion
+                        cache={
+                          Object {
+                            "insert": [Function],
+                            "inserted": Object {
+                              "6tb1tw-euiPopover": true,
+                              "zih94u-render": true,
+                            },
                             "key": "css",
                             "nonce": undefined,
-                            "prepend": undefined,
-                            "tags": Array [
-                              <style
-                                data-emotion="css"
-                                data-s=""
-                              >
-                                
-                                .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
-                              </style>,
-                              <style
-                                data-emotion="css"
-                                data-s=""
-                              >
-                                
-                                .css-zih94u-render{display:block;}
-                              </style>,
-                            ],
-                          },
-                        }
-                      }
-                      isStringTag={true}
-                      serialized={
-                        Object {
-                          "map": undefined,
-                          "name": "6tb1tw-euiPopover",
-                          "next": undefined,
-                          "styles": "position:relative;vertical-align:middle;max-inline-size: 100%;;;label:euiPopover;;;display:block;;",
-                          "toString": [Function],
-                        }
-                      }
-                    />
-                    <div
-                      className="euiPopover emotion-euiPopover"
-                      onKeyDown={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchStart={[Function]}
-                    >
-                      <div
-                        css="unknown styles"
-                      >
-                        <Insertion
-                          cache={
-                            Object {
-                              "insert": [Function],
-                              "inserted": Object {
-                                "6tb1tw-euiPopover": true,
-                                "zih94u-render": true,
-                              },
+                            "registered": Object {},
+                            "sheet": StyleSheet {
+                              "_alreadyInsertedOrderInsensitiveRule": true,
+                              "_insertTag": [Function],
+                              "before": null,
+                              "container": <head>
+                                <style
+                                  data-emotion="css"
+                                  data-s=""
+                                >
+                                  
+                                  .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                                </style>
+                                <style
+                                  data-emotion="css"
+                                  data-s=""
+                                >
+                                  
+                                  .css-zih94u-render{display:block;}
+                                </style>
+                              </head>,
+                              "ctr": 2,
+                              "insertionPoint": undefined,
+                              "isSpeedy": false,
                               "key": "css",
                               "nonce": undefined,
-                              "registered": Object {},
-                              "sheet": StyleSheet {
-                                "_alreadyInsertedOrderInsensitiveRule": true,
-                                "_insertTag": [Function],
-                                "before": null,
-                                "container": <head>
-                                  <style
-                                    data-emotion="css"
-                                    data-s=""
-                                  >
-                                    
-                                    .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
-                                  </style>
-                                  <style
-                                    data-emotion="css"
-                                    data-s=""
-                                  >
-                                    
-                                    .css-zih94u-render{display:block;}
-                                  </style>
-                                </head>,
-                                "ctr": 2,
-                                "insertionPoint": undefined,
-                                "isSpeedy": false,
-                                "key": "css",
-                                "nonce": undefined,
-                                "prepend": undefined,
-                                "tags": Array [
-                                  <style
-                                    data-emotion="css"
-                                    data-s=""
-                                  >
-                                    
-                                    .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
-                                  </style>,
-                                  <style
-                                    data-emotion="css"
-                                    data-s=""
-                                  >
-                                    
-                                    .css-zih94u-render{display:block;}
-                                  </style>,
-                                ],
-                              },
-                            }
+                              "prepend": undefined,
+                              "tags": Array [
+                                <style
+                                  data-emotion="css"
+                                  data-s=""
+                                >
+                                  
+                                  .emotion-euiPopover{position:relative;vertical-align:middle;max-inline-size:100%;display:block;}
+                                </style>,
+                                <style
+                                  data-emotion="css"
+                                  data-s=""
+                                >
+                                  
+                                  .css-zih94u-render{display:block;}
+                                </style>,
+                              ],
+                            },
                           }
-                          isStringTag={true}
-                          serialized={
-                            Object {
-                              "map": undefined,
-                              "name": "zih94u-render",
-                              "next": undefined,
-                              "styles": "display:block;;label:render;",
-                              "toString": [Function],
-                            }
+                        }
+                        isStringTag={true}
+                        serialized={
+                          Object {
+                            "map": undefined,
+                            "name": "zih94u-render",
+                            "next": undefined,
+                            "styles": "display:block;;label:render;",
+                            "toString": [Function],
                           }
-                        />
+                        }
+                      />
+                      <div
+                        className="euiPopover__anchor css-zih94u-render"
+                      >
                         <div
-                          className="euiPopover__anchor css-zih94u-render"
+                          className="react-datepicker__input-container"
                         >
-                          <div
-                            className="react-datepicker__input-container"
-                          >
-                            <input
-                              aria-label="Press the down key to open a popover containing a calendar."
-                              className="euiDatePicker euiFieldText euiFieldText--withIcon testClass1 testClass2"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onChange={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onKeyDown={[Function]}
-                              readOnly={false}
-                              type="text"
-                              value=""
-                            />
-                          </div>
+                          <input
+                            aria-label="Press the down key to open a popover containing a calendar."
+                            className="euiDatePicker euiFieldText euiFieldText--withIcon testClass1 testClass2"
+                            disabled={false}
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            readOnly={false}
+                            type="text"
+                            value=""
+                          />
                         </div>
                       </div>
                     </div>
                   </div>
-                </EuiOutsideClickDetector>
-              </EuiPopover>
-            </DatePicker>
-          </EuiValidatableControl>
+                </div>
+              </EuiOutsideClickDetector>
+            </EuiPopover>
+          </DatePicker>
           <EuiFormControlLayoutIcons
             icon="calendar"
           >

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -204,7 +204,7 @@ exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
             >
               <input
                 aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText--withIcon euiFieldText-isInvalid euiDatePickerRange__start"
+                class="euiDatePicker euiFieldText euiFormControlLayout--1icons euiFieldText--withIcon euiDatePickerRange__start"
                 type="text"
                 value=""
               />
@@ -223,6 +223,14 @@ exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
               data-euiicon-type="calendar"
             />
           </span>
+        </div>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+        >
+          <span
+            color="danger"
+            data-euiicon-type="warning"
+          />
         </div>
       </div>
     </div>
@@ -255,12 +263,20 @@ exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
             >
               <input
                 aria-label="Press the down key to open a popover containing a calendar."
-                class="euiDatePicker euiFieldText euiFieldText-isInvalid euiDatePickerRange__end"
+                class="euiDatePicker euiFieldText euiFormControlLayout--1icons euiDatePickerRange__end"
                 type="text"
                 value=""
               />
             </div>
           </div>
+        </div>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+        >
+          <span
+            color="danger"
+            data-euiicon-type="warning"
+          />
         </div>
       </div>
     </div>

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`EuiDatePickerRange isInvalid is rendered 1`] = `
   >
     <span
       color="danger"
-      data-euiicon-type="warning"
+      data-euiicon-type="sortRight"
     />
   </span>
   <span

--- a/src/components/date_picker/_date_picker_range.scss
+++ b/src/components/date_picker/_date_picker_range.scss
@@ -60,6 +60,6 @@
   align-items: center;
 }
 
-.euiDatePickerRange--isInvalid .euiDatePickerRange__delimeter {
+.euiDatePickerRange--isInvalid:not(.euiDatePickerRange--isDisabled):not(.euiDatePickerRange--readOnly) .euiDatePickerRange__delimeter {
   @include euiFormControlInvalidStyle;
 }

--- a/src/components/date_picker/date_picker.test.tsx
+++ b/src/components/date_picker/date_picker.test.tsx
@@ -16,9 +16,7 @@ import { EuiContext } from '../context';
 
 describe('EuiDatePicker', () => {
   test('is rendered', () => {
-    const component = shallow<EuiDatePicker>(
-      <EuiDatePicker {...requiredProps} />
-    );
+    const component = shallow(<EuiDatePicker {...requiredProps} />);
 
     expect(component).toMatchSnapshot(); // snapshot of wrapping dom
     expect(component.find('ContextConsumer').shallow()).toMatchSnapshot(); // snapshot of DatePicker usage

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -11,15 +11,18 @@ import React, {
   Component,
   MouseEventHandler,
   Ref,
+  useState,
+  useCallback,
 } from 'react';
 import classNames from 'classnames';
 
 import { Moment } from 'moment'; // eslint-disable-line import/named
 
-import { EuiFormControlLayout, EuiValidatableControl } from '../form';
+import { EuiFormControlLayout, useEuiValidatableControl } from '../form';
 import { EuiFormControlLayoutIconsProps } from '../form/form_control_layout/form_control_layout_icons';
 import { getFormControlClassNameForIconCount } from '../form/form_control_layout/_num_icons';
 
+import { useCombinedRefs } from '../../services';
 import { EuiI18nConsumer } from '../context';
 import { CommonProps } from '../common';
 
@@ -184,7 +187,6 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
       'euiFieldText-isLoading': isLoading,
       'euiFieldText--withIcon': !inline && showIcon,
       'euiFieldText--isClearable': !inline && selected && onClear,
-      'euiFieldText-isInvalid': isInvalid,
     },
     className
   );
@@ -207,6 +209,14 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
     fullDateFormat = `${dateFormat} ${timeFormat}`;
   }
 
+  // Set an internal ref on ReactDatePicker's `input` so we can set its :invalid state via useEuiValidatableControl
+  const [inputValidityRef, _setInputValidityRef] = useState(null);
+  const setInputValidityRef = useCallback((ref) => {
+    _setInputValidityRef(ref?.input);
+  }, []);
+  useEuiValidatableControl({ isInvalid, controlEl: inputValidityRef });
+  const inputRefs = useCombinedRefs([inputRef, setInputValidityRef]);
+
   return (
     <span className={classes}>
       <EuiFormControlLayout
@@ -216,49 +226,47 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
         isLoading={isLoading}
         isInvalid={isInvalid}
       >
-        <EuiValidatableControl isInvalid={isInvalid}>
-          <EuiI18nConsumer>
-            {({ locale: contextLocale }) => {
-              return (
-                <ReactDatePicker
-                  adjustDateOnChange={adjustDateOnChange}
-                  calendarClassName={calendarClassName}
-                  className={datePickerClasses}
-                  customInput={customInput}
-                  dateFormat={fullDateFormat}
-                  dayClassName={dayClassName}
-                  disabled={disabled}
-                  excludeDates={excludeDates}
-                  filterDate={filterDate}
-                  injectTimes={injectTimes}
-                  inline={inline}
-                  locale={locale || contextLocale}
-                  maxDate={maxDate}
-                  maxTime={maxTime}
-                  minDate={minDate}
-                  minTime={minTime}
-                  onChange={onChange}
-                  openToDate={openToDate}
-                  placeholderText={placeholder}
-                  popperClassName={popperClassName}
-                  ref={inputRef}
-                  selected={selected}
-                  shouldCloseOnSelect={shouldCloseOnSelect}
-                  showMonthDropdown
-                  showTimeSelect={showTimeSelectOnly ? true : showTimeSelect}
-                  showTimeSelectOnly={showTimeSelectOnly}
-                  showYearDropdown
-                  timeFormat={timeFormat}
-                  utcOffset={utcOffset}
-                  yearDropdownItemNumber={7}
-                  accessibleMode
-                  popperPlacement={popoverPlacement}
-                  {...rest}
-                />
-              );
-            }}
-          </EuiI18nConsumer>
-        </EuiValidatableControl>
+        <EuiI18nConsumer>
+          {({ locale: contextLocale }) => {
+            return (
+              <ReactDatePicker
+                adjustDateOnChange={adjustDateOnChange}
+                calendarClassName={calendarClassName}
+                className={datePickerClasses}
+                customInput={customInput}
+                dateFormat={fullDateFormat}
+                dayClassName={dayClassName}
+                disabled={disabled}
+                excludeDates={excludeDates}
+                filterDate={filterDate}
+                injectTimes={injectTimes}
+                inline={inline}
+                locale={locale || contextLocale}
+                maxDate={maxDate}
+                maxTime={maxTime}
+                minDate={minDate}
+                minTime={minTime}
+                onChange={onChange}
+                openToDate={openToDate}
+                placeholderText={placeholder}
+                popperClassName={popperClassName}
+                ref={inputRefs}
+                selected={selected}
+                shouldCloseOnSelect={shouldCloseOnSelect}
+                showMonthDropdown
+                showTimeSelect={showTimeSelectOnly ? true : showTimeSelect}
+                showTimeSelectOnly={showTimeSelectOnly}
+                showYearDropdown
+                timeFormat={timeFormat}
+                utcOffset={utcOffset}
+                yearDropdownItemNumber={7}
+                accessibleMode
+                popperPlacement={popoverPlacement}
+                {...rest}
+              />
+            );
+          }}
+        </EuiI18nConsumer>
       </EuiFormControlLayout>
     </span>
   );

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -13,6 +13,7 @@ import { Moment } from 'moment'; // eslint-disable-line import/named
 
 import { EuiFormControlLayout, EuiValidatableControl } from '../form';
 import { EuiFormControlLayoutIconsProps } from '../form/form_control_layout/form_control_layout_icons';
+import { getFormControlClassNameForIconCount } from '../form/form_control_layout/_num_icons';
 
 import { EuiI18nConsumer } from '../context';
 import { ApplyClassComponentDefaults, CommonProps } from '../common';
@@ -185,9 +186,15 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
       'euiDatePicker--inline': inline,
     });
 
+    const numIconsClass = getFormControlClassNameForIconCount({
+      isInvalid,
+      isLoading,
+    });
+
     const datePickerClasses = classNames(
       'euiDatePicker',
       'euiFieldText',
+      numIconsClass,
       {
         'euiFieldText--fullWidth': fullWidth,
         'euiFieldText-isLoading': isLoading,
@@ -223,6 +230,7 @@ export class EuiDatePicker extends Component<_EuiDatePickerProps> {
           fullWidth={fullWidth}
           clear={selected && onClear ? { onClick: onClear } : undefined}
           isLoading={isLoading}
+          isInvalid={isInvalid}
         >
           <EuiValidatableControl isInvalid={isInvalid}>
             <EuiI18nConsumer>

--- a/src/components/date_picker/date_picker.tsx
+++ b/src/components/date_picker/date_picker.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, MouseEventHandler, Ref } from 'react';
+import React, {
+  FunctionComponent,
+  Component,
+  MouseEventHandler,
+  Ref,
+} from 'react';
 import classNames from 'classnames';
 
 import { Moment } from 'moment'; // eslint-disable-line import/named
@@ -16,7 +21,7 @@ import { EuiFormControlLayoutIconsProps } from '../form/form_control_layout/form
 import { getFormControlClassNameForIconCount } from '../form/form_control_layout/_num_icons';
 
 import { EuiI18nConsumer } from '../context';
-import { ApplyClassComponentDefaults, CommonProps } from '../common';
+import { CommonProps } from '../common';
 
 import { PopoverAnchorPosition } from '../popover';
 
@@ -70,7 +75,7 @@ interface EuiExtendedDatePickerProps
   /**
    * ref for the ReactDatePicker instance
    */
-  inputRef: Ref<Component<ReactDatePickerProps, any, any>>;
+  inputRef?: Ref<Component<ReactDatePickerProps, any, any>>;
 
   /**
    * Provides styling to the input when invalid
@@ -120,163 +125,141 @@ interface EuiExtendedDatePickerProps
   popoverPlacement?: PopoverAnchorPosition;
 }
 
-type _EuiDatePickerProps = CommonProps & EuiExtendedDatePickerProps;
+export type EuiDatePickerProps = CommonProps & EuiExtendedDatePickerProps;
 
-export type EuiDatePickerProps = ApplyClassComponentDefaults<
-  typeof EuiDatePicker
->;
+export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
+  adjustDateOnChange = true,
+  calendarClassName,
+  className,
+  customInput,
+  dateFormat = euiDatePickerDefaultDateFormat,
+  dayClassName,
+  disabled,
+  excludeDates,
+  filterDate,
+  fullWidth = false,
+  iconType,
+  injectTimes,
+  inline,
+  inputRef,
+  isInvalid,
+  isLoading,
+  locale,
+  maxDate,
+  maxTime,
+  minDate,
+  minTime,
+  onChange,
+  onClear,
+  openToDate,
+  placeholder,
+  popperClassName,
+  popoverPlacement = 'downLeft',
+  selected,
+  shadow = true,
+  shouldCloseOnSelect = true,
+  showIcon = true,
+  showTimeSelect = false,
+  showTimeSelectOnly,
+  timeFormat = euiDatePickerDefaultTimeFormat,
+  utcOffset,
+  ...rest
+}) => {
+  const classes = classNames('euiDatePicker', {
+    'euiDatePicker--shadow': shadow,
+    'euiDatePicker--inline': inline,
+  });
 
-export class EuiDatePicker extends Component<_EuiDatePickerProps> {
-  static defaultProps = {
-    adjustDateOnChange: true,
-    dateFormat: euiDatePickerDefaultDateFormat,
-    fullWidth: false,
-    inputRef: () => {},
-    isLoading: false,
-    shadow: true,
-    shouldCloseOnSelect: true,
-    showIcon: true,
-    showTimeSelect: false,
-    timeFormat: euiDatePickerDefaultTimeFormat,
-    popoverPlacement: 'downLeft',
-  };
+  const numIconsClass = getFormControlClassNameForIconCount({
+    isInvalid,
+    isLoading,
+  });
 
-  render() {
-    const {
-      adjustDateOnChange,
-      calendarClassName,
-      className,
-      customInput,
-      dateFormat,
-      dayClassName,
-      disabled,
-      excludeDates,
-      filterDate,
-      fullWidth,
-      iconType,
-      injectTimes,
-      inline,
-      inputRef,
-      isInvalid,
-      isLoading,
-      locale,
-      maxDate,
-      maxTime,
-      minDate,
-      minTime,
-      onChange,
-      onClear,
-      openToDate,
-      placeholder,
-      popperClassName,
-      popoverPlacement,
-      selected,
-      shadow,
-      shouldCloseOnSelect,
-      showIcon,
-      showTimeSelect,
-      showTimeSelectOnly,
-      timeFormat,
-      utcOffset,
-      ...rest
-    } = this.props;
+  const datePickerClasses = classNames(
+    'euiDatePicker',
+    'euiFieldText',
+    numIconsClass,
+    {
+      'euiFieldText--fullWidth': fullWidth,
+      'euiFieldText-isLoading': isLoading,
+      'euiFieldText--withIcon': !inline && showIcon,
+      'euiFieldText--isClearable': !inline && selected && onClear,
+      'euiFieldText-isInvalid': isInvalid,
+    },
+    className
+  );
 
-    const classes = classNames('euiDatePicker', {
-      'euiDatePicker--shadow': shadow,
-      'euiDatePicker--inline': inline,
-    });
-
-    const numIconsClass = getFormControlClassNameForIconCount({
-      isInvalid,
-      isLoading,
-    });
-
-    const datePickerClasses = classNames(
-      'euiDatePicker',
-      'euiFieldText',
-      numIconsClass,
-      {
-        'euiFieldText--fullWidth': fullWidth,
-        'euiFieldText-isLoading': isLoading,
-        'euiFieldText--withIcon': !inline && showIcon,
-        'euiFieldText--isClearable': !inline && selected && onClear,
-        'euiFieldText-isInvalid': isInvalid,
-      },
-      className
-    );
-
-    let optionalIcon: EuiFormControlLayoutIconsProps['icon'];
-    if (inline || customInput || !showIcon) {
-      optionalIcon = undefined;
-    } else if (iconType) {
-      optionalIcon = iconType;
-    } else if (showTimeSelectOnly) {
-      optionalIcon = 'clock';
-    } else {
-      optionalIcon = 'calendar';
-    }
-
-    // In case the consumer did not alter the default date format but wants
-    // to add the time select, we append the default time format
-    let fullDateFormat = dateFormat;
-    if (showTimeSelect && dateFormat === euiDatePickerDefaultDateFormat) {
-      fullDateFormat = `${dateFormat} ${timeFormat}`;
-    }
-
-    return (
-      <span className={classes}>
-        <EuiFormControlLayout
-          icon={optionalIcon}
-          fullWidth={fullWidth}
-          clear={selected && onClear ? { onClick: onClear } : undefined}
-          isLoading={isLoading}
-          isInvalid={isInvalid}
-        >
-          <EuiValidatableControl isInvalid={isInvalid}>
-            <EuiI18nConsumer>
-              {({ locale: contextLocale }) => {
-                return (
-                  <ReactDatePicker
-                    adjustDateOnChange={adjustDateOnChange}
-                    calendarClassName={calendarClassName}
-                    className={datePickerClasses}
-                    customInput={customInput}
-                    dateFormat={fullDateFormat}
-                    dayClassName={dayClassName}
-                    disabled={disabled}
-                    excludeDates={excludeDates}
-                    filterDate={filterDate}
-                    injectTimes={injectTimes}
-                    inline={inline}
-                    locale={locale || contextLocale}
-                    maxDate={maxDate}
-                    maxTime={maxTime}
-                    minDate={minDate}
-                    minTime={minTime}
-                    onChange={onChange}
-                    openToDate={openToDate}
-                    placeholderText={placeholder}
-                    popperClassName={popperClassName}
-                    ref={inputRef}
-                    selected={selected}
-                    shouldCloseOnSelect={shouldCloseOnSelect}
-                    showMonthDropdown
-                    showTimeSelect={showTimeSelectOnly ? true : showTimeSelect}
-                    showTimeSelectOnly={showTimeSelectOnly}
-                    showYearDropdown
-                    timeFormat={timeFormat}
-                    utcOffset={utcOffset}
-                    yearDropdownItemNumber={7}
-                    accessibleMode
-                    popperPlacement={popoverPlacement}
-                    {...rest}
-                  />
-                );
-              }}
-            </EuiI18nConsumer>
-          </EuiValidatableControl>
-        </EuiFormControlLayout>
-      </span>
-    );
+  let optionalIcon: EuiFormControlLayoutIconsProps['icon'];
+  if (inline || customInput || !showIcon) {
+    optionalIcon = undefined;
+  } else if (iconType) {
+    optionalIcon = iconType;
+  } else if (showTimeSelectOnly) {
+    optionalIcon = 'clock';
+  } else {
+    optionalIcon = 'calendar';
   }
-}
+
+  // In case the consumer did not alter the default date format but wants
+  // to add the time select, we append the default time format
+  let fullDateFormat = dateFormat;
+  if (showTimeSelect && dateFormat === euiDatePickerDefaultDateFormat) {
+    fullDateFormat = `${dateFormat} ${timeFormat}`;
+  }
+
+  return (
+    <span className={classes}>
+      <EuiFormControlLayout
+        icon={optionalIcon}
+        fullWidth={fullWidth}
+        clear={selected && onClear ? { onClick: onClear } : undefined}
+        isLoading={isLoading}
+        isInvalid={isInvalid}
+      >
+        <EuiValidatableControl isInvalid={isInvalid}>
+          <EuiI18nConsumer>
+            {({ locale: contextLocale }) => {
+              return (
+                <ReactDatePicker
+                  adjustDateOnChange={adjustDateOnChange}
+                  calendarClassName={calendarClassName}
+                  className={datePickerClasses}
+                  customInput={customInput}
+                  dateFormat={fullDateFormat}
+                  dayClassName={dayClassName}
+                  disabled={disabled}
+                  excludeDates={excludeDates}
+                  filterDate={filterDate}
+                  injectTimes={injectTimes}
+                  inline={inline}
+                  locale={locale || contextLocale}
+                  maxDate={maxDate}
+                  maxTime={maxTime}
+                  minDate={minDate}
+                  minTime={minTime}
+                  onChange={onChange}
+                  openToDate={openToDate}
+                  placeholderText={placeholder}
+                  popperClassName={popperClassName}
+                  ref={inputRef}
+                  selected={selected}
+                  shouldCloseOnSelect={shouldCloseOnSelect}
+                  showMonthDropdown
+                  showTimeSelect={showTimeSelectOnly ? true : showTimeSelect}
+                  showTimeSelectOnly={showTimeSelectOnly}
+                  showYearDropdown
+                  timeFormat={timeFormat}
+                  utcOffset={utcOffset}
+                  yearDropdownItemNumber={7}
+                  accessibleMode
+                  popperPlacement={popoverPlacement}
+                  {...rest}
+                />
+              );
+            }}
+          </EuiI18nConsumer>
+        </EuiValidatableControl>
+      </EuiFormControlLayout>
+    </span>
+  );
+};

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -48,7 +48,7 @@ export type EuiDatePickerRangeProps = CommonProps & {
   isCustom?: boolean;
 
   /**
-   * Will turn the range delimeter into an alert icon and pass through to each control
+   * Will color the range delimiter the `danger` color and pass through to each control
    */
   isInvalid?: boolean;
 
@@ -159,10 +159,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
 
   const delimiter = (
     <span className="euiDatePickerRange__delimeter">
-      <EuiIcon
-        color={isInvalid ? 'danger' : 'subdued'}
-        type={isInvalid ? 'warning' : 'sortRight'}
-      />
+      <EuiIcon color={isInvalid ? 'danger' : 'subdued'} type="sortRight" />
     </span>
   );
 

--- a/src/components/form/field_text/_field_text.scss
+++ b/src/components/form/field_text/_field_text.scss
@@ -1,13 +1,6 @@
 .euiFieldText {
   @include euiFormControlStyle;
   @include euiFormControlWithIcon($isIconOptional: true, $side: 'left');
-
-  /* Invalid state normally comes from :invalid, but several components
-  /* like EuiDatePicker need it toggled through an extra class.
-  */
-  &.euiFieldText-isInvalid {
-    @include euiFormControlInvalidStyle;
-  }
 }
 
 .euiFieldText--withIcon.euiFieldText--compressed {

--- a/src/components/form/validatable_control/index.ts
+++ b/src/components/form/validatable_control/index.ts
@@ -6,5 +6,11 @@
  * Side Public License, v 1.
  */
 
-export type { EuiValidatableControlProps } from './validatable_control';
-export { EuiValidatableControl } from './validatable_control';
+export type {
+  EuiValidatableControlProps,
+  UseEuiValidatableControlProps,
+} from './validatable_control';
+export {
+  EuiValidatableControl,
+  useEuiValidatableControl,
+} from './validatable_control';

--- a/src/components/form/validatable_control/validatable_control.test.tsx
+++ b/src/components/form/validatable_control/validatable_control.test.tsx
@@ -8,8 +8,12 @@
 
 import React from 'react';
 import { render, mount } from 'enzyme';
+import { renderHook } from '@testing-library/react-hooks';
 
-import { EuiValidatableControl } from './validatable_control';
+import {
+  EuiValidatableControl,
+  useEuiValidatableControl,
+} from './validatable_control';
 
 describe('EuiValidatableControl', () => {
   test('is rendered', () => {
@@ -152,5 +156,29 @@ describe('EuiValidatableControl', () => {
       // Ensure that the child element has changed
       expect(ref.current).not.toBe(prevRef);
     });
+  });
+});
+
+describe('useEuiValidatableControl', () => {
+  const controlEl = document.createElement('input');
+
+  it('sets the validity of the passed control element', () => {
+    const { rerender } = renderHook(useEuiValidatableControl, {
+      initialProps: { isInvalid: true, controlEl },
+    });
+    expect(controlEl.validity.valid).toEqual(false);
+
+    rerender({ isInvalid: false, controlEl });
+    expect(controlEl.validity.valid).toEqual(true);
+  });
+
+  it('sets the `aria-invalid` of the passed control element', () => {
+    const { rerender } = renderHook(useEuiValidatableControl, {
+      initialProps: { isInvalid: true, controlEl },
+    });
+    expect(controlEl.getAttribute('aria-invalid')).toEqual('true');
+
+    rerender({ isInvalid: false, controlEl });
+    expect(controlEl.getAttribute('aria-invalid')).toEqual('false');
   });
 });

--- a/src/components/form/validatable_control/validatable_control.tsx
+++ b/src/components/form/validatable_control/validatable_control.tsx
@@ -33,11 +33,12 @@ function isMutableRef(
   return ref != null && ref.hasOwnProperty('current');
 }
 
+/**
+ * The `EuiValidatableControl` component should be used in scenarios where
+ * we can render the validated `<input>` as its direct child.
+ */
 export interface EuiValidatableControlProps {
   isInvalid?: boolean;
-  /**
-   * ReactNode to render as this component's content
-   */
   children: ReactElementWithRef;
 }
 
@@ -63,23 +64,60 @@ export const EuiValidatableControl: FunctionComponent<
     [childRef]
   );
 
-  useEffect(() => {
-    if (
-      control.current === null ||
-      typeof control.current.setCustomValidity !== 'function'
-    ) {
-      return; // jsdom doesn't polyfill this for the server-side
-    }
-
-    if (isInvalid) {
-      control.current.setCustomValidity('Invalid');
-    } else {
-      control.current.setCustomValidity('');
-    }
-  });
+  useSetControlValidity({ controlEl: control.current, isInvalid });
 
   return cloneElement(child, {
     ref: replacedRef,
     'aria-invalid': isInvalid,
   });
+};
+
+/**
+ * The `UseEuiValidatableControl` hook should be used in scenarios where
+ * we *cannot* control where the validated `<input>` is rendered (e.g., ReactDatePicker)
+ * and instead need to access the input via a ref and pass the element in directly
+ */
+export interface UseEuiValidatableControlProps {
+  isInvalid?: boolean;
+  controlEl: HTMLInputElement | HTMLConstraintValidityElement | null;
+}
+
+export const useEuiValidatableControl = ({
+  isInvalid,
+  controlEl,
+}: UseEuiValidatableControlProps) => {
+  useSetControlValidity({ controlEl, isInvalid });
+
+  useEffect(() => {
+    if (!controlEl) return;
+
+    if (typeof isInvalid === 'boolean') {
+      controlEl.setAttribute('aria-invalid', String(isInvalid));
+    } else {
+      controlEl.removeAttribute('aria-invalid');
+    }
+  }, [isInvalid, controlEl]);
+};
+
+/**
+ * Internal `setCustomValidity` helper
+ */
+const useSetControlValidity = ({
+  controlEl,
+  isInvalid,
+}: UseEuiValidatableControlProps) => {
+  useEffect(() => {
+    if (
+      controlEl == null ||
+      typeof controlEl.setCustomValidity !== 'function'
+    ) {
+      return;
+    }
+
+    if (isInvalid) {
+      controlEl.setCustomValidity('Invalid');
+    } else {
+      controlEl.setCustomValidity('');
+    }
+  }, [isInvalid, controlEl]);
 };

--- a/upcoming_changelogs/6677.md
+++ b/upcoming_changelogs/6677.md
@@ -1,0 +1,1 @@
+- Updated `EuiDatePicker` to display a warning icon and correctly set `aria-invalid` when `isInvalid` is passed


### PR DESCRIPTION
## Summary

As part of my on-call work this week, I'm finishing up some older backlog work, in this case https://github.com/elastic/eui/issues/2017.

This PR:

- Adds the alert icon (and icon offset/padding affordance) to `EuiDatePicker`
- Converts `EuiDatePicker` from a class component to a function component
- Removes the need for `.euiFieldText-isInvalid` by adding a new `useEuiValidatableControl` hook that allows passing in control/input elements instead of relying on direct children
- Updates `EuiDatePickerRange` to account for the underlying date picker component using `:invalid` styling

**I strongly recommend following along [by commit](https://github.com/elastic/eui/pull/6677/commits) with whitespace changes turned off**, as there are a lot of "lines" changed that are just indentation changes.

### Before
<img width="627" alt="" src="https://user-images.githubusercontent.com/549407/229653467-9034d126-7a14-4c86-b7d9-b86a8fa88af0.png">

<img width="451" alt="" src="https://user-images.githubusercontent.com/549407/229653573-bbec480a-8f81-4743-89cd-1fbf5dcb0fd5.png">

### After
<img width="574" alt="" src="https://user-images.githubusercontent.com/549407/229653470-7b681db0-7605-4e12-89e8-df22b7ab1aad.png">

<img width="452" alt="" src="https://user-images.githubusercontent.com/549407/229653568-e246bfb5-dcec-4ee8-99c0-87356ef1c955.png">

## QA

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~