### PR TITLE
[EuiContextMenu] Added optional `onPanelChange` callback hook.

### DIFF
--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -139,8 +139,13 @@ describe('EuiContextMenu', () => {
       });
 
       it('allows you to click the title button to go back to the previous panel', async () => {
+        const onPanelChange = jest.fn();
         const component = mount(
-          <EuiContextMenu panels={panels} initialPanelId={2} />
+          <EuiContextMenu
+            panels={panels}
+            initialPanelId={2}
+            onPanelChange={onPanelChange}
+          />
         );
 
         await tick(20);
@@ -155,6 +160,7 @@ describe('EuiContextMenu', () => {
         await tick(20);
 
         expect(takeMountedSnapshot(component)).toMatchSnapshot();
+        expect(onPanelChange).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -160,7 +160,10 @@ describe('EuiContextMenu', () => {
         await tick(20);
 
         expect(takeMountedSnapshot(component)).toMatchSnapshot();
-        expect(onPanelChange).toHaveBeenCalledTimes(1);
+        expect(onPanelChange).toHaveBeenCalledWith({
+          panelId: 1,
+          direction: 'previous',
+        });
       });
     });
 

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -76,7 +76,7 @@ export type EuiContextMenuProps = CommonProps &
      * Optional callback that fires on every panel change. Passes back
      * the new panel ID and whether its direction was `next` or `previous`.
      */
-    onPanelChange?: (args: {
+    onPanelChange?: (panelDetails: {
       panelId: EuiContextMenuPanelId;
       direction?: EuiContextMenuPanelTransitionDirection;
     }) => void;

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -72,6 +72,15 @@ export const SIZES = keysOf(sizeToClassNameMap);
 export type EuiContextMenuProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'style'> & {
     panels?: EuiContextMenuPanelDescriptor[];
+    /**
+     *
+     * Optional callback that fires on every panel change. Passes back
+     * the new panel ID and whether its direction was `next` or `previous`.
+     */
+    onPanelChange?: (args: {
+      panelId: EuiContextMenuPanelId;
+      direction?: EuiContextMenuPanelTransitionDirection;
+    }) => void;
     initialPanelId?: EuiContextMenuPanelId;
     /**
      * Alters the size of the items and the title
@@ -221,6 +230,8 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
       transitionDirection: direction,
       isOutgoingPanelVisible: true,
     });
+
+    this.props.onPanelChange?.({ panelId, direction });
   }
 
   showNextPanel = (itemIndex?: number) => {
@@ -407,7 +418,14 @@ export class EuiContextMenu extends Component<EuiContextMenuProps, State> {
   }
 
   render() {
-    const { panels, className, initialPanelId, size, ...rest } = this.props;
+    const {
+      panels,
+      onPanelChange,
+      className,
+      initialPanelId,
+      size,
+      ...rest
+    } = this.props;
 
     const incomingPanel = this.renderPanel(this.state.incomingPanelId!, 'in');
     let outgoingPanel;

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -73,7 +73,6 @@ export type EuiContextMenuProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'style'> & {
     panels?: EuiContextMenuPanelDescriptor[];
     /**
-     *
      * Optional callback that fires on every panel change. Passes back
      * the new panel ID and whether its direction was `next` or `previous`.
      */

--- a/upcoming_changelogs/6767.md
+++ b/upcoming_changelogs/6767.md
@@ -1,0 +1,1 @@
+- Added `onPanelChange` callback to `EuiContextMenu` to provide consumer access to `panelId` and `direction`.


### PR DESCRIPTION
## Summary

@tonyghiani requested a callback to know when navigating into and out of nested panels in `EuiContextMenu`. He specced out the feature for the EUI team in a Slack discussion. Cee and I discussed it and pair coded the solution presented here.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
