### PR TITLE
[wiki] Document `yarn kbn watch` command for Kibana plugins

### DIFF
--- a/wiki/eui-team-processes/upgrading-kibana.md
+++ b/wiki/eui-team-processes/upgrading-kibana.md
@@ -116,6 +116,10 @@ node x-pack/plugins/observability/scripts/e2e.js --server
 node scripts/functional_test_runner/ --config x-pack/plugins/observability/e2e/synthetics_run.ts --bail --no-headless
 ```
 
+### Debugging Kibana plugins
+
+Some EUI component usages are in `src/plugins/` as opposed to Kibana's `src/` or `x-pack/` folders (which hot reload automatically on page refresh). Kibana plugins **do not** update automatically unless you start a `yarn kbn watch` process in a new terminal alongside `yarn start`.
+
 ### Other
 
 Most other issues reported by CI (e.g., Check Doc API Changes) will contain resolution instructions. Some failures (e.g.  Build API Docs) may be intermittent failures and can be resolved by re-starting CI by leaving a comment of `@elasticmachine merge upstream`.

--- a/wiki/eui-team-processes/upgrading-kibana.md
+++ b/wiki/eui-team-processes/upgrading-kibana.md
@@ -118,7 +118,7 @@ node scripts/functional_test_runner/ --config x-pack/plugins/observability/e2e/s
 
 ### Debugging Kibana plugins
 
-Some EUI component usages are in `src/plugins/` as opposed to Kibana's `src/` or `x-pack/` folders (which hot reload automatically on page refresh). Kibana plugins **do not** update automatically unless you start a `yarn kbn watch` process in a new terminal alongside `yarn start`.
+Some EUI component usages are in `src/plugins/`. Kibana plugins **do not** hot reload automatically. You must start a `yarn kbn watch` process in a new terminal, alongside `yarn start`.
 
 ### Other
 


### PR DESCRIPTION
## Summary

Trevor and I were tweaking a shared plugin component for while debugging a Kibana upgrade today and realized we both can never remember what the dang command for hot reloading plugin changes is. We're memorializing this our docs so we can quickly reference it in the future.