### PR TITLE
[Spike] EUI snapshot serializer

### DIFF
--- a/src/test/snapshot_serializers/components.ts
+++ b/src/test/snapshot_serializers/components.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// Components that should render as <EuiComponent /> only, with no children
+// Their content is either too complex to attempt to render
+// or irrelevant/completely controlled by EUI
+export const COMPONENTS_EMPTY = [
+  'EuiDataGrid',
+  'EuiInMemoryTable',
+  'EuiBasicTable',
+  'EuiSpacer',
+  'EuiHorizontalRule',
+];
+
+// Components that should render with their text content only
+export const COMPONENTS_TEXT = ['EuiButton', 'EuiBadge'];
+
+// Components that should attempt to snapshot all HTML content within them
+// as their content is likely important / custom to the consumer
+export const COMPONENTS_HTML = [
+  'EuiPageTemplate',
+  'EuiPageSection',
+  'EuiPage',
+  'EuiPanel',
+  'EuiFlexGrid',
+  'EuiFlexGroup',
+  'EuiFlexItem',
+  'EuiText',
+  'EuiTitle',
+];

--- a/src/test/snapshot_serializers/enzyme/index.ts
+++ b/src/test/snapshot_serializers/enzyme/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { euiEnzymeShallowSnapshotSerializer } from './shallow';
+export { euiEnzymeMountSnapshotSerializer } from './mount';
+export { euiEnzymeRenderSnapshotSerializer } from './render';

--- a/src/test/snapshot_serializers/enzyme/mount.ts
+++ b/src/test/snapshot_serializers/enzyme/mount.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ReactWrapper } from 'enzyme';
+
+import { fixIndentation } from '../utils';
+import {
+  getEnzymeProps,
+  stripUnderscorePrefix,
+  cleanEuiComponentNames,
+} from './utils';
+
+/**
+ * Utils
+ */
+const isReactWrapper = (wrapper: any) =>
+  wrapper?.constructor?.name === ReactWrapper.name;
+
+const printChildrenShallowly = (children: string) => {
+  // Remove annoying Emotion wrappers
+  children = children.replace(/^\s*<EmotionCssPropInternal[^\n]*>\n?/gm, '');
+  children = children.replace(/^\s*<\/EmotionCssPropInternal>\n?/gm, '');
+  children = children.replace(/^\s*<Insertion[^\n]*>\n?/gm, '');
+  children = children.replace(/^\s*<\/Insertion>\n?/gm, '');
+
+  // Strip/replace any underscore-prefixed EUI component names
+  children = cleanEuiComponentNames(children);
+
+  // Attempt to remove rendered DOM content that are EUI and can be represented by wrappers
+  // Determine this via, e.g. <button className="euiButton [...whatever other classes" [whatever props]>
+  const tagRegex = /^(?<tagName>\s*<[a-z]+)[^\n]* className="eui[A-Z][A-Za-z]+[\s\w-]*"[^\n]*>\n/m;
+  let tagMatch;
+  while ((tagMatch = children.match(tagRegex))) {
+    const tagName = tagMatch.groups?.tagName;
+    const closingTagRegex = new RegExp(
+      `^${tagName?.replace('<', '</')}>\\n`,
+      'm'
+    );
+    children = children.replace(tagRegex, '');
+    children = children.replace(closingTagRegex, '');
+  }
+
+  // Indentation will potentially be messed up due to removed content/wrappers - we'll need to restore it manually
+  children = fixIndentation(children.trim());
+
+  return children;
+};
+
+/**
+ * Snapshot serializer
+ */
+export const euiEnzymeMountSnapshotSerializer = {
+  test: (val: any) => {
+    if (isReactWrapper(val)) {
+      return val.name().startsWith('Eui') || val.name().startsWith('_Eui');
+    } else {
+      return false;
+    }
+  },
+  print: (val: ReactWrapper) => {
+    const euiComponentName = stripUnderscorePrefix(val.name());
+
+    let props = getEnzymeProps(val);
+    props = props ? ` ${props}` : '';
+
+    const children = printChildrenShallowly(val.children().debug());
+
+    return children
+      ? `<${euiComponentName}${props}>\n${children}\n</${euiComponentName}>`
+      : `<${euiComponentName}${props} />`;
+  },
+};

