### PR TITLE
[EuiInlineEdit] Add `onKeyDown` Mapping for Saving and Canceling Edits

### DIFF
--- a/src-docs/src/views/inline_edit/inline_edit_text.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_text.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiInlineEditText,
@@ -31,19 +31,6 @@ export default () => {
     setToggleTextButtonSize(optionId);
   };
 
-  const customKeyDown = (event: KeyboardEvent) => {
-    // if (event.key === 'Enter') {
-    //   alert('Hey this is a custom keydown message!');
-    // } else {
-    //   return;
-    // }
-    switch (event.key) {
-      case 'Enter':
-        alert('Hey this is a custom keydown message!');
-        break;
-    }
-  };
-
   return (
     <>
       <EuiButtonGroup
@@ -61,11 +48,6 @@ export default () => {
         inputAriaLabel="Edit text inline"
         defaultValue="Hello World!"
         size={toggleTextButtonSize}
-        editModeProps={{
-          inputProps: {
-            onKeyDown: customKeyDown,
-          },
-        }}
       />
     </>
   );

--- a/src-docs/src/views/inline_edit/inline_edit_text.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_text.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, KeyboardEvent } from 'react';
 
 import {
   EuiInlineEditText,
@@ -31,6 +31,14 @@ export default () => {
     setToggleTextButtonSize(optionId);
   };
 
+  const customKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      alert('Hey this is a custom keydown message!');
+    } else {
+      return;
+    }
+  };
+
   return (
     <>
       <EuiButtonGroup
@@ -48,6 +56,11 @@ export default () => {
         inputAriaLabel="Edit text inline"
         defaultValue="Hello World!"
         size={toggleTextButtonSize}
+        editModeProps={{
+          inputProps: {
+            onKeyDown: customKeyDown,
+          },
+        }}
       />
     </>
   );

--- a/src-docs/src/views/inline_edit/inline_edit_text.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_text.tsx
@@ -32,10 +32,15 @@ export default () => {
   };
 
   const customKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      alert('Hey this is a custom keydown message!');
-    } else {
-      return;
+    // if (event.key === 'Enter') {
+    //   alert('Hey this is a custom keydown message!');
+    // } else {
+    //   return;
+    // }
+    switch (event.key) {
+      case 'Enter':
+        alert('Hey this is a custom keydown message!');
+        break;
     }
   };
 

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -27,15 +27,22 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.cancelButtonProps 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>
@@ -169,15 +176,22 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.formRowProps 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>
@@ -307,7 +321,7 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
             >
               <label
                 class="euiFormLabel euiFormControlLayout__prepend"
-                for="generated-id"
+                for="__inlineEditInput_generated-id"
               >
                 Prepend Example
               </label>
@@ -315,15 +329,22 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth euiFieldText--inGroup"
                   data-test-subj="customInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>
@@ -455,15 +476,22 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.saveButtonProps 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>
@@ -595,11 +623,12 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-invalid="true"
                   aria-label="Edit inline"
                   class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
@@ -613,6 +642,12 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
                 </div>
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>
@@ -744,10 +779,11 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-label="Edit inline"
                   class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth euiFieldText-isLoading"
                   data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
@@ -762,6 +798,12 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
                 </div>
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>
@@ -847,15 +889,22 @@ exports[`EuiInlineEditForm Edit Mode renders 1`] = `
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
+                  aria-describedby="inlineEdit_generated-id"
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
+                  id="__inlineEditInput_generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
+            <span
+              hidden=""
+              id="inlineEdit_generated-id"
+            >
+              Press Enter to save your edited text. Press Escape to cancel your edit.
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -31,20 +31,20 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.cancelButtonProps 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
@@ -180,20 +180,20 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.formRowProps 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
@@ -321,7 +321,7 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
             >
               <label
                 class="euiFormLabel euiFormControlLayout__prepend"
-                for="__inlineEditInput_generated-id"
+                for="generated-id"
               >
                 Prepend Example
               </label>
@@ -333,20 +333,20 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth euiFieldText--inGroup"
                   data-test-subj="customInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
@@ -480,20 +480,20 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.saveButtonProps 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
@@ -628,7 +628,7 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
@@ -642,14 +642,14 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
                 </div>
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
@@ -783,7 +783,7 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth euiFieldText-isLoading"
                   data-test-subj="euiInlineEditModeInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
@@ -798,14 +798,14 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
                 </div>
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
@@ -893,20 +893,20 @@ exports[`EuiInlineEditForm Edit Mode renders 1`] = `
                   aria-label="Edit inline"
                   class="euiFieldText euiFieldText--fullWidth"
                   data-test-subj="euiInlineEditModeInput"
