### PR TITLE
[EuiInlineEdit] DOM cleanup, a11y improvements, and fix breaking `onChange` bug

### DIFF
--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -67,59 +67,37 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.cancelButtonProps 1`] = `
             role="status"
           />
         </div>
-        <button
-          aria-label="Save edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-          data-test-subj="euiInlineEditModeSaveButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="check"
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="false"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
         <div
-          class="emotion-euiScreenReaderOnly"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
+          <button
+            aria-label="Save edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
           >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Uh no. Do not save."
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-disabled"
+            data-test-subj="euiInlineEditModeCancelButton"
+            disabled=""
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
         </div>
-        <button
-          aria-label="Uh no. Do not save."
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-disabled"
-          data-test-subj="euiInlineEditModeCancelButton"
-          disabled=""
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
       </div>
     </div>
   </div>
@@ -194,58 +172,36 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.formRowProps 1`] = `
             role="status"
           />
         </div>
-        <button
-          aria-label="Save edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-          data-test-subj="euiInlineEditModeSaveButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="check"
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="false"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
         <div
-          class="emotion-euiScreenReaderOnly"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
+          <button
+            aria-label="Save edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
           >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Cancel edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+            data-test-subj="euiInlineEditModeCancelButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
         </div>
-        <button
-          aria-label="Cancel edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-          data-test-subj="euiInlineEditModeCancelButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
       </div>
     </div>
   </div>
@@ -325,58 +281,36 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
             role="status"
           />
         </div>
-        <button
-          aria-label="Save edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-          data-test-subj="euiInlineEditModeSaveButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="check"
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="false"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
         <div
-          class="emotion-euiScreenReaderOnly"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
+          <button
+            aria-label="Save edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
           >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Cancel edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+            data-test-subj="euiInlineEditModeCancelButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
         </div>
-        <button
-          aria-label="Cancel edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-          data-test-subj="euiInlineEditModeCancelButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
       </div>
     </div>
   </div>
@@ -450,58 +384,36 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.saveButtonProps 1`] = `
             role="status"
           />
         </div>
-        <button
-          aria-label="Yes! Let's save."
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-primary"
-          data-test-subj="euiInlineEditModeSaveButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="check"
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="false"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
         <div
-          class="emotion-euiScreenReaderOnly"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
+          <button
+            aria-label="Yes! Let's save."
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-primary"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
           >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Cancel edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+            data-test-subj="euiInlineEditModeCancelButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
         </div>
-        <button
-          aria-label="Cancel edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-          data-test-subj="euiInlineEditModeCancelButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
       </div>
     </div>
   </div>
@@ -584,58 +496,36 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
             role="status"
           />
         </div>
-        <button
-          aria-label="Save edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-          data-test-subj="euiInlineEditModeSaveButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="check"
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="false"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
         <div
-          class="emotion-euiScreenReaderOnly"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
+          <button
+            aria-label="Save edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
           >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Cancel edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+            data-test-subj="euiInlineEditModeCancelButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
         </div>
-        <button
-          aria-label="Cancel edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-          data-test-subj="euiInlineEditModeCancelButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
       </div>
     </div>
   </div>
@@ -703,25 +593,32 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
       >
         <div
           aria-label="Loading "
-          class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
           role="progressbar"
