### PR TITLE
[EuiInlineEdit] Create `placeholder` prop for Inline Edit & Friends

### DIFF
--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -153,7 +153,7 @@ export const InlineEditExample = {
       playground: inlineEditTitleConfig,
     },
     {
-      title: 'Setting a placeholder',
+      title: 'Setting placeholder instructions',
       text: (
         <>
           <p>

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -30,6 +30,14 @@ const inlineEditTitleSnippet = `<EuiInlineEditTitle
   size="m"
 />`;
 
+import InlineEditPlaceholder from './inline_edit_placeholder';
+const inlineEditPlaceholderSource = require('!!raw-loader!./inline_edit_placeholder');
+const inlineEditPlaceholderSnippet = `<EuiInlineEditText
+  inputAriaLabel="Edit text inline"
+  defaultValue=""
+  placeholder="This is placeholder text!"
+/>`;
+
 import InlineEditSave from './inline_edit_save';
 const inlineEditSaveSource = require('!!raw-loader!././inline_edit_save');
 const inlineEditModeSaveSnippet = `<EuiInlineEditText
@@ -143,6 +151,27 @@ export const InlineEditExample = {
       props: { EuiInlineEditTitle },
       snippet: inlineEditTitleSnippet,
       playground: inlineEditTitleConfig,
+    },
+    {
+      title: 'Setting a placeholder',
+      text: (
+        <>
+          <p>
+            Use the <EuiCode>placeholder</EuiCode> property to add a placeholder
+            to the input form control in edit mode. When{' '}
+            <EuiCode>defaultValue</EuiCode> is empty or any empty string is
+            saved, the placeholder value will display in read mode.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: inlineEditPlaceholderSource,
+        },
+      ],
+      demo: <InlineEditPlaceholder />,
+      snippet: inlineEditPlaceholderSnippet,
     },
     {
       title: 'Saving edited text',

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -153,25 +153,6 @@ export const InlineEditExample = {
       playground: inlineEditTitleConfig,
     },
     {
-      title: 'Setting placeholder instructions',
-      text: (
-        <>
-          <p>
-            The <EuiCode>placeholder</EuiCode> property will display in both read and edit mode whenever the <strong>EuiInlineEdit</strong>'s value is empty.
-            Use placeholder text to provide guidance or instructions to consumers as to what they're editing.
-          </p>
-        </>
-      ),
-      source: [
-        {
-          type: GuideSectionTypes.TSX,
-          code: inlineEditPlaceholderSource,
-        },
-      ],
-      demo: <InlineEditPlaceholder />,
-      snippet: inlineEditPlaceholderSnippet,
-    },
-    {
       title: 'Saving edited text',
       text: (
         <p>
@@ -220,6 +201,27 @@ export const InlineEditExample = {
         },
       ],
       demo: <InlineEditValidation />,
+    },
+    {
+      title: 'Setting placeholder instructions',
+      text: (
+        <>
+          <p>
+            The <EuiCode>placeholder</EuiCode> property will display in both
+            read and edit mode whenever the <strong>EuiInlineEdit</strong>'s
+            value is empty. Use placeholder text to provide guidance or
+            instructions to consumers as to what they're editing.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: inlineEditPlaceholderSource,
+        },
+      ],
+      demo: <InlineEditPlaceholder />,
+      snippet: inlineEditPlaceholderSnippet,
     },
     {
       title: 'Start in edit mode',

--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -157,10 +157,8 @@ export const InlineEditExample = {
       text: (
         <>
           <p>
-            Use the <EuiCode>placeholder</EuiCode> property to add a placeholder
-            to the input form control in edit mode. When{' '}
-            <EuiCode>defaultValue</EuiCode> is empty or any empty string is
-            saved, the placeholder value will display in read mode.
+            The <EuiCode>placeholder</EuiCode> property will display in both read and edit mode whenever the <strong>EuiInlineEdit</strong>'s value is empty.
+            Use placeholder text to provide guidance or instructions to consumers as to what they're editing.
           </p>
         </>
       ),

--- a/src-docs/src/views/inline_edit/inline_edit_placeholder.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_placeholder.tsx
@@ -10,9 +10,9 @@ export default () => {
   return (
     <>
       <EuiInlineEditText
-        inputAriaLabel="Edit text inline"
+        inputAriaLabel="Placeholder text example"
         defaultValue=""
-        placeholder="This is placeholder text!"
+        placeholder="Add a description"
       />
 
       <EuiSpacer />

--- a/src-docs/src/views/inline_edit/inline_edit_placeholder.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_placeholder.tsx
@@ -19,9 +19,9 @@ export default () => {
 
       <EuiInlineEditTitle
         heading="h3"
-        inputAriaLabel="Edit title inline"
+        inputAriaLabel="Placeholder title example"
         defaultValue=""
-        placeholder="This is a placeholder title!"
+        placeholder="Set your username"
       />
     </>
   );

--- a/src-docs/src/views/inline_edit/inline_edit_placeholder.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_placeholder.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import {
+  EuiInlineEditText,
+  EuiInlineEditTitle,
+  EuiSpacer,
+} from '../../../../src';
+
+export default () => {
+  return (
+    <>
+      <EuiInlineEditText
+        inputAriaLabel="Edit text inline"
+        defaultValue=""
+        placeholder="This is placeholder text!"
+      />
+
+      <EuiSpacer />
+
+      <EuiInlineEditTitle
+        heading="h3"
+        inputAriaLabel="Edit title inline"
+        defaultValue=""
+        placeholder="This is a placeholder title!"
+      />
+    </>
+  );
+};

--- a/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
+++ b/src/components/inline_edit/__snapshots__/inline_edit_form.test.tsx.snap
@@ -557,6 +557,93 @@ exports[`EuiInlineEditForm edit mode isLoading 1`] = `
 </div>
 `;
 
+exports[`EuiInlineEditForm edit mode placeholder 1`] = `
+<div
+  class="euiInlineEdit testClass1 testClass2"
+>
+  <div
+    class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-stretch-row"
+  >
+    <div
+      class="euiFlexItem emotion-euiFlexItem-grow-1"
+    >
+      <div
+        class="euiFormRow euiFormRow--fullWidth"
+        id="generated-id-row"
+      >
+        <div
+          class="euiFormRow__fieldWrapper"
+        >
+          <div
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          >
+            <div
+              class="euiFormControlLayout__childrenWrapper"
+            >
+              <input
+                aria-describedby="inlineEdit_generated-id"
+                aria-label="Edit inline"
+                class="euiFieldText euiFieldText--fullWidth"
+                data-test-subj="euiInlineEditModeInput"
+                id="generated-id"
+                placeholder="This is a placeholder."
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        hidden=""
+        id="inlineEdit_generated-id"
+      >
+        Press Enter to save your edited text. Press Escape to cancel your edit.
+      </span>
+    </div>
+    <div
+      class="euiFlexItem emotion-euiFlexItem-growZero"
+    >
+      <div
+        aria-busy="false"
+        data-test-subj="euiSkeletonLoadingAriaWrapper"
+      >
+        <div
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-s-flexStart-stretch-row"
+        >
+          <button
+            aria-label="Save edit"
+            class="euiButtonIcon emotion-euiButtonIcon-m-base-success"
+            data-test-subj="euiInlineEditModeSaveButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="check"
+            />
+          </button>
+          <button
+            aria-label="Cancel edit"
+            class="euiButtonIcon emotion-euiButtonIcon-m-base-danger"
+            data-test-subj="euiInlineEditModeCancelButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiInlineEditForm edit mode renders 1`] = `
 <div
   class="euiInlineEdit testClass1 testClass2"
@@ -668,6 +755,39 @@ exports[`EuiInlineEditForm read mode isReadOnly 1`] = `
     hidden=""
     id="inlineEdit_generated-id"
   />
+</div>
+`;
+
+exports[`EuiInlineEditForm read mode placeholder 1`] = `
+<div
+  class="euiInlineEdit testClass1 testClass2"
+>
+  <button
+    aria-describedby="inlineEdit_generated-id"
+    class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-m-empty-text-flush-both-euiInlineEditReadMode-hasPlaceholder"
+    data-test-subj="euiInlineReadModeButton"
+    type="button"
+  >
+    <span
+      class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+    >
+      <span
+        class="eui-textTruncate euiButtonEmpty__text"
+      >
+        This is a placeholder.
+      </span>
+      <span
+        color="inherit"
+        data-euiicon-type="pencil"
+      />
+    </span>
+  </button>
+  <span
+    hidden=""
+    id="inlineEdit_generated-id"
+  >
+    Click to edit this text inline.
+  </span>
 </div>
 `;
 

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -7,7 +7,7 @@
  */
 
 import { css } from '@emotion/react';
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, tint } from '../../services';
 
 export const euiInlineEditReadModeStyles = ({ euiTheme }: UseEuiTheme) => {
   return {
@@ -25,8 +25,7 @@ export const euiInlineEditReadModeStyles = ({ euiTheme }: UseEuiTheme) => {
     hasPlaceholder: css`
       .euiText,
       .euiTitle {
-        font-style: italic;
-        color: ${euiTheme.colors.subduedText};
+        color: ${tint(euiTheme.colors.subduedText, 0.15)};
       }
     `,
   };

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -21,5 +21,13 @@ export const euiInlineEditReadModeStyles = ({ euiTheme }: UseEuiTheme) => {
         user-select: text;
       }
     `,
+
+    hasPlaceholder: css`
+      .euiText,
+      .euiTitle {
+        font-style: italic;
+        color: ${euiTheme.colors.subduedText};
+      }
+    `,
   };
 };

--- a/src/components/inline_edit/inline_edit_form.styles.ts
+++ b/src/components/inline_edit/inline_edit_form.styles.ts
@@ -25,7 +25,7 @@ export const euiInlineEditReadModeStyles = ({ euiTheme }: UseEuiTheme) => {
     hasPlaceholder: css`
       .euiText,
       .euiTitle {
-        color: ${tint(euiTheme.colors.subduedText, 0.15)};
+        color: ${tint(euiTheme.colors.subduedText, 0.08)};
       }
     `,
   };

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -481,7 +481,7 @@ describe('EuiInlineEditForm', () => {
         expect(getByText('New message!')).toBeTruthy();
       });
 
-      it('correctly applies `inputModeProps.placeholder`', () => {
+      it('allows overriding `placeholder` with `inputModeProps.placeholder`', () => {
         const { getByTestSubject } = render(
           <EuiInlineEditForm
             {...commonInlineEditFormProps}

--- a/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/src/components/inline_edit/inline_edit_form.test.tsx
@@ -75,6 +75,19 @@ describe('EuiInlineEditForm', () => {
 
       expect(container.firstChild).toMatchSnapshot();
     });
+
+    test('placeholder', () => {
+      const { container, getByText } = render(
+        <EuiInlineEditForm
+          {...commonInlineEditFormProps}
+          defaultValue=""
+          placeholder="This is a placeholder."
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+      expect(getByText('This is a placeholder.')).toBeTruthy();
+    });
   });
 
   describe('edit mode', () => {
@@ -201,6 +214,25 @@ describe('EuiInlineEditForm', () => {
       expect(
         getByTestSubject('euiInlineEditModeInput').hasAttribute('aria-invalid')
       ).toBeTruthy();
+    });
+
+    test('placeholder', () => {
+      const { container, getByTestSubject } = render(
+        <EuiInlineEditForm
+          {...commonInlineEditFormProps}
+          startWithEditOpen={true}
+          defaultValue=""
+          placeholder="This is a placeholder."
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+      expect(
+        getByTestSubject('euiInlineEditModeInput').getAttribute('placeholder')
+      ).toBeTruthy();
+      expect(
+        getByTestSubject('euiInlineEditModeInput').getAttribute('value')
+      ).toBeFalsy();
     });
   });
 
@@ -447,6 +479,26 @@ describe('EuiInlineEditForm', () => {
         expect(onKeyDown).toHaveBeenCalled();
         expect(getByTestSubject('euiInlineReadModeButton')).toBeTruthy();
         expect(getByText('New message!')).toBeTruthy();
+      });
+
+      it('correctly applies `inputModeProps.placeholder`', () => {
+        const { getByTestSubject } = render(
+          <EuiInlineEditForm
+            {...commonInlineEditFormProps}
+            startWithEditOpen={true}
+            defaultValue=""
+            placeholder="This is A!"
+            editModeProps={{
+              inputProps: {
+                placeholder: 'The real placeholder!',
+              },
+            }}
+          />
+        );
+
+        expect(
+          getByTestSubject('euiInlineEditModeInput').getAttribute('placeholder')
+        ).toEqual('The real placeholder!');
       });
     });
   });

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -40,6 +40,7 @@ import { euiInlineEditReadModeStyles } from './inline_edit_form.styles';
 export type EuiInlineEditCommonProps = HTMLAttributes<HTMLDivElement> &
   CommonProps & {
     defaultValue: string;
+    placeholder?: string;
     /**
      * Callback that fires when a user clicks the save button.
      * Passes the current edited text value as an argument.
@@ -121,6 +122,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   children,
   sizes,
   defaultValue,
+  placeholder,
   inputAriaLabel,
   startWithEditOpen,
   readModeProps,
@@ -133,12 +135,6 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const classes = classNames('euiInlineEdit', className);
 
   const euiTheme = useEuiTheme();
-
-  const readModeStyles = euiInlineEditReadModeStyles(euiTheme);
-  const readModeCssStyles = [
-    readModeStyles.euiInlineEditReadMode,
-    isReadOnly && readModeStyles.isReadOnly,
-  ];
 
   const { controlHeight, controlCompressedHeight } = euiFormVariables(euiTheme);
   const loadingSkeletonSize = sizes.compressed
@@ -171,6 +167,14 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const [isEditing, setIsEditing] = useState(false || startWithEditOpen);
   const [editModeValue, setEditModeValue] = useState(defaultValue);
   const [readModeValue, setReadModeValue] = useState(defaultValue);
+  const showPlaceholder = placeholder && !readModeValue;
+
+  const readModeStyles = euiInlineEditReadModeStyles(euiTheme);
+  const readModeCssStyles = [
+    readModeStyles.euiInlineEditReadMode,
+    isReadOnly && readModeStyles.isReadOnly,
+    showPlaceholder && readModeStyles.hasPlaceholder,
+  ];
 
   const activateEditMode = () => {
     setIsEditing(true);
@@ -234,6 +238,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
             isInvalid={isInvalid}
             isLoading={isLoading}
             data-test-subj="euiInlineEditModeInput"
+            placeholder={placeholder}
             {...editModeProps?.inputProps}
             inputRef={setEditModeRefs}
             onChange={(e) => {
@@ -337,7 +342,7 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
           readModeProps?.onClick?.(e);
         }}
       >
-        {children(readModeValue)}
+        {children(readModeValue || placeholder)}
       </EuiButtonEmpty>
       <span id={readModeDescribedById} hidden>
         {!isReadOnly && (

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -167,13 +167,12 @@ export const EuiInlineEditForm: FunctionComponent<EuiInlineEditFormProps> = ({
   const [isEditing, setIsEditing] = useState(false || startWithEditOpen);
   const [editModeValue, setEditModeValue] = useState(defaultValue);
   const [readModeValue, setReadModeValue] = useState(defaultValue);
-  const showPlaceholder = placeholder && !readModeValue;
 
   const readModeStyles = euiInlineEditReadModeStyles(euiTheme);
   const readModeCssStyles = [
     readModeStyles.euiInlineEditReadMode,
     isReadOnly && readModeStyles.isReadOnly,
-    showPlaceholder && readModeStyles.hasPlaceholder,
+    placeholder && !readModeValue && readModeStyles.hasPlaceholder,
   ];
 
   const activateEditMode = () => {

--- a/src/components/inline_edit/inline_edit_text.tsx
+++ b/src/components/inline_edit/inline_edit_text.tsx
@@ -32,6 +32,7 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   className,
   size = 'm',
   defaultValue,
+  placeholder,
   inputAriaLabel,
   startWithEditOpen,
   readModeProps: _readModeProps,
@@ -62,6 +63,7 @@ export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   const formProps = {
     sizes,
     defaultValue,
+    placeholder,
     inputAriaLabel,
     startWithEditOpen,
     readModeProps,

--- a/src/components/inline_edit/inline_edit_title.tsx
+++ b/src/components/inline_edit/inline_edit_title.tsx
@@ -39,6 +39,7 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   size = 'm',
   heading,
   defaultValue,
+  placeholder,
   inputAriaLabel,
   startWithEditOpen,
   readModeProps: _readModeProps,
@@ -78,6 +79,7 @@ export const EuiInlineEditTitle: FunctionComponent<EuiInlineEditTitleProps> = ({
   const formProps = {
     sizes,
     defaultValue,
+    placeholder,
     inputAriaLabel,
     startWithEditOpen,
     readModeProps,

--- a/upcoming_changelogs/6883.md
+++ b/upcoming_changelogs/6883.md
@@ -1,0 +1,1 @@
+- Added `placeholder` prop to `EuiInlineEdit`


### PR DESCRIPTION
Fixes #6857 || Original PR: #6872

## Summary
Creation of the `placeholder` prop for `EuiInlineEdit`.

Read Mode:
The `placeholder` value is displayed in `readMode` when the placeholder is present and no `defaultValue` is passed in or if `readModeValue` is empty. The `placeholder` text will also appear in a light color in `readMode`.

Edit Mode:
`placeholder` is passed to the `editMode` input form control.

![image](https://github.com/elastic/eui/assets/40739624/a37ffb7c-e088-4c76-b9e9-e8f43ebb201c)


## QA

Head over to EuiInlineEdit in staging and ensure you can do the following:

- [x] Distinguish the difference between placeholder stying and default styling in readMode
- [x]  See the placeholder text on the edit mode form control after clicking on the read mode button
- [x]  Head to edit mode as if you're going to change the text. Cancel your edit and select the read mode button again. The placeholder should still be visible.
- [x]  Head to edit mode, make a text change, and save. Select the read mode button again and you should find your text populated in the form control.
- [x] Head to edit mode and save empty text. The placeholder should show in read mode.

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
