### PR TITLE
[EuiCollapsibleNav][Docs] Make `CollapsibleNav` Items Accessible on Small Screens and In Browsers with High Zoom

### DIFF
--- a/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
+++ b/src-docs/src/views/collapsible_nav/collapsible_nav_all.tsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 
+import { css } from '@emotion/react';
+import { logicalCSSWithFallback } from '../../../../src/global_styling';
+
 import {
   EuiCollapsibleNav,
   EuiCollapsibleNavGroup,
@@ -148,6 +151,11 @@ const CollapsibleNavAll = () => {
         </EuiHeaderSectionItemButton>
       }
       onClose={() => setNavIsOpen(false)}
+      css={css`
+        @media (max-height: 15em) {
+          ${logicalCSSWithFallback('overflow-y', 'auto')}
+        }
+      `} // Accessibility - Add scroll to nav on very small screens
     >
       {/* Dark deployments section */}
       <EuiFlexItem grow={false} style={{ flexShrink: 0 }}>
@@ -176,7 +184,6 @@ const CollapsibleNavAll = () => {
       <EuiFlexItem grow={false} style={{ flexShrink: 0 }}>
         <EuiCollapsibleNavGroup
           background="light"
-          className="eui-yScroll"
           style={{ maxHeight: '40vh' }}
         >
           <EuiPinnableListGroup
@@ -197,7 +204,16 @@ const CollapsibleNavAll = () => {
       <EuiHorizontalRule margin="none" />
 
       {/* BOTTOM */}
-      <EuiFlexItem className="eui-yScroll">
+      <EuiFlexItem
+        className="eui-yScroll"
+        css={css`
+          @media (max-height: 15em) {
+            flex-shrink: 0 !important;
+            flex-grow: 1 !important;
+            flex-basis: auto !important;
+          }
+        `} // Accessibility - Allows nav items to be seen and interacted with on very small screen sizes
+      >
         {/* Kibana section */}
         <EuiCollapsibleNavGroup
           title={


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/6702

## Summary
A user submitted an issue where they were unable to use the main collapsible nav when their browser was zoomed in at 400% for accessibility. The nav items weren't visible and could not be interacted with at this level. 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/40739624/234444373-b9539160-a069-4e4f-9bdc-c01a9405f11c.png">

### ✨ What changed?
When the container for the collapsible nav has a `max-height` of `15em`, overflow and additional flex properties are used to allow the nav groups to be traversed. 

https://user-images.githubusercontent.com/40739624/234677283-f93063d2-8cf3-4127-aded-17da04a7502a.mov

### ✨ QA
View the Kibana homepage and set the Zoom on your browser to 400%. This will need to be done in a relatively small window (like the one on your computer itself, not an external monitor). Open the main navigation menu on the left. You should be able to navigate all links in menu with both keyboard and by scrolling the sections. 
## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist
- [x] Checked in **mobile**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
