### PR TITLE
[EuiPagination] Remove Unneeded Styling Post `EuiButtonEmpty` Emotion Conversion

### DIFF
--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -807,7 +807,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
       >
         <nav
           aria-label="Pagination for table: "
-          class="euiPagination emotion-euiPagination-EuiPagination"
+          class="euiPagination emotion-euiPagination"
         >
           <span
             aria-atomic="true"

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -819,7 +819,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           </span>
           <button
             aria-label="Previous page"
-            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
             data-test-subj="pagination-button-previous"
             disabled=""
             type="button"
@@ -884,7 +884,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           <a
             aria-controls="__table_generated-id"
             aria-label="Next page"
-            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
             data-test-subj="pagination-button-next"
             href="#__table_generated-id"
             rel="noreferrer"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
       >
         <nav
           aria-label="Pagination for table: "
-          class="euiPagination emotion-euiPagination-EuiPagination"
+          class="euiPagination emotion-euiPagination"
         >
           <span
             aria-atomic="true"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           <a
             aria-controls="__table_generated-id"
             aria-label="Previous page"
-            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
             data-test-subj="pagination-button-previous"
             href="#__table_generated-id"
             rel="noreferrer"
@@ -226,7 +226,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
           </ul>
           <button
             aria-label="Next page"
-            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
             data-test-subj="pagination-button-next"
             disabled=""
             type="button"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
       <a
         aria-controls="generated-id"
         aria-label="Previous page"
-        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
         data-test-subj="pagination-button-previous"
         href="#generated-id"
         rel="noreferrer"
@@ -118,7 +118,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
       </ul>
       <button
         aria-label="Next page"
