### PR TITLE
Infra/catalog info pin to feature

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -211,10 +211,10 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_release_deploy_docs.yml"
-      default_branch: main
+      default_branch: feature/buildkite-migration # TODO: Set to main when the feature is merged
       provider_settings:
         build_branches: false
-        build_tags: false # Will be set to true when the branch is merged into main
+        build_tags: false # TODO: Set to true when the feature is merged
         build_pull_requests: false
       teams:
         eui-team:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -86,6 +86,7 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
+      default_branch: feature/buildkite-migration
       # Job runs as a step in pull request combined job
       provider_settings:
         build_branches: false
@@ -125,6 +126,7 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
+      default_branch: feature/buildkite-migration
       # Job runs as a step in pull request combined job
       provider_settings:
         build_branches: false
@@ -165,12 +167,55 @@ spec:
     spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml"
+      default_branch: feature/buildkite-migration
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
       provider_settings:
         build_branches: false
         build_tags: false
         build_pull_requests: true
         filter_enabled: true
         filter_condition: build.pull_request.base_branch == "feature/buildkite-migration"
+      teams:
+        eui-team:
+         access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+
+############################ Tagged release deploy docs #############################
+# Publish docs to EUI subdomain when we tag a new release
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-eui-release-deploy-docs
+  description: EUI pipeline to deploy docs to the EUI subdomain when we tag a new release
+  links: [
+    {
+      title: "EUI - release-deploy-docs",
+      url: "https://buildkite.com/elastic/eui-release-deploy-docs",
+    }
+  ]
+
+spec:
+  type: buildkite-pipeline
+  owner: group:eui-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: eui-release-deploy-docs
+    spec:
+      repository: elastic/eui
+      pipeline_file: ".buildkite/pipelines/pipeline_release_deploy_docs.yml"
+      default_branch: main
+      provider_settings:
+        build_branches: false
+        build_tags: false # Will be set to true when the branch is merged into main
+        build_pull_requests: false
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Summary

* Updates the Buildkite config document to point jobs at `feature/buildkite-migration`. Buildkite will now pick up the correct instructions to test and deploy PR docs.
* Adds Buildkite comments showing job and step status
* Adds a placeholder job for deploying docs when we tag a new release

## QA

QA will be done manually in Buildkite on feature branch.
