### PR TITLE
Allow arbitrary sort fields in `EuiTableSortingType`

### DIFF
--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -145,12 +145,12 @@ export interface EuiTableActionsColumnType<T> {
   width?: string;
 }
 
-export interface EuiTableSortingType<T> {
+export interface EuiTableSortingType<T, K extends keyof any = keyof T> {
   /**
    * Indicates the property/field to sort on
    */
   sort?: {
-    field: keyof T;
+    field: K;
     direction: 'asc' | 'desc';
   };
   /**

--- a/upcoming_changelogs/6830.md
+++ b/upcoming_changelogs/6830.md
@@ -1,0 +1,1 @@
+- Extended `EuiTableSortingType` with an optional parameter to allow arbitrary sort field names.


### PR DESCRIPTION
## Summary

When creating a standalone `EuiTableSortingType` object, the `sort.field` property is hardcoded to `keyof T`. This PR adds an optional generic parameter, defaulting to the existing derived top-level keys of `T`, but allowing arbitrary values if desired.

(In practice this `T` is only used to extract its keys, so having both params is arguably superfluous. But in the interest of backward compatibility...)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
