### PR TITLE
[EuiSkeleton] Add new props that allow for more screen reader control

### DIFF
--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 import {
@@ -7,6 +8,7 @@ import {
   EuiSkeletonRectangle,
   EuiSkeletonCircle,
   EuiSkeletonLoading,
+  EuiScreenReaderLive,
   EuiText,
   EuiSpacer,
   EuiCallOut,
@@ -68,6 +70,15 @@ const skeletonLoadingSnippet = `<EuiSkeletonLoading
       {/* Equivalent loaded content */}
     </>
   }
+/>`;
+
+import SkeletonLiveProps from './skeleton_live_props';
+const skeletonLivePropsSource = require('!!raw-loader!./skeleton_live_props');
+const skeletonLivePropsSnippet = `<EuiSkeletonText
+  announceLoadingStatus={true}
+  announceLoadedStatus={false}
+  ariaLiveProps={ariaLiveProps}
+  contentAriaLabel="Example text"
 />`;
 
 export const SkeletonExample = {
@@ -221,6 +232,43 @@ export const SkeletonExample = {
       props: { EuiSkeletonLoading },
       snippet: skeletonLoadingSnippet,
       demo: <SkeletonLoading />,
+    },
+    {
+      title: 'Customizing screen reader announcements',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: skeletonLivePropsSource,
+        },
+      ],
+      text: (
+        <EuiText>
+          <p>
+            <strong>EuiSkeleton</strong> components assume that the page starts
+            as loading and transitions to loaded, and the default screen reader
+            experience is set up accordingly (
+            <EuiCode>announceLoadedStatus={'{true}'}</EuiCode>).
+          </p>
+          <p>
+            In scenarios where that is not the case (i.e., transitioning to
+            loading), you can customize what statuses are announced to screen
+            readers by setting <EuiCode>announceLoadingStatus</EuiCode> to true,
+            or <EuiCode>announceLoadedStatus</EuiCode> to false. Submitting the
+            below example announces a loading status, but not a loaded status.
+          </p>
+          <p>
+            As an optional escape hatch, <EuiCode>ariaLiveProps</EuiCode> is
+            also available and accepts any{' '}
+            <Link to="/utilities/accessibility#screen-reader-live-region">
+              <strong>EuiScreenReaderLive</strong>
+            </Link>{' '}
+            props.
+          </p>
+        </EuiText>
+      ),
+      props: { EuiSkeletonLoading, EuiScreenReaderLive },
+      snippet: skeletonLivePropsSnippet,
+      demo: <SkeletonLiveProps />,
     },
   ],
 };

--- a/src-docs/src/views/skeleton/skeleton_live_props.tsx
+++ b/src-docs/src/views/skeleton/skeleton_live_props.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+
+import {
+  EuiSkeletonLoading,
+  EuiSkeletonRectangle,
+  EuiFieldText,
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  useEuiTheme,
+} from '../../../../src';
+
+export default () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const simulateLoading = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 3000);
+  };
+
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <EuiSkeletonLoading
+        isLoading={isLoading}
+        announceLoadedStatus={false} // Prevents unnecessary announcement on page load
+        announceLoadingStatus={true} // Announces on submit
+        ariaLiveProps={{ role: 'alert' }} // Allows customizing the aria-live region
+        contentAriaLabel="Demo form"
+        loadingContent={
+          <EuiSkeletonRectangle width="100%" height={euiTheme.size.xxl} />
+        }
+        loadedContent={
+          <form onSubmit={simulateLoading}>
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem>
+                <EuiFieldText
+                  fullWidth
+                  aria-label="Input that transitions to loading"
+                  defaultValue="Replaced with a loading skeleton on submit"
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton type="submit" fill>
+                  Submit
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton>Cancel</EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </form>
+        }
+      />
+    </>
+  );
+};

--- a/src/components/skeleton/__snapshots__/skeleton_loading.test.tsx.snap
+++ b/src/components/skeleton/__snapshots__/skeleton_loading.test.tsx.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiSkeletonLoading aria-live behavior announceLoadedStatus - allows turning off live announcements 1`] = `
+<div
+  aria-busy="false"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <span
+    data-test-subj="loaded"
+  />
+</div>
+`;
+
+exports[`EuiSkeletonLoading aria-live behavior announceLoadingStatus - allows enabling live announcements 1`] = `
+<div
+  aria-busy="true"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    class="emotion-euiScreenReaderOnly"
+  >
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      role="status"
+    >
+      Loading Sample user data
+    </div>
+    <div
+      aria-atomic="true"
+      aria-hidden="true"
+      aria-live="off"
+      role="status"
+    />
+  </div>
+  <span
+    aria-label="Loading Sample user data"
+    data-test-subj="loading"
+    role="progressbar"
+  />
+</div>
+`;
+
+exports[`EuiSkeletonLoading aria-live behavior ariaLiveProps 1`] = `
+<div
+  aria-busy="false"
+  data-test-subj="euiSkeletonLoadingAriaWrapper"
+>
+  <div
+    class="emotion-euiScreenReaderOnly"
+  >
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      role="alert"
+    >
+      Loaded Sample user data
+    </div>
+    <div
+      aria-atomic="true"
+      aria-hidden="true"
+      aria-live="off"
+      role="alert"
+    />
+  </div>
+  <span
+    data-test-subj="loaded"
+  />
+</div>
+`;
+
 exports[`EuiSkeletonLoading renders \`loadedContent\` when \`isLoading\` is false 1`] = `
 <div
   aria-busy="false"

--- a/src/components/skeleton/skeleton_circle.tsx
+++ b/src/components/skeleton/skeleton_circle.tsx
@@ -29,6 +29,9 @@ export const EuiSkeletonCircle: FunctionComponent<EuiSkeletonCircleProps> = ({
   size = 'm',
   className,
   contentAriaLabel,
+  announceLoadingStatus,
+  announceLoadedStatus,
+  ariaLiveProps,
   ariaWrapperProps,
   children,
   ...rest
@@ -49,6 +52,9 @@ export const EuiSkeletonCircle: FunctionComponent<EuiSkeletonCircleProps> = ({
       }
       loadedContent={children || ''}
       contentAriaLabel={contentAriaLabel}
+      announceLoadingStatus={announceLoadingStatus}
+      announceLoadedStatus={announceLoadedStatus}
+      ariaLiveProps={ariaLiveProps}
       {...ariaWrapperProps}
     />
   );

--- a/src/components/skeleton/skeleton_loading.test.tsx
+++ b/src/components/skeleton/skeleton_loading.test.tsx
@@ -43,4 +43,41 @@ describe('EuiSkeletonLoading', () => {
     expect(queryByTestSubject('loaded')).toBeTruthy();
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  describe('aria-live behavior', () => {
+    test('announceLoadingStatus - allows enabling live announcements', () => {
+      const { container, getByText } = render(
+        <EuiSkeletonLoading {...contentProps} announceLoadingStatus={true} />
+      );
+
+      expect(getByText('Loading Sample user data')).toBeTruthy();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('announceLoadedStatus - allows turning off live announcements', () => {
+      const { container, queryByText } = render(
+        <EuiSkeletonLoading
+          {...contentProps}
+          isLoading={false}
+          announceLoadedStatus={false}
+        />
+      );
+
+      expect(queryByText('Loaded Sample user data')).toBeFalsy();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('ariaLiveProps', () => {
+      const { container, getByRole } = render(
+        <EuiSkeletonLoading
+          {...contentProps}
+          isLoading={false}
+          ariaLiveProps={{ role: 'alert' }}
+        />
+      );
+
+      expect(getByRole('alert')).toBeTruthy();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/skeleton/skeleton_rectangle.tsx
+++ b/src/components/skeleton/skeleton_rectangle.tsx
@@ -35,6 +35,9 @@ export const EuiSkeletonRectangle: FunctionComponent<EuiSkeletonRectangleProps> 
   style,
   className,
   contentAriaLabel,
+  announceLoadingStatus,
+  announceLoadedStatus,
+  ariaLiveProps,
   ariaWrapperProps,
   children,
   ...rest
@@ -56,6 +59,9 @@ export const EuiSkeletonRectangle: FunctionComponent<EuiSkeletonRectangleProps> 
       }
       loadedContent={children || ''}
       contentAriaLabel={contentAriaLabel}
+      announceLoadingStatus={announceLoadingStatus}
+      announceLoadedStatus={announceLoadedStatus}
+      ariaLiveProps={ariaLiveProps}
       {...ariaWrapperProps}
     />
   );

--- a/src/components/skeleton/skeleton_text.tsx
+++ b/src/components/skeleton/skeleton_text.tsx
@@ -38,6 +38,9 @@ export const EuiSkeletonText: FunctionComponent<EuiSkeletonTextProps> = ({
   size = 'm',
   className,
   contentAriaLabel,
+  announceLoadingStatus,
+  announceLoadedStatus,
+  ariaLiveProps,
   ariaWrapperProps,
   children,
   ...rest
@@ -61,6 +64,9 @@ export const EuiSkeletonText: FunctionComponent<EuiSkeletonTextProps> = ({
       }
       loadedContent={children || ''}
       contentAriaLabel={contentAriaLabel}
+      announceLoadingStatus={announceLoadingStatus}
+      announceLoadedStatus={announceLoadedStatus}
+      ariaLiveProps={ariaLiveProps}
       {...ariaWrapperProps}
     />
   );

--- a/src/components/skeleton/skeleton_title.tsx
+++ b/src/components/skeleton/skeleton_title.tsx
@@ -30,6 +30,9 @@ export const EuiSkeletonTitle: FunctionComponent<EuiSkeletonTitleProps> = ({
   size = 'm',
   className,
   contentAriaLabel,
+  announceLoadingStatus,
+  announceLoadedStatus,
+  ariaLiveProps,
   ariaWrapperProps,
   children,
   ...rest
@@ -50,6 +53,9 @@ export const EuiSkeletonTitle: FunctionComponent<EuiSkeletonTitleProps> = ({
       }
       loadedContent={children || ''}
       contentAriaLabel={contentAriaLabel}
+      announceLoadingStatus={announceLoadingStatus}
+      announceLoadedStatus={announceLoadedStatus}
+      ariaLiveProps={ariaLiveProps}
       {...ariaWrapperProps}
     />
   );

--- a/upcoming_changelogs/6752.md
+++ b/upcoming_changelogs/6752.md
@@ -1,0 +1,1 @@
+- Updated all `EuiSkeleton` components with new props that allow for more control over screen reader live announcements: `announceLoadingStatus`, `announceLoadedStatus`, and `ariaLiveProps`


### PR DESCRIPTION
## Summary

![screencap](https://user-images.githubusercontent.com/549407/236004467-cf68384d-d904-4319-9345-376471f75842.gif)

When using `EuiSkeletonRectangle` in the new EuiInlineEdit component, I realized we need more customization around when loading/loaded announcements were made. These new props (hopefully) solve that issue:

- `announceLoadingStatus` (defaults to false)
- `announceLoadedStatus` (defaults to true)
- `ariaLiveProps` (escape hatch props passthrough to the underlying `aria-live` region - allows setting role, or conditionally turning off the `aria-live`, etc)

I'm aiming to ship these new props alongside the deprecation/removal of `EuiLoadingContent` to smooth over the transition.

## QA

- Go to https://eui.elastic.co/pr_6752/#/display/skeleton#customizing-screen-reader-announcements and test with a screen reader

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~