### PR TITLE
[EuiFieldNumber] Clean up native `:invalid` detection

### DIFF
--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -134,7 +134,6 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
           >
             <input
               aria-describedby="generated-id generated-id"
-              aria-invalid="false"
               aria-label="Time value"
               class="euiFieldNumber euiFieldNumber--compressed"
               type="number"

--- a/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
@@ -6,12 +6,10 @@ exports[`EuiFieldNumber is rendered 1`] = `
   fullwidth="false"
   icon="warning"
   inputid="1"
-  isinvalid="false"
   isloading="false"
 >
   <eui-validatable-control>
     <input
-      aria-invalid="false"
       aria-label="aria-label"
       class="euiFieldNumber testClass1 testClass2 euiFieldNumber--withIcon"
       data-test-subj="test subject string"
@@ -30,7 +28,6 @@ exports[`EuiFieldNumber is rendered 1`] = `
 exports[`EuiFieldNumber props controlOnly is rendered 1`] = `
 <eui-validatable-control>
   <input
-    aria-invalid="false"
     class="euiFieldNumber"
     type="number"
     value=""
@@ -42,12 +39,10 @@ exports[`EuiFieldNumber props fullWidth is rendered 1`] = `
 <eui-form-control-layout
   compressed="false"
   fullwidth="true"
-  isinvalid="false"
   isloading="false"
 >
   <eui-validatable-control>
     <input
-      aria-invalid="false"
       class="euiFieldNumber euiFieldNumber--fullWidth"
       type="number"
       value=""
@@ -80,12 +75,10 @@ exports[`EuiFieldNumber props isLoading is rendered 1`] = `
 <eui-form-control-layout
   compressed="false"
   fullwidth="false"
-  isinvalid="false"
   isloading="true"
 >
   <eui-validatable-control>
     <input
-      aria-invalid="false"
       class="euiFieldNumber euiFormControlLayout--1icons euiFieldNumber-isLoading"
       type="number"
       value=""
@@ -98,13 +91,11 @@ exports[`EuiFieldNumber props readOnly is rendered 1`] = `
 <eui-form-control-layout
   compressed="false"
   fullwidth="false"
-  isinvalid="false"
   isloading="false"
   readonly="true"
 >
   <eui-validatable-control>
     <input
-      aria-invalid="false"
       class="euiFieldNumber"
       readonly=""
       type="number"
@@ -118,12 +109,10 @@ exports[`EuiFieldNumber props value no initial value 1`] = `
 <eui-form-control-layout
   compressed="false"
   fullwidth="false"
-  isinvalid="false"
   isloading="false"
 >
   <eui-validatable-control>
     <input
-      aria-invalid="false"
       class="euiFieldNumber"
       type="number"
       value=""
@@ -136,12 +125,10 @@ exports[`EuiFieldNumber props value value is number 1`] = `
 <eui-form-control-layout
   compressed="false"
   fullwidth="false"
-  isinvalid="false"
   isloading="false"
 >
   <eui-validatable-control>
     <input
-      aria-invalid="false"
       class="euiFieldNumber"
       type="number"
       value="0"

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -11,13 +11,11 @@ import React, {
   Ref,
   FunctionComponent,
   useState,
-  useRef,
   useCallback,
 } from 'react';
 import { CommonProps } from '../../common';
 import classNames from 'classnames';
 
-import { useCombinedRefs } from '../../../services';
 import { IconType } from '../../icon';
 
 import { EuiValidatableControl } from '../validatable_control';
@@ -103,7 +101,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     inputRef,
     readOnly,
     controlOnly,
-    onKeyDown: _onKeyDown,
+    onKeyUp: _onKeyUp,
     ...rest
   } = props;
 
@@ -112,20 +110,17 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   // `aria-invalid` as well as display an icon. We also want to *not* set this on
   // EuiValidatableControl, in order to not override custom validity messages
   const [isNativelyInvalid, setIsNativelyInvalid] = useState(false);
-  const validityRef = useRef<HTMLInputElement | null>(null);
-  const setRefs = useCombinedRefs([validityRef, inputRef]);
 
   // Note that we can't use hook into `onChange` because browsers don't emit change events
   // for invalid values - see https://github.com/facebook/react/issues/16554
-  const onKeyDown = useCallback(
+  const onKeyUp = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      _onKeyDown?.(e);
-      // Wait a beat before checking validity - we can't use `e.target` as it's stale
-      requestAnimationFrame(() => {
-        setIsNativelyInvalid(!validityRef.current!.validity.valid);
-      });
+      _onKeyUp?.(e);
+
+      const { validity } = e.target as HTMLInputElement;
+      setIsNativelyInvalid(!validity.valid);
     },
-    [_onKeyDown]
+    [_onKeyUp]
   );
 
   const numIconsClass = controlOnly
@@ -155,8 +150,8 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
         placeholder={placeholder}
         readOnly={readOnly}
         className={classes}
-        ref={setRefs}
-        onKeyDown={onKeyDown}
+        ref={inputRef}
+        onKeyUp={onKeyUp}
         aria-invalid={isInvalid || isNativelyInvalid}
         {...rest}
       />

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -109,7 +109,9 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   // will set :invalid state automatically, but we need to also set
   // `aria-invalid` as well as display an icon. We also want to *not* set this on
   // EuiValidatableControl, in order to not override custom validity messages
-  const [isNativelyInvalid, setIsNativelyInvalid] = useState(false);
+  const [isNativelyInvalid, setIsNativelyInvalid] = useState<
+    true | undefined
+  >();
 
   // Note that we can't use hook into `onChange` because browsers don't emit change events
   // for invalid values - see https://github.com/facebook/react/issues/16554
