### PR TITLE
[EuiScreenReaderOnly] Add `preventCopy` prop

### DIFF
--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -15,6 +15,7 @@ import {
 import ScreenReaderLive from './screen_reader_live';
 import ScreenReaderLiveFocus from './screen_reader_live_focus';
 import ScreenReaderOnly from './screen_reader';
+import ScreenReaderPreventCopy from './screen_reader_prevent_copy';
 import ScreenReaderFocus from './screen_reader_focus';
 import SkipLink from './skip_link';
 import StylesHelpers from './styles_helpers';
@@ -22,6 +23,7 @@ import StylesHelpers from './styles_helpers';
 const screenReaderLiveSource = require('!!raw-loader!./screen_reader_live');
 const screenReaderLiveFocusSource = require('!!raw-loader!./screen_reader_live_focus');
 const screenReaderOnlySource = require('!!raw-loader!./screen_reader');
+const screenReaderPreventCopySource = require('!!raw-loader!./screen_reader_prevent_copy');
 const screenReaderFocusSource = require('!!raw-loader!./screen_reader_focus');
 
 const skipLinkSource = require('!!raw-loader!./skip_link');
@@ -74,7 +76,8 @@ export const AccessibilityExample = {
           <EuiSpacer />
           <p>
             <em>
-              Using a screen reader, verify that there is a second paragraph.
+              Use a screen reader, or select and copy both lines in the below
+              demo, to verify that there is a second paragraph.
             </em>
           </p>
         </>
@@ -91,12 +94,44 @@ export const AccessibilityExample = {
       source: [
         {
           type: GuideSectionTypes.JS,
+          code: screenReaderPreventCopySource,
+        },
+      ],
+      text: (
+        <>
+          <h3 id="preventCopy">Preventing users from copying hidden text</h3>
+          <p>
+            As you may have noticed in the previous demo, screen reader only
+            text is still selectable and copyable. If for any reason you do not
+            want this behavior, simply use the <EuiCode>preventCopy</EuiCode>{' '}
+            prop.
+          </p>
+          <p>
+            <em>
+              Select and copy both lines in the below demo and confirm only the
+              visible lines are copied.
+            </em>
+          </p>
+        </>
+      ),
+      props: {
+        EuiScreenReaderOnly,
+      },
+      snippet: `<EuiScreenReaderOnly preventCopy>
+  <!-- visually hidden content, cannot be selected or copied -->
+</EuiScreenReaderOnly>`,
+      demo: <ScreenReaderPreventCopy />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
           code: screenReaderFocusSource,
         },
       ],
       text: (
         <>
-          <h3>Showing on focus</h3>
+          <h3 id="showOnFocus">Showing on focus</h3>
           <p>
             If the wrapped element <strong>is focusable</strong>, you must use
             the <EuiCode>showOnFocus</EuiCode> prop to visibly show the element

--- a/src-docs/src/views/accessibility/screen_reader_prevent_copy.tsx
+++ b/src-docs/src/views/accessibility/screen_reader_prevent_copy.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { EuiScreenReaderOnly, EuiText } from '../../../../src/components';
+
+export default () => (
+  <EuiText>
+    <p>This is the first paragraph. It is visible and copyable.</p>
+    <EuiScreenReaderOnly preventCopy>
+      <p>
+        This is the second paragraph. It is hidden for sighted users, and is not
+        selectable or copyable by users, but remains visible to screen readers.
+      </p>
+    </EuiScreenReaderOnly>
+    <p>This is the third paragraph. It is visible and copyable.</p>
+  </EuiText>
+);

--- a/src/components/accessibility/screen_reader_only/__snapshots__/screen_reader_only.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_only/__snapshots__/screen_reader_only.test.tsx.snap
@@ -16,6 +16,14 @@ exports[`EuiScreenReaderOnly adds an accessibility class to a child element when
 </p>
 `;
 
+exports[`EuiScreenReaderOnly preventCopy 1`] = `
+<span
+  class="emotion-euiScreenReaderOnly-preventCopy"
+>
+  Text
+</span>
+`;
+
 exports[`EuiScreenReaderOnly showOnFocus 1`] = `
 <a
   class="emotion-euiScreenReaderOnly-showOnFocus"

--- a/src/components/accessibility/screen_reader_only/__snapshots__/screen_reader_only.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_only/__snapshots__/screen_reader_only.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiScreenReaderOnly adds an accessibility class to a child element and 
 <p
   class="foo bar emotion-euiScreenReaderOnly"
 >
-  This paragraph is not visibile to sighted users but will be read by screenreaders.
+  This paragraph is not visible to sighted users but will be read by screenreaders.
 </p>
 `;
 
@@ -12,7 +12,7 @@ exports[`EuiScreenReaderOnly adds an accessibility class to a child element when
 <p
   class="emotion-euiScreenReaderOnly"
 >
-  This paragraph is not visibile to sighted users but will be read by screenreaders.
+  This paragraph is not visible to sighted users but will be read by screenreaders.
 </p>
 `;
 

--- a/src/components/accessibility/screen_reader_only/__snapshots__/screen_reader_only.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_only/__snapshots__/screen_reader_only.test.tsx.snap
@@ -16,9 +16,9 @@ exports[`EuiScreenReaderOnly adds an accessibility class to a child element when
 </p>
 `;
 
-exports[`EuiScreenReaderOnly will show on focus 1`] = `
+exports[`EuiScreenReaderOnly showOnFocus 1`] = `
 <a
-  class="emotion-euiScreenReaderOnly"
+  class="emotion-euiScreenReaderOnly-showOnFocus"
   href="#"
 >
   Link

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.styles.ts
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.styles.ts
@@ -34,13 +34,15 @@ export const euiScreenReaderOnly = () => `
 /*
  * Styles
  */
-export const euiScreenReaderOnlyStyles = (showOnFocus?: boolean) => ({
-  euiScreenReaderOnly: showOnFocus
-    ? css`
-        // The :active selector is necessary for Safari which removes :focus when a button is pressed
-        &:not(:focus):not(:active):not(:focus-within) {
-          ${euiScreenReaderOnly()}
-        }
-      `
-    : css(euiScreenReaderOnly()),
+export const euiScreenReaderOnlyStyles = () => ({
+  // Note: the default SR only CSS and `showOnFocus` CSS are mutually exclusive
+  euiScreenReaderOnly: css`
+    ${euiScreenReaderOnly()}
+  `,
+  'euiScreenReaderOnly-showOnFocus': css`
+    // The :active selector is necessary for Safari which removes :focus when a button is pressed
+    &:not(:focus):not(:active):not(:focus-within) {
+      ${euiScreenReaderOnly()}
+    }
+  `,
 });

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.styles.ts
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.styles.ts
@@ -45,4 +45,7 @@ export const euiScreenReaderOnlyStyles = () => ({
       ${euiScreenReaderOnly()}
     }
   `,
+  preventCopy: css`
+    user-select: none;
+  `,
 });

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
@@ -39,7 +39,7 @@ describe('EuiScreenReaderOnly', () => {
     });
   });
 
-  test('will show on focus', () => {
+  test('showOnFocus', () => {
     const component = render(
       <EuiScreenReaderOnly showOnFocus>
         <a href="#">Link</a>

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
@@ -49,4 +49,14 @@ describe('EuiScreenReaderOnly', () => {
 
     expect(component).toMatchSnapshot();
   });
+
+  test('preventCopy', () => {
+    const component = render(
+      <EuiScreenReaderOnly preventCopy>
+        <span>Text</span>
+      </EuiScreenReaderOnly>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
@@ -17,7 +17,7 @@ describe('EuiScreenReaderOnly', () => {
       const $paragraph = render(
         <EuiScreenReaderOnly>
           <p>
-            This paragraph is not visibile to sighted users but will be read by
+            This paragraph is not visible to sighted users but will be read by
             screenreaders.
           </p>
         </EuiScreenReaderOnly>
@@ -25,11 +25,12 @@ describe('EuiScreenReaderOnly', () => {
 
       expect($paragraph).toMatchSnapshot();
     });
+
     test('and combines other classNames (foo, bar) given as props on the child', () => {
       const $paragraph = render(
         <EuiScreenReaderOnly>
           <p className="foo bar">
-            This paragraph is not visibile to sighted users but will be read by
+            This paragraph is not visible to sighted users but will be read by
             screenreaders.
           </p>
         </EuiScreenReaderOnly>

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
@@ -24,11 +24,18 @@ export interface EuiScreenReaderOnlyProps {
    * For keyboard navigation, force content to display visually upon focus/focus-within.
    */
   showOnFocus?: boolean;
+
+  /**
+   * Despite being visually hidden, text within `EuiScreenReaderOnly` will still
+   * be selectable and copyable. Set this to `true` if you do not want your
+   * screen reader text to be copied.
+   */
+  preventCopy?: boolean;
 }
 
 export const EuiScreenReaderOnly: FunctionComponent<
   EuiScreenReaderOnlyProps
-> = ({ children, className, showOnFocus }) => {
+> = ({ children, className, showOnFocus, preventCopy }) => {
   const classes = classNames(className, children.props.className);
 
   const styles = euiScreenReaderOnlyStyles();
@@ -36,6 +43,7 @@ export const EuiScreenReaderOnly: FunctionComponent<
     showOnFocus
       ? styles['euiScreenReaderOnly-showOnFocus']
       : styles.euiScreenReaderOnly,
+    preventCopy && styles.preventCopy,
   ];
 
   const props = {

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
@@ -30,8 +30,12 @@ export const EuiScreenReaderOnly: FunctionComponent<
 > = ({ children, className, showOnFocus }) => {
   const classes = classNames(className, children.props.className);
 
-  const styles = euiScreenReaderOnlyStyles(showOnFocus);
-  const cssStyles = [styles.euiScreenReaderOnly];
+  const styles = euiScreenReaderOnlyStyles();
+  const cssStyles = [
+    showOnFocus
+      ? styles['euiScreenReaderOnly-showOnFocus']
+      : styles.euiScreenReaderOnly,
+  ];
 
   const props = {
     className: classes.length ? classes : undefined,

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.tsx
@@ -18,11 +18,12 @@ export interface EuiScreenReaderOnlyProps {
    */
   children: ReactElement;
 
+  className?: string;
+
   /**
    * For keyboard navigation, force content to display visually upon focus/focus-within.
    */
   showOnFocus?: boolean;
-  className?: string;
 }
 
 export const EuiScreenReaderOnly: FunctionComponent<

--- a/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
+++ b/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiSkipLink is rendered 1`] = `
 <a
   aria-label="aria-label"
-  class="euiSkipLink testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-euiScreenReaderOnly"
+  class="euiSkipLink testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
   data-test-subj="test subject string"
   href="#somewhere"
   rel="noreferrer"
@@ -22,7 +22,7 @@ exports[`EuiSkipLink is rendered 1`] = `
 
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
 <a
-  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-absolute-euiScreenReaderOnly"
+  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-absolute-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -34,7 +34,7 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
 <a
-  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-fixed-euiScreenReaderOnly"
+  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-fixed-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
   tabindex="0"
@@ -47,7 +47,7 @@ exports[`EuiSkipLink props position fixed is rendered 1`] = `
 
 exports[`EuiSkipLink props position static is rendered 1`] = `
 <a
-  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-euiScreenReaderOnly"
+  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -59,7 +59,7 @@ exports[`EuiSkipLink props position static is rendered 1`] = `
 
 exports[`EuiSkipLink props tabIndex is rendered 1`] = `
 <a
-  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-euiScreenReaderOnly"
+  class="euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-s-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
   tabindex="-1"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -735,7 +735,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 1
                   </p>
@@ -768,7 +767,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 1
                   </p>
@@ -801,7 +799,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 2
                   </p>
@@ -834,7 +831,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 2
                   </p>
@@ -867,7 +863,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 3
                   </p>
@@ -900,7 +895,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 3
                   </p>
@@ -1253,7 +1247,6 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
-                      hidden=""
                     >
                       - leading, column 1, row 1
                     </p>
@@ -1292,7 +1285,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 2, row 1
                   </p>
@@ -1325,7 +1317,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 3, row 1
                   </p>
@@ -1366,7 +1357,6 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
-                      hidden=""
                     >
                       - trailing, column 4, row 1
                     </p>
@@ -1413,7 +1403,6 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
-                      hidden=""
                     >
                       - leading, column 1, row 2
                     </p>
@@ -1452,7 +1441,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 2, row 2
                   </p>
@@ -1485,7 +1473,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 3, row 2
                   </p>
@@ -1526,7 +1513,6 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
-                      hidden=""
                     >
                       - trailing, column 4, row 2
                     </p>
@@ -1573,7 +1559,6 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
-                      hidden=""
                     >
                       - leading, column 1, row 3
                     </p>
@@ -1612,7 +1597,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 2, row 3
                   </p>
@@ -1645,7 +1629,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 3, row 3
                   </p>
@@ -1686,7 +1669,6 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
-                      hidden=""
                     >
                       - trailing, column 4, row 3
                     </p>
@@ -1998,7 +1980,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 1
                   </p>
@@ -2031,7 +2012,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 1
                   </p>
@@ -2064,7 +2044,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 2
                   </p>
@@ -2097,7 +2076,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 2
                   </p>
@@ -2130,7 +2108,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 3
                   </p>
@@ -2163,7 +2140,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 3
                   </p>
@@ -2467,7 +2443,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 1
                   </p>
@@ -2500,7 +2475,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 1
                   </p>
@@ -2533,7 +2507,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 2
                   </p>
@@ -2566,7 +2539,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 2
                   </p>
@@ -2599,7 +2571,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - A, column 1, row 3
                   </p>
@@ -2632,7 +2603,6 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
-                    hidden=""
                   >
                     - B, column 2, row 3
                   </p>

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -734,7 +734,7 @@ Array [
                     0, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 1
                   </p>
@@ -766,7 +766,7 @@ Array [
                     0, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 1
                   </p>
@@ -798,7 +798,7 @@ Array [
                     1, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 2
                   </p>
@@ -830,7 +830,7 @@ Array [
                     1, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 2
                   </p>
@@ -862,7 +862,7 @@ Array [
                     2, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 3
                   </p>
@@ -894,7 +894,7 @@ Array [
                     2, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 3
                   </p>
@@ -1246,7 +1246,7 @@ Array [
                       0
                     </div>
                     <p
-                      class="emotion-euiScreenReaderOnly"
+                      class="emotion-euiScreenReaderOnly-preventCopy"
                     >
                       - leading, column 1, row 1
                     </p>
@@ -1284,7 +1284,7 @@ Array [
                     0, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 2, row 1
                   </p>
@@ -1316,7 +1316,7 @@ Array [
                     0, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 3, row 1
                   </p>
@@ -1356,7 +1356,7 @@ Array [
                       0
                     </div>
                     <p
-                      class="emotion-euiScreenReaderOnly"
+                      class="emotion-euiScreenReaderOnly-preventCopy"
                     >
                       - trailing, column 4, row 1
                     </p>
@@ -1402,7 +1402,7 @@ Array [
                       1
                     </div>
                     <p
-                      class="emotion-euiScreenReaderOnly"
+                      class="emotion-euiScreenReaderOnly-preventCopy"
                     >
                       - leading, column 1, row 2
                     </p>
@@ -1440,7 +1440,7 @@ Array [
                     1, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 2, row 2
                   </p>
@@ -1472,7 +1472,7 @@ Array [
                     1, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 3, row 2
                   </p>
@@ -1512,7 +1512,7 @@ Array [
                       1
                     </div>
                     <p
-                      class="emotion-euiScreenReaderOnly"
+                      class="emotion-euiScreenReaderOnly-preventCopy"
                     >
                       - trailing, column 4, row 2
                     </p>
@@ -1558,7 +1558,7 @@ Array [
                       2
                     </div>
                     <p
-                      class="emotion-euiScreenReaderOnly"
+                      class="emotion-euiScreenReaderOnly-preventCopy"
                     >
                       - leading, column 1, row 3
                     </p>
@@ -1596,7 +1596,7 @@ Array [
                     2, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 2, row 3
                   </p>
@@ -1628,7 +1628,7 @@ Array [
                     2, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 3, row 3
                   </p>
@@ -1668,7 +1668,7 @@ Array [
                       2
                     </div>
                     <p
-                      class="emotion-euiScreenReaderOnly"
+                      class="emotion-euiScreenReaderOnly-preventCopy"
                     >
                       - trailing, column 4, row 3
                     </p>
@@ -1979,7 +1979,7 @@ Array [
                     0, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 1
                   </p>
@@ -2011,7 +2011,7 @@ Array [
                     0, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 1
                   </p>
@@ -2043,7 +2043,7 @@ Array [
                     1, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 2
                   </p>
@@ -2075,7 +2075,7 @@ Array [
                     1, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 2
                   </p>
@@ -2107,7 +2107,7 @@ Array [
                     2, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 3
                   </p>
@@ -2139,7 +2139,7 @@ Array [
                     2, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 3
                   </p>
@@ -2442,7 +2442,7 @@ Array [
                     0, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 1
                   </p>
@@ -2474,7 +2474,7 @@ Array [
                     0, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 1
                   </p>
@@ -2506,7 +2506,7 @@ Array [
                     1, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 2
                   </p>
@@ -2538,7 +2538,7 @@ Array [
                     1, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 2
                   </p>
@@ -2570,7 +2570,7 @@ Array [
                     2, A
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - A, column 1, row 3
                   </p>
@@ -2602,7 +2602,7 @@ Array [
                     2, B
                   </div>
                   <p
-                    class="emotion-euiScreenReaderOnly"
+                    class="emotion-euiScreenReaderOnly-preventCopy"
                   >
                     - B, column 2, row 3
                   </p>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -147,7 +147,6 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
-            hidden=""
           >
             - 
             columnA, column 1, row 1
@@ -181,7 +180,6 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
-            hidden=""
           >
             - 
             columnB, column 2, row 1
@@ -219,7 +217,6 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
-            hidden=""
           >
             - 
             columnA, column 1, row 2
@@ -253,7 +250,6 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
-            hidden=""
           >
             - 
             columnB, column 2, row 2

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
             hello
           </div>
           <p
-            class="emotion-euiScreenReaderOnly"
+            class="emotion-euiScreenReaderOnly-preventCopy"
           >
             - 
             columnA, column 1, row 1
@@ -179,7 +179,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
             world
           </div>
           <p
-            class="emotion-euiScreenReaderOnly"
+            class="emotion-euiScreenReaderOnly-preventCopy"
           >
             - 
             columnB, column 2, row 1
@@ -216,7 +216,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
             lorem
           </div>
           <p
-            class="emotion-euiScreenReaderOnly"
+            class="emotion-euiScreenReaderOnly-preventCopy"
           >
             - 
             columnA, column 1, row 2
@@ -249,7 +249,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
             ipsum
           </div>
           <p
-            class="emotion-euiScreenReaderOnly"
+            class="emotion-euiScreenReaderOnly-preventCopy"
           >
             - 
             columnB, column 2, row 2

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -146,7 +146,6 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
-            hidden=""
           >
             - columnA, column 1, row 1
           </p>
@@ -181,7 +180,6 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
-            hidden=""
           >
             - columnB, column 2, row 1
           </p>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
             </span>
           </div>
           <p
-            class="emotion-euiScreenReaderOnly"
+            class="emotion-euiScreenReaderOnly-preventCopy"
           >
             - columnA, column 1, row 1
           </p>
@@ -179,7 +179,7 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
             </span>
           </div>
           <p
-            class="emotion-euiScreenReaderOnly"
+            class="emotion-euiScreenReaderOnly-preventCopy"
           >
             - columnB, column 2, row 1
           </p>

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -73,7 +73,6 @@ exports[`EuiDataGridCell renders 1`] = `
       </div>
       <p
         class="emotion-euiScreenReaderOnly"
-        hidden=""
       >
         - someColumn, column 1, row 1
       </p>

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`EuiDataGridCell renders 1`] = `
         </div>
       </div>
       <p
-        class="emotion-euiScreenReaderOnly"
+        class="emotion-euiScreenReaderOnly-preventCopy"
       >
         - someColumn, column 1, row 1
       </p>

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -91,7 +91,7 @@ const EuiDataGridCellContent: FunctionComponent<
             {...rest}
           />
         </div>
-        <EuiScreenReaderOnly>
+        <EuiScreenReaderOnly preventCopy>
           <p>
             {'- '}
             <EuiI18n

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -47,7 +47,6 @@ const EuiDataGridCellContent: FunctionComponent<
     setCellContentsRef: EuiDataGridCell['setCellContentsRef'];
     isExpanded: boolean;
     isDefinedHeight: boolean;
-    isFocused: boolean;
     ariaRowIndex: number;
   }
 > = memo(
@@ -61,7 +60,6 @@ const EuiDataGridCellContent: FunctionComponent<
     ariaRowIndex,
     rowHeightUtils,
     isDefinedHeight,
-    isFocused,
     ...rest
   }) => {
     // React is more permissible than the TS types indicate
@@ -94,7 +92,7 @@ const EuiDataGridCellContent: FunctionComponent<
           />
         </div>
         <EuiScreenReaderOnly>
-          <p hidden={!isFocused}>
+          <p>
             {'- '}
             <EuiI18n
               token="euiDataGridCell.position"
@@ -662,7 +660,6 @@ export class EuiDataGridCell extends Component<
       isExpandable,
       isExpanded: popoverIsOpen,
       isDetails: false,
-      isFocused: this.state.isFocused,
       setCellContentsRef: this.setCellContentsRef,
       rowHeightsOptions,
       rowHeightUtils,

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -123,7 +123,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<
             {display || displayAsText || id}
           </div>
           {sortingScreenReaderText && (
-            <EuiScreenReaderOnly>
+            <EuiScreenReaderOnly preventCopy>
               <p>{sortingScreenReaderText}</p>
             </EuiScreenReaderOnly>
           )}

--- a/upcoming_changelogs/6806.md
+++ b/upcoming_changelogs/6806.md
@@ -1,0 +1,5 @@
+- Updated `EuiScreenReaderOnly` with a new `preventCopy` prop
+
+**Bug fixes**
+
+- Users attempting to copy and paste multiple cells from `EuiDataGrid` will no longer copy row/column data

--- a/upcoming_changelogs/6817.md
+++ b/upcoming_changelogs/6817.md
@@ -1,1 +1,0 @@
-- Updated `EuiDataGrid` to only render screen reader text announcing cell position if the cell is currently focused. This should improve the ability to copy and paste multiple cells without SR text.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6804
reverts https://github.com/elastic/eui/pull/6817 (`isFocused` workaround should no longer be needed)

This PR adds a `preventCopy` prop to EuiScreenReaderOnly, and applies said functionality to `EuiDataGrid` to prevent customers copying data from grabbing the SR information about row/column count.

I recommend, as always, following along by commit to separate out cleanup tasks.

## QA

- Go to http://localhost:8030/#/utilities/accessibility
- Copy both lines in the first demo
- [ ] Paste into any notepad and confirm the visually hidden text was copied (should have 3 lines)
- Copy both lines in the second demo
- [ ] Paste into any notepad and confirm the visually hidden text was not copied (should have 2 lines)

---

- Go to http://localhost:8030/#/tabular-content/data-grid
- Attempt to copy multiple cells worth of data
- [ ] Paste it into any textarea or notepad, and confirm just the visible text was copied

### General checklist

- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~