### PR TITLE
[EuiDataGrid] Reduce hidden SR text when copying text from multiple cells

### DIFF
--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -735,6 +735,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 1
                   </p>
@@ -767,6 +768,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 1
                   </p>
@@ -799,6 +801,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 2
                   </p>
@@ -831,6 +834,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 2
                   </p>
@@ -863,6 +867,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 3
                   </p>
@@ -895,6 +900,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 3
                   </p>
@@ -1247,6 +1253,7 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
+                      hidden=""
                     >
                       - leading, column 1, row 1
                     </p>
@@ -1285,6 +1292,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 2, row 1
                   </p>
@@ -1317,6 +1325,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 3, row 1
                   </p>
@@ -1357,6 +1366,7 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
+                      hidden=""
                     >
                       - trailing, column 4, row 1
                     </p>
@@ -1403,6 +1413,7 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
+                      hidden=""
                     >
                       - leading, column 1, row 2
                     </p>
@@ -1441,6 +1452,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 2, row 2
                   </p>
@@ -1473,6 +1485,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 3, row 2
                   </p>
@@ -1513,6 +1526,7 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
+                      hidden=""
                     >
                       - trailing, column 4, row 2
                     </p>
@@ -1559,6 +1573,7 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
+                      hidden=""
                     >
                       - leading, column 1, row 3
                     </p>
@@ -1597,6 +1612,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 2, row 3
                   </p>
@@ -1629,6 +1645,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 3, row 3
                   </p>
@@ -1669,6 +1686,7 @@ Array [
                     </div>
                     <p
                       class="emotion-euiScreenReaderOnly"
+                      hidden=""
                     >
                       - trailing, column 4, row 3
                     </p>
@@ -1980,6 +1998,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 1
                   </p>
@@ -2012,6 +2031,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 1
                   </p>
@@ -2044,6 +2064,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 2
                   </p>
@@ -2076,6 +2097,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 2
                   </p>
@@ -2108,6 +2130,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 3
                   </p>
@@ -2140,6 +2163,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 3
                   </p>
@@ -2443,6 +2467,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 1
                   </p>
@@ -2475,6 +2500,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 1
                   </p>
@@ -2507,6 +2533,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 2
                   </p>
@@ -2539,6 +2566,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 2
                   </p>
@@ -2571,6 +2599,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - A, column 1, row 3
                   </p>
@@ -2603,6 +2632,7 @@ Array [
                   </div>
                   <p
                     class="emotion-euiScreenReaderOnly"
+                    hidden=""
                   >
                     - B, column 2, row 3
                   </p>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -147,6 +147,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
+            hidden=""
           >
             - 
             columnA, column 1, row 1
@@ -180,6 +181,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
+            hidden=""
           >
             - 
             columnB, column 2, row 1
@@ -217,6 +219,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
+            hidden=""
           >
             - 
             columnA, column 1, row 2
@@ -250,6 +253,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
+            hidden=""
           >
             - 
             columnB, column 2, row 2

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -146,6 +146,7 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
+            hidden=""
           >
             - columnA, column 1, row 1
           </p>
@@ -180,6 +181,7 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
           </div>
           <p
             class="emotion-euiScreenReaderOnly"
+            hidden=""
           >
             - columnB, column 2, row 1
           </p>

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`EuiDataGridCell renders 1`] = `
       </div>
       <p
         class="emotion-euiScreenReaderOnly"
+        hidden=""
       >
         - someColumn, column 1, row 1
       </p>

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -47,6 +47,7 @@ const EuiDataGridCellContent: FunctionComponent<
     setCellContentsRef: EuiDataGridCell['setCellContentsRef'];
     isExpanded: boolean;
     isDefinedHeight: boolean;
+    isFocused: boolean;
     ariaRowIndex: number;
   }
 > = memo(
@@ -60,6 +61,7 @@ const EuiDataGridCellContent: FunctionComponent<
     ariaRowIndex,
     rowHeightUtils,
     isDefinedHeight,
+    isFocused,
     ...rest
   }) => {
     // React is more permissible than the TS types indicate
@@ -92,7 +94,7 @@ const EuiDataGridCellContent: FunctionComponent<
           />
         </div>
         <EuiScreenReaderOnly>
-          <p>
+          <p hidden={!isFocused}>
             {'- '}
             <EuiI18n
               token="euiDataGridCell.position"
@@ -660,6 +662,7 @@ export class EuiDataGridCell extends Component<
       isExpandable,
       isExpanded: popoverIsOpen,
       isDetails: false,
+      isFocused: this.state.isFocused,
       setCellContentsRef: this.setCellContentsRef,
       rowHeightsOptions,
       rowHeightUtils,

--- a/upcoming_changelogs/6817.md
+++ b/upcoming_changelogs/6817.md
@@ -1,0 +1,1 @@
+- Updated `EuiDataGrid` to only render screen reader text announcing cell position if the cell is currently focused. This should improve the ability to copy and paste multiple cells without SR text.


### PR DESCRIPTION
## Summary

This PR attempts to provide an interim workaround to https://github.com/elastic/eui/issues/6804 while https://github.com/elastic/eui/pull/6806 is blocked due to a Chromium bug.

It adds the `hidden` attribute to SR text of cells that aren't currently being focused, which prevents the text from being selected/copied in all browsers. The currently focused cell should not be `hidden` and should still read out its cell position to screen readers.

It's not 100% perfect as the cell position of the currently focused cell will still be end up in a copy/paste selection, but that's infinitely easier to edit once vs having to modify **every** single cell.

## QA

- Go to http://localhost:8030/#/tabular-content/data-grid-advanced#ref-methods with a screen reader open
- [x] Confirm that using the up/down arrow navigation keys to navigate between cells still reads out the column name and cell column/row index
- [x] Confirm that clicking the "focus cell" button to a specific cell still reads out the SR info
- [x] Attempt to copy and paste multiple cells (see below screenshot). Confirm that only the currently focused cell copies with SR text and all other cells do not

![screencap](https://github.com/elastic/eui/assets/549407/203ede5a-6b19-4d50-a828-105aa48c855b)

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