-          style="inline-size: 40px; block-size: 40px;"
-        />
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="true"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
-        <div
-          aria-label="Loading "
-          class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
-          role="progressbar"
-          style="inline-size: 40px; block-size: 40px;"
-        />
+        >
+          <div
+            aria-busy="true"
+            data-test-subj="euiSkeletonLoadingAriaWrapper"
+          >
+            <div
+              aria-label="Loading "
+              class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
+              role="progressbar"
+              style="inline-size: 40px; block-size: 40px;"
+            />
+          </div>
+          <div
+            aria-busy="true"
+            data-test-subj="euiSkeletonLoadingAriaWrapper"
+          >
+            <div
+              aria-label="Loading "
+              class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
+              role="progressbar"
+              style="inline-size: 40px; block-size: 40px;"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -795,58 +692,36 @@ exports[`EuiInlineEditForm Edit Mode renders 1`] = `
             role="status"
           />
         </div>
-        <button
-          aria-label="Save edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-          data-test-subj="euiInlineEditModeSaveButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="check"
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem emotion-euiFlexItem-growZero"
-    >
-      <div
-        aria-busy="false"
-        data-test-subj="euiSkeletonLoadingAriaWrapper"
-      >
         <div
-          class="emotion-euiScreenReaderOnly"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
+          <button
+            aria-label="Save edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
           >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Cancel edit"
+            class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+            data-test-subj="euiInlineEditModeCancelButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
         </div>
-        <button
-          aria-label="Cancel edit"
-          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-          data-test-subj="euiInlineEditModeCancelButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
       </div>
     </div>
   </div>

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -5,143 +5,121 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.cancelButtonProps 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout__childrenWrapper"
             >
-              <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFieldText--fullWidth"
-                  data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
-      </div>
-      <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Save edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-                data-test-subj="euiInlineEditModeSaveButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="check"
-                />
-              </button>
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFieldText--fullWidth"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
             </div>
           </div>
         </div>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="emotion-euiScreenReaderOnly"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
           >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Uh no. Do not save."
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-disabled"
-                data-test-subj="euiInlineEditModeCancelButton"
-                disabled=""
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="cross"
-                />
-              </button>
-            </div>
+            Loaded 
           </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
         </div>
+        <button
+          aria-label="Save edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+          data-test-subj="euiInlineEditModeSaveButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="check"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loaded 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <button
+          aria-label="Uh no. Do not save."
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-disabled"
+          data-test-subj="euiInlineEditModeCancelButton"
+          disabled=""
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -153,143 +131,121 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.formRowProps 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        data-test-subj="customErrorText"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          data-test-subj="customErrorText"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout__childrenWrapper"
             >
-              <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFieldText--fullWidth"
-                  data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
-      </div>
-      <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Save edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-                data-test-subj="euiInlineEditModeSaveButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="check"
-                />
-              </button>
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFieldText--fullWidth"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
             </div>
           </div>
         </div>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="emotion-euiScreenReaderOnly"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
           >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Cancel edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-                data-test-subj="euiInlineEditModeCancelButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="cross"
-                />
-              </button>
-            </div>
+            Loaded 
           </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
         </div>
+        <button
+          aria-label="Save edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+          data-test-subj="euiInlineEditModeSaveButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="check"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loaded 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <button
+          aria-label="Cancel edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+          data-test-subj="euiInlineEditModeCancelButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -301,148 +257,126 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
           >
-            <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+            <label
+              class="euiFormLabel euiFormControlLayout__prepend"
+              for="generated-id"
             >
-              <label
-                class="euiFormLabel euiFormControlLayout__prepend"
-                for="generated-id"
-              >
-                Prepend Example
-              </label>
-              <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFieldText--fullWidth euiFieldText--inGroup"
-                  data-test-subj="customInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
-      </div>
-      <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
+              Prepend Example
+            </label>
             <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
+              class="euiFormControlLayout__childrenWrapper"
             >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Save edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-                data-test-subj="euiInlineEditModeSaveButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="check"
-                />
-              </button>
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFieldText--fullWidth euiFieldText--inGroup"
+                data-test-subj="customInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
             </div>
           </div>
         </div>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="emotion-euiScreenReaderOnly"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
           >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Cancel edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-                data-test-subj="euiInlineEditModeCancelButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="cross"
-                />
-              </button>
-            </div>
+            Loaded 
           </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
         </div>
+        <button
+          aria-label="Save edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+          data-test-subj="euiInlineEditModeSaveButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="check"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loaded 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <button
+          aria-label="Cancel edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+          data-test-subj="euiInlineEditModeCancelButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -454,142 +388,120 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.saveButtonProps 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout__childrenWrapper"
             >
-              <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFieldText--fullWidth"
-                  data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
-      </div>
-      <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Yes! Let's save."
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-primary"
-                data-test-subj="euiInlineEditModeSaveButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="check"
-                />
-              </button>
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFieldText--fullWidth"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
             </div>
           </div>
         </div>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="emotion-euiScreenReaderOnly"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
           >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Cancel edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-                data-test-subj="euiInlineEditModeCancelButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="cross"
-                />
-              </button>
-            </div>
+            Loaded 
           </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
         </div>
+        <button
+          aria-label="Yes! Let's save."
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-primary"
+          data-test-subj="euiInlineEditModeSaveButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="check"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loaded 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <button
+          aria-label="Cancel edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+          data-test-subj="euiInlineEditModeCancelButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -601,151 +513,129 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout__childrenWrapper"
             >
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-invalid="true"
+                aria-label="Edit inline"
+                class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
               <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-invalid="true"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth"
-                  data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
-                />
-                <div
-                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-                >
-                  <span
-                    color="danger"
-                    data-euiicon-type="warning"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
-      </div>
-      <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Save edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-                data-test-subj="euiInlineEditModeSaveButton"
-                type="button"
+                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
               >
                 <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="check"
+                  color="danger"
+                  data-euiicon-type="warning"
                 />
-              </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="emotion-euiScreenReaderOnly"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
           >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Cancel edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-                data-test-subj="euiInlineEditModeCancelButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="cross"
-                />
-              </button>
-            </div>
+            Loaded 
           </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
         </div>
+        <button
+          aria-label="Save edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+          data-test-subj="euiInlineEditModeSaveButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="check"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loaded 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <button
+          aria-label="Cancel edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+          data-test-subj="euiInlineEditModeCancelButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -757,105 +647,81 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout__childrenWrapper"
             >
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth euiFieldText-isLoading"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
               <div
-                class="euiFormControlLayout__childrenWrapper"
+                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
               >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFormControlLayout--1icons euiFieldText--fullWidth euiFieldText-isLoading"
-                  data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
+                <span
+                  aria-label="Loading"
+                  class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
+                  role="progressbar"
                 />
-                <div
-                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-                >
-                  <span
-                    aria-label="Loading"
-                    class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
-                    role="progressbar"
-                  />
-                </div>
               </div>
             </div>
           </div>
         </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
+        aria-busy="true"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="true"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                aria-label="Loading "
-                class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
-                id="generated-id"
-                role="progressbar"
-                style="inline-size: 40px; block-size: 40px;"
-              />
-            </div>
-          </div>
-        </div>
+          aria-label="Loading "
+          class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
+          role="progressbar"
+          style="inline-size: 40px; block-size: 40px;"
+        />
       </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="true"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="true"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                aria-label="Loading "
-                class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
-                id="generated-id"
-                role="progressbar"
-                style="inline-size: 40px; block-size: 40px;"
-              />
-            </div>
-          </div>
-        </div>
+          aria-label="Loading "
+          class="euiSkeletonRectangle emotion-euiSkeletonGradientAnimation-euiSkeletonRectangle-m"
+          role="progressbar"
+          style="inline-size: 40px; block-size: 40px;"
+        />
       </div>
     </div>
   </div>
@@ -867,142 +733,120 @@ exports[`EuiInlineEditForm Edit Mode renders 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <div
-    class="euiForm"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
   >
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
     >
       <div
