### PR TITLE
[EuiForm] Increase Contrast on `EuiForm` Section Controls to Pass WCAG AA Standards

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,5 @@
   "printWidth": 80,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5",
-  "editor.formatOnSave": true
+  "trailingComma": "es5"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "parser": "typescript",
-  "printWidth": 80,
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "editor.formatOnSave": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "printWidth": 80,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "editor.formatOnSave": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "parser": "typescript",
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "editor.formatOnSave": true
+}

--- a/src/components/form/form.styles.test.tsx
+++ b/src/components/form/form.styles.test.tsx
@@ -68,7 +68,7 @@ describe('euiFormVariables', () => {
     expect(result.current.controlPlaceholderText).toEqual('#878b95');
     expect(result.current.inputGroupLabelBackground).toEqual('#2c2f37');
     expect(result.current.customControlDisabledIconColor).toEqual('#33373f');
-    expect(result.current.customControlBorderColor).toEqual('#1e1f26');
+    expect(result.current.customControlBorderColor).toEqual('#16171c');
   });
 });
 

--- a/src/components/form/form.styles.ts
+++ b/src/components/form/form.styles.ts
@@ -59,7 +59,7 @@ export const euiFormVariables = (euiThemeContext: UseEuiTheme) => {
       ? shade(euiTheme.colors.mediumShade, 0.38)
       : tint(euiTheme.colors.mediumShade, 0.485),
     customControlBorderColor: isColorDark
-      ? shade(euiTheme.colors.lightestShade, 0.18)
+      ? shade(euiTheme.colors.lightestShade, 0.4)
       : tint(euiTheme.colors.lightestShade, 0.3),
   };
 

--- a/src/components/form/form.styles.ts
+++ b/src/components/form/form.styles.ts
@@ -53,7 +53,7 @@ export const euiFormVariables = (euiThemeContext: UseEuiTheme) => {
     inputGroupBorder: 'none',
   };
 
-  // Colors - specific for checkboxes and radios
+  // Colors - specific to checkboxes, radios, switches, and range thumbs
   const customControlColors = {
     customControlDisabledIconColor: isColorDark
       ? shade(euiTheme.colors.mediumShade, 0.38)

--- a/src/components/form/form.styles.ts
+++ b/src/components/form/form.styles.ts
@@ -60,7 +60,7 @@ export const euiFormVariables = (euiThemeContext: UseEuiTheme) => {
       : tint(euiTheme.colors.mediumShade, 0.485),
     customControlBorderColor: isColorDark
       ? shade(euiTheme.colors.lightestShade, 0.4)
-      : tint(euiTheme.colors.lightestShade, 0.3),
+      : tint(euiTheme.colors.lightestShade, 0.31),
   };
 
   const controlLayout = {

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -2,6 +2,9 @@
 // stylelint-disable max-nesting-depth
 
 .euiSwitch {
+  $euiSwitchOffDisabledColor: lightOrDarkTheme(transparentize($euiColorLightShade, .5), transparentize($euiColorDarkShade, .4));
+  $euiSwitchDisabledThumbColor: lightOrDarkTheme(transparentize($euiColorDarkShade, .5), $euiColorDarkShade);
+
   position: relative;
   display: inline-flex;
   align-items: flex-start;
@@ -51,12 +54,12 @@
       }
 
       .euiSwitch__body {
-        background-color: lightOrDarkTheme(transparentize($euiColorLightShade, .5), transparentize($euiColorDarkShade, .4));
+        background-color: $euiSwitchOffDisabledColor;
       }
 
       .euiSwitch__thumb {
         background-color: rgba(0,0,0,0);
-        border-color: lightOrDarkTheme(transparentize($euiColorDarkShade, .5), $euiColorDarkShade);
+        border-color: $euiSwitchDisabledThumbColor;
         box-shadow: none;
       }
 
@@ -195,7 +198,7 @@
     .euiSwitch__button[aria-checked='false'],
     .euiSwitch__button[aria-checked='true']:disabled {
       .euiSwitch__thumb {
-        border-color: $euiFormCustomControlBorderColor;
+        border-color: $euiSwitchDisabledThumbColor;
       }
     }
 

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -51,12 +51,12 @@
       }
 
       .euiSwitch__body {
-        background-color: $euiSwitchOffDisabledColor;
+        background-color: lightOrDarkTheme(transparentize($euiColorLightShade, .5), transparentize($euiColorDarkShade, .4));
       }
 
       .euiSwitch__thumb {
-        background-color: $euiSwitchOffThumbDisabledColor;
-        border-color: $euiSwitchOffThumbDisabledBorderColor;
+        background-color: rgba(0,0,0,0);
+        border-color: lightOrDarkTheme(transparentize($euiColorDarkShade, .5), $euiColorDarkShade);
         box-shadow: none;
       }
 
@@ -108,7 +108,7 @@
     width: $euiSwitchWidth - ($euiSwitchThumbSize / 2) + $euiSizeS;
     height: $euiSwitchIconHeight;
     transition: left $euiAnimSpeedNormal $euiAnimSlightBounce, right $euiAnimSpeedNormal $euiAnimSlightBounce;
-    fill: $euiTextColor;
+    fill: $euiColorEmptyShade;
   }
 
   .euiSwitch__icon--checked {

--- a/src/components/form/switch/_switch.scss
+++ b/src/components/form/switch/_switch.scss
@@ -24,30 +24,6 @@
       @include euiCustomControlFocused;
     }
 
