### PR TITLE
[EuiRange] Remove 20 tick hard limit, detect minimum tick width instead

### DIFF
--- a/src-docs/src/views/range/range_example.js
+++ b/src-docs/src/views/range/range_example.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 
@@ -235,12 +236,21 @@ export const RangeControlExample = {
             To pass completely custom tick marks, you can pass an array of
             objects that require a <EuiCode>value</EuiCode> and{' '}
             <EuiCode>label</EuiCode>. The value must be included in the range of
-            values (min-max), though the label may be anythin you choose.
+            values (min-max), though the label may be anything you choose.
           </p>
-          <EuiCallOut color="warning" title="Maximum of 20 ticks allowed">
+          <EuiCallOut
+            color="warning"
+            title="Minimum of 5px width per tick allowed"
+          >
             <p>
-              Spacing can get quite cramped with lots of ticks so we max out the
-              number to 20.
+              If the width available for each tick displayed is below 5px, the
+              range component will error. Test your usage at multiple screen
+              widths to ensure all ticks are visible on the page at all times,
+              or use EUI's <EuiCode>useIsWithinBreakpoints</EuiCode>{' '}
+              <Link to="/theming/breakpoints/values?themeLanguage=js">
+                hook utility
+              </Link>{' '}
+              to reduce the tick interval responsively.
             </p>
           </EuiCallOut>
         </>

--- a/src-docs/src/views/range/ticks.tsx
+++ b/src-docs/src/views/range/ticks.tsx
@@ -8,6 +8,7 @@ import {
   EuiDualRange,
   EuiDualRangeProps,
   useGeneratedHtmlId,
+  useIsWithinBreakpoints,
 } from '../../../../src';
 
 export default () => {
@@ -38,7 +39,7 @@ export default () => {
     prefix: 'dualRangeLongLabels',
   });
 
-  const rangeNoLinearId = useGeneratedHtmlId({ prefix: 'rangeNoLinaerId' });
+  const rangeNoLinearId = useGeneratedHtmlId({ prefix: 'rangeNoLinear' });
 
   return (
     <>
@@ -56,7 +57,7 @@ export default () => {
       <EuiSpacer size="xl" />
 
       <EuiTitle size="xxs">
-        <h3>Custom tick interval</h3>
+        <h3>Custom responsive tick interval</h3>
       </EuiTitle>
 
       <EuiSpacer size="l" />
@@ -70,8 +71,8 @@ export default () => {
         showInput
         showRange
         showTicks
-        tickInterval={20}
-        aria-label="An example of EuiRange with custom tickInterval"
+        tickInterval={useIsWithinBreakpoints(['xs', 's']) ? 25 : 20}
+        aria-label="An example of EuiRange with a custom & responsive tickInterval"
       />
 
       <EuiSpacer size="xl" />

--- a/src/components/form/range/__snapshots__/range_track.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range_track.test.tsx.snap
@@ -132,5 +132,3 @@ exports[`EuiRangeTrack thrown errors should throw error if custom tick value is 
 exports[`EuiRangeTrack thrown errors should throw error if custom tick value is lower than \`min\` 1`] = `"The value of -100 is lower than the min value of 0."`;
 
 exports[`EuiRangeTrack thrown errors should throw error if custom tick value is off sequence from \`step\` 1`] = `"The value of 10 is not included in the possible sequence provided by the step of 50."`;
-
-exports[`EuiRangeTrack thrown errors should throw error if there are too many ticks to render 1`] = `"The number of ticks to render is too high (21), reduce the interval."`;

--- a/src/components/form/range/range_track.test.tsx
+++ b/src/components/form/range/range_track.test.tsx
@@ -61,13 +61,6 @@ describe('EuiRangeTrack', () => {
       expect(component).toThrowErrorMatchingSnapshot();
     });
 
-    test('should throw error if there are too many ticks to render', () => {
-      const component = () =>
-        render(<EuiRangeTrack min={0} max={21} showTicks />);
-
-      expect(component).toThrowErrorMatchingSnapshot();
-    });
-
     test('should throw error if `tickInterval` is off sequence from `step`', () => {
       const component = () =>
         render(
@@ -124,6 +117,46 @@ describe('EuiRangeTrack', () => {
         );
 
       expect(component).toThrowErrorMatchingSnapshot();
+    });
+
+    describe('too many ticks to render', () => {
+      let consoleWarn: jest.SpyInstance;
+
+      beforeAll(() => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+          configurable: true,
+          value: 100,
+        });
+        consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      });
+
+      afterAll(() => {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+          value: 0,
+        });
+        consoleWarn.mockRestore();
+      });
+
+      test('should warn if each tick has under 20px of width', () => {
+        render(<EuiRangeTrack min={0} max={100} tickInterval={10} showTicks />);
+
+        expect(consoleWarn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'The number of ticks to render (11) is too high for the range width'
+          )
+        );
+      });
+
+      test('should throw an error if each tick has under 5px of width', () => {
+        const component = () =>
+          render(
+            <EuiRangeTrack min={0} max={100} tickInterval={2} showTicks />
+          );
+
+        expect(component).toThrow(
+          'The number of ticks to render (51) is too high for the range width'
+        );
+      });
     });
   });
 });

--- a/src/components/form/range/range_track.tsx
+++ b/src/components/form/range/range_track.tsx
@@ -93,9 +93,7 @@ export const EuiRangeTrack: FunctionComponent<EuiRangeTrackProps> = ({
 
     // Error out if there are too many ticks to render
     if (sequence.length > 20) {
-      throw new Error(
-        `The number of ticks to render is too high (${sequence.length}), reduce the interval.`
-      );
+      console.warn(`The number of ticks to render is too high (${sequence.length}), reduce the interval.`)
     }
 
     return sequence;

--- a/src/components/form/range/range_track.tsx
+++ b/src/components/form/range/range_track.tsx
@@ -93,7 +93,9 @@ export const EuiRangeTrack: FunctionComponent<EuiRangeTrackProps> = ({
 
     // Error out if there are too many ticks to render
     if (sequence.length > 20) {
-      console.warn(`The number of ticks to render is too high (${sequence.length}), reduce the interval.`)
+      console.warn(
+        `The number of ticks to render (${sequence.length}) is potentially too high. Please ensure all ticks are visible on the page at multiple screen widths, and reduce the interval if not.`
+      );
     }
 
     return sequence;

--- a/upcoming_changelogs/6829.md
+++ b/upcoming_changelogs/6829.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- `EuiRange` & `EuiDualRange` no longer have a hard limit of 20 displayed ticks. The component now instead detects the width available, and throws an error if each tick has less than 5 pixels of width. We recommend testing your tick usage at smaller screens to ensure they always display legibly to users.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6807

This PR removes the hard-coded limit (thrown error) of 20 ticks visible, and instead uses the width of the track (on mount) to detect if each tick has a minimum width.

- If each tick has 5px or less of width, the component throws/errors and will not render (same behavior as before when more than 20 ticks were visible).
- If the component has between 5 to 20px of width available, the component will warn to the console, but not throw, and will still render
- If each tick has more than 20px of width, no warning or error will be thrown.

![screencap](https://github.com/elastic/eui/assets/549407/40b1b2a3-8f26-440b-a005-2f2aeb0f2f4f)

## QA

### General checklist

- [x] Sign CLA
- [x] Checked in **mobile** (some warnings throw on the docs page, but no errors)
- [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
- [x] Checked for **breaking changes** and labeled appropriately