### PR TITLE
[BUILDKITE] Update Terraform config to only build (run jobs) on one branch

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -73,13 +73,6 @@ metadata:
       url: "https://buildkite.com/elastic/eui-pull-request-test",
     }
   ]
-  # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
-  provider_settings:
-    build_branches: true
-    build_tags: false
-    build_pull_requests: false
-    filter_enabled: true
-    filter_condition: build.branch == "feature/buildkite-migration"
       
 spec:
   type: buildkite-pipeline
@@ -93,6 +86,13 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
+      # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
+      provider_settings:
+        build_branches: true
+        build_tags: false
+        build_pull_requests: false
+        filter_enabled: true
+        filter_condition: build.branch == "feature/buildkite-migration"
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -73,10 +73,13 @@ metadata:
       url: "https://buildkite.com/elastic/eui-pull-request-test",
     }
   ]
+  # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
   provider_settings: {
-    build_pull_requests: false,
-    filter_enabled: true,
-    filter_condition: build.pull_request.base_branch == "feature/buildkite-migration"
+    build_branches                            = false
+    build_tags                                = false
+    build_pull_requests                       = true
+    pull_request_branch_filter_enabled        = true
+    pull_request_branch_filter_configuration  = build.pull_request.base_branch == "feature/buildkite-migration"
   }
       
 spec:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -74,13 +74,12 @@ metadata:
     }
   ]
   # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
-  provider_settings: {
-    build_branches          = true
-    build_tags              = false
-    build_pull_requests     = false
-    filter_enabled          = true
-    filter_condition        = build.branch == "feature/buildkite-migration"
-  }
+  provider_settings:
+    build_branches: true
+    build_tags: false
+    build_pull_requests: false
+    filter_enabled: true
+    filter_condition: build.branch == "feature/buildkite-migration"
       
 spec:
   type: buildkite-pipeline

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -75,11 +75,11 @@ metadata:
   ]
   # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
   provider_settings: {
-    build_branches                            = false
-    build_tags                                = false
-    build_pull_requests                       = true
-    pull_request_branch_filter_enabled        = true
-    pull_request_branch_filter_configuration  = build.pull_request.base_branch == "feature/buildkite-migration"
+    build_branches          = true
+    build_tags              = false
+    build_pull_requests     = false
+    filter_enabled          = true
+    filter_condition        = build.branch == "feature/buildkite-migration"
   }
       
 spec:


### PR DESCRIPTION
## Summary
This PR fixes some logic from my earlier PR https://github.com/elastic/eui/pull/6789. I realized later in the day that I needed to focus on **branches** instead of **pull requests** and filter to my long-tail `feature/buildkite-migration` branch. This PR updates the `catalog-info.yaml` file to accomplish that task.

## QA
I've read through the docs recommended by our Ops team a second time and will confirm this updates the BK pipeline settings correctly.