### PR TITLE
[DataGrid] Fix row height calculation for datagrid with 1 item and rowHeightOption: 'auto'

### DIFF
--- a/src/components/datagrid/utils/row_heights.test.ts
+++ b/src/components/datagrid/utils/row_heights.test.ts
@@ -97,6 +97,10 @@ describe('RowHeightUtils', () => {
           34
         );
       });
+
+      it('should use default height for rowIndex 0 and autoHeight', () => {
+        expect(rowHeightUtils.getCalculatedHeight('auto', 34, 0)).toEqual(34);
+      });
     });
 
     describe('lineCounts', () => {
@@ -139,7 +143,7 @@ describe('RowHeightUtils', () => {
       });
 
       it('gets the max height for the current row from the heights cache', () => {
-        expect(rowHeightUtils.getCalculatedHeight('auto', 34, 1)).toEqual(0); // 0 is expected since the cache is empty
+        expect(rowHeightUtils.getCalculatedHeight('auto', 34, 1)).toEqual(34); // 0 is expected since the cache is empty
         expect(getRowHeightSpy).toHaveBeenCalled();
       });
 

--- a/src/components/datagrid/utils/row_heights.ts
+++ b/src/components/datagrid/utils/row_heights.ts
@@ -81,8 +81,8 @@ export class RowHeightUtils {
       }
     }
 
-    if (heightOption === AUTO_HEIGHT && rowIndex != null) {
-      return this.getRowHeight(rowIndex);
+    if (heightOption === AUTO_HEIGHT && isNumber(rowIndex)) {
+      return this.getRowHeight(rowIndex) || defaultHeight;
     }
 
     return defaultHeight;

--- a/upcoming_changelogs/6831.md
+++ b/upcoming_changelogs/6831.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an issue with EuiDataGrid and rowHeightOptions: 'auto' with 1 and only 1 row item


### PR DESCRIPTION
## Summary

I think an issue exists for uses of data grid with rowHeightOptions: 'auto' where the table will calculate an incorrect row height of 0 for a table with 1 row. The test case of:

```
      it('should use default height for rowIndex 0 and autoHeight', () => {
        expect(rowHeightUtils.getCalculatedHeight('auto', 34, 0)).toEqual(34);
      });
```

will currently fail in main, and is I think what leads to the issue reported in https://github.com/elastic/kibana/issues/132901 , https://github.com/elastic/sdh-security-team/issues/390 ,  and various other places since the conversion of security solution alerts table to datagrid and row height auto. Note that in each of the reported occurences of this bug, there's always exactly 1 (rowIndex of 0) item in the table.
## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
