### PR TITLE
[DX] Leveraging JSDoc for font-weight and size tokens

### DIFF
--- a/src/global_styling/variables/animations.ts
+++ b/src/global_styling/variables/animations.ts
@@ -35,10 +35,18 @@ export const EuiThemeAnimationSpeeds = [
 
 export type _EuiThemeAnimationSpeed = (typeof EuiThemeAnimationSpeeds)[number];
 
-export type _EuiThemeAnimationSpeeds = Record<
-  _EuiThemeAnimationSpeed,
-  CSSProperties['animationDuration']
->;
+export type _EuiThemeAnimationSpeeds = {
+  /** - Default value: 90ms */
+  extraFast: CSSProperties['animationDuration'];
+  /** - Default value: 150ms */
+  fast: CSSProperties['animationDuration'];
+  /** - Default value: 250ms */
+  normal: CSSProperties['animationDuration'];
+  /** - Default value: 350ms */
+  slow: CSSProperties['animationDuration'];
+  /** - Default value: 500ms */
+  extraSlow: CSSProperties['animationDuration'];
+};
 
 /**
  * Easings / Timing functions

--- a/src/global_styling/variables/borders.ts
+++ b/src/global_styling/variables/borders.ts
@@ -12,10 +12,12 @@ import { ColorModeSwitch } from '../../services/theme/types';
 export interface _EuiThemeBorderWidthValues {
   /**
    * Thinnest width for border
+   * - Default value: 1px
    */
   thin: CSSProperties['borderWidth'];
   /**
    * Thickest width for border
+   * - Default value: 2px
    */
   thick: CSSProperties['borderWidth'];
 }
