### PR TITLE
[EuiNotificationBadge] Add success color

### DIFF
--- a/src-docs/src/views/badge/notification_badge.tsx
+++ b/src-docs/src/views/badge/notification_badge.tsx
@@ -1,5 +1,18 @@
 import React from 'react';
 
-import { EuiNotificationBadge } from '../../../../src/components/badge/notification_badge';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiNotificationBadge,
+} from '../../../../src/components';
 
-export default () => <EuiNotificationBadge>3</EuiNotificationBadge>;
+export default () => (
+  <EuiFlexGroup gutterSize="s">
+    <EuiFlexItem grow={false}>
+      <EuiNotificationBadge>3</EuiNotificationBadge>
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiNotificationBadge color="success">3</EuiNotificationBadge>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);

--- a/src-docs/src/views/badge/notification_badge.tsx
+++ b/src-docs/src/views/badge/notification_badge.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiNotificationBadge,
-} from '../../../../src/components';
+import { EuiFlexGroup, EuiNotificationBadge } from '../../../../src/components';
 
 export default () => (
   <EuiFlexGroup responsive={false} gutterSize="s">
-    <EuiFlexItem grow={false}>
-      <EuiNotificationBadge>3</EuiNotificationBadge>
-    </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <EuiNotificationBadge color="success">3</EuiNotificationBadge>
-    </EuiFlexItem>
+    <EuiNotificationBadge>1</EuiNotificationBadge>
+    <EuiNotificationBadge color="success">2</EuiNotificationBadge>
+    <EuiNotificationBadge color="subdued">3</EuiNotificationBadge>
   </EuiFlexGroup>
 );

