### PR TITLE
[EuiCodeBlock] Fix line numbers appearing in copied content

### DIFF
--- a/src-docs/src/views/code/line_numbers_highlight.tsx
+++ b/src-docs/src/views/code/line_numbers_highlight.tsx
@@ -4,6 +4,7 @@ import { EuiCodeBlock, EuiCode } from '../../../../src/components';
 
 export default () => (
   <EuiCodeBlock
+    isCopyable
     language="json"
     fontSize="m"
     paddingSize="m"

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -114,16 +114,16 @@ exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="1"
           />
           <div
-            class="euiPopover emotion-euiPopover-euiCodeBlockAnnotation"
+            class="euiPopover euiCodeBlock__lineAnnotation emotion-euiPopover-euiCodeBlockAnnotation"
           >
             <div
               class="euiPopover__anchor css-16vtueo-render"
@@ -152,12 +152,12 @@ exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="2"
           />
         </span>
@@ -190,12 +190,12 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="1"
           />
         </span>
@@ -210,12 +210,12 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="2"
           />
         </span>
@@ -248,12 +248,12 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="1"
           />
         </span>
@@ -268,12 +268,12 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="2"
           />
         </span>
@@ -306,12 +306,12 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:16px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="10"
           />
         </span>
@@ -326,12 +326,12 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
         class="euiCodeBlock__line emotion-euiCodeBlock__line-hasLineNumbers"
       >
         <span
-          class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
+          class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
           style="inline-size:16px"
         >
           <span
             aria-hidden="true"
-            class="emotion-euiCodeBlock__lineNumber"
+            class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumber"
             data-line-number="11"
           />
         </span>

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -115,15 +115,13 @@ exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="1"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            1
-          </span>
+            data-line-number="1"
+          />
           <div
             class="euiPopover emotion-euiPopover-euiCodeBlockAnnotation"
           >
@@ -155,15 +153,13 @@ exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="2"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            2
-          </span>
+            data-line-number="2"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
@@ -195,15 +191,13 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="1"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            1
-          </span>
+            data-line-number="1"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText-isHighlighted"
@@ -217,15 +211,13 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="2"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            2
-          </span>
+            data-line-number="2"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
@@ -257,15 +249,13 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="1"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            1
-          </span>
+            data-line-number="1"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
@@ -279,15 +269,13 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="2"
           style="inline-size:8px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            2
-          </span>
+            data-line-number="2"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
@@ -319,15 +307,13 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="10"
           style="inline-size:16px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            10
-          </span>
+            data-line-number="10"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"
@@ -341,15 +327,13 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
       >
         <span
           class="euiCodeBlock__lineNumber emotion-euiCodeBlock__lineNumberWrapper"
-          data-line-number="11"
           style="inline-size:16px"
         >
           <span
             aria-hidden="true"
             class="emotion-euiCodeBlock__lineNumber"
-          >
-            11
-          </span>
+            data-line-number="11"
+          />
         </span>
         <span
           class="euiCodeBlock__lineText emotion-euiCodeBlock__lineText"

--- a/src/components/code/__snapshots__/code_block_annotations.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block_annotations.test.tsx.snap
@@ -4,7 +4,8 @@ exports[`EuiCodeBlockAnnotation renders 1`] = `
 <body>
   <div>
     <div
-      class="euiPopover euiPopover-isOpen emotion-euiPopover-euiCodeBlockAnnotation"
+      class="euiPopover euiPopover-isOpen testClass1 testClass2 emotion-euiPopover-euiCodeBlockAnnotation"
+      data-test-subj="test subject string"
     >
       <div
         class="euiPopover__anchor css-16vtueo-render"
@@ -35,6 +36,7 @@ exports[`EuiCodeBlockAnnotation renders 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-label="aria-label"
         aria-live="off"
         aria-modal="true"
         class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-isOpen-bottom"

--- a/src/components/code/__snapshots__/utils.test.tsx.snap
+++ b/src/components/code/__snapshots__/utils.test.tsx.snap
@@ -11,6 +11,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 1,
@@ -21,7 +22,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -89,6 +90,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 2,
@@ -99,7 +101,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -239,6 +241,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 3,
@@ -249,7 +252,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -321,6 +324,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 10,
@@ -331,7 +335,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -399,6 +403,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 11,
@@ -409,7 +414,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -549,6 +554,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 12,
@@ -559,7 +565,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -631,6 +637,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 1,
@@ -646,7 +653,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -714,6 +721,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 2,
@@ -724,7 +732,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -864,6 +872,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 3,
@@ -874,7 +883,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -946,6 +955,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 1,
@@ -956,7 +966,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -1024,6 +1034,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 2,
@@ -1034,7 +1045,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -1174,6 +1185,7 @@ Array [
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
+                "euiCodeBlock__lineNumber",
                 "css-19pu25o-euiCodeBlock__lineNumber",
               ],
               "data-line-number": 3,
@@ -1184,7 +1196,7 @@ Array [
         ],
         "properties": Object {
           "className": Array [
-            "euiCodeBlock__lineNumber",
+            "euiCodeBlock__lineNumberWrapper",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
           "style": Object {
@@ -1445,6 +1457,7 @@ exports[`shared utils nodeToHtml handles rendering custom annotation types 1`] =
     key="node-0-0"
   >
     <EuiCodeBlockAnnotation
+      className="euiCodeBlock__lineAnnotation"
       key="0"
       lineNumber={3}
     >

--- a/src/components/code/__snapshots__/utils.test.tsx.snap
+++ b/src/components/code/__snapshots__/utils.test.tsx.snap
@@ -7,17 +7,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "1",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 1,
             },
             "tagName": "span",
             "type": "element",
@@ -28,7 +24,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 1,
           "style": Object {
             "inlineSize": 8,
           },
@@ -90,17 +85,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "2",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 2,
             },
             "tagName": "span",
             "type": "element",
@@ -111,7 +102,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 2,
           "style": Object {
             "inlineSize": 8,
           },
@@ -245,17 +235,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "3",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 3,
             },
             "tagName": "span",
             "type": "element",
@@ -266,7 +252,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 3,
           "style": Object {
             "inlineSize": 8,
           },
@@ -332,17 +317,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "10",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 10,
             },
             "tagName": "span",
             "type": "element",