-                  id="__inlineEditInput_generated-id"
+                  id="generated-id"
                   type="text"
                   value="Hello World!"
                 />
               </div>
             </div>
-            <span
-              hidden=""
-              id="inlineEdit_generated-id"
-            >
-              Press Enter to save your edited text. Press Escape to cancel your edit.
-            </span>
           </div>
         </div>
+        <span
+          hidden=""
+          id="inlineEdit_generated-id"
+        >
+          Press Enter to save your edited text. Press Escape to cancel your edit.
+        </span>
       </div>
       <div
         class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -376,22 +376,25 @@ describe('EuiInlineEditForm', () => {
       it('calls passed `inputModeProps.onKeyDown` callbacks', () => {
         const onKeyDown = jest.fn();
 
-        const { getByTestSubject } = render(
+        const { getByTestSubject, getByText } = render(
           <EuiInlineEditForm
             {...commonInlineEditFormProps}
-            onSave={onSave}
             startWithEditOpen={true}
             editModeProps={{ inputProps: { onKeyDown } }}
           />
         );
 
+        fireEvent.change(getByTestSubject('euiInlineEditModeInput'), {
+          target: { value: 'New message!' },
+        });
         fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
           key: 'Enter',
         });
 
-        // If a keyDown event is mapped to Enter/Escape, both the default and custom events should run
+        // Both EUI and consumer `onKeyDown` events should have run
         expect(onKeyDown).toHaveBeenCalled();
-        expect(onSave).toHaveBeenCalled();
+        expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+        expect(getByText('New message!')).toBeTruthy();
       });
     });
   });

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -333,5 +333,91 @@ describe('EuiInlineEditForm', () => {
         });
       });
     });