--- a/src-docs/src/views/badge/notification_badge.tsx
+++ b/src-docs/src/views/badge/notification_badge.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../src/components';
 
 export default () => (
-  <EuiFlexGroup gutterSize="s">
+  <EuiFlexGroup responsive={false} gutterSize="s">
     <EuiFlexItem grow={false}>
       <EuiNotificationBadge>3</EuiNotificationBadge>
     </EuiFlexItem>

--- a/src-docs/src/views/filter_group/filter_group_multi.js
+++ b/src-docs/src/views/filter_group/filter_group_multi.js
@@ -63,6 +63,7 @@ export default () => {
   const button = (
     <EuiFilterButton
       iconType="arrowDown"
+      badgeColor="success"
       onClick={onButtonClick}
       isSelected={isPopoverOpen}
       numFilters={items.filter((item) => item.checked !== 'off').length}

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -3,9 +3,8 @@
 exports[`EuiBadge is disabled 1`] = `
 <span
   aria-label="aria-label"
-  class="euiBadge testClass1 testClass2 emotion-euiBadge-disabled"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default-disabled"
   data-test-subj="test subject string"
-  style="background-color:#D3DAE6;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -22,9 +21,8 @@ exports[`EuiBadge is disabled 1`] = `
 exports[`EuiBadge is rendered 1`] = `
 <span
   aria-label="aria-label"
-  class="euiBadge testClass1 testClass2 emotion-euiBadge"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default"
   data-test-subj="test subject string"
-  style="background-color:#D3DAE6;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -40,8 +38,7 @@ exports[`EuiBadge is rendered 1`] = `
 
 exports[`EuiBadge is rendered with href and rel provided 1`] = `
 <span
-  class="euiBadge testClass1 testClass2 emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -62,11 +59,10 @@ exports[`EuiBadge is rendered with href and rel provided 1`] = `
 exports[`EuiBadge is rendered with href provided 1`] = `
 <a
   aria-label="aria-label"
-  class="euiBadge testClass1 testClass2 emotion-euiBadge-clickable"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default-clickable"
   data-test-subj="test subject string"
   href="/#/"
   rel="noreferrer"
-  style="background-color:#D3DAE6;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -82,8 +78,7 @@ exports[`EuiBadge is rendered with href provided 1`] = `
 
 exports[`EuiBadge is rendered with iconOnClick and href provided 1`] = `
 <span
-  class="euiBadge testClass1 testClass2 emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -103,8 +98,7 @@ exports[`EuiBadge is rendered with iconOnClick and href provided 1`] = `
 
 exports[`EuiBadge is rendered with iconOnClick and onClick provided 1`] = `
 <span
-  class="euiBadge testClass1 testClass2 emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -123,9 +117,8 @@ exports[`EuiBadge is rendered with iconOnClick and onClick provided 1`] = `
 exports[`EuiBadge is rendered with iconOnClick provided 1`] = `
 <span
   aria-label="aria-label"
-  class="euiBadge testClass1 testClass2 emotion-euiBadge"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default"
   data-test-subj="test subject string"
-  style="background-color:#D3DAE6;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -142,9 +135,8 @@ exports[`EuiBadge is rendered with iconOnClick provided 1`] = `
 exports[`EuiBadge is rendered with onClick provided 1`] = `
 <button
   aria-label="aria-label"
-  class="euiBadge testClass1 testClass2 emotion-euiBadge-clickable"
+  class="euiBadge testClass1 testClass2 emotion-euiBadge-default-clickable"
   data-test-subj="test subject string"
-  style="background-color:#D3DAE6;color:#000"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -160,8 +152,7 @@ exports[`EuiBadge is rendered with onClick provided 1`] = `
 
 exports[`EuiBadge props color accent is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#f583b7;color:#000"
+  class="euiBadge emotion-euiBadge-accent"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -211,8 +202,7 @@ exports[`EuiBadge props color accepts rgba 1`] = `
 
 exports[`EuiBadge props color danger is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#BD271E;color:#FFF"
+  class="euiBadge emotion-euiBadge-danger"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -228,8 +218,7 @@ exports[`EuiBadge props color danger is rendered 1`] = `
 
 exports[`EuiBadge props color default is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -261,8 +250,7 @@ exports[`EuiBadge props color hollow is rendered 1`] = `
 
 exports[`EuiBadge props color primary is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#07C;color:#FFF"
+  class="euiBadge emotion-euiBadge-primary"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -278,8 +266,7 @@ exports[`EuiBadge props color primary is rendered 1`] = `
 
 exports[`EuiBadge props color success is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#4dd2ca;color:#000"
+  class="euiBadge emotion-euiBadge-success"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -295,8 +282,7 @@ exports[`EuiBadge props color success is rendered 1`] = `
 
 exports[`EuiBadge props color warning is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#FEC514;color:#000"
+  class="euiBadge emotion-euiBadge-warning"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -312,8 +298,7 @@ exports[`EuiBadge props color warning is rendered 1`] = `
 
 exports[`EuiBadge props iconSide left is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -334,8 +319,7 @@ exports[`EuiBadge props iconSide left is rendered 1`] = `
 
 exports[`EuiBadge props iconSide right is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -356,8 +340,7 @@ exports[`EuiBadge props iconSide right is rendered 1`] = `
 
 exports[`EuiBadge props iconType is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000"
+  class="euiBadge emotion-euiBadge-default"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -378,8 +361,8 @@ exports[`EuiBadge props iconType is rendered 1`] = `
 
 exports[`EuiBadge props style is rendered 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-default"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -395,8 +378,8 @@ exports[`EuiBadge props style is rendered 1`] = `
 
 exports[`EuiBadge props style is rendered with accent 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#f583b7;color:#000;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-accent"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -412,8 +395,8 @@ exports[`EuiBadge props style is rendered with accent 1`] = `
 
 exports[`EuiBadge props style is rendered with danger 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#BD271E;color:#FFF;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-danger"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -429,8 +412,8 @@ exports[`EuiBadge props style is rendered with danger 1`] = `
 
 exports[`EuiBadge props style is rendered with default 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#D3DAE6;color:#000;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-default"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -480,8 +463,8 @@ exports[`EuiBadge props style is rendered with hollow 2`] = `
 
 exports[`EuiBadge props style is rendered with primary 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#07C;color:#FFF;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-primary"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -497,8 +480,8 @@ exports[`EuiBadge props style is rendered with primary 1`] = `
 
 exports[`EuiBadge props style is rendered with success 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#4dd2ca;color:#000;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-success"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -514,8 +497,8 @@ exports[`EuiBadge props style is rendered with success 1`] = `
 
 exports[`EuiBadge props style is rendered with warning 1`] = `
 <span
-  class="euiBadge emotion-euiBadge"
-  style="background-color:#FEC514;color:#000;border:4px solid tomato"
+  class="euiBadge emotion-euiBadge-warning"
+  style="border:4px solid tomato"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/badge/badge.styles.ts
+++ b/src/components/badge/badge.styles.ts
@@ -16,11 +16,12 @@ import {
   logicalTextAlignCSS,
   mathWithUnits,
 } from '../../global_styling';
-import { euiButtonColor } from '../../themes/amsterdam/global_styling/mixins';
-import { UseEuiTheme, tint, transparentize } from '../../services';
+import { UseEuiTheme, transparentize } from '../../services';
+import { euiBadgeColors } from './color_utils';
 
 export const euiBadgeStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme, colorMode } = euiThemeContext;
+  const { euiTheme } = euiThemeContext;
+  const badgeColors = euiBadgeColors(euiThemeContext);
 
   return {
     euiBadge: css`
@@ -72,23 +73,27 @@ export const euiBadgeStyles = (euiThemeContext: UseEuiTheme) => {
         cursor: not-allowed;
       }
     `,
+
+    // Colors
+    default: css(badgeColors.default),
+    hollow: css`
+      color: ${badgeColors.hollow.color};
+      background-color: ${badgeColors.hollow.backgroundColor};
+      border-color: ${badgeColors.hollow.borderColor};
+    `,
+    primary: css(badgeColors.primary),
+    accent: css(badgeColors.accent),
+    warning: css(badgeColors.warning),
+    danger: css(badgeColors.danger),
+    success: css(badgeColors.success),
     disabled: css`
       /* stylelint-disable declaration-no-important */
 
       /* Using !important to override inline styles */
-      color: ${euiButtonColor(euiThemeContext, 'disabled').color} !important;
-      background-color: ${euiButtonColor(euiThemeContext, 'disabled')
-        .backgroundColor} !important;
+      color: ${badgeColors.disabled.color} !important;
+      background-color: ${badgeColors.disabled.backgroundColor} !important;
 
       /* stylelint-enable declaration-no-important */
-    `,
-    // Hollow has a border and is mostly used for autocompleters.
-    hollow: css`
-      background-color: ${euiTheme.colors.emptyShade};
-      border-color: ${colorMode === 'DARK'
-        ? tint(euiTheme.border.color, 0.15)
-        : euiTheme.border.color};
-      color: ${euiTheme.colors.text};
     `,
 
     // Content wrapper

--- a/src/components/badge/badge_group/__snapshots__/badge_group.test.tsx.snap
+++ b/src/components/badge/badge_group/__snapshots__/badge_group.test.tsx.snap
@@ -25,8 +25,7 @@ exports[`EuiBadgeGroup is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <span
-    class="euiBadge emotion-euiBadge"
-    style="background-color:#D3DAE6;color:#000"
+    class="euiBadge emotion-euiBadge-default"
   >
     <span
       class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -14,10 +14,12 @@ import {
   euiTextTruncate,
   mathWithUnits,
 } from '../../../global_styling';
-import { UseEuiTheme, tint, isColorDark, hexToRgb } from '../../../services';
+import { UseEuiTheme } from '../../../services';
+import { euiBadgeColors } from '../color_utils';
 
 export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme, colorMode } = euiThemeContext;
+  const badgeColors = euiBadgeColors(euiThemeContext);
 
   return {
     euiBetaBadge: css`
@@ -39,16 +41,13 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     // Colors
-    accent: css`
-      ${getBadgeColors(euiTheme.colors.accentText, euiThemeContext)}
-    `,
-    subdued: css`
-      ${getBadgeColors(tint(euiTheme.colors.lightShade, 0.3), euiThemeContext)}
-    `,
+    accent: css(badgeColors.accentText),
+    subdued: css(badgeColors.subdued),
     hollow: css`
-      ${getBadgeColors(euiTheme.colors.emptyShade, euiThemeContext)}
+      color: ${badgeColors.hollow.color};
+      background-color: ${badgeColors.hollow.backgroundColor};
       box-shadow: inset 0 0 0 ${euiTheme.border.width.thin}
-        ${euiTheme.border.color};
+        ${badgeColors.hollow.borderColor};
     `,
     // Font sizes
     m: css`
@@ -92,19 +91,4 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       vertical-align: middle;
     `,
   };
-};
-
-// Util for detecting text color based on badge bg color
-export const getBadgeColors = (
-  backgroundColor: string,
-  { euiTheme }: UseEuiTheme
-) => {
-  const textColor = isColorDark(...hexToRgb(backgroundColor))
-    ? euiTheme.colors.ghost
-    : euiTheme.colors.ink;
-
-  return `
-    background-color: ${backgroundColor};
-    color: ${textColor};
-  `;
 };

--- a/src/components/badge/color_utils.ts
+++ b/src/components/badge/color_utils.ts
@@ -28,7 +28,7 @@ export const euiBadgeColors = (euiThemeContext: UseEuiTheme) => {
     disabled: euiButtonColor(euiThemeContext, 'disabled'),
     // Colors unique to badges
     default: getBadgeColors(euiThemeContext, euiTheme.colors.lightShade),
-    // Hollow has a border and is mostly used for autocompleters
+    // Hollow has a border and is used for autocompleters and beta badges
     hollow: {
       ...getBadgeColors(euiThemeContext, euiTheme.colors.emptyShade),
       borderColor:
@@ -36,6 +36,12 @@ export const euiBadgeColors = (euiThemeContext: UseEuiTheme) => {
           ? tint(euiTheme.border.color, 0.15)
           : euiTheme.border.color,
     },
+    // Colors used by beta and notification badges
+    subdued: getBadgeColors(
+      euiThemeContext,
+      tint(euiTheme.colors.lightShade, 0.3)
+    ),
+    accentText: getBadgeColors(euiThemeContext, euiTheme.colors.accentText),
   };
 };
 

--- a/src/components/badge/color_utils.ts
+++ b/src/components/badge/color_utils.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import chroma from 'chroma-js';
+
+import { UseEuiTheme, isColorDark, tint } from '../../services';
+import {
+  euiButtonColor,
+  euiButtonFillColor,
+} from '../../themes/amsterdam/global_styling/mixins';
+import { chromaValid, parseColor } from '../color_picker/utils';
+
+export const euiBadgeColors = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme, colorMode } = euiThemeContext;
+
+  return {
+    // Colors shared between buttons and badges
+    primary: euiButtonFillColor(euiThemeContext, 'primary'),
+    success: euiButtonFillColor(euiThemeContext, 'success'),
+    warning: euiButtonFillColor(euiThemeContext, 'warning'),
+    danger: euiButtonFillColor(euiThemeContext, 'danger'),
+    accent: euiButtonFillColor(euiThemeContext, 'accent'),
+    disabled: euiButtonColor(euiThemeContext, 'disabled'),
+    // Colors unique to badges
+    default: getBadgeColors(euiThemeContext, euiTheme.colors.lightShade),
+    // Hollow has a border and is mostly used for autocompleters
+    hollow: {
+      ...getBadgeColors(euiThemeContext, euiTheme.colors.emptyShade),
+      borderColor:
+        colorMode === 'DARK'
+          ? tint(euiTheme.border.color, 0.15)
+          : euiTheme.border.color,
+    },
+  };
+};
+
+export const getBadgeColors = (
+  euiThemeContext: UseEuiTheme,
+  backgroundColor: string
+) => {
+  const color = getTextColor(euiThemeContext, backgroundColor);
+
+  return {
+    backgroundColor,
+    color,
+  };
+};
+
+export const getTextColor = ({ euiTheme }: UseEuiTheme, bgColor: string) => {
+  const textColor = isColorDark(...chroma(bgColor).rgb())
+    ? euiTheme.colors.ghost
+    : euiTheme.colors.ink;
+
+  return textColor;
+};
+
+export const getColorContrast = (textColor: string, color: string) => {
+  return chroma.contrast(textColor, color);
+};
+
+export const getIsValidColor = (color?: string) => {
+  return chromaValid(parseColor(color || '') || '');
+};

--- a/src/components/badge/notification_badge/__snapshots__/badge_notification.test.tsx.snap
+++ b/src/components/badge/notification_badge/__snapshots__/badge_notification.test.tsx.snap
@@ -26,6 +26,14 @@ exports[`EuiNotificationBadge props color subdued is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiNotificationBadge props color success is rendered 1`] = `
+<span
+  class="euiNotificationBadge emotion-euiNotificationBadge-s-success"
+>
+  5
+</span>
+`;
+
 exports[`EuiNotificationBadge props size m is rendered 1`] = `
 <span
   class="euiNotificationBadge emotion-euiNotificationBadge-m-accent"

--- a/src/components/badge/notification_badge/badge_notification.styles.ts
+++ b/src/components/badge/notification_badge/badge_notification.styles.ts
@@ -14,12 +14,12 @@ import {
   euiNumberFormat,
   mathWithUnits,
 } from '../../../global_styling';
-import { UseEuiTheme, tint } from '../../../services';
-import { euiButtonFillColor } from '../../../themes/amsterdam/global_styling/mixins';
-import { getBadgeColors } from '../beta_badge/beta_badge.styles';
+import { UseEuiTheme } from '../../../services';
+import { euiBadgeColors } from '../color_utils';
 
 export const euiNotificationBadgeStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
+  const badgeColors = euiBadgeColors(euiThemeContext);
 
   return {
     euiNotificationBadge: css`
@@ -54,16 +54,8 @@ export const euiNotificationBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('min-width', euiTheme.size.l)}
     `,
     // Colors
-    accent: css`
-      ${getBadgeColors(euiTheme.colors.accentText, euiThemeContext)}
-    `,
-    success: css`
-      background-color: ${euiButtonFillColor(euiThemeContext, 'success')
-        .backgroundColor};
-      color: ${euiTheme.colors.ink};
-    `,
-    subdued: css`
-      ${getBadgeColors(tint(euiTheme.colors.lightShade, 0.3), euiThemeContext)}
-    `,
+    accent: css(badgeColors.accentText),
+    success: css(badgeColors.success),
+    subdued: css(badgeColors.subdued),
   };
 };

--- a/src/components/badge/notification_badge/badge_notification.styles.ts
+++ b/src/components/badge/notification_badge/badge_notification.styles.ts
@@ -15,7 +15,7 @@ import {
   mathWithUnits,
 } from '../../../global_styling';
 import { UseEuiTheme, tint } from '../../../services';
-
+import { euiButtonFillColor } from '../../../themes/amsterdam/global_styling/mixins';
 import { getBadgeColors } from '../beta_badge/beta_badge.styles';
 
 export const euiNotificationBadgeStyles = (euiThemeContext: UseEuiTheme) => {
@@ -56,6 +56,11 @@ export const euiNotificationBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     // Colors
     accent: css`
       ${getBadgeColors(euiTheme.colors.accentText, euiThemeContext)}
+    `,
+    success: css`
+      background-color: ${euiButtonFillColor(euiThemeContext, 'success')
+        .backgroundColor};
+      color: ${euiTheme.colors.ink};
     `,
     subdued: css`
       ${getBadgeColors(tint(euiTheme.colors.lightShade, 0.3), euiThemeContext)}

--- a/src/components/badge/notification_badge/badge_notification.tsx
+++ b/src/components/badge/notification_badge/badge_notification.tsx
@@ -13,7 +13,7 @@ import { useEuiTheme } from '../../../services';
 
 import { euiNotificationBadgeStyles } from './badge_notification.styles';
 
-export const COLORS = ['accent', 'subdued'] as const;
+export const COLORS = ['accent', 'subdued', 'success'] as const;
 export type BadgeNotificationColor = (typeof COLORS)[number];
 
 export const SIZES = ['s', 'm'] as const;

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -42,6 +42,25 @@ exports[`EuiFilterButton is rendered 1`] = `
 </button>
 `;
 
+exports[`EuiFilterButton props badgeColor is rendered 1`] = `
+<button
+  class="euiButtonEmpty euiFilterButton css-wvaqcf-empty-text"
+  type="button"
+>
+  <span
+    class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+  >
+    <span
+      class="euiButtonEmpty__text"
+    >
+      <span
+        class="euiFilterButton__textShift"
+      />
+    </span>
+  </span>
+</button>
+`;
+
 exports[`EuiFilterButton props grow can be turned off 1`] = `
 <button
   class="euiButtonEmpty euiFilterButton euiFilterButton--noGrow css-wvaqcf-empty-text"

--- a/src/components/filter_group/filter_button.test.tsx
+++ b/src/components/filter_group/filter_button.test.tsx
@@ -103,5 +103,13 @@ describe('EuiFilterButton', () => {
         expect(component).toMatchSnapshot();
       });
     });
+
+    describe('badgeColor', () => {
+      it('is rendered', () => {
+        const component = render(<EuiFilterButton badgeColor="success" />);
+
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -16,6 +16,9 @@ import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button/button_empty';
 import { useInnerText } from '../inner_text';
 import { DistributiveOmit } from '../common';
 
+export const COLORS = ['accent', 'success'] as const;
+export type BadgeNotificationColor = (typeof COLORS)[number];
+
 export type EuiFilterButtonProps = {
   /**
    * Bolds the button if true
@@ -43,6 +46,10 @@ export type EuiFilterButtonProps = {
    * Remove border after button, good for opposite filters
    */
   withNext?: boolean;
+  /**
+   * Change color of the counter badge
+   */
+  badgeColor?: BadgeNotificationColor;
 } & DistributiveOmit<EuiButtonEmptyProps, 'flush' | 'size'>;
 
 export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
@@ -51,6 +58,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   iconType,
   iconSide = 'right',
   color = 'text',
+  badgeColor = 'accent',
   hasActiveFilters,
   numFilters,
   numActiveFilters,
@@ -103,7 +111,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     <EuiNotificationBadge
       className="euiFilterButton__notification"
       aria-label={hasActiveFilters ? activeBadgeLabel : availableBadgeLabel}
-      color={isDisabled || !hasActiveFilters ? 'subdued' : 'accent'}
+      color={isDisabled || !hasActiveFilters ? 'subdued' : badgeColor}
       role="marquee" // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role
     >
       {badgeCount}

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -10,14 +10,12 @@ import React, { Fragment, FunctionComponent } from 'react';
 import classNames from 'classnames';
 
 import { useEuiI18n } from '../i18n';
-import { EuiNotificationBadge } from '../badge/notification_badge';
+import { EuiNotificationBadge } from '../badge';
+import { BadgeNotificationColor } from '../badge/notification_badge/badge_notification';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button/button_empty';
 
 import { useInnerText } from '../inner_text';
 import { DistributiveOmit } from '../common';
-
-export const COLORS = ['accent', 'success'] as const;
-export type BadgeNotificationColor = (typeof COLORS)[number];
 
 export type EuiFilterButtonProps = {
   /**

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -77,8 +77,7 @@ exports[`EuiNotificationEvent props badgeColor is rendered 1`] = `
         class="euiNotificationEventMeta__section"
       >
         <span
-          class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge"
-          style="background-color:#FEC514;color:#000"
+          class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-warning"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
@@ -43,8 +43,7 @@ exports[`EuiNotificationEventMeta props badgeColor  is rendered 1`] = `
     class="euiNotificationEventMeta__section"
   >
     <span
-      class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge"
-      style="background-color:#4dd2ca;color:#000"
+      class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-success"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"

--- a/upcoming_changelogs/6864.md
+++ b/upcoming_changelogs/6864.md
@@ -1,2 +1,3 @@
 - Added success color `EuiNotificationBadge`
 - Added `badgeColor` prop to `EuiFilterButton`
+- Updated `EuiBadge` to use CSS-in-JS for named colors instead of inline styles. Custom colors will still use inline styles.

--- a/upcoming_changelogs/6864.md
+++ b/upcoming_changelogs/6864.md
@@ -1,0 +1,2 @@
+- Added success color `EuiNotificationBadge`
+- Added `badgeColor` prop to `EuiFilterButton`


### PR DESCRIPTION
## Summary

- Add `success` as a new `color` in **EuiNotificationBadge**
- Add a new prop to **EuiFilterButton** called `badgeColor` to support `success` in addition to `accent`.

#### The reasoning behind the new background color

- This request originated from feedback from the Security Solution. They are using **controls** on their Alerts page and mentioned the dark pink color could be interpreted as something negative or alarming, which is not the intended case when displaying the number of selections in a control. They expressed a desire for a more neutral color. One suggestion that came up was to use `subdued`. However, we're already using that `color` when `isDisabled` is set to `true`. As an alternative, I suggested the `success` color, which they agreed with. 

- I am using the background color from the `success` **EuiBadge** as it seems to be a better fit than `euiTheme.colors.successText`.

<img width="171" alt="Frame 148" src="https://github.com/elastic/eui/assets/4016496/704bc920-e793-4115-bdb5-9b18f760f48f">

<details>
  <summary>Page where request originated</summary>
  
  ![image (3)](https://github.com/elastic/eui/assets/4016496/ef4d2b0c-0aff-478d-b5db-21950dfa082b)
  
</details>

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
