### PR TITLE
[BUILDKITE] Adding IAC scaffold for new EUI agent.

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -1,0 +1,6 @@
+# 🏠/.buildkite/pipelines/pipeline_pull_request_test.yml
+
+steps:
+  - label: ":hammer: EUI pull request test"
+    command: "echo 'This will run our EUI tests!'"
+

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,5 @@
+################################################################################
+###################### catalog-info for EUI ######################
 # Declare a Backstage Component that represents your application.
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
@@ -20,6 +22,8 @@ spec:
   system: ci-systems
   lifecycle: production
 
+###############################################################################
+############################# Buildkite pipelines ##############################
 # Declare your Buildkite pipeline.
 # This declaration creates the Backstage entity and the pipeline in Buildkite.
 ---
@@ -48,6 +52,40 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipeline.yml"
+      teams:
+        eui-team:
+         access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+############################ Pull request test #############################
+# Run all unit and functional tests
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-eui-pull-request-test
+  description: EUI pipeline to run unit and functional tests on pull request
+  links: [
+    {
+      title: "EUI - pull-request-test",
+      url: "https://buildkite.com/elastic/eui-pull-request-test",
+    }
+  ]
+      
+spec:
+  type: buildkite-pipeline
+  owner: group:eui-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: eui-pull-request-test
+    spec:
+      repository: elastic/eui
+      pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Summary

This PR is infrastructure as code (IAC) to scaffold a new Buildkite agent. Merging this into `main` is the first step, then I can work from a long-tail feature branch for defining the actual job.

## QA

QA will be done after the job merges to verify the new agent was built correctly. I'll rebase my feature branch onto `main` and start building against it for the remainder of work on this agent.