### PR TITLE
[BUILDKITE] Fix mis-labeled `GIT_BRANCH` variable in combined test and deploy PR job

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
@@ -10,5 +10,5 @@ steps:
         label: ":newspaper: EUI pull request deploy docs"
         build:
           env:
-            GITHUB_BRANCH: "${BUILDKITE_REFSPEC}"
+            GIT_BRANCH: +refs/pull/*:refs/remotes/origin/pr/*
 

--- a/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
@@ -10,5 +10,4 @@ steps:
         label: ":newspaper: EUI pull request deploy docs"
         build:
           env:
-            GIT_BRANCH: +refs/pull/*:refs/remotes/origin/pr/*
-
+            GIT_BRANCH: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
## Summary

PR fixes a mis-labeled Buildkite env variable, and an incorrect output string value.

## QA

This fix should allow the PR https://github.com/elastic/eui/pull/6871 to run correctly. That PR is failing because of the missing `GIT_BRANCH` variable. QA will happen on the other PR after this one is merged. I will re-run the existing PR jobs, and verify they both pass as expected.