--- a/src/test/snapshot_serializers/enzyme/render.ts
+++ b/src/test/snapshot_serializers/enzyme/render.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  getEuiComponentFromClassName,
+  removeSerializedSyntax,
+  fixIndentation,
+  printEmptyComponent,
+  printWrappingComponent,
+} from '../utils';
+import { COMPONENTS_HTML, COMPONENTS_TEXT } from '../components';
+
+/**
+ * Utils
+ */
+const isCheerioWrapper = (wrapper: any) => wrapper?.cheerio != null;
+
+/**
+ * Snapshot serializer
+ */
+export const euiEnzymeRenderSnapshotSerializer = {
+  test: (val: any) => {
+    if (isCheerioWrapper(val)) {
+      return val.attr('class')?.startsWith('eui');
+    } else {
+      return false;
+    }
+  },
+  print: (val: Cheerio, serialize: Function) => {
+    const euiComponentName = getEuiComponentFromClassName(val.attr('class'))!;
+
+    if (COMPONENTS_HTML.includes(euiComponentName)) {
+      let children = '';
+      children = serialize(val.children());
+      children = removeSerializedSyntax(children);
+      children = children.replace(/\n\n/g, '');
+      children = fixIndentation(children.trim());
+
+      return printWrappingComponent(euiComponentName, `\n${children}\n`);
+    }
+    if (COMPONENTS_TEXT.includes(euiComponentName)) {
+      return printWrappingComponent(euiComponentName, val.text());
+    }
+    // Default to rendering an empty component
+    return printEmptyComponent(euiComponentName);
+  },
+};

--- a/src/test/snapshot_serializers/enzyme/shallow.ts
+++ b/src/test/snapshot_serializers/enzyme/shallow.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ShallowWrapper } from 'enzyme';
+
+import { getEuiComponentFromClassName } from '../utils';
+import {
+  getEnzymeProps,
+  stripUnderscorePrefix,
+  cleanEuiComponentNames,
+} from './utils';
+
+/**
+ * Utils
+ */
+const isShallowWrapper = (wrapper: any) =>
+  wrapper?.constructor?.name === ShallowWrapper.name;
+
+const getShallowName = (wrapper: ShallowWrapper) => {
+  let name = wrapper.name();
+  // Emotion bogarts the name with its own wrapper :(
+  if (name === 'EmotionCssPropInternal') {
+    name = wrapper.prop('__EMOTION_LABEL_PLEASE_DO_NOT_USE__');
+    // Sometimes the emotion label isn't set - fall back to the className
+    if (!name)
+      name = getEuiComponentFromClassName(wrapper.prop('className')) || '';
+  }
+  // Some display names have underscored prefixes
+  name = stripUnderscorePrefix(name);
+  return name;
+};
+
+const printChildren = (children: string) => {
+  children = children.replace(/\n\n/g, '').replace(/\n/g, '\n  '); // Fix indentation and spacing
+  children = cleanEuiComponentNames(children);
+  return children;
+};
+
+/**
+ * Snapshot serializer
+ */
+export const euiEnzymeShallowSnapshotSerializer = {
+  test: (val: any) => {
+    if (isShallowWrapper(val)) {
+      if (val.name() === 'ContextProvider') {
+        // Skip context providers
+        return true;
+      } else {
+        const name = getShallowName(val);
+        return name.startsWith('Eui');
+      }
+    } else {
+      return false;
+    }
+  },
+  print: (val: ShallowWrapper, serialize: Function) => {
+    if (val.name() === 'ContextProvider') return serialize(val.children());
+
+    const euiComponentName = getShallowName(val);
+
+    let props = getEnzymeProps(val);
+    props = props ? ` ${props}` : '';
+
+    const children = printChildren(val.children().debug());
+    return children
+      ? `<${euiComponentName}${props}>\n  ${children}\n</${euiComponentName}>`
+      : `<${euiComponentName}${props} />`;
+  },
+};

--- a/src/test/snapshot_serializers/enzyme/utils.ts
+++ b/src/test/snapshot_serializers/enzyme/utils.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { ShallowWrapper, ReactWrapper } from 'enzyme';
+
+export const getEnzymeProps = (wrapper: ShallowWrapper | ReactWrapper) => {
+  const props = wrapper.props() || ({} as any);
+  const keys = Object.keys(props).filter((key) => {
+    if (key === 'children') return false;
+    if (key === 'css') return false;
+    if (key.startsWith('__EMOTION')) return false;
+    return true;
+  });
+  return keys
+    .map((key) => {
+      let value = props[key];
+      value = typeof value === 'string' ? `"${value}"` : `{${String(value)}}`;
+      return `${key}=${value}`;
+    })
+    .join(' ');
+};
+
+export const stripUnderscorePrefix = (string?: string) => {
+  return string?.replace(/^_/, '') || '';
+};
+
+export const cleanEuiComponentNames = (string: string) => {
+  string = string.replace(/<_Eui/g, '<Eui');
+  string = string.replace(/<\/_Eui/g, '</Eui');
+  return string;
+};

--- a/src/test/snapshot_serializers/rtl/index.ts
+++ b/src/test/snapshot_serializers/rtl/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { euiRTLRenderSnapshotSerializer } from './render';

