### PR TITLE
[EuiPopoverFooter] Fix buggy panel padding size context

### DIFF
--- a/src-docs/src/views/popover/popover.tsx
+++ b/src-docs/src/views/popover/popover.tsx
@@ -1,74 +1,33 @@
 import React, { useState } from 'react';
-import moment from 'moment';
-import {
-  EuiPopover,
-  EuiPopoverTitle,
-  EuiPopoverFooter,
-  EuiButton,
-  EuiButtonEmpty,
-  EuiHorizontalRule,
-  EuiDatePickerRange,
-  EuiDatePicker,
-} from '../../../../src';
+
+import { EuiPopover, EuiButtonEmpty, EuiText } from '../../../../src';
 
 export default () => {
-  const [isPopoverOpen3, setIsPopoverOpen3] = useState(false);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const onButtonClick3 = () =>
-    setIsPopoverOpen3((isPopoverOpen3) => !isPopoverOpen3);
-  const closePopover3 = () => setIsPopoverOpen3(false);
+  const onButtonClick = () =>
+    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
+  const closePopover = () => setIsPopoverOpen(false);
 
-  const [startDate, setStartDate] = useState(moment());
-  const [endDate, setEndDate] = useState(moment().add(11, 'd'));
+  const button = (
+    <EuiButtonEmpty
+      iconType="documentation"
+      iconSide="right"
+      onClick={onButtonClick}
+    >
+      How it works
+    </EuiButtonEmpty>
+  );
 
   return (
     <EuiPopover
-      button={
-        <EuiButtonEmpty
-          iconType="questionInCircle"
-          iconSide="right"
-          onClick={onButtonClick3}
-        >
-          With title and footer button
-        </EuiButtonEmpty>
-      }
-      isOpen={isPopoverOpen3}
-      closePopover={closePopover3}
-      anchorPosition="upCenter"
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
     >
-      <EuiPopoverTitle>Edit schedule</EuiPopoverTitle>
-      <EuiDatePickerRange
-        isInvalid={startDate > endDate}
-        startDateControl={
-          <EuiDatePicker
-            selected={startDate}
-            onChange={(date) => date && setStartDate(date)}
-            startDate={startDate}
-            endDate={endDate}
-            aria-label="Start date"
-            showTimeSelect
-          />
-        }
-        endDateControl={
-          <EuiDatePicker
-            selected={endDate}
-            onChange={(date) => date && setEndDate(date)}
-            startDate={startDate}
-            endDate={endDate}
-            aria-label="End date"
-            showTimeSelect
-          />
-        }
-      />
-      <EuiHorizontalRule margin="m" />
-      <EuiButton fill fullWidth>
-        Save schedule
-      </EuiButton>
-      <EuiPopoverFooter>
-        <EuiButton fullWidth color="danger">
-          Delete schedule
-        </EuiButton>
-      </EuiPopoverFooter>
+      <EuiText style={{ width: 300 }}>
+        <p>Popover content that&rsquo;s wider than the default width</p>
+      </EuiText>
     </EuiPopover>
   );
 };

--- a/src-docs/src/views/popover/popover.tsx
+++ b/src-docs/src/views/popover/popover.tsx
@@ -1,33 +1,74 @@
 import React, { useState } from 'react';