@@ -353,7 +334,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 10,
           "style": Object {
             "inlineSize": 16,
           },
@@ -415,17 +395,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "11",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 11,
             },
             "tagName": "span",
             "type": "element",
@@ -436,7 +412,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 11,
           "style": Object {
             "inlineSize": 16,
           },
@@ -570,17 +545,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "12",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 12,
             },
             "tagName": "span",
             "type": "element",
@@ -591,7 +562,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 12,
           "style": Object {
             "inlineSize": 16,
           },
@@ -657,17 +627,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "1",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 1,
             },
             "tagName": "span",
             "type": "element",
@@ -683,7 +649,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 1,
           "style": Object {
             "inlineSize": 8,
           },
@@ -745,17 +710,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "2",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 2,
             },
             "tagName": "span",
             "type": "element",
@@ -766,7 +727,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 2,
           "style": Object {
             "inlineSize": 8,
           },
@@ -900,17 +860,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "3",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 3,
             },
             "tagName": "span",
             "type": "element",
@@ -921,7 +877,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 3,
           "style": Object {
             "inlineSize": 8,
           },
@@ -987,17 +942,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "1",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 1,
             },
             "tagName": "span",
             "type": "element",
@@ -1008,7 +959,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 1,
           "style": Object {
             "inlineSize": 8,
           },
@@ -1070,17 +1020,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "2",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 2,
             },
             "tagName": "span",
             "type": "element",
@@ -1091,7 +1037,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 2,
           "style": Object {
             "inlineSize": 8,
           },
