### PR TITLE
[EuiAvatar] Add letter `casing` prop support and default to capitaizing initials

### DIFF
--- a/src-docs/src/views/avatar/avatar_initials.js
+++ b/src-docs/src/views/avatar/avatar_initials.js
@@ -1,31 +1,45 @@
 import React from 'react';
 
-import { EuiAvatar, EuiTitle, EuiSpacer } from '../../../../src/components';
+import {
+  EuiAvatar,
+  EuiTitle,
+  EuiSpacer,
+  EuiFlexGroup,
+} from '../../../../src/components';
 
 export default () => (
-  <div>
+  <>
     <EuiTitle size="xs">
       <h3>Single vs multi-word</h3>
     </EuiTitle>
     <EuiSpacer />
-    <EuiAvatar name="Single" />
-    &emsp;
-    <EuiAvatar name="Two Words" />
-    &emsp;
-    <EuiAvatar name="More Than Two Words" />
-    &emsp;
-    <EuiAvatar name="lowercase words" />
+    <EuiFlexGroup responsive={false} gutterSize="xs">
+      <EuiAvatar name="Single" />
+      <EuiAvatar name="Two Words" />
+      <EuiAvatar name="More Than Two Words" />
+      <EuiAvatar name="lower_case_single" />
+    </EuiFlexGroup>
+    <EuiSpacer />
+    <EuiTitle size="xs">
+      <h3>Letter casing</h3>
+    </EuiTitle>
+    <EuiSpacer />
+    <EuiFlexGroup responsive={false} gutterSize="xs">
+      <EuiAvatar name="capitalized - default" />
+      <EuiAvatar name="upper case" casing="uppercase" />
+      <EuiAvatar name="LOWER CASE" casing="lowercase" />
+      <EuiAvatar name="weird Casing but Okay" casing="none" />
+    </EuiFlexGroup>
     <EuiSpacer />
     <EuiTitle size="xs">
       <h4>Custom</h4>
     </EuiTitle>
     <EuiSpacer />
-    <EuiAvatar name="Kibana" initialsLength={2} />
-    &emsp;
-    <EuiAvatar name="Leonardo Dude" initialsLength={1} />
-    &emsp;
-    <EuiAvatar name="Not provided" initials="?" />
-    &emsp;
-    <EuiAvatar name="Engineering User" initials="En" initialsLength={2} />
-  </div>
+    <EuiFlexGroup responsive={false} gutterSize="xs">
+      <EuiAvatar name="Kibana" initialsLength={2} />
+      <EuiAvatar name="Leonardo Dude" initialsLength={1} />
+      <EuiAvatar name="Not provided" initials="?" />
+      <EuiAvatar name="Engineering User" initials="En" initialsLength={2} />
+    </EuiFlexGroup>
+  </>
 );

--- a/src/components/avatar/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__snapshots__/avatar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiAvatar allows a name composed entirely of whitespace 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2 emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2 emotion-euiAvatar-user-m-capitalize"
   data-test-subj="test subject string"
   role="img"
   style="background-color:#ee789d;color:#000000"
@@ -20,8 +20,72 @@ exports[`EuiAvatar allows a name composed entirely of whitespace 1`] = `
 exports[`EuiAvatar is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2 emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2 emotion-euiAvatar-user-m-capitalize"
   data-test-subj="test subject string"
+  role="img"
+  style="background-color:#e4a6c7;color:#000000"
+  title="name"
+>
+  <span
+    aria-hidden="true"
+  >
+    n
+  </span>
+</div>
+`;
+
+exports[`EuiAvatar props casing capitalize is rendered 1`] = `
+<div
+  aria-label="name"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
+  role="img"
+  style="background-color:#e4a6c7;color:#000000"
+  title="name"
+>
+  <span
+    aria-hidden="true"
+  >
+    n
+  </span>
+</div>
+`;
+
+exports[`EuiAvatar props casing lowercase is rendered 1`] = `
+<div
+  aria-label="name"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-lowercase"
+  role="img"
+  style="background-color:#e4a6c7;color:#000000"
+  title="name"
+>
+  <span
+    aria-hidden="true"
+  >
+    n
+  </span>
+</div>
+`;
+
+exports[`EuiAvatar props casing none is rendered 1`] = `
+<div
+  aria-label="name"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-none"
+  role="img"
+  style="background-color:#e4a6c7;color:#000000"
+  title="name"
+>
+  <span
+    aria-hidden="true"
+  >
+    n
+  </span>
+</div>
+`;
+
+exports[`EuiAvatar props casing uppercase is rendered 1`] = `
+<div
+  aria-label="name"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -37,7 +101,7 @@ exports[`EuiAvatar is rendered 1`] = `
 exports[`EuiAvatar props color as null is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   title="name"
 >