-        class="euiFlexItem emotion-euiFlexItem-grow-1"
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="euiFormRow__fieldWrapper"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
+              class="euiFormControlLayout__childrenWrapper"
             >
-              <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-describedby="inlineEdit_generated-id"
-                  aria-label="Edit inline"
-                  class="euiFieldText euiFieldText--fullWidth"
-                  data-test-subj="euiInlineEditModeInput"
-                  id="generated-id"
-                  type="text"
-                  value="Hello World!"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
-          hidden=""
-          id="inlineEdit_generated-id"
-        >
-          Press Enter to save your edited text. Press Escape to cancel your edit.
-        </span>
-      </div>
-      <div
-        class="euiFlexItem euiInlineEdit testClass1 testClass2 emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
-        >
-          <div
-            class="euiFormRow__fieldWrapper"
-          >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Save edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
-                data-test-subj="euiInlineEditModeSaveButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="check"
-                />
-              </button>
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFieldText--fullWidth"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                type="text"
+                value="Hello World!"
+              />
             </div>
           </div>
         </div>
       </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
       <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="euiFormRow euiFormRow--fullWidth"
-          id="generated-id-row"
+          class="emotion-euiScreenReaderOnly"
         >
           <div
-            class="euiFormRow__fieldWrapper"
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
           >
-            <div
-              aria-busy="false"
-              data-test-subj="euiSkeletonLoadingAriaWrapper"
-            >
-              <div
-                class="emotion-euiScreenReaderOnly"
-              >
-                <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  role="status"
-                >
-                  Loaded 
-                </div>
-                <div
-                  aria-atomic="true"
-                  aria-hidden="true"
-                  aria-live="off"
-                  role="status"
-                />
-              </div>
-              <button
-                aria-label="Cancel edit"
-                class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
-                data-test-subj="euiInlineEditModeCancelButton"
-                type="button"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiButtonIcon__icon"
-                  color="inherit"
-                  data-euiicon-type="cross"
-                />
-              </button>
-            </div>
+            Loaded 
           </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
         </div>
