### PR TITLE
[BUILDKITE] Scaffolding PR deploy docs job.

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
@@ -1,0 +1,6 @@
+# 🏠/.buildkite/pipelines/pipeline_pull_request_test.yml
+
+steps:
+  - label: ":hammer: EUI pull request deploy docs"
+    command: "echo 'This will deploy our EUI docs!'"
+

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -59,7 +59,7 @@ spec:
           access_level: READ_ONLY
 
 ############################ Pull request test #############################
-# Run all unit and functional tests
+# Run all unit and functional tests on PR
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -87,6 +87,47 @@ spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
       # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
+      provider_settings:
+        build_branches: true
+        build_tags: false
+        build_pull_requests: false
+        filter_enabled: true
+        filter_condition: build.branch == "feature/buildkite-migration"
+      teams:
+        eui-team:
+         access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+############################ Pull request deploy docs #############################
+# Deploy docs to cloud on PR
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-eui-pull-request-deploy-docs
+  description: EUI pipeline to deploy docs to cloud on pull request
+  links: [
+    {
+      title: "EUI - pull-request-deploy-docs",
+      url: "https://buildkite.com/elastic/eui-pull-request-deploy-docs",
+    }
+  ]
+      
+spec:
+  type: buildkite-pipeline
+  owner: group:eui-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: eui-pull-request-deploy-docs
+    spec:
+      repository: elastic/eui
+      pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
+      # Pull request deploy docs - only run when code is pushed to feature/buildkite-migration branch. For now.
       provider_settings:
         build_branches: true
         build_tags: false


### PR DESCRIPTION
## Summary

Scaffolding a new job for deploying docs with unique URL on pull request. This is just the required configuration and a simple shell echo to verify the job is in place. The actual work to create the job will be done in another PR.

## QA

@1Copenut will verify the job is appearing in Buildkite and 🤞 not running on PRs to `main`.