### PR TITLE
Update stale bot skips, messages, and durations

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          stale-issue-message: '👋 Hi there - this issue hasn''t had any activity in 6 months. If the EUI team has not explicitly expressed that this is something on our immediate roadmap, it''s unlikely that we''ll pick this issue up. We would sincerely appreciate a PR/community contribution if this is something that matters to you! If not, and there is no further activity on this issue for another 6 months (i.e. it''s stale for over a year), the issue will be auto-closed.'
+          stale-issue-message: '👋 Hi there - this issue hasn''t had any activity in 6 months. If the EUI team has not explicitly expressed that this is something on our roadmap, it''s unlikely that we''ll pick this issue up. We would sincerely appreciate a PR/community contribution if this is something that matters to you! If not, and there is no further activity on this issue for another 6 months (i.e. it''s stale for over a year), the issue will be auto-closed.'
           close-issue-message: '❌ Per our previous message, this issue is auto-closing after having been open and inactive for a year. If you still feel strongly about it and are interested in contributing, please let us know with a comment.'
           days-before-issue-stale: 180
           days-before-close: 180

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-issue-message: '👋 Hi there - this issue hasn''t had any activity in 6 months. If the EUI team has not explicitly expressed that this is something on our immediate roadmap, it''s unlikely that we''ll pick this issue up. We would sincerely appreciate a PR/community contribution if this is something that matters to you! If not, and there is no further activity on this issue for another 6 months (i.e. it''s stale for over a year), the issue will be auto-closed.'
-          close-issue-message: '❌ Per our previous message, this issue is auto-closing due to lack of activity. If you still strongly feel it must be completed or are interested in contributing, please let us know with a comment.'
+          close-issue-message: '❌ Per our previous message, this issue is auto-closing after having been open and inactive for a year. If you still feel strongly about it and are interested in contributing, please let us know with a comment.'
           days-before-issue-stale: 180
           days-before-close: 180
           stale-issue-label: 'stale-issue'

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          stale-issue-message: '👋 Hey there. This issue hasn''t had any activity for 180 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
-          close-issue-message: '❌ We''re automatically closing this issue due to lack of activity. Please comment if you feel this was done in error.'
+          stale-issue-message: '👋 Hi there - this issue hasn''t had any activity in 6 months. If the EUI team has not explicitly expressed that this is something on our immediate roadmap, it''s unlikely that we''ll pick this issue up. We would sincerely appreciate a PR/community contribution if this is something that matters to you! If not, and there is no further activity on this issue for another 6 months (i.e. it''s stale for over a year), the issue will be auto-closed.'
+          close-issue-message: '❌ Per our previous message, this issue is auto-closing due to lack of activity. If you still strongly feel it must be completed or are interested in contributing, please let us know with a comment.'
           days-before-issue-stale: 180
-          days-before-close: 7
+          days-before-close: 180
           stale-issue-label: 'stale-issue'
           close-issue-label: 'stale-issue-closed'
           exempt-issue-labels: 'bug,meta'

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-issue-message: '👋 Hi there - this issue hasn''t had any activity in 6 months. If the EUI team has not explicitly expressed that this is something on our roadmap, it''s unlikely that we''ll pick this issue up. We would sincerely appreciate a PR/community contribution if this is something that matters to you! If not, and there is no further activity on this issue for another 6 months (i.e. it''s stale for over a year), the issue will be auto-closed.'
-          close-issue-message: '❌ Per our previous message, this issue is auto-closing after having been open and inactive for a year. If you still feel strongly about it and are interested in contributing, please let us know with a comment.'
+          close-issue-message: '❌ Per our previous message, this issue is auto-closing after having been open and inactive for a year. If you strongly feel this is still a high-priority issue, or are interested in contributing, please leave a comment or open a new issue linking to this one for context.'
           days-before-issue-stale: 180
           days-before-close: 180
           stale-issue-label: 'stale-issue'

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -27,7 +27,6 @@ jobs:
           exempt-issue-labels: 'bug,meta'
           stale-pr-label: 'stale-pr'
           close-pr-label: 'stale-pr-closed'
-          exempt-all-assignees: true
           operations-per-run: 1000
           remove-stale-when-updated: true
           enable-statistics: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v8.0.0
         with:
           stale-pr-message: '👋 Hey there. This PR hasn''t had any activity for 90 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
           close-pr-message: '❌ We''re automatically closing this PR due to lack of activity. Please comment if you feel this was done in error.'
