### PR TITLE
[EuiInlineEdit] Create `isReadOnly` Prop for Read Mode

### DIFF
--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -67,6 +67,22 @@ const inlineEditModeSaveSnippet = `<EuiInlineEditText
 import InlineEditValidation from './inline_edit_validation';
 const inlineEditValidationSource = require('!!raw-loader!././inline_edit_validation');
 
+import InlineEditReadOnly from './inline_edit_read_only';
+const InlineEditReadOnlySource = require('!!raw-loader!././inline_edit_read_only');
+const inlineEditReadOnlySnippet = `<EuiInlineEditText
+  inputAriaLabel="Edit text inline"
+  defaultValue="This is read only text!"
+  isReadOnly={isReadOnly}
+/>
+
+<EuiInlineEditTitle
+  inputAriaLabel="Edit title inline"
+  defaultValue="This is a read only title!"
+  heading="h3"
+  isReadOnly={isReadOnly}
+/>
+`;
+
 export const InlineEditExample = {
   title: 'Inline edit',
   intro: (
@@ -203,7 +219,7 @@ export const InlineEditExample = {
               properties
             </li>
             <li>
-              <EuiCode>editMode.inputRowProps</EuiCode> accepts any{' '}
+              <EuiCode>editMode.inputProps</EuiCode> accepts any{' '}
               <Link to="/forms/form-controls#text-field">
                 <strong>EuiFieldText</strong>
               </Link>{' '}
@@ -234,6 +250,26 @@ export const InlineEditExample = {
       ],
       demo: <InlineEditModeProps />,
       snippet: inlineEditModePropsSnippet,
+    },
+    {
+      title: 'Read only',
+      text: (
+        <>
+          <p>
+            Use the <EuiCode>isReadOnly</EuiCode> prop to lock{' '}
+            <EuiCode>EuiInlineEdit</EuiCode> in read mode and display the text
+            value. This does not affect the input form control in edit mode.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: InlineEditReadOnlySource,
+        },
+      ],
+      demo: <InlineEditReadOnly />,
+      snippet: inlineEditReadOnlySnippet,
     },
   ],
 };

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -193,6 +193,26 @@ export const InlineEditExample = {
       demo: <InlineEditValidation />,
     },
     {
+      title: 'Read only',
+      text: (
+        <>
+          <p>
+            Use the <EuiCode>isReadOnly</EuiCode> prop to lock{' '}
+            <EuiCode>EuiInlineEdit</EuiCode> in read mode and display the text
+            value. This does not affect the input form control in edit mode.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: InlineEditReadOnlySource,
+        },
+      ],
+      demo: <InlineEditReadOnly />,
+      snippet: inlineEditReadOnlySnippet,
+    },
+    {
       title: 'Customizing read and edit modes',
       text: (
         <>
@@ -250,26 +270,6 @@ export const InlineEditExample = {
       ],
       demo: <InlineEditModeProps />,
       snippet: inlineEditModePropsSnippet,
-    },
-    {
-      title: 'Read only',
-      text: (
-        <>
-          <p>
-            Use the <EuiCode>isReadOnly</EuiCode> prop to lock{' '}
-            <EuiCode>EuiInlineEdit</EuiCode> in read mode and display the text
-            value. This does not affect the input form control in edit mode.
-          </p>
-        </>
-      ),
-      source: [
-        {
-          type: GuideSectionTypes.TSX,
-          code: InlineEditReadOnlySource,
-        },
-      ],
-      demo: <InlineEditReadOnly />,
-      snippet: inlineEditReadOnlySnippet,
     },
   ],
 };

--- a/src-docs/src/views/inline_edit/inline_edit_read_only.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_read_only.tsx
@@ -13,7 +13,7 @@ export default () => {
   return (
     <>
       <EuiSwitch
-        label="Toggle isReadOnly"
+        label="Toggle read only"
         checked={isReadOnly}
         onChange={(e) => setIsReadOnly(e.target.checked)}
       />

--- a/src-docs/src/views/inline_edit/inline_edit_read_only.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_read_only.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+import {
+  EuiInlineEditText,
+  EuiInlineEditTitle,
+  EuiSpacer,
+  EuiSwitch,
+} from '../../../../src';
+
+export default () => {
+  const [isReadOnly, setIsReadOnly] = useState(true);
+
+  return (
+    <>
+      <EuiSwitch
+        label="Toggle isReadOnly"
+        checked={isReadOnly}
+        onChange={(e) => setIsReadOnly(e.target.checked)}
+      />
+
+      <EuiSpacer />
+
+      <EuiInlineEditText
+        inputAriaLabel="Edit text inline"
+        defaultValue="This is read only text!"
+        isReadOnly={isReadOnly}
+      />
+
+      <EuiSpacer />
+
+      <EuiInlineEditTitle
+        inputAriaLabel="Edit title inline"
+        defaultValue="This is a read only title!"
+        heading="h3"
+        isReadOnly={isReadOnly}
+      />
+    </>
+  );
+};

--- a/src-docs/src/views/inline_edit/inline_edit_text.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_text.tsx
@@ -5,7 +5,6 @@ import {
   EuiSpacer,
   EuiButtonGroup,
   EuiInlineEditTextProps,
-  EuiSwitch,
 } from '../../../../src';
 
 export default () => {
@@ -32,13 +31,6 @@ export default () => {
     setToggleTextButtonSize(optionId);
   };
 
-  /* isReadOnly toggle */
-  const [isReadOnly, setIsReadOnly] = useState(false);
-
-  const onChange = (e: any) => {
-    setIsReadOnly(e.target.checked);
-  };
-
   return (
     <>
       <EuiButtonGroup
@@ -52,19 +44,10 @@ export default () => {
 
       <EuiSpacer />
 
-      <EuiSwitch
-        label="isReadOnly"
-        checked={isReadOnly}
-        onChange={(e) => onChange(e)}
-      />
-
-      <EuiSpacer />
-
       <EuiInlineEditText
         inputAriaLabel="Edit text inline"
         defaultValue="Hello World!"
         size={toggleTextButtonSize}
-        isReadOnly={isReadOnly}
       />
     </>
   );

--- a/src-docs/src/views/inline_edit/inline_edit_text.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_text.tsx
@@ -5,6 +5,7 @@ import {
   EuiSpacer,
   EuiButtonGroup,
   EuiInlineEditTextProps,
+  EuiSwitch,
 } from '../../../../src';
 
 export default () => {
@@ -31,6 +32,13 @@ export default () => {
     setToggleTextButtonSize(optionId);
   };
 
+  /* isReadOnly toggle */
+  const [isReadOnly, setIsReadOnly] = useState(false);
+
+  const onChange = (e: any) => {
+    setIsReadOnly(e.target.checked);
+  };
+
   return (
     <>
       <EuiButtonGroup
@@ -44,10 +52,19 @@ export default () => {
 
       <EuiSpacer />
 
+      <EuiSwitch
+        label="isReadOnly"
+        checked={isReadOnly}
+        onChange={(e) => onChange(e)}
+      />
+
+      <EuiSpacer />
+
       <EuiInlineEditText
         inputAriaLabel="Edit text inline"
         defaultValue="Hello World!"
         size={toggleTextButtonSize}
+        isReadOnly={isReadOnly}
       />
     </>
   );

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -649,7 +649,7 @@ exports[`EuiInlineEditForm Read Mode isReadOnly 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wxssql-empty-disabled-euiInlineEditButton-isReadOnly"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-19hs4ci-empty-disabled-euiInlineEditButton-isReadOnly"
     data-test-subj="euiInlineReadModeButton"
     disabled=""
     type="button"

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -649,7 +649,7 @@ exports[`EuiInlineEditForm Read Mode isReadOnly 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-tnjw7o-empty-disabled-euiInlineEditForm-isReadOnly"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wxssql-empty-disabled-euiInlineEditButton-isReadOnly"
     data-test-subj="euiInlineReadModeButton"
     disabled=""
     type="button"
@@ -679,7 +679,7 @@ exports[`EuiInlineEditForm Read Mode readModeProps 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-6n5oyg-empty-primary-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-ioyorl-empty-primary-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -713,7 +713,7 @@ exports[`EuiInlineEditForm Read Mode renders 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -747,7 +747,7 @@ exports[`EuiInlineEditForm Read Mode sizes 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -643,13 +643,43 @@ exports[`EuiInlineEditForm Edit Mode renders 1`] = `
 </div>
 `;
 
+exports[`EuiInlineEditForm Read Mode isReadOnly 1`] = `
+<div
+  class="euiInlineEdit testClass1 testClass2"
+>
+  <button
+    aria-describedby="inlineEdit_generated-id"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-tnjw7o-empty-disabled-euiInlineEditForm-isReadOnly"
+    data-test-subj="euiInlineReadModeButton"
+    disabled=""
+    type="button"
+  >
+    <span
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+    >
+      <span
+        class="euiButtonEmpty__text"
+      >
+        Hello World!
+      </span>
+    </span>
+  </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
+</div>
+`;
+
 exports[`EuiInlineEditForm Read Mode readModeProps 1`] = `
 <div
   class="euiInlineEdit testClass1 testClass2"
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-9t7nyf-empty-primary"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-6n5oyg-empty-primary-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -683,7 +713,7 @@ exports[`EuiInlineEditForm Read Mode renders 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -717,7 +747,7 @@ exports[`EuiInlineEditForm Read Mode sizes 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >

--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -1,12 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiInlineEditText isReadOnly 1`] = `
+<div
+  class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-m-m"
+>
+  <button
+    aria-describedby="inlineEdit_generated-id"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wxssql-empty-disabled-euiInlineEditButton-isReadOnly"
+    data-test-subj="euiInlineReadModeButton"
+    disabled=""
+    role="paragraph"
+    type="button"
+  >
+    <span
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+    >
+      <span
+        class="euiButtonEmpty__text"
+      >
+        <div
+          class="euiText eui-textTruncate emotion-euiText-m"
+        >
+          Hello World!
+        </div>
+      </span>
+    </span>
+  </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
+</div>
+`;
+
 exports[`EuiInlineEditText renders 1`] = `
 <div
   class="euiInlineEdit euiInlineEditText testClass1 testClass2 emotion-euiInlineEditText-m-m"
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -44,7 +79,7 @@ exports[`EuiInlineEditText text sizes renders m 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -82,7 +117,7 @@ exports[`EuiInlineEditText text sizes renders s 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -120,7 +155,7 @@ exports[`EuiInlineEditText text sizes renders xs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >

--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiInlineEditText renders 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -44,7 +44,7 @@ exports[`EuiInlineEditText text sizes renders m 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -82,7 +82,7 @@ exports[`EuiInlineEditText text sizes renders s 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -120,7 +120,7 @@ exports[`EuiInlineEditText text sizes renders xs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >

--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiInlineEditText isReadOnly 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wxssql-empty-disabled-euiInlineEditButton-isReadOnly"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-19hs4ci-empty-disabled-euiInlineEditButton-isReadOnly"
     data-test-subj="euiInlineReadModeButton"
     disabled=""
     role="paragraph"

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiInlineEditTitle isReadOnly 1`] = `
   <button
     aria-describedby="inlineEdit_generated-id"
     aria-level="1"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wxssql-empty-disabled-euiInlineEditButton-isReadOnly"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-19hs4ci-empty-disabled-euiInlineEditButton-isReadOnly"
     data-test-subj="euiInlineReadModeButton"
     disabled=""
     role="heading"

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -1,12 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiInlineEditTitle isReadOnly 1`] = `
+<div
+  class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-m-m"
+>
+  <button
+    aria-describedby="inlineEdit_generated-id"
+    aria-level="1"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wxssql-empty-disabled-euiInlineEditButton-isReadOnly"
+    data-test-subj="euiInlineReadModeButton"
+    disabled=""
+    role="heading"
+    type="button"
+  >
+    <span
+      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+    >
+      <span
+        class="euiButtonEmpty__text"
+      >
+        <h1
+          class="euiTitle eui-textTruncate emotion-euiTitle-m"
+        >
+          Hello World!
+        </h1>
+      </span>
+    </span>
+  </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click this button to edit this text inline.
+  </span>
+</div>
+`;
+
 exports[`EuiInlineEditTitle renders 1`] = `
 <div
   class="euiInlineEdit euiInlineEditTitle testClass1 testClass2 emotion-euiInlineEditTitle-m-m"
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -44,7 +80,7 @@ exports[`EuiInlineEditTitle title sizes renders size l 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -82,7 +118,7 @@ exports[`EuiInlineEditTitle title sizes renders size m 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -120,7 +156,7 @@ exports[`EuiInlineEditTitle title sizes renders size s 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -158,7 +194,7 @@ exports[`EuiInlineEditTitle title sizes renders size xs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -196,7 +232,7 @@ exports[`EuiInlineEditTitle title sizes renders size xxs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -234,7 +270,7 @@ exports[`EuiInlineEditTitle title sizes renders size xxxs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-gj4z04-empty-text-euiInlineEditButton"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiInlineEditTitle renders 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -44,7 +44,7 @@ exports[`EuiInlineEditTitle title sizes renders size l 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -82,7 +82,7 @@ exports[`EuiInlineEditTitle title sizes renders size m 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -120,7 +120,7 @@ exports[`EuiInlineEditTitle title sizes renders size s 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -158,7 +158,7 @@ exports[`EuiInlineEditTitle title sizes renders size xs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -196,7 +196,7 @@ exports[`EuiInlineEditTitle title sizes renders size xxs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >
@@ -234,7 +234,7 @@ exports[`EuiInlineEditTitle title sizes renders size xxxs 1`] = `
 >
   <button
     aria-describedby="inlineEdit_generated-id"
-    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-wvaqcf-empty-text"
+    class="euiButtonEmpty euiButtonEmpty--small euiButtonEmpty--flushBoth css-2otmvb-empty-text-euiInlineEditForm"
     data-test-subj="euiInlineReadModeButton"
     type="button"
   >

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -16,7 +16,7 @@ export const euiInlineEditFormStyles = ({ euiTheme }: UseEuiTheme) => {
     // Override the cursor and allow users to highlight text when read mode is in the read only state
     isReadOnly: css`
       &.euiButtonEmpty:disabled {
-        cursor: default;
+        cursor: text;
         color: ${euiTheme.colors.text};
         user-select: text;
       }

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -14,6 +14,7 @@ export const euiInlineEditFormStyles = ({ euiTheme }: UseEuiTheme) => {
     euiInlineEditButton: css``,
 
     // Override the cursor and allow users to highlight text when read mode is in the read only state
+    // Once EuiEmptyButton has been converted to Emotion, remove this extra selector
     isReadOnly: css`
       &.euiButtonEmpty:disabled {
         cursor: text;

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+
+export const euiInlineEditFormStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    euiInlineEditForm: css``,
+
+    // Override the cursor and allow users to highlight text when read mode is in the read only state
+    isReadOnly: css`
+      &.euiButtonEmpty:disabled {
+        cursor: default;
+        color: ${euiTheme.colors.text};
+        user-select: text;
+      }
+    `,
+  };
+};

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -11,7 +11,7 @@ import { UseEuiTheme } from '../../services';
 
 export const euiInlineEditFormStyles = ({ euiTheme }: UseEuiTheme) => {
   return {
-    euiInlineEditForm: css``,
+    euiInlineEditButton: css``,
 
     // Override the cursor and allow users to highlight text when read mode is in the read only state
     isReadOnly: css`

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -38,7 +38,11 @@ describe('EuiInlineEditForm', () => {
 
     test('isReadOnly', () => {
       const { container, getByTestSubject } = render(
-        <EuiInlineEditForm isReadOnly={true} {...commonInlineEditFormProps} />
+        <EuiInlineEditForm
+          isReadOnly={true}
+          startWithEditOpen={true}
+          {...commonInlineEditFormProps}
+        />
       );
 
       expect(container.firstChild).toMatchSnapshot();

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -36,6 +36,16 @@ describe('EuiInlineEditForm', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    test('isReadOnly', () => {
+      const { container, getByTestSubject } = render(
+        <EuiInlineEditForm isReadOnly={true} {...commonInlineEditFormProps} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+
+      expect(getByTestSubject('euiInlineReadModeButton')).toBeDisabled();
+    });
+
     test('readModeProps', () => {
       const { container, getByTestSubject } = render(
         <EuiInlineEditForm

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -11,6 +11,7 @@ import React, {
   FunctionComponent,
   useState,
   useRef,
+  useEffect,
   HTMLAttributes,
   MouseEvent,
   KeyboardEvent,
@@ -208,6 +209,13 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     }
   };
 
+  // If the state of isReadOnly changes while in edit mode, switch b
+  useEffect(() => {
+    if (isReadOnly) {
+      setIsEditing(false);
+    }
+  }, [isReadOnly]);
+
   const editModeForm = (
     <EuiFlexGroup gutterSize="s">
       <EuiFlexItem>
@@ -343,8 +351,6 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   );
 
   return (
-    <div className={classes}>
-      {isEditing && !isReadOnly ? editModeForm : readModeElement}
-    </div>
+    <div className={classes}>{isEditing ? editModeForm : readModeElement}</div>
   );
 };

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -343,6 +343,8 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   );
 
   return (
-    <div className={classes}>{isEditing ? editModeForm : readModeElement}</div>
+    <div className={classes}>
+      {isEditing && !isReadOnly ? editModeForm : readModeElement}
+    </div>
   );
 };

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -209,7 +209,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     }
   };
 
-  // If the state of isReadOnly changes while in edit mode, switch b
+  // If the state of isReadOnly changes while in edit mode, switch back to read mode
   useEffect(() => {
     if (isReadOnly) {
       setIsEditing(false);

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -134,7 +134,10 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const euiTheme = useEuiTheme();
 
   const styles = euiInlineEditFormStyles(euiTheme);
-  const readOnlyStyles = [styles.euiInlineEditForm, styles.isReadOnly];
+  const readOnlyStyles = [
+    styles.euiInlineEditForm,
+    isReadOnly && styles.isReadOnly,
+  ];
 
   const { controlHeight, controlCompressedHeight } = euiFormVariables(euiTheme);
   const loadingSkeletonSize = sizes.compressed

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -241,14 +241,15 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             )}
           />
         </EuiFormRow>
-        {!isReadOnly && (
-          <span id={editModeDescribedById} hidden>
+
+        <span id={editModeDescribedById} hidden>
+          {!isReadOnly && (
             <EuiI18n
               token="euiInlineEditForm.inputKeyboardInstructions"
               default="Press Enter to save your edited text. Press Escape to cancel your edit."
             />
-          </span>
-        )}
+          )}
+        </span>
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -33,6 +33,7 @@ import { EuiSkeletonLoading, EuiSkeletonRectangle } from '../skeleton';
 import { useEuiTheme, useCombinedRefs, keys } from '../../services';
 import { EuiI18n, useEuiI18n } from '../i18n';
 import { useGeneratedHtmlId } from '../../services/accessibility';
+import { euiInlineEditFormStyles } from './inline_edit_form.styles';
 
 // Props shared between the internal form component as well as consumer-facing components
 export type EuiInlineEditCommonProps = HTMLAttributes<HTMLDivElement> &
@@ -80,6 +81,10 @@ export type EuiInlineEditCommonProps = HTMLAttributes<HTMLDivElement> &
      * Invalid state - only displayed edit mode
      */
     isInvalid?: boolean;
+    /**
+     * Locks inline edit in read mode and displays the text value
+     */
+    isReadOnly?: boolean;
   };
 
 // Internal-only props, passed by the consumer-facing components
@@ -122,10 +127,15 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   isLoading = false,
   isInvalid,
   onSave,
+  isReadOnly,
 }) => {
   const classes = classNames('euiInlineEdit', className);
 
   const euiTheme = useEuiTheme();
+
+  const styles = euiInlineEditFormStyles(euiTheme);
+  const readOnlyStyles = [styles.euiInlineEditForm, styles.isReadOnly];
+
   const { controlHeight, controlCompressedHeight } = euiFormVariables(euiTheme);
   const loadingSkeletonSize = sizes.compressed
     ? controlCompressedHeight
@@ -296,12 +306,14 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
     <>
       <EuiButtonEmpty
         color="text"
-        iconType="pencil"
+        iconType={isReadOnly ? undefined : 'pencil'}
         iconSide="right"
         flush="both"
         iconSize={sizes.iconSize}
         size={sizes.buttonSize}
         data-test-subj="euiInlineReadModeButton"
+        disabled={isReadOnly}
+        css={readOnlyStyles}
         {...readModeProps}
         buttonRef={setReadModeRefs}
         aria-describedby={classNames(

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -135,7 +135,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
 
   const styles = euiInlineEditFormStyles(euiTheme);
   const readOnlyStyles = [
-    styles.euiInlineEditForm,
+    styles.euiInlineEditButton,
     isReadOnly && styles.isReadOnly,
   ];
 
@@ -241,12 +241,14 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             )}
           />
         </EuiFormRow>
-        <span id={editModeDescribedById} hidden>
-          <EuiI18n
-            token="euiInlineEditForm.inputKeyboardInstructions"
-            default="Press Enter to save your edited text. Press Escape to cancel your edit."
-          />
-        </span>
+        {!isReadOnly && (
+          <span id={editModeDescribedById} hidden>
+            <EuiI18n
+              token="euiInlineEditForm.inputKeyboardInstructions"
+              default="Press Enter to save your edited text. Press Escape to cancel your edit."
+            />
+          </span>
+        )}
       </EuiFlexItem>
 
       <EuiFlexItem grow={false}>

--- a/src/components/inline_edit/inline_edit_text.test.tsx
+++ b/src/components/inline_edit/inline_edit_text.test.tsx
@@ -28,6 +28,19 @@ describe('EuiInlineEditText', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('isReadOnly', () => {
+    const { container, getByTestSubject } = render(
+      <EuiInlineEditText isReadOnly={true} {...inlineEditTextProps} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    expect(getByTestSubject('euiInlineReadModeButton')).toHaveAttribute(
+      'role',
+      'paragraph'
+    );
+  });
+
   describe('text sizes', () => {
     // Remove 'relative' from text sizes available for EuiInlineEditText
     const availableTextSizes = TEXT_SIZES.filter((size) => size !== 'relative');

--- a/src/components/inline_edit/inline_edit_text.tsx
+++ b/src/components/inline_edit/inline_edit_text.tsx
@@ -38,6 +38,7 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   editModeProps,
   isLoading,
   isInvalid,
+  isReadOnly,
   ...rest
 }) => {
   const classes = classNames('euiInlineEditText', className);
@@ -49,6 +50,12 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   const isSmallSize = ['xs', 's'].includes(size);
   const sizes = isSmallSize ? SMALL_SIZE_FORM : MEDIUM_SIZE_FORM;
 
+  if (isReadOnly) {
+    readModeProps
+      ? (readModeProps.role = 'paragraph')
+      : (readModeProps = { role: 'paragraph' });
+  }
+
   const formProps = {
     sizes,
     defaultValue,
@@ -58,6 +65,7 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
     editModeProps,
     isLoading,
     isInvalid,
+    isReadOnly,
   };
 
   return (

--- a/src/components/inline_edit/inline_edit_text.tsx
+++ b/src/components/inline_edit/inline_edit_text.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { useMemo, FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { EuiText, EuiTextProps } from '../text';
 import {
@@ -34,7 +34,7 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   defaultValue,
   inputAriaLabel,
   startWithEditOpen,
-  readModeProps,
+  readModeProps: _readModeProps,
   editModeProps,
   isLoading,
   isInvalid,
@@ -50,11 +50,14 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   const isSmallSize = ['xs', 's'].includes(size);
   const sizes = isSmallSize ? SMALL_SIZE_FORM : MEDIUM_SIZE_FORM;
 
-  if (isReadOnly) {
-    readModeProps
-      ? (readModeProps.role = 'paragraph')
-      : (readModeProps = { role: 'paragraph' });
-  }
+  const readModeProps = useMemo(() => {
+    if (!isReadOnly) return _readModeProps;
+
+    return {
+      ..._readModeProps,
+      role: 'paragraph',
+    };
+  }, [_readModeProps, isReadOnly]);
 
   const formProps = {
     sizes,

--- a/src/components/inline_edit/inline_edit_title.test.tsx
+++ b/src/components/inline_edit/inline_edit_title.test.tsx
@@ -40,7 +40,7 @@ describe('EuiInlineEditTitle', () => {
   });
 
   test('isReadOnly', () => {
-    const { container, getByTestSubject } = render(
+    const { container, getByTestSubject, getByRole } = render(
       <EuiInlineEditTitle isReadOnly={true} {...inlineEditTitleProps} />
     );
 
@@ -50,10 +50,7 @@ describe('EuiInlineEditTitle', () => {
       'role',
       'heading'
     );
-    expect(getByTestSubject('euiInlineReadModeButton')).toHaveAttribute(
-      'aria-level',
-      '1'
-    );
+    expect(getByRole('heading')).toHaveAttribute('aria-level', '1');
   });
 
   describe('title sizes', () => {

--- a/src/components/inline_edit/inline_edit_title.test.tsx
+++ b/src/components/inline_edit/inline_edit_title.test.tsx
@@ -39,6 +39,23 @@ describe('EuiInlineEditTitle', () => {
     expect(container.querySelector('h3')).toBeTruthy();
   });
 
+  test('isReadOnly', () => {
+    const { container, getByTestSubject } = render(
+      <EuiInlineEditTitle isReadOnly={true} {...inlineEditTitleProps} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+
+    expect(getByTestSubject('euiInlineReadModeButton')).toHaveAttribute(
+      'role',
+      'heading'
+    );
+    expect(getByTestSubject('euiInlineReadModeButton')).toHaveAttribute(
+      'aria-level',
+      '1'
+    );
+  });
+
   describe('title sizes', () => {
     TITLE_SIZES.forEach((size) => {
       it(`renders size ${size}`, () => {

--- a/src/components/inline_edit/inline_edit_title.test.tsx
+++ b/src/components/inline_edit/inline_edit_title.test.tsx
@@ -40,7 +40,7 @@ describe('EuiInlineEditTitle', () => {
   });
 
   test('isReadOnly', () => {
-    const { container, getByTestSubject, getByRole } = render(
+    const { container, getByTestSubject } = render(
       <EuiInlineEditTitle isReadOnly={true} {...inlineEditTitleProps} />
     );
 
@@ -50,7 +50,10 @@ describe('EuiInlineEditTitle', () => {
       'role',
       'heading'
     );
-    expect(getByRole('heading')).toHaveAttribute('aria-level', '1');
+    expect(getByTestSubject('euiInlineReadModeButton')).toHaveAttribute(
+      'aria-level',
+      '1'
+    );
   });
 
   describe('title sizes', () => {

--- a/src/components/inline_edit/inline_edit_title.tsx
+++ b/src/components/inline_edit/inline_edit_title.tsx
@@ -45,6 +45,7 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   editModeProps,
   isLoading,
   isInvalid,
+  isReadOnly,
   ...rest
 }) => {
   const classes = classNames('euiInlineEditTitle', className);
@@ -58,6 +59,22 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   const isSmallSize = ['xxxs', 'xxs', 'xs', 's'].includes(size);
   const sizes = isSmallSize ? SMALL_SIZE_FORM : MEDIUM_SIZE_FORM;
 
+  // When the heading level is h1-h6, apply a role and aria-level
+  if (isReadOnly && heading !== 'span') {
+    const headingNumber = Number(heading.substring(1));
+    readModeProps
+      ? Object.assign(readModeProps, {
+          role: 'heading',
+          'aria-level': headingNumber,
+        })
+      : (readModeProps = { role: 'heading', 'aria-level': headingNumber });
+    // Span elements should not be assigned an aria-level
+  } else if (isReadOnly) {
+    readModeProps
+      ? (readModeProps.role = 'paragraph')
+      : (readModeProps = { role: 'paragraph' });
+  }
+
   const formProps = {
     sizes,
     defaultValue,
@@ -67,6 +84,7 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
     editModeProps,
     isLoading,
     isInvalid,
+    isReadOnly,
   };
 
   return (

--- a/src/components/inline_edit/inline_edit_title.tsx
+++ b/src/components/inline_edit/inline_edit_title.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { useMemo, FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { EuiTitle, EuiTitleSize } from '../title';
 import {
@@ -41,7 +41,7 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   defaultValue,
   inputAriaLabel,
   startWithEditOpen,
-  readModeProps,
+  readModeProps: _readModeProps,
   editModeProps,
   isLoading,
   isInvalid,
@@ -59,21 +59,21 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   const isSmallSize = ['xxxs', 'xxs', 'xs', 's'].includes(size);
   const sizes = isSmallSize ? SMALL_SIZE_FORM : MEDIUM_SIZE_FORM;
 
-  // When the heading level is h1-h6, apply a role and aria-level
-  if (isReadOnly && heading !== 'span') {
+  const readModeProps = useMemo(() => {
+    if (!isReadOnly) return _readModeProps;
+
     const headingNumber = Number(heading.substring(1));
-    readModeProps
-      ? Object.assign(readModeProps, {
+    return headingNumber
+      ? {
+          ..._readModeProps,
           role: 'heading',
           'aria-level': headingNumber,
-        })
-      : (readModeProps = { role: 'heading', 'aria-level': headingNumber });
-    // Span elements should not be assigned an aria-level
-  } else if (isReadOnly) {
-    readModeProps
-      ? (readModeProps.role = 'paragraph')
-      : (readModeProps = { role: 'paragraph' });
-  }
+        }
+      : {
+          ..._readModeProps,
+          role: 'paragraph',
+        };
+  }, [_readModeProps, isReadOnly, heading]);
 
   const formProps = {
     sizes,


### PR DESCRIPTION
Included in #3928 

## Summary

✅ Create the `isReadOnly` prop for `EuiInlineEdit`. When the prop is true, a disabled `EuiEmptyButton` is displayed which locks the user in read mode and displays the text value. This does not affect edit mode. 

https://github.com/elastic/eui/assets/40739624/5a10ec7c-d7c0-4652-a935-4f3f2a2c9f9f

## QA

- [ ] View the new [Inline Edit Read Only example in the PR preview](https://eui.elastic.co/pr_6777/#/display/inline-edit#read-only) to toggle the `isReadOnly` prop. When the prop is set to `true`, you should not be able to transfer to edit mode. You should also see the default cursor and should be able to highlight and copy text.

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes

