### PR TITLE
[BUILDKITE]: JSON config to trigger PRs from forked repos

### DIFF
--- a/.buildkite/.pull-requests.json
+++ b/.buildkite/.pull-requests.json
@@ -1,0 +1,16 @@
+{
+  "jobs": [
+    {
+      "enabled": true,
+      "pipeline_slug": "eui-pull-request-test-and-deploy",
+      "allowed_list": ["eui-team"],
+      "allowed_repo_permissions": ["admin", "write"],
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "set_commit_status": true,
+      "skip_ci_labels": ["skip-ci"]
+    }
+  ]
+}

--- a/.buildkite/.pull-requests.json
+++ b/.buildkite/.pull-requests.json
@@ -3,14 +3,14 @@
     {
       "enabled": true,
       "pipeline_slug": "eui-pull-request-test-and-deploy",
-      "allowed_list": ["eui-team"],
+      "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "set_commit_status": true,
-      "skip_ci_labels": ["skip-ci"],
+      "skip_ci_on_only_changed": ["^.github/", "^generator-eui/", "^wiki/"],
       "target_branch": "feature/buildkite-migration"
     }
   ]

--- a/.buildkite/.pull-requests.json
+++ b/.buildkite/.pull-requests.json
@@ -10,7 +10,8 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "set_commit_status": true,
-      "skip_ci_labels": ["skip-ci"]
+      "skip_ci_labels": ["skip-ci"],
+      "target_branch": "feature/buildkite-migration"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adding the required config file to accept PRs from forked `EUI` repos securely. This config is very basic and locked down to just the EUI team for the moment.

## QA

QA will be a manual process, and will be tested against the `feature/buildkite-migration` branch for now. Will include the following:

- [x] Create a PR from my forked EUI before this config is merged. Expect this PR not to start the Buildkite job and will be closed after verifying the pull request job does not start.
- [ ] Create a PR from my forked EUI repo after this config is merged. I'll add a basic Buildkite doc file to verify pull request job starts correctly.
- [ ] Create a comment in the branch PR to verify pull request job starts
