### PR TITLE
[EuiFlyout] Fix broken push flyout behavior

### DIFF
--- a/src/components/flyout/flyout.spec.tsx
+++ b/src/components/flyout/flyout.spec.tsx
@@ -62,6 +62,19 @@ describe('EuiFlyout', () => {
         'euiFlyoutCloseButton'
       );
     });
+
+    it('does not focus trap or scrollLock for push flyouts', () => {
+      cy.mount(
+        <>
+          <div style={{ height: 2000 }}>Body scroll</div>
+          <Flyout type="push" pushMinBreakpoint="xs" size="100px" />
+        </>
+      );
+
+      cy.get('body').realClick({ position: 'topLeft' }).realPress('End'); // TODO: Use cypress-real-event's `realMouseWheel` API, whenever they release it
+      cy.wait(500); // Wait a tick to let scroll position update
+      cy.window().its('scrollY').should('not.equal', 0);
+    });
   });
 
   describe('Close behavior: standard', () => {

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -405,7 +405,7 @@ export const EuiFlyout = forwardRef(
     let flyout = (
       <EuiFocusTrap
         disabled={isPushed}
-        scrollLock={ownFocus}
+        scrollLock={hasOverlayMask}
         clickOutsideDisables={!ownFocus}
         onClickOutside={onClickOutside}
         {...focusTrapProps}

--- a/src/components/focus_trap/focus_trap.spec.tsx
+++ b/src/components/focus_trap/focus_trap.spec.tsx
@@ -255,6 +255,19 @@ describe('EuiFocusTrap', () => {
       cy.window().its('scrollY').should('not.equal', 0);
     });
 
+    it('does not scrollLock if the focus trap is disabled', () => {
+      cy.realMount(
+        <div style={{ height: 2000 }}>
+          <EuiFocusTrap disabled={true} scrollLock={true}>
+            Test
+          </EuiFocusTrap>
+        </div>
+      );
+
+      scrollSelector('body');
+      cy.window().its('scrollY').should('not.equal', 0);
+    });
+
     it('prevents scrolling on the page body', () => {
       cy.realMount(
         <div style={{ height: 2000 }}>

--- a/src/components/focus_trap/focus_trap.tsx
+++ b/src/components/focus_trap/focus_trap.tsx
@@ -146,7 +146,7 @@ export class EuiFocusTrap extends Component<EuiFocusTrapProps, State> {
     return (
       <FocusOn {...focusOnProps}>
         {children}
-        {scrollLock && <RemoveScrollBar gapMode={gapMode} />}
+        {!isDisabled && scrollLock && <RemoveScrollBar gapMode={gapMode} />}
       </FocusOn>
     );
   }

--- a/upcoming_changelogs/6764.md
+++ b/upcoming_changelogs/6764.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed broken push `EuiFlyout` behavior


### PR DESCRIPTION
## Summary

https://github.com/elastic/eui/pull/6645 and https://github.com/elastic/eui/pull/6744 made EuiFlyouts use `padding-right` to preserve scrollbar width, which `react-remove-scrollbar` unfortunately sets `!important` for, which overrides [the inline padding styles](https://github.com/elastic/eui/blob/329eb41a8c36ba76be780fc6a45d375cf7184033/src/components/flyout/flyout.tsx#L217-L228) push flyouts use to push the page content.

The fix to this issue that push flyouts should not have `scrollLock` enabled - I've taken several measures at both the `EuiFlyout` and `EuiFocusTrap` levels to ensure this is the case.

## QA

- Go to https://elastic.github.io/eui/#/layout/flyout#push-versus-overlay
- [x] Confirm prod does not correctly push the body content
- Go to http://localhost:8030/#/layout/flyout#push-versus-overlay
- [x] Confirm local/staging correctly pushes the body content

### General checklist

- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
