### PR TITLE
[EuiComboBox] Only delete the last selected pill when pressing the backspace key when the input caret is present

### DIFF
--- a/src/components/combo_box/combo_box.spec.tsx
+++ b/src/components/combo_box/combo_box.spec.tsx
@@ -8,7 +8,7 @@
 
 /// <reference types="../../../cypress/support"/>
 
-import React from 'react';
+import React, { useState } from 'react';
 import { EuiComboBox } from './index';
 
 describe('EuiComboBox', () => {
@@ -32,6 +32,88 @@ describe('EuiComboBox', () => {
       cy.get('span').contains('Item 2').realClick();
 
       cy.focused().should('have.attr', 'data-test-subj', 'comboBoxSearchInput');
+    });
+  });
+
+  describe('Backspace to delete last pill', () => {
+    const options = [
+      { label: 'Item 1' },
+      { label: 'Item 2' },
+      { label: 'Item 3' },
+    ];
+
+    const TestComboBox = (...rest) => {
+      const [selectedOptions, setSelected] = useState([]);
+      const onChange = (selectedOptions) => {
+        setSelected(selectedOptions);
+      };
+      return (
+        <EuiComboBox
+          options={options}
+          selectedOptions={selectedOptions}
+          onChange={onChange}
+          {...rest}
+        />
+      );
+    };
+
+    it('does not delete the last pill if there is search text', () => {
+      cy.realMount(<TestComboBox />);
+      cy.get('[data-test-subj=comboBoxSearchInput]').realClick();
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+      cy.get('.euiComboBoxPill').should('have.length', 2);
+
+      cy.get('[data-test-subj=comboBoxSearchInput]').type('test');
+      cy.get('[data-test-subj=comboBoxSearchInput]').realPress('Backspace');
+
+      cy.get('[data-test-subj=comboBoxSearchInput]')
+        .invoke('val')
+        .should('equal', 'tes');
+      cy.get('.euiComboBoxPill').should('have.length', 2);
+    });
+
+    it('does not delete the last pill if the input is not active when backspace is pressed', () => {
+      cy.realMount(<TestComboBox />);
+      cy.get('[data-test-subj=comboBoxSearchInput]').realClick();
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+      cy.get('[data-test-subj=comboBoxSearchInput]').type('test');
+      cy.realPress('Escape');
+      cy.get('.euiComboBoxPill').should('have.length', 1);
+
+      cy.realPress(['Shift', 'Tab']); // Should be focused on the first pill's X button
+      cy.realPress('Backspace');
+      cy.get('.euiComboBoxPill').should('have.length', 1);
+
+      cy.repeatRealPress('Tab', 2); // Should be focused on the clear button
+      cy.realPress('Backspace');
+      cy.get('.euiComboBoxPill').should('have.length', 1);
+    });
+
+    it('deletes the last pill added when backspace on the input is pressed ', () => {
+      cy.realMount(<TestComboBox />);
+      cy.get('[data-test-subj=comboBoxSearchInput]').realClick();
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+      cy.get('.euiComboBoxPill').should('have.length', 2);
+
+      cy.get('[data-test-subj=comboBoxSearchInput]').realPress('Backspace');
+      cy.get('.euiComboBoxPill').should('have.length', 1);
+    });
+
+    it('opens up the selection list again after deleting the active single selection ', () => {
+      cy.realMount(<TestComboBox singleSelection />);
+      cy.get('[data-test-subj=comboBoxSearchInput]').realClick();
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+
+      cy.realPress('Backspace');
+      cy.get('[data-test-subj=comboBoxOptionsList]').should('have.length', 1);
     });
   });
 });

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -418,26 +418,6 @@ export class EuiComboBox<T> extends Component<
     this.onSearchChange('');
   };
 
-  removeLastOption = () => {
-    if (!this.props.selectedOptions.length) {
-      return;
-    }
-
-    // Backspace will be used to delete the input, not a pill.
-    if (this.state.searchValue.length) {
-      return;
-    }
-
-    // Delete last pill.
-    this.onRemoveOption(
-      this.props.selectedOptions[this.props.selectedOptions.length - 1]
-    );
-
-    if (Boolean(this.props.singleSelection) && !this.state.isListOpen) {
-      this.openList();
-    }
-  };
-
   addCustomOption = (isContainerBlur: boolean, searchValue: string) => {
     const {
       isCaseSensitive,
@@ -623,11 +603,6 @@ export class EuiComboBox<T> extends Component<
         } else {
           this.openList();
         }
-        break;
-
-      case keys.BACKSPACE:
-        event.stopPropagation();
-        this.removeLastOption();
         break;
 
       case keys.ESCAPE:

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -479,7 +479,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
         hasShadow={false}
         className={classes}
         panelRef={this.listRefCallback}
-        data-test-subj={`comboBoxOptionsList ${dataTestSubj}`}
+        data-test-subj={classNames('comboBoxOptionsList', dataTestSubj)}
         style={{ ...style, zIndex: zIndex }}
         isOpen
         isAttached

--- a/upcoming_changelogs/6699.md
+++ b/upcoming_changelogs/6699.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` to only delete the last selected item on backspace if the input caret is present


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/590

What this PR does:

- Prevents `backspace` keypresses on the `clear` button from triggering the last pill deletion
- Prevents `backspace` keypresses on when other pills are focused from triggering the last pill deletion

What this PR **does not do**:

- Allow `backspace` keypresses on pills to delete the pill that's currently focused (I agree with @1Copenut who mentioned in a meeting that that behavior felt unintuitive, and would require extra SR instructions to tell people it's even an option. We can potentially revisit this in the future if it becomes a feature request, but I don't see it as necessary for now)

## QA

- Go to https://eui.elastic.co/pr_6699/#/forms/combo-box (first demo)
- Using your keyboard, tab to the X button of the already selected Mimas or Iapetus pills
- [x] Press your backspace key and confirm nothing happens
- Tab to the input and press backspace
- [x] Confirm the Iapetus pill is deleted correctly
- Tab to the clear button and press backspace
- [x] Confirm nothing happens and the Mimas pill remains as-is

### General checklist

- [x] Added or updated ~**[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately
