### PR TITLE
[EuiPageHeader] `rightSideItems` Update DOM to Match Display Order

### DIFF
--- a/src-docs/src/views/page_header/page_header.tsx
+++ b/src-docs/src/views/page_header/page_header.tsx
@@ -11,5 +11,6 @@ export default () => (
       <EuiButton fill>Add something</EuiButton>,
       <EuiButton>Do something</EuiButton>,
     ]}
+    responsive="reverse"
   />
 );

--- a/src-docs/src/views/page_header/page_header.tsx
+++ b/src-docs/src/views/page_header/page_header.tsx
@@ -11,6 +11,5 @@ export default () => (
       <EuiButton fill>Add something</EuiButton>,
       <EuiButton>Do something</EuiButton>,
     ]}
-    responsive="reverse"
   />
 );

--- a/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -93,14 +93,14 @@ exports[`EuiPageHeader props alignItems center is rendered 1`] = `
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 1
+              Button 2
             </button>
           </div>
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 2
+              Button 1
             </button>
           </div>
         </div>
@@ -185,14 +185,14 @@ exports[`EuiPageHeader props alignItems top is rendered 1`] = `
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 1
+              Button 2
             </button>
           </div>
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 2
+              Button 1
             </button>
           </div>
         </div>

--- a/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -41,20 +41,20 @@ exports[`EuiPageHeader props alignItems bottom is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 1
+              Button 2
             </button>
           </div>
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 2
+              Button 1
             </button>
           </div>
         </div>
@@ -87,7 +87,7 @@ exports[`EuiPageHeader props alignItems center is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
@@ -133,20 +133,20 @@ exports[`EuiPageHeader props alignItems stretch is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 1
+              Button 2
             </button>
           </div>
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 2
+              Button 1
             </button>
           </div>
         </div>
@@ -179,7 +179,7 @@ exports[`EuiPageHeader props alignItems top is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-growZero"
       >
         <div
-          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+          class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
@@ -362,21 +362,21 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
       >
         <div
           aria-label="aria-label"
-          class="euiFlexGroup testClass1 testClass2 emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-rowReverse"
+          class="euiFlexGroup testClass1 testClass2 emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row"
           data-test-subj="test subject string"
         >
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 1
+              Button 2
             </button>
           </div>
           <div
             class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button>
-              Button 2
+              Button 1
             </button>
           </div>
         </div>

--- a/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -84,14 +84,14 @@ exports[`EuiPageHeaderContent props alignItems center is rendered 1`] = `
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>
@@ -168,14 +168,14 @@ exports[`EuiPageHeaderContent props alignItems top is rendered 1`] = `
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>
@@ -544,14 +544,14 @@ exports[`EuiPageHeaderContent props rightSideItems is rendered with rightSideGro
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>

--- a/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -36,20 +36,20 @@ exports[`EuiPageHeaderContent props alignItems bottom is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-growZero"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>
@@ -78,7 +78,7 @@ exports[`EuiPageHeaderContent props alignItems center is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-growZero"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
@@ -120,20 +120,20 @@ exports[`EuiPageHeaderContent props alignItems stretch is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-growZero"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>
@@ -162,7 +162,7 @@ exports[`EuiPageHeaderContent props alignItems top is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-growZero"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
@@ -321,20 +321,20 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
       class="euiFlexItem emotion-euiFlexItem-growZero"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>
@@ -500,20 +500,20 @@ exports[`EuiPageHeaderContent props rightSideItems is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-growZero"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-rowReverse"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 1
+            Button 2
           </button>
         </div>
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero"
         >
           <button>
-            Button 2
+            Button 1
           </button>
         </div>
       </div>

--- a/src/components/page/page_header/page_header_content.tsx
+++ b/src/components/page/page_header/page_header_content.tsx
@@ -344,25 +344,34 @@ export const EuiPageHeaderContent: FunctionComponent<EuiPageHeaderContentProps> 
 
   let rightSideFlexItem;
   if (rightSideItems && rightSideItems.length) {
-    const wrapWithFlex = () => {
-      return rightSideItems.map((item, index) => {
-        return (
-          <EuiFlexItem grow={false} key={index}>
-            {item}
-          </EuiFlexItem>
-        );
-      });
+    const wrapWithFlex = (reverse: boolean) => {
+      const reverseRightSideItems = reverse
+        ? rightSideItems.reverse()
+        : undefined;
+
+      if (reverseRightSideItems) {
+        return reverseRightSideItems.map((item, index) => {
+          return (
+            <EuiFlexItem grow={false} key={index}>
+              {item}
+            </EuiFlexItem>
+          );
+        });
+      } else {
+        return rightSideItems.map((item, index) => {
+          return (
+            <EuiFlexItem grow={false} key={index}>
+              {item}
+            </EuiFlexItem>
+          );
+        });
+      }
     };
 
     rightSideFlexItem = (
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup
-          wrap
-          responsive={false}
-          direction={isResponsiveBreakpoint ? undefined : 'rowReverse'}
-          {...rightSideGroupProps}
-        >
-          {wrapWithFlex()}
+        <EuiFlexGroup wrap responsive={false} {...rightSideGroupProps}>
+          {wrapWithFlex(isResponsiveBreakpoint ? false : true)}
         </EuiFlexGroup>
       </EuiFlexItem>
     );

--- a/src/components/page/page_header/page_header_content.tsx
+++ b/src/components/page/page_header/page_header_content.tsx
@@ -345,27 +345,15 @@ export const EuiPageHeaderContent: FunctionComponent<EuiPageHeaderContentProps> 
   let rightSideFlexItem;
   if (rightSideItems && rightSideItems.length) {
     const wrapWithFlex = (reverse: boolean) => {
-      const reverseRightSideItems = reverse
-        ? rightSideItems.reverse()
-        : undefined;
+      const itemsToRender = reverse
+        ? [...rightSideItems].reverse()
+        : rightSideItems;
 
-      if (reverseRightSideItems) {
-        return reverseRightSideItems.map((item, index) => {
-          return (
-            <EuiFlexItem grow={false} key={index}>
-              {item}
-            </EuiFlexItem>
-          );
-        });
-      } else {
-        return rightSideItems.map((item, index) => {
-          return (
-            <EuiFlexItem grow={false} key={index}>
-              {item}
-            </EuiFlexItem>
-          );
-        });
-      }
+      return itemsToRender.map((item, index) => (
+        <EuiFlexItem grow={false} key={index}>
+          {item}
+        </EuiFlexItem>
+      ));
     };
 
     rightSideFlexItem = (

--- a/upcoming_changelogs/6753.md
+++ b/upcoming_changelogs/6753.md
@@ -1,2 +1,2 @@
-- Improved accessibility in `EuiPageHeader` by ensuring the right side menu items come into focus from left to right. 
+- Improved keyboard accessibility in `EuiPageHeader` by ensuring the right side menu items come into focus from left to right. 
 

--- a/upcoming_changelogs/6753.md
+++ b/upcoming_changelogs/6753.md
@@ -1,0 +1,2 @@
+- Improved accessibility in `EuiPageHeader` by ensuring the right side menu items come into focus from left to right. 
+


### PR DESCRIPTION
Fixes #6693

## Summary
EuiPageHeader [intentionally sets the content of the header](https://github.com/elastic/eui/blob/f7a86007ac173e113af8a3797ebbdaa0cf09443f/src/components/page/page_header/page_header_content.tsx#L362) to have a flex-direction of row-reverse. This is causing the last element of the within the array of items to catch focus first (via screenreader and keyboard).

This PR takes the responsibility of display order away from `flex`. Instead, the array is cloned and reversed so that the DOM matches the display order. Now, when accessed by keyboard, the first element in the list catches focus first. 

<details>
     <summary> Before & After </summary>
     <br/>

https://user-images.githubusercontent.com/40739624/236049754-9871a1d8-bc89-4950-868f-f9800b4a2b5f.mov

https://user-images.githubusercontent.com/40739624/236049759-e73a3fef-8fbf-4358-b1bd-9ca1516e743f.mov

</details>


## QA
View the [Page Header component](https://eui.elastic.co/pr_6753/#/layout/page-header) in the PR preview. Use a keyboard to navigate the examples. For each, the `Do Something` button should catch focus before the `Add Something`

### General checklist
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