-    &:disabled {
-      &:hover,
-      ~ .euiSwitch__label:hover {
-        cursor: not-allowed;
-      }
-
-      .euiSwitch__body {
-        background-color: $euiSwitchOffColor;
-      }
-
-      .euiSwitch__thumb {
-        @include euiCustomControlDisabled;
-        background-color: $euiSwitchOffColor;
-      }
-
-      .euiSwitch__icon {
-        fill: $euiFormCustomControlDisabledIconColor;
-      }
-
-      + .euiSwitch__label {
-        color: $euiFormControlDisabledColor;
-      }
-    }
-
     &[aria-checked='false'] {
       .euiSwitch__body {
         background-color: $euiSwitchOffColor;
@@ -65,6 +41,31 @@
           right: auto;
           left: -($euiSwitchWidth - ($euiSwitchThumbSize / 2));
         }
+      }
+    }
+
+    &:disabled {
+      &:hover,
+      ~ .euiSwitch__label:hover {
+        cursor: not-allowed;
+      }
+
+      .euiSwitch__body {
+        background-color: $euiSwitchOffDisabledColor;
+      }
+
+      .euiSwitch__thumb {
+        background-color: $euiSwitchOffThumbDisabledColor;
+        border-color: $euiSwitchOffThumbDisabledBorderColor;
+        box-shadow: none;
+      }
+
+      .euiSwitch__icon {
+        fill: $euiColorDarkShade;
+      }
+
+      + .euiSwitch__label {
+        color: $euiFormControlDisabledColor;
       }
     }
   }

--- a/src/global_styling/variables/_form.scss
+++ b/src/global_styling/variables/_form.scss
@@ -33,7 +33,7 @@ $euiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($euiColorPrimary, 2
 $euiFormBorderColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
-$euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 18%, 30%) !default;
+$euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 40%, 30%) !default;
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 0 transparent !default;
 $euiFormControlPlaceholderText: makeHighContrastColor($euiTextSubduedColor, $euiFormBackgroundColor) !default;

--- a/src/global_styling/variables/_form.scss
+++ b/src/global_styling/variables/_form.scss
@@ -33,7 +33,7 @@ $euiFormBorderOpaqueColor: shadeOrTint(desaturate(adjust-hue($euiColorPrimary, 2
 $euiFormBorderColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormBorderDisabledColor: transparentize($euiFormBorderOpaqueColor, .9) !default;
 $euiFormCustomControlDisabledIconColor: shadeOrTint($euiColorMediumShade, 38%, 48.5%) !default; // exact 508c foreground for $euiColorLightShade
-$euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 40%, 30%) !default;
+$euiFormCustomControlBorderColor: shadeOrTint($euiColorLightestShade, 40%, 31%) !default;
 $euiFormControlDisabledColor: $euiColorMediumShade !default;
 $euiFormControlBoxShadow: 0 0 transparent !default;
 $euiFormControlPlaceholderText: makeHighContrastColor($euiTextSubduedColor, $euiFormBackgroundColor) !default;

--- a/src/global_styling/variables/_form.scss
+++ b/src/global_styling/variables/_form.scss
@@ -39,7 +39,7 @@ $euiFormControlBoxShadow: 0 0 transparent !default;
 $euiFormControlPlaceholderText: makeHighContrastColor($euiTextSubduedColor, $euiFormBackgroundColor) !default;
 $euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 50%, 15%) !default;
 $euiFormInputGroupBorder: none !default;
-$euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorMediumShade, .8), transparentize($euiColorMediumShade, .3)) !default;
+$euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorDarkShade, .25), transparentize($euiColorDarkShade, .4)) !default;
 
 // Icons sizes
 $euiFormControlIconSizes: (

--- a/src/global_styling/variables/_form.scss
+++ b/src/global_styling/variables/_form.scss
@@ -40,6 +40,9 @@ $euiFormControlPlaceholderText: makeHighContrastColor($euiTextSubduedColor, $eui
 $euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 50%, 15%) !default;
 $euiFormInputGroupBorder: none !default;
 $euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorDarkShade, .25), transparentize($euiColorDarkShade, .4)) !default;
