### PR TITLE
[EuiSitewideSearch] Increase Color Contrast on Meta Labels to Meet WCAG 4.5 Contrast Ratio

### DIFF
--- a/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
+++ b/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
@@ -164,7 +164,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'Visualization',
-        type: 'deployment',
+        type: 'application',
       },
     ],
   },
@@ -176,7 +176,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'Dashboard',
-        type: 'article',
+        type: 'application',
         highlightSearchString: true,
       },
     ],
@@ -186,7 +186,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'TSVB visualization',
-        type: 'case',
+        type: 'application',
       },
     ],
   },
@@ -198,7 +198,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'Discover',
-        type: 'platform',
+        type: 'application',
       },
     ],
   },

--- a/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
+++ b/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
@@ -164,7 +164,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'Visualization',
-        type: 'application',
+        type: 'deployment',
       },
     ],
   },
@@ -176,7 +176,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'Dashboard',
-        type: 'application',
+        type: 'article',
         highlightSearchString: true,
       },
     ],
@@ -186,7 +186,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'TSVB visualization',
-        type: 'application',
+        type: 'case',
       },
     ],
   },
@@ -198,7 +198,7 @@ const searchData: EuiSelectableTemplateSitewideOption[] = [
     meta: [
       {
         text: 'Discover',
-        type: 'application',
+        type: 'platform',
       },
     ],
   },

--- a/src/components/selectable/selectable_templates/_variables.scss
+++ b/src/components/selectable/selectable_templates/_variables.scss
@@ -1,22 +1,25 @@
+// The $euiFocusBackgroundColor without the alpha channel
+$euiSelectableTemplateFocusBackground: rgb(232, 241, 250);
+
 $euiSelectableTemplateSitewideTypes: (
   'application': (
-    'color': makeHighContrastColor($euiColorVis1),
+    'color': makeHighContrastColor($euiColorVis1, $euiSelectableTemplateFocusBackground),
     'font-weight': $euiFontWeightMedium,
   ),
   'deployment': (
-    'color': makeHighContrastColor($euiColorVis0),
+    'color': makeHighContrastColor($euiColorVis0, $euiSelectableTemplateFocusBackground),
     'font-weight': $euiFontWeightMedium,
   ),
   'article': (
-    'color': makeHighContrastColor($euiColorVis3),
+    'color': makeHighContrastColor($euiColorVis3, $euiSelectableTemplateFocusBackground),
     'font-weight': $euiFontWeightMedium,
   ),
   'case': (
-    'color': makeHighContrastColor($euiColorVis9),
+    'color': makeHighContrastColor($euiColorVis9, $euiSelectableTemplateFocusBackground),
     'font-weight': $euiFontWeightMedium,
   ),
   'platform': (
-    'color': makeHighContrastColor($euiColorVis5),
+    'color': makeHighContrastColor($euiColorVis5, $euiSelectableTemplateFocusBackground),
     'font-weight': $euiFontWeightMedium,
   ),
 );

