### PR TITLE
[EuiTextArea] Add alert icon when `isInvalid` and `isLoading` support

### DIFF
--- a/src-docs/src/views/form_controls/text_area.js
+++ b/src-docs/src/views/form_controls/text_area.js
@@ -12,7 +12,7 @@ export default () => {
 
   return (
     /* DisplayToggles wrapper for Docs only */
-    <DisplayToggles canLoading={false}>
+    <DisplayToggles>
       <EuiTextArea
         placeholder="Placeholder text"
         aria-label="Use aria labels when no actual label is in use"

--- a/src/components/form/text_area/__snapshots__/text_area.test.tsx.snap
+++ b/src/components/form/text_area/__snapshots__/text_area.test.tsx.snap
@@ -1,10 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTextArea is rendered 1`] = `
-<textarea
-  aria-label="aria-label"
-  class="euiTextArea euiTextArea--resizeVertical testClass1 testClass2"
-  data-test-subj="test subject string"
-  rows="6"
-/>
+<div
+  class="euiFormControlLayout euiFormControlLayout--euiTextArea"
+>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
+    <textarea
+      aria-label="aria-label"
+      class="euiTextArea euiTextArea--resizeVertical testClass1 testClass2"
+      data-test-subj="test subject string"
+      rows="6"
+    />
+  </div>
+</div>
 `;

--- a/src/components/form/text_area/_text_area.scss
+++ b/src/components/form/text_area/_text_area.scss
@@ -9,6 +9,15 @@
   }
 }
 
+.euiFormControlLayout--euiTextArea {
+  height: auto;
+
+  .euiFormControlLayoutIcons {
+    top: auto;
+    bottom: $euiFormControlPadding;
+  }
+}
+
 // resize modifiers
 $textareaResizing: (
   vertical: 'resizeVertical',

--- a/src/components/form/text_area/text_area.tsx
+++ b/src/components/form/text_area/text_area.tsx
@@ -9,6 +9,8 @@
 import React, { TextareaHTMLAttributes, Ref, FunctionComponent } from 'react';
 import { CommonProps } from '../../common';
 import classNames from 'classnames';
+
+import { EuiFormControlLayout } from '../form_control_layout';
 import { EuiValidatableControl } from '../validatable_control';
 import { useFormContext } from '../eui_form_context';
 
@@ -79,18 +81,24 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
   }
 
   return (
-    <EuiValidatableControl isInvalid={isInvalid}>
-      <textarea
-        className={classes}
-        {...rest}
-        rows={definedRows}
-        name={name}
-        id={id}
-        ref={inputRef}
-        placeholder={placeholder}
-      >
-        {children}
-      </textarea>
-    </EuiValidatableControl>
+    <EuiFormControlLayout
+      fullWidth={fullWidth}
+      isInvalid={isInvalid}
+      className="euiFormControlLayout--euiTextArea"
+    >
+      <EuiValidatableControl isInvalid={isInvalid}>
+        <textarea
+          className={classes}
+          {...rest}
+          rows={definedRows}
+          name={name}
+          id={id}
+          ref={inputRef}
+          placeholder={placeholder}
+        >
+          {children}
+        </textarea>
+      </EuiValidatableControl>
+    </EuiFormControlLayout>
   );
 };

--- a/src/components/form/text_area/text_area.tsx
+++ b/src/components/form/text_area/text_area.tsx
@@ -16,6 +16,7 @@ import { useFormContext } from '../eui_form_context';
 
 export type EuiTextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> &
   CommonProps & {
+    isLoading?: boolean;
     isInvalid?: boolean;
     /**
      * Expand to fill 100% of the parent.
@@ -52,6 +53,7 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
     fullWidth = defaultFullWidth,
     id,
     inputRef,
+    isLoading,
     isInvalid,
     name,
     placeholder,
@@ -83,6 +85,7 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
   return (
     <EuiFormControlLayout
       fullWidth={fullWidth}
+      isLoading={isLoading}
       isInvalid={isInvalid}
       className="euiFormControlLayout--euiTextArea"
     >

--- a/upcoming_changelogs/6679.md
+++ b/upcoming_changelogs/6679.md
@@ -1,0 +1,2 @@
+- Updated `EuiTextArea` to display an alert icon when `isInvalid`
+- Updated `EuiTextArea` to support the `isLoading` prop


### PR DESCRIPTION
## Summary

As part of my on-call work this week, I'm finishing up some older backlog work, in this case https://github.com/elastic/eui/issues/2017.

Quick note about this implementation - I'm aware that the text and icons may overlap and be difficult to see or read, but I consider that to be an edge case (most text won't go all the way to the bottom and all the way to the right), and to be a lesser evil than not showing enough information. I'd prefer to wait to see if it becomes an issue, and iterate on it in the future if it does.

### Before
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/229662994-5502acd0-50a4-4bc5-b490-0e92b2cf0104.png">

### After
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/229662771-03af0282-e6bb-48f6-b980-a715f2025410.png">
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/229662851-88b309fd-7e3b-45ec-8f9d-304466ae212c.png">
<img width="400" alt="" src="https://user-images.githubusercontent.com/549407/229662857-b1159236-3d99-4b44-a06e-e0a509dc1421.png">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~ Existing tests are nonexistent for this component. We should remedy this later in storybook

- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart - will investigate later