### PR TITLE
[EuiDataGrid] Safari workaround for cell actions hover animation

### DIFF
--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -39,11 +39,12 @@
       animation-fill-mode: forwards;
     }
     /*
-     * TODO: Super annoying Safari workaround
      * For some incredibly bizarre reason, Safari doesn't correctly update the flex
      * width of the content (when rows are an undefined height/single flex row),
      * which causes the action icons to overlap & makes the content less readable.
      * This workaround "animation" forces a rerender of the flex content width
+     *
+     * TODO: Remove this workaround once https://bugs.webkit.org/show_bug.cgi?id=258539 is resolved
      */
     .euiDataGridRowCell__expandContent {
       animation-name: euiDataGridCellActionsSafariWorkaround;

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -38,6 +38,21 @@
       animation-delay: $euiAnimSpeedNormal;
       animation-fill-mode: forwards;
     }
+    /*
+     * TODO: Super annoying Safari workaround
+     * For some incredibly bizarre reason, Safari doesn't correctly update the flex
+     * width of the content (when rows are an undefined height/single flex row),
+     * which causes the action icons to overlap & makes the content less readable.
+     * This workaround "animation" forces a rerender of the flex content width
+     */
+    .euiDataGridRowCell__expandContent {
+      animation-name: euiDataGridCellActionsSafariWorkaround;
+      animation-duration: 1000ms; // I don't know why the duration matters or why it being longer works more consistently 🥲
+      animation-delay: $euiAnimSpeedNormal + $euiAnimSpeedExtraFast; // Wait for above animation to finish
+      animation-iteration-count: 1;
+      animation-fill-mode: forwards;
+      animation-timing-function: linear;
+    }
   }
 
   // On focus, directly show action buttons (without animation)
@@ -241,5 +256,16 @@
   to {
     margin-left: $euiDataGridCellPaddingM;
     width: $euiSizeM;
+  }
+}
+@keyframes euiDataGridCellActionsSafariWorkaround {
+  from {
+    width: 100%;
+    flex-basis: 100%;
+  }
+
+  to {
+    width: auto;
+    flex-basis: auto;
   }
 }

--- a/upcoming_changelogs/6881.md
+++ b/upcoming_changelogs/6881.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed Safari-only bug for single-line row `EuiDataGrid`s, where cell actions on hover would overlap instead of pushing content to the left 


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6851

## Problem

![before](https://github.com/elastic/eui/assets/549407/dc1f20ff-a72d-4c69-ba06-7a5f2eac0d79)

For some incredibly bizarre reason, Safari doesn't correctly update the flex width of the cell content (when rows are an undefined height/single flex row), which causes the action icons to overlap the content and makes the content less readable even when there is room for both the cell content and cell actions.

## Solution

![after](https://github.com/elastic/eui/assets/549407/28667b52-94c8-4750-bc78-6e1ceec45aeb)

This workaround "animation" forces a rerender of the flex content width after the cell actions are done animating in. If the duration time is reduced, the fix becomes flaky/intermittent, occasionally working and occasionally not. No, I do not understand why 💀 

I've filed a bug for Safari for this behavior here: https://bugs.webkit.org/show_bug.cgi?id=258539

## QA

- **In Safari**, go to https://eui.elastic.co/pr_6881/#/tabular-content/data-grid
    - Hover your mouse over any account or amount cell
    - [x] Confirm that the cell content correctly shifts to the left and remains fully readable
- **In Chrome or Firefox**, go to https://eui.elastic.co/pr_6881/#/tabular-content/data-grid
    - Hover your mouse over any account or amount cell
    - [x] Confirm that the cell content correctly shifts to the left smoothly (should not have the same animation jerkiness that Safari does)

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
