### PR TITLE
Updated get started guide

### DIFF
--- a/src-docs/src/views/guidelines/getting_started/_app_setup.tsx
+++ b/src-docs/src/views/guidelines/getting_started/_app_setup.tsx
@@ -19,13 +19,15 @@ export const AppSetup: FunctionComponent<AppSetup> = ({}) => {
       {`import React from 'react';
 import '@elastic/eui/dist/eui_theme_${colorMode.toLowerCase()}.css';
 
-import { EuiProvider } from '@elastic/eui';
+import { EuiProvider, EuiText } from '@elastic/eui';
 
-const MyApp = ({ Page }) => (
+const MyApp = () => (
   <EuiProvider colorMode="${colorMode.toLowerCase()}">
-    <Page />
+    <EuiText><p>Hello World!</p></EuiText>
   </EuiProvider>
-);`}
+);
+
+export default MyApp;`}
     </EuiCodeBlock>
   );
 

--- a/wiki/consuming-eui/README.md
+++ b/wiki/consuming-eui/README.md
@@ -60,7 +60,7 @@ import '@elastic/eui/dist/eui_theme_light.css';
 import { EuiProvider, EuiText } from '@elastic/eui';
 
 const MyApp = () => (
-  <EuiProvider colorMode="${colorMode.toLowerCase()}">
+  <EuiProvider colorMode="light">
     <EuiText><p>Hello World!</p></EuiText>
   </EuiProvider>
 );

--- a/wiki/consuming-eui/README.md
+++ b/wiki/consuming-eui/README.md
@@ -57,13 +57,15 @@ As of April 2022 EUI is in the process of [migrating to Emotion JS for the CSS a
 import React from 'react';
 import '@elastic/eui/dist/eui_theme_light.css';
 
-import { EuiProvider } from '@elastic/eui';
+import { EuiProvider, EuiText } from '@elastic/eui';
 
-const MyApp = ({ Page }) => (
-  <EuiProvider colorMode="light">
-    <Page />
+const MyApp = () => (
+  <EuiProvider colorMode="${colorMode.toLowerCase()}">
+    <EuiText><p>Hello World!</p></EuiText>
   </EuiProvider>
 );
+
+export default MyApp;
 ```
 
 #### The recommended method to consume theming variables using Emotion


### PR DESCRIPTION
I changed the snippet to be a stand-alone snippet that can be copied and replaced over an App.tsx file from create-react-app. I felt like it wasn't obvious or helpful to have `Page` included as part of the setup guide.