@@ -37,6 +37,7 @@ jobs:
           days-before-close: 180
           stale-issue-label: 'stale-issue'
           close-issue-label: 'stale-issue-closed'
+          close-issue-reason: 'not_planned'
           exempt-issue-labels: 'bug,meta'
           operations-per-run: 1000
           remove-stale-when-updated: true
@@ -56,6 +57,7 @@ jobs:
           remove-stale-when-updated: true
           stale-issue-message: ''
           close-issue-message: '👋 This issue hasn''t seen activity in 3 days, so we''re automatically closing this issue as answered. Please leave a comment if that''s not the case, or if you have any remaining questions or issues.'
+          close-issue-reason: 'completed'
           operations-per-run: 1000
           enable-statistics: true
           debug-only: false

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -24,10 +24,9 @@ jobs:
           days-before-close: 7
           stale-issue-label: 'stale-issue'
           close-issue-label: 'stale-issue-closed'
-          exempt-issue-labels: 'bug,skip-stale-check,meta'
+          exempt-issue-labels: 'bug,meta'
           stale-pr-label: 'stale-pr'
           close-pr-label: 'stale-pr-closed'
-          exempt-pr-labels: 'skip-stale-check,meta'
           exempt-all-assignees: true
           operations-per-run: 1000
           remove-stale-when-updated: true

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -7,31 +7,42 @@ permissions:
   contents: read
 
 jobs:
-  stale:
+  stale-prs: # close stale PRs after ~3 months
     permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v3
         with:
-          stale-issue-message: '👋 Hey there. This issue hasn''t had any activity for 180 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
           stale-pr-message: '👋 Hey there. This PR hasn''t had any activity for 90 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
-          close-issue-message: '❌ We''re automatically closing this issue due to lack of activity. Please comment if you feel this was done in error.'
           close-pr-message: '❌ We''re automatically closing this PR due to lack of activity. Please comment if you feel this was done in error.'
           days-before-pr-stale: 90
-          days-before-issue-stale: 180
           days-before-close: 7
-          stale-issue-label: 'stale-issue'
-          close-issue-label: 'stale-issue-closed'
-          exempt-issue-labels: 'bug,meta'
           stale-pr-label: 'stale-pr'
           close-pr-label: 'stale-pr-closed'
           operations-per-run: 1000
           remove-stale-when-updated: true
           enable-statistics: true
           debug-only: false
-  answered: # automatically close issues labeled as 'answered' if there was no response in 3 days
+  stale-issues: # close stale issues after ~1 year
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: '👋 Hey there. This issue hasn''t had any activity for 180 days. We''ll automatically close it if that trend continues for another week. If you feel this issue is still valid and needs attention please let us know with a comment.'
+          close-issue-message: '❌ We''re automatically closing this issue due to lack of activity. Please comment if you feel this was done in error.'
+          days-before-issue-stale: 180
+          days-before-close: 7
+          stale-issue-label: 'stale-issue'
+          close-issue-label: 'stale-issue-closed'
+          exempt-issue-labels: 'bug,meta'
+          operations-per-run: 1000
+          remove-stale-when-updated: true
+          enable-statistics: true
+          debug-only: false
+  answered-issues: # close answered issues after 3 days if no response
     permissions:
       issues: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

What this PR does:

- Removes the `skip-stale-check` label: we no longer want to give ourselves the free "out" of infinitely ignoring stale closures. Instead, we should be either doing the work of addressing the issue, or determining that we as a team simply don't have the bandwidth and closing it for that reason.
- Removes skipping the stale check if the issue is assigned to someone. Just because an issue is assigned does not mean it's being actively worked on, and we need to hold assignees accountable.
- Extends the stale issue length from 6 months to ~1 year (i.e., giving us a bit more grace period before definitively closing issues the EUI team will not be working on).
- Updates the messaging around stale issues to clarify what will happen (auto closing), and what issue-openers can do (contribute).

What this PR **does not** do:

- Leaves the stale closures of open PRs as-is, as that is not an issue we've frequently run into, but breaks stale PRs into a separate job for easier reading/cognitive load
- Leaves closures of the `answered` tag as-is
- Does not yet add documentation around all the above decisions: I would like to re-work the docs in the EUI codebase significantly, primarily README, FAQ, and CONTRIBUTING.md which are woefully out of date and could stand to be consolidated so they don't sit tucked away and unread for so long.

## QA

### General checklist

N/A, team process/tech debt only