### PR TITLE
[EuiIcon] Fix missing `style` prop on custom icons

### DIFF
--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -47,6 +47,7 @@ function testIcon(props: PropsOf<typeof EuiIcon>) {
 describe('EuiIcon', () => {
   test('is rendered', testIcon({ type: 'search', ...requiredProps }));
 
+  shouldRenderCustomStyles(<EuiIcon type="customImg" />);
   shouldRenderCustomStyles(<EuiIcon type="videoPlayer" />);
 
   describe('props', () => {

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -288,6 +288,7 @@ export class EuiIconClass extends PureComponent<
           src={icon}
           className={classes}
           css={cssStyles}
+          style={style}
           tabIndex={tabIndex}
           {...(rest as ImgHTMLAttributes<HTMLImageElement>)}
         />

--- a/upcoming_changelogs/6888.md
+++ b/upcoming_changelogs/6888.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiIcon` not correctly passing the `style` prop custom `img` icons
+


### PR DESCRIPTION
## Summary

We were pulling out `style` from `props` but only passing it to svg `EuiIcon`s and not img `EuiIcon`s.

This would result in consumers passing in both a custom image and a `style` prop to `EuiIcon` not having that `style` render whatsoever.

_(Bug discovered during `shouldRenderCustomStyles` work, pulling it out to its own PR for easy review and a separate changelog)_

## QA

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
