### PR TITLE
Update Docker image to use Debian Bullseye

### DIFF
--- a/scripts/deploy/build_docs
+++ b/scripts/deploy/build_docs
@@ -2,7 +2,7 @@
 
 set -e
 
-NODE_IMG="docker.elastic.co/eui/ci:3.5"
+NODE_IMG="docker.elastic.co/eui/ci:4.0"
 
 # Compile using node image
 echo "Building docs using ${NODE_IMG} Docker image"

--- a/scripts/docker-ci/Dockerfile
+++ b/scripts/docker-ci/Dockerfile
@@ -5,7 +5,7 @@
 FROM node:16.19.1
 
 # See https://crbug.com/795759
-RUN apt-get update && apt-get install -yq libgconf-2-4
+RUN apt-get update && apt-get install -yq libgconf-2-4 && apt-get upgrade -y
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y wget xvfb --no-install-recommends \
     && apt-get update \
     && apt-get install -y google-chrome-stable \
     --no-install-recommends \
+    && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge --auto-remove -y curl \
     && rm -rf /src/*.deb

--- a/scripts/docker-ci/Dockerfile
+++ b/scripts/docker-ci/Dockerfile
@@ -2,10 +2,10 @@
 # https://github.com/zenato/docker-puppeteer/blob/master/Dockerfile
 
 # >=12.0 required (for cypress), but latest right now is 16.19.1
-FROM node:16.19.1
+FROM node:16.19.1-bullseye
 
 # See https://crbug.com/795759
-RUN apt-get update && apt-get install -yq libgconf-2-4 && apt-get upgrade -y
+RUN apt-get update && apt-get install -yq libgconf-2-4
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 

--- a/scripts/test-a11y-docker.js
+++ b/scripts/test-a11y-docker.js
@@ -1,6 +1,6 @@
 const { execSync } = require('child_process');
 
-execSync('docker pull docker.elastic.co/eui/ci:3.5', {
+execSync('docker pull docker.elastic.co/eui/ci:4.0', {
   stdio: 'inherit',
 });
 /* eslint-disable-next-line no-multi-str */
@@ -9,7 +9,7 @@ execSync(
   -i --rm --cap-add=SYS_ADMIN --volume=$(pwd):/app --workdir=/app \
   -e GIT_COMMITTER_NAME=test -e GIT_COMMITTER_EMAIL=test -e HOME=/tmp \
   --user=$(id -u):$(id -g) \
-  docker.elastic.co/eui/ci:3.5 \
+  docker.elastic.co/eui/ci:4.0 \
   bash -c \'npm config set spin false \
     && /opt/yarn*/bin/yarn \
     && yarn cypress install \

--- a/scripts/test-docker.js
+++ b/scripts/test-docker.js
@@ -1,6 +1,6 @@
 const { execSync } = require('child_process');
 
-execSync('docker pull docker.elastic.co/eui/ci:3.5', {
+execSync('docker pull docker.elastic.co/eui/ci:4.0', {
   stdio: 'inherit',
 });
 /* eslint-disable-next-line no-multi-str */
@@ -9,7 +9,7 @@ execSync(
   -i --rm --cap-add=SYS_ADMIN --volume=$(pwd):/app --workdir=/app \
   -e GIT_COMMITTER_NAME=test -e GIT_COMMITTER_EMAIL=test -e HOME=/tmp \
   --user=$(id -u):$(id -g) \
-  docker.elastic.co/eui/ci:3.5 \
+  docker.elastic.co/eui/ci:4.0 \
   bash -c \'npm config set spin false \
     && /opt/yarn*/bin/yarn \
     && yarn cypress install \


### PR DESCRIPTION
## Summary

I created a new Docker image that uses Debian 11 (Bullseye) with our same workflow commands and added a general update command to the script.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

Checks will be in the CI log files only. This update is to an upstream Docker image used to run our regular test and deploy scripts.

- [x] Checked for **breaking changes** and labeled appropriately
- [x] Verified Docker image built and ran PR tests / deployed docs successfully
