### PR TITLE
[EuiInlineEdit] Final screen reader / a11y polish pass

### DIFF
--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -667,9 +667,7 @@ exports[`EuiInlineEditForm Read Mode isReadOnly 1`] = `
   <span
     hidden=""
     id="inlineEdit_generated-id"
-  >
-    Click to edit this text inline.
-  </span>
+  />
 </div>
 `;
 

--- a/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_text.test.tsx.snap
@@ -29,9 +29,7 @@ exports[`EuiInlineEditText isReadOnly 1`] = `
   <span
     hidden=""
     id="inlineEdit_generated-id"
-  >
-    Click to edit this text inline.
-  </span>
+  />
 </div>
 `;
 

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`EuiInlineEditTitle isReadOnly 1`] = `
       >
         <h1
           class="euiTitle eui-textTruncate emotion-euiTitle-m"
+          role="presentation"
         >
           Hello World!
         </h1>

--- a/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_title.test.tsx.snap
@@ -30,9 +30,7 @@ exports[`EuiInlineEditTitle isReadOnly 1`] = `
   <span
     hidden=""
     id="inlineEdit_generated-id"
-  >
-    Click to edit this text inline.
-  </span>
+  />
 </div>
 `;
 

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -201,6 +201,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const editModeInputOnKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     switch (event.key) {
       case keys.ENTER:
+        event.preventDefault(); // Enter keypresses will not proceed otherwise on webkit browsers & screen readers
         saveInlineEditValue();
         break;
       case keys.ESCAPE:

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -249,14 +249,11 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             )}
           />
         </EuiFormRow>
-
         <span id={editModeDescribedById} hidden>
-          {!isReadOnly && (
-            <EuiI18n
-              token="euiInlineEditForm.inputKeyboardInstructions"
-              default="Press Enter to save your edited text. Press Escape to cancel your edit."
-            />
-          )}
+          <EuiI18n
+            token="euiInlineEditForm.inputKeyboardInstructions"
+            default="Press Enter to save your edited text. Press Escape to cancel your edit."
+          />
         </span>
       </EuiFlexItem>
 
@@ -342,10 +339,12 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
         {children(readModeValue)}
       </EuiButtonEmpty>
       <span id={readModeDescribedById} hidden>
-        <EuiI18n
-          token="euiInlineEditForm.activateEditModeDescription"
-          default="Click to edit this text inline."
-        />
+        {!isReadOnly && (
+          <EuiI18n
+            token="euiInlineEditForm.activateEditModeDescription"
+            default="Click to edit this text inline."
+          />
+        )}
       </span>
     </>
   );

--- a/src/components/inline_edit/inline_edit_title.tsx
+++ b/src/components/inline_edit/inline_edit_title.tsx
@@ -96,7 +96,9 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
     >
       {(titleReadModeValue) => (
         <EuiTitle size={size} className="eui-textTruncate">
-          <H>{titleReadModeValue}</H>
+          <H role={isReadOnly ? 'presentation' : undefined}>
+            {titleReadModeValue}
+          </H>
         </EuiTitle>
       )}
     </EuiInlineEditForm>


### PR DESCRIPTION
## Summary

See commit history

## QA

- Read-only should not have aria-describedby attribute or SR-only text blocks rendered. ( https://github.com/elastic/eui/pull/6777#discussion_r1197090164 )

- Read-only headings should no longer announce to VoiceOver as headings twice ( https://github.com/elastic/eui/pull/6777#discussion_r1195501995 ):
  - Since the buttons are disabled, it might read out as “button, dimmed” and I’m not sure there’s anything we can do about that.
  - Test this pattern with VO and NVDA. Experimentation will be in order.
  - I’d like SRs to announce “button, dimmed” for both or neither if we can get to that level of consistency.

- Enter button consistency ( https://github.com/elastic/eui/pull/6757#discussion_r1197033809 ):
  - VO + Safari and NVDA + Chrome should correctly save and revert to read only mode

### General checklist

- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
