### PR TITLE
build(node): update node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "eui.d.ts",
   "docker_image": "18.16.0",
   "engines": {
-    "node": ">=18.0.0 < 19.0.0"
+    "node": "16.x || 18.x || >=20.0"
   },
   "sideEffects": [
     "*.css",

--- a/upcoming_changelogs/6884.md
+++ b/upcoming_changelogs/6884.md
@@ -1,0 +1,1 @@
+- Updated supported Node engine versions to allow Node 16, 18 and >=20


### PR DESCRIPTION
## Summary

Update supported Node versions in `package.json` to allow:
- Node 16 LTS (EOL 2023-09-11)
- Node 18 LTS (EOL 2025-04-30)
- Node 20 and up (EOL 2026-04-30 for Node 20)

Node 19 reached end of life this month.

## QA

1. Pull the branch
2. Use nvm to switch between node versions
3. Make sure `yarn` runs successfully on any Node 16, 18 and 20

### General checklist

- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