@@ -1225,17 +1170,13 @@ Array [
       Object {
         "children": Array [
           Object {
-            "children": Array [
-              Object {
-                "type": "text",
-                "value": "3",
-              },
-            ],
+            "children": Array [],
             "properties": Object {
               "aria-hidden": true,
               "className": Array [
-                "css-5u6z3m-euiCodeBlock__lineNumber",
+                "css-19pu25o-euiCodeBlock__lineNumber",
               ],
+              "data-line-number": 3,
             },
             "tagName": "span",
             "type": "element",
@@ -1246,7 +1187,6 @@ Array [
             "euiCodeBlock__lineNumber",
             "css-wlfghs-euiCodeBlock__lineNumberWrapper",
           ],
-          "data-line-number": 3,
           "style": Object {
             "inlineSize": 8,
           },

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -200,20 +200,6 @@ describe('EuiCodeBlock', () => {
       expect(component).toMatchSnapshot();
     });
 
-    it('correctly copies virtualized text', () => {
-      const component = render(
-        <EuiCodeBlock
-          isCopyable
-          isVirtualized={true}
-          overflowHeight="50%"
-          {...requiredProps}
-        >
-          {code}
-        </EuiCodeBlock>
-      );
-      expect(component.find('.euiCodeBlock__copyButton')).toHaveLength(1);
-    });
-
     describe('type checks', () => {
       it('requires overflowHeight', () => {
         // @ts-expect-error should expect overflowHeight

--- a/src/components/code/code_block_annotations.test.tsx
+++ b/src/components/code/code_block_annotations.test.tsx
@@ -10,15 +10,17 @@ import React from 'react';
 
 import { fireEvent } from '@testing-library/dom';
 import { render, waitForEuiPopoverOpen } from '../../test/rtl';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test';
 
 import { EuiCodeBlockAnnotation } from './code_block_annotations';
 
 describe('EuiCodeBlockAnnotation', () => {
-  // No `requiredProps` or `shouldRenderCustomStyles` - this is not currently meant to be a highly customizable component
+  shouldRenderCustomStyles(<EuiCodeBlockAnnotation lineNumber={10} />);
 
   it('renders', async () => {
     const { baseElement, getByTestSubject } = render(
-      <EuiCodeBlockAnnotation lineNumber={10}>
+      <EuiCodeBlockAnnotation lineNumber={10} {...requiredProps}>
         <span data-test-subj="popoverContent">Popover content</span>
       </EuiCodeBlockAnnotation>
     );

--- a/src/components/code/code_block_annotations.tsx
+++ b/src/components/code/code_block_annotations.tsx
@@ -9,6 +9,7 @@
 import React, { FunctionComponent, ReactNode, useState } from 'react';
 
 import { useEuiTheme } from '../../services';
+import { CommonProps } from '../common';
 import { useEuiI18n } from '../i18n';
 import { EuiPopover } from '../popover';
 import { EuiIcon } from '../icon';
@@ -18,9 +19,13 @@ import { euiCodeBlockAnnotationsStyles } from './code_block_annotations.style';
 
 export type LineAnnotationMap = Record<number, ReactNode>;
 
-export const EuiCodeBlockAnnotation: FunctionComponent<{
+type EuiCodeBlockAnnotationProps = CommonProps & {
   lineNumber: number;
-}> = ({ lineNumber, children }) => {
+};
+
+export const EuiCodeBlockAnnotation: FunctionComponent<
+  EuiCodeBlockAnnotationProps
+> = ({ lineNumber, children, ...rest }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const ariaLabel = useEuiI18n(
@@ -41,6 +46,8 @@ export const EuiCodeBlockAnnotation: FunctionComponent<{
 
   return (
     <EuiPopover
+      css={styles.euiCodeBlockAnnotation}
+      {...rest}
       isOpen={isOpen}
       closePopover={() => setIsOpen(false)}
       button={
@@ -57,7 +64,6 @@ export const EuiCodeBlockAnnotation: FunctionComponent<{
           />
         </button>
       }
-      css={styles.euiCodeBlockAnnotation}
       zIndex={Number(euiTheme.levels.mask) + 1} // Ensure fullscreen annotation popovers sit above the mask
       anchorPosition="downLeft"
       panelProps={{ 'data-test-subj': 'euiCodeBlockAnnotationPopover' }}

--- a/src/components/code/code_block_copy.spec.tsx
+++ b/src/components/code/code_block_copy.spec.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../cypress/support" />
+
+import React from 'react';
+
+import { EuiCodeBlock } from './code_block';
+
+const codeBlockContent = `"OriginLocation": [
+  {
+    "coordinates": [
+      -97.43309784,
+      37.64989853
+    ],
+    "type": "Point"
+  }
+],`;
+
+describe('EuiCodeBlock copy UX', () => {
+  beforeEach(() => {
+    // Clipboard permissions are required for copy behavior to work in non-Electron browsers
+    // @see https://github.com/cypress-io/cypress-example-recipes/blob/182400395817a14f0c7f18889b2fcc6b4d189434/examples/testing-dom__clipboard/cypress/e2e/permissions-spec.cy.js#L37
+    cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Browser.grantPermissions',
+        params: {
+          permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+          origin: window.location.origin,
+        },
+      })
+    );
+  });
+
+  const assertClipboardContentEquals = (expectedText: string) => {
+    cy.window()
+      .its('navigator.clipboard')
+      .invoke('readText')
+      .then((clipboard) => {
+        expect(clipboard).equals(expectedText);
+      });
+  };
+
+  it('correctly copies content', () => {
+    cy.realMount(<EuiCodeBlock isCopyable>{codeBlockContent}</EuiCodeBlock>);
+
+    cy.get('[data-test-subj="euiCodeBlockCopy"]').realClick();
+    assertClipboardContentEquals(codeBlockContent);
+  });
+
+  it('correctly copies virtualized content', () => {
+    cy.realMount(
+      <EuiCodeBlock isCopyable isVirtualized={true} overflowHeight="50%">
+        {codeBlockContent}
+      </EuiCodeBlock>
+    );
+
+    cy.get('[data-test-subj="euiCodeBlockCopy"]').realClick();
+    assertClipboardContentEquals(codeBlockContent);
+  });
+
+  it('correctly copies content with line numbers and annotations', () => {
+    cy.realMount(
+      <EuiCodeBlock
+        isCopyable
+        lineNumbers={{
+          start: 32,
+          highlight: '32, 34-37, 40',
+          annotations: {
+            34: 'Coordinates can be obtained from Elastic Maps',
+            38: <>Allowed types: Point, Area</>,
+          },
+        }}
+      >
+        {codeBlockContent}
+      </EuiCodeBlock>
+    );
+
+    cy.get('[data-test-subj="euiCodeBlockCopy"]').realClick();
+    assertClipboardContentEquals(codeBlockContent);
+  });
+});

--- a/src/components/code/code_block_copy.tsx
+++ b/src/components/code/code_block_copy.tsx
@@ -45,6 +45,7 @@ export const useCopy = ({
               iconType="copyClipboard"
               color="text"
               aria-label={copyAriaLabel}
+              data-test-subj="euiCodeBlockCopy"
             />
           )}
         </EuiCopy>

--- a/src/components/code/code_block_line.styles.ts
+++ b/src/components/code/code_block_line.styles.ts
@@ -58,6 +58,12 @@ export const euiCodeBlockLineStyles = (euiThemeContext: UseEuiTheme) => {
         color: ${euiTheme.colors.subduedText};
         text-align: end;
         display: block;
+
+        // Note: This must use a CSS pseudo element to print the line number
+        // to prevent line numbers from being copied as text
+        &::before {
+          content: attr(data-line-number);
+        }
       `,
     },
   };

--- a/src/components/code/utils.test.tsx
+++ b/src/components/code/utils.test.tsx
@@ -139,7 +139,7 @@ describe('line utils', () => {
           expect(highlight).toMatchSnapshot();
           expect(
             // @ts-expect-error RefractorNode
-            highlight[0].children[0].properties['data-line-number']
+            highlight[0].children[0].children[0].properties['data-line-number']
           ).toBe(10);
         });
       });

--- a/src/components/code/utils.tsx
+++ b/src/components/code/utils.tsx
@@ -237,7 +237,6 @@ function wrapLines(
         tagName: 'span',
         properties: {
           style: { inlineSize: width },
-          ['data-line-number']: lineNumber,
           className: ['euiCodeBlock__lineNumber', lineNumberWrapperStyles],
         },
         children: [],
@@ -250,9 +249,10 @@ function wrapLines(
         tagName: 'span',
         properties: {
           className: [lineNumberStyles],
+          ['data-line-number']: lineNumber,
           ['aria-hidden']: true,
         },
-        children: [{ type: 'text', value: String(lineNumber) }],
+        children: [],
       };
       lineNumberWrapperElement.children.push(lineNumberElement);
 

--- a/src/components/code/utils.tsx
+++ b/src/components/code/utils.tsx
@@ -80,8 +80,12 @@ export const nodeToHtml = (
         children.map((el, i) =>
           // @ts-ignore - using a custom type here to handle JSX annotations
           el.type === 'annotation' ? (
-            // @ts-ignore - custom keys are passed by annotationElement below
-            <EuiCodeBlockAnnotation lineNumber={el.lineNumber} children={el.annotation} key={i} /> // prettier-ignore
+            <EuiCodeBlockAnnotation
+              className="euiCodeBlock__lineAnnotation"
+              lineNumber={(el as any).lineNumber}
+              children={(el as any).annotation}
+              key={i}
+            />
           ) : (
             nodeToHtml(el, i, nodes, depth + 1)
           )
@@ -237,7 +241,10 @@ function wrapLines(
         tagName: 'span',
         properties: {
           style: { inlineSize: width },
-          className: ['euiCodeBlock__lineNumber', lineNumberWrapperStyles],
+          className: [
+            'euiCodeBlock__lineNumberWrapper',
+            lineNumberWrapperStyles,
+          ],
         },
         children: [],
       };
@@ -248,7 +255,7 @@ function wrapLines(
         type: 'element',
         tagName: 'span',
         properties: {
-          className: [lineNumberStyles],
+          className: ['euiCodeBlock__lineNumber', lineNumberStyles],
           ['data-line-number']: lineNumber,
           ['aria-hidden']: true,
         },


### PR DESCRIPTION
## Summary

I broke this behavior in https://github.com/elastic/eui/pull/6580 (annotation feature) by switching from rendering the line numbers as `::before` pseudo elements to actual text node. I've reverted the rendering to use pseudo elements, and cleaned up line number classNames slightly to better reflect the intended DOM structure (see individual commits).

I've additionally added new Cypress tests to ensure copy functionality doesn't regress in the future.

## QA

- Go to http://localhost:8030/#/editors-syntax/code#line-numbers
- Scroll down to the 2nd example with annotations
- Click the copy button, and paste into any text editor
-[ ] Confirm the code block content pastes without any line numbers present

### General checklist

- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~