### PR TITLE
Add basic React 18 support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -11,8 +11,8 @@ module.exports = {
       "corejs": !process.env.NO_COREJS_POLYFILL ? '3.6' : undefined,
       "modules": process.env.BABEL_MODULES ? process.env.BABEL_MODULES === 'false' ? false : process.env.BABEL_MODULES : "commonjs" // babel's default is commonjs
     }],
-    ["@babel/typescript", { isTSX: true, allExtensions: true }],
-    "@babel/react",
+    ["@babel/react", { runtime: 'classic' }],
+    ["@babel/typescript", { isTSX: true, allExtensions: true, allowDeclareFields: true }],
     [
       "@emotion/babel-preset-css-prop",
       {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "resolutions": {
     "**/prismjs": "1.27.0",
-    "**/react": "^17.0.0"
+    "**/react": "^18.2.0",
+    "**/@types/react": "^18.2.6"
   },
   "pre-commit": [
     "test-staged"
@@ -146,8 +147,8 @@
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^24.0.6",
     "@types/node": "^10.17.5",
-    "@types/react": "^17.0.38",
-    "@types/react-dom": "^17.0.11",
+    "@types/react": "^18.2.6",
+    "@types/react-dom": "^18.2.4",
     "@types/react-is": "^17.0.3",
     "@types/react-router-dom": "^5.1.5",
     "@types/tabbable": "^3.1.2",
@@ -223,9 +224,9 @@
     "prop-types": "^15.6.0",
     "puppeteer": "^5.5.0",
     "raw-loader": "^4.0.1",
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "react-docgen-typescript": "^2.2.2",
-    "react-dom": "^17.0.2",
+    "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-redux": "^7.2.1",
     "react-refresh": "^0.11.0",
@@ -261,12 +262,12 @@
     "@elastic/datemath": "^5.0.2",
     "@emotion/css": "11.x",
     "@emotion/react": "11.x",
-    "@types/react": "^16.9 || ^17.0",
-    "@types/react-dom": "^16.9 || ^17.0",
+    "@types/react": "^16.9 || ^17.0 || ^18.0",
+    "@types/react-dom": "^16.9 || ^17.0 || ^18.0",
     "moment": "^2.13.0",
     "prop-types": "^15.5.0",
-    "react": "^16.12 || ^17.0",
-    "react-dom": "^16.12 || ^17.0",
+    "react": "^16.12 || ^17.0 || ^18.0",
+    "react-dom": "^16.12 || ^17.0 || ^18.0",
     "typescript": "~4.5.3"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "resolutions": {
     "**/prismjs": "1.27.0",
-    "**/react": "^18.2.0",
-    "**/@types/react": "^18.2.6"
+    "**/react": "^18",
+    "**/@types/react": "^18"
   },
   "pre-commit": [
     "test-staged"
@@ -147,8 +147,8 @@
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^24.0.6",
     "@types/node": "^10.17.5",
-    "@types/react": "^18.2.6",
-    "@types/react-dom": "^18.2.4",
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
     "@types/react-is": "^17.0.3",
     "@types/react-router-dom": "^5.1.5",
     "@types/tabbable": "^3.1.2",

--- a/src-docs/src/components/with_theme/theme_context.tsx
+++ b/src-docs/src/components/with_theme/theme_context.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { EUI_THEMES, EUI_THEME } from '../../../../src/themes';
 // @ts-ignore importing from a JS file
 import { applyTheme } from '../../services';
@@ -45,7 +45,7 @@ interface State {
 
 export const ThemeContext = React.createContext(defaultState);
 
-export class ThemeProvider extends React.Component<object, State> {
+export class ThemeProvider extends React.Component<PropsWithChildren, State> {
   constructor(props: object) {
     super(props);
 

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -1,5 +1,5 @@
-import React, { createElement } from 'react';
-import ReactDOM from 'react-dom';
+import React, { createElement, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { Router, Switch, Route, Redirect } from 'react-router';
 import { Helmet } from 'react-helmet';
@@ -40,130 +40,133 @@ const routes = [
   ...childRoutes,
 ];
 
-ReactDOM.render(
-  <Provider store={store}>
-    <ThemeProvider>
-      <AppContext>
-        <Router history={history}>
-          <Switch>
-            {routes.map(
-              ({
-                name,
-                path,
-                sections,
-                isBeta,
-                isNew,
-                component,
-                from,
-                to,
-              }) => {
-                const meta = (
-                  <Helmet>
-                    <title>{`${name} - Elastic UI Framework`}</title>
-                  </Helmet>
-                );
-                const mainComponent = (
-                  <Route
-                    key={path}
-                    path={`/${path}`}
-                    render={(props) => {
-                      const { location } = props;
-                      // prevents encoded urls with a section id to fail
-                      if (location.pathname.includes('%23')) {
-                        const url = decodeURIComponent(location.pathname);
-                        return <Redirect push to={url} />;
-                      } else {
-                        return (
-                          <AppView
-                            currentRoute={{
-                              name,
-                              path,
-                              sections,
-                              isBeta,
-                              isNew,
-                            }}
-                          >
-                            {({ theme }) => (
-                              <>
-                                {meta}
-                                {createElement(component, {
-                                  selectedTheme: theme,
-                                  title: name,
-                                })}
-                              </>
-                            )}
-                          </AppView>
-                        );
-                      }
-                    }}
-                  />
-                );
+const root = createRoot(document.getElementById('guide'));
 
-                const standaloneSections = [];
-                (sections || []).forEach(
-                  ({ id, fullScreen, sections: subSections }) => {
-                    if (fullScreen) {
-                      const { slug, demo } = fullScreen;
-                      standaloneSections.push(
-                        <Route
-                          key={`/${path}/${slug}`}
-                          path={`/${path}/${slug}`}
-                          render={() => (
-                            <ExampleContext.Provider
-                              value={{ parentPath: `/${path}#${id}` }}
+root.render(
+  <StrictMode>
+    <Provider store={store}>
+      <ThemeProvider>
+        <AppContext>
+          <Router history={history}>
+            <Switch>
+              {routes.map(
+                ({
+                  name,
+                  path,
+                  sections,
+                  isBeta,
+                  isNew,
+                  component,
+                  from,
+                  to,
+                }) => {
+                  const meta = (
+                    <Helmet>
+                      <title>{`${name} - Elastic UI Framework`}</title>
+                    </Helmet>
+                  );
+                  const mainComponent = (
+                    <Route
+                      key={path}
+                      path={`/${path}`}
+                      render={(props) => {
+                        const { location } = props;
+                        // prevents encoded urls with a section id to fail
+                        if (location.pathname.includes('%23')) {
+                          const url = decodeURIComponent(location.pathname);
+                          return <Redirect push to={url} />;
+                        } else {
+                          return (
+                            <AppView
+                              currentRoute={{
+                                name,
+                                path,
+                                sections,
+                                isBeta,
+                                isNew,
+                              }}
                             >
-                              {meta}
-                              {demo}
-                            </ExampleContext.Provider>
-                          )}
-                        />
-                      );
-                    }
-                    if (subSections) {
-                      subSections.forEach(({ fullScreen, id: sectionId }) => {
-                        if (fullScreen) {
-                          const { slug, demo } = fullScreen;
-                          standaloneSections.push(
-                            <Route
-                              key={`/${path}/${id}/${slug}`}
-                              path={`/${path}/${id}/${slug}`}
-                              render={() => (
-                                <ExampleContext.Provider
-                                  value={{
-                                    parentPath: `/${path}/${id}#${sectionId}`,
-                                  }}
-                                >
+                              {({ theme }) => (
+                                <>
                                   {meta}
-                                  {demo}
-                                </ExampleContext.Provider>
+                                  {createElement(component, {
+                                    selectedTheme: theme,
+                                    title: name,
+                                  })}
+                                </>
                               )}
-                            />
+                            </AppView>
                           );
                         }
-                      });
+                      }}
+                    />
+                  );
+
+                  const standaloneSections = [];
+                  (sections || []).forEach(
+                    ({ id, fullScreen, sections: subSections }) => {
+                      if (fullScreen) {
+                        const { slug, demo } = fullScreen;
+                        standaloneSections.push(
+                          <Route
+                            key={`/${path}/${slug}`}
+                            path={`/${path}/${slug}`}
+                            render={() => (
+                              <ExampleContext.Provider
+                                value={{ parentPath: `/${path}#${id}` }}
+                              >
+                                {meta}
+                                {demo}
+                              </ExampleContext.Provider>
+                            )}
+                          />
+                        );
+                      }
+                      if (subSections) {
+                        subSections.forEach(({ fullScreen, id: sectionId }) => {
+                          if (fullScreen) {
+                            const { slug, demo } = fullScreen;
+                            standaloneSections.push(
+                              <Route
+                                key={`/${path}/${id}/${slug}`}
+                                path={`/${path}/${id}/${slug}`}
+                                render={() => (
+                                  <ExampleContext.Provider
+                                    value={{
+                                      parentPath: `/${path}/${id}#${sectionId}`,
+                                    }}
+                                  >
+                                    {meta}
+                                    {demo}
+                                  </ExampleContext.Provider>
+                                )}
+                              />
+                            );
+                          }
+                        });
+                      }
                     }
-                  }
-                );
-                standaloneSections.filter((x) => !!x);
+                  );
+                  standaloneSections.filter((x) => !!x);
 
-                // place standaloneSections before mainComponent so their routes take precedent
-                const routes = [...standaloneSections, mainComponent];
+                  // place standaloneSections before mainComponent so their routes take precedent
+                  const routes = [...standaloneSections, mainComponent];
 
-                if (from)
-                  return [
-                    ...routes,
-                    <Route exact path={`/${from}`}>
-                      <Redirect to={`/${to}`} />
-                    </Route>,
-                  ];
-                else if (component) return routes;
-                return null;
-              }
-            )}
-          </Switch>
-        </Router>
-      </AppContext>
-    </ThemeProvider>
-  </Provider>,
-  document.getElementById('guide')
+                  if (from)
+                    return [
+                      ...routes,
+                      <Route exact path={`/${from}`}>
+                        <Redirect to={`/${to}`} />
+                      </Route>,
+                    ];
+                  else if (component) return routes;
+                  return null;
+                }
+              )}
+            </Switch>
+          </Router>
+        </AppContext>
+      </ThemeProvider>
+    </Provider>
+  </StrictMode>
 );

--- a/src-docs/src/views/flex/wrapper_styles.tsx
+++ b/src-docs/src/views/flex/wrapper_styles.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { css } from '@emotion/react';
 import {
   useEuiTheme,
@@ -18,7 +18,9 @@ export const flexItemHiglightStyles = ({ euiTheme }: UseEuiTheme) => {
   `;
 };
 
-export const FlexItemHighlightWrapper: React.FC = ({ children }) => {
+export const FlexItemHighlightWrapper: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
   const euiTheme = useEuiTheme();
   return <div css={flexItemHiglightStyles(euiTheme)}>{children}</div>;
 };

--- a/src-docs/src/views/theme/color_mode/inverse.tsx
+++ b/src-docs/src/views/theme/color_mode/inverse.tsx
@@ -1,4 +1,8 @@
-import React, { useState, FC } from 'react';
+import React, {
+  useState,
+  FC,
+  PropsWithChildren,
+} from 'react';
 import {
   EuiThemeProvider,
   useEuiTheme,
@@ -66,7 +70,7 @@ export default () => {
   );
 };
 
-const ThemedChildren: FC = ({ children, ...rest }) => {
+const ThemedChildren: FC<PropsWithChildren> = ({ children, ...rest }) => {
   const { colorMode: _colorMode } = useEuiTheme();
   const colorMode = _colorMode.toLowerCase();
   return (
@@ -101,7 +105,7 @@ const ThemedChildren: FC = ({ children, ...rest }) => {
   );
 };
 
-const Popover: FC = ({ children }) => {
+const Popover: FC<PropsWithChildren> = ({ children }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   return (
     <EuiPopover
@@ -123,7 +127,7 @@ const Popover: FC = ({ children }) => {
   );
 };
 
-const Modal: FC = ({ children }) => {
+const Modal: FC<PropsWithChildren> = ({ children }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   return (
     <>
@@ -151,7 +155,7 @@ const Modal: FC = ({ children }) => {
   );
 };
 
-const Flyout: FC = ({ children }) => {
+const Flyout: FC<PropsWithChildren> = ({ children }) => {
   const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
   return (
     <>

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -13,6 +13,7 @@ import React, {
   MouseEventHandler,
   ReactNode,
   useState,
+  PropsWithChildren,
 } from 'react';
 import classNames from 'classnames';
 
@@ -64,7 +65,8 @@ type _EuiBreadcrumbProps = {
   isOnlyBreadcrumb?: boolean;
   highlightLastBreadcrumb?: boolean;
   truncateLastBreadcrumb?: boolean;
-} & Pick<EuiBreadcrumbProps, 'truncate'>;
+} & Pick<EuiBreadcrumbProps, 'truncate'> &
+  PropsWithChildren;
 
 export const EuiBreadcrumb: FunctionComponent<
   HTMLAttributes<HTMLLIElement> & _EuiBreadcrumbProps

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -58,15 +58,14 @@ export type EuiBreadcrumbProps = Omit<
   };
 
 // Used internally only by the parent EuiBreadcrumbs
-type _EuiBreadcrumbProps = {
-  type: 'page' | 'application';
-  isFirstBreadcrumb?: boolean;
-  isLastBreadcrumb?: boolean;
-  isOnlyBreadcrumb?: boolean;
-  highlightLastBreadcrumb?: boolean;
-  truncateLastBreadcrumb?: boolean;
-} & Pick<EuiBreadcrumbProps, 'truncate'> &
-  PropsWithChildren;
+type _EuiBreadcrumbProps = PropsWithChildren & Pick<EuiBreadcrumbProps, 'truncate'> & {
+    type: 'page' | 'application';
+    isFirstBreadcrumb?: boolean;
+    isLastBreadcrumb?: boolean;
+    isOnlyBreadcrumb?: boolean;
+    highlightLastBreadcrumb?: boolean;
+    truncateLastBreadcrumb?: boolean;
+  };
 
 export const EuiBreadcrumb: FunctionComponent<
   HTMLAttributes<HTMLLIElement> & _EuiBreadcrumbProps

--- a/src/components/code/code_block_annotations.tsx
+++ b/src/components/code/code_block_annotations.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, ReactNode, useState } from 'react';
+import React, {
+  FunctionComponent,
+  PropsWithChildren,
+  ReactNode,
+  useState,
+} from 'react';
 
 import { useEuiTheme } from '../../services';
 import { CommonProps } from '../common';
@@ -19,9 +24,10 @@ import { euiCodeBlockAnnotationsStyles } from './code_block_annotations.style';
 
 export type LineAnnotationMap = Record<number, ReactNode>;
 
-type EuiCodeBlockAnnotationProps = CommonProps & {
-  lineNumber: number;
-};
+type EuiCodeBlockAnnotationProps = PropsWithChildren &
+  CommonProps & {
+    lineNumber: number;
+  };
 
 export const EuiCodeBlockAnnotation: FunctionComponent<
   EuiCodeBlockAnnotationProps

--- a/src/components/code/code_block_full_screen.tsx
+++ b/src/components/code/code_block_full_screen.tsx
@@ -88,9 +88,9 @@ export const useFullScreen = ({
 /**
  * Portalled full screen wrapper
  */
-export const EuiCodeBlockFullScreenWrapper: FunctionComponent<PropsWithChildren> = ({
-  children,
-}) => {
+export const EuiCodeBlockFullScreenWrapper: FunctionComponent<
+  PropsWithChildren
+> = ({ children }) => {
   const euiThemeContext = useEuiTheme();
 
   const styles = euiCodeBlockStyles(euiThemeContext);

--- a/src/components/code/code_block_full_screen.tsx
+++ b/src/components/code/code_block_full_screen.tsx
@@ -12,6 +12,7 @@ import React, {
   useState,
   useCallback,
   useMemo,
+  PropsWithChildren,
 } from 'react';
 import { keys, useEuiTheme } from '../../services';
 import { useEuiI18n } from '../i18n';
@@ -87,7 +88,7 @@ export const useFullScreen = ({
 /**
  * Portalled full screen wrapper
  */
-export const EuiCodeBlockFullScreenWrapper: FunctionComponent = ({
+export const EuiCodeBlockFullScreenWrapper: FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
   const euiThemeContext = useEuiTheme();

--- a/src/components/combo_box/combo_box_options_list/combo_box_title.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_title.tsx
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 
-export const EuiComboBoxTitle: FunctionComponent<{}> = ({ children }) => (
-  <div className="euiComboBoxTitle">{children}</div>
-);
+export const EuiComboBoxTitle: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => <div className="euiComboBoxTitle">{children}</div>;

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -14,7 +14,6 @@ import {
   FunctionComponent,
   JSXElementConstructor,
   MouseEventHandler,
-  SFC,
 } from 'react';
 import { Interpolation, Theme } from '@emotion/react';
 
@@ -58,7 +57,7 @@ export function keysOf<T, K extends keyof T>(obj: T): K[] {
  */
 export type ValueOf<T> = T[keyof T];
 
-export type PropsOf<C> = C extends SFC<infer SFCProps>
+export type PropsOf<C> = C extends FunctionComponent<infer SFCProps>
   ? SFCProps
   : C extends FunctionComponent<infer FunctionProps>
   ? FunctionProps

--- a/src/components/datagrid/body/data_grid_body_virtualized.tsx
+++ b/src/components/datagrid/body/data_grid_body_virtualized.tsx
@@ -14,6 +14,7 @@ import React, {
   useContext,
   useEffect,
   useRef,
+  PropsWithChildren,
 } from 'react';
 import {
   GridChildComponentProps,
@@ -68,9 +69,15 @@ export const DataGridWrapperRowsContext =
     footerRow: null,
   });
 
+type InnerElementProps = PropsWithChildren & {
+  style: {
+    height: number;
+  };
+};
+
 const InnerElement: VariableSizeGridProps['innerElementType'] = forwardRef<
   HTMLDivElement,
-  { style: { height: number } }
+  InnerElementProps
 >(({ children, style, ...rest }, ref) => {
   const { headerRowHeight, headerRow, footerRow } = useContext(
     DataGridWrapperRowsContext

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -17,6 +17,7 @@ import {
   MutableRefObject,
   Ref,
   Component,
+  PropsWithChildren,
 } from 'react';
 import {
   VariableSizeGridProps,
@@ -151,7 +152,7 @@ export interface EuiDataGridControlHeaderCellProps {
   headerIsInteractive: boolean;
 }
 
-export interface EuiDataGridHeaderCellWrapperProps {
+export interface EuiDataGridHeaderCellWrapperProps extends PropsWithChildren {
   id: string;
   index: number;
   headerIsInteractive: boolean;

--- a/src/components/delay_render/delay_render.tsx
+++ b/src/components/delay_render/delay_render.tsx
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import { Component } from 'react';
+import { Component, PropsWithChildren } from 'react';
 
-export interface EuiDelayRenderProps {
+export interface EuiDelayRenderProps extends PropsWithChildren {
   delay: number;
 }
 

--- a/src/components/form/form.styles.test.tsx
+++ b/src/components/form/form.styles.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useEuiTheme } from '../../services';
 import { EuiProvider } from '../provider';
@@ -17,7 +17,7 @@ import {
   euiCustomControl,
 } from './form.styles';
 
-const darkModeWrapper: React.FC = ({ children }) => (
+const darkModeWrapper: React.FC<PropsWithChildren> = ({ children }) => (
   <EuiProvider colorMode="DARK">{children}</EuiProvider>
 );
 

--- a/src/components/form/form.styles.test.tsx
+++ b/src/components/form/form.styles.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { PropsWithChildren } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useEuiTheme } from '../../services';
 import { EuiProvider } from '../provider';
@@ -17,9 +17,9 @@ import {
   euiCustomControl,
 } from './form.styles';
 
-const darkModeWrapper: React.FC<PropsWithChildren> = ({ children }) => (
-  <EuiProvider colorMode="DARK">{children}</EuiProvider>
-);
+const darkModeWrapper: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => <EuiProvider colorMode="DARK">{children}</EuiProvider>;
 
 describe('euiFormVariables', () => {
   it('outputs an object of reusable form vars', () => {
@@ -181,7 +181,7 @@ describe('euiCustomControl', () => {
     expect(result.current).toMatchInlineSnapshot(`
       "
           padding: 7px;
-          
+
           border: 1px solid #f5f7fc;
           background: #FFF no-repeat center;
 
@@ -200,7 +200,7 @@ describe('euiCustomControl', () => {
     expect(result.current).toMatchInlineSnapshot(`
       "
           padding: 15px;
-          
+
           border: 1px solid #f5f7fc;
           background: #FFF no-repeat center;
 

--- a/src/components/form/range/range_track.tsx
+++ b/src/components/form/range/range_track.tsx
@@ -33,7 +33,7 @@ import type {
 import { euiRangeTrackStyles } from './range_track.styles';
 
 export interface EuiRangeTrackProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'>,
     _SharedRangesValues,
     _SharedRangeDataStructures,
     Pick<_SharedRangeVisualConfiguration, 'showTicks' | 'showRange'>,

--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -21,17 +21,18 @@ import { EuiIcon } from '../../icon';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button';
 import { EuiHideFor, EuiShowFor } from '../../responsive';
 
-export type EuiHeaderSectionItemButtonProps = EuiButtonEmptyProps & {
-  /**
-   * Inserts the node into a EuiBadgeNotification and places it appropriately against the button.
-   * Or pass `true` to render a simple dot
-   */
-  notification?: EuiNotificationBadgeProps['children'] | boolean;
-  /**
-   * Changes the color of the notification background
-   */
-  notificationColor?: EuiNotificationBadgeProps['color'];
-};
+export type EuiHeaderSectionItemButtonProps = EuiButtonEmptyProps &
+  PropsWithChildren & {
+    /**
+     * Inserts the node into a EuiBadgeNotification and places it appropriately against the button.
+     * Or pass `true` to render a simple dot
+     */
+    notification?: EuiNotificationBadgeProps['children'] | boolean;
+    /**
+     * Changes the color of the notification background
+     */
+    notificationColor?: EuiNotificationBadgeProps['color'];
+  };
 
 export type EuiHeaderSectionItemButtonRef =
   | (HTMLButtonElement & { euiAnimate: () => void })
@@ -39,7 +40,7 @@ export type EuiHeaderSectionItemButtonRef =
 
 export const EuiHeaderSectionItemButton = forwardRef<
   EuiHeaderSectionItemButtonRef,
-  PropsWithChildren<EuiHeaderSectionItemButtonProps>
+  EuiHeaderSectionItemButtonProps
 >(
   (
     {

--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -21,8 +21,8 @@ import { EuiIcon } from '../../icon';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button';
 import { EuiHideFor, EuiShowFor } from '../../responsive';
 
-export type EuiHeaderSectionItemButtonProps = EuiButtonEmptyProps &
-  PropsWithChildren & {
+export type EuiHeaderSectionItemButtonProps = PropsWithChildren &
+  EuiButtonEmptyProps & {
     /**
      * Inserts the node into a EuiBadgeNotification and places it appropriately against the button.
      * Or pass `true` to render a simple dot

--- a/src/components/image/image_types.ts
+++ b/src/components/image/image_types.ts
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { HTMLAttributes, ReactNode, ImgHTMLAttributes } from 'react';
+import {
+  HTMLAttributes,
+  ReactNode,
+  ImgHTMLAttributes,
+  PropsWithChildren,
+} from 'react';
 import { CommonProps, ExclusiveUnion } from '../common';
 
 export const SIZES = ['s', 'm', 'l', 'xl', 'fullWidth', 'original'] as const;
@@ -96,21 +101,23 @@ export type EuiImageWrapperProps = Pick<
   | 'fullScreenIconColor'
   | 'allowFullScreen'
   | 'onFullScreen'
-> & {
-  isFullWidth: boolean;
-  setIsFullScreen: (isFullScreen: boolean) => void;
-};
+> &
+  PropsWithChildren & {
+    isFullWidth: boolean;
+    setIsFullScreen: (isFullScreen: boolean) => void;
+  };
 
 export type EuiImageButtonProps = Pick<
   EuiImageProps,
   'hasShadow' | 'fullScreenIconColor'
-> & {
-  hasAlt: boolean;
-  onClick: () => void;
-  onKeyDown?: (e: React.KeyboardEvent) => void;
-  isFullWidth: boolean;
-  isFullScreen?: boolean;
-};
+> &
+  PropsWithChildren & {
+    hasAlt: boolean;
+    onClick: () => void;
+    onKeyDown?: (e: React.KeyboardEvent) => void;
+    isFullWidth: boolean;
+    isFullScreen?: boolean;
+  };
 
 export type EuiImageCaptionProps = Pick<EuiImageProps, 'caption'> & {
   isOnOverlayMask?: boolean;

--- a/src/components/image/image_types.ts
+++ b/src/components/image/image_types.ts
@@ -90,28 +90,25 @@ export type EuiImageProps = CommonProps &
     wrapperProps?: CommonProps & HTMLAttributes<HTMLDivElement>;
   };
 
-export type EuiImageWrapperProps = Pick<
-  EuiImageProps,
-  | 'alt'
-  | 'caption'
-  | 'float'
-  | 'margin'
-  | 'hasShadow'
-  | 'wrapperProps'
-  | 'fullScreenIconColor'
-  | 'allowFullScreen'
-  | 'onFullScreen'
-> &
-  PropsWithChildren & {
+export type EuiImageWrapperProps = PropsWithChildren &
+  Pick<
+    EuiImageProps,
+    | 'alt'
+    | 'caption'
+    | 'float'
+    | 'margin'
+    | 'hasShadow'
+    | 'wrapperProps'
+    | 'fullScreenIconColor'
+    | 'allowFullScreen'
+    | 'onFullScreen'
+  > & {
     isFullWidth: boolean;
     setIsFullScreen: (isFullScreen: boolean) => void;
   };
 
-export type EuiImageButtonProps = Pick<
-  EuiImageProps,
-  'hasShadow' | 'fullScreenIconColor'
-> &
-  PropsWithChildren & {
+export type EuiImageButtonProps = PropsWithChildren &
+  Pick<EuiImageProps, 'hasShadow' | 'fullScreenIconColor'> & {
     hasAlt: boolean;
     onClick: () => void;
     onKeyDown?: (e: React.KeyboardEvent) => void;

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -89,7 +89,10 @@ export type EuiInlineEditCommonProps = HTMLAttributes<HTMLDivElement> &
   };
 
 // Internal-only props, passed by the consumer-facing components
-export type EuiInlineEditFormProps = EuiInlineEditCommonProps & {
+export type EuiInlineEditFormProps = Omit<
+  EuiInlineEditCommonProps,
+  'children'
+> & {
   /**
    * Form sizes
    */

--- a/src/components/inner_text/render_to_text.test.tsx
+++ b/src/components/inner_text/render_to_text.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { mount } from 'enzyme';
 import { useRenderToText } from './render_to_text';
 
@@ -14,7 +14,7 @@ describe('useRenderToText', () => {
   it("Returns a ReactNode's rendered string content", () => {
     const renderedTexts: string[] = [];
 
-    const Component: FunctionComponent = ({ children }) => {
+    const Component: FunctionComponent<PropsWithChildren> = ({ children }) => {
       const text = useRenderToText(children);
       renderedTexts.push(text);
       return <div>{text}</div>;

--- a/src/components/markdown_editor/markdown_editor_drop_zone.tsx
+++ b/src/components/markdown_editor/markdown_editor_drop_zone.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent, PropsWithChildren, useEffect } from 'react';
 import classNames from 'classnames';
 import { useDropzone } from 'react-dropzone';
 import { EuiMarkdownEditorFooter } from './markdown_editor_footer';
@@ -19,7 +19,7 @@ import {
 } from './markdown_types';
 import { useResizeObserver } from '../observer/resize_observer';
 
-interface EuiMarkdownEditorDropZoneProps {
+interface EuiMarkdownEditorDropZoneProps extends PropsWithChildren {
   uiPlugins: EuiMarkdownEditorUiPlugin[];
   errors: EuiMarkdownParseError[];
   dropHandlers: EuiMarkdownDropHandler[];

--- a/src/components/markdown_editor/plugins/markdown_checkbox/renderer.tsx
+++ b/src/components/markdown_editor/plugins/markdown_checkbox/renderer.tsx
@@ -6,17 +6,20 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, useContext } from 'react';
+import React, { FunctionComponent, PropsWithChildren, useContext } from 'react';
 import { EuiCheckbox } from '../../../form/checkbox';
 import { EuiMarkdownContext } from '../../markdown_context';
 import { useGeneratedHtmlId } from '../../../../services/accessibility';
 import { EuiMarkdownAstNodePosition } from '../../markdown_types';
 import { CheckboxNodeDetails } from './types';
 
-export const CheckboxMarkdownRenderer: FunctionComponent<
+type CheckboxMarkdownRendererProps = PropsWithChildren &
   CheckboxNodeDetails & {
     position: EuiMarkdownAstNodePosition;
-  }
+  };
+
+export const CheckboxMarkdownRenderer: FunctionComponent<
+  CheckboxMarkdownRendererProps
 > = ({ position, lead, label, isChecked, children }) => {
   const { replaceNode } = useContext(EuiMarkdownContext);
   return (

--- a/src/components/markdown_editor/plugins/markdown_tooltip/renderer.tsx
+++ b/src/components/markdown_editor/plugins/markdown_tooltip/renderer.tsx
@@ -12,8 +12,8 @@ import { EuiToolTip } from '../../../tool_tip';
 import { EuiIcon } from '../../../icon';
 import { TooltipNodeDetails } from './types';
 
-type TooltipMarkdownRendererProps = TooltipNodeDetails &
-  PropsWithChildren & {
+type TooltipMarkdownRendererProps = PropsWithChildren &
+  TooltipNodeDetails & {
     position: EuiMarkdownAstNodePosition;
   };
 

--- a/src/components/markdown_editor/plugins/markdown_tooltip/renderer.tsx
+++ b/src/components/markdown_editor/plugins/markdown_tooltip/renderer.tsx
@@ -6,16 +6,19 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { EuiMarkdownAstNodePosition } from '../../markdown_types';
 import { EuiToolTip } from '../../../tool_tip';
 import { EuiIcon } from '../../../icon';
 import { TooltipNodeDetails } from './types';
 
-export const tooltipMarkdownRenderer: FunctionComponent<
-  TooltipNodeDetails & {
+type TooltipMarkdownRendererProps = TooltipNodeDetails &
+  PropsWithChildren & {
     position: EuiMarkdownAstNodePosition;
-  }
+  };
+
+export const tooltipMarkdownRenderer: FunctionComponent<
+  TooltipMarkdownRendererProps
 > = ({ content, children }) => {
   return (
     <span>

--- a/src/components/observer/mutation_observer/mutation_observer.test.tsx
+++ b/src/components/observer/mutation_observer/mutation_observer.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useState, PropsWithChildren } from 'react';
 import { mount } from 'enzyme';
 import { EuiMutationObserver, useMutationObserver } from './mutation_observer';
 import { sleep } from '../../../test';
@@ -51,14 +51,16 @@ describe('useMutationObserver', () => {
     expect.assertions(2);
 
     const mutationCallback = jest.fn();
-    const Wrapper: FunctionComponent<{}> = jest.fn(({ children }) => {
-      const [ref, setRef] = useState<Element | null>(null);
-      useMutationObserver(ref, mutationCallback, {
-        childList: true,
-        subtree: true,
-      });
-      return <div ref={setRef}>{children}</div>;
-    });
+    const Wrapper: FunctionComponent<PropsWithChildren> = jest.fn(
+      ({ children }) => {
+        const [ref, setRef] = useState<Element | null>(null);
+        useMutationObserver(ref, mutationCallback, {
+          childList: true,
+          subtree: true,
+        });
+        return <div ref={setRef}>{children}</div>;
+      }
+    );
 
     const component = mount(<Wrapper children={<div>Hello World</div>} />);
 

--- a/src/components/observer/resize_observer/resize_observer.test.tsx
+++ b/src/components/observer/resize_observer/resize_observer.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, PropsWithChildren, useState } from 'react';
 import { mount } from 'enzyme';
 import { EuiResizeObserver, useResizeObserver } from './resize_observer';
 import { sleep } from '../../../test';
@@ -49,7 +49,7 @@ describe.skip('testResizeObservers', () => {
       expect.assertions(2);
       const onResize = jest.fn();
 
-      const Wrapper: FunctionComponent<{}> = ({ children }) => {
+      const Wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => {
         return (
           <EuiResizeObserver onResize={onResize}>
             {(resizeRef: (e: HTMLElement | null) => void) => (
@@ -85,11 +85,13 @@ describe.skip('testResizeObservers', () => {
     it('watches for a resize', async () => {
       expect.assertions(2);
 
-      const Wrapper: FunctionComponent<{}> = jest.fn(({ children }) => {
-        const [ref, setRef] = useState<Element | null>(null);
-        useResizeObserver(ref);
-        return <div ref={setRef}>{children}</div>;
-      });
+      const Wrapper: FunctionComponent<PropsWithChildren> = jest.fn(
+        ({ children }) => {
+          const [ref, setRef] = useState<Element | null>(null);
+          useResizeObserver(ref);
+          return <div ref={setRef}>{children}</div>;
+        }
+      );
 
       const component = mount(<Wrapper children={<div>Hello World</div>} />);
 

--- a/src/components/page/page_body/page_body.tsx
+++ b/src/components/page/page_body/page_body.tsx
@@ -21,7 +21,8 @@ type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType<any>;
 
 export type EuiPageBodyProps<T extends ComponentTypes = 'main'> = CommonProps &
   ComponentProps<T> &
-  _EuiPageRestrictWidth & {
+  _EuiPageRestrictWidth &
+  PropsWithChildren & {
     /**
      * Sets the HTML element for `EuiPageBody`.
      */
@@ -50,7 +51,7 @@ export const EuiPageBody = <T extends ComponentTypes>({
   paddingSize = 'none',
   borderRadius = 'none',
   ...rest
-}: PropsWithChildren<EuiPageBodyProps<T>>) => {
+}: EuiPageBodyProps<T>) => {
   // Set max-width as a style prop
   const widthStyles = setStyleForRestrictedPageWidth(
     restrictWidth,

--- a/src/components/page/page_body/page_body.tsx
+++ b/src/components/page/page_body/page_body.tsx
@@ -19,27 +19,28 @@ import { euiPageBodyStyles } from './page_body.styles';
 
 type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType<any>;
 
-export type EuiPageBodyProps<T extends ComponentTypes = 'main'> = CommonProps &
-  ComponentProps<T> &
-  _EuiPageRestrictWidth &
-  PropsWithChildren & {
-    /**
-     * Sets the HTML element for `EuiPageBody`.
-     */
-    component?: T;
-    /**
-     * Uses an EuiPanel as the main component instead of a plain div
-     */
-    panelled?: boolean;
-    /**
-     * Extends any extra EuiPanel props if `panelled=true`
-     */
-    panelProps?: Omit<EuiPanelProps, 'paddingSize'>;
-    /**
-     * Adjusts the padding
-     */
-    paddingSize?: EuiPaddingSize;
-  };
+export type EuiPageBodyProps<T extends ComponentTypes = 'main'> =
+  PropsWithChildren &
+    CommonProps &
+    ComponentProps<T> &
+    _EuiPageRestrictWidth & {
+      /**
+       * Sets the HTML element for `EuiPageBody`.
+       */
+      component?: T;
+      /**
+       * Uses an EuiPanel as the main component instead of a plain div
+       */
+      panelled?: boolean;
+      /**
+       * Extends any extra EuiPanel props if `panelled=true`
+       */
+      panelProps?: Omit<EuiPanelProps, 'paddingSize'>;
+      /**
+       * Adjusts the padding
+       */
+      paddingSize?: EuiPaddingSize;
+    };
 
 export const EuiPageBody = <T extends ComponentTypes>({
   children,

--- a/src/components/page_template/inner/page_inner.tsx
+++ b/src/components/page_template/inner/page_inner.tsx
@@ -20,7 +20,8 @@ export type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType;
 
 export type _EuiPageInnerProps<T extends ComponentTypes = 'main'> =
   CommonProps &
-    ComponentProps<T> & {
+    ComponentProps<T> &
+    PropsWithChildren & {
       /**
        * Sets which HTML element to render.
        */
@@ -52,7 +53,7 @@ export const _EuiPageInner = <T extends ComponentTypes>({
   paddingSize = 'none',
   responsive = ['xs', 's'],
   ...rest
-}: PropsWithChildren<_EuiPageInnerProps<T>>) => {
+}: _EuiPageInnerProps<T>) => {
   const themeContext = useEuiTheme();
   const isResponding = useIsWithinBreakpoints(responsive);
   const styles = euiPageInnerStyles(themeContext);

--- a/src/components/page_template/inner/page_inner.tsx
+++ b/src/components/page_template/inner/page_inner.tsx
@@ -19,9 +19,9 @@ import { euiPageInnerStyles } from './page_inner.styles';
 export type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType;
 
 export type _EuiPageInnerProps<T extends ComponentTypes = 'main'> =
-  CommonProps &
-    ComponentProps<T> &
-    PropsWithChildren & {
+  PropsWithChildren &
+    CommonProps &
+    ComponentProps<T> & {
       /**
        * Sets which HTML element to render.
        */

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -11,7 +11,7 @@
  * into portals.
  */
 
-import { Component, ReactNode } from 'react';
+import React, { Component, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 import { EuiNestedThemeContext } from '../../services';
@@ -95,8 +95,8 @@ export class EuiPortal extends Component<EuiPortalProps> {
   }
 
   render() {
-    return this.portalNode
-      ? createPortal(this.props.children, this.portalNode)
-      : null;
+    return this.portalNode ? (
+      <>{createPortal(this.props.children, this.portalNode)}</>
+    ) : null;
   }
 }

--- a/src/components/provider/cache/cache_provider.tsx
+++ b/src/components/provider/cache/cache_provider.tsx
@@ -10,14 +10,14 @@ import React, { PropsWithChildren } from 'react';
 import { EmotionCache } from '@emotion/css';
 import { CacheProvider } from '@emotion/react';
 
-export interface EuiCacheProviderProps {
+export interface EuiCacheProviderProps extends PropsWithChildren {
   cache?: false | EmotionCache;
 }
 
 export const EuiCacheProvider = ({
   cache,
   children,
-}: PropsWithChildren<EuiCacheProviderProps>) => {
+}: EuiCacheProviderProps) => {
   return children && cache ? (
     <CacheProvider value={cache}>{children}</CacheProvider>
   ) : (

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -29,7 +29,8 @@ const isEmotionCacheObject = (
 
 export interface EuiProviderProps<T>
   extends Omit<EuiThemeProviderProps<T>, 'children' | 'theme'>,
-    EuiGlobalStylesProps {
+    EuiGlobalStylesProps,
+    PropsWithChildren {
   /**
    * Provide a specific EuiTheme; Defaults to EuiThemeAmsterdam;
    * Pass `null` to remove all theming including global reset
@@ -71,7 +72,7 @@ export const EuiProvider = <T extends {} = {}>({
   colorMode,
   modify,
   children,
-}: PropsWithChildren<EuiProviderProps<T>>) => {
+}: EuiProviderProps<T>) => {
   let defaultCache;
   let globalCache;
   let utilityCache;

--- a/src/components/provider/provider.tsx
+++ b/src/components/provider/provider.tsx
@@ -28,9 +28,9 @@ const isEmotionCacheObject = (
 ): obj is EmotionCache => obj.hasOwnProperty('key');
 
 export interface EuiProviderProps<T>
-  extends Omit<EuiThemeProviderProps<T>, 'children' | 'theme'>,
+  extends PropsWithChildren,
     EuiGlobalStylesProps,
-    PropsWithChildren {
+    Omit<EuiThemeProviderProps<T>, 'children' | 'theme'> {
   /**
    * Provide a specific EuiTheme; Defaults to EuiThemeAmsterdam;
    * Pass `null` to remove all theming including global reset

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -46,7 +46,7 @@ import {
 import { euiResizableContainerStyles } from './resizable_container.styles';
 
 export interface EuiResizableContainerProps
-  extends HTMLAttributes<HTMLDivElement>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'>,
     CommonProps {
   /**
    * Specify the container direction

--- a/src/components/table/mobile/table_sort_mobile_item.tsx
+++ b/src/components/table/mobile/table_sort_mobile_item.tsx
@@ -6,13 +6,15 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
 
 import { EuiContextMenuItem } from '../../context_menu';
 
-export interface EuiTableSortMobileItemProps extends CommonProps {
+export interface EuiTableSortMobileItemProps
+  extends CommonProps,
+    PropsWithChildren {
   /**
    * Callback to know when an item has been clicked
    */

--- a/src/components/table/mobile/table_sort_mobile_item.tsx
+++ b/src/components/table/mobile/table_sort_mobile_item.tsx
@@ -13,8 +13,8 @@ import { CommonProps } from '../../common';
 import { EuiContextMenuItem } from '../../context_menu';
 
 export interface EuiTableSortMobileItemProps
-  extends CommonProps,
-    PropsWithChildren {
+  extends PropsWithChildren,
+    CommonProps {
   /**
    * Callback to know when an item has been clicked
    */

--- a/src/components/table/table_body.tsx
+++ b/src/components/table/table_body.tsx
@@ -9,8 +9,8 @@
 import React, { FunctionComponent, PropsWithChildren, Ref } from 'react';
 import { CommonProps } from '../common';
 
-export type EuiTableBodyProps = CommonProps &
-  PropsWithChildren & {
+export type EuiTableBodyProps = PropsWithChildren &
+  CommonProps & {
     bodyRef?: Ref<HTMLTableSectionElement>;
   };
 

--- a/src/components/table/table_body.tsx
+++ b/src/components/table/table_body.tsx
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, Ref } from 'react';
+import React, { FunctionComponent, PropsWithChildren, Ref } from 'react';
 import { CommonProps } from '../common';
 
-export type EuiTableBodyProps = CommonProps & {
-  bodyRef?: Ref<HTMLTableSectionElement>;
-};
+export type EuiTableBodyProps = CommonProps &
+  PropsWithChildren & {
+    bodyRef?: Ref<HTMLTableSectionElement>;
+  };
 
 export const EuiTableBody: FunctionComponent<EuiTableBodyProps> = ({
   children,

--- a/src/components/table/table_footer.tsx
+++ b/src/components/table/table_footer.tsx
@@ -6,14 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { CommonProps } from '../common';
 
-export const EuiTableFooter: FunctionComponent<CommonProps> = ({
-  children,
-  className,
-  ...rest
-}) => {
+export const EuiTableFooter: FunctionComponent<
+  PropsWithChildren & CommonProps
+> = ({ children, className, ...rest }) => {
   return (
     <tfoot className={className} {...rest}>
       <tr>{children}</tr>

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -22,6 +22,7 @@ export const SIZES = ['s', 'm', 'l', 'xl'] as const;
 export type EuiTabsSizes = (typeof SIZES)[number];
 
 export type EuiTabsProps = CommonProps &
+  PropsWithChildren &
   HTMLAttributes<HTMLDivElement> & {
     /**
      * ReactNode to render as this component's content
@@ -45,7 +46,7 @@ export type EuiTabsProps = CommonProps &
 
 export type EuiTabRef = HTMLDivElement;
 
-export const EuiTabs = forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
+export const EuiTabs = forwardRef<EuiTabRef, EuiTabsProps>(
   (
     {
       children,
@@ -54,7 +55,7 @@ export const EuiTabs = forwardRef<EuiTabRef, PropsWithChildren<EuiTabsProps>>(
       expand = false,
       size = 'm',
       ...rest
-    }: PropsWithChildren<EuiTabsProps>,
+    }: EuiTabsProps,
     ref
   ) => {
     const euiTheme = useEuiTheme();

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -21,9 +21,9 @@ import { EuiTabsContext } from './tabs_context';
 export const SIZES = ['s', 'm', 'l', 'xl'] as const;
 export type EuiTabsSizes = (typeof SIZES)[number];
 
-export type EuiTabsProps = CommonProps &
+export type EuiTabsProps = HTMLAttributes<HTMLDivElement> &
   PropsWithChildren &
-  HTMLAttributes<HTMLDivElement> & {
+  CommonProps & {
     /**
      * ReactNode to render as this component's content
      */

--- a/src/services/breakpoint/current_breakpoint.tsx
+++ b/src/services/breakpoint/current_breakpoint.tsx
@@ -13,6 +13,7 @@ import React, {
   useMemo,
   useCallback,
   FunctionComponent,
+  PropsWithChildren,
 } from 'react';
 
 import { keysOf } from '../../components/common';
@@ -33,7 +34,7 @@ export const CurrentEuiBreakpointContext =
  * Top level provider (nested within EuiProvider) which provides a single
  * resize listener that returns the current breakpoint based on window width
  */
-export const CurrentEuiBreakpointProvider: FunctionComponent = ({
+export const CurrentEuiBreakpointProvider: FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
   // Obtain the breakpoints map from the EUI theme

--- a/src/services/breakpoint/current_breakpoint.tsx
+++ b/src/services/breakpoint/current_breakpoint.tsx
@@ -34,9 +34,9 @@ export const CurrentEuiBreakpointContext =
  * Top level provider (nested within EuiProvider) which provides a single
  * resize listener that returns the current breakpoint based on window width
  */
-export const CurrentEuiBreakpointProvider: FunctionComponent<PropsWithChildren> = ({
-  children,
-}) => {
+export const CurrentEuiBreakpointProvider: FunctionComponent<
+  PropsWithChildren
+> = ({ children }) => {
   // Obtain the breakpoints map from the EUI theme
   const {
     euiTheme: { breakpoint: breakpoints },

--- a/src/services/theme/provider.tsx
+++ b/src/services/theme/provider.tsx
@@ -42,7 +42,7 @@ export const setEuiDevProviderWarning = (level: LEVELS | undefined) =>
   (providerWarning = level);
 export const getEuiDevProviderWarning = () => providerWarning;
 
-export interface EuiThemeProviderProps<T> {
+export interface EuiThemeProviderProps<T> extends PropsWithChildren {
   theme?: EuiThemeSystem<T>;
   colorMode?: EuiThemeColorMode;
   modify?: EuiThemeModifications<T>;
@@ -67,7 +67,7 @@ export const EuiThemeProvider = <T extends {} = {}>({
   modify: _modifications,
   children,
   wrapperProps,
-}: PropsWithChildren<EuiThemeProviderProps<T>>) => {
+}: EuiThemeProviderProps<T>) => {
   const { isGlobalTheme, bodyColor } = useContext(EuiNestedThemeContext);
   const parentSystem = useContext(EuiSystemContext);
   const parentModifications = useContext(EuiModificationsContext);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4852,10 +4852,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^18.2.4":
-  version "18.2.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.4.tgz#13f25bfbf4e404d26f62ac6e406591451acba9e0"
-  integrity sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==
+"@types/react-dom@^18.2.6":
+  version "18.2.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.6.tgz#ad621fa71a8db29af7c31b41b2ea3d8a6f4144d1"
+  integrity sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==
   dependencies:
     "@types/react" "*"
 
@@ -4921,7 +4921,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^18.2.6":
+"@types/react@*", "@types/react@>=16", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^18", "@types/react@^18.2.14":
   version "18.2.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
   integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
@@ -18018,7 +18018,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^18.2.0:
+react@^18, react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4845,17 +4845,17 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@<18.0.0", "@types/react-dom@^17.0.11":
-  version "17.0.20"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
-  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.9.0":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
   dependencies:
-    "@types/react" "^17"
+    "@types/react" "*"
 
-"@types/react-dom@>=16.9.0":
-  version "18.2.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.6.tgz#ad621fa71a8db29af7c31b41b2ea3d8a6f4144d1"
-  integrity sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==
+"@types/react-dom@^18.2.4":
+  version "18.2.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.4.tgz#13f25bfbf4e404d26f62ac6e406591451acba9e0"
+  integrity sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==
   dependencies:
     "@types/react" "*"
 
@@ -4921,37 +4921,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.2.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.6.tgz#5cd53ee0d30ffc193b159d3516c8c8ad2f19d571"
-  integrity sha512-wRZClXn//zxCFW+ye/D2qY65UsYP1Fpex2YXorHc8awoNamkMZSvBxwxdYVInsHOZZd2Ppq8isnSzJL5Mpf8OA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16", "@types/react@>=16.9.0":
-  version "18.2.13"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.13.tgz#a98c09bde8b18f80021935b11d2d29ef5f4dcb2f"
-  integrity sha512-vJ+zElvi/Zn9cVXB5slX2xL8PZodPCwPRDpittQdw43JR2AJ5k3vKdgJJyneV/cYgIbLQUwXa9JVDvUZXGba+Q==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16":
-  version "16.14.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.43.tgz#bc6e7a0e99826809591d38ddf1193955de32c446"
-  integrity sha512-7zdjv7jvoLLQg1tTvpQsm+hyNUMT2mPlNV1+d0I8fbGhkJl82spopMyBlu4wb1dviZAxpGdk5eHu/muacknnfw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17", "@types/react@^17.0.38":
-  version "17.0.62"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.62.tgz#2efe8ddf8533500ec44b1334dd1a97caa2f860e3"
-  integrity sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==
+"@types/react@*", "@types/react@>=16", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^18.2.6":
+  version "18.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
+  integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10758,10 +10731,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-lock@^0.11.2:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.3.tgz#c094e8f109d780f56038abdeec79328fd56b627f"
-  integrity sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==
+focus-lock@^0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.6.tgz#e8821e21d218f03e100f7dc27b733f9c4f61e683"
+  integrity sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==
   dependencies:
     tslib "^2.0.3"
 
@@ -17769,14 +17742,13 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
 react-dropzone@^11.5.3:
   version "11.5.3"
@@ -17817,26 +17789,26 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
-react-focus-lock@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.2.tgz#a57dfd7c493e5a030d87f161c96ffd082bd920f2"
-  integrity sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==
+react-focus-lock@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.4.tgz#4753f6dcd167c39050c9d84f9c63c71b3ff8462e"
+  integrity sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.11.2"
+    focus-lock "^0.11.6"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
 react-focus-on@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.7.0.tgz#bf782b51483d52d1d336b7b09cb864897af26cdf"
-  integrity sha512-TsCnbJr4qjqFatJ4U1N8qGSZH+FUzxJ5mJ5ta7TY2YnDmUbGGmcvZMTZgGjQ1fl6vlztsMyg6YyZlPAeeIhEUg==
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.8.2.tgz#f62c68fb0a9bc9bde5609c2db38dffa3a1096529"
+  integrity sha512-+JvIRBqvDMnIsEruDSkIWHFBWdpfJ9V9eQPsGaifEUGGm9fw52sZgWqHYa94XJxVMrdxXhdrEwyO6QaUlucEww==
   dependencies:
     aria-hidden "^1.2.2"
-    react-focus-lock "^2.9.2"
-    react-remove-scroll "^2.5.5"
+    react-focus-lock "^2.9.4"
+    react-remove-scroll "^2.5.6"
     react-style-singleton "^2.2.0"
     tslib "^2.3.1"
     use-callback-ref "^1.3.0"
@@ -17925,7 +17897,7 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.4:
+react-remove-scroll-bar@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
   integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
@@ -17933,12 +17905,12 @@ react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.4:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
-  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+react-remove-scroll@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz#7510b8079e9c7eebe00e65a33daaa3aa29a10336"
+  integrity sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==
   dependencies:
-    react-remove-scroll-bar "^2.3.3"
+    react-remove-scroll-bar "^2.3.4"
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
@@ -18046,13 +18018,12 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^17.0.0, react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -18973,6 +18944,13 @@ scheduler@^0.20.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
 
 schema-utils@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
## Summary

This is the first set of changes needed to make EUI compatible with React 18. Following @cee-chen suggestion in #6772, I divided the work into more branches that are easier to review and merge into our feature branch (`feature/react-18`).

This PR contains:

- Upgrade react, react-dom and its types to v18
- Update package.json resolutions to force @types/react version to v18
- Fix component types to follow React 18 changes, most notably add `PropsWithChildren` to components accepting the `children` property
- Switch to using the new `createRoot` API in docs entrypoint

## QA

1. Pull the changes and run `yarn` to fetch new dependencies
2. Run `yarn build` and confirm the application builds successfully
3. Run `yarn start`, wait for it to load and open `http://localhost:8030` to confirm the application is loading
4. See the homepage and other component pages opening as expected

Please note that the work is not final and there are additional changes that need to be made to make the application stable and tests passing. At this stage, some pages may crash the application, portals are not working and the majority of tests are failing. This is expected and will be addressed in next PRs.

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
