### PR TITLE
fix(EuiCode): fix code block copy button not including the last character

### DIFF
--- a/src/components/code/code_block_copy.spec.tsx
+++ b/src/components/code/code_block_copy.spec.tsx
@@ -105,8 +105,6 @@ describe('EuiCodeBlock copy UX', () => {
     cy.realMount(<EuiCodeBlock isCopyable>{questionContent}</EuiCodeBlock>);
 
     cy.get('[data-test-subj="euiCodeBlockCopy"]').realClick();
-    // TODO: Remove incorrect assertion and uncomment correct assertion once bug is fixed
-    assertClipboardContentEquals('hello\n\nworld');
-    // assertClipboardContentEquals(questionContent);
+    assertClipboardContentEquals(questionContent);
   });
 });

--- a/src/components/code/code_block_copy.tsx
+++ b/src/components/code/code_block_copy.tsx
@@ -28,11 +28,8 @@ export const useCopy = ({
   const [innerTextRef, _innerText] = useInnerText('');
   const innerText = useMemo(
     () =>
-      _innerText
-        // Normalize line terminations to match native JS format
-        ?.replace(NEW_LINE_REGEX_GLOBAL, '\n')
-        // Reduce two or more consecutive new line characters to a single one
-        .replace(/\n{2,}/g, '\n') || '',
+      // Normalize line terminations to match native JS format
+      _innerText?.replace(NEW_LINE_REGEX_GLOBAL, '\n') || '',
     [_innerText]
   );
   const textToCopy = isVirtualized ? `${children}` : innerText; // Virtualized code blocks do not have inner text

--- a/src/components/code/code_block_copy.tsx
+++ b/src/components/code/code_block_copy.tsx
@@ -11,6 +11,7 @@ import { useInnerText } from '../inner_text';
 import { EuiCopy } from '../copy';
 import { useEuiI18n } from '../i18n';
 import { EuiButtonIcon } from '../button';
+import { NEW_LINE_REGEX_GLOBAL } from './utils';
 
 /**
  * Hook that returns copy-related state/logic/utils
@@ -26,7 +27,12 @@ export const useCopy = ({
 }) => {
   const [innerTextRef, _innerText] = useInnerText('');
   const innerText = useMemo(
-    () => _innerText?.replace(/[\r\n?]{2}|\n\n/g, '\n') || '',
+    () =>
+      _innerText
+        // Normalize line terminations to match native JS format
+        ?.replace(NEW_LINE_REGEX_GLOBAL, '\n')
+        // Reduce two or more consecutive new line characters to a single one
+        .replace(/\n{2,}/g, '\n') || '',
     [_innerText]
   );
   const textToCopy = isVirtualized ? `${children}` : innerText; // Virtualized code blocks do not have inner text

--- a/src/components/code/code_block_copy.tsx
+++ b/src/components/code/code_block_copy.tsx
@@ -28,8 +28,11 @@ export const useCopy = ({
   const [innerTextRef, _innerText] = useInnerText('');
   const innerText = useMemo(
     () =>
-      // Normalize line terminations to match native JS format
-      _innerText?.replace(NEW_LINE_REGEX_GLOBAL, '\n') || '',
+      _innerText
+        // Normalize line terminations to match native JS format
+        ?.replace(NEW_LINE_REGEX_GLOBAL, '\n')
+        // Reduce two or more consecutive new line characters to a single one
+        .replace(/\n{2,}/g, '\n') || '',
     [_innerText]
   );
   const textToCopy = isVirtualized ? `${children}` : innerText; // Virtualized code blocks do not have inner text

--- a/src/components/code/code_block_copy.tsx
+++ b/src/components/code/code_block_copy.tsx
@@ -32,6 +32,8 @@ export const useCopy = ({
         // Normalize line terminations to match native JS format
         ?.replace(NEW_LINE_REGEX_GLOBAL, '\n')
         // Reduce two or more consecutive new line characters to a single one
+        // This is needed primarily because of how syntax highlighting
+        // generated DOM elements affect `innerText` output.
         .replace(/\n{2,}/g, '\n') || '',
     [_innerText]
   );

--- a/src/components/code/utils.tsx
+++ b/src/components/code/utils.tsx
@@ -41,6 +41,22 @@ export type EuiCodeSharedProps = CommonProps &
 export const SUPPORTED_LANGUAGES = listLanguages();
 export const DEFAULT_LANGUAGE = 'text';
 
+/**
+ * Platform-agnostic new line regex that safely matches all standard
+ * line termination conventions:
+ * - LF: Unix-based platforms and JS-native sources like text areas
+ * - CRLF: Windows
+ * - CR: Mac Classic; to support files saved a long time ago
+ */
+export const NEW_LINE_REGEX = /\r\n|\r|\n/;
+
+/**
+ * Platform-agnostic global new line regex that safely matches all standard
+ * line termination conventions.
+ * See [NEW_LINE_REGEX]{@link NEW_LINE_REGEX} for more details.
+ */
+export const NEW_LINE_REGEX_GLOBAL = new RegExp(NEW_LINE_REGEX, 'g');
+
 export const checkSupportedLanguage = (language: string): string => {
   return SUPPORTED_LANGUAGES.includes(language) ? language : DEFAULT_LANGUAGE;
 };
@@ -139,12 +155,12 @@ const addLineData = (
   return nodes.reduce<ExtendedRefractorNode[]>((result, node) => {
     const lineStart = data.lineNumber;
     if (node.type === 'text') {
-      if (!node.value.match(/\r\n?|\n/)) {
+      if (!node.value.match(NEW_LINE_REGEX)) {
         node.lineStart = lineStart;
         node.lineEnd = lineStart;
         result.push(node);
       } else {
-        const lines = node.value.split(/\r\n?|\n/);
+        const lines = node.value.split(NEW_LINE_REGEX);
         lines.forEach((line, i) => {
           const num = i === 0 ? data.lineNumber : ++data.lineNumber;
           result.push({

--- a/upcoming_changelogs/6794.md
+++ b/upcoming_changelogs/6794.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed `EuiCode` potentially incorrectly ignoring lines ending with a question mark when using the Copy button.
+- Fixed `EuiCodeBlock` potentially incorrectly ignoring lines ending with a question mark when using the Copy button.

--- a/upcoming_changelogs/6794.md
+++ b/upcoming_changelogs/6794.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiCode` potentially incorrectly ignoring lines ending with a question mark when using the Copy button.


### PR DESCRIPTION
## Summary

This PR fixes #6585 that was caused by an incorrect regex being used in `src/components/code/code_block_copy.tsx`. Rest of the replace logic stays the same.

## QA

### General checklist

- ~Checked in both **light and dark** modes~
- ~Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
- ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- ~Checked for **breaking changes** and labeled appropriately~
- ~Checked for **accessibility** including keyboard-only and screenreader modes~
- ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
