### PR TITLE
[EuiSearchBar] Fix quoted phrases (without a field) removing quotes

### DIFF
--- a/src-docs/src/views/search_bar/search_bar_example.js
+++ b/src-docs/src/views/search_bar/search_bar_example.js
@@ -44,6 +44,10 @@ export const SearchBarExample = {
               terms in them but do not have the word &quot;production&quot;
             </li>
             <li>
+              Phrases can be matched by surrounding multiple words with quotes -
+              Example, <EuiCode>&quot;website url&quot;</EuiCode>.
+            </li>
+            <li>
               Field/value search - one can search for terms within specific
               fields - Example,
               <EuiCode>tag:bug -severity:high</EuiCode>. In this example the

--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_dsl.test.ts.snap
@@ -511,3 +511,24 @@ Object {
   },
 }
 `;
+
+exports[`astToEsQueryDsl ast·-·'"john·smith"·-"sales team"' 1`] = `
+Object {
+  "bool": Object {
+    "must": Array [
+      Object {
+        "simple_query_string": Object {
+          "query": "\\"john smith\\"",
+        },
+      },
+    ],
+    "must_not": Array [
+      Object {
+        "simple_query_string": Object {
+          "query": "\\"sales team\\"",
+        },
+      },
+    ],
+  },
+}
+`;

--- a/src/components/search_bar/query/__snapshots__/ast_to_es_query_string.test.ts.snap
+++ b/src/components/search_bar/query/__snapshots__/ast_to_es_query_string.test.ts.snap
@@ -23,3 +23,5 @@ exports[`astToEsQueryString ast - date:'2004-03' -date<'2004-03-10' 1`] = `"+dat
 exports[`astToEsQueryString ast - date>'2004-02' -otherDate>='2004-03-10' 1`] = `"+date:>=2004-03 -date:>=2004-03-10"`;
 
 exports[`astToEsQueryString ast - date>='2004-03-22' 1`] = `"+date:>=2004-03-22"`;
+
+exports[`astToEsQueryString ast·-·'"john·smith"·-"sales team"' 1`] = `"+\\"john smith\\" -\\"sales team\\""`;

--- a/src/components/search_bar/query/ast_to_es_query_dsl.test.ts
+++ b/src/components/search_bar/query/ast_to_es_query_dsl.test.ts
@@ -25,6 +25,13 @@ describe('astToEsQueryDsl', () => {
     expect(query).toMatchSnapshot();
   });
 
+  test('ast·-·\'"john·smith"·-"sales team"\'', () => {
+    const query = astToEsQueryDsl(
+      AST.create([AST.Term.must('john smith'), AST.Term.mustNot('sales team')])
+    );
+    expect(query).toMatchSnapshot();
+  });
+
   test("ast - '-group:es group:kibana -group:beats group:logstash'", () => {
     const query = astToEsQueryDsl(
       AST.create([

--- a/src/components/search_bar/query/ast_to_es_query_dsl.ts
+++ b/src/components/search_bar/query/ast_to_es_query_dsl.ts
@@ -100,7 +100,14 @@ const processDateOperation = (value: DateValue, operator?: OperatorType) => {
 
 export const _termValuesToQuery = (values: Value[], options: Options) => {
   const body: { query: string; fields?: string[] } = {
-    query: values.join(' '),
+    query: values
+      .map((value: Value) => {
+        if (isString(value) && value.match(/\s/)) {
+          return `"${value}"`;
+        }
+        return value;
+      })
+      .join(' '),
   };
   if (body.query === '') {
     return;

--- a/src/components/search_bar/query/ast_to_es_query_string.test.ts
+++ b/src/components/search_bar/query/ast_to_es_query_string.test.ts
@@ -25,6 +25,13 @@ describe('astToEsQueryString', () => {
     expect(query).toMatchSnapshot();
   });
 
+  test('ast·-·\'"john·smith"·-"sales team"\'', () => {
+    const query = astToEsQueryString(
+      AST.create([AST.Term.must('john smith'), AST.Term.mustNot('sales team')])
+    );
+    expect(query).toMatchSnapshot();
+  });
+
   test("ast - '-group:es group:kibana -group:beats group:logstash'", () => {
     const query = astToEsQueryString(
       AST.create([

--- a/src/components/search_bar/query/ast_to_es_query_string.ts
+++ b/src/components/search_bar/query/ast_to_es_query_string.ts
@@ -201,6 +201,9 @@ const emitTermClause = (clause: TermClause, isGroupMember: boolean): string => {
   }
 
   const matchOp = emitMatch(match);
+  if (isString(value) && value.match(/\s/)) {
+    return `${matchOp}"${escapeValue(value)}"`;
+  }
   return `${matchOp}${escapeValue(value)}`;
 };
 

--- a/upcoming_changelogs/6714.md
+++ b/upcoming_changelogs/6714.md
@@ -1,0 +1,8 @@
+**Bug fixes**
+
+- Fixed an issue with search bar where quoted phrases were not quoted when generating an Elasticsearch query.
+
+**Breaking changes**
+
+- Changed search bar Elasticsearch query generation so that quoted phrases now will generate an Elasticsearch query that matches the entire phrase.
+

--- a/upcoming_changelogs/6714.md
+++ b/upcoming_changelogs/6714.md
@@ -1,8 +1,4 @@
 **Bug fixes**
 
-- Fixed an issue with search bar where quoted phrases were not quoted when generating an Elasticsearch query.
-
-**Breaking changes**
-
-- Changed search bar Elasticsearch query generation so that quoted phrases now will generate an Elasticsearch query that matches the entire phrase.
+- Fixed an issue with `EuiSearchBar` where quoted phrases were not quoted when generating an Elasticsearch query.
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where multi-word terms (without a field) aren't quoted properly when converted to an Elasticsearch query.

### Before

<img width="498" alt="Screenshot 2023-04-17 at 8 16 40 AM" src="https://user-images.githubusercontent.com/504326/232339748-cdfa177b-4b43-40ab-9fde-76adc7dfb22f.png">


### After

<img width="505" alt="Screenshot 2023-04-17 at 8 16 19 AM" src="https://user-images.githubusercontent.com/504326/232339753-02dfce0b-d72e-4877-9720-a47ae29a7a04.png">


## QA

### General checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#changelog)** entry exists and is marked appropriately


~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/documentation-guidelines.md#adding-playground-toggles)**~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~