@@ -23,10 +25,12 @@ export interface _EuiThemeBorderWidthValues {
 export interface _EuiThemeBorderRadiusValues {
   /**
    * Primary corner radius size
+   * - Default value: 6px
    */
   medium: CSSProperties['borderRadius'];
   /**
    * Small corner radius size
+   * - Default value: 4px
    */
   small: CSSProperties['borderRadius'];
 }
@@ -52,14 +56,17 @@ export interface _EuiThemeBorderValues extends _EuiThemeBorderColorValues {
 export interface _EuiThemeBorderTypes {
   /**
    * Full `border` property string computed using `border.width.thin` and `border.color`
+   * - Default value: 1px solid [colors.lightShade]
    */
   thin: CSSProperties['border'];
   /**
    * Full `border` property string computed using `border.width.thick` and `border.color`
+   * - Default value: 2px solid [colors.lightShade]
    */
   thick: CSSProperties['border'];
   /**
    * Full editable style `border` property string computed using `border.width.thick` and `border.color`
+   * - Default value: 2px dotted [colors.lightShade]
    */
   editable: CSSProperties['border'];
 }

--- a/src/global_styling/variables/breakpoint.ts
+++ b/src/global_styling/variables/breakpoint.ts
@@ -12,5 +12,17 @@ export const EuiThemeBreakpoints = ['xs', 's', 'm', 'l', 'xl'] as const;
 // in case consumers add custom breakpoint sizes, such as xxl or xxs
 export type _EuiThemeBreakpoint = string;
 
-// Set the minimum window width at which to start to the breakpoint
-export type _EuiThemeBreakpoints = Record<_EuiThemeBreakpoint, number>;
+// Explicitly list out each key so we can document default values
+// via JSDoc (which is available to devs in IDE via intellisense)
+export type _EuiThemeBreakpoints = Record<_EuiThemeBreakpoint, number> & {
+  /** - Default value: 0 */
+  xs: number;
+  /** - Default value: 575 */
+  s: number;
+  /** - Default value: 768 */
+  m: number;
+  /** - Default value: 992 */
+  l: number;
+  /** - Default value: 1200 */
+  xl: number;
+};

--- a/src/global_styling/variables/levels.ts
+++ b/src/global_styling/variables/levels.ts
@@ -38,7 +38,23 @@ export const EuiThemeLevels = [
 
 export type _EuiThemeLevel = (typeof EuiThemeLevels)[number];
 
-export type _EuiThemeLevels = Record<
-  _EuiThemeLevel,
-  NonNullable<CSSProperties['zIndex']>
->;
+export type _EuiThemeLevels = {
+  /** - Default value: 9000 */
+  toast: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 8000 */
+  modal: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 6000 */
+  mask: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 6000 */
+  navigation: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 2000 */
+  menu: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 1000 */
+  header: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 1000 */
+  flyout: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 1000 */
+  maskBelowHeader: NonNullable<CSSProperties['zIndex']>;
+  /** - Default value: 0 */
+  content: NonNullable<CSSProperties['zIndex']>;
+};

--- a/src/global_styling/variables/size.ts
+++ b/src/global_styling/variables/size.ts
@@ -21,6 +21,27 @@ export const EuiThemeSizes = [
   'xxxxl',
 ] as const;
 
-export type _EuiThemeSize = (typeof EuiThemeSizes)[number];
+export type _EuiThemeSize = typeof EuiThemeSizes[number];
 
-export type _EuiThemeSizes = Record<_EuiThemeSize, string>;
+export type _EuiThemeSizes = {
+  /** value: 2px */
+  xxs: string;
+  /** value: 4px */
+  xs: string;
+  /** value: 8px */
+  s: string;
+  /** value: 12px */
+  m: string;
+  /** value: 16px */
+  base: string;
+  /** value: 24px */
+  l: string;
+  /** value: 32px */
+  xl: string;
+  /** value: 40px */
+  xxl: string;
+  /** value: 48px */
+  xxxl: string;
+  /** value: 64px */
+  xxxxl: string;
+};

--- a/src/global_styling/variables/size.ts
+++ b/src/global_styling/variables/size.ts
@@ -6,6 +6,9 @@
  * Side Public License, v 1.
  */
 
+/**
+ * - Default value: 16
+ */
 export type _EuiThemeBase = number;
 
 export const EuiThemeSizes = [
@@ -21,27 +24,27 @@ export const EuiThemeSizes = [
   'xxxxl',
 ] as const;
 
-export type _EuiThemeSize = typeof EuiThemeSizes[number];
+export type _EuiThemeSize = (typeof EuiThemeSizes)[number];
 
 export type _EuiThemeSizes = {
-  /** value: 2px */
+  /** - Default value: 2px */
   xxs: string;
-  /** value: 4px */
+  /** - Default value: 4px */
   xs: string;
-  /** value: 8px */
+  /** - Default value: 8px */
   s: string;
-  /** value: 12px */
+  /** - Default value: 12px */
   m: string;
-  /** value: 16px */
+  /** - Default value: 16px */
   base: string;
-  /** value: 24px */
+  /** - Default value: 24px */
   l: string;
-  /** value: 32px */
+  /** - Default value: 32px */
   xl: string;
-  /** value: 40px */
+  /** - Default value: 40px */
   xxl: string;
-  /** value: 48px */
+  /** - Default value: 48px */
   xxxl: string;
-  /** value: 64px */
+  /** - Default value: 64px */
   xxxxl: string;
 };

--- a/src/global_styling/variables/size.ts
+++ b/src/global_styling/variables/size.ts
@@ -6,9 +6,6 @@
  * Side Public License, v 1.
  */
 
-/**
- * - Default value: 16
- */
 export type _EuiThemeBase = number;
 
 export const EuiThemeSizes = [

--- a/src/global_styling/variables/states.ts
+++ b/src/global_styling/variables/states.ts
@@ -24,10 +24,12 @@ export interface _EuiThemeFocusOutline {
 export interface _EuiThemeFocus {
   /**
    * Default color of the focus ring, some components may override this property
+   * - Default value: currentColor
    */
   color: ColorModeSwitch;
   /**
    * Thickness of the outline
+   * - Default value: 2px
    */
   width: CSSProperties['borderWidth'];
   /**

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -17,7 +17,7 @@ export const EuiThemeFontSizeMeasurements = ['rem', 'px', 'em'] as const;
 export type _EuiThemeFontSizeMeasurement =
   (typeof EuiThemeFontSizeMeasurements)[number];
 
-  /*
+/*
  * Font scale
  */
 

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -128,8 +128,7 @@ export interface _EuiThemeTitle {
 export type _EuiThemeFont = _EuiThemeFontBase & {
   scale: _EuiThemeFontScales;
   /**
-   * Reference:
-   * https://eui.elastic.co/#/theming/typography/values%23font-weight
+   * @see {@link https://eui.elastic.co/#/theming/typography/values%23font-weight | Reference} for more information
    */
   weight: _EuiThemeFontWeights;
   body: _EuiThemeBody;

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -14,9 +14,10 @@ import { CSSProperties } from 'react';
 
 export const EuiThemeFontSizeMeasurements = ['rem', 'px', 'em'] as const;
 
-export type _EuiThemeFontSizeMeasurement = typeof EuiThemeFontSizeMeasurements[number];
+export type _EuiThemeFontSizeMeasurement =
+  (typeof EuiThemeFontSizeMeasurements)[number];
 
-/*
+  /*
  * Font scale
  */
 
@@ -31,7 +32,7 @@ export const EuiThemeFontScales = [
   'xxl',
 ] as const;
 
-export type _EuiThemeFontScale = typeof EuiThemeFontScales[number];
+export type _EuiThemeFontScale = (typeof EuiThemeFontScales)[number];
 
 export type _EuiThemeFontScales = Record<_EuiThemeFontScale, number>;
 
@@ -80,18 +81,18 @@ export const EuiThemeFontWeights = [
   'bold',
 ] as const;
 
-export type _EuiThemeFontWeight = typeof EuiThemeFontWeights[number];
+export type _EuiThemeFontWeight = (typeof EuiThemeFontWeights)[number];
 
 export type _EuiThemeFontWeights = {
-  /** value: 300 */
+  /** - Default value: 300 */
   light: CSSProperties['fontWeight'];
-  /** value: 400 */
+  /** - Default value: 400 */
   regular: CSSProperties['fontWeight'];
-  /** value: 500 */
+  /** - Default value: 500 */
   medium: CSSProperties['fontWeight'];
-  /** value: 600 */
+  /** - Default value: 600 */
   semiBold: CSSProperties['fontWeight'];
-  /** value: 700 */
+  /** - Default value: 700 */
   bold: CSSProperties['fontWeight'];
 };
 

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -14,8 +14,7 @@ import { CSSProperties } from 'react';
 
 export const EuiThemeFontSizeMeasurements = ['rem', 'px', 'em'] as const;
 
-export type _EuiThemeFontSizeMeasurement =
-  (typeof EuiThemeFontSizeMeasurements)[number];
+export type _EuiThemeFontSizeMeasurement = typeof EuiThemeFontSizeMeasurements[number];
 
 /*
  * Font scale
@@ -32,7 +31,7 @@ export const EuiThemeFontScales = [
   'xxl',
 ] as const;
 
-export type _EuiThemeFontScale = (typeof EuiThemeFontScales)[number];
+export type _EuiThemeFontScale = typeof EuiThemeFontScales[number];
 
 export type _EuiThemeFontScales = Record<_EuiThemeFontScale, number>;
 
@@ -81,12 +80,20 @@ export const EuiThemeFontWeights = [
   'bold',
 ] as const;
 
-export type _EuiThemeFontWeight = (typeof EuiThemeFontWeights)[number];
+export type _EuiThemeFontWeight = typeof EuiThemeFontWeights[number];
 
-export type _EuiThemeFontWeights = Record<
-  _EuiThemeFontWeight,
-  CSSProperties['fontWeight']
->;
+export type _EuiThemeFontWeights = {
+  /** value: 300 */
+  light: CSSProperties['fontWeight'];
+  /** value: 400 */
+  regular: CSSProperties['fontWeight'];
+  /** value: 500 */
+  medium: CSSProperties['fontWeight'];
+  /** value: 600 */
+  semiBold: CSSProperties['fontWeight'];
+  /** value: 700 */
+  bold: CSSProperties['fontWeight'];
+};
 
 /**
  * Body / Base styles
@@ -120,6 +127,10 @@ export interface _EuiThemeTitle {
 
 export type _EuiThemeFont = _EuiThemeFontBase & {
   scale: _EuiThemeFontScales;
+  /**
+   * Reference:
+   * https://eui.elastic.co/#/theming/typography/values%23font-weight
+   */
   weight: _EuiThemeFontWeights;
   body: _EuiThemeBody;
   title: _EuiThemeTitle;

--- a/src/services/breakpoint/_sorting.test.ts
+++ b/src/services/breakpoint/_sorting.test.ts
@@ -18,7 +18,7 @@ describe('sortMapByLargeToSmallValues', () => {
         medium: 10,
         large: 30,
         small: 5,
-      })
+      } as any)
     ).toEqual({
       large: 30,
       medium: 10,
@@ -34,7 +34,7 @@ describe('sortMapBySmallToLargeValues', () => {
         large: 100,
         medium: 10,
         small: 1,
-      })
+      } as any)
     ).toEqual({
       small: 1,
       medium: 10,

--- a/src/services/breakpoint/_sorting.ts
+++ b/src/services/breakpoint/_sorting.ts
@@ -13,11 +13,11 @@ export const sortMapByLargeToSmallValues = (
 ) =>
   Object.fromEntries(
     Object.entries(breakpointsMap).sort(([, a], [, b]) => b - a)
-  );
+  ) as _EuiThemeBreakpoints;
 
 export const sortMapBySmallToLargeValues = (
   breakpointsMap: _EuiThemeBreakpoints
 ) =>
   Object.fromEntries(
     Object.entries(breakpointsMap).sort(([, a], [, b]) => a - b)
-  );
+  ) as _EuiThemeBreakpoints;

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -46,6 +46,7 @@ export type StrictColorModeSwitch<T = string> = {
 
 export type EuiThemeShape = {
   colors: _EuiThemeColors;
+  /** - Default value: 16 */
   base: _EuiThemeBase;
   /**
    * @see {@link https://eui.elastic.co/#/theming/sizing | Reference} for more information

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -47,6 +47,9 @@ export type StrictColorModeSwitch<T = string> = {
 export type EuiThemeShape = {
   colors: _EuiThemeColors;
   base: _EuiThemeBase;
+  /**
+   * @see {@link https://eui.elastic.co/#/theming/sizing | Reference} for more information
+   */
   size: _EuiThemeSizes;
   font: _EuiThemeFont;
   border: _EuiThemeBorder;


### PR DESCRIPTION
### Summary

This PR leverage JSDocs to provide the value for font weight and sizing tokens, to be a nice time-saver when using autocomplete suggestions from the IDE to provide the values of a token as the example:

![image](https://github.com/elastic/eui/assets/19270322/3c00445b-6038-4cbe-90f3-4ca0118b6a6f)

![image](https://github.com/elastic/eui/assets/19270322/07724f7d-d06f-4010-8e93-f1a63014ab42)


Also, added direct links referring to the Eui Docs:

![image](https://github.com/elastic/eui/assets/19270322/0f003fa7-7445-45f9-836f-258b386b9205)

![image](https://github.com/elastic/eui/assets/19270322/0c6b3d4a-f4ec-4c31-b7c7-8b921c009d6a)


### Reason

When developing some feature from a Figma file, we often have to deal with translating fixed values of the properties (i.e sizing, font weight, ...etc) into the corresponding EUI Token, so we need to look for the matching value for a EUI token, and for that, we need to visit the [EUI Website](https://elastic.github.io/eui), since Typescript autocomplete only tells us about its type:

![image](https://github.com/elastic/eui/assets/19270322/e474738a-b6eb-49e5-b32c-876d28c645f6)

![image](https://github.com/elastic/eui/assets/19270322/59067615-e227-46be-8dbe-414b23dda4a8)


Currently, Typescript suggestions only tell us about its type (i.e string, FontWeight):

![image](https://github.com/elastic/eui/assets/19270322/0029730e-8b4f-408f-8671-3aeed9883289)

![image](https://github.com/elastic/eui/assets/19270322/17c3b94b-d5ef-4dc9-901f-6f0148cdcde5)

Also, it's useful for debugging, when we are looking at a code already using the Eui Token and want to know it's value quickly.


### Pros

It's a relatively easy effort that can bring significant DX Improvements: 

- Avoid losing focus due to having to switch from VSCode, Figma file, and EUI website
- Improve development speed

### Cons

The only con I can think of is that if any of the values change, they need to be changed in the JSDoc definition as well, but the suggested tokens are very unlikely to change.
 

@elastic/eui-team  Let me know what you think about the proposal. In case it's approved, more values can be added for other static tokens that can leverage JSDoc as needed.