### PR TITLE
[babel] Remove unused babel plugins/dependencies

### DIFF
--- a/.babelrc-test-env.js
+++ b/.babelrc-test-env.js
@@ -1,9 +1,8 @@
 module.exports = {
-  "extends": "./.babelrc.js",
-  "plugins": [
-    "@babel/plugin-transform-runtime",
-    "@babel/plugin-transform-async-to-generator",
-    "@babel/plugin-syntax-dynamic-import",
-    "dynamic-import-node"
+  extends: './.babelrc.js',
+  plugins: [
+    '@babel/plugin-transform-runtime',
+    '@babel/plugin-transform-async-to-generator',
+    'dynamic-import-node',
   ],
 };

--- a/.babelrc-test-env.js
+++ b/.babelrc-test-env.js
@@ -3,6 +3,5 @@ module.exports = {
   plugins: [
     '@babel/plugin-transform-runtime',
     '@babel/plugin-transform-async-to-generator',
-    'dynamic-import-node',
   ],
 };

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -23,7 +23,6 @@ module.exports = {
     ],
   ],
   "plugins": [
-    "@babel/plugin-syntax-dynamic-import",
     `${__dirname}/scripts/babel/proptypes-from-ts-props`,
     "add-module-exports",
     // stage 3

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "@babel/core": "^7.21.3",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-async-to-generator": "^7.20.7",
     "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/preset-env": "^7.20.2",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-add-module-exports": "^1.0.2",
-    "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-pegjs-inline-precompile": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "argparse": "^2.0.1",
     "autoprefixer": "^9.8.6",
     "axe-core": "^4.4.1",
-    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.1.0",

--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -14,7 +14,6 @@ function stripTypeScript(filename, ast) {
     filename: filename,
     babelrc: false,
     presets: ['@babel/typescript'],
-    plugins: ['@babel/plugin-syntax-dynamic-import'],
   }).code;
 }
 
