### PR TITLE
Revising Buildkite config file to run `pull_request_test` on one branch only

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -73,6 +73,11 @@ metadata:
       url: "https://buildkite.com/elastic/eui-pull-request-test",
     }
   ]
+  provider_settings: {
+    build_pull_requests: false,
+    filter_enabled: true,
+    filter_condition: build.pull_request.base_branch == "feature/buildkite-migration"
+  }
       
 spec:
   type: buildkite-pipeline


### PR DESCRIPTION
## Summary

After talking with our Ops team, I found out the `catalog-info.yaml` file needed a few more declarations to ensure the Buildkite job(s) run only on my feature branch. At least for now. This PR updates the catalog-info file with the needed Terraform declarations to limit builds to `feature/buildkite-migration`.

## QA

Will verify builds are only happening on my feature branch after the change is merged.