+        <button
+          aria-label="Save edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-success"
+          data-test-subj="euiInlineEditModeSaveButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="check"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loaded 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <button
+          aria-label="Cancel edit"
+          class="euiButtonIcon euiButtonIcon--medium emotion-euiButtonIcon-base-danger"
+          data-test-subj="euiInlineEditModeCancelButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
       </div>
     </div>
   </div>

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -648,6 +648,7 @@ exports[`EuiInlineEditForm Read Mode readModeProps 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-9t7nyf-empty-primary"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -667,6 +668,12 @@ exports[`EuiInlineEditForm Read Mode readModeProps 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -675,6 +682,7 @@ exports[`EuiInlineEditForm Read Mode renders 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -694,6 +702,12 @@ exports[`EuiInlineEditForm Read Mode renders 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -702,6 +716,7 @@ exports[`EuiInlineEditForm Read Mode sizes 1`] = `
   class="euiInlineEdit testClass1 testClass2"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -721,5 +736,11 @@ exports[`EuiInlineEditForm Read Mode sizes 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -51,23 +51,6 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.cancelButtonProps 1`] = `
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="emotion-euiScreenReaderOnly"
-        >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
-          >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
-        </div>
-        <div
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
           <button
@@ -155,23 +138,6 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.formRowProps 1`] = `
         aria-busy="false"
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
-        <div
-          class="emotion-euiScreenReaderOnly"
-        >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
-          >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
-        </div>
         <div
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
@@ -265,23 +231,6 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.inputProps 1`] = `
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="emotion-euiScreenReaderOnly"
-        >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
-          >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
-        </div>
-        <div
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
           <button
@@ -367,23 +316,6 @@ exports[`EuiInlineEditForm Edit Mode editModeProps.saveButtonProps 1`] = `
         aria-busy="false"
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
-        <div
-          class="emotion-euiScreenReaderOnly"
-        >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
-          >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
-        </div>
         <div
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
@@ -480,23 +412,6 @@ exports[`EuiInlineEditForm Edit Mode isInvalid 1`] = `
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
-          class="emotion-euiScreenReaderOnly"
-        >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
-          >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
-        </div>
-        <div
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >
           <button
@@ -592,6 +507,23 @@ exports[`EuiInlineEditForm Edit Mode isLoading 1`] = `
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
         <div
+          class="emotion-euiScreenReaderOnly"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            role="status"
+          >
+            Loading 
+          </div>
+          <div
+            aria-atomic="true"
+            aria-hidden="true"
+            aria-live="off"
+            role="status"
+          />
+        </div>
+        <div
           aria-label="Loading "
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
           role="progressbar"
@@ -675,23 +607,6 @@ exports[`EuiInlineEditForm Edit Mode renders 1`] = `
         aria-busy="false"
         data-test-subj="euiSkeletonLoadingAriaWrapper"
       >
-        <div
-          class="emotion-euiScreenReaderOnly"
-        >
-          <div
-            aria-atomic="true"
-            aria-live="polite"
-            role="status"
-          >
-            Loaded 
-          </div>
-          <div
-            aria-atomic="true"
-            aria-hidden="true"
-            aria-live="off"
-            role="status"
-          />
-        </div>
         <div
           class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
         >

--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EuiInlineEditText renders 1`] = `
   class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-m-m"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -28,6 +29,12 @@ exports[`EuiInlineEditText renders 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -36,6 +43,7 @@ exports[`EuiInlineEditText text sizes renders m 1`] = `
   class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-m-m"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -59,6 +67,12 @@ exports[`EuiInlineEditText text sizes renders m 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -67,6 +81,7 @@ exports[`EuiInlineEditText text sizes renders s 1`] = `
   class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-s-s"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -90,6 +105,12 @@ exports[`EuiInlineEditText text sizes renders s 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -98,6 +119,7 @@ exports[`EuiInlineEditText text sizes renders xs 1`] = `
   class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-xs-xs"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -121,5 +143,11 @@ exports[`EuiInlineEditText text sizes renders xs 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EuiInlineEditTitle renders 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-m-m"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -28,6 +29,12 @@ exports[`EuiInlineEditTitle renders 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -36,6 +43,7 @@ exports[`EuiInlineEditTitle title sizes renders size l 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-l-l"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -59,6 +67,12 @@ exports[`EuiInlineEditTitle title sizes renders size l 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -67,6 +81,7 @@ exports[`EuiInlineEditTitle title sizes renders size m 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-m-m"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -90,6 +105,12 @@ exports[`EuiInlineEditTitle title sizes renders size m 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -98,6 +119,7 @@ exports[`EuiInlineEditTitle title sizes renders size s 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-s-s"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -121,6 +143,12 @@ exports[`EuiInlineEditTitle title sizes renders size s 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -129,6 +157,7 @@ exports[`EuiInlineEditTitle title sizes renders size xs 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-xs-xs"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -152,6 +181,12 @@ exports[`EuiInlineEditTitle title sizes renders size xs 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -160,6 +195,7 @@ exports[`EuiInlineEditTitle title sizes renders size xxs 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-xxs-xxs"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -183,6 +219,12 @@ exports[`EuiInlineEditTitle title sizes renders size xxs 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;
 
@@ -191,6 +233,7 @@ exports[`EuiInlineEditTitle title sizes renders size xxxs 1`] = `
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-xxxs-xxxs"
 >
   <button
+    aria-describedby="inlineEdit_generated-id"
     class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
     data-test-subj="euiInlineReadModeButton"
     type="button"
@@ -214,5 +257,11 @@ exports[`EuiInlineEditTitle title sizes renders size xxxs 1`] = `
       </span>
     </span>
   </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
 </div>
 `;

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -202,7 +202,7 @@ describe('EuiInlineEditForm', () => {
       onSave.mockReset();
     });
 
-    it('toggles to editMode when the readModeButton is clicked', () => {
+    it('activates editMode when the readModeButton is clicked', () => {
       const { getByTestSubject, queryByTestSubject } = render(
         <EuiInlineEditForm
           {...commonInlineEditFormProps}

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -76,6 +76,8 @@ describe('EuiInlineEditForm', () => {
     });
 
     test('editModeProps.inputProps', () => {
+      const onChange = jest.fn();
+
       const { container, getByTestSubject } = render(
         <EuiInlineEditForm
           {...commonInlineEditFormProps}
@@ -84,13 +86,21 @@ describe('EuiInlineEditForm', () => {
             inputProps: {
               prepend: 'Prepend Example',
               'data-test-subj': 'customInput',
+              onChange,
             },
           }}
         />
       );
-
       expect(container.firstChild).toMatchSnapshot();
-      expect(getByTestSubject('customInput')).toBeTruthy();
+
+      const mockChangeEvent = { target: { value: 'changed' } };
+      fireEvent.change(getByTestSubject('customInput'), mockChangeEvent);
+      expect(onChange).toHaveBeenCalled();
+
+      // Consumer `onChange` callbacks should not override EUI's
+      expect(
+        (getByTestSubject('customInput') as HTMLInputElement).value
+      ).toEqual('changed');
     });
 
     test('editModeProps.formRowProps', () => {

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -191,9 +191,16 @@ describe('EuiInlineEditForm', () => {
   });
 
   describe('Toggling between readMode and editMode', () => {
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: Function) => cb());
+
     const onClick = jest.fn();
     const onSave = jest.fn();
-    beforeEach(() => jest.resetAllMocks());
+    beforeEach(() => {
+      onClick.mockReset();
+      onSave.mockReset();
+    });
 
     it('toggles to editMode when the readModeButton is clicked', () => {
       const { getByTestSubject, queryByTestSubject } = render(
@@ -204,8 +211,13 @@ describe('EuiInlineEditForm', () => {
       );
 
       fireEvent.click(getByTestSubject('euiInlineReadModeButton'));
-      expect(getByTestSubject('euiInlineEditModeInput')).toBeTruthy();
+
       expect(queryByTestSubject('euiInlineReadModeButton')).toBeFalsy();
+      waitFor(() => {
+        expect(document.activeElement).toEqual(
+          getByTestSubject('euiInlineEditModeInput')
+        );
+      });
       expect(onClick).toHaveBeenCalledTimes(1);
     });
 
@@ -227,7 +239,11 @@ describe('EuiInlineEditForm', () => {
       ).toEqual('New message!');
       fireEvent.click(getByTestSubject('euiInlineEditModeSaveButton'));
 
-      expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+      waitFor(() => {
+        expect(document.activeElement).toEqual(
+          getByTestSubject('euiInlineReadModeButton')
+        );
+      });
       expect(getByText('New message!')).toBeTruthy();
       expect(onSave).toHaveBeenCalledWith('New message!');
       expect(onClick).toHaveBeenCalledTimes(1);
@@ -251,7 +267,11 @@ describe('EuiInlineEditForm', () => {
       ).toEqual('New message!');
       fireEvent.click(getByTestSubject('euiInlineEditModeCancelButton'));
 
-      expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+      waitFor(() => {
+        expect(document.activeElement).toEqual(
+          getByTestSubject('euiInlineReadModeButton')
+        );
+      });
       expect(getByText('Hello World!')).toBeTruthy();
       expect(onSave).not.toHaveBeenCalled();
       expect(onClick).toHaveBeenCalledTimes(1);
@@ -360,7 +380,11 @@ describe('EuiInlineEditForm', () => {
           key: 'Enter',
         });
 
-        expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+        waitFor(() => {
+          expect(document.activeElement).toEqual(
+            getByTestSubject('euiInlineReadModeButton')
+          );
+        });
         expect(getByText('New message!')).toBeTruthy();
       });
 
@@ -379,7 +403,11 @@ describe('EuiInlineEditForm', () => {
           key: 'Escape',
         });
 
-        expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
+        waitFor(() => {
+          expect(document.activeElement).toEqual(
+            getByTestSubject('euiInlineReadModeButton')
+          );
+        });
         expect(getByText('Hello World!')).toBeTruthy();
       });
 

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -139,11 +139,10 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     'Cancel edit'
   );
 
+  const readModeDescribedById = useGeneratedHtmlId({ prefix: 'inlineEdit' });
   const editModeDescribedById = useGeneratedHtmlId({ prefix: 'inlineEdit' });
 
   const [isEditing, setIsEditing] = useState(false || startWithEditOpen);
-  const inlineEditInputId = useGeneratedHtmlId({ prefix: '__inlineEditInput' });
-
   const [editModeValue, setEditModeValue] = useState(defaultValue);
   const [readModeValue, setReadModeValue] = useState(defaultValue);
 
@@ -187,7 +186,6 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
         >
           <EuiFieldText
             fullWidth
-            id={inlineEditInputId}
             value={editModeValue}
             onChange={(e) => {
               setEditModeValue(e.target.value);
@@ -274,23 +272,35 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   );
 
   const readModeElement = (
-    <EuiButtonEmpty
-      color="text"
-      iconType="pencil"
-      iconSide="right"
-      autoFocus
-      flush="both"
-      iconSize={sizes.iconSize}
-      size={sizes.buttonSize}
-      data-test-subj="euiInlineReadModeButton"
-      {...readModeProps}
-      onClick={(e) => {
-        setIsEditing(true);
-        readModeProps?.onClick?.(e);
-      }}
-    >
-      {children(readModeValue)}
-    </EuiButtonEmpty>
+    <>
+      <EuiButtonEmpty
+        color="text"
+        iconType="pencil"
+        iconSide="right"
+        autoFocus
+        flush="both"
+        iconSize={sizes.iconSize}
+        size={sizes.buttonSize}
+        data-test-subj="euiInlineReadModeButton"
+        {...readModeProps}
+        aria-describedby={classNames(
+          readModeDescribedById,
+          readModeProps?.['aria-describedby']
+        )}
+        onClick={(e) => {
+          setIsEditing(true);
+          readModeProps?.onClick?.(e);
+        }}
+      >
+        {children(readModeValue)}
+      </EuiButtonEmpty>
+      <span id={readModeDescribedById} hidden>
+        <EuiI18n
+          token="euiInlineEditForm.toggleEditModeDescription"
+          default="Click this button to edit this text inline."
+        />
+      </span>
+    </>
   );
 
   return (

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -187,9 +187,6 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
           <EuiFieldText
             fullWidth
             value={editModeValue}
-            onChange={(e) => {
-              setEditModeValue(e.target.value);
-            }}
             aria-label={inputAriaLabel}
             autoFocus
             compressed={sizes.compressed}
@@ -197,14 +194,18 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             isLoading={isLoading}
             data-test-subj="euiInlineEditModeInput"
             {...editModeProps?.inputProps}
+            onChange={(e) => {
+              setEditModeValue(e.target.value);
+              editModeProps?.inputProps?.onChange?.(e);
+            }}
+            onKeyDown={(e) => {
+              editModeInputOnKeyDown(e);
+              editModeProps?.inputProps?.onKeyDown?.(e);
+            }}
             aria-describedby={classNames(
               editModeDescribedById,
               editModeProps?.inputProps?.['aria-describedby']
             )}
-            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-              editModeInputOnKeyDown(e);
-              editModeProps?.inputProps?.onKeyDown?.(e);
-            }}
           />
         </EuiFormRow>
         <span id={editModeDescribedById} hidden>

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -220,6 +220,8 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
       <EuiFlexItem grow={false}>
         <EuiSkeletonLoading
           isLoading={isLoading}
+          announceLoadingStatus={true}
+          announceLoadedStatus={false}
           loadingContent={
             <EuiFlexGroup gutterSize="s">
               <EuiSkeletonRectangle

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -21,7 +21,6 @@ import {
   EuiFormRow,
   EuiFormRowProps,
   EuiFieldText,
-  EuiForm,
   EuiFieldTextProps,
 } from '../form';
 import { euiFormVariables } from '../form/form.styles';
@@ -178,98 +177,94 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   };
 
   const editModeForm = (
-    <EuiForm fullWidth>
-      <EuiFlexGroup gutterSize="s">
-        <EuiFlexItem>
-          <EuiFormRow
+    <EuiFlexGroup gutterSize="s">
+      <EuiFlexItem>
+        <EuiFormRow
+          fullWidth
+          isInvalid={isInvalid}
+          error={isInvalid && editModeProps?.formRowProps?.error}
+          {...editModeProps?.formRowProps}
+        >
+          <EuiFieldText
+            fullWidth
+            id={inlineEditInputId}
+            value={editModeValue}
+            onChange={(e) => {
+              setEditModeValue(e.target.value);
+            }}
+            aria-label={inputAriaLabel}
+            autoFocus
+            compressed={sizes.compressed}
             isInvalid={isInvalid}
-            error={isInvalid && editModeProps?.formRowProps?.error}
-            {...editModeProps?.formRowProps}
-          >
-            <EuiFieldText
-              id={inlineEditInputId}
-              value={editModeValue}
-              onChange={(e) => {
-                setEditModeValue(e.target.value);
-              }}
-              aria-label={inputAriaLabel}
-              autoFocus
-              compressed={sizes.compressed}
-              isInvalid={isInvalid}
-              isLoading={isLoading}
-              data-test-subj="euiInlineEditModeInput"
-              {...editModeProps?.inputProps}
-              aria-describedby={classNames(
-                editModeDescribedById,
-                editModeProps?.inputProps?.['aria-describedby']
-              )}
-              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-                editModeInputOnKeyDown(e);
-                editModeProps?.inputProps?.onKeyDown?.(e);
-              }}
-            />
-          </EuiFormRow>
-          <span id={editModeDescribedById} hidden>
-            <EuiI18n
-              token="euiInlineEditForm.inputKeyboardInstructions"
-              default="Press Enter to save your edited text. Press Escape to cancel your edit."
-            />
-          </span>
-        </EuiFlexItem>
+            isLoading={isLoading}
+            data-test-subj="euiInlineEditModeInput"
+            {...editModeProps?.inputProps}
+            aria-describedby={classNames(
+              editModeDescribedById,
+              editModeProps?.inputProps?.['aria-describedby']
+            )}
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+              editModeInputOnKeyDown(e);
+              editModeProps?.inputProps?.onKeyDown?.(e);
+            }}
+          />
+        </EuiFormRow>
+        <span id={editModeDescribedById} hidden>
+          <EuiI18n
+            token="euiInlineEditForm.inputKeyboardInstructions"
+            default="Press Enter to save your edited text. Press Escape to cancel your edit."
+          />
+        </span>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false} className={classes}>
-          <EuiFormRow>
-            <EuiSkeletonRectangle
-              isLoading={isLoading}
-              height={loadingSkeletonSize}
-              width={loadingSkeletonSize}
-              borderRadius="m"
-            >
-              <EuiButtonIcon
-                iconType="check"
-                aria-label={defaultSaveButtonAriaLabel}
-                color="success"
-                display="base"
-                size={sizes.buttonSize}
-                iconSize={sizes.iconSize}
-                data-test-subj="euiInlineEditModeSaveButton"
-                {...editModeProps?.saveButtonProps}
-                onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                  saveInlineEditValue();
-                  editModeProps?.saveButtonProps?.onClick?.(e);
-                }}
-              />
-            </EuiSkeletonRectangle>
-          </EuiFormRow>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle
+          isLoading={isLoading}
+          height={loadingSkeletonSize}
+          width={loadingSkeletonSize}
+          borderRadius="m"
+        >
+          <EuiButtonIcon
+            iconType="check"
+            aria-label={defaultSaveButtonAriaLabel}
+            color="success"
+            display="base"
+            size={sizes.buttonSize}
+            iconSize={sizes.iconSize}
+            data-test-subj="euiInlineEditModeSaveButton"
+            {...editModeProps?.saveButtonProps}
+            onClick={(e: MouseEvent<HTMLButtonElement>) => {
+              saveInlineEditValue();
+              editModeProps?.saveButtonProps?.onClick?.(e);
+            }}
+          />
+        </EuiSkeletonRectangle>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiFormRow>
-            <EuiSkeletonRectangle
-              isLoading={isLoading}
-              height={loadingSkeletonSize}
-              width={loadingSkeletonSize}
-              borderRadius="m"
-            >
-              <EuiButtonIcon
-                iconType="cross"
-                aria-label={defaultCancelButtonAriaLabel}
-                color="danger"
-                display="base"
-                size={sizes.buttonSize}
-                iconSize={sizes.iconSize}
-                data-test-subj="euiInlineEditModeCancelButton"
-                {...editModeProps?.cancelButtonProps}
-                onClick={(e: MouseEvent<HTMLButtonElement>) => {
-                  cancelInlineEdit();
-                  editModeProps?.cancelButtonProps?.onClick?.(e);
-                }}
-              />
-            </EuiSkeletonRectangle>
-          </EuiFormRow>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiForm>
+      <EuiFlexItem grow={false}>
+        <EuiSkeletonRectangle
+          isLoading={isLoading}
+          height={loadingSkeletonSize}
+          width={loadingSkeletonSize}
+          borderRadius="m"
+        >
+          <EuiButtonIcon
+            iconType="cross"
+            aria-label={defaultCancelButtonAriaLabel}
+            color="danger"
+            display="base"
+            size={sizes.buttonSize}
+            iconSize={sizes.iconSize}
+            data-test-subj="euiInlineEditModeCancelButton"
+            {...editModeProps?.cancelButtonProps}
+            onClick={(e: MouseEvent<HTMLButtonElement>) => {
+              cancelInlineEdit();
+              editModeProps?.cancelButtonProps?.onClick?.(e);
+            }}
+          />
+        </EuiSkeletonRectangle>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 
   const readModeElement = (

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -158,7 +158,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const [editModeValue, setEditModeValue] = useState(defaultValue);
   const [readModeValue, setReadModeValue] = useState(defaultValue);
 
-  const toggleEditMode = () => {
+  const activateEditMode = () => {
     setIsEditing(true);
     // Waits a tick for state to settle and the focus target to render
     requestAnimationFrame(() => editModeFocusRef.current?.focus());
@@ -309,7 +309,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
           readModeProps?.['aria-describedby']
         )}
         onClick={(e: MouseEvent<HTMLButtonElement>) => {
-          toggleEditMode();
+          activateEditMode();
           readModeProps?.onClick?.(e);
         }}
       >
@@ -317,7 +317,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
       </EuiButtonEmpty>
       <span id={readModeDescribedById} hidden>
         <EuiI18n
-          token="euiInlineEditForm.toggleEditModeDescription"
+          token="euiInlineEditForm.activateEditModeDescription"
           default="Click this button to edit this text inline."
         />
       </span>

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -28,7 +28,7 @@ import { EuiButtonIcon, EuiButtonEmpty } from '../button';
 import { EuiButtonIconPropsForButton } from '../button/button_icon';
 import { EuiButtonEmptyPropsForButton } from '../button/button_empty/button_empty';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
-import { EuiSkeletonRectangle } from '../skeleton';
+import { EuiSkeletonLoading, EuiSkeletonRectangle } from '../skeleton';
 import { useEuiTheme, keys } from '../../services';
 import { EuiI18n, useEuiI18n } from '../i18n';
 import { useGeneratedHtmlId } from '../../services/accessibility';
@@ -218,51 +218,55 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>
-        <EuiSkeletonRectangle
+        <EuiSkeletonLoading
           isLoading={isLoading}
-          height={loadingSkeletonSize}
-          width={loadingSkeletonSize}
-          borderRadius="m"
-        >
-          <EuiButtonIcon
-            iconType="check"
-            aria-label={defaultSaveButtonAriaLabel}
-            color="success"
-            display="base"
-            size={sizes.buttonSize}
-            iconSize={sizes.iconSize}
-            data-test-subj="euiInlineEditModeSaveButton"
-            {...editModeProps?.saveButtonProps}
-            onClick={(e: MouseEvent<HTMLButtonElement>) => {
-              saveInlineEditValue();
-              editModeProps?.saveButtonProps?.onClick?.(e);
-            }}
-          />
-        </EuiSkeletonRectangle>
-      </EuiFlexItem>
-
-      <EuiFlexItem grow={false}>
-        <EuiSkeletonRectangle
-          isLoading={isLoading}
-          height={loadingSkeletonSize}
-          width={loadingSkeletonSize}
-          borderRadius="m"
-        >
-          <EuiButtonIcon
-            iconType="cross"
-            aria-label={defaultCancelButtonAriaLabel}
-            color="danger"
-            display="base"
-            size={sizes.buttonSize}
-            iconSize={sizes.iconSize}
-            data-test-subj="euiInlineEditModeCancelButton"
-            {...editModeProps?.cancelButtonProps}
-            onClick={(e: MouseEvent<HTMLButtonElement>) => {
-              cancelInlineEdit();
-              editModeProps?.cancelButtonProps?.onClick?.(e);
-            }}
-          />
-        </EuiSkeletonRectangle>
+          loadingContent={
+            <EuiFlexGroup gutterSize="s">
+              <EuiSkeletonRectangle
+                height={loadingSkeletonSize}
+                width={loadingSkeletonSize}
+                borderRadius="m"
+              />
+              <EuiSkeletonRectangle
+                height={loadingSkeletonSize}
+                width={loadingSkeletonSize}
+                borderRadius="m"
+              />
+            </EuiFlexGroup>
+          }
+          loadedContent={
+            <EuiFlexGroup gutterSize="s">
+              <EuiButtonIcon
+                iconType="check"
+                aria-label={defaultSaveButtonAriaLabel}
+                color="success"
+                display="base"
+                size={sizes.buttonSize}
+                iconSize={sizes.iconSize}
+                data-test-subj="euiInlineEditModeSaveButton"
+                {...editModeProps?.saveButtonProps}
+                onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                  saveInlineEditValue();
+                  editModeProps?.saveButtonProps?.onClick?.(e);
+                }}
+              />
+              <EuiButtonIcon
+                iconType="cross"
+                aria-label={defaultCancelButtonAriaLabel}
+                color="danger"
+                display="base"
+                size={sizes.buttonSize}
+                iconSize={sizes.iconSize}
+                data-test-subj="euiInlineEditModeCancelButton"
+                {...editModeProps?.cancelButtonProps}
+                onClick={(e: MouseEvent<HTMLButtonElement>) => {
+                  cancelInlineEdit();
+                  editModeProps?.cancelButtonProps?.onClick?.(e);
+                }}
+              />
+            </EuiFlexGroup>
+          }
+        />
       </EuiFlexItem>
     </EuiFlexGroup>
   );


### PR DESCRIPTION
## Summary

This PR originally started as just screen reader improvements to the `isLoading` state and then I ended up doing a bunch of other misc cleanup and fixes 😅 I recommend checking individual commit messages for details and reasonings behind changes:

- DOM cleanup: 894da9a0a65065913f2ef8027cdab8f615e92915
- `isLoading` screen reader UX improvement:
  - d1b75f98f345af03389e787ff39368b89883517d
  - 76e04a49d4e416439bf37d2ff3839c7a484cb81c
- Read mode screen reader UX improvement: ac19b54e97354398ccbcc849e6cad54ea9f6c54d
- `onChange` bugfix: a5001a7a371a67591fb0cb975c47140ddf1004ca
- `autoFocus` fix: a236a56177674bbffdcf44678987bb8ff9f59d1f

## QA

- Go to http://localhost:8030/#/display/inline-edit#validating-edited-text
- Start VoiceOver
- Tab to the inline edit read mode button (for the Validation example specifically)
- [x] Confirm that the button accurately describes what will happen on click
- Press enter to toggle edit mode
- [x] Confirm your screen reader does not read out "Loaded" 2x (compare against [staging](https://eui.elastic.co/pr_6743/#/display/inline-edit))
- Tab to and press enter on the save button.
- [x] Confirm that your screen reader reads out a "Loading" status (validation example only)

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ Skipped this for the new EuiSkeleton components - the API is fairly edge case, and I think the props docs sufficiently covers usage