### PR TITLE
[GitHub Actions] Add auto-responses based on applied labels

### DIFF
--- a/.github/workflows/label_commenter.yml
+++ b/.github/workflows/label_commenter.yml
@@ -1,0 +1,20 @@
+name: Auto-respond to issues with comments based on labels
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1
+        with:
+          config_file: .github/workflows/label_commenter_config.yml

--- a/.github/workflows/label_commenter_config.yml
+++ b/.github/workflows/label_commenter_config.yml
@@ -1,0 +1,9 @@
+comment:  # Leaving these empty keys here in case we want to add to them in the future
+  header: ''
+  footer: ''
+
+labels:
+  - name: help wanted
+    labeled:
+      issue:
+        body: 👋 Thank you for your suggestion or request! While the EUI team agrees that it's valid, it's unlikely that we will prioritize this issue on our roadmap. We'll leave the issue open if you or anyone else in the community wants to own it or implement it by contributing to EUI. If not, this issue will auto close in a year.

--- a/.github/workflows/label_commenter_config.yml
+++ b/.github/workflows/label_commenter_config.yml
@@ -6,4 +6,4 @@ labels:
   - name: help wanted
     labeled:
       issue:
-        body: 👋 Thank you for your suggestion or request! While the EUI team agrees that it's valid, it's unlikely that we will prioritize this issue on our roadmap. We'll leave the issue open if you or anyone else in the community wants to own it or implement it by contributing to EUI. If not, this issue will auto close in a year.
+        body: 👋 Thank you for your suggestion or request! While the EUI team agrees that it's valid, it's unlikely that we will prioritize this issue on our roadmap. We'll leave the issue open if you or anyone else in the community wants to implement it by contributing to EUI. If not, this issue will auto close in one year.


### PR DESCRIPTION
## Summary

This PR sets up the [Label Commenter](https://github.com/marketplace/actions/label-commenter) GitHub action, which has the `github-actions` bot auto-reply with a response of our configuration based on any label applied.

I've set currently set up just one auto response based on the `help wanted` label (indicating EUI will not be actively working on the issue and that the opener or the community at large will be expected to).

You can see it in action here in my fork: https://github.com/cee-chen/eui/issues/6

<img width="994" alt="" src="https://user-images.githubusercontent.com/549407/232602535-034b0fcd-4f30-492b-83d8-ebe19b239f90.png">

## QA

### General checklist

N/A - dev/GitHub only