@@ -52,7 +116,7 @@ exports[`EuiAvatar props color as null is rendered 1`] = `
 exports[`EuiAvatar props color as plain is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user-plain"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize-plain"
   role="img"
   title="name"
 >
@@ -67,7 +131,7 @@ exports[`EuiAvatar props color as plain is rendered 1`] = `
 exports[`EuiAvatar props color as string is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#000;color:#FFFFFF"
   title="name"
@@ -83,7 +147,7 @@ exports[`EuiAvatar props color as string is rendered 1`] = `
 exports[`EuiAvatar props color as subdued is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user-subdued"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize-subdued"
   role="img"
   title="name"
 >
@@ -98,7 +162,7 @@ exports[`EuiAvatar props color as subdued is rendered 1`] = `
 exports[`EuiAvatar props iconType and iconColor as null is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -113,7 +177,7 @@ exports[`EuiAvatar props iconType and iconColor as null is rendered 1`] = `
 exports[`EuiAvatar props iconType and iconColor is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -129,7 +193,7 @@ exports[`EuiAvatar props iconType and iconColor is rendered 1`] = `
 exports[`EuiAvatar props iconType and iconSize is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -145,7 +209,7 @@ exports[`EuiAvatar props iconType and iconSize is rendered 1`] = `
 exports[`EuiAvatar props iconType is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -161,7 +225,7 @@ exports[`EuiAvatar props iconType is rendered 1`] = `
 exports[`EuiAvatar props imageUrl is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000;background-image:url(image url)"
   title="name"
@@ -171,7 +235,7 @@ exports[`EuiAvatar props imageUrl is rendered 1`] = `
 exports[`EuiAvatar props initials is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -187,7 +251,7 @@ exports[`EuiAvatar props initials is rendered 1`] = `
 exports[`EuiAvatar props initialsLength is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -202,7 +266,7 @@ exports[`EuiAvatar props initialsLength is rendered 1`] = `
 
 exports[`EuiAvatar props isDisabled is rendered 1`] = `
 <div
-  class="euiAvatar euiAvatar--m euiAvatar--user euiAvatar-isDisabled emotion-euiAvatar-m-user-isDisabled"
+  class="euiAvatar euiAvatar--m euiAvatar--user euiAvatar-isDisabled emotion-euiAvatar-user-m-capitalize-isDisabled"
   role="presentation"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -218,7 +282,7 @@ exports[`EuiAvatar props isDisabled is rendered 1`] = `
 exports[`EuiAvatar props size l is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--l euiAvatar--user emotion-euiAvatar-l-user"
