### PR TITLE
[EuiComboBox] Bug fix for `append` and `prepend` icons

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -96,7 +96,6 @@ module.exports = {
     ],
 
     // TODO: It may be worth investigating and updating these rules to their more modern counterparts
-    'selector-not-notation': 'simple',
     'color-function-notation': 'legacy',
     'alpha-value-notation': 'number',
 
@@ -109,6 +108,7 @@ module.exports = {
     'scss/at-rule-conditional-no-parentheses': null,
     'scss/double-slash-comment-empty-line-before': null,
     'scss/at-if-no-null': null,
+    'selector-not-notation': null,
   },
   ignoreFiles: [
     'generator-eui/**/*.scss',

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -119,11 +119,4 @@
       padding-bottom: 0;
     }
   }
-
-  // Overrides the euiFormControlLayout prepend and append height that is 100%
-  .euiFormControlLayout__prepend,
-  .euiFormControlLayout__append {
-    // stylelint-disable-next-line declaration-no-important
-    height: auto !important;
-  }
 }

--- a/src/components/combo_box/_combo_box.scss
+++ b/src/components/combo_box/_combo_box.scss
@@ -8,12 +8,17 @@
   /**
    * 1. Allow pills to truncate their text with an ellipsis.
    * 2. Don't allow pills/placeholder to overlap with the caret, loading icon or clear button.
-   * 3. The height on combo can be larger than normal text inputs.
+   * 3. The height on combo can be larger than normal text inputs except for single-selection comboboxes.
    */
 
-  &--compressed,
-  .euiFormControlLayout {
-    height: auto;
+  &--compressed:not(.euiComboBox--appended, .euiComboBox--prepended) {
+    height: auto; /* 3 */
+  }
+
+  &:not(.euiComboBox--appended, .euiComboBox--prepended) {
+    .euiFormControlLayout {
+      height: auto; /* 3 */
+    }
   }
 
   .euiComboBox__inputWrap {

--- a/upcoming_changelogs/6766.md
+++ b/upcoming_changelogs/6766.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` so `append` and `prepend` icon buttons are full height and vertically centered.


### PR DESCRIPTION
## Summary

Prepended and appended icon buttons were not centering the icon vertically in `EuiComboBox`. This PR fixes the CSS by updating a `height: auto` rule to be more specific.

Will QA for browsers, light/dark mode, and mobile in staging URL.

---
<img width="649" alt="Screen Shot 2023-05-10 at 12 42 46 PM" src="https://github.com/elastic/eui/assets/934879/eac70e77-28ff-40ad-a2fd-c74233610f5e">


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
