### PR TITLE
[EuiFieldNumber] Update native validity state on blur & report/surface native validation messages

### DIFF
--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -52,6 +52,14 @@ describe('EuiFieldNumber', () => {
       checkIsInvalid();
     });
 
+    it('shows invalid state on blur', () => {
+      cy.mount(<EuiFieldNumber max={1} value={2} />);
+      checkIsValid();
+      cy.get('input').click();
+      cy.get('body').click('bottomRight');
+      checkIsInvalid();
+    });
+
     // TODO: Consider adding a Cypress visual snapshot/diff plugin here
     // to confirm that the native browser validity report displays as expected
   });

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -51,5 +51,8 @@ describe('EuiFieldNumber', () => {
       cy.get('input').click().type('2');
       checkIsInvalid();
     });
+
+    // TODO: Consider adding a Cypress visual snapshot/diff plugin here
+    // to confirm that the native browser validity report displays as expected
   });
 });

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -77,6 +77,16 @@ export type EuiFieldNumberProps = Omit<
      * @default false
      */
     compressed?: boolean;
+
+    /**
+     * By default, native browser invalidity messages will be reported on user input
+     * (e.g., if consumers exceed the set `min` or `max` range, or do not match `step` increments).
+     * These messages are displayed via the browser `reportValidity` API.
+     *
+     * If you would prefer to use your own error messaging, set this flag to `false`.
+     * @default true
+     */
+    reportNativeInvalidity?: boolean;
   };
 
 export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
@@ -102,6 +112,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     readOnly,
     controlOnly,
     onKeyUp: _onKeyUp,
+    reportNativeInvalidity = true,
     ...rest
   } = props;
 
@@ -119,12 +130,17 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       _onKeyUp?.(e);
 
-      const { validity } = e.target as HTMLInputElement;
       // Prefer `undefined` over `false` so that the `aria-invalid` prop unsets completely
-      const isInvalid = !validity.valid || undefined;
+      const isInvalid = !e.currentTarget.validity.valid || undefined;
       setIsNativelyInvalid(isInvalid);
+
+      // Some browser (i.e. Safari) don't make their native error messages visible -
+      // the `reportValidity` API more clearly surfaces these messages
+      if (isInvalid && reportNativeInvalidity) {
+        e.currentTarget.reportValidity();
+      }
     },
-    [_onKeyUp]
+    [_onKeyUp, reportNativeInvalidity]
   );
 
   const numIconsClass = controlOnly


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6747

As @dej611 noted in the linked issue, several browsers (namely Safari) do a really poor job of surfacing their native validity messages, meaning that we're rendering inputs as invalid/with a scary warning icon without actually telling users why.

The native browser way of handling this would be to use the [reportValidity](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/reportValidity) API, which renders minimally intrusive browser tooltips with the native error messages, without requiring a hover action from users.

If consumers would prefer to [render their own error messages](https://codesandbox.io/s/hungry-cerf-m14fpn?file=/demo.js) via `<EuiFormRow error={}>`, they can do so and turn off the browser-level invalid reports via `reportNativeInvalidity={false}`.

### Chrome/Edge:
![edge](https://user-images.githubusercontent.com/549407/236948853-4bc6acbc-cd5d-4e9e-9630-3f1c7b9ab7e0.gif)

### Firefox:
![firefox](https://user-images.githubusercontent.com/549407/236948297-c32cf98e-35a4-46f3-a1ba-a8c8c2a2fbf9.gif)

### Safari
(Safari's validation is still kinda garbage but a bit better than before)
![safari](https://user-images.githubusercontent.com/549407/236948857-5fa7c988-e73d-4f60-a7ae-7a3b03e59870.gif)

## QA

### General checklist

- [x] Checked in both **light and dark** modes (_native browser reporting follows system darkmode, not EUI darkmode_)
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