-
-import { EuiPopover, EuiButtonEmpty, EuiText } from '../../../../src';
+import moment from 'moment';
+import {
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiPopoverFooter,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiHorizontalRule,
+  EuiDatePickerRange,
+  EuiDatePicker,
+} from '../../../../src';
 
 export default () => {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [isPopoverOpen3, setIsPopoverOpen3] = useState(false);
 
-  const onButtonClick = () =>
-    setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
-  const closePopover = () => setIsPopoverOpen(false);
+  const onButtonClick3 = () =>
+    setIsPopoverOpen3((isPopoverOpen3) => !isPopoverOpen3);
+  const closePopover3 = () => setIsPopoverOpen3(false);
 
-  const button = (
-    <EuiButtonEmpty
-      iconType="documentation"
-      iconSide="right"
-      onClick={onButtonClick}
-    >
-      How it works
-    </EuiButtonEmpty>
-  );
+  const [startDate, setStartDate] = useState(moment());
+  const [endDate, setEndDate] = useState(moment().add(11, 'd'));
 
   return (
     <EuiPopover
-      button={button}
-      isOpen={isPopoverOpen}
-      closePopover={closePopover}
+      button={
+        <EuiButtonEmpty
+          iconType="questionInCircle"
+          iconSide="right"
+          onClick={onButtonClick3}
+        >
+          With title and footer button
+        </EuiButtonEmpty>
+      }
+      isOpen={isPopoverOpen3}
+      closePopover={closePopover3}
+      anchorPosition="upCenter"
     >
-      <EuiText style={{ width: 300 }}>
-        <p>Popover content that&rsquo;s wider than the default width</p>
-      </EuiText>
+      <EuiPopoverTitle>Edit schedule</EuiPopoverTitle>
+      <EuiDatePickerRange
+        isInvalid={startDate > endDate}
+        startDateControl={
+          <EuiDatePicker
+            selected={startDate}
+            onChange={(date) => date && setStartDate(date)}
+            startDate={startDate}
+            endDate={endDate}
+            aria-label="Start date"
+            showTimeSelect
+          />
+        }
+        endDateControl={
+          <EuiDatePicker
+            selected={endDate}
+            onChange={(date) => date && setEndDate(date)}
+            startDate={startDate}
+            endDate={endDate}
+            aria-label="End date"
+            showTimeSelect
+          />
+        }
+      />
+      <EuiHorizontalRule margin="m" />
+      <EuiButton fill fullWidth>
+        Save schedule
+      </EuiButton>
+      <EuiPopoverFooter>
+        <EuiButton fullWidth color="danger">
+          Delete schedule
+        </EuiButton>
+      </EuiPopoverFooter>
     </EuiPopover>
   );
 };

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -19,7 +19,7 @@ Array [
     </div>
   </div>,
   <div
-    class="euiPopoverFooter emotion-euiPopoverFooter-l"
+    class="euiPopoverFooter emotion-euiPopoverFooter-l-l"
   >
     <div
       class="euiFlexGroup emotion-euiFlexGroup-wrap-s-flexStart-stretch-row"

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
       </div>
     </div>
     <div
-      class="euiPopoverFooter emotion-euiPopoverFooter-s"
+      class="euiPopoverFooter emotion-euiPopoverFooter-s-s"
     >
       <div
         class="euiFlexGroup emotion-euiFlexGroup-s-spaceBetween-stretch-row"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -231,7 +231,7 @@ exports[`useDataGridColumnSorting columnSorting renders a toolbar button/popover
       </div>
     </div>
     <div
-      class="euiPopoverFooter emotion-euiPopoverFooter-s"
+      class="euiPopoverFooter emotion-euiPopoverFooter-s-s"
     >
       <div
         class="euiFlexGroup emotion-euiFlexGroup-m-spaceBetween-stretch-row"

--- a/src/components/popover/__snapshots__/popover_footer.test.tsx.snap
+++ b/src/components/popover/__snapshots__/popover_footer.test.tsx.snap
@@ -3,43 +3,43 @@
 exports[`EuiPopoverFooter is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiPopoverFooter testClass1 testClass2 emotion-euiPopoverFooter-l"
+  class="euiPopoverFooter testClass1 testClass2 emotion-euiPopoverFooter-l-l"
   data-test-subj="test subject string"
 />
 `;
 
 exports[`EuiPopoverFooter props paddingSize l is rendered 1`] = `
 <div
-  class="euiPopoverFooter emotion-euiPopoverFooter-l"
+  class="euiPopoverFooter emotion-euiPopoverFooter-l-l"
 />
 `;
 
 exports[`EuiPopoverFooter props paddingSize m is rendered 1`] = `
 <div
-  class="euiPopoverFooter emotion-euiPopoverFooter-m"
+  class="euiPopoverFooter emotion-euiPopoverFooter-l-m"
 />
 `;
 
 exports[`EuiPopoverFooter props paddingSize none is rendered 1`] = `
 <div
-  class="euiPopoverFooter emotion-euiPopoverFooter"
+  class="euiPopoverFooter emotion-euiPopoverFooter-l"
 />
 `;
 
 exports[`EuiPopoverFooter props paddingSize s is rendered 1`] = `
 <div
-  class="euiPopoverFooter emotion-euiPopoverFooter-s"
+  class="euiPopoverFooter emotion-euiPopoverFooter-l-s"
 />
 `;
 
 exports[`EuiPopoverFooter props paddingSize xl is rendered 1`] = `
 <div
-  class="euiPopoverFooter emotion-euiPopoverFooter-xl"
+  class="euiPopoverFooter emotion-euiPopoverFooter-l-xl"
 />
 `;
 
 exports[`EuiPopoverFooter props paddingSize xs is rendered 1`] = `
 <div
-  class="euiPopoverFooter emotion-euiPopoverFooter-xs"
+  class="euiPopoverFooter emotion-euiPopoverFooter-l-xs"
 />
 `;

--- a/src/components/popover/popover_footer.styles.ts
+++ b/src/components/popover/popover_footer.styles.ts
@@ -16,26 +16,46 @@ import {
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
-export const euiPopoverFooterStyles = (
-  euiThemeContext: UseEuiTheme,
-  panelPadding: EuiPaddingSize
-) => {
+export const euiPopoverFooterStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
-  // If the popover's containing panel has padding applied,
-  // ensure the title expands to cover that padding and
-  const panelPaddingSize = euiPaddingSize(euiThemeContext, panelPadding);
 
   return {
     // Base
     euiPopoverFooter: css`
       ${euiFontSize(euiThemeContext, 's')};
       ${logicalCSS('border-top', euiTheme.border.thin)};
-
-      // Negative margins for panel padding
-      ${logicalShorthandCSS(
-        'margin',
-        `${panelPaddingSize} -${panelPaddingSize} -${panelPaddingSize}`
-      )}
     `,
+    // If the popover's containing panel has padding applied,
+    // ensure the title expands to cover that padding via negative margins
+    panelPaddingSizes: {
+      none: css``,
+      xs: css`
+        ${panelPaddingOffset(euiThemeContext, 'xs')}
+      `,
+      s: css`
+        ${panelPaddingOffset(euiThemeContext, 's')}
+      `,
+      m: css`
+        ${panelPaddingOffset(euiThemeContext, 'm')}
+      `,
+      l: css`
+        ${panelPaddingOffset(euiThemeContext, 'l')}
+      `,
+      xl: css`
+        ${panelPaddingOffset(euiThemeContext, 'xl')}
+      `,
+    },
   };
+};
+
+export const panelPaddingOffset = (
+  euiThemeContext: UseEuiTheme,
+  size: EuiPaddingSize
+) => {
+  const panelPaddingSize = euiPaddingSize(euiThemeContext, size);
+
+  return logicalShorthandCSS(
+    'margin',
+    `${panelPaddingSize} -${panelPaddingSize} -${panelPaddingSize}`
+  );
 };

--- a/src/components/popover/popover_footer.tsx
+++ b/src/components/popover/popover_footer.tsx
@@ -33,12 +33,12 @@ export const EuiPopoverFooter: EuiPopoverFooterProps = ({
 }) => {
   const { paddingSize: panelPadding } = useContext(EuiPopoverPanelContext);
   const euiTheme = useEuiTheme();
-  const styles = euiPopoverFooterStyles(euiTheme, panelPadding);
+  const styles = euiPopoverFooterStyles(euiTheme);
   const paddingStyles = useEuiPaddingCSS();
   const cssStyles = [
     styles.euiPopoverFooter,
-    // If a paddingSize is not directly provided, inherit from the EuiPopoverPanel
-    paddingStyles[paddingSize || panelPadding],
+    styles.panelPaddingSizes[panelPadding],
+    paddingStyles[paddingSize || panelPadding], // If a paddingSize is not directly provided, inherit from the EuiPopoverPanel
   ];
 
   const classes = classNames('euiPopoverFooter', className);

--- a/src/components/popover/popover_panel/_popover_panel.tsx
+++ b/src/components/popover/popover_panel/_popover_panel.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { createContext, FunctionComponent, useContext } from 'react';
+import React, { createContext, FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { useEuiTheme } from '../../../services';
 import { EuiPaddingSize } from '../../../global_styling';
@@ -14,12 +14,12 @@ import { EuiPanel, _EuiPanelDivlike } from '../../panel/panel';
 import { EuiPopoverArrowPositions } from '../popover_arrow';
 import { euiPopoverPanelStyles } from './_popover_panel.styles';
 
-interface ContextShape {
-  paddingSize: EuiPaddingSize;
-}
+const DEFAULT_PANEL_PADDING_SIZE = 'l';
 
-export const EuiPopoverPanelContext = createContext<ContextShape>({
-  paddingSize: 'l',
+export const EuiPopoverPanelContext = createContext<{
+  paddingSize: EuiPaddingSize;
+}>({
+  paddingSize: DEFAULT_PANEL_PADDING_SIZE,
 });
 
 export type EuiPopoverPanelProps = _EuiPanelDivlike;
@@ -46,8 +46,7 @@ export const EuiPopoverPanel: FunctionComponent<
   position,
   ...rest
 }) => {
-  const panelContext = useContext(EuiPopoverPanelContext);
-  if (rest.paddingSize) panelContext.paddingSize = rest.paddingSize;
+  const { paddingSize = DEFAULT_PANEL_PADDING_SIZE } = rest;
 
   const euiThemeContext = useEuiTheme();
   // Using BEM child class for BWC
@@ -77,7 +76,7 @@ export const EuiPopoverPanel: FunctionComponent<
   }
 
   return (
-    <EuiPopoverPanelContext.Provider value={panelContext}>
+    <EuiPopoverPanelContext.Provider value={{ paddingSize }}>
       <EuiPanel
         className={classes}
         css={panelCSS}

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`EuiTourStep accepts an array of buttons in the footerAction prop 1`] = 
             You are here
           </div>
           <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-euiTourFooter"
+            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
           >
             <div
               class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
@@ -174,7 +174,7 @@ exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
             You are here
           </div>
           <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-euiTourFooter"
+            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
           >
             <div
               class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
@@ -277,7 +277,7 @@ exports[`EuiTourStep can have subtitle 1`] = `
             You are here
           </div>
           <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-euiTourFooter"
+            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
           >
             <div
               class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
@@ -375,7 +375,7 @@ exports[`EuiTourStep can override the footer action 1`] = `
             You are here
           </div>
           <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-euiTourFooter"
+            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
           >
             <div
               class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
@@ -457,7 +457,7 @@ exports[`EuiTourStep can turn off the beacon 1`] = `
             You are here
           </div>
           <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-euiTourFooter"
+            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
           >
             <div
               class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
@@ -555,7 +555,7 @@ exports[`EuiTourStep is rendered 1`] = `
             You are here
           </div>
           <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-euiTourFooter"
+            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
           >
             <div
               class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"

--- a/upcoming_changelogs/6698.md
+++ b/upcoming_changelogs/6698.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiPopoverFooter` bug causing nested popovers within popovers (note: not a recommended use-case) to unintentionally override its panel padding size inherited from context


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6695

The main (fairly simple) context fix is in https://github.com/elastic/eui/pull/6698/commits/7619bfc084916abb2af33da03f5f4a064765fb0e.

The [other commits](https://github.com/elastic/eui/pull/6698/commits) are an Emotion cleanup that I noticed while here and should have caught when cleaning up `EuiPopoverTitle` in #6221

## Repro steps

- Go to https://codesandbox.io/s/exciting-water-vq07t2?file=/demo.js
- Open the popover, and then click the date range picker in the popover
- Click any time or date in the nested popover (causing a state rerender)
- Close the date popover and notice that the original popover's footer has now changed/bugged out

![before](https://user-images.githubusercontent.com/549407/230451190-8bfb1a39-bb94-456f-bac7-ccf2130c9137.gif)

## QA

- Go to http://localhost:8030/#/layout/popover
- Click the popover button in the first example
- Open the nested date range picker popover, click any date/time
- [x] Confirm that the original popover's footer has **not** changed/bugged out

![after](https://user-images.githubusercontent.com/549407/230451772-58a7162b-da91-4c1d-a2ab-0406da2fbf35.gif)

### General checklist

- [x] Revert [REVERT ME] commit
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**~ I skipped writing a specific regression test for this bug as nested popovers are generally a recommended-against edge-case, and code regression is incredibly unlikely as the context usage was simply wrong in the first place