-        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
         data-test-subj="pagination-button-next"
         disabled=""
         type="button"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`EuiDataGrid pagination renders 1`] = `
   >
     <nav
       aria-label="Pagination for preceding grid: test grid"
-      class="euiPagination emotion-euiPagination-EuiPagination"
+      class="euiPagination emotion-euiPagination"
     >
       <span
         aria-atomic="true"

--- a/src/components/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/src/components/pagination/__snapshots__/pagination.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiPagination is rendered 1`] = `
 <nav
   aria-label="aria-label"
-  class="euiPagination testClass1 testClass2 emotion-euiPagination-EuiPagination"
+  class="euiPagination testClass1 testClass2 emotion-euiPagination"
   data-test-subj="test subject string"
 >
   <span
@@ -74,7 +74,7 @@ exports[`EuiPagination is rendered 1`] = `
 
 exports[`EuiPagination props activePage can be -1 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -145,7 +145,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
 
 exports[`EuiPagination props activePage is rendered 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -194,7 +194,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
     </li>
     <li
       aria-label="Skipping pages 2 to 3"
-      class="euiPagination__item css-1fxcamg-isPlaceholder"
+      class="euiPagination__item emotion-euiPagination__ellipsis"
     >
       …
     </li>
@@ -360,7 +360,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
 
 exports[`EuiPagination props aria-controls is rendered 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -430,7 +430,7 @@ exports[`EuiPagination props aria-controls is rendered 1`] = `
 
 exports[`EuiPagination props compressed is rendered 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -512,7 +512,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
 
 exports[`EuiPagination props pageCount can be 0 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -583,7 +583,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
 
 exports[`EuiPagination props pageCount is rendered 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -714,7 +714,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
     </li>
     <li
       aria-label="Skipping pages 6 to 9"
-      class="euiPagination__item css-1fxcamg-isPlaceholder"
+      class="euiPagination__item emotion-euiPagination__ellipsis"
     >
       …
     </li>
@@ -758,7 +758,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
 
 exports[`EuiPagination props responsive can be customized 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"
@@ -827,7 +827,7 @@ exports[`EuiPagination props responsive can be customized 1`] = `
 
 exports[`EuiPagination props responsive can be false 1`] = `
 <nav
-  class="euiPagination emotion-euiPagination-EuiPagination"
+  class="euiPagination emotion-euiPagination"
 >
   <span
     aria-atomic="true"

--- a/src/components/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/src/components/pagination/__snapshots__/pagination.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`EuiPagination is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -57,7 +57,7 @@ exports[`EuiPagination is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -86,7 +86,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </span>
   <button
     aria-label="First page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-first"
     title="First page"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </button>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     title="Previous page"
     type="button"
@@ -114,7 +114,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </button>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -128,7 +128,7 @@ exports[`EuiPagination props activePage can be -1 1`] = `
   </button>
   <button
     aria-label="Last page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-last"
     disabled=""
     type="button"
@@ -157,7 +157,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     title="Previous page"
     type="button"
@@ -343,7 +343,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-next"
     title="Next page"
     type="button"
@@ -372,7 +372,7 @@ exports[`EuiPagination props aria-controls is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -413,7 +413,7 @@ exports[`EuiPagination props aria-controls is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -442,7 +442,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </span>
   <button
     aria-label="First page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-first"
     disabled=""
     type="button"
@@ -456,7 +456,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </button>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -481,7 +481,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </div>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -495,7 +495,7 @@ exports[`EuiPagination props compressed is rendered 1`] = `
   </button>
   <button
     aria-label="Last page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-last"
     disabled=""
     type="button"
@@ -524,7 +524,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </span>
   <button
     aria-label="First page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-first"
     disabled=""
     type="button"
@@ -538,7 +538,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </button>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -552,7 +552,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </button>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-next"
     title="Next page"
     type="button"
@@ -566,7 +566,7 @@ exports[`EuiPagination props pageCount can be 0 1`] = `
   </button>
   <button
     aria-label="Last page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-last"
     title="Last page"
     type="button"
@@ -595,7 +595,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -741,7 +741,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
     data-test-subj="pagination-button-next"
     title="Next page"
     type="button"
@@ -770,7 +770,7 @@ exports[`EuiPagination props responsive can be customized 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -810,7 +810,7 @@ exports[`EuiPagination props responsive can be customized 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"
@@ -839,7 +839,7 @@ exports[`EuiPagination props responsive can be false 1`] = `
   </span>
   <button
     aria-label="Previous page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-previous"
     disabled=""
     type="button"
@@ -879,7 +879,7 @@ exports[`EuiPagination props responsive can be false 1`] = `
   </ul>
   <button
     aria-label="Next page"
-    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationArrowButton"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
     data-test-subj="pagination-button-next"
     disabled=""
     type="button"

--- a/src/components/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/src/components/pagination/__snapshots__/pagination.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`EuiPagination props activePage is rendered 1`] = `
     </li>
     <li
       aria-label="Skipping pages 2 to 3"
-      class="euiPagination__item css-izv4uh-isPlaceholder"
+      class="euiPagination__item css-1fxcamg-isPlaceholder"
     >
       …
     </li>
@@ -714,7 +714,7 @@ exports[`EuiPagination props pageCount is rendered 1`] = `
     </li>
     <li
       aria-label="Skipping pages 6 to 9"
-      class="euiPagination__item css-izv4uh-isPlaceholder"
+      class="euiPagination__item css-1fxcamg-isPlaceholder"
     >
       …
     </li>

--- a/src/components/pagination/pagination.styles.ts
+++ b/src/components/pagination/pagination.styles.ts
@@ -30,8 +30,7 @@ export const euiPaginationStyles = (euiThemeContext: UseEuiTheme) => {
     euiPagination__compressedText: css`
       display: inline-flex;
       align-items: center;
-      /* Override EuiText line-height */
-      line-height: 1 !important; /* stylelint-disable-line declaration-no-important */
+      line-height: 1; /* Overrides EuiText line-height */
 
       > span {
         ${logicalCSS('margin-horizontal', euiTheme.size.s)}

--- a/src/components/pagination/pagination.styles.ts
+++ b/src/components/pagination/pagination.styles.ts
@@ -11,6 +11,7 @@ import {
   logicalCSS,
   logicalCSSWithFallback,
   euiScrollBarStyles,
+  euiFontSize,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
@@ -44,6 +45,12 @@ export const euiPaginationStyles = (euiThemeContext: UseEuiTheme) => {
     euiPagination__list: css`
       display: flex;
       align-items: baseline;
+    `,
+    euiPagination__ellipsis: css`
+      color: ${euiTheme.colors.disabledText};
+      font-size: ${euiFontSize(euiThemeContext, 's').fontSize};
+      ${logicalCSS('padding-horizontal', euiTheme.size.s)}
+      ${logicalCSS('height', euiTheme.size.l)}
     `,
   };
 };

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -21,7 +21,6 @@ import {
 } from '../../services';
 import { EuiScreenReaderOnly } from '../accessibility';
 import { euiPaginationStyles } from './pagination.styles';
-import { euiPaginationButtonStyles } from './pagination_button.styles';
 
 const MAX_VISIBLE_PAGES = 5;
 const NUMBER_SURROUNDING_PAGES = Math.floor(MAX_VISIBLE_PAGES * 0.5);
@@ -82,8 +81,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
   );
 
   const euiTheme = useEuiTheme();
-  const paginationStyles = euiPaginationStyles(euiTheme);
-  const { isPlaceholder } = euiPaginationButtonStyles(euiTheme);
+  const styles = euiPaginationStyles(euiTheme);
 
   // Force to `compressed` version if specified or within the responsive breakpoints
   const compressed = _compressed || isResponsive;
@@ -154,7 +152,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
       centerPageCount = (
         <EuiText
           size="s"
-          css={paginationStyles.euiPagination__compressedText}
+          css={styles.euiPagination__compressedText}
           className="euiPagination__compressedText"
         >
           <EuiI18n
@@ -219,7 +217,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
                 <li
                   aria-label={firstRangeAriaLabel}
                   className="euiPagination__item"
-                  css={isPlaceholder}
+                  css={styles.euiPagination__ellipsis}
                 >
                   &hellip;
                 </li>
@@ -263,7 +261,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
                 <li
                   aria-label={lastRangeAriaLabel}
                   className="euiPagination__item"
-                  css={isPlaceholder}
+                  css={styles.euiPagination__ellipsis}
                 >
                   &hellip;
                 </li>
@@ -293,7 +291,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
       centerPageCount = (
         <ul
           className="euiPagination__list"
-          css={paginationStyles.euiPagination__list}
+          css={styles.euiPagination__list}
           {...accessibleName}
         >
           {firstPageButtons}
@@ -328,7 +326,7 @@ export const EuiPagination: FunctionComponent<Props> = ({
   const accessiblePageCount = `${accessiblePageString()} ${ofLabel} ${accessibleCollectionString}`;
 
   return (
-    <nav css={[paginationStyles.euiPagination]} className={classes} {...rest}>
+    <nav css={styles.euiPagination} className={classes} {...rest}>
       <EuiScreenReaderOnly>
         <span aria-atomic="true" aria-relevant="additions text" role="status">
           {accessiblePageCount}

--- a/src/components/pagination/pagination_button.styles.ts
+++ b/src/components/pagination/pagination_button.styles.ts
@@ -7,14 +7,13 @@
  */
 
 import { css } from '@emotion/react';
-import { logicalCSS, mathWithUnits, euiFontSize } from '../../global_styling';
+import { logicalCSS, euiFontSize } from '../../global_styling';
 import { euiButtonEmptyColor } from '../../themes/amsterdam/global_styling/mixins';
 import { UseEuiTheme } from '../../services';
 
 export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
-  const fontSizeS = euiFontSize(euiThemeContext, 's');
-  const halfSizeM = mathWithUnits(euiTheme.size.m, (x) => x / 2);
+  const fontSizeS = euiFontSize(euiThemeContext, 's').fontSize;
   const disabled = euiButtonEmptyColor(euiThemeContext, 'disabled');
 
   return {
@@ -34,11 +33,9 @@ export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     isPlaceholder: css`
-      align-items: baseline;
+      align-self: baseline;
       color: ${disabled.color};
-      ${fontSizeS}
-      ${logicalCSS('padding-top', halfSizeM)}
-      ${logicalCSS('padding-bottom', 0)}
+      font-size: ${fontSizeS};
       ${logicalCSS('padding-horizontal', euiTheme.size.s)}
       ${logicalCSS('height', euiTheme.size.l)}
     `,

--- a/src/components/pagination/pagination_button.styles.ts
+++ b/src/components/pagination/pagination_button.styles.ts
@@ -7,12 +7,7 @@
  */
 
 import { css } from '@emotion/react';
-import {
-  logicalCSS,
-  logicalTextAlignCSS,
-  mathWithUnits,
-  euiFontSize,
-} from '../../global_styling';
+import { logicalCSS, mathWithUnits, euiFontSize } from '../../global_styling';
 import { euiButtonEmptyColor } from '../../themes/amsterdam/global_styling/mixins';
 import { UseEuiTheme } from '../../services';
 
@@ -22,19 +17,9 @@ export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const halfSizeM = mathWithUnits(euiTheme.size.m, (x) => x / 2);
   const disabled = euiButtonEmptyColor(euiThemeContext, 'disabled');
 
-  // && to increase specificity. Can likely be removed once EuiButtonEmpty has been converted.
-
   return {
     // Base
-    euiPaginationButton: css`
-      && {
-        ${fontSizeS}
-        padding: 0;
-        ${logicalTextAlignCSS('center')}
-        border-radius: ${euiTheme.border.radius.medium};
-        outline-offset: -${euiTheme.focus.width};
-      }
-    `,
+    euiPaginationButton: css``,
     // States
     isActive: css`
       && {

--- a/src/components/pagination/pagination_button.styles.ts
+++ b/src/components/pagination/pagination_button.styles.ts
@@ -7,14 +7,10 @@
  */
 
 import { css } from '@emotion/react';
-import { logicalCSS, euiFontSize } from '../../global_styling';
-import { euiButtonEmptyColor } from '../../themes/amsterdam/global_styling/mixins';
 import { UseEuiTheme } from '../../services';
 
 export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
-  const fontSizeS = euiFontSize(euiThemeContext, 's').fontSize;
-  const disabled = euiButtonEmptyColor(euiThemeContext, 'disabled');
 
   return {
     // Base
@@ -31,13 +27,6 @@ export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
         cursor: default;
         text-decoration: underline;
       }
-    `,
-    isPlaceholder: css`
-      align-self: baseline;
-      color: ${disabled.color};
-      font-size: ${fontSizeS};
-      ${logicalCSS('padding-horizontal', euiTheme.size.s)}
-      ${logicalCSS('height', euiTheme.size.l)}
     `,
   };
 };

--- a/src/components/pagination/pagination_button.styles.ts
+++ b/src/components/pagination/pagination_button.styles.ts
@@ -51,9 +51,3 @@ export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
     `,
   };
 };
-
-export const euiPaginationButtonArrowStyles = ({ euiTheme }: UseEuiTheme) => ({
-  euiPaginationArrowButton: css`
-    outline-offset: -${euiTheme.focus.width};
-  `,
-});

--- a/src/components/pagination/pagination_button.styles.ts
+++ b/src/components/pagination/pagination_button.styles.ts
@@ -24,30 +24,23 @@ export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     // States
     isActive: css`
-      && {
-        font-weight: ${euiTheme.font.weight.bold};
-        color: ${euiTheme.colors.primary};
+      font-weight: ${euiTheme.font.weight.bold};
+      color: ${euiTheme.colors.primary};
 
-        .euiButtonEmpty__content {
-          cursor: default;
-        }
-
-        &&,
-        &&:hover {
-          text-decoration: underline;
-        }
+      &,
+      &:hover {
+        cursor: default;
+        text-decoration: underline;
       }
     `,
     isPlaceholder: css`
-      && {
-        align-items: baseline;
-        color: ${disabled.color};
-        ${fontSizeS}
-        ${logicalCSS('padding-top', halfSizeM)}
-        ${logicalCSS('padding-bottom', 0)}
-        ${logicalCSS('padding-horizontal', euiTheme.size.s)}
-        ${logicalCSS('height', euiTheme.size.l)}
-      }
+      align-items: baseline;
+      color: ${disabled.color};
+      ${fontSizeS}
+      ${logicalCSS('padding-top', halfSizeM)}
+      ${logicalCSS('padding-bottom', 0)}
+      ${logicalCSS('padding-horizontal', euiTheme.size.s)}
+      ${logicalCSS('height', euiTheme.size.l)}
     `,
   };
 };

--- a/src/components/pagination/pagination_button.styles.ts
+++ b/src/components/pagination/pagination_button.styles.ts
@@ -19,7 +19,9 @@ export const euiPaginationButtonStyles = (euiThemeContext: UseEuiTheme) => {
 
   return {
     // Base
-    euiPaginationButton: css``,
+    euiPaginationButton: css`
+      outline-offset: -${euiTheme.focus.width};
+    `,
     // States
     isActive: css`
       && {

--- a/src/components/pagination/pagination_button.tsx
+++ b/src/components/pagination/pagination_button.tsx
@@ -17,10 +17,6 @@ import { euiPaginationButtonStyles } from './pagination_button.styles';
 
 export type EuiPaginationButtonProps = EuiButtonEmptyProps & {
   isActive?: boolean;
-  /**
-   * For ellipsis or other non-clickable buttons.
-   */
-  isPlaceholder?: boolean;
   pageIndex: number;
   totalPages?: number;
 };
@@ -39,7 +35,6 @@ type Props = ExclusiveUnion<
 export const EuiPaginationButton: FunctionComponent<Props> = ({
   className,
   isActive,
-  isPlaceholder,
   pageIndex,
   totalPages,
   ...rest
@@ -49,7 +44,6 @@ export const EuiPaginationButton: FunctionComponent<Props> = ({
   const paginationButtonCss = [
     styles.euiPaginationButton,
     isActive && styles.isActive,
-    isPlaceholder && styles.isPlaceholder,
   ];
 
   const classes = classNames('euiPaginationButton', className);
@@ -60,7 +54,7 @@ export const EuiPaginationButton: FunctionComponent<Props> = ({
     size: 's',
     color: 'text',
     'data-test-subj': `pagination-button-${pageIndex}`,
-    isDisabled: isPlaceholder || isActive,
+    isDisabled: isActive,
     ...(isActive && { 'aria-current': true }),
     ...(rest['aria-controls'] && { href: `#${rest['aria-controls']}` }),
     ...rest,

--- a/src/components/pagination/pagination_button_arrow.tsx
+++ b/src/components/pagination/pagination_button_arrow.tsx
@@ -16,7 +16,7 @@ import {
 import { keysOf } from '../common';
 import { useEuiI18n } from '../i18n';
 import { useEuiTheme } from '../../services';
-import { euiPaginationButtonArrowStyles } from './pagination_button.styles';
+import { euiPaginationButtonStyles } from './pagination_button.styles';
 
 const typeToIconTypeMap = {
   first: 'arrowStart',
@@ -42,7 +42,7 @@ export const EuiPaginationButtonArrow: FunctionComponent<Props> = ({
   onClick,
 }) => {
   const euiTheme = useEuiTheme();
-  const styles = euiPaginationButtonArrowStyles(euiTheme);
+  const styles = euiPaginationButtonStyles(euiTheme);
 
   const labels = {
     first: useEuiI18n('euiPaginationButtonArrow.firstPage', 'First page'),
@@ -63,7 +63,7 @@ export const EuiPaginationButtonArrow: FunctionComponent<Props> = ({
 
   return (
     <EuiButtonIcon
-      css={styles.euiPaginationArrowButton}
+      css={styles.euiPaginationButton}
       className={classNames('euiPaginationArrowButton', className)}
       color="text"
       aria-label={labels[type]}

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`EuiTablePagination is rendered 1`] = `
   >
     <nav
       aria-label="aria-label"
-      class="euiPagination testClass1 testClass2 emotion-euiPagination-EuiPagination"
+      class="euiPagination testClass1 testClass2 emotion-euiPagination"
       data-test-subj="test subject string"
     >
       <span
@@ -203,7 +203,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
   >
     <nav
       aria-label="aria-label"
-      class="euiPagination testClass1 testClass2 emotion-euiPagination-EuiPagination"
+      class="euiPagination testClass1 testClass2 emotion-euiPagination"
       data-test-subj="test subject string"
     >
       <span

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       </span>
       <button
         aria-label="Previous page"
-        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
         data-test-subj="pagination-button-previous"
         title="Previous page"
         type="button"
@@ -174,7 +174,7 @@ exports[`EuiTablePagination is rendered 1`] = `
       </ul>
       <button
         aria-label="Next page"
-        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
         data-test-subj="pagination-button-next"
         title="Next page"
         type="button"
@@ -216,7 +216,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
       </span>
       <button
         aria-label="Previous page"
-        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
         data-test-subj="pagination-button-previous"
         title="Previous page"
         type="button"
@@ -337,7 +337,7 @@ exports[`EuiTablePagination is rendered when hiding the per page options 1`] = `
       </ul>
       <button
         aria-label="Next page"
-        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationArrowButton"
+        class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
         data-test-subj="pagination-button-next"
         title="Next page"
         type="button"

--- a/upcoming_changelogs/6893.md
+++ b/upcoming_changelogs/6893.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiPaginationButton` styling affected by `EuiButtonEmpty`'s Emotion conversion
+

--- a/upcoming_changelogs/6893.md
+++ b/upcoming_changelogs/6893.md
@@ -2,3 +2,6 @@
 
 - Fixed `EuiPaginationButton` styling affected by `EuiButtonEmpty`'s Emotion conversion
 
+**Breaking changes**
+
+- Removed `isPlaceholder` prop from `EuiPaginationButton`


### PR DESCRIPTION
Fixes #6890

## Summary
When `EuiPagination` was converted to Emotion, a style hack was set and put in place in anticipation of the `EuiButtonEmpty` conversion. Now that the conversion is complete we no longer need the specificity hack. 

With both styles in place, the numbers within `EuiPagination` aren't spaced properly.

<img width="400px" src="https://github.com/elastic/eui/assets/40739624/dc07d6e9-4cb6-4bb9-bf00-b79bfcf24991"/>


## QA
1. Find the incorrect styling [in production](https://elastic.github.io/eui/#/navigation/pagination) and confirm that the numbers are too close together within `EuiPagination`
2. Compare [staging](https://eui.elastic.co/pr_6893/#/navigation/pagination) and the [PR preview before the `EuiButtonEmpty` conversion](https://eui.elastic.co/pr_6861/#/navigation/pagination). Visually, they should be the same.


### General checklist
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A [changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md) entry exists and is marked appropriately