### PR TITLE
Agent memory value needed to be a string.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 ## 🏠/.buildkite/pipeline.yml
 
 agents:
-  memory: 4G 
+  memory: "4G" 
 
 steps:
   - label: ":wave: Greetings!"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 ## 🏠/.buildkite/pipeline.yml
 
 agents:
-  memory: "4G" 
+  memory: "4G"
 
 steps:
   - label: ":wave: Greetings!"


### PR DESCRIPTION
## Summary

The `pipeline.yml` file agent entry for memory needed to be a string "4G". This PR should fix the error being thrown.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Will confirm Buildkite passes CI run
