### PR TITLE
[EuiMarkdownEditor] Allow markdown plugins to disable toolbar button

### DIFF
--- a/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -93,6 +93,7 @@ interface EuiMarkdownEditorToolbarButtonProps {
   selectedNode: null | any;
   handleMdButtonClick: (mdButtonId: string) => void;
   isEditable: boolean;
+  isDisabled?: boolean;
   id: string;
   nodeId: string;
   label: string;
@@ -102,6 +103,7 @@ const EuiMarkdownEditorToolbarButton = ({
   selectedNode,
   handleMdButtonClick,
   isEditable,
+  isDisabled,
   id,
   nodeId,
   label,
@@ -122,7 +124,7 @@ const EuiMarkdownEditorToolbarButton = ({
       onClick={() => handleMdButtonClick(id)}
       iconType={icon}
       aria-label={label}
-      isDisabled={!isEditable}
+      isDisabled={!isEditable || isDisabled}
     />
   );
 };
@@ -205,6 +207,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
                       selectedNode={selectedNode}
                       handleMdButtonClick={handleMdButtonClick}
                       isEditable={isEditable}
+                      isDisabled={button.isDisabled}
                       id={name}
                       nodeId={name}
                       label={button.label}

--- a/src/components/markdown_editor/markdown_types.ts
+++ b/src/components/markdown_editor/markdown_types.ts
@@ -71,6 +71,7 @@ export type EuiMarkdownEditorUiPlugin<NodeShape = any> = {
   button: {
     label: string;
     iconType: IconType;
+    isDisabled?: boolean;
   };
   helpText?: ReactNode;
 } & (PluginWithImmediateFormatting | PluginWithDelayedFormatting<NodeShape>);

--- a/upcoming_changelogs/6840.md
+++ b/upcoming_changelogs/6840.md
@@ -1,0 +1,1 @@
+Add ability for markdown plugins to disable toolbar buttons

--- a/upcoming_changelogs/6840.md
+++ b/upcoming_changelogs/6840.md
@@ -1,1 +1,1 @@
-Add ability for markdown plugins to disable toolbar buttons
+- Added ability for `EuiMarkdownEditor` plugins to disable toolbar buttons


### PR DESCRIPTION
## Summary
 
Exposes an additional prop to markdown ui plugin button configurations, isDisabled, to be passed through to the underlying button in the toolbar. Use case being an instance where a markdown plugin is disabled for some reason, in the screenshot below this is due to a license level restriction. 
![image](https://github.com/elastic/eui/assets/56408403/2d255b31-0e81-49d6-93ce-dd4e0e876b3d)


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