+
+    describe('keyboard events', () => {
+      test('hitting enter saves saves text and returns to readMode', () => {
+        const { getByTestSubject, getByText } = render(
+          <EuiInlineEditForm
+            {...commonInlineEditFormProps}
+            onSave={onSave}
+            startWithEditOpen={true}
+          />
+        );
+
+        fireEvent.change(getByTestSubject('euiInlineEditModeInput'), {
+          target: { value: 'New message!' },
+        });
+        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
+          key: 'Enter',
+        });
+
+        expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+        expect(getByText('New message!')).toBeTruthy();
+        expect(onSave).toHaveBeenCalledWith('New message!');
+      });
+
+      test('hitting escape cancels text and returns to readMode', () => {
+        const { getByTestSubject, getByText } = render(
+          <EuiInlineEditForm
+            {...commonInlineEditFormProps}
+            onSave={onSave}
+            startWithEditOpen={true}
+          />
+        );
+
+        fireEvent.change(getByTestSubject('euiInlineEditModeInput'), {
+          target: { value: 'New message!' },
+        });
+        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
+          key: 'Escape',
+        });
+
+        expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+        expect(getByText('Hello World!')).toBeTruthy();
+        expect(onSave).not.toHaveBeenCalled();
+      });
+
+      test('hitting unmapped keys like shift and delete do not change the state of the component', () => {
+        const { getByTestSubject, queryByTestSubject } = render(
+          <EuiInlineEditForm
+            {...commonInlineEditFormProps}
+            onSave={onSave}
+            startWithEditOpen={true}
+          />
+        );
+
+        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
+          key: 'Shift',
+        });
+        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
+          key: 'Delete',
+        });
+
+        expect(queryByTestSubject('euiInlineReadModeButton')).toBeFalsy();
+        expect(getByTestSubject('euiInlineEditModeInput')).toBeTruthy();
+        expect(onSave).not.toHaveBeenCalled();
+      });
+
+      test('calls a custom keyDown function passed in with editModeProps overrides the default event', () => {
+        const onKeyDown = jest.fn();
+
+        const { getByTestSubject } = render(
+          <EuiInlineEditForm
+            {...commonInlineEditFormProps}
+            onSave={onSave}
+            startWithEditOpen={true}
+            editModeProps={{ inputProps: { onKeyDown: onKeyDown } }}
+          />
+        );
+
+        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
+          key: 'Enter',
+        });
+
+        // If a keyDown event is mapped to Enter/Escape, it should override the default save/cancel event
+        expect(onKeyDown).toHaveBeenCalled();
+        expect(onSave).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -335,11 +335,10 @@ describe('EuiInlineEditForm', () => {
     });
 
     describe('keyboard events', () => {
-      test('hitting enter saves saves text and returns to readMode', () => {
+      test('pressing the Enter key saves text and returns to readMode', () => {
         const { getByTestSubject, getByText } = render(
           <EuiInlineEditForm
             {...commonInlineEditFormProps}
-            onSave={onSave}
             startWithEditOpen={true}
           />
         );
@@ -353,14 +352,12 @@ describe('EuiInlineEditForm', () => {
 
         expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
         expect(getByText('New message!')).toBeTruthy();
-        expect(onSave).toHaveBeenCalledWith('New message!');
       });
 
-      test('hitting escape cancels text and returns to readMode', () => {
+      test('pressing the Escape key cancels text changes and returns to readMode', () => {
         const { getByTestSubject, getByText } = render(
           <EuiInlineEditForm
             {...commonInlineEditFormProps}
-            onSave={onSave}
             startWithEditOpen={true}
           />
         );
@@ -374,31 +371,9 @@ describe('EuiInlineEditForm', () => {
 
         expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
         expect(getByText('Hello World!')).toBeTruthy();
-        expect(onSave).not.toHaveBeenCalled();
       });
 
-      test('hitting unmapped keys like shift and delete do not change the state of the component', () => {
-        const { getByTestSubject, queryByTestSubject } = render(
-          <EuiInlineEditForm
-            {...commonInlineEditFormProps}
-            onSave={onSave}
-            startWithEditOpen={true}
-          />
-        );
-
-        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
-          key: 'Shift',
-        });
-        fireEvent.keyDown(getByTestSubject('euiInlineEditModeInput'), {
-          key: 'Delete',
-        });
-
-        expect(queryByTestSubject('euiInlineReadModeButton')).toBeFalsy();
-        expect(getByTestSubject('euiInlineEditModeInput')).toBeTruthy();
-        expect(onSave).not.toHaveBeenCalled();
-      });
-
-      test('calls a custom keyDown function passed in with editModeProps overrides the default event', () => {
+      it('calls passed `inputModeProps.onKeyDown` callbacks', () => {
         const onKeyDown = jest.fn();
 
         const { getByTestSubject } = render(
@@ -406,7 +381,7 @@ describe('EuiInlineEditForm', () => {
             {...commonInlineEditFormProps}
             onSave={onSave}
             startWithEditOpen={true}
-            editModeProps={{ inputProps: { onKeyDown: onKeyDown } }}
+            editModeProps={{ inputProps: { onKeyDown } }}
           />
         );
 
@@ -414,9 +389,9 @@ describe('EuiInlineEditForm', () => {
           key: 'Enter',
         });
 
-        // If a keyDown event is mapped to Enter/Escape, it should override the default save/cancel event
+        // If a keyDown event is mapped to Enter/Escape, both the default and custom events should run
         expect(onKeyDown).toHaveBeenCalled();
-        expect(onSave).not.toHaveBeenCalled();
+        expect(onSave).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -13,7 +13,6 @@ import React, {
   HTMLAttributes,
   MouseEvent,
   KeyboardEvent,
-  KeyboardEventHandler,
 } from 'react';
 import classNames from 'classnames';
 
@@ -165,19 +164,14 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     setIsEditing(false);
   };
 
-  const editModeInputOnKeyDown: KeyboardEventHandler = (
-    event: KeyboardEvent<HTMLElement>
-  ) => {
-    if (event.key === keys.ENTER) {
-      event.preventDefault();
-      event.stopPropagation();
-      saveInlineEditValue();
-    } else if (event.key === keys.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      cancelInlineEdit();
-    } else {
-      return;
+  const editModeInputOnKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    switch (event.key) {
+      case keys.ENTER:
+        saveInlineEditValue();
+        break;
+      case keys.ESCAPE:
+        cancelInlineEdit();
+        break;
     }
   };
 
@@ -202,11 +196,11 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
               isInvalid={isInvalid}
               isLoading={isLoading}
               data-test-subj="euiInlineEditModeInput"
+              {...editModeProps?.inputProps}
               onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
                 editModeInputOnKeyDown(e);
                 editModeProps?.inputProps?.onKeyDown?.(e);
               }}
-              {...editModeProps?.inputProps}
             />
           </EuiFormRow>
         </EuiFlexItem>

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -33,7 +33,7 @@ import { EuiButtonEmptyPropsForButton } from '../button/button_empty/button_empt
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSkeletonRectangle } from '../skeleton';
 import { useEuiTheme, keys } from '../../services';
-import { useEuiI18n } from '../i18n';
+import { EuiI18n, useEuiI18n } from '../i18n';
 import { useGeneratedHtmlId } from '../../services/accessibility';
 
 // Props shared between the internal form component as well as consumer-facing components
@@ -142,6 +142,8 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     'Cancel edit'
   );
 
+  const editModeDescribedById = useGeneratedHtmlId({ prefix: 'inlineEdit' });
+
   const [isEditing, setIsEditing] = useState(false || startWithEditOpen);
   const inlineEditInputId = useGeneratedHtmlId({ prefix: '__inlineEditInput' });
 
@@ -194,24 +196,36 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             error={isInvalid && editModeProps?.formRowProps?.error}
             {...editModeProps?.formRowProps}
           >
-            <EuiFieldText
-              id={inlineEditInputId}
-              inputRef={editModeInputRef}
-              value={editModeValue}
-              onChange={(e) => {
-                setEditModeValue(e.target.value);
-              }}
-              aria-label={inputAriaLabel}
-              compressed={sizes.compressed}
-              isInvalid={isInvalid}
-              isLoading={isLoading}
-              data-test-subj="euiInlineEditModeInput"
-              {...editModeProps?.inputProps}
-              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-                editModeInputOnKeyDown(e);
-                editModeProps?.inputProps?.onKeyDown?.(e);
-              }}
-            />
+            <>
+              <EuiFieldText
+                id={inlineEditInputId}
+                inputRef={editModeInputRef}
+                value={editModeValue}
+                onChange={(e) => {
+                  setEditModeValue(e.target.value);
+                }}
+                aria-label={inputAriaLabel}
+                compressed={sizes.compressed}
+                isInvalid={isInvalid}
+                isLoading={isLoading}
+                data-test-subj="euiInlineEditModeInput"
+                {...editModeProps?.inputProps}
+                aria-describedby={classNames(
+                  editModeDescribedById,
+                  editModeProps?.inputProps?.['aria-describedby']
+                )}
+                onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                  editModeInputOnKeyDown(e);
+                  editModeProps?.inputProps?.onKeyDown?.(e);
+                }}
+              />
+              <span id={editModeDescribedById} hidden>
+                <EuiI18n
+                  token="euiInlineEditForm.inputKeyboardInstructions"
+                  default="Press Enter to save your edited text. Press Escape to cancel your edit."
+                />
+              </span>
+            </>
           </EuiFormRow>
         </EuiFlexItem>
 

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -13,6 +13,8 @@ import React, {
   HTMLAttributes,
   MouseEvent,
   KeyboardEvent,
+  useRef,
+  useEffect,
 } from 'react';
 import classNames from 'classnames';
 
@@ -146,6 +148,14 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const [editModeValue, setEditModeValue] = useState(defaultValue);
   const [readModeValue, setReadModeValue] = useState(defaultValue);
 
+  const editModeInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      editModeInputRef.current?.focus();
+    }
+  }, [isEditing]);
+
   const cancelInlineEdit = () => {
     setEditModeValue(readModeValue);
     setIsEditing(false);
@@ -186,12 +196,12 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
           >
             <EuiFieldText
               id={inlineEditInputId}
+              inputRef={editModeInputRef}
               value={editModeValue}
               onChange={(e) => {
                 setEditModeValue(e.target.value);
               }}
               aria-label={inputAriaLabel}
-              autoFocus
               compressed={sizes.compressed}
               isInvalid={isInvalid}
               isLoading={isLoading}
@@ -265,13 +275,12 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
       color="text"
       iconType="pencil"
       iconSide="right"
-      autoFocus
       flush="both"
       iconSize={sizes.iconSize}
       size={sizes.buttonSize}
       data-test-subj="euiInlineReadModeButton"
       {...readModeProps}
-      onClick={(e) => {
+      onClick={(e: MouseEvent<HTMLButtonElement>) => {
         setIsEditing(true);
         readModeProps?.onClick?.(e);
       }}

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -12,6 +12,8 @@ import React, {
   useState,
   HTMLAttributes,
   MouseEvent,
+  KeyboardEvent,
+  KeyboardEventHandler,
 } from 'react';
 import classNames from 'classnames';
 
@@ -29,7 +31,7 @@ import { EuiButtonIconPropsForButton } from '../button/button_icon';
 import { EuiButtonEmptyPropsForButton } from '../button/button_empty/button_empty';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSkeletonRectangle } from '../skeleton';
-import { useEuiTheme } from '../../services';
+import { useEuiTheme, keys } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { useGeneratedHtmlId } from '../../services/accessibility';
 
@@ -163,6 +165,22 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     setIsEditing(false);
   };
 
+  const editModeInputOnKeyDown: KeyboardEventHandler = (
+    event: KeyboardEvent<HTMLElement>
+  ) => {
+    if (event.key === keys.ENTER) {
+      event.preventDefault();
+      event.stopPropagation();
+      saveInlineEditValue();
+    } else if (event.key === keys.ESCAPE) {
+      event.preventDefault();
+      event.stopPropagation();
+      cancelInlineEdit();
+    } else {
+      return;
+    }
+  };
+
   const editModeForm = (
     <EuiForm fullWidth>
       <EuiFlexGroup gutterSize="s">
@@ -184,6 +202,10 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
               isInvalid={isInvalid}
               isLoading={isLoading}
               data-test-subj="euiInlineEditModeInput"
+              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                editModeInputOnKeyDown(e);
+                editModeProps?.inputProps?.onKeyDown?.(e);
+              }}
               {...editModeProps?.inputProps}
             />
           </EuiFormRow>

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -13,8 +13,6 @@ import React, {
   HTMLAttributes,
   MouseEvent,
   KeyboardEvent,
-  useRef,
-  useEffect,
 } from 'react';
 import classNames from 'classnames';
 
@@ -150,14 +148,6 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const [editModeValue, setEditModeValue] = useState(defaultValue);
   const [readModeValue, setReadModeValue] = useState(defaultValue);
 
-  const editModeInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (isEditing) {
-      editModeInputRef.current?.focus();
-    }
-  }, [isEditing]);
-
   const cancelInlineEdit = () => {
     setEditModeValue(readModeValue);
     setIsEditing(false);
@@ -199,12 +189,12 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             <>
               <EuiFieldText
                 id={inlineEditInputId}
-                inputRef={editModeInputRef}
                 value={editModeValue}
                 onChange={(e) => {
                   setEditModeValue(e.target.value);
                 }}
                 aria-label={inputAriaLabel}
+                autoFocus
                 compressed={sizes.compressed}
                 isInvalid={isInvalid}
                 isLoading={isLoading}
@@ -289,12 +279,13 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
       color="text"
       iconType="pencil"
       iconSide="right"
+      autoFocus
       flush="both"
       iconSize={sizes.iconSize}
       size={sizes.buttonSize}
       data-test-subj="euiInlineReadModeButton"
       {...readModeProps}
-      onClick={(e: MouseEvent<HTMLButtonElement>) => {
+      onClick={(e) => {
         setIsEditing(true);
         readModeProps?.onClick?.(e);
       }}

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -186,37 +186,35 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             error={isInvalid && editModeProps?.formRowProps?.error}
             {...editModeProps?.formRowProps}
           >
-            <>
-              <EuiFieldText
-                id={inlineEditInputId}
-                value={editModeValue}
-                onChange={(e) => {
-                  setEditModeValue(e.target.value);
-                }}
-                aria-label={inputAriaLabel}
-                autoFocus
-                compressed={sizes.compressed}
-                isInvalid={isInvalid}
-                isLoading={isLoading}
-                data-test-subj="euiInlineEditModeInput"
-                {...editModeProps?.inputProps}
-                aria-describedby={classNames(
-                  editModeDescribedById,
-                  editModeProps?.inputProps?.['aria-describedby']
-                )}
-                onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-                  editModeInputOnKeyDown(e);
-                  editModeProps?.inputProps?.onKeyDown?.(e);
-                }}
-              />
-              <span id={editModeDescribedById} hidden>
-                <EuiI18n
-                  token="euiInlineEditForm.inputKeyboardInstructions"
-                  default="Press Enter to save your edited text. Press Escape to cancel your edit."
-                />
-              </span>
-            </>
+            <EuiFieldText
+              id={inlineEditInputId}
+              value={editModeValue}
+              onChange={(e) => {
+                setEditModeValue(e.target.value);
+              }}
+              aria-label={inputAriaLabel}
+              autoFocus
+              compressed={sizes.compressed}
+              isInvalid={isInvalid}
+              isLoading={isLoading}
+              data-test-subj="euiInlineEditModeInput"
+              {...editModeProps?.inputProps}
+              aria-describedby={classNames(
+                editModeDescribedById,
+                editModeProps?.inputProps?.['aria-describedby']
+              )}
+              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                editModeInputOnKeyDown(e);
+                editModeProps?.inputProps?.onKeyDown?.(e);
+              }}
+            />
           </EuiFormRow>
+          <span id={editModeDescribedById} hidden>
+            <EuiI18n
+              token="euiInlineEditForm.inputKeyboardInstructions"
+              default="Press Enter to save your edited text. Press Escape to cancel your edit."
+            />
+          </span>
         </EuiFlexItem>
 
         <EuiFlexItem grow={false} className={classes}>


### PR DESCRIPTION
Relates to #3928 

## Summary

Allows users to select `Enter` to save and `Escape` to cancel inline edits. When a custom `onKeyDown` function is passed in through `editModeProps.inputProps` , it will take priority and override the default functionality. 

## QA

- [x] 1. Use the `Enter` key to save an edit -- ([use the title example](https://eui.elastic.co/pr_6742/#/display/inline-edit#display-and-edit-headings-and-titles))
- [x] 2. Use the `Escape` key to cancel an edit -- ([use the title example](https://eui.elastic.co/pr_6742/#/display/inline-edit#display-and-edit-headings-and-titles))
- [x] 3. View a custom `keyDown` event that works along with the default `Enter` key event -- ([use the text example](https://eui.elastic.co/pr_6742/#/display/inline-edit#display-and-edit-basic-text))

### General checklist
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes

