### PR TITLE
[BUILDKITE] Scaffolding job to run test and deploy jobs on PR.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -86,13 +86,11 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
-      # Not running this job individually. Part of build and deploy job now.
+      # Job runs as a step in pull request combined job
       provider_settings:
         build_branches: false
         build_tags: false
         build_pull_requests: false
-        # filter_enabled: true
-        # filter_condition: build.branch == "feature/buildkite-migration"
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ
@@ -127,13 +125,11 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
-      # Not running this job individually. Part of build and deploy job now.
+      # Job runs as a step in pull request combined job
       provider_settings:
         build_branches: false
         build_tags: false
         build_pull_requests: false
-        # filter_enabled: true
-        # filter_condition: build.branch == "feature/buildkite-migration"
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ
@@ -169,7 +165,6 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
-      # Pull request deploy docs - only run when code is pushed to feature/buildkite-migration branch. For now.
       provider_settings:
         build_branches: false
         build_tags: false

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -86,13 +86,13 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
-      # Pull request test - only run when code is pushed to feature/buildkite-migration branch. For now.
+      # Not running this job individually. Part of build and deploy job now.
       provider_settings:
-        build_branches: true
+        build_branches: false
         build_tags: false
         build_pull_requests: false
-        filter_enabled: true
-        filter_condition: build.branch == "feature/buildkite-migration"
+        # filter_enabled: true
+        # filter_condition: build.branch == "feature/buildkite-migration"
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ
@@ -127,13 +127,55 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
-      # Pull request deploy docs - only run when code is pushed to feature/buildkite-migration branch. For now.
+      # Not running this job individually. Part of build and deploy job now.
       provider_settings:
-        build_branches: true
+        build_branches: false
         build_tags: false
         build_pull_requests: false
+        # filter_enabled: true
+        # filter_condition: build.branch == "feature/buildkite-migration"
+      teams:
+        eui-team:
+         access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+
+############################ Pull request combined job #############################
+# Orchestrate tests and deploying docs to cloud on branch PR
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-eui-pull-request-test-and-deploy
+  description: EUI pipeline to run tests and deploy docs to cloud on branch pull request
+  links: [
+    {
+      title: "EUI - pull-request-test-and-deploy",
+      url: "https://buildkite.com/elastic/eui-pull-request-test-and-deploy",
+    }
+  ]
+      
+spec:
+  type: buildkite-pipeline
+  owner: group:eui-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: eui-pull-request-test-and-deploy
+    spec:
+      repository: elastic/eui
+      pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
+      # Pull request deploy docs - only run when code is pushed to feature/buildkite-migration branch. For now.
+      provider_settings:
+        build_branches: false
+        build_tags: false
+        build_pull_requests: true
         filter_enabled: true
-        filter_condition: build.branch == "feature/buildkite-migration"
+        filter_condition: build.pull_request.base_branch == "feature/buildkite-migration"
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Summary

This job will run the two previous jobs I've created, namely [pull request test](https://github.com/elastic/eui/blob/17647029fd47be52a027b24dc41e4908ae435326/catalog-info.yaml#L61) and [pull request deploy docs](https://github.com/elastic/eui/blob/17647029fd47be52a027b24dc41e4908ae435326/catalog-info.yaml#L102). Those jobs with now **only** run when this third job is triggered on a pull request.

This PR adds the third job configuration, disables the two existing jobs from running on their own, and changes the job run parameters to PR instead of code push.

## QA

@1Copenut will verify this job is created by Buildkite correctly and only runs when PRs are pointed at the `feature/buildkite-migration` branch.