--- a/src/test/snapshot_serializers/rtl/render.ts
+++ b/src/test/snapshot_serializers/rtl/render.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  getEuiComponentFromClassName,
+  fixIndentation,
+  printEmptyComponent,
+  printWrappingComponent,
+  removeSerializedSyntax,
+} from '../utils';
+import { COMPONENTS_HTML, COMPONENTS_TEXT } from '../components';
+
+export const euiRTLRenderSnapshotSerializer = {
+  test: (val: any) => {
+    if (val instanceof HTMLElement) {
+      return val.className?.startsWith('eui');
+    } else {
+      return false;
+    }
+  },
+  print: (val: HTMLElement, serialize: Function) => {
+    const euiComponentName = getEuiComponentFromClassName(val.className)!;
+
+    if (COMPONENTS_HTML.includes(euiComponentName)) {
+      let children = '';
+      try {
+        children = serialize(val.children); // serialize sometimes throws an error :/
+        children = removeSerializedSyntax(children);
+      } catch {
+        // Fall back to displaying the raw HTML if we can't serialize the children
+        children = val.innerHTML;
+        children = children.split('>').join('>\n');
+        children = children.split(/(?<!>)<\//).join('\n</'); // Negative lookbehind for, e.g. Text</div>
+      }
+      children = fixIndentation(children.trim());
+
+      return printWrappingComponent(euiComponentName, `\n${children}\n`);
+    }
+    if (COMPONENTS_TEXT.includes(euiComponentName)) {
+      return printWrappingComponent(euiComponentName, val.textContent);
+    }
+    // Default to rendering an empty component
+    return printEmptyComponent(euiComponentName);
+  },
+};

--- a/src/test/snapshot_serializers/serializers.test.tsx
+++ b/src/test/snapshot_serializers/serializers.test.tsx
@@ -1,0 +1,531 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render, mount, shallow } from 'enzyme';
+import { render as rtlRender } from '../rtl';
+
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiPageTemplate,
+  EuiPageSection,
+  EuiDataGrid,
+} from '../../components';
+
+import { euiRTLRenderSnapshotSerializer } from './rtl';
+import {
+  euiEnzymeShallowSnapshotSerializer,
+  euiEnzymeMountSnapshotSerializer,
+  euiEnzymeRenderSnapshotSerializer,
+} from './enzyme';
+
+describe('snapshot serializer that flattens rendered output', () => {
+  expect.addSnapshotSerializer(euiRTLRenderSnapshotSerializer);
+  expect.addSnapshotSerializer(euiEnzymeShallowSnapshotSerializer);
+  expect.addSnapshotSerializer(euiEnzymeMountSnapshotSerializer);
+  expect.addSnapshotSerializer(euiEnzymeRenderSnapshotSerializer);
+
+  /* eslint-disable quotes */
+
+  test('text only component', () => {
+    const buttonTest = <EuiButton>Test</EuiButton>;
+    expect(rtlRender(buttonTest).container.firstChild).toMatchInlineSnapshot(
+      `<EuiButton>Test</EuiButton>`
+    );
+    expect(render(buttonTest)).toMatchInlineSnapshot(
+      `<EuiButton>Test</EuiButton>`
+    );
+    expect(mount(buttonTest)).toMatchInlineSnapshot(`
+      <EuiButton size="m" color="primary">
+        <EuiButtonDisplay className="euiButton css-1yt0a74-base-primary" size="m">
+          <EuiButtonDisplayContent isLoading={[undefined]} isDisabled={false} iconType={[undefined]} iconSide="left" iconSize={[undefined]} textProps={[undefined]}>
+            <span className="css-1km4ln8-euiButtonDisplayContent">
+              <span className="eui-textTruncate">
+                Test
+              </span>
+            </span>
+          </EuiButtonDisplayContent>
+        </EuiButtonDisplay>
+      </EuiButton>
+    `);
+    expect(shallow(buttonTest)).toMatchInlineSnapshot(`
+      <EuiButton className="euiButton" size="m">
+        Test
+      </EuiButton>
+    `);
+  });
+
+  test('medium component', () => {
+    const containerTest = (
+      <EuiFlexGroup gutterSize="s">
+        <EuiFlexItem>
+          <div>Hello</div>
+          <button data-test-subj="consumerContent">World</button>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSpacer size="xl" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+
+    expect(rtlRender(containerTest).container.firstChild)
+      .toMatchInlineSnapshot(`
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <div>
+            Hello
+          </div>
+          <button
+            data-test-subj="consumerContent"
+          >
+            World
+          </button>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiSpacer />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    `);
+    expect(render(containerTest)).toMatchInlineSnapshot(`
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <div>
+            Hello
+          </div>
+          <button
+            data-test-subj="consumerContent"
+          >
+            World
+          </button>
+          <div
+            class="euiSpacer euiSpacer--xl emotion-euiSpacer-xl"
+          />
+          </EuiFlexItem>
+      </EuiFlexGroup>
+    `);
+    expect(mount(containerTest)).toMatchInlineSnapshot(`
+      <EuiFlexGroup gutterSize="s">
+        <EuiFlexItem>
+          <div>
+            Hello
+          </div>
+          <button data-test-subj="consumerContent">
+            World
+          </button>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSpacer size="xl">
+          </EuiSpacer>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    `);
+    expect(shallow(containerTest)).toMatchInlineSnapshot(`
+      <EuiFlexGroup className="euiFlexGroup">
+        <EuiFlexItem>
+          <div>
+            Hello
+          </div>
+          <button data-test-subj="consumerContent">
+            World
+          </button>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiSpacer size="xl" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    `);
+  });
+
+  test('HTML - harder component', () => {
+    const pageTest = (
+      <EuiPageTemplate>
+        <EuiPageSection>
+          <div>Hello</div>
+          <button data-test-subj="consumerContent">World</button>
+        </EuiPageSection>
+      </EuiPageTemplate>
+    );
+
+    expect(rtlRender(pageTest).container.firstChild).toMatchInlineSnapshot(`
+      <EuiPageTemplate>
+        <main
+          class="emotion-euiPageInner"
+          id="EuiPageTemplateInner_generated-id"
+        >
+          <section
+            class="emotion-euiPageSection-l-top-transparent"
+          >
+            <div
+              class="emotion-euiPageSection__content-l"
+            >
+              <div>
+                Hello
+              </div>
+              <button
+                data-test-subj="consumerContent"
+              >
+                World
+              </button>
+            </div>
+          </section>
+        </main>
+      </EuiPageTemplate>
+    `);
+    expect(render(pageTest)).toMatchInlineSnapshot(`
+      <EuiPageTemplate>
+        <main
+          class="emotion-euiPageInner"
+          id="EuiPageTemplateInner_generated-id"
+        >
+          <section
+            class="emotion-euiPageSection-l-top-transparent"
+          >
+            <div
+              class="emotion-euiPageSection__content-l"
+            >
+              <div>
+                Hello
+              </div>
+              <button
+                data-test-subj="consumerContent"
+              >
+                World
+              </button>
+            </div>
+          </section>
+        </main>
+      </EuiPageTemplate>
+    `);
+    expect(mount(pageTest)).toMatchInlineSnapshot(`
+      <EuiPageTemplate>
+        <EuiPageOuter responsive={{...}} style={{...}} className="euiPageTemplate">
+          <EuiPageInner component={[undefined]} id="EuiPageTemplateInner_generated-id" border={false} panelled={false} responsive={{...}}>
+            <main id="EuiPageTemplateInner_generated-id" className="css-nq554q-euiPageInner">
+              <EuiPageSection>
+                <section className="css-1lbu2ui-euiPageSection-l-top-transparent">
+                  <div style={{...}} className="css-xelgj7-euiPageSection__content-l">
+                    <div>
+                      Hello
+                    </div>
+                    <button data-test-subj="consumerContent">
+                      World
+                    </button>
+                  </div>
+                </section>
+              </EuiPageSection>
+            </main>
+          </EuiPageInner>
+        </EuiPageOuter>
+      </EuiPageTemplate>
+    `);
+    expect(shallow(pageTest)).toMatchInlineSnapshot(`
+      <EuiPageOuter responsive={xs,s} style={[object Object]} className="euiPageTemplate">
+        <EuiPageInner component={[undefined]} id="EuiPageTemplateInner_generated-id" border={false} panelled={false} responsive={{...}}>
+          <EuiPageSection>
+            <div>
+              Hello
+            </div>
+            <button data-test-subj="consumerContent">
+              World
+            </button>
+          </EuiPageSection>
+        </EuiPageInner>
+      </EuiPageOuter>
+    `);
+  });
+
+  test('the worst component', () => {
+    const gridTest = (
+      <EuiDataGrid
+        aria-label="test"
+        columns={[{ id: 'test' }]}
+        columnVisibility={{
+          visibleColumns: ['id'],
+          setVisibleColumns: () => {},
+        }}
+        rowCount={1}
+        renderCellValue={() => 'test'}
+      />
+    );
+
+    expect(rtlRender(gridTest).container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="-1"
+        />
+        <EuiDataGrid />
+        <div
+          data-focus-guard="true"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+          tabindex="-1"
+        />
+      </div>
+    `);
+
+    expect(render(gridTest)).toMatchInlineSnapshot(`
+      Array [
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />,
+        <div
+          class="euiDataGrid__focusWrap"
+          data-focus-lock-disabled="disabled"
+        >
+          <div
+            class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter"
+          >
+            <div
+              class="euiDataGrid__controls"
+              data-test-subj="dataGridControls"
+            >
+              <div
+                class="euiDataGrid__leftControls"
+              >
+                <div
+                  class="euiPopover emotion-euiPopover"
+                  data-test-subj="dataGridColumnSelectorPopover"
+                >
+                  <div
+                    class="euiPopover__anchor css-16vtueo-render"
+                  >
+                    <button
+                      class="euiButtonEmpty euiButtonEmpty--xSmall euiDataGrid__controlBtn css-wvaqcf-empty-text"
+                      data-test-subj="dataGridColumnSelectorButton"
+                      type="button"
+                    >
+                      <span
+                        class="euiButtonContent euiButtonEmpty__content"
+                      >
+                        <span
+                          class="euiButtonContent__icon"
+                          color="inherit"
+                          data-euiicon-type="listAdd"
+                        />
+                        <span
+                          class="euiButtonEmpty__text"
+                        >
+                          Columns
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="euiDataGrid__rightControls"
+              >
+                <div
+                  class="euiPopover emotion-euiPopover"
+                  data-test-subj="dataGridKeyboardShortcutsPopover"
+                >
+                  <div
+                    class="euiPopover__anchor css-16vtueo-render"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      <button
+                        aria-label="Keyboard shortcuts"
+                        class="euiButtonIcon euiButtonIcon--xSmall emotion-euiButtonIcon-empty-text-hoverStyles"
+                        data-test-subj="dataGridKeyboardShortcutsButton"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="keyboard"
+                        />
+                      </button>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="euiPopover emotion-euiPopover"
+                  data-test-subj="dataGridDisplaySelectorPopover"
+                >
+                  <div
+                    class="euiPopover__anchor css-16vtueo-render"
+                  >
+                    <span
+                      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                    >
+                      <button
+                        aria-label="Display options"
+                        class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
+                        data-test-subj="dataGridDisplaySelectorButton"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="euiButtonIcon__icon"
+                          color="inherit"
+                          data-euiicon-type="tableDensityNormal"
+                        />
+                      </button>
+                    </span>
+                  </div>
+                </div>
+                <span
+                  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                >
+                  <button
+                    aria-label="Enter fullscreen"
+                    class="euiButtonIcon euiButtonIcon--xSmall euiDataGrid__controlBtn emotion-euiButtonIcon-empty-text-hoverStyles"
+                    data-test-subj="dataGridFullScreenButton"
+                    type="button"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="euiButtonIcon__icon"
+                      color="inherit"
+                      data-euiicon-type="fullScreen"
+                    />
+                  </button>
+                </span>
+              </div>
+            </div>
+            <div
+              aria-label="test"
+              aria-rowcount="1"
+              class="euiDataGrid__content"
+              data-test-subj="euiDataGridBody"
+              id="generated-id"
+              role="grid"
+              tabindex="0"
+            >
+              <div
+                class="euiDataGrid__virtualized"
+                style="position:relative;height:9007199254740991px;width:9007199254740991px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+              >
+                <div
+                  style="height:50px;width:0"
+                >
+                  <div
+                    class="euiDataGridHeader"
+                    data-test-subj="dataGridHeader"
+                    role="row"
+                  />
+                </div>
+              </div>
+            </div>
+            <p
+              hidden=""
+              id="generated-id"
+            >
+              Cell contains interactive content.
+            </p>
+          </div>
+        </div>,
+        <div
+          data-focus-guard="true"
+          style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+          tabindex="-1"
+        />,
+      ]
+    `);
+
+    expect(mount(gridTest)).toMatchInlineSnapshot(`
+      <EuiDataGrid aria-label="test" columns={[object Object]} columnVisibility={[object Object]} rowCount={1} renderCellValue={function renderCellValue() {
+              return 'test';
+            }}>
+        <EuiFocusTrap disabled={true} className="euiDataGrid__focusWrap" clickOutsideDisables={false} returnFocus={true} noIsolation={true} scrollLock={false} gapMode="padding">
+          <ForwardRef returnFocus={true} noIsolation={true} enabled={false} className="euiDataGrid__focusWrap" onClickOutside={[Function (anonymous)]} scrollLock={false}>
+            <ForwardRef returnFocus={true} noIsolation={true} enabled={false} className="euiDataGrid__focusWrap" onClickOutside={[Function (anonymous)]} scrollLock={false} sideCar={[Function: RequireSideCar]}>
+              <ForwardRef(FocusLockUI) sideCar={[Function: RequireSideCar]} disabled={true} returnFocus={true} autoFocus={true} shards={[undefined]} onActivation={[undefined]} onDeactivation={[undefined]} className="euiDataGrid__focusWrap" whiteList={[undefined]} lockProps={{...}} focusOptions={[undefined]} as={{...}} noFocusGuards={false} persistentFocus={false} crossFrame={true} hasPositiveIndices={[undefined]} allowTextSelection={[undefined]} group={[undefined]}>
+                <div data-focus-guard={true} tabIndex={-1} style={{...}} />
+                <ForwardRef data-focus-lock-disabled="disabled" data-focus-lock={[undefined]} sideCar={[Function: RequireSideCar]} shards={[undefined]} allowPinchZoom={[undefined]} as={[undefined]} inert={false} style={[undefined]} enabled={false} className="euiDataGrid__focusWrap" onBlur={[Function: useMedium]} onFocus={[Function (anonymous)]} removeScrollBar={true}>
+                  <EuiDataGridToolbar gridWidth={0} minSizeForControls={[undefined]} toolbarVisibility={true} isFullScreen={false} fullScreenSelector={{...}} keyboardShortcuts={{...}} displaySelector={{...}} columnSelector={{...}} columnSorting={{...}}>
+                    <EuiPopover data-test-subj="dataGridColumnSelectorPopover" isOpen={false} closePopover={[Function: closePopover]} anchorPosition="downLeft" panelPaddingSize="s" hasDragDrop={true} button={{...}} ownFocus={true} hasArrow={true} display="inline-block">
+                      <EuiButtonEmpty size="xs" iconType="listAdd" color="text" className="euiDataGrid__controlBtn" data-test-subj="dataGridColumnSelectorButton" onClick={[Function: onClick]}>
+                        <EuiButtonContentDeprecated isLoading={[undefined]} iconType="listAdd" iconSide="left" iconSize="s" textProps={{...}} className="euiButtonEmpty__content">
+                          <EuiIcon className="euiButtonContent__icon" type="listAdd" size="s" color="inherit">
+                          </EuiIcon>
+                          <EuiI18n token="euiColumnSelector.button" default="Columns">
+                            Columns
+                          </EuiI18n>
+                        </EuiButtonContentDeprecated>
+                      </EuiButtonEmpty>
+                    </EuiPopover>
+                    <EuiPopover data-test-subj="dataGridKeyboardShortcutsPopover" isOpen={false} closePopover={[Function: closePopover]} anchorPosition="downRight" button={{...}} ownFocus={true} panelPaddingSize="m" hasArrow={true} display="inline-block">
+                      <EuiToolTip content="Keyboard shortcuts" delay="long" position="top" display="inlineBlock">
+                        <EuiToolTipAnchor onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseOver={[Function (anonymous)]} onMouseOut={[Function (anonymous)]} id="generated-id" className="" display="inlineBlock" isVisible={false}>
+                          <EuiButtonIcon size="xs" iconType="keyboard" color="text" data-test-subj="dataGridKeyboardShortcutsButton" onClick={[Function: onClick]} aria-label="Keyboard shortcuts" onFocus={[Function: onFocus]} onBlur={[Function: onBlur]}>
+                            <EuiIcon className="euiButtonIcon__icon" type="keyboard" size="m" aria-hidden="true" color="inherit">
+                            </EuiIcon>
+                          </EuiButtonIcon>
+                        </EuiToolTipAnchor>
+                      </EuiToolTip>
+                    </EuiPopover>
+                    <EuiPopover data-test-subj="dataGridDisplaySelectorPopover" isOpen={false} closePopover={[Function: closePopover]} anchorPosition="downRight" panelPaddingSize="s" panelClassName="euiDataGrid__displayPopoverPanel" button={{...}} ownFocus={true} hasArrow={true} display="inline-block">
+                      <EuiToolTip content="Display options" delay="long" position="top" display="inlineBlock">
+                        <EuiToolTipAnchor onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseOver={[Function (anonymous)]} onMouseOut={[Function (anonymous)]} id="generated-id" className="" display="inlineBlock" isVisible={false}>
+                          <EuiButtonIcon size="xs" iconType="tableDensityNormal" className="euiDataGrid__controlBtn" color="text" data-test-subj="dataGridDisplaySelectorButton" onClick={[Function: onClick]} aria-label="Display options" onFocus={[Function: onFocus]} onBlur={[Function: onBlur]}>
+                            <EuiIcon className="euiButtonIcon__icon" type="tableDensityNormal" size="m" aria-hidden="true" color="inherit">
+                            </EuiIcon>
+                          </EuiButtonIcon>
+                        </EuiToolTipAnchor>
+                      </EuiToolTip>
+                    </EuiPopover>
+                    <EuiToolTip content="Enter fullscreen" delay="long" position="top" display="inlineBlock">
+                      <EuiToolTipAnchor onBlur={[Function (anonymous)]} onFocus={[Function (anonymous)]} onMouseOver={[Function (anonymous)]} onMouseOut={[Function (anonymous)]} id="generated-id" className="" display="inlineBlock" isVisible={false}>
+                        <EuiButtonIcon size="xs" iconType="fullScreen" color="text" className="euiDataGrid__controlBtn" data-test-subj="dataGridFullScreenButton" onClick={[Function: onClick]} aria-label="Enter fullscreen" onFocus={[Function: onFocus]} onBlur={[Function: onBlur]}>
+                          <EuiIcon className="euiButtonIcon__icon" type="fullScreen" size="m" aria-hidden="true" color="inherit">
+                          </EuiIcon>
+                        </EuiButtonIcon>
+                      </EuiToolTipAnchor>
+                    </EuiToolTip>
+                  </EuiDataGridToolbar>
+                  <EuiDataGridBody columns={{...}} visibleColCount={0} leadingControlColumns={{...}} schema={{...}} trailingControlColumns={{...}} setVisibleColumns={[Function: setVisibleColumns]} switchColumnPos={[Function (anonymous)]} onColumnResize={[undefined]} headerIsInteractive={false} handleHeaderMutation={[Function (anonymous)]} schemaDetectors={{...}} pagination={[undefined]} renderCellValue={[Function: renderCellValue]} renderCellPopover={[undefined]} renderFooterCellValue={[undefined]} rowCount={1} visibleRows={{...}} interactiveCellId="generated-id" rowHeightsOptions={{...}} virtualizationOptions={{...}} isFullScreen={false} gridStyles={{...}} gridWidth={0} gridRef={{...}} gridItemsRendered={{...}} wrapperRef={{...}} renderCustomGridBody={[undefined]}>
+                    <EuiDataGridBodyVirtualized columns={{...}} visibleColCount={0} leadingControlColumns={{...}} schema={{...}} trailingControlColumns={{...}} setVisibleColumns={[Function: setVisibleColumns]} switchColumnPos={[Function (anonymous)]} onColumnResize={[undefined]} headerIsInteractive={false} handleHeaderMutation={[Function (anonymous)]} schemaDetectors={{...}} pagination={[undefined]} renderCellValue={[Function: renderCellValue]} renderCellPopover={[undefined]} renderFooterCellValue={[undefined]} rowCount={1} visibleRows={{...}} interactiveCellId="generated-id" rowHeightsOptions={{...}} virtualizationOptions={{...}} isFullScreen={false} gridStyles={{...}} gridWidth={0} gridRef={{...}} gridItemsRendered={{...}} wrapperRef={{...}}>
+                      <Grid className="euiDataGrid__virtualized" onItemsRendered={[Function: onItemsRendered]} innerElementType={{...}} outerRef={{...}} innerRef={{...}} columnCount={0} width={9007199254740991} columnWidth={[Function (anonymous)]} height={9007199254740991} rowHeight={[Function (anonymous)]} itemData={{...}} rowCount={1} direction="ltr" useIsScrolling={false}>
+                        <EuiDataGridInnerElement style={{...}}>
+                          <div style={{...}}>
+                            <EuiDataGridHeaderRow headerIsInteractive={false} switchColumnPos={[Function (anonymous)]} setVisibleColumns={[Function: setVisibleColumns]} leadingControlColumns={{...}} trailingControlColumns={{...}} columns={{...}} columnWidths={{...}} defaultColumnWidth={100} setColumnWidth={[Function (anonymous)]} schema={{...}} schemaDetectors={{...}}>
+                            </EuiDataGridHeaderRow>
+                          </div>
+                        </EuiDataGridInnerElement>
+                      </Grid>
+                    </EuiDataGridBodyVirtualized>
+                  </EuiDataGridBody>
+                  <p id="generated-id" hidden={true}>
+                    <EuiI18n token="euiDataGrid.screenReaderNotice" default="Cell contains interactive content.">
+                      Cell contains interactive content.
+                    </EuiI18n>
+                  </p>
+                </ForwardRef>
+                <div data-focus-guard={true} tabIndex={-1} style={{...}} />
+              </ForwardRef(FocusLockUI)>
+            </ForwardRef>
+          </ForwardRef>
+        </EuiFocusTrap>
+      </EuiDataGrid>
+    `);
+
+    expect(shallow(gridTest)).toMatchInlineSnapshot(`
+      <EuiFocusTrap disabled={true} className="euiDataGrid__focusWrap" clickOutsideDisables={false} returnFocus={true} noIsolation={true} scrollLock={false} gapMode="padding">
+        <div className="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter" onKeyDown={[Function (anonymous)]} style={{...}}>
+          <EuiDataGridToolbar gridWidth={0} minSizeForControls={[undefined]} toolbarVisibility={true} isFullScreen={false} fullScreenSelector={{...}} keyboardShortcuts={{...}} displaySelector={{...}} columnSelector={{...}} columnSorting={{...}} />
+          <div onKeyDown={[Function (anonymous)]} data-test-subj="euiDataGridBody" className="euiDataGrid__content" role="grid" aria-rowcount={1} id="generated-id" tabIndex={0} onKeyUp={[Function: onKeyUp]} aria-label="test">
+            <EuiDataGridBody columns={{...}} visibleColCount={0} leadingControlColumns={{...}} schema={{...}} trailingControlColumns={{...}} setVisibleColumns={[Function: setVisibleColumns]} switchColumnPos={[Function (anonymous)]} onColumnResize={[undefined]} headerIsInteractive={false} handleHeaderMutation={[Function (anonymous)]} schemaDetectors={{...}} pagination={[undefined]} renderCellValue={[Function: renderCellValue]} renderCellPopover={[undefined]} renderFooterCellValue={[undefined]} rowCount={1} visibleRows={{...}} interactiveCellId="generated-id" rowHeightsOptions={{...}} virtualizationOptions={{...}} isFullScreen={false} gridStyles={{...}} gridWidth={0} gridRef={{...}} gridItemsRendered={{...}} wrapperRef={{...}} renderCustomGridBody={[undefined]} />
+          </div>
+          <p id="generated-id" hidden={true}>
+            <EuiI18n token="euiDataGrid.screenReaderNotice" default="Cell contains interactive content." />
+          </p>
+        </div>
+      </EuiFocusTrap>
+    `);
+  });
+});

--- a/src/test/snapshot_serializers/utils.ts
+++ b/src/test/snapshot_serializers/utils.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const printEmptyComponent = (componentName: string) =>
+  `<${componentName} />`;
+
+export const printWrappingComponent = (
+  componentName: string,
+  content: string | null = ''
+) =>
+  content
+    ? `<${componentName}>${content}</${componentName}>`
+    : printEmptyComponent(componentName);
+
+export const getEuiComponentFromClassName = (className?: string) => {
+  if (!className) return;
+
+  const euiClassNameRegex = /^(?<euiComponent>eui[A-Z][A-Za-z]+)/;
+  const euiMatch = className.match(euiClassNameRegex);
+  const euiClassName = euiMatch?.groups?.euiComponent;
+
+  if (euiClassName) {
+    // Capitalize the first letter to get the component name
+    return euiClassName.charAt(0).toUpperCase() + euiClassName.slice(1);
+  }
+};
+
+export const fixIndentation = (children: string, startingIndentLevel = 1) => {
+  // Flatten/remove existing indentation
+  children = children.replace(/^\s+/gm, '');
+
+  // Restore component indentation
+  const INDENT = '  ';
+  let currentIndentLevel = startingIndentLevel;
+
+  children = children
+    .split('\n')
+    .map((line) => {
+      const isClosingComponent = line.startsWith('</');
+      const isSelfContainedComponent = line.endsWith('/>');
+      const isOpeningComponent =
+        !isClosingComponent &&
+        !isSelfContainedComponent &&
+        line.startsWith('<');
+      const isEndOfOpeningComponent = line === '>' || line === '/>';
+
+      if (isClosingComponent) currentIndentLevel -= 1;
+
+      const indentedLine = isEndOfOpeningComponent
+        ? `${INDENT.repeat(currentIndentLevel - 1)}${line}`
+        : `${INDENT.repeat(currentIndentLevel)}${line}`;
+
+      if (isOpeningComponent) currentIndentLevel += 1;
+
+      return indentedLine;
+    })
+    .join('\n');
+
+  return children;
+};
+
+export const removeSerializedSyntax = (children: string) => {
+  children = children.replace(/^HTMLCollection \[/, '');
+  children = children.replace(/^Array \[/, '');
+  children = children.replace(/,$/gm, '');
+  children = children.replace(/]$/, '');
+  return children;
+};


### PR DESCRIPTION
## Summary

This PR is a 1-2 day spike at writing an exportable set of EUI snapshot serializer. The goal of the serializer is to flatten EUI components in snapshots **only** (i.e., not full `jest.mock()` scenarios that replacement the component in all test scenarios) to reduce exposure to the inner workings of our components (e.g. classes, styles, DOM). The reduced snapshotted DOM would ideally result in smaller downstream snapshot churn in Kibana, and as such fewer codeowner pings.

This PR was opened mostly to preserve a copy of the spike code as well as provide a place where certain parts of the code can be discussed - it is not meant to be merged in.