### PR TITLE
[BUILDKITE] Streamline PR job by removing second `npm run build` from combined PR job

### DIFF
--- a/.buildkite/scripts/pipeline_pull_request_test.sh
+++ b/.buildkite/scripts/pipeline_pull_request_test.sh
@@ -9,5 +9,4 @@ docker run \
   docker.elastic.co/eui/ci:5.0 \
   bash -c "/opt/yarn*/bin/yarn \
   && yarn cypress install \
-  && NODE_OPTIONS=\"--max-old-space-size=2048\" npm run test-ci \
-  && npm run build"
+  && NODE_OPTIONS=\"--max-old-space-size=2048\" npm run test-ci"

--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -6,18 +6,19 @@
     project-type: multijob
     concurrent: true
     node: master
-    triggers:
-      - github-pull-request:
-          org-list:
-            - elastic
-          white-list:
-            - renovate
-            - renovatebot
-          allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '(.*(?:jenkins\W+)?test\W+(?:this|it)(?:\W+please)?.*)|^retest$'
-          github-hooks: true
-          status-context: eui-ci
-          cancel-builds-on-update: true
+    triggers: [] # Should prevent job from auto-running
+    # triggers:
+    #   - github-pull-request:
+    #       org-list:
+    #         - elastic
+    #       white-list:
+    #         - renovate
+    #         - renovatebot
+    #       allow-whitelist-orgs-as-admins: true
+    #       trigger-phrase: '(.*(?:jenkins\W+)?test\W+(?:this|it)(?:\W+please)?.*)|^retest$'
+    #       github-hooks: true
+    #       status-context: eui-ci
+    #       cancel-builds-on-update: true
     builders:
       - multijob:
           name: run child jobs

--- a/scripts/deploy/build_docs
+++ b/scripts/deploy/build_docs
@@ -10,8 +10,8 @@ docker pull $NODE_IMG
 docker run \
     --rm -i \
     --env HOME=/tmp \
-    --user=$(id -u):$(id -g) \
-    --volume $PWD:/app \
+    --"user=$(id -u)":"$(id -g)" \
+    --volume "$PWD":/app \
     --workdir /app \
     $NODE_IMG \
     bash -c 'yarn && npm run build && npm run build-docs'


### PR DESCRIPTION
## Summary

PR removes the `npm run build` from the Buildkite test PR job. The command runs in the Buildkite deploy PR docs job. Running the build command twice seems unnecessary.

## QA

QA will consist of checking that all tests ran successfully, and that docs were deployed correctly. The `npm run build` command will run twice on this PR, because the change needs to be merged into the `feature/buildkite-migration` branch before Buildkite will pick it up. The next PR I issue should run the build step only once.

### General checklist

- [x] Checked that all tests pass in Buildkite logs
- [x] Checked that docs deployed correctly with a valid PR link
- [x] Check that Buildkite comments appear in the PR comment stream
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Checked for **breaking changes** and labeled appropriately