+  class="euiAvatar euiAvatar--l euiAvatar--user emotion-euiAvatar-user-l-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -234,7 +298,7 @@ exports[`EuiAvatar props size l is rendered 1`] = `
 exports[`EuiAvatar props size m is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-m-user"
+  class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -250,7 +314,7 @@ exports[`EuiAvatar props size m is rendered 1`] = `
 exports[`EuiAvatar props size s is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--s euiAvatar--user emotion-euiAvatar-s-user"
+  class="euiAvatar euiAvatar--s euiAvatar--user emotion-euiAvatar-user-s-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -266,7 +330,7 @@ exports[`EuiAvatar props size s is rendered 1`] = `
 exports[`EuiAvatar props size xl is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--xl euiAvatar--user emotion-euiAvatar-xl-user"
+  class="euiAvatar euiAvatar--xl euiAvatar--user emotion-euiAvatar-user-xl-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"
@@ -282,7 +346,7 @@ exports[`EuiAvatar props size xl is rendered 1`] = `
 exports[`EuiAvatar props type is rendered 1`] = `
 <div
   aria-label="name"
-  class="euiAvatar euiAvatar--m euiAvatar--space emotion-euiAvatar-m-space"
+  class="euiAvatar euiAvatar--m euiAvatar--space emotion-euiAvatar-space-m-capitalize"
   role="img"
   style="background-color:#e4a6c7;color:#000000"
   title="name"

--- a/src/components/avatar/avatar.styles.ts
+++ b/src/components/avatar/avatar.styles.ts
@@ -83,4 +83,17 @@ export const euiAvatarStyles = ({ euiTheme }: UseEuiTheme) => ({
       fontSize: `calc(${euiTheme.size.xl} * 0.8)`,
     })
   ),
+  // Casing
+  capitalize: css`
+    text-transform: capitalize;
+  `,
+  uppercase: css`
+    text-transform: uppercase;
+  `,
+  lowercase: css`
+    text-transform: lowercase;
+  `,
+  none: css`
+    text-transform: none;
+  `,
 });

--- a/src/components/avatar/avatar.test.tsx
+++ b/src/components/avatar/avatar.test.tsx
@@ -11,7 +11,7 @@ import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
-import { EuiAvatar, SIZES } from './avatar';
+import { EuiAvatar, SIZES, CASING } from './avatar';
 
 describe('EuiAvatar', () => {
   shouldRenderCustomStyles(<EuiAvatar name="name" />);
@@ -75,6 +75,16 @@ describe('EuiAvatar', () => {
       SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {
           const component = render(<EuiAvatar name="name" size={size} />);
+
+          expect(component).toMatchSnapshot();
+        });
+      });
+    });
+
+    describe('casing', () => {
+      CASING.forEach((casing) => {
+        it(`${casing} is rendered`, () => {
+          const component = render(<EuiAvatar name="name" casing={casing} />);
 
           expect(component).toMatchSnapshot();
         });

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -26,6 +26,9 @@ export type EuiAvatarSize = typeof SIZES[number];
 export const TYPES = ['space', 'user'] as const;
 export type EuiAvatarType = typeof TYPES[number];
 
+export const CASING = ['capitalize', 'uppercase', 'lowercase', 'none'] as const;
+export type EuiAvatarCasing = typeof CASING[number];
+
 /**
  * The avatar can only display one type of content,
  * initials, or image, or iconType
@@ -91,6 +94,14 @@ export type EuiAvatarProps = Omit<HTMLAttributes<HTMLDivElement>, 'color'> &
     size?: EuiAvatarSize;
 
     /**
+     * Sets the letter casing of the displayed initials.
+     *
+     * Defaults to `capitalize` (first letter will be capitalized, but not subsequent letters).
+     * Set to `none` to use the existing casing of the passed `name` or `initials`.
+     */
+    casing?: EuiAvatarCasing;
+
+    /**
      * Grays out the avatar to simulate being disabled
      */
     isDisabled?: boolean;
@@ -108,6 +119,7 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
   name,
   size = 'm',
   type = 'user',
+  casing = 'capitalize',
   isDisabled = false,
   style,
   ...rest
@@ -132,8 +144,9 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
 
   const cssStyles = [
     styles.euiAvatar,
-    styles[size],
     styles[type],
+    styles[size],
+    styles[casing],
     isPlain && styles.plain,
     isSubdued && styles.subdued,
     isDisabled && styles.isDisabled,


### PR DESCRIPTION
## Summary

@dimadavid recently brought up that certain lowercase letters look vertically off in EuiAvatar, and proposed a workaround of always ensuring displayed initials are in uppercase.

<img src="https://user-images.githubusercontent.com/549407/234949190-17b5cd92-182b-43e2-ac98-6bdf308059a6.png" width="500" alt="">

Based on our current EuiAvatar docs, which specifically display initials such as `Ki` and `En`, I opted instead to default to `capitalize` and to add a new `casing` prop to allow consumers to quickly and easily customize their use-cases as needed.

## QA

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately


~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~