+$euiSwitchOffDisabledColor: lightOrDarkTheme(transparentize($euiColorLightShade, .5), transparentize($euiColorDarkShade, .4)) !default;
+$euiSwitchOffThumbDisabledColor: rgba(0,0,0,0) !default;
+$euiSwitchOffThumbDisabledBorderColor: lightOrDarkTheme(transparentize($euiColorDarkShade, .5), $euiColorDarkShade) !default;
 
 // Icons sizes
 $euiFormControlIconSizes: (

--- a/src/global_styling/variables/_form.scss
+++ b/src/global_styling/variables/_form.scss
@@ -40,9 +40,6 @@ $euiFormControlPlaceholderText: makeHighContrastColor($euiTextSubduedColor, $eui
 $euiFormInputGroupLabelBackground: tintOrShade($euiColorLightShade, 50%, 15%) !default;
 $euiFormInputGroupBorder: none !default;
 $euiSwitchOffColor: lightOrDarkTheme(transparentize($euiColorDarkShade, .25), transparentize($euiColorDarkShade, .4)) !default;
-$euiSwitchOffDisabledColor: lightOrDarkTheme(transparentize($euiColorLightShade, .5), transparentize($euiColorDarkShade, .4)) !default;
-$euiSwitchOffThumbDisabledColor: rgba(0,0,0,0) !default;
-$euiSwitchOffThumbDisabledBorderColor: lightOrDarkTheme(transparentize($euiColorDarkShade, .5), $euiColorDarkShade) !default;
 
 // Icons sizes
 $euiFormControlIconSizes: (

--- a/upcoming_changelogs/6729.md
+++ b/upcoming_changelogs/6729.md
@@ -1,0 +1,1 @@
+- Improved the contrast ratio of `EuiCheckbox`, `EuiRadio`, and `EuiSwitch` to meet WCAG AA guidelines.


### PR DESCRIPTION
Fixes #6690
Fixes #6692

## Summary

### Increase contrast ratio for checkbox border in `EuiCheckbox` (#6690)
The current contrast ratio for checkbox outlines in both light and dark modes does not meet WCAG AA guidelines for UI components. This PR increases the threshold for the shade and tint that are used the generate the outline color. 
  
<br />

 ⭐ **What else does this affect?**
In order to increase the contrast ratios, I used the `euiFormCustomControlBorderColor` used with both SASS and Emotion. 

There should be no large visual differences with this change. This key affects the following components:

- [EuiSwitch](https://eui.elastic.co/pr_6729/#/forms/selection-controls#switch) - Thumb/Slider
- `euiCustomControl` mixin
    - [EuiColorPicker](https://eui.elastic.co/pr_6729/#/forms/color-selection#color-picker) - Hue range, color stops
    - [EuiRadio](https://eui.elastic.co/pr_6729/#/forms/selection-controls#radio) - Radio button outline
    - [EuiRange](https://eui.elastic.co/pr_6729/#/forms/range-sliders) - Range thumb

<br />

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/40739624/233732908-5242a180-77c1-4863-be3d-35d23c638c90.png">

<br />

<details><summary>Contrast Details</summary>
**Before**
<img width="1326" alt="image" src="https://user-images.githubusercontent.com/40739624/233718591-92da931b-f922-40b7-af3c-0f84a8927a89.png">

<br />

**After**
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/40739624/233722476-70bbd67c-4fab-4fe5-b952-0854bb3bfb99.png">

</details>



---

### Increase contrast ratio for `EuiSwitch` Body (#6692)
The current contrast ratio for the switch toggle body in both light and dark modes does not meet WCAG AA guidelines for UI components. The `$euiSwitchOffColor` key was updated the adjust the background accordingly and increase the contrast ratio. _I will say this is a stark difference because the ratio was super low._

 ⭐ **Just a note:**
When disabled in light mode, the contrast ratio for the switch thumb on the switch body is low. [Guidelines](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html#inactive-controls) state that this is ok because it's disabled. 

<br />

<img width="997" alt="image" src="https://user-images.githubusercontent.com/40739624/234132483-de098b16-1143-4f37-b6bc-107f959bca3d.png">

<br />

<details><summary>Contrast Details</summary>
**Before**
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/40739624/233732780-3f54afea-8186-494a-8837-1174a242c041.png">

<br />

</details>

## QA

**General QA**
- [x] `EuiCheckbox` outline and `EuiSwitch` background should meet the suggested 3.0 contrast ratio.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
