### PR TITLE
Created issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.md
+++ b/.github/ISSUE_TEMPLATE/accessibility.md
@@ -1,0 +1,53 @@
+---
+name: ❓ Report an Accessibility issue
+about: Report an Accessibility issue
+title: ''
+labels: accessibility
+assignees: ''
+
+---
+
+**Describe the problem**
+<!-- This is a detailed description. It should provide more background information about the issue and whom it affects. -->
+
+**To Reproduce**
+<!-- Provide as much information as you can. Include assistive technologies used, steps taken, or configuration files adjusted, to achieve a similar testing state. -->
+
+## Environment
+
+<!--
+* Operating System, including `<VERSION>` or "latest"
+* Browser, including `<VERSION>` or "latest"
+* Screenreading device, if applicable
+* Server destination (localhost, Docker container, staging, production)
+-->
+
+## Proposed solution
+
+<!-- Include code snippets if that might help fixing the issue. -->
+<!-- Remove the \ before and after the diff backticks. -->
+
+\```diff
+! https://github.com/github/linguist/blob/master/vendor/README.md
+
+! Adding an SR-only span to make the setting more
+! explicit for screen readers
+<button
+  class="cd-c-button cd-c-button--large"
+  type="button"
+>
+- Previous high
++ Previous high score
++ {' '}
++ <span class="cd-u-visibility--sr-only">on Expert setting</span>
+</button>
+\```
+
+## WCAG or Vendor Guidance (optional)
+
+- [WCAG 2.1 Success Criteria](https://www.w3.org/TR/WCAG21/) for relevant items to link here.
+- [MDN Web Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility) for browser behaviors, code snippets, and polyfills.
+
+## Screenshots or Trace Logs
+
+<!-- Drop any screenshots or error logs that might be useful for debugging -->

--- a/.github/ISSUE_TEMPLATE/accessibility.md
+++ b/.github/ISSUE_TEMPLATE/accessibility.md
@@ -1,6 +1,6 @@
 ---
-name: ❓ Report an Accessibility issue
-about: Report an Accessibility issue
+name: ❓ Report an accessibility issue
+about: Report an accessibility issue
 title: ''
 labels: accessibility
 assignees: ''
@@ -25,9 +25,8 @@ assignees: ''
 ## Proposed solution
 
 <!-- Include code snippets if that might help fixing the issue. -->
-<!-- Remove the \ before and after the diff backticks. -->
 
-\```diff
+```diff
 ! https://github.com/github/linguist/blob/master/vendor/README.md
 
 ! Adding an SR-only span to make the setting more
@@ -41,7 +40,7 @@ assignees: ''
 + {' '}
 + <span class="cd-u-visibility--sr-only">on Expert setting</span>
 </button>
-\```
+```
 
 ## WCAG or Vendor Guidance (optional)
 

--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -13,3 +13,12 @@ You may find your question has already been asked, please check the following pl
 
 - [Search in Github](https://github.com/search?q=repo%3Aelastic%2Feui+your%20question&type=issues) - your question may have been asked and answered in another issue.
 - Check out our [docs](https://elastic.github.io/eui/#/), the answer to most questions can be found there.
+
+**Key information**
+- EUI version:
+- React version:
+- Build tool: (e.g. Webpack, Vite, Rollup, Next.js)
+
+**Minimum reproducible sandbox**
+
+If you're having an implementation usage issue and are asking for debugging help, please try to create a minimum reproducible sandbox (visit our [docs site](https://elastic.github.io/eui/) and click the CodeSandbox logo in the top-right corner).

--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -1,0 +1,16 @@
+---
+name: Ask a question
+about: Ask for help with usage
+title: ''
+labels: question
+assignees: ''
+
+---
+
+**Before you ask**
+
+You may find your question has already been asked, please check the following places first:
+
+- Search in Github, your question may have been answered in an issue.
+- Check out our [docs](https://elastic.github.io/eui/#/), the answer to most questions can be found there.
+- Elastic employees have access to the internal #eui Slack channel.

--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -1,5 +1,5 @@
 ---
-name: Ask a question
+name: ❓ Usage question
 about: Ask for help with usage
 title: ''
 labels: question

--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -11,6 +11,6 @@ assignees: ''
 
 You may find your question has already been asked, please check the following places first:
 
-- Search in Github, your question may have been answered in an issue.
+- [Search in Github](https://github.com/search?q=repo%3Aelastic%2Feui+your%20question&type=issues) - your question may have been asked and answered in another issue.
 - Check out our [docs](https://elastic.github.io/eui/#/), the answer to most questions can be found there.
 - Elastic employees have access to the internal #eui Slack channel.

--- a/.github/ISSUE_TEMPLATE/ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-a-question.md
@@ -13,4 +13,3 @@ You may find your question has already been asked, please check the following pl
 
 - [Search in Github](https://github.com/search?q=repo%3Aelastic%2Feui+your%20question&type=issues) - your question may have been asked and answered in another issue.
 - Check out our [docs](https://elastic.github.io/eui/#/), the answer to most questions can be found there.
-- Elastic employees have access to the internal #eui Slack channel.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,18 +20,11 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Minimum reproducible code sandbox**
-It is extremely helpful for us if you are able to reproduce your issue in a [code sandbox](https://codesandbox.io/) example.
-
-The easiest way to do this is using a component example from [the EUI documentation site](https://elastic.github.io/eui/#/) as a starting point. You can find "Try out this demo on Code Sandbox" links on all of our component demos.
+**Minimum reproducible sandbox**
+It is extremely helpful for us if you are able to reproduce your issue in a minimum reproducible sandbox (visit our [docs site](https://elastic.github.io/eui/) and click the CodeSandbox logo in the top-right corner).
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,7 +20,7 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Code sandbox**
+**Minimum reproducible code sandbox**
 It is extremely helpful for us if you are able to reproduce your issue in a [code sandbox](https://codesandbox.io/) example.
 
 The easiest way to do this is using a component example from [the EUI documentation site](https://elastic.github.io/eui/#/) as a starting point. You can find "Try out this demo on Code Sandbox" links on all of our component demos.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: 🐛 Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug, ⚠️ needs validation

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, ⚠️ needs validation
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Code sandbox**
+It is extremely helpful for us if you are able to reproduce your issue in a [code sandbox](https://codesandbox.io/) example.
+
+The easiest way to do this is using a component example from [the EUI documentation site](https://elastic.github.io/eui/#/) as a starting point. You can find "Try out this demo on Code Sandbox" links on all of our component demos.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: ✨ Feature request
 about: Suggest an idea for this project
 title: ''
 labels: feature request


### PR DESCRIPTION
closes #6706

The following are a basic set of templates that mainly apply the correct labels and prompt the issue reporter for additional information.

The "Ask a question" template also takes the opportunity to preemptively ask the user to check for existing answers first, and points them to the correct location.

The Bug report and Feature request templates are primarily based on Github's default template. I modified the Bug report a bit to ask users to provide a code sandbox if possible.

Let me know what you think. Is there anything else we'd like to include?