### PR TITLE
[EuiTable] Remove overflow/height animation causing Safari cross-browser issues

### DIFF
--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -12,7 +12,6 @@ import {
   EuiHealth,
   EuiDescriptionList,
   EuiScreenReaderOnly,
-  EuiCodeBlock,
 } from '../../../../../src/components';
 
 type User = {
@@ -120,12 +119,9 @@ export default () => {
           description: <EuiHealth color={color}>{label}</EuiHealth>,
         },
       ];
-      itemIdToExpandedRowMapValues[user.id] =
-        user.id % 2 === 0 ? (
-          <EuiCodeBlock isCopyable>Test 1 2 3</EuiCodeBlock>
-        ) : (
-          <EuiDescriptionList listItems={listItems} />
-        );
+      itemIdToExpandedRowMapValues[user.id] = (
+        <EuiDescriptionList listItems={listItems} />
+      );
     }
     setItemIdToExpandedRowMap(itemIdToExpandedRowMapValues);
   };

--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -12,6 +12,7 @@ import {
   EuiHealth,
   EuiDescriptionList,
   EuiScreenReaderOnly,
+  EuiCodeBlock,
 } from '../../../../../src/components';
 
 type User = {
@@ -119,9 +120,12 @@ export default () => {
           description: <EuiHealth color={color}>{label}</EuiHealth>,
         },
       ];
-      itemIdToExpandedRowMapValues[user.id] = (
-        <EuiDescriptionList listItems={listItems} />
-      );
+      itemIdToExpandedRowMapValues[user.id] =
+        user.id % 2 === 0 ? (
+          <EuiCodeBlock isCopyable>Test 1 2 3</EuiCodeBlock>
+        ) : (
+          <EuiDescriptionList listItems={listItems} />
+        );
     }
     setItemIdToExpandedRowMap(itemIdToExpandedRowMapValues);
   };

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -227,22 +227,20 @@
 }
 
 // Animate expanded row must be on the contents div inside
-
+// This adds a quick pop in animation, but does not attempt to animate to height auto
+// - down that road dragons lie. @see https://github.com/elastic/eui/issues/6770
 .euiTableRow-isExpandedRow .euiTableCellContent {
-  overflow: hidden;
-  animation: $euiAnimSpeedNormal $euiAnimSlightResistance 1 normal forwards growExpandedRow;
+  animation: $euiAnimSpeedFast $euiAnimSlightBounce 1 normal none growExpandedRow;
 }
 
 @keyframes growExpandedRow {
   0% {
-    max-height: 0;
-  }
-
-  99% {
-    max-height: 100vh;
+    opacity: 0;
+    transform: translateY(-$euiSizeM);
   }
 
   100% {
-    max-height: unset;
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -230,7 +230,7 @@
 // This adds a quick pop in animation, but does not attempt to animate to height auto
 // - down that road dragons lie. @see https://github.com/elastic/eui/issues/6770
 .euiTableRow-isExpandedRow .euiTableCellContent {
-  animation: $euiAnimSpeedFast $euiAnimSlightBounce 1 normal none growExpandedRow;
+  animation: $euiAnimSpeedFast $euiAnimSlightResistance 1 normal none growExpandedRow;
 }
 
 @keyframes growExpandedRow {

--- a/upcoming_changelogs/6826.md
+++ b/upcoming_changelogs/6826.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed the expanded row animation on `EuiBasicTable` causing cross-browser Safari issues


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6770

Counter to our guesses/musings in the above linked thread, the issue with Safari was not the mutation observer (never fired) nor stale refs/rerenders. After adding timeouts of increasing lengths, I realized it was the animation itself that was causing Safari to return empty `innerText`.

The `overflow: hidden` on the container, in combination with the `max-height`, makes Safari calculate that the container's children are not visible. For not-visible children, `innerText` becomes `''` (you can test this right now in your browser by setting any DOM node to `visibility: hidden` and then pasting its `.innerText` value in the console).

I initially played around with a couple different options to try to keep the "expanding animation". I tried the `display: grid` hack instead of `max-height`, I tried removing `overflow` and set an `opacity` instead (but didn't really like how it looked) and I briefly contemplated calculating and setting `height` via JS instead of CSS 😅 Finally, I decided I preferred to subtract instead of adding.

Since the animation honestly is adding no actual functionality, and the `max-height` CSS hack is laggy on almost every browser, I opted to not animate height whatsoever which allows the expansion to be immediate, and instead added a very light and far more performant opacity/translate Y animation. IMO, the outcome is a snappier and slightly more responsive feel.

![screencap](https://github.com/elastic/eui/assets/549407/4534dbe2-a95b-4474-89af-c37eaba5033c)

## QA

Old animation for reference: https://eui.elastic.co/v81.2.0/#/tabular-content/tables#expanding-rows

- In Safari, go to https://eui.elastic.co/pr_6826/#/tabular-content/tables#expanding-rows
- Expand rows until you get one with a `EuiCodeBlock` in it (this may take several pages, it's random as the table is sorted)
- [x] Confirm that the copy button is present and works as expected
- In a non-Safari browser, go to https://eui.elastic.co/pr_6826/#/tabular-content/tables#expanding-rows
- [x] Confirm that for both code and non-code content, the animation looks and feels relatively smooth (Safari struggles with this animation for some reason)

### General checklist

- [x] Revert [REVERT ME] commit
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ - Not sure there's anything we can meaningfully test here since it's such a browser-specific issue + a CSS change
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ - Checking with the Figma working group to see if animations are a part of our Figma library