### PR TITLE
[EuiFilePicker] Use alert icon when `isInvalid`

### DIFF
--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -367,7 +367,7 @@ export const FormControlsExample = {
       playground: TextAreaConfig,
     },
     {
-      title: 'File Picker',
+      title: 'File picker',
       source: [
         {
           type: GuideSectionTypes.JS,

--- a/src/components/form/file_picker/_file_picker.scss
+++ b/src/components/form/file_picker/_file_picker.scss
@@ -101,8 +101,9 @@
     height: $euiFilePickerTallHeight - $euiSizeL; /* 4 */
   }
 
-  .euiFilePicker-isInvalid & {
-    border: $euiBorderWidthThick dashed $euiColorDanger;
+  // To match other EUI form controls, do not color the border red if focused or disabled
+  .euiFilePicker-isInvalid:not(.euiFilePicker__showDrop) .euiFilePicker__input:not(:disabled):not(:focus) + & {
+    border-color: $euiColorDanger;
   }
 }
 

--- a/src/components/form/file_picker/file_picker.tsx
+++ b/src/components/form/file_picker/file_picker.tsx
@@ -244,8 +244,10 @@ export class EuiFilePicker extends Component<EuiFilePickerProps> {
                 <div className="euiFilePicker__prompt" id={promptId}>
                   <EuiIcon
                     className="euiFilePicker__icon"
-                    color={disabled ? 'subdued' : 'primary'}
-                    type="importAction"
+                    color={
+                      isInvalid ? 'danger' : disabled ? 'subdued' : 'primary' // eslint-disable-line no-nested-ternary
+                    }
+                    type={isInvalid ? 'alert' : 'importAction'}
                     size={normalFormControl ? 'm' : 'l'}
                     aria-hidden="true"
                   />

--- a/upcoming_changelogs/6678.md
+++ b/upcoming_changelogs/6678.md
@@ -1,0 +1,1 @@
+- Updated `EuiFilePicker` to display an alert icon when `isInvalid`


### PR DESCRIPTION
## Summary

As part of my on-call work this week, I'm finishing up some older backlog work, in this case https://github.com/elastic/eui/issues/2017.

### Before

<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/229657245-7756ac09-8db5-47ad-80af-6e10a8be5e87.png"> <img width="300" alt="" src="https://user-images.githubusercontent.com/549407/229657253-e1074439-0013-44e7-bf1e-3e1f9938a406.png">

### After

<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/229657073-4952fd79-a65e-4540-87b8-b6ffc4e236d6.png"> <img width="300" alt="" src="https://user-images.githubusercontent.com/549407/229657101-6989fcc2-62fb-4a92-afb1-efdd43f9c134.png">

#### Non-large:

<img width="300" alt="" src="https://user-images.githubusercontent.com/549407/229657080-239e2573-27df-4402-a24a-d586f40c67e0.png"> <img width="300" alt="" src="https://user-images.githubusercontent.com/549407/229657103-ce773134-e505-40bd-a942-b832add05feb.png">

## QA

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~ There aren't really any for EuiFilePicker. We should remedy this when we switch to Storybook

- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart - I need to do this later once I figure out Figma.