@@ -118,7 +120,9 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
       _onKeyUp?.(e);
 
       const { validity } = e.target as HTMLInputElement;
-      setIsNativelyInvalid(!validity.valid);
+      // Prefer `undefined` over `false` so that the `aria-invalid` prop unsets completely
+      const isInvalid = !validity.valid || undefined;
+      setIsNativelyInvalid(isInvalid);
     },
     [_onKeyUp]
   );
@@ -152,7 +156,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
         className={classes}
         ref={inputRef}
         onKeyUp={onKeyUp}
-        aria-invalid={isInvalid || isNativelyInvalid}
+        aria-invalid={isInvalid == null ? isNativelyInvalid : isInvalid}
         {...rest}
       />
     </EuiValidatableControl>

--- a/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
@@ -63,7 +63,6 @@ exports[`EuiDualRange input props can be applied to min and max inputs 1`] = `
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        aria-invalid="false"
         aria-label="Min value"
         class="euiFieldNumber euiRangeInput euiRangeInput--min emotion-euiRangeInput"
         max="8"
@@ -113,7 +112,6 @@ exports[`EuiDualRange input props can be applied to min and max inputs 1`] = `
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        aria-invalid="false"
         aria-label="Max value"
         class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
         max="10"
@@ -323,7 +321,6 @@ exports[`EuiDualRange props inputs should render 1`] = `
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        aria-invalid="false"
         aria-label="aria-label"
         class="euiFieldNumber euiRangeInput euiRangeInput--min emotion-euiRangeInput"
         max="8"
@@ -375,7 +372,6 @@ exports[`EuiDualRange props inputs should render 1`] = `
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        aria-invalid="false"
         aria-label="aria-label"
         class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
         max="100"
@@ -532,7 +528,6 @@ exports[`EuiDualRange props loading should display when showInput="inputWithPopo
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-invalid="false"
             class="euiFieldNumber euiFormControlLayoutDelimited__input emotion-euiRangeInput"
             max="8"
             min="0"
@@ -551,7 +546,6 @@ exports[`EuiDualRange props loading should display when showInput="inputWithPopo
             </span>
           </div>
           <input
-            aria-invalid="false"
             class="euiFieldNumber euiFormControlLayoutDelimited__input emotion-euiRangeInput"
             max="100"
             min="1"
@@ -621,7 +615,6 @@ exports[`EuiDualRange props slider should display in popover 1`] = `
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-invalid="false"
             class="euiFieldNumber euiFormControlLayoutDelimited__input emotion-euiRangeInput"
             max="8"
             min="0"
@@ -640,7 +633,6 @@ exports[`EuiDualRange props slider should display in popover 1`] = `
             </span>
           </div>
           <input
-            aria-invalid="false"
             class="euiFieldNumber euiFormControlLayoutDelimited__input emotion-euiRangeInput"
             max="100"
             min="1"

--- a/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -255,7 +255,6 @@ exports[`EuiRange props input should render 1`] = `
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        aria-invalid="false"
         aria-label="aria-label"
         class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
         data-test-subj="test subject string"
@@ -355,7 +354,6 @@ exports[`EuiRange props loading should display when showInput="inputWithPopover"
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-invalid="false"
             aria-label="aria-label"
             class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons euiFieldNumber-isLoading"
             data-test-subj="test subject string"
@@ -428,7 +426,6 @@ exports[`EuiRange props slider should display in popover 1`] = `
           class="euiFormControlLayout__childrenWrapper"
         >
           <input
-            aria-invalid="false"
             aria-label="aria-label"
             class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
             data-test-subj="test subject string"

--- a/src/components/form/range/__snapshots__/range_input.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range_input.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`EuiRangeInput renders 1`] = `
     class="euiFormControlLayout__childrenWrapper"
   >
     <input
-      aria-invalid="false"
       class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
       max="100"
       min="0"

--- a/upcoming_changelogs/6741.md
+++ b/upcoming_changelogs/6741.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFieldNumber`'s native browser validity detection causing extra unnecessary rerenders


### PR DESCRIPTION
## Summary

For some arcane React reason, our `EuiFieldNumber` change in https://github.com/elastic/eui/pull/6704/commits/37c35ea5ebfea0a069396207767dba65403e809b (that added detection of native browser `:invalid` state) is causing extra rerender cycles and redux sync issues with the Lens team, which is reproducibly causing a failure/bug in the latest Kibana upgrade: https://github.com/elastic/kibana/pull/155208

After a bit of debugging with Drew and determination of what can and can't be fixed on their end, I spiked out reverting the `isNativeInvalid` functionality and confirmed that seemed to fix the issue on my local Kibana. I then experimented with rewriting the native detection logic to try and reduce vectors that could be causing the extra rerender, and... I think it worked??

Honestly, I'm not sure why this is happening. It could be the switch to `onKeyUp`, it could be the removal of refs (implying `useCombinedRefs` was somehow problematic? 😕), it could have been the `requestAnimationFrame`. The code is definitely cleaner now though, so all in all I think it's a win?... 😅 

## QA

- Check out https://github.com/elastic/kibana/pull/155208
- Run `yarn build-pack`
- Go through [the testing in Kibana steps](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to point the EUI at the built tgz
- Go to local Kibana
  -  Create a Lens visualization
  - Drag `@timestamp` to the middle
  - Click the "Add layer" button
  - Select Annotations
  - Click the annotation "Events" button
  - Under "Placement type", select "Custom query"
  - Under the empty "Annotation query", type `*`
  - [x] Confirm the `*` on the non-popover-input does not go away
  - Close the popover
  - Under "Target date field", select any other option
  - [x] Confirm the annotations do not disappear from the page

### General checklist

- [ ] CI/all previous tests pass as before (invalid functionality was retained)
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