@@ -107,10 +106,10 @@ function resolveOmitToPropTypes(node, state) {
   // extract the string values of keys to remove
   const keysToRemove = new Set(
     toRemovePropTypes.arguments[0].elements
-      .map(keyToRemove =>
+      .map((keyToRemove) =>
         types.isStringLiteral(keyToRemove) ? keyToRemove.value : null
       )
-      .filter(x => x !== null)
+      .filter((x) => x !== null)
   );
 
   // filter out omitted properties
@@ -305,7 +304,7 @@ function resolveIdentifierToPropTypes(node, state) {
       const propertyName = property.key.name;
       const isOptional = !isPropTypeRequired(types, property.value);
       const existsOnB =
-        propsOnB.find(property => property.key.name === propertyName) != null;
+        propsOnB.find((property) => property.key.name === propertyName) != null;
       if (isOptional || !existsOnB) {
         optionalProps.add(propertyName);
       }
@@ -315,7 +314,7 @@ function resolveIdentifierToPropTypes(node, state) {
       const propertyName = property.key.name;
       const isOptional = !isPropTypeRequired(types, property.value);
       const existsOnA =
-        propsOnA.find(property => property.key.name === propertyName) != null;
+        propsOnA.find((property) => property.key.name === propertyName) != null;
       if (isOptional || !existsOnA) {
         optionalProps.add(propertyName);
       }
@@ -510,7 +509,7 @@ function getPropTypesForNode(node, optional, state) {
 
     // translates intersections (Foo & Bar & Baz) to a shape with the types' members (Foo, Bar, Baz) merged together
     case 'TSIntersectionType':
-      const usableNodes = [...node.types].filter(node => {
+      const usableNodes = [...node.types].filter((node) => {
         const nodePropTypes = getPropTypesForNode(node, true, state);
 
         if (
@@ -547,7 +546,7 @@ function getPropTypesForNode(node, optional, state) {
           nodePropTypes.callee.property.name === 'oneOfType'
         ) {
           const properties = nodePropTypes.arguments[0].elements
-            .map(propType => {
+            .map((propType) => {
               // This exists on a oneOfType which must be expressed as an optional proptype
               propType = makePropTypeOptional(types, propType);
 
@@ -562,12 +561,12 @@ function getPropTypesForNode(node, optional, state) {
               }
 
               // extract all of the properties from this group and make them optional
-              return propType.arguments[0].properties.map(property => {
+              return propType.arguments[0].properties.map((property) => {
                 property.value = makePropTypeOptional(types, property.value);
                 return property;
               });
             })
-            .filter(x => x !== null)
+            .filter((x) => x !== null)
             .reduce((allProperties, properties) => {
               return [...allProperties, ...properties];
             }, []);
@@ -608,7 +607,9 @@ function getPropTypesForNode(node, optional, state) {
           if (mergedProperties.hasOwnProperty(typeProperty.key.name)) {
             const existing = mergedProperties[typeProperty.key.name];
             if (!areExpressionsIdentical(existing, typeProperty.value)) {
-              mergedProperties[typeProperty.key.name] = types.callExpression(
+              mergedProperties[
+                typeProperty.key.name
+              ] = types.callExpression(
                 types.memberExpression(
                   types.identifier('PropTypes'),
                   types.identifier('oneOfType')
@@ -651,7 +652,7 @@ function getPropTypesForNode(node, optional, state) {
           ),
           [
             types.objectExpression(
-              propertyKeys.map(propKey => {
+              propertyKeys.map((propKey) => {
                 const objectProperty = types.objectProperty(
                   types.identifier(propKey),
                   mergedProperties[propKey]
@@ -688,13 +689,13 @@ function getPropTypesForNode(node, optional, state) {
               // This helps filter out index signatures from interfaces,
               // which don't translate to prop types.
               .filter(
-                property =>
+                (property) =>
                   property.key != null &&
                   !types.isTSNeverKeyword(
                     property.typeAnnotation.typeAnnotation
                   )
               )
-              .map(property => {
+              .map((property) => {
                 let propertyPropType =
                   property.type === 'TSMethodSignature'
                     ? getPropTypesForNode(
@@ -768,9 +769,11 @@ function getPropTypesForNode(node, optional, state) {
         ),
         [
           types.arrayExpression(
-            node.properties.map(property =>
+            node.properties.map((property) =>
               types.stringLiteral(
-                property.key ? property.key.name || property.key.value : property.argument.name
+                property.key
+                  ? property.key.name || property.key.value
+                  : property.argument.name
               )
             )
           ),
@@ -788,7 +791,7 @@ function getPropTypesForNode(node, optional, state) {
         [
           types.objectExpression(
             node.members
-              .map(property => {
+              .map((property) => {
                 // skip never keyword
                 if (
                   types.isTSNeverKeyword(property.typeAnnotation.typeAnnotation)
@@ -823,7 +826,7 @@ function getPropTypesForNode(node, optional, state) {
                 }
                 return objectProperty;
               })
-              .filter(x => x != null)
+              .filter((x) => x != null)
           ),
         ]
       );
@@ -834,7 +837,7 @@ function getPropTypesForNode(node, optional, state) {
     // literal values are extracted into a `oneOf`, if all members are literals this oneOf is used
     // otherwise `oneOfType` is used - if there are any literal values it contains the literals' `oneOf`
     case 'TSUnionType':
-      const tsUnionTypes = node.types.map(node =>
+      const tsUnionTypes = node.types.map((node) =>
         getPropTypesForNode(node, false, state)
       );
 
@@ -904,7 +907,7 @@ function getPropTypesForNode(node, optional, state) {
 
     // translate enum to PropTypes.oneOf
     case 'TSEnumDeclaration':
-      const memberTypes = node.members.map(member =>
+      const memberTypes = node.members.map((member) =>
         getPropTypesForNode(member, true, state)
       );
       propType = types.callExpression(
@@ -1062,7 +1065,7 @@ const typeDefinitionExtractors = {
     // only process relative imports for typescript definitions (avoid node_modules)
     if (isPathRelative && isImportTypecript) {
       // find the variable names being imported
-      const importedTypeNames = node.specifiers.map(specifier => {
+      const importedTypeNames = node.specifiers.map((specifier) => {
         switch (specifier.type) {
           case 'ImportSpecifier':
             return specifier.imported.name;
@@ -1161,14 +1164,12 @@ const typeDefinitionExtractors = {
    * @param node
    * @returns Array
    */
-  TSInterfaceDeclaration: node => {
+  TSInterfaceDeclaration: (node) => {
     const { id } = node;
 
     if (id.type !== 'Identifier') {
       throw new Error(
-        `TSInterfaceDeclaration typeDefinitionExtract could not understand id type ${
-          id.type
-        }`
+        `TSInterfaceDeclaration typeDefinitionExtract could not understand id type ${id.type}`
       );
     }
 
@@ -1180,14 +1181,12 @@ const typeDefinitionExtractors = {
    * @param node
    * @returns Array
    */
-  TSTypeAliasDeclaration: node => {
+  TSTypeAliasDeclaration: (node) => {
     const { id, typeAnnotation } = node;
 
     if (id.type !== 'Identifier') {
       throw new Error(
-        `TSTypeAliasDeclaraction typeDefinitionExtract could not understand id type ${
-          id.type
-        }`
+        `TSTypeAliasDeclaraction typeDefinitionExtract could not understand id type ${id.type}`
       );
     }
     return [{ name: id.name, definition: typeAnnotation }];
@@ -1198,14 +1197,12 @@ const typeDefinitionExtractors = {
    * @param node
    * @returns Array
    */
-  TSEnumDeclaration: node => {
+  TSEnumDeclaration: (node) => {
     const { id } = node;
 
     if (id.type !== 'Identifier') {
       throw new Error(
-        `TSEnumDeclaration typeDefinitionExtract could not understand id type ${
-          id.type
-        }`
+        `TSEnumDeclaration typeDefinitionExtract could not understand id type ${id.type}`
       );
     }
 
@@ -1217,7 +1214,7 @@ const typeDefinitionExtractors = {
    * @param node
    * @returns Array
    */
-  VariableDeclaration: node => {
+  VariableDeclaration: (node) => {
     return node.declarations.reduce((declarations, declaration) => {
       if (
         declaration.init != null &&
@@ -1389,7 +1386,7 @@ module.exports = function propTypesFromTypeScript({ types }) {
             {
               ImportDeclaration: ({ node }) => {
                 if (node.source.value === 'react') {
-                  node.specifiers.forEach(specifier => {
+                  node.specifiers.forEach((specifier) => {
                     if (specifier.type === 'ImportSpecifier') {
                       importsFromReact.add(specifier.local.name);
                     }
@@ -1414,7 +1411,7 @@ module.exports = function propTypesFromTypeScript({ types }) {
               this.file.opts.filename
             ),
             fs: opts.fs || fs,
-            parse: code => babelCore.parse(code, state.file.opts),
+            parse: (code) => babelCore.parse(code, state.file.opts),
           };
 
           // collect named TS type definitions for later reference
@@ -1505,7 +1502,7 @@ module.exports = function propTypesFromTypeScript({ types }) {
         )
           return;
 
-        const resolveVariableDeclarator = variableDeclarator => {
+        const resolveVariableDeclarator = (variableDeclarator) => {
           const { id } = variableDeclarator;
           const idTypeAnnotation = id.typeAnnotation;
           let fileCodeNeedsUpdating = false;

--- a/scripts/jest/.babelrc.js
+++ b/scripts/jest/.babelrc.js
@@ -1,11 +1,11 @@
 module.exports = {
-  "extends": "../../.babelrc.js",
-  "presets": [
-    ["@babel/env", {
-      "targets": { "node": "current" }
-    }],
-  ],
-  "plugins": [
-    "dynamic-import-node"
+  extends: '../../.babelrc.js',
+  presets: [
+    [
+      '@babel/env',
+      {
+        targets: { node: 'current' },
+      },
+    ],
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3668,13 +3668,6 @@ babel-plugin-add-module-exports@^1.0.2:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz#6caa4ddbe1f578c6a5264d4d3e6c8a2720a7ca2b"
   integrity sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==
 
-babel-plugin-dynamic-import-node@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"
-  integrity sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
-  dependencies:
-    object.assign "^4.1.0"
-
 babel-plugin-inline-react-svg@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-react-svg/-/babel-plugin-inline-react-svg-1.1.1.tgz#3fce30c5653a6c032c21ccc2b3e0141cd494b1d8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3615,11 +3615,6 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"


### PR DESCRIPTION
## Summary

This PR is part of our ongoing `babel` upgrade work (https://github.com/elastic/eui/issues/6652). It removes the following unused babel packages:

- `@babel/plugin-syntax-dynamic-import`
    - Per Babel's docs (https://babeljs.io/docs/babel-plugin-syntax-dynamic-import.html), `@babel/plugin-syntax-dynamic-import` is now included automatically in `@babel/core` above v7.8.0 (which we're above) as well as in `@babel/preset-env` which we already have. As such, we shouldn't need to define it manually in our package.json or as a babel plugin.
- `babel-plugin-dynamic-import-node`
    - same reasoning as above - `EuiIcon` Jest tests do not fail with this removed, which would be the primary usage
- `babel-core@7.0.0-bridge.0`
    - doesn't seem to be affecting anything either. will wait and see if CI throws

## QA

- [x] CI passes
- No changelog, tech debt only
