### PR TITLE
[EuiFieldNumber] Default to `step="any"` and check native validity on blur

### DIFF
--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -346,7 +346,6 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
           >
             <input
               aria-describedby="generated-id generated-id"
-              aria-invalid="false"
               aria-label="Refresh interval value"
               class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
               data-test-subj="superDatePickerRefreshIntervalInput"

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
               aria-describedby="generated-id generated-id"
               aria-label="Time value"
               class="euiFieldNumber euiFieldNumber--compressed"
+              step="any"
               type="number"
               value="15"
             />
@@ -350,6 +351,7 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
               class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
               data-test-subj="superDatePickerRefreshIntervalInput"
               disabled=""
+              step="any"
               type="number"
               value="0"
             />

--- a/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`EuiFieldNumber props controlOnly is rendered 1`] = `
 <eui-validatable-control>
   <input
     class="euiFieldNumber"
+    step="any"
     type="number"
     value=""
   />
@@ -44,6 +45,7 @@ exports[`EuiFieldNumber props fullWidth is rendered 1`] = `
   <eui-validatable-control>
     <input
       class="euiFieldNumber euiFieldNumber--fullWidth"
+      step="any"
       type="number"
       value=""
     />
@@ -64,6 +66,7 @@ exports[`EuiFieldNumber props isInvalid is rendered from a prop 1`] = `
     <input
       aria-invalid="true"
       class="euiFieldNumber euiFormControlLayout--1icons"
+      step="any"
       type="number"
       value=""
     />
@@ -80,6 +83,7 @@ exports[`EuiFieldNumber props isLoading is rendered 1`] = `
   <eui-validatable-control>
     <input
       class="euiFieldNumber euiFormControlLayout--1icons euiFieldNumber-isLoading"
+      step="any"
       type="number"
       value=""
     />
@@ -98,6 +102,7 @@ exports[`EuiFieldNumber props readOnly is rendered 1`] = `
     <input
       class="euiFieldNumber"
       readonly=""
+      step="any"
       type="number"
       value=""
     />
@@ -114,6 +119,7 @@ exports[`EuiFieldNumber props value no initial value 1`] = `
   <eui-validatable-control>
     <input
       class="euiFieldNumber"
+      step="any"
       type="number"
       value=""
     />
@@ -130,6 +136,7 @@ exports[`EuiFieldNumber props value value is number 1`] = `
   <eui-validatable-control>
     <input
       class="euiFieldNumber"
+      step="any"
       type="number"
       value="0"
     />

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -59,5 +59,12 @@ describe('EuiFieldNumber', () => {
       cy.get('body').click('bottomRight');
       checkIsInvalid();
     });
+
+    it('does not show invalid state on decimal values by default', () => {
+      cy.mount(<EuiFieldNumber />);
+      checkIsValid();
+      cy.get('input').click().type('1.5');
+      checkIsValid();
+    });
   });
 });

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -51,5 +51,13 @@ describe('EuiFieldNumber', () => {
       cy.get('input').click().type('2');
       checkIsInvalid();
     });
+
+    it('shows invalid state on blur', () => {
+      cy.mount(<EuiFieldNumber max={1} value={2} />);
+      checkIsValid();
+      cy.get('input').click();
+      cy.get('body').click('bottomRight');
+      checkIsInvalid();
+    });
   });
 });

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -48,8 +48,9 @@ export type EuiFieldNumberProps = Omit<
     max?: number;
     /**
      * Specifies the granularity that the value must adhere to.
-     * Accepts a `number` or the string `'any'` for no stepping to allow for any value.
-     * Defaults to `1`
+     * Accepts a `number`, e.g. `1` for integers, or `0.5` for decimal steps.
+     * Defaults to `"any"` for no stepping, which allows any decimal value(s).
+     * @default "any"
      */
     step?: number | 'any';
     inputRef?: Ref<HTMLInputElement>;
@@ -91,6 +92,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     name,
     min,
     max,
+    step = 'any',
     value,
     isInvalid,
     fullWidth = defaultFullWidth,
@@ -140,9 +142,10 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
       <input
         type="number"
         id={id}
+        name={name}
         min={min}
         max={max}
-        name={name}
+        step={step}
         value={value}
         placeholder={placeholder}
         readOnly={readOnly}

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -151,7 +151,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
         readOnly={readOnly}
         className={classes}
         ref={inputRef}
-        aria-invalid={isInvalid == null ? isNativelyInvalid : isInvalid}
+        aria-invalid={isInvalid || isNativelyInvalid}
         onKeyUp={(e) => {
           // Note that we can't use `onChange` because browsers don't emit change events
           // for invalid text - see https://github.com/facebook/react/issues/16554

--- a/src/components/form/range/__snapshots__/range_input.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range_input.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`EuiRangeInput renders 1`] = `
       class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
       max="100"
       min="0"
+      step="any"
       style="inline-size: calc(12px + 1ch + 2em + 0px);"
       type="number"
       value="0"

--- a/upcoming_changelogs/6760.md
+++ b/upcoming_changelogs/6760.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- `EuiFieldNumber` now defaults the `step` prop to `"any"`


### PR DESCRIPTION
## Summary

This PR is a follow-up to our existing EuiFieldNumber enhancement that added detection of native browser invalidity (https://github.com/elastic/eui/pull/6741, https://github.com/elastic/eui/commit/37c35ea5ebfea0a069396207767dba65403e809b).

Specifically, this PR is meant to address a comment left in a Kibana upgrade: https://github.com/elastic/kibana/pull/155208#issuecomment-1531455336.

## Problem

Initially I thought the `:invalid` issue on `EuiFieldNumbers` intended for decimal usage was already a problem beforehand. As it turns out, it had **not** been a visual problem because

1. On blur, `<input type="number">`s with an undefined step **update their validity status** to accept the decimal as valid (default browser behavior). Screencap of said behavior:
    ![screencap](https://github.com/elastic/eui/assets/549407/bb4544b8-857b-4670-b42c-10228030dd1a)

3. Our `:focus` styles (blue underline) were taking precedence over the `:invalid` styles (red underline) and as such the invalid styling was never actually visible for decimal inputs. When we added the icon, the "invalid" state suddenly became visible. And then on blur, both focus and invalid styles would go away 💀 

## Solution

This PR smooths out UX issues around the `step` behavior for number inputs that contain decimals by defaulting to `step="any"`. After discussing and talking through the default browser behavior with @ryankeairns and @1Copenut, we determined that while EUI normally prefers to stick as close to browser implementation as possible, in this case the browser implementation felt clunky and bad, and this was clearly a case where changing the default would result in significant UX improvement.

Note that with `step="any"`, the stepper increment/decrement still defaults to `1` which is the same behavior as before.

This PR also adds the native validity check to `onBlur` as well, since browsers do apparently use that event (as well as change/keyup) to determine validity.

## QA

- Go to https://eui.elastic.co/pr_6760/#/forms/form-controls#number-field and type in a long float/decimal
- [x] Confirm no invalid icon appears while typing
- [x] Use the default browser stepper arrows and confirm they still increment/decrement by `1`

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