--- a/src/components/selectable/selectable_templates/_variables.scss
+++ b/src/components/selectable/selectable_templates/_variables.scss
@@ -1,25 +1,26 @@
-// The $euiFocusBackgroundColor without the alpha channel
-$euiSelectableTemplateFocusBackground: rgb(232, 241, 250);
+// The $euiFocusBackgroundColor without the alpha channel in light and dark mode
+$euiSelectableTemplateFocusBackgroundLight: rgb(232, 241, 250);
+$euiSelectableTemplateFocusBackgroundDark: rgb(35,56,77);
 
 $euiSelectableTemplateSitewideTypes: (
   'application': (
-    'color': makeHighContrastColor($euiColorVis1, $euiSelectableTemplateFocusBackground),
+    'color': lightOrDarkTheme(makeHighContrastColor($euiColorVis1, $euiSelectableTemplateFocusBackgroundLight), makeHighContrastColor($euiColorVis1, $euiSelectableTemplateFocusBackgroundDark)),
     'font-weight': $euiFontWeightMedium,
   ),
   'deployment': (
-    'color': makeHighContrastColor($euiColorVis0, $euiSelectableTemplateFocusBackground),
+    'color': lightOrDarkTheme(makeHighContrastColor($euiColorVis0, $euiSelectableTemplateFocusBackgroundLight), makeHighContrastColor($euiColorVis0, $euiSelectableTemplateFocusBackgroundDark)),
     'font-weight': $euiFontWeightMedium,
   ),
   'article': (
-    'color': makeHighContrastColor($euiColorVis3, $euiSelectableTemplateFocusBackground),
+    'color': lightOrDarkTheme(makeHighContrastColor($euiColorVis3, $euiSelectableTemplateFocusBackgroundLight), makeHighContrastColor($euiColorVis3, $euiSelectableTemplateFocusBackgroundDark)),
     'font-weight': $euiFontWeightMedium,
   ),
   'case': (
-    'color': makeHighContrastColor($euiColorVis9, $euiSelectableTemplateFocusBackground),
+    'color': lightOrDarkTheme(makeHighContrastColor($euiColorVis9, $euiSelectableTemplateFocusBackgroundLight), makeHighContrastColor($euiColorVis9, $euiSelectableTemplateFocusBackgroundDark)),
     'font-weight': $euiFontWeightMedium,
   ),
   'platform': (
-    'color': makeHighContrastColor($euiColorVis5, $euiSelectableTemplateFocusBackground),
+    'color': lightOrDarkTheme(makeHighContrastColor($euiColorVis5, $euiSelectableTemplateFocusBackgroundLight), makeHighContrastColor($euiColorVis5, $euiSelectableTemplateFocusBackgroundDark)),
     'font-weight': $euiFontWeightMedium,
   ),
 );

--- a/upcoming_changelogs/6761.md
+++ b/upcoming_changelogs/6761.md
@@ -1,0 +1,1 @@
+- Improved the contrast ratio of meta labels within `EuiSelectableTemplateSitewide` to meet WCAG AA guidelines.


### PR DESCRIPTION
Fixes #6623 

## Summary
✅ Increased the color contrast on `EuiSitewideSearch` item meta labels to meet WCAG 4.5 contrast ratio requirement in both light mode and dark mode. 

These colors are calculated using the `makeHighContrastColor` color function, but they did not take a background color into account. This means the color was being calculated with the assumption that the background was white. On hover, these items have a light blue background. These colors will now be calculated with the hover background color in mind. 

<details>
<summary>🎨  Color Details & Changes</summary>

<br/>

**Light Mode Difference**

<img width="782" alt="image" src="https://github.com/elastic/eui/assets/40739624/03159416-0f7a-4f33-ae14-ec2934124594">

<br/>

**Dark Mode Difference**

<img width="791" alt="image" src="https://github.com/elastic/eui/assets/40739624/3d6036cb-78eb-4821-a581-5ebaf244f0d3">


| Sitewide Type | Color Before | Contrast Before | Color After (Light) | Contrast After (Light) | Color After (Dark) | Contrast After (Dark)
| -------------- | ------------ | ---------------- | ----------- | --------------- |  --------------- |  --------------- | 
| `Application` |  `#4e779c` | 4.14 | `#4a7194` | 4.5 | `#7ea6cc` | 4.7 |
| `Deployment` | `#3b7d6a` | 4.25 | `#387765` | 4.6 | `#54B399` | 4.74 |
| `Article` | `#8365a6` | 4.2 | `#7c609e` | 4.57 | `#ae96cb` | 4.6 |
| `Case` | `#bc533e` | 4.13 | `#aa4b38` | 4.87 | `#eb836e` | 4.58 |
| `Platform` | `#807234` | 4.2 | `#7a6c31` | 4.56 | `#D6BF57` | 6.56 |


</details>

## QA

- [ ] Use the [PR preview](https://eui.elastic.co/pr_6761/#/templates/sitewide-search#basic-setup) to view the `Basic Setup` example. Select the search box and hover over list items. You may want to use the developer tools to activate the hover state for the drop down items. Confirm that the meta labels below the links are in high contrast in comparison to the background. 

<img width="608" alt="image" src="https://github.com/elastic/eui/assets/40739624/04061750-1cb4-4935-b4ab-8d7eab5c0b15">


### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
