### PR TITLE
Updating `catalog-info.yml` to run combined PR job on Buildkite

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -164,7 +164,7 @@ spec:
       name: eui-pull-request-test-and-deploy
     spec:
       repository: elastic/eui
-      pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
+      pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml"
       provider_settings:
         build_branches: false
         build_tags: false


### PR DESCRIPTION
## Summary

Updating `catalog-info.yml` to point at the consolidated Buildkite PR job that will test and build docs.

## QA

QA will happen in CI logs and feature branch(es). There should be no errors here, but I'll add an empty BK job file if needed.
