### PR TITLE
[EuiInlineEdit] Create `EuiInlineEdit` Docs

### DIFF
--- a/src-docs/src/views/inline_edit/inline_edit_confirm.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_confirm.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { EuiInlineEditText } from '../../../../src';
 
 export default () => {
-  // TO DO: Convert this example to use something like a modal
   const confirmInlineEditChanges = () => {
     // eslint-disable-next-line no-restricted-globals
     const flag = confirm('Are you sure you want to save?') ? true : false;
@@ -14,14 +13,8 @@ export default () => {
     <>
       <EuiInlineEditText
         inputAriaLabel="Edit text inline"
-        defaultValue="Hello World!"
+        defaultValue="Hello! I will need to confirm my changes."
         size="m"
-        editModeProps={{
-          inputProps: { icon: 'cross' },
-        }}
-        readModeProps={{
-          color: 'success',
-        }}
         onConfirm={confirmInlineEditChanges}
       />
     </>

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -139,7 +139,7 @@ export const InlineEditExample = {
 
           <p>
             Customize the <EuiCode>editMode</EuiCode> state by passing{' '}
-            <EuiCode>editModeProps</EuiCode> . These properties are applied
+            <EuiCode>editModeProps</EuiCode>. These properties are applied
             directly to the{' '}
             <Link to="/forms/form-layouts#form-and-form-rows">
               <strong>EuiFormRow</strong>

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 import { GuideSectionTypes } from '../../components';
 
 import {
@@ -29,7 +31,7 @@ export const InlineEditExample = {
   intro: (
     <>
       <EuiText>
-        The <strong>EuiInlineEdit</strong> component is useful for updating
+        The <strong>EuiInlineEdit</strong> components are useful for updating
         single-line text outside of a form. The component has two states:{' '}
         <EuiCode>readMode</EuiCode> shows editable text inside of a button and{' '}
         <EuiCode>editMode</EuiCode> displays a form control to update the text.
@@ -59,13 +61,13 @@ export const InlineEditExample = {
       props: { EuiInlineEditText },
     },
     {
-      title: 'Display and edit headers and titles',
+      title: 'Display and edit headings and titles',
       text: (
         <>
           <p>
             Use <strong>EuiInlineEditTitle</strong> to display and edit titles.
-            Use the <EuiCode>heading</EuiCode> property to select the level of
-            heading to be used for the title in <EuiCode>readMode</EuiCode>.
+            Use the <EuiCode>heading</EuiCode> property to set the heading level
+            in <EuiCode>readMode</EuiCode>.
           </p>
         </>
       ),
@@ -77,53 +79,6 @@ export const InlineEditExample = {
       ],
       demo: <InlineEditTitle />,
       props: { EuiInlineEditTitle },
-    },
-    {
-      title: 'Customizing read and edit modes',
-      text: (
-        <>
-          <p>
-            Customize the <EuiCode>readMode</EuiCode> empty button by passing{' '}
-            <strong>EuiInlineEdit</strong> the <EuiCode>readModeProps</EuiCode>{' '}
-            property. <EuiCode>readMode</EuiCode> accepts{' '}
-            <EuiCode>EuiButtonEmpty</EuiCode> properties with the exception of{' '}
-            <EuiCode>onClick</EuiCode>.
-          </p>
-
-          <p>
-            Customize the <EuiCode>editMode</EuiCode> state by passing{' '}
-            <strong>EuiInlineEdit</strong> the <EuiCode>editModeProps</EuiCode>{' '}
-            property. These properties are applied directly to the{' '}
-            <EuiCode>EuiFormRow</EuiCode> and
-            <EuiCode>EuiFieldText</EuiCode> components.
-          </p>
-        </>
-      ),
-      source: [
-        {
-          type: GuideSectionTypes.TSX,
-          code: inlineEditModePropsSource,
-        },
-      ],
-      demo: <InlineEditModeProps />,
-    },
-    {
-      title: 'Confirm inline edit',
-      text: (
-        <>
-          <p>
-            Use the <EuiCode>onConfirm</EuiCode> property to pass a function
-            that will prompt users to confirm their changes.
-          </p>
-        </>
-      ),
-      source: [
-        {
-          type: GuideSectionTypes.TSX,
-          code: inlineEditConfirmSource,
-        },
-      ],
-      demo: <InlineEditConfirm />,
     },
     {
       title: 'Loading and invalid states',
@@ -149,6 +104,61 @@ export const InlineEditExample = {
         },
       ],
       demo: <InlineEditStates />,
+    },
+    {
+      title: 'Confirm inline edit',
+      text: (
+        <>
+          <p>
+            Use the <EuiCode>onConfirm</EuiCode> property to pass a function
+            that will prompt users to confirm their changes.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: inlineEditConfirmSource,
+        },
+      ],
+      demo: <InlineEditConfirm />,
+    },
+    {
+      title: 'Customizing read and edit modes',
+      text: (
+        <>
+          <p>
+            Customize the <EuiCode>readMode</EuiCode> state by passing{' '}
+            <EuiCode>readModeProps</EuiCode>. <EuiCode>readMode</EuiCode>{' '}
+            accepts{' '}
+            <Link to="/navigation/button#empty-button">
+              <strong>EuiButtonEmpty</strong>
+            </Link>{' '}
+            properties with the exception of <EuiCode>onClick</EuiCode>.
+          </p>
+
+          <p>
+            Customize the <EuiCode>editMode</EuiCode> state by passing{' '}
+            <EuiCode>editModeProps</EuiCode> . These properties are applied
+            directly to the{' '}
+            <Link to="/forms/form-layouts#form-and-form-rows">
+              <strong>EuiFormRow</strong>
+            </Link>{' '}
+            and{' '}
+            <Link to="/forms/form-controls#text-field">
+              <strong>EuiFieldText</strong>
+            </Link>{' '}
+            components.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: inlineEditModePropsSource,
+        },
+      ],
+      demo: <InlineEditModeProps />,
     },
   ],
 };

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -15,6 +15,9 @@ const inlineEditTextSource = require('!!raw-loader!./inline_edit_text');
 import InlineEditTitle from './inline_edit_title';
 const inlineEditTitleSource = require('!!raw-loader!./inline_edit_title');
 
+import InlineEditModeProps from './inline_edit_mode_props';
+const inlineEditModePropsSource = require('!!raw-loader!./inline_edit_mode_props');
+
 import InlineEditConfirm from './inline_edit_confirm';
 const inlineEditConfirmSource = require('!!raw-loader!././inline_edit_confirm');
 
@@ -25,17 +28,24 @@ export const InlineEditExample = {
   title: 'Inline edit',
   intro: (
     <>
-      <EuiText>This is where the description will go</EuiText>
+      <EuiText>
+        The <strong>EuiInlineEdit</strong> component is useful for updating
+        single-line text outside of a form. The component has two states:{' '}
+        <EuiCode>readMode</EuiCode> shows editable text inside of a button and{' '}
+        <EuiCode>editMode</EuiCode> displays a form control to update the text.
+      </EuiText>
     </>
   ),
   sections: [
     {
-      title: 'InlineEditText',
+      title: 'Display and edit basic text',
       text: (
         <>
           <p>
-            Description needed: how to use the <strong>EuiInlineEdit</strong>{' '}
-            component.
+            Use <strong>EuiInlineEditText</strong> to display and edit basic
+            text. Adjust the <EuiCode>size</EuiCode> property to change the font
+            size in both <EuiCode>readMode</EuiCode> and{' '}
+            <EuiCode>editMode</EuiCode>.
           </p>
         </>
       ),
@@ -49,12 +59,13 @@ export const InlineEditExample = {
       props: { EuiInlineEditText },
     },
     {
-      title: 'InlineEditTitle',
+      title: 'Display and edit headers and titles',
       text: (
         <>
           <p>
-            Description needed: how to use the <strong>EuiInlineEdit</strong>{' '}
-            component.
+            Use <strong>EuiInlineEditTitle</strong> to display and edit titles.
+            Use the <EuiCode>heading</EuiCode> property to select the level of
+            heading to be used for the title in <EuiCode>readMode</EuiCode>.
           </p>
         </>
       ),
@@ -68,12 +79,41 @@ export const InlineEditExample = {
       props: { EuiInlineEditTitle },
     },
     {
+      title: 'Customizing read and edit modes',
+      text: (
+        <>
+          <p>
+            Customize the <EuiCode>readMode</EuiCode> empty button by passing{' '}
+            <strong>EuiInlineEdit</strong> the <EuiCode>readModeProps</EuiCode>{' '}
+            property. <EuiCode>readMode</EuiCode> accepts{' '}
+            <EuiCode>EuiButtonEmpty</EuiCode> properties with the exception of{' '}
+            <EuiCode>onClick</EuiCode>.
+          </p>
+
+          <p>
+            Customize the <EuiCode>editMode</EuiCode> state by passing{' '}
+            <strong>EuiInlineEdit</strong> the <EuiCode>editModeProps</EuiCode>{' '}
+            property. These properties are applied directly to the{' '}
+            <EuiCode>EuiFormRow</EuiCode> and
+            <EuiCode>EuiFieldText</EuiCode> components.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: inlineEditModePropsSource,
+        },
+      ],
+      demo: <InlineEditModeProps />,
+    },
+    {
       title: 'Confirm inline edit',
       text: (
         <>
           <p>
-            Description needed: how to use the <strong>EuiInlineEdit</strong>{' '}
-            component.
+            Use the <EuiCode>onConfirm</EuiCode> property to pass a function
+            that will prompt users to confirm their changes.
           </p>
         </>
       ),
@@ -84,7 +124,6 @@ export const InlineEditExample = {
         },
       ],
       demo: <InlineEditConfirm />,
-      props: { EuiInlineEditText },
     },
     {
       title: 'Loading and invalid states',

--- a/src-docs/src/views/inline_edit/inline_edit_mode_props.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_mode_props.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { EuiInlineEditText } from '../../../../src';
+
+export default () => {
+  return (
+    <EuiInlineEditText
+      inputAriaLabel="Edit text inline for readMode and editMode props"
+      defaultValue="This inline edit component has been customized!"
+      size="m"
+      readModeProps={{ color: 'primary', iconSide: 'left' }}
+      editModeProps={{
+        inputProps: {
+          prepend: 'Prepend Example',
+        },
+      }}
+    />
+  );
+};

--- a/src-docs/src/views/inline_edit/inline_edit_text.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_text.tsx
@@ -4,7 +4,7 @@ import {
   EuiInlineEditText,
   EuiSpacer,
   EuiButtonGroup,
-  EuiInlineEditTextSizes,
+  EuiInlineEditTextProps,
 } from '../../../../src';
 
 export default () => {
@@ -24,10 +24,10 @@ export default () => {
   ];
 
   const [toggleTextButtonSize, setToggleTextButtonSize] = useState<
-    EuiInlineEditTextSizes
+    EuiInlineEditTextProps['size']
   >('m');
 
-  const textSizeOnChange = (optionId: EuiInlineEditTextSizes) => {
+  const textSizeOnChange = (optionId: EuiInlineEditTextProps['size']) => {
     setToggleTextButtonSize(optionId);
   };
 
@@ -37,7 +37,9 @@ export default () => {
         legend="Text size"
         options={textSizeButtons}
         idSelected={toggleTextButtonSize as string}
-        onChange={(id) => textSizeOnChange(id as EuiInlineEditTextSizes)}
+        onChange={(id) =>
+          textSizeOnChange(id as EuiInlineEditTextProps['size'])
+        }
       />
 
       <EuiSpacer />

--- a/src/components/inline_edit/index.ts
+++ b/src/components/inline_edit/index.ts
@@ -7,7 +7,9 @@
  */
 
 export { EuiInlineEditText } from './inline_edit_text';
+export type { EuiInlineEditTextProps } from './inline_edit_text';
 
 export { EuiInlineEditTitle } from './inline_edit_title';
+export type { EuiInlineEditTitleProps } from './inline_edit_title';
 
 export type { EuiInlineEditTextSizes } from './inline_edit_text';

--- a/src/components/inline_edit/index.ts
+++ b/src/components/inline_edit/index.ts
@@ -11,5 +11,3 @@ export type { EuiInlineEditTextProps } from './inline_edit_text';
 
 export { EuiInlineEditTitle } from './inline_edit_title';
 export type { EuiInlineEditTitleProps } from './inline_edit_title';
-
-export type { EuiInlineEditTextSizes } from './inline_edit_text';


### PR DESCRIPTION
## Summary

Creation of the `EuiInlineEdit` component docs. These docs cover:
- [x] Base Inline Edit Text and Title variations
- [x] `editMode` and `readMode` props
- [x]  Validation and loading states
- [x] `onConfirm` function prop

*Note: the `startWithEditOpen` prop doesn't have its own example (I thought it was self-explanatory) 

## QA
Please [visit the PR preview](https://eui.elastic.co/pr_6697/#/display/inline-edit) for `EuiInlineEdit` and read through the docs and examples