### PR TITLE
[Beta] Add `EuiCollapsibleNavItem` component

### DIFF
--- a/src-docs/webpack.config.js
+++ b/src-docs/webpack.config.js
@@ -153,7 +153,7 @@ const webpackConfig = new Promise(async (resolve, reject) => {
         }),
 
         new CircularDependencyPlugin({
-          exclude: /node_modules/,
+          exclude: /node_modules|collapsible_nav_item/, // EuiCollapsibleNavItem is intentionally recursive to support any amount of nested accordion items
           failOnError: true,
         }),
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -1,0 +1,375 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiFlyoutBody, EuiFlyoutFooter } from '../flyout';
+
+import { EuiCollapsibleNavItem } from './collapsible_nav_item';
+import { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
+
+// TODO: EuiCollapsibleNavBetaProps
+const meta: Meta<{}> = {
+  title: 'EuiCollapsibleNavBeta',
+};
+export default meta;
+type Story = StoryObj<{}>;
+
+// TODO: Make this a stateful component in upcoming EuiCollapsibleNavBeta work
+const OpenCollapsibleNav: FunctionComponent<{}> = ({ children }) => {
+  return (
+    <EuiCollapsibleNavBeta isOpen={true} onClose={() => {}}>
+      {children}
+    </EuiCollapsibleNavBeta>
+  );
+};
+
+export const KibanaExample: Story = {
+  render: () => (
+    <OpenCollapsibleNav>
+      <EuiFlyoutBody>
+        <EuiCollapsibleNavItem
+          title="Home"
+          iconType="home"
+          isSelected
+          href="#"
+        />
+        <EuiCollapsibleNavItem
+          title="Recent"
+          iconType="clock"
+          items={[
+            { title: 'Lorem ipsum', iconType: 'visMapRegion', href: '#' },
+            { title: 'Consectetur cursus', iconType: 'visPie', href: '#' },
+            { title: 'Ultricies tellus', iconType: 'visMetric', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Elasticsearch"
+          iconType="logoElasticsearch"
+          href="#"
+          items={[
+            { title: 'Get started', href: '#' },
+            { title: 'Explore', isGroupTitle: true },
+            { title: 'Discover', href: '#' },
+            { title: 'Dashboards', href: '#' },
+            { title: 'Visualize library', href: '#' },
+            { title: 'Content', isGroupTitle: true },
+            { title: 'Indices', href: '#' },
+            { title: 'Transforms', href: '#' },
+            { title: 'Indexing API', href: '#' },
+            { title: 'Security', isGroupTitle: true },
+            { title: 'API keys', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Enterprise Search"
+          iconType="logoEnterpriseSearch"
+          href="#"
+          items={[
+            { title: 'ESRE', href: '#' },
+            { title: 'Vector search', href: '#' },
+            { title: 'Content', href: '#' },
+            { title: 'Search applications', href: '#' },
+            { title: 'Behavioral analytics', href: '#' },
+            { title: 'Elasticsearch', href: '#' },
+            { title: 'App search', href: '#' },
+            { title: 'Workplace search', href: '#' },
+            { title: 'Search experiences', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Observability"
+          iconType="logoObservability"
+          href="#"
+          items={[
+            { title: 'Get started', href: '#' },
+            { title: 'Alerts', href: '#' },
+            { title: 'Cases', href: '#' },
+            { title: 'SLOs', href: '#' },
+            { title: 'Signals', isGroupTitle: true },
+            { title: 'Logs', href: '#' },
+            {
+              title: 'Tracing',
+              href: '#',
+              items: [
+                { title: 'Services', href: '#' },
+                { title: 'Traces', href: '#' },
+                { title: 'Dependencies', href: '#' },
+              ],
+            },
+            { title: 'Toolbox', isGroupTitle: true },
+            { title: 'Visualize library', href: '#' },
+            { title: 'Dashboards', href: '#' },
+            {
+              title: 'AIOps',
+              href: '#',
+              items: [
+                { title: 'Anomaly detection', href: '#' },
+                { title: 'Spike analysis', href: '#' },
+                { title: 'Change point detection', href: '#' },
+                { title: 'Notifications', href: '#' },
+              ],
+            },
+            { title: 'Add data', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Security"
+          iconType="logoSecurity"
+          href="#"
+          items={[
+            { title: 'Get started', href: '#' },
+            { title: 'Dashboards', href: '#' },
+            { title: 'Alerts', href: '#' },
+            { title: 'Findings', href: '#' },
+            { title: 'Cases', href: '#' },
+            { title: 'Investigation', href: '#' },
+            { title: 'Intelligence', href: '#' },
+            {
+              title: 'Explore',
+              href: '#',
+              items: [
+                { title: 'Host', href: '#' },
+                { title: 'Users', href: '#' },
+                { title: 'Network', href: '#' },
+              ],
+            },
+            { title: 'Assets', href: '#' },
+            {
+              title: 'Rules',
+              href: '#',
+              items: [
+                { title: 'SIEM rules', href: '#' },
+                { title: 'Shared exception list', href: '#' },
+                { title: 'CIS benchmark rules', href: '#' },
+                { title: 'Defend rules', href: '#' },
+              ],
+            },
+            {
+              title: 'Machine learning',
+              href: '#',
+              items: [
+                { title: 'Overview', href: '#' },
+                { title: 'Notifications', href: '#' },
+                { title: 'Memory usage', href: '#' },
+                { title: 'Anomaly detection', href: '#' },
+                { title: 'Data frame analytics', href: '#' },
+                { title: 'Model management', href: '#' },
+              ],
+            },
+            {
+              title: 'Settings',
+              href: '#',
+              items: [
+                { title: 'Endpoints', href: '#' },
+                { title: 'OS query', href: '#' },
+                { title: 'Response actions history', href: '#' },
+                { title: 'Event filters', href: '#' },
+                { title: 'Host isolation', href: '#' },
+              ],
+            },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Analytics"
+          iconType="stats"
+          href="#"
+          items={[
+            { title: 'Discover', href: '#' },
+            { title: 'Dashboard', href: '#' },
+            { title: 'Visualize library', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Machine learning"
+          iconType="indexMapping"
+          href="#"
+          items={[
+            { title: 'Overview', href: '#' },
+            { title: 'Notifications', href: '#' },
+            { title: 'Memory usage', href: '#' },
+            { title: 'Anomaly detection', isGroupTitle: true },
+            { title: 'Jobs', href: '#' },
+            { title: 'Anomaly explorer', href: '#' },
+            { title: 'Single metric viewer', href: '#' },
+            { title: 'Settings', href: '#' },
+            { title: 'Data frame analytics', isGroupTitle: true },
+            { title: 'Jobs', href: '#' },
+            { title: 'Results explorer', href: '#' },
+            { title: 'Analytics map', href: '#' },
+            { title: 'Model management', isGroupTitle: true },
+            { title: 'Trained models', href: '#' },
+            { title: 'Data visualizer', isGroupTitle: true },
+            { title: 'File', href: '#' },
+            { title: 'Data view', href: '#' },
+          ]}
+        />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiCollapsibleNavItem
+          title="Developer tools"
+          iconType="editorCodeBlock"
+          href="#"
+          items={[
+            { title: 'Console', href: '#' },
+            { title: 'Search profiler', href: '#' },
+            { title: 'Grok debugger', href: '#' },
+            { title: 'Painless lab', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Management"
+          iconType="gear"
+          items={[
+            { title: 'Integrations', href: '#' },
+            { title: 'Fleet', href: '#' },
+            { title: 'Osquery', href: '#' },
+            { title: 'Stack monitoring', href: '#' },
+            { title: 'Stack management', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          title="Project settings"
+          iconType="gear"
+          items={[
+            { title: 'Management', href: '#' },
+            {
+              title: 'Users and roles',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+            {
+              title: 'Performance',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+            {
+              title: 'Billing and subscription',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+          ]}
+        />
+      </EuiFlyoutFooter>
+    </OpenCollapsibleNav>
+  ),
+};
+
+// Security has a very custom nav
+export const SecurityExample: Story = {
+  render: () => (
+    <OpenCollapsibleNav>
+      <EuiFlyoutBody>
+        <EuiCollapsibleNavItem
+          title="Recent"
+          iconType="clock"
+          items={[
+            { title: 'Lorem ipsum', iconType: 'visMapRegion', href: '#' },
+            { title: 'Consectetur cursus', iconType: 'visPie', href: '#' },
+            { title: 'Ultricies tellus', iconType: 'visMetric', href: '#' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          isSelected
+          title="Security"
+          iconType="logoSecurity"
+          href="#"
+          // Workaround to always display this section as open and remove the accordion toggle
+          // Rather than baking in a top-level prop to support this behavior, this is likely
+          // the path we'd recommend to Security instead if their use-case isn't standard
+          accordionProps={{
+            forceState: 'open',
+            arrowProps: { css: { display: 'none' } },
+          }}
+          items={[
+            { title: 'Get started', href: '#' },
+            { title: 'Dashboards', href: '#' },
+            { title: 'Alerts', href: '#' },
+            { title: 'Findings', href: '#' },
+            { title: 'Cases', href: '#' },
+            { title: 'Investigation', href: '#' },
+            { title: 'Intelligence', href: '#' },
+            {
+              title: 'Explore',
+              href: '#',
+              items: [
+                { title: 'Host', href: '#' },
+                { title: 'Users', href: '#' },
+                { title: 'Network', href: '#' },
+              ],
+            },
+            { title: 'Assets', href: '#' },
+            {
+              title: 'Rules',
+              href: '#',
+              items: [
+                { title: 'SIEM rules', href: '#' },
+                { title: 'Shared exception list', href: '#' },
+                { title: 'CIS benchmark rules', href: '#' },
+                { title: 'Defend rules', href: '#' },
+              ],
+            },
+            {
+              title: 'Machine learning',
+              href: '#',
+              items: [
+                { title: 'Overview', href: '#' },
+                { title: 'Notifications', href: '#' },
+                { title: 'Memory usage', href: '#' },
+                { title: 'Anomaly detection', href: '#' },
+                { title: 'Data frame analytics', href: '#' },
+                { title: 'Model management', href: '#' },
+              ],
+            },
+            {
+              title: 'Settings',
+              href: '#',
+              items: [
+                { title: 'Endpoints', href: '#' },
+                { title: 'OS query', href: '#' },
+                { title: 'Response actions history', href: '#' },
+                { title: 'Event filters', href: '#' },
+                { title: 'Host isolation', href: '#' },
+              ],
+            },
+          ]}
+        />
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiCollapsibleNavItem
+          title="Developer tools"
+          iconType="editorCodeBlock"
+          href="#"
+        />
+        <EuiCollapsibleNavItem
+          title="Project settings"
+          iconType="gear"
+          items={[
+            { title: 'Management', href: '#' },
+            {
+              title: 'Users and roles',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+            {
+              title: 'Performance',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+            {
+              title: 'Billing and subscription',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+          ]}
+        />
+      </EuiFlyoutFooter>
+    </OpenCollapsibleNav>
+  ),
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -34,24 +34,19 @@ export const KibanaExample: Story = {
   render: () => (
     <OpenCollapsibleNav>
       <EuiFlyoutBody>
-        <EuiCollapsibleNavItem
-          title="Home"
-          iconType="home"
-          isSelected
-          href="#"
-        />
+        <EuiCollapsibleNavItem title="Home" icon="home" isSelected href="#" />
         <EuiCollapsibleNavItem
           title="Recent"
-          iconType="clock"
+          icon="clock"
           items={[
-            { title: 'Lorem ipsum', iconType: 'visMapRegion', href: '#' },
-            { title: 'Consectetur cursus', iconType: 'visPie', href: '#' },
-            { title: 'Ultricies tellus', iconType: 'visMetric', href: '#' },
+            { title: 'Lorem ipsum', icon: 'visMapRegion', href: '#' },
+            { title: 'Consectetur cursus', icon: 'visPie', href: '#' },
+            { title: 'Ultricies tellus', icon: 'visMetric', href: '#' },
           ]}
         />
         <EuiCollapsibleNavItem
           title="Elasticsearch"
-          iconType="logoElasticsearch"
+          icon="logoElasticsearch"
           href="#"
           items={[
             { title: 'Get started', href: '#' },
@@ -69,7 +64,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Enterprise Search"
-          iconType="logoEnterpriseSearch"
+          icon="logoEnterpriseSearch"
           href="#"
           items={[
             { title: 'ESRE', href: '#' },
@@ -85,7 +80,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Observability"
-          iconType="logoObservability"
+          icon="logoObservability"
           href="#"
           items={[
             { title: 'Get started', href: '#' },
@@ -121,7 +116,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Security"
-          iconType="logoSecurity"
+          icon="logoSecurity"
           href="#"
           items={[
             { title: 'Get started', href: '#' },
@@ -178,7 +173,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Analytics"
-          iconType="stats"
+          icon="stats"
           href="#"
           items={[
             { title: 'Discover', href: '#' },
@@ -188,7 +183,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Machine learning"
-          iconType="indexMapping"
+          icon="indexMapping"
           href="#"
           items={[
             { title: 'Overview', href: '#' },
@@ -214,7 +209,7 @@ export const KibanaExample: Story = {
       <EuiFlyoutFooter>
         <EuiCollapsibleNavItem
           title="Developer tools"
-          iconType="editorCodeBlock"
+          icon="editorCodeBlock"
           href="#"
           items={[
             { title: 'Console', href: '#' },
@@ -225,7 +220,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Management"
-          iconType="gear"
+          icon="gear"
           items={[
             { title: 'Integrations', href: '#' },
             { title: 'Fleet', href: '#' },
@@ -236,7 +231,7 @@ export const KibanaExample: Story = {
         />
         <EuiCollapsibleNavItem
           title="Project settings"
-          iconType="gear"
+          icon="gear"
           items={[
             { title: 'Management', href: '#' },
             {
@@ -268,17 +263,17 @@ export const SecurityExample: Story = {
       <EuiFlyoutBody>
         <EuiCollapsibleNavItem
           title="Recent"
-          iconType="clock"
+          icon="clock"
           items={[
-            { title: 'Lorem ipsum', iconType: 'visMapRegion', href: '#' },
-            { title: 'Consectetur cursus', iconType: 'visPie', href: '#' },
-            { title: 'Ultricies tellus', iconType: 'visMetric', href: '#' },
+            { title: 'Lorem ipsum', icon: 'visMapRegion', href: '#' },
+            { title: 'Consectetur cursus', icon: 'visPie', href: '#' },
+            { title: 'Ultricies tellus', icon: 'visMetric', href: '#' },
           ]}
         />
         <EuiCollapsibleNavItem
           isSelected
           title="Security"
-          iconType="logoSecurity"
+          icon="logoSecurity"
           href="#"
           // Workaround to always display this section as open and remove the accordion toggle
           // Rather than baking in a top-level prop to support this behavior, this is likely
@@ -344,12 +339,12 @@ export const SecurityExample: Story = {
       <EuiFlyoutFooter>
         <EuiCollapsibleNavItem
           title="Developer tools"
-          iconType="editorCodeBlock"
+          icon="editorCodeBlock"
           href="#"
         />
         <EuiCollapsibleNavItem
           title="Project settings"
-          iconType="gear"
+          icon="gear"
           items={[
             { title: 'Management', href: '#' },
             {

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+import { logicalCSS } from '../../global_styling';
+
+export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiCollapsibleNavBeta: css`
+      ${logicalCSS('border-top', euiTheme.border.thin)}
+      ${logicalCSS('border-right', euiTheme.border.thin)}
+
+      .euiFlyoutFooter {
+        background-color: ${euiTheme.colors.emptyShade};
+        ${logicalCSS('border-top', euiTheme.border.thin)}
+      }
+    `,
+  };
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import { useEuiTheme } from '../../services';
+
+import {
+  EuiCollapsibleNav,
+  EuiCollapsibleNavProps,
+} from '../collapsible_nav/collapsible_nav';
+
+import { euiCollapsibleNavBetaStyles } from './collapsible_nav_beta.styles';
+
+/**
+ * TODO: Actual component in a follow-up PR
+ */
+export const EuiCollapsibleNavBeta = (props: EuiCollapsibleNavProps) => {
+  const euiTheme = useEuiTheme();
+  const styles = euiCollapsibleNavBetaStyles(euiTheme);
+
+  return (
+    <EuiCollapsibleNav
+      css={styles.euiCollapsibleNavBeta}
+      size={248}
+      {...props}
+    />
+  );
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNavAccordion renders as a sub item 1`] = `
+<div
+  class="euiAccordion euiCollapsibleNavAccordion emotion-euiCollapsibleNavAccordion-isSubItem"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <div
+      aria-controls="generated-id"
+      class="euiAccordion__button emotion-euiAccordion__button"
+      id="generated-id"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      >
+        <span
+          class="euiCollapsibleNavLink emotion-euiCollapsibleNavLink-isSubItem"
+        >
+          Accordion header
+        </span>
+      </span>
+    </div>
+    <button
+      aria-controls="generated-id"
+      aria-expanded="false"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-arrowRight-euiCollapsibleNavAccordion__arrow"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
+    id="generated-id"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      >
+        <div
+          class="euiCollapsibleNavAccordion__children emotion-euiCollapsibleNavAccordion__children-isSubItem"
+        >
+          <span
+            class="euiCollapsibleNavLink euiCollapsibleNavItem euiCollapsibleNavSubItem emotion-euiCollapsibleNavLink-isSubItem"
+          >
+            <span
+              class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+            >
+              sub item
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavAccordion renders as a top level item 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiAccordion euiCollapsibleNavAccordion testClass1 testClass2 emotion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <div
+      aria-controls="generated-id"
+      class="euiAccordion__button emotion-euiAccordion__button"
+      id="generated-id"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      >
+        <span
+          class="euiCollapsibleNavLink emotion-euiCollapsibleNavLink-isTopItem"
+        >
+          Accordion header
+        </span>
+      </span>
+    </div>
+    <button
+      aria-controls="generated-id"
+      aria-expanded="false"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-arrowRight-euiCollapsibleNavAccordion__arrow"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
+    id="generated-id"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      >
+        <div
+          class="euiCollapsibleNavAccordion__children emotion-euiCollapsibleNavAccordion__children-isTopItem"
+        >
+          <span
+            class="euiCollapsibleNavLink euiCollapsibleNavItem euiCollapsibleNavSubItem emotion-euiCollapsibleNavLink-isSubItem"
+          >
+            <span
+              class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+            >
+              sub item
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiAccordion euiCollapsibleNavAccordion euiCollapsibleNavItem testClass1 testClass2 emotion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <div
+      aria-controls="generated-id"
+      class="euiAccordion__button emotion-euiAccordion__button"
+      id="generated-id"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      >
+        <span
+          class="euiCollapsibleNavLink emotion-euiCollapsibleNavLink-isTopItem"
+        >
+          <span
+            class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+          >
+            Item
+          </span>
+        </span>
+      </span>
+    </div>
+    <button
+      aria-controls="generated-id"
+      aria-expanded="false"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-arrowRight-euiCollapsibleNavAccordion__arrow"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
+    id="generated-id"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      >
+        <div
+          class="euiCollapsibleNavAccordion__children emotion-euiCollapsibleNavAccordion__children-isTopItem"
+        >
+          <span
+            aria-label="aria-label"
+            class="euiCollapsibleNavLink euiCollapsibleNavItem euiCollapsibleNavSubItem emotion-euiCollapsibleNavLink-isSubItem"
+            data-test-subj="test subject string"
+          >
+            <span
+              class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+            >
+              Sub-item
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavItem renders a top level link if items are missing or empty 1`] = `
+<a
+  aria-label="aria-label"
+  class="euiLink euiCollapsibleNavLink euiCollapsibleNavItem testClass1 testClass2 emotion-euiLink-primary-euiCollapsibleNavLink-isTopItem-isNotAccordion-isInteractive-euiTestCss"
+  data-test-subj="test subject string"
+  href="#"
+  rel="noreferrer"
+>
+  <span
+    class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+  >
+    Item
+  </span>
+</a>
+`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_link.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_link.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNavLink renders a button if an onClick is passed but not a href 1`] = `
+<button
+  class="euiLink euiCollapsibleNavLink emotion-euiLink-primary-euiCollapsibleNavLink-isTopItem-isNotAccordion-isInteractive"
+  type="button"
+>
+  Link
+</button>
+`;
+
+exports[`EuiCollapsibleNavLink renders a link 1`] = `
+<a
+  aria-label="aria-label"
+  class="euiLink euiCollapsibleNavLink testClass1 testClass2 emotion-euiLink-primary-euiCollapsibleNavLink-isTopItem-isInteractive-euiTestCss"
+  data-test-subj="test subject string"
+  href="#"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  Link
+  <span
+    class="emotion-euiLink__externalIcon"
+    data-euiicon-type="popout"
+  >
+    External link
+  </span>
+  <span
+    class="emotion-euiScreenReaderOnly-euiLink__screenReaderText"
+  >
+    (opens in a new tab or window)
+  </span>
+</a>
+`;
+
+exports[`EuiCollapsibleNavLink renders as a static span if \`isInteractive\` is false 1`] = `
+<span
+  class="euiCollapsibleNavLink emotion-euiCollapsibleNavLink-isTopItem-isNotAccordion"
+>
+  Link
+</span>
+`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import {
+  logicalCSS,
+  mathWithUnits,
+  euiCanAnimate,
+} from '../../../global_styling';
+import { UseEuiTheme } from '../../../services';
+
+import { euiCollapsibleNavItemVariables } from './collapsible_nav_item.styles';
+
+export const euiCollapsibleNavAccordionStyles = (
+  euiThemeContext: UseEuiTheme
+) => {
+  const { euiTheme } = euiThemeContext;
+  const sharedStyles = euiCollapsibleNavItemVariables(euiThemeContext);
+
+  return {
+    // NOTE: Specific usage of `>`s selectors are important here, because accordions can be nested
+    // - just because a parent accordion is open or selected does not mean its child accordion is the same
+    euiCollapsibleNavAccordion: css`
+      .euiAccordion__button {
+        overflow: hidden; /* Title text truncation doesn't work otherwise */
+
+        /* unset accordion underline - only show for EuiLinks (which display their own underlines)
+         * so that behavior between link accordions and non-link accordions is consistent */
+        &:hover,
+        &:focus {
+          cursor: default;
+          text-decoration: none;
+        }
+      }
+
+      .euiAccordion__triggerWrapper {
+        border-radius: ${sharedStyles.borderRadius};
+
+        ${euiCanAnimate} {
+          transition: background-color ${sharedStyles.animation};
+        }
+      }
+
+      .euiAccordion__buttonContent {
+        ${logicalCSS('max-width', '100%')}
+        flex-basis: 100%;
+        display: flex;
+        align-items: center;
+      }
+
+      .euiCollapsibleNavLink {
+        ${logicalCSS('width', '100%')}
+      }
+    `,
+    isTopItem: css`
+      margin: ${sharedStyles.padding};
+
+      & > .euiAccordion__triggerWrapper {
+        &:hover {
+          background-color: ${sharedStyles.backgroundHoverColor};
+        }
+      }
+    `,
+    isSelected: css`
+      & > .euiAccordion__triggerWrapper {
+        background-color: ${sharedStyles.backgroundSelectedColor};
+
+        &:hover {
+          background-color: ${sharedStyles.backgroundSelectedColor};
+        }
+      }
+    `,
+    isSubItem: css`
+      &.euiAccordion-isOpen {
+        ${logicalCSS('margin-bottom', euiTheme.size.m)}
+      }
+    `,
+    // Arrow element
+    euiCollapsibleNavAccordion__arrow: css`
+      /* Slight visual offset from edge of entire item */
+      ${logicalCSS('margin-right', euiTheme.size.xs)}
+
+      /* Give the arrow button its own clearer hover animation to indicate its hitbox */
+      ${euiCanAnimate} {
+        transition: background-color ${sharedStyles.animation};
+      }
+
+      &:hover,
+      &:focus-visible {
+        background-color: ${euiTheme.colors.lightShade};
+
+        & > .euiIcon {
+          color: ${sharedStyles.color};
+        }
+      }
+
+      /* Rotate the arrow icon, not the button itself -
+       * otherwise the background rotates and looks a bit silly */
+      transform: none !important; /* stylelint-disable-line declaration-no-important */
+
+      & > .euiIcon {
+        color: ${sharedStyles.rightIconColor};
+        transform: rotate(-90deg);
+
+        ${euiCanAnimate} {
+          transition: transform ${sharedStyles.animation},
+            color ${sharedStyles.animation};
+        }
+      }
+
+      &.euiAccordion__iconButton-isOpen > .euiIcon {
+        color: ${sharedStyles.color};
+        transform: rotate(90deg);
+      }
+    `,
+    // Children wrapper
+    children: {
+      euiCollapsibleNavAccordion__children: css``,
+      isTopItem: css`
+        ${logicalCSS('padding-top', euiTheme.size.xs)}
+        ${logicalCSS('padding-left', euiTheme.size.xl)}
+      `,
+      isSubItem: css`
+        ${logicalCSS('border-left', euiTheme.border.thin)}
+        ${logicalCSS('margin-left', euiTheme.size.s)}
+        ${logicalCSS(
+          'padding-left',
+          mathWithUnits(
+            [euiTheme.size.s, euiTheme.border.width.thin],
+            (x, y) => x - y
+          )
+        )}
+      `,
+    },
+  };
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { render } from '../../../test/rtl';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test';
+
+import { EuiCollapsibleNavAccordion } from './collapsible_nav_accordion';
+
+describe('EuiCollapsibleNavAccordion', () => {
+  const props = {
+    buttonContent: 'Accordion header',
+    items: [{ title: 'sub item' }],
+  };
+
+  shouldRenderCustomStyles(<EuiCollapsibleNavAccordion {...props} />, {
+    childProps: [
+      'linkProps',
+      'accordionProps',
+      'accordionProps.arrowProps',
+      'accordionProps.buttonProps',
+    ],
+  });
+
+  it('renders as a top level item', () => {
+    const { container } = render(
+      <EuiCollapsibleNavAccordion {...requiredProps} {...props} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders as a sub item', () => {
+    const { container } = render(
+      <EuiCollapsibleNavAccordion {...props} isSubItem />
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders as selected', () => {
+    const { container } = render(
+      <EuiCollapsibleNavAccordion {...props} isSelected />
+    );
+    expect((container.firstChild as HTMLElement).className).toContain(
+      'isSelected'
+    );
+  });
+
+  describe('when any items have an icon', () => {
+    it('renders all items without icon with an `empty` icon', () => {
+      const { container } = render(
+        <EuiCollapsibleNavAccordion
+          {...props}
+          items={[
+            { title: '1', iconType: 'home' },
+            { title: '2' },
+            { title: '3' },
+            { title: '4' },
+            { title: '5', iconType: 'faceHappy' },
+          ]}
+        />
+      );
+
+      expect(
+        container.querySelectorAll('[data-euiicon-type="empty"]')
+      ).toHaveLength(3);
+    });
+  });
+
+  describe('when the accordion header is a link and the link is clicked', () => {
+    it('does not trigger the accordion opening', () => {
+      const { getByTestSubject, container } = render(
+        <EuiCollapsibleNavAccordion
+          {...props}
+          href="#"
+          linkProps={{ 'data-test-subj': 'link' }}
+          accordionProps={{ arrowProps: { 'data-test-subj': 'toggle' } }}
+        />
+      );
+
+      fireEvent.click(getByTestSubject('link'));
+      expect(
+        container.querySelector('.euiAccordion__childWrapper')
+      ).toHaveStyleRule('opacity', '0');
+
+      fireEvent.click(getByTestSubject('toggle'));
+      expect(
+        container.querySelector('.euiAccordion__childWrapper')
+      ).toHaveStyleRule('opacity', '1');
+    });
+  });
+});

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.test.tsx
@@ -59,11 +59,11 @@ describe('EuiCollapsibleNavAccordion', () => {
         <EuiCollapsibleNavAccordion
           {...props}
           items={[
-            { title: '1', iconType: 'home' },
+            { title: '1', icon: 'home' },
             { title: '2' },
             { title: '3' },
             { title: '4' },
-            { title: '5', iconType: 'faceHappy' },
+            { title: '5', icon: 'faceHappy' },
           ]}
         />
       );

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
@@ -110,6 +110,9 @@ export const EuiCollapsibleNavAccordion: FunctionComponent<
       className="euiCollapsibleNavAccordion__children"
     >
       {items.map((item, index) => (
+        // This is an intentional circular dependency between the accordion & parent item display.
+        // EuiSideNavItem is purposely recursive to support any amount of nested sub items,
+        // and split up into separate files/components for better dev readability
         <EuiCollapsibleNavSubItem key={index} iconType={iconType} {...item} />
       ))}
     </div>

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  ReactNode,
+  MouseEvent,
+  useCallback,
+  useMemo,
+} from 'react';
+import classNames from 'classnames';
+
+import { useEuiTheme, useGeneratedHtmlId } from '../../../services';
+import { EuiAccordion } from '../../accordion';
+
+import {
+  EuiCollapsibleNavSubItem,
+  _SharedEuiCollapsibleNavItemProps,
+  _EuiCollapsibleNavItemDisplayProps,
+  EuiCollapsibleNavItemProps,
+} from './collapsible_nav_item';
+import { EuiCollapsibleNavLink } from './collapsible_nav_link';
+import { euiCollapsibleNavAccordionStyles } from './collapsible_nav_accordion.styles';
+
+type EuiCollapsibleNavAccordionProps = Omit<
+  _SharedEuiCollapsibleNavItemProps,
+  'items'
+> &
+  _EuiCollapsibleNavItemDisplayProps & {
+    buttonContent: ReactNode;
+    // On the main `EuiCollapsibleNavItem` component, this uses `EuiCollapsibleNavSubItemProps`
+    // to allow for section headings, but by the time `items` reaches this component, we
+    // know for sure it's an actual accordion item and not a section heading
+    items: EuiCollapsibleNavItemProps[];
+  };
+
+/**
+ * Internal nav accordion component.
+ *
+ * Renders children as either a nav link or any number/nesting of more nav accordions.
+ * Triggering the open/closed state is handled only by the accordion `arrow` for
+ * UX consistency, as accordion/nav titles can be their own links to pages.
+ */
+export const EuiCollapsibleNavAccordion: FunctionComponent<
+  EuiCollapsibleNavAccordionProps
+> = ({
+  id,
+  className,
+  items,
+  href, // eslint-disable-line local/href-with-rel
+  isSubItem,
+  isSelected,
+  linkProps,
+  accordionProps,
+  buttonContent,
+  children: _children, // Make sure this isn't spread
+  ...rest
+}) => {
+  const classes = classNames('euiCollapsibleNavAccordion', className);
+  const groupID = useGeneratedHtmlId({ conditionalId: id });
+
+  const euiTheme = useEuiTheme();
+  const styles = euiCollapsibleNavAccordionStyles(euiTheme);
+  const cssStyles = [
+    styles.euiCollapsibleNavAccordion,
+    isSubItem ? styles.isSubItem : styles.isTopItem,
+    isSelected && styles.isSelected,
+    accordionProps?.css,
+  ];
+
+  /**
+   * Title / accordion trigger
+   */
+  const isTitleInteractive = !!(href || linkProps?.onClick);
+
+  // Stop propagation on the title so that the accordion toggle doesn't occur on click
+  // (should only occur on accordion arrow click for UX consistency)
+  const stopPropagationClick = useCallback(
+    (e: MouseEvent<HTMLAnchorElement> & MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      linkProps?.onClick?.(e);
+    },
+    [linkProps?.onClick] // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  /**
+   * Child items
+   */
+  // If any of the sub items have an icon, default to an
+  // iconType of `empty` so that all text lines up vertically
+  const itemsHaveIcons = useMemo(
+    () => items.some((item) => !!item.iconType),
+    [items]
+  );
+  const iconType = itemsHaveIcons ? 'empty' : undefined;
+
+  const childrenCssStyles = [
+    styles.children.euiCollapsibleNavAccordion__children,
+    isSubItem ? styles.children.isSubItem : styles.children.isTopItem,
+  ];
+
+  const children = (
+    <div
+      css={childrenCssStyles}
+      className="euiCollapsibleNavAccordion__children"
+    >
+      {items.map((item, index) => (
+        <EuiCollapsibleNavSubItem key={index} iconType={iconType} {...item} />
+      ))}
+    </div>
+  );
+
+  return (
+    <EuiAccordion
+      id={groupID}
+      className={classes}
+      initialIsOpen={isSelected}
+      buttonElement="div"
+      buttonContent={
+        <EuiCollapsibleNavLink
+          href={href}
+          {...linkProps}
+          isSelected={isSelected}
+          isSubItem={isSubItem}
+          onClick={stopPropagationClick}
+          isInteractive={isTitleInteractive}
+        >
+          {buttonContent}
+        </EuiCollapsibleNavLink>
+      }
+      arrowDisplay="right"
+      {...rest}
+      {...accordionProps}
+      css={cssStyles}
+      arrowProps={{
+        iconSize: 's',
+        ...accordionProps?.arrowProps,
+        css: [
+          styles.euiCollapsibleNavAccordion__arrow,
+          accordionProps?.arrowProps?.css,
+        ],
+      }}
+    >
+      {children}
+    </EuiAccordion>
+  );
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
@@ -92,12 +92,12 @@ export const EuiCollapsibleNavAccordion: FunctionComponent<
    * Child items
    */
   // If any of the sub items have an icon, default to an
-  // iconType of `empty` so that all text lines up vertically
+  // icon of `empty` so that all text lines up vertically
   const itemsHaveIcons = useMemo(
-    () => items.some((item) => !!item.iconType),
+    () => items.some((item) => !!item.icon),
     [items]
   );
-  const iconType = itemsHaveIcons ? 'empty' : undefined;
+  const icon = itemsHaveIcons ? 'empty' : undefined;
 
   const childrenCssStyles = [
     styles.children.euiCollapsibleNavAccordion__children,
@@ -113,7 +113,7 @@ export const EuiCollapsibleNavAccordion: FunctionComponent<
         // This is an intentional circular dependency between the accordion & parent item display.
         // EuiSideNavItem is purposely recursive to support any amount of nested sub items,
         // and split up into separate files/components for better dev readability
-        <EuiCollapsibleNavSubItem key={index} iconType={iconType} {...item} />
+        <EuiCollapsibleNavSubItem key={index} icon={icon} {...item} />
       ))}
     </div>
   );

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiCollapsibleNavBeta } from '../collapsible_nav_beta';
 
 import {
   EuiCollapsibleNavItem,
@@ -40,4 +43,155 @@ export const Playground: Story = {
       },
     ],
   },
+};
+
+export const EdgeCaseTesting: Story = {
+  render: ({ ...args }) => (
+    <EuiCollapsibleNavBeta isOpen={true} onClose={() => {}}>
+      <div className="eui-yScroll">
+        <EuiCollapsibleNavItem {...args} href="#" title="Link with no icon" />
+        <EuiCollapsibleNavItem
+          {...args}
+          href="#"
+          title="Link with icon"
+          iconType="home"
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="External link with icon"
+          iconType="link"
+          href="#"
+          linkProps={{ target: '_blank' }}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          onClick={() => {}}
+          title="Button with no icon"
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          linkProps={{ onClick: () => {} }}
+          title="Button with icon"
+          iconType="home"
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with no icon"
+          items={[
+            { ...args, title: 'Link with no icon', href: '#' },
+            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with icon"
+          iconType="clock"
+          items={[
+            { ...args, title: 'Link with no icon', href: '#' },
+            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with nested accordions"
+          accordionProps={{ initialIsOpen: true }}
+          items={[
+            { ...args, title: 'Link', href: '#', isSelected: true },
+            { ...args, title: 'Button', onClick: () => {} },
+            { ...args, title: 'Span', href: '#' },
+            {
+              title: 'Section 2',
+              isGroupTitle: true,
+            },
+            {
+              ...args,
+              title: 'Test 2',
+              href: '#',
+              linkProps: { target: '_blank' },
+            },
+            { ...args, title: 'Not a link' },
+            {
+              ...args,
+              title: 'Nested accordion - span',
+              items: [{ title: 'grandchild' }, { title: 'grandchild 2' }],
+            },
+            {
+              ...args,
+              title: 'Nested accordion - link',
+              href: '#',
+              items: [
+                { title: 'grandchild', href: '#' },
+                { title: 'grandchild 2', href: '#' },
+              ],
+            },
+            {
+              title: 'Section 3',
+              titleElement: 'h3',
+              isGroupTitle: true,
+            },
+            {
+              ...args,
+              title: 'Nested accordion with grandchildren',
+              accordionProps: { initialIsOpen: true },
+              items: [
+                { title: 'grandchild' },
+                { title: 'grandchild 2', isSelected: true },
+                {
+                  title: 'Nested nested accordion',
+                  accordionProps: { initialIsOpen: true },
+                  items: [
+                    {
+                      title: 'greatgrandchild truncation testing',
+                      href: '#',
+                      linkProps: { target: '_blank' },
+                      isSelected: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with icon and link"
+          href="#"
+          items={[
+            { ...args, title: 'Link with no icon', href: '#' },
+            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with icon and external link"
+          href="#"
+          linkProps={{ target: '_blank' }} // hmm
+          items={[
+            { ...args, title: 'Link with no icon', href: '#' },
+            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+          ]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with no items"
+          href="#"
+          items={[]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with no items and no link"
+          items={[]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="No link or accordion, very very long truncated text"
+          iconType="home"
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="No icon, very very long truncated text"
+        />
+      </div>
+    </EuiCollapsibleNavBeta>
+  ),
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -27,7 +27,7 @@ export const Playground: Story = {
   args: {
     title: 'Home',
     titleElement: 'span',
-    iconType: 'home',
+    icon: 'home',
     accordionProps: {
       initialIsOpen: true,
     },
@@ -54,12 +54,12 @@ export const EdgeCaseTesting: Story = {
           {...args}
           href="#"
           title="Link with icon"
-          iconType="home"
+          icon="home"
         />
         <EuiCollapsibleNavItem
           {...args}
           title="External link with icon"
-          iconType="link"
+          icon="link"
           href="#"
           linkProps={{ target: '_blank' }}
         />
@@ -72,23 +72,23 @@ export const EdgeCaseTesting: Story = {
           {...args}
           linkProps={{ onClick: () => {} }}
           title="Button with icon"
-          iconType="home"
+          icon="home"
         />
         <EuiCollapsibleNavItem
           {...args}
           title="Accordion with no icon"
           items={[
             { ...args, title: 'Link with no icon', href: '#' },
-            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+            { ...args, title: 'Link with icon', href: '#', icon: 'alert' },
           ]}
         />
         <EuiCollapsibleNavItem
           {...args}
           title="Accordion with icon"
-          iconType="clock"
+          icon="clock"
           items={[
             { ...args, title: 'Link with no icon', href: '#' },
-            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+            { ...args, title: 'Link with icon', href: '#', icon: 'alert' },
           ]}
         />
         <EuiCollapsibleNavItem
@@ -158,7 +158,7 @@ export const EdgeCaseTesting: Story = {
           href="#"
           items={[
             { ...args, title: 'Link with no icon', href: '#' },
-            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+            { ...args, title: 'Link with icon', href: '#', icon: 'alert' },
           ]}
         />
         <EuiCollapsibleNavItem
@@ -168,7 +168,7 @@ export const EdgeCaseTesting: Story = {
           linkProps={{ target: '_blank' }} // hmm
           items={[
             { ...args, title: 'Link with no icon', href: '#' },
-            { ...args, title: 'Link with icon', href: '#', iconType: 'alert' },
+            { ...args, title: 'Link with icon', href: '#', icon: 'alert' },
           ]}
         />
         <EuiCollapsibleNavItem
@@ -185,7 +185,7 @@ export const EdgeCaseTesting: Story = {
         <EuiCollapsibleNavItem
           {...args}
           title="No link or accordion, very very long truncated text"
-          iconType="home"
+          icon="home"
         />
         <EuiCollapsibleNavItem
           {...args}

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  EuiCollapsibleNavItem,
+  EuiCollapsibleNavItemProps,
+} from './collapsible_nav_item';
+
+const meta: Meta<EuiCollapsibleNavItemProps> = {
+  title: 'EuiCollapsibleNavItem',
+  component: EuiCollapsibleNavItem,
+};
+export default meta;
+type Story = StoryObj<EuiCollapsibleNavItemProps>;
+
+export const Playground: Story = {
+  args: {
+    title: 'Home',
+    titleElement: 'span',
+    iconType: 'home',
+    accordionProps: {
+      initialIsOpen: true,
+    },
+    items: [
+      {
+        title: 'Child link one',
+        href: '#',
+      },
+      {
+        title: 'Child link two',
+        href: '#',
+        linkProps: { target: '_blank' },
+      },
+    ],
+  },
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.styles.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../../services';
+import {
+  logicalCSS,
+  logicalShorthandCSS,
+  euiFontSize,
+} from '../../../global_styling';
+import { euiButtonColor } from '../../../themes/amsterdam/global_styling/mixins/button';
+
+/**
+ * Style variables shared between accordion, link, and sub items
+ */
+export const euiCollapsibleNavItemVariables = (
+  euiThemeContext: UseEuiTheme
+) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    height: euiTheme.size.xl,
+    padding: euiTheme.size.s,
+    ...euiFontSize(euiThemeContext, 's'),
+    animation: `${euiTheme.animation.normal} ease-in-out`, // Matches EuiButton
+    borderRadius: euiTheme.border.radius.small,
+    backgroundHoverColor: euiTheme.colors.lightestShade,
+    backgroundSelectedColor: euiButtonColor(euiThemeContext, 'text')
+      .backgroundColor,
+    color: euiTheme.colors.text,
+    rightIconColor: euiTheme.colors.disabledText,
+  };
+};
+
+/**
+ * Title styles
+ */
+
+export const euiCollapsibleNavItemTitleStyles = {
+  euiCollapsibleNavItem__title: css`
+    flex-grow: 1;
+  `,
+};
+
+export const euiCollapsibleNavSubItemGroupTitleStyles = ({
+  euiTheme,
+}: UseEuiTheme) => {
+  return {
+    euiCollapsibleNavItem__groupTitle: css`
+      ${logicalCSS('margin-top', euiTheme.size.base)}
+      ${logicalShorthandCSS(
+        'padding',
+        `${euiTheme.size.xs} ${euiTheme.size.s}`
+      )}
+    `,
+  };
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
@@ -87,12 +87,29 @@ describe('EuiCollapsibleNavItem', () => {
 
     it('allows rendering an icon', () => {
       const { container } = render(
-        <EuiCollapsibleNavItem title="Item" iconType="home" />
+        <EuiCollapsibleNavItem title="Item" icon="home" />
       );
 
       expect(
         container.querySelector('[data-euiicon-type="home"]')
       ).toBeTruthy();
+    });
+
+    it('allows passing custom props to the icon', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem
+          title="Item"
+          icon="home"
+          iconProps={{ size: 's', color: 'primary' }}
+        />
+      );
+
+      // NOTE: We stub out rendered EuiIcons, so this as useful an assertion as it gets.
+      // Converting this into a visual screenshot test would probably be more useful
+      expect(container.querySelector('[data-euiicon-type]')).toHaveAttribute(
+        'color',
+        'primary'
+      );
     });
   });
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../../test/rtl';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test';
+
+import { EuiCollapsibleNavItem } from './collapsible_nav_item';
+
+describe('EuiCollapsibleNavItem', () => {
+  shouldRenderCustomStyles(
+    <EuiCollapsibleNavItem
+      title="Title"
+      href="#"
+      items={[{ title: 'Sub-item' }]}
+    />,
+    { childProps: ['linkProps', 'accordionProps'] }
+  );
+
+  it('renders a top level accordion if items exist', () => {
+    const { container } = render(
+      <EuiCollapsibleNavItem
+        {...requiredProps}
+        title="Item"
+        items={[{ title: 'Sub-item', ...requiredProps }]}
+      />
+    );
+
+    expect(container.firstChild).toHaveClass('euiAccordion');
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a top level link if items are missing or empty', () => {
+    const { container } = render(
+      <EuiCollapsibleNavItem
+        {...requiredProps}
+        title="Item"
+        href="#"
+        items={[]}
+      />
+    );
+
+    expect(container.firstChild).toHaveClass('euiLink');
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('link interactivity', () => {
+    it('renders a static span if no href or onClick is present', () => {
+      const { container } = render(<EuiCollapsibleNavItem title="Text" />);
+      expect(container.firstChild!.nodeName).toEqual('SPAN');
+    });
+
+    it('renders an anchor link if href is present', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem title="Link" href="#" />
+      );
+      expect(container.firstChild!.nodeName).toEqual('A');
+    });
+
+    it('renders a button if onClick is present', () => {
+      const { rerender, container } = render(
+        <EuiCollapsibleNavItem title="Button" onClick={() => {}} />
+      );
+      expect(container.firstChild!.nodeName).toEqual('BUTTON');
+
+      rerender(
+        <EuiCollapsibleNavItem title="Item" linkProps={{ onClick: () => {} }} />
+      );
+      expect(container.firstChild!.nodeName).toEqual('BUTTON');
+    });
+  });
+
+  describe('title display', () => {
+    it('allows customizing the title element', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem title="Item" titleElement="h2" />
+      );
+
+      expect(container.querySelector('h2')).toHaveTextContent('Item');
+    });
+
+    it('allows rendering an icon', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem title="Item" iconType="home" />
+      );
+
+      expect(
+        container.querySelector('[data-euiicon-type="home"]')
+      ).toBeTruthy();
+    });
+  });
+
+  describe('sub items', () => {
+    it('renders each nested `items` array with a subitem component/styling', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem
+          title="Item"
+          items={[
+            { title: '1' },
+            { title: '2' },
+            { title: '3', items: [{ title: '4' }, { title: '5' }] },
+          ]}
+        />
+      );
+
+      expect(
+        container.querySelectorAll('.euiCollapsibleNavSubItem')
+      ).toHaveLength(5);
+    });
+
+    it('renders group titles', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem
+          title="Item"
+          items={[
+            { isGroupTitle: true, title: 'Section' },
+            { title: 'Hello' },
+            { title: 'World' },
+          ]}
+        />
+      );
+
+      expect(container.querySelector('.euiCollapsibleNavItem__groupTitle'))
+        .toMatchInlineSnapshot(`
+        <div
+          class="euiTitle euiCollapsibleNavItem__groupTitle eui-textTruncate emotion-euiTitle-xxxs-euiCollapsibleNavItem__groupTitle"
+        >
+          Section
+        </div>
+      `);
+    });
+
+    it('allows customizing the group title element', () => {
+      const { container } = render(
+        <EuiCollapsibleNavItem
+          title="Item"
+          items={[
+            {
+              isGroupTitle: true,
+              title: 'Group title',
+              titleElement: 'h2',
+            },
+            { title: 'Link 1', titleElement: 'h3' },
+          ]}
+        />
+      );
+
+      expect(container.querySelector('.euiCollapsibleNavItem__groupTitle'))
+        .toMatchInlineSnapshot(`
+        <h2
+          class="euiTitle euiCollapsibleNavItem__groupTitle eui-textTruncate emotion-euiTitle-xxxs-euiCollapsibleNavItem__groupTitle"
+        >
+          Group title
+        </h2>
+      `);
+    });
+  });
+});

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -70,7 +70,7 @@ export type EuiCollapsibleNavItemProps = {
   /**
    * Optional icon to render to the left of title content
    */
-  iconType?: IconType;
+  icon?: IconType;
 } & _SharedEuiCollapsibleNavItemProps;
 
 export type EuiCollapsibleNavSubItemGroupTitle = Pick<
@@ -108,7 +108,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
   isSubItem,
   title,
   titleElement,
-  iconType,
+  icon,
   className,
   items,
   children, // Ensure children isn't spread
@@ -124,7 +124,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
     <EuiCollapsibleNavItemTitle
       title={title}
       titleElement={titleElement}
-      iconType={iconType}
+      icon={icon}
     />
   );
 
@@ -160,14 +160,14 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
  * Internal subcomponent for title display
  */
 const EuiCollapsibleNavItemTitle: FunctionComponent<
-  Pick<EuiCollapsibleNavItemProps, 'title' | 'titleElement' | 'iconType'>
-> = ({ title, titleElement = 'span', iconType }) => {
+  Pick<EuiCollapsibleNavItemProps, 'title' | 'titleElement' | 'icon'>
+> = ({ title, titleElement = 'span', icon }) => {
   const styles = euiCollapsibleNavItemTitleStyles;
   const TitleElement = titleElement;
 
   return (
     <>
-      {iconType && <EuiIcon type={iconType} />}
+      {icon && <EuiIcon type={icon} />}
 
       <TitleElement
         className="euiCollapsibleNavItem__title eui-textTruncate"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, ReactNode, HTMLAttributes } from 'react';
+import classNames from 'classnames';
+
+import { useEuiTheme } from '../../../services';
+import { CommonProps, ExclusiveUnion } from '../../common';
+
+import { EuiIcon, IconType } from '../../icon';
+import { EuiLinkProps } from '../../link';
+import { EuiAccordionProps } from '../../accordion';
+import { EuiTitle } from '../../title';
+
+import { EuiCollapsibleNavAccordion } from './collapsible_nav_accordion';
+import { EuiCollapsibleNavLink } from './collapsible_nav_link';
+import {
+  euiCollapsibleNavItemTitleStyles,
+  euiCollapsibleNavSubItemGroupTitleStyles,
+} from './collapsible_nav_item.styles';
+
+export type _SharedEuiCollapsibleNavItemProps = HTMLAttributes<HTMLElement> &
+  CommonProps & {
+    /**
+     * The nav item link.
+     * If not included, and no `onClick` is specified, the nav item
+     * will render as an non-interactive `<span>`.
+     */
+    href?: string;
+    /**
+     * When passed, an `EuiAccordion` with nested child item links will be rendered.
+     *
+     * Accepts any #EuiCollapsibleNavItem prop, and also accepts an
+     * #EuiCollapsibleNavSubItemGroupTitle
+     */
+    items?: EuiCollapsibleNavSubItemProps[];
+    /**
+     * If `items` is specified, use this prop to pass any prop that `EuiAccordion`
+     * accepts, including props that control the toggled state of the accordion
+     * (e.g. `initialIsOpen`, `forceState`)
+     */
+    accordionProps?: Partial<EuiAccordionProps>;
+    /**
+     * If a `href` is specified, use this prop to pass any prop that `EuiLink` accepts
+     */
+    linkProps?: Partial<EuiLinkProps>;
+    /**
+     * Highlights whether an item is currently selected, e.g.
+     * if the user is on the same page as the nav link
+     */
+    isSelected?: boolean;
+  };
+
+export type EuiCollapsibleNavItemProps = {
+  /**
+   * ReactNode to render as this component's title
+   */
+  title: ReactNode;
+  /**
+   * Allows customizing title's element.
+   * Consider using a heading element for better accessibility.
+   * Defaults to an unsemantic `span` or `div`, depending on context.
+   */
+  titleElement?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'div';
+  /**
+   * Optional icon to render to the left of title content
+   */
+  iconType?: IconType;
+} & _SharedEuiCollapsibleNavItemProps;
+
+export type EuiCollapsibleNavSubItemGroupTitle = Pick<
+  EuiCollapsibleNavItemProps,
+  'title' | 'titleElement'
+> & {
+  /**
+   * Pass this flag to seperate links by group title headings.
+   * Strongly consider using the `titleElement` prop for accessibility.
+   */
+  isGroupTitle?: boolean;
+};
+
+export type EuiCollapsibleNavSubItemProps = ExclusiveUnion<
+  EuiCollapsibleNavItemProps,
+  EuiCollapsibleNavSubItemGroupTitle
+>;
+
+export type _EuiCollapsibleNavItemDisplayProps = {
+  /**
+   * Determines whether the item should render as a top-level nav item
+   * or a nested nav subitem. Set internally by EUI
+   */
+  isSubItem?: boolean;
+};
+
+/**
+ * Internal DRY subcomponent shared between top level items and sub items
+ * that handles title display/rendering, and can be used to recursively
+ * determine whether to render an accordion or a link
+ */
+const EuiCollapsibleNavItemDisplay: FunctionComponent<
+  EuiCollapsibleNavItemProps & _EuiCollapsibleNavItemDisplayProps
+> = ({
+  isSubItem,
+  title,
+  titleElement,
+  iconType,
+  className,
+  items,
+  children, // Ensure children isn't spread
+  ...props
+}) => {
+  const classes = classNames(
+    'euiCollapsibleNavItem',
+    { euiCollapsibleNavSubItem: isSubItem },
+    className
+  );
+
+  const headerContent = (
+    <EuiCollapsibleNavItemTitle
+      title={title}
+      titleElement={titleElement}
+      iconType={iconType}
+    />
+  );
+
+  const isAccordion = items && items.length > 0;
+  if (isAccordion) {
+    return (
+      <EuiCollapsibleNavAccordion
+        className={classes}
+        buttonContent={headerContent}
+        items={items}
+        {...props}
+        isSubItem={isSubItem}
+      />
+    );
+  }
+
+  return (
+    <EuiCollapsibleNavLink
+      className={classes}
+      {...(props as EuiLinkProps)} // EuiLink ExclusiveUnion type shenanigans
+      isSubItem={isSubItem}
+      isNotAccordion
+      isInteractive={
+        !!(props.href || props.onClick || props.linkProps?.onClick)
+      }
+    >
+      {headerContent}
+    </EuiCollapsibleNavLink>
+  );
+};
+
+/**
+ * Internal subcomponent for title display
+ */
+const EuiCollapsibleNavItemTitle: FunctionComponent<
+  Pick<EuiCollapsibleNavItemProps, 'title' | 'titleElement' | 'iconType'>
+> = ({ title, titleElement = 'span', iconType }) => {
+  const styles = euiCollapsibleNavItemTitleStyles;
+  const TitleElement = titleElement;
+
+  return (
+    <>
+      {iconType && <EuiIcon type={iconType} />}
+
+      <TitleElement
+        className="euiCollapsibleNavItem__title eui-textTruncate"
+        css={styles.euiCollapsibleNavItem__title}
+      >
+        {title}
+      </TitleElement>
+    </>
+  );
+};
+
+/**
+ * Sub-items can either be a group title, to visually separate sections
+ * of nav links, or they can simply be more links or accordions
+ */
+export const EuiCollapsibleNavSubItem: FunctionComponent<
+  EuiCollapsibleNavSubItemProps
+> = ({ isGroupTitle, className, ...props }) => {
+  const euiTheme = useEuiTheme();
+  const styles = euiCollapsibleNavSubItemGroupTitleStyles(euiTheme);
+
+  if (isGroupTitle) {
+    const TitleElement = props.titleElement || 'div';
+    return (
+      <EuiTitle
+        size="xxxs"
+        css={styles.euiCollapsibleNavItem__groupTitle}
+        className="euiCollapsibleNavItem__groupTitle eui-textTruncate"
+      >
+        <TitleElement>{props.title}</TitleElement>
+      </EuiTitle>
+    );
+  }
+
+  return <EuiCollapsibleNavItemDisplay {...props} isSubItem />;
+};
+
+/**
+ * The actual exported component
+ */
+
+export const EuiCollapsibleNavItem: FunctionComponent<
+  EuiCollapsibleNavItemProps
+> = (props) => <EuiCollapsibleNavItemDisplay {...props} isSubItem={false} />;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { useEuiTheme } from '../../../services';
 import { CommonProps, ExclusiveUnion } from '../../common';
 
-import { EuiIcon, IconType } from '../../icon';
+import { EuiIcon, IconType, EuiIconProps } from '../../icon';
 import { EuiLinkProps } from '../../link';
 import { EuiAccordionProps } from '../../accordion';
 import { EuiTitle } from '../../title';
@@ -71,6 +71,10 @@ export type EuiCollapsibleNavItemProps = {
    * Optional icon to render to the left of title content
    */
   icon?: IconType;
+  /**
+   * Optional props to pass to the title icon
+   */
+  iconProps?: Partial<EuiIconProps>;
 } & _SharedEuiCollapsibleNavItemProps;
 
 export type EuiCollapsibleNavSubItemGroupTitle = Pick<
@@ -109,6 +113,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
   title,
   titleElement,
   icon,
+  iconProps,
   className,
   items,
   children, // Ensure children isn't spread
@@ -125,6 +130,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
       title={title}
       titleElement={titleElement}
       icon={icon}
+      iconProps={iconProps}
     />
   );
 
@@ -160,14 +166,17 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
  * Internal subcomponent for title display
  */
 const EuiCollapsibleNavItemTitle: FunctionComponent<
-  Pick<EuiCollapsibleNavItemProps, 'title' | 'titleElement' | 'icon'>
-> = ({ title, titleElement = 'span', icon }) => {
+  Pick<
+    EuiCollapsibleNavItemProps,
+    'title' | 'titleElement' | 'icon' | 'iconProps'
+  >
+> = ({ title, titleElement = 'span', icon, iconProps }) => {
   const styles = euiCollapsibleNavItemTitleStyles;
   const TitleElement = titleElement;
 
   return (
     <>
-      {icon && <EuiIcon type={icon} />}
+      {icon && <EuiIcon type={icon} {...iconProps} />}
 
       <TitleElement
         className="euiCollapsibleNavItem__title eui-textTruncate"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.styles.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import {
+  euiCanAnimate,
+  logicalCSS,
+  mathWithUnits,
+} from '../../../global_styling';
+import { UseEuiTheme } from '../../../services';
+
+import { euiCollapsibleNavItemVariables } from './collapsible_nav_item.styles';
+
+export const euiCollapsibleNavLinkStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+  const sharedStyles = euiCollapsibleNavItemVariables(euiThemeContext);
+
+  return {
+    // Shared between all links
+    euiCollapsibleNavLink: css`
+      display: flex;
+      align-items: center;
+      ${logicalCSS('height', sharedStyles.height)}
+      padding: ${sharedStyles.padding};
+
+      font-size: ${sharedStyles.fontSize};
+      line-height: ${sharedStyles.lineHeight};
+      color: ${sharedStyles.color};
+      border-radius: ${sharedStyles.borderRadius};
+
+      &:focus {
+        outline-offset: -${euiTheme.focus.width};
+        text-decoration-thickness: unset; /* unsets EuiLink style */
+      }
+
+      [class*='euiLink__externalIcon'] {
+        /* Align with accordion arrows */
+        ${logicalCSS('margin-right', euiTheme.size.xxs)}
+        color: ${sharedStyles.rightIconColor};
+      }
+    `,
+    isSelected: css`
+      background-color: ${sharedStyles.backgroundSelectedColor};
+    `,
+    isTopItem: {
+      isTopItem: css`
+        font-weight: ${euiTheme.font.weight.semiBold};
+        gap: ${euiTheme.size.base}; /* Distance between icon and text */
+
+        /* If EuiLink falls through to render a button, fix button display */
+        &:is(button) {
+          inline-size: calc(
+            100% - ${mathWithUnits(sharedStyles.padding, (x) => x * 2)}
+          );
+        }
+      `,
+      isNotAccordion: css`
+        margin: ${sharedStyles.padding};
+      `,
+      isInteractive: css`
+        ${euiCanAnimate} {
+          transition: background-color ${sharedStyles.animation};
+        }
+
+        &:hover,
+        &:focus-visible {
+          background-color: ${sharedStyles.backgroundHoverColor};
+        }
+      `,
+    },
+    isSubItem: css`
+      font-weight: ${euiTheme.font.weight.regular};
+      gap: ${euiTheme.size.s}; /* Distance between icon and text */
+    `,
+  };
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../../test/rtl';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test';
+
+import { EuiCollapsibleNavLink } from './collapsible_nav_link';
+
+describe('EuiCollapsibleNavLink', () => {
+  shouldRenderCustomStyles(
+    <EuiCollapsibleNavLink>Link</EuiCollapsibleNavLink>,
+    { childProps: ['linkProps'] }
+  );
+
+  it('renders a link', () => {
+    const { container } = render(
+      <EuiCollapsibleNavLink
+        href="#"
+        rel="noopener"
+        linkProps={{ target: '_blank' }}
+        {...requiredProps}
+      >
+        Link
+      </EuiCollapsibleNavLink>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a button if an onClick is passed but not a href', () => {
+    const { container } = render(
+      <EuiCollapsibleNavLink onClick={() => {}} isNotAccordion>
+        Link
+      </EuiCollapsibleNavLink>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders as a static span if `isInteractive` is false', () => {
+    const { container } = render(
+      <EuiCollapsibleNavLink isInteractive={false} isNotAccordion>
+        Link
+      </EuiCollapsibleNavLink>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, ReactNode } from 'react';
+import classNames from 'classnames';
+
+import { useEuiTheme } from '../../../services';
+import { EuiLink, EuiLinkProps } from '../../link';
+
+import type {
+  _SharedEuiCollapsibleNavItemProps,
+  _EuiCollapsibleNavItemDisplayProps,
+} from './collapsible_nav_item';
+import { euiCollapsibleNavLinkStyles } from './collapsible_nav_link.styles';
+
+type EuiCollapsibleNavLinkProps = Omit<EuiLinkProps, 'children'> &
+  Omit<_SharedEuiCollapsibleNavItemProps, 'items' | 'accordionProps'> &
+  _EuiCollapsibleNavItemDisplayProps & {
+    children: ReactNode;
+    isInteractive?: boolean;
+    isNotAccordion?: boolean;
+  };
+
+/**
+ * Internal nav link component.
+ *
+ * Can be rendered as a standalone nav item, or as part of an accordion header.
+ * Can also be rendered as top-level item (has a background hover) or as a
+ * sub-item (renders closer to plain text).
+ *
+ * In terms of DOM output, follows the same logic as EuiLink (renders either
+ * an `a` tag or a `button` if no valid link exists), and can also additionally
+ * rendered a plain `span` if the item is not interactive.
+ */
+export const EuiCollapsibleNavLink: FunctionComponent<
+  EuiCollapsibleNavLinkProps
+> = ({
+  href,
+  rel,
+  children,
+  className,
+  isSelected,
+  isInteractive = true,
+  isNotAccordion,
+  isSubItem,
+  linkProps,
+  ...rest
+}) => {
+  const classes = classNames('euiCollapsibleNavLink', className);
+  const euiTheme = useEuiTheme();
+  const styles = euiCollapsibleNavLinkStyles(euiTheme);
+  const cssStyles = [
+    styles.euiCollapsibleNavLink,
+    isSelected && styles.isSelected,
+    isSubItem ? styles.isSubItem : styles.isTopItem.isTopItem,
+    isNotAccordion && !isSubItem && styles.isTopItem.isNotAccordion,
+    isInteractive &&
+      !isSelected &&
+      !isSubItem &&
+      styles.isTopItem.isInteractive,
+    linkProps?.css,
+  ];
+
+  return isInteractive ? (
+    <EuiLink
+      href={href}
+      rel={rel}
+      className={classes}
+      {...({ ...rest, ...linkProps } as any)} // EuiLink ExclusiveUnion shenanigans
+      css={cssStyles}
+    >
+      {children}
+    </EuiLink>
+  ) : (
+    <span className={classes} css={cssStyles} {...rest}>
+      {children}
+    </span>
+  );
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/index.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type {
+  EuiCollapsibleNavItemProps,
+  EuiCollapsibleNavSubItemProps,
+  EuiCollapsibleNavSubItemGroupTitle,
+} from './collapsible_nav_item';
+
+export { EuiCollapsibleNavItem } from './collapsible_nav_item';

--- a/src/components/collapsible_nav_beta/index.ts
+++ b/src/components/collapsible_nav_beta/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * NOTE: This is currently still a beta component, being exported for Kibana
+ * development usage. It is not yet fully documented or supported.
+ */
+
+export { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
+
+export type {
+  EuiCollapsibleNavItemProps,
+  EuiCollapsibleNavSubItemProps,
+  EuiCollapsibleNavSubItemGroupTitle,
+} from './collapsible_nav_item';
+export { EuiCollapsibleNavItem } from './collapsible_nav_item';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,6 +33,7 @@ export * from './card';
 export * from './code';
 
 export * from './collapsible_nav';
+export * from './collapsible_nav_beta';
 
 export * from './color_picker';
 


### PR DESCRIPTION
## Summary

This PR sets up a new `EuiCollapsibleNavItem` component that follows the new nav redesign and UX outlined in https://github.com/elastic/eui/issues/6759.

This PR, as noted by the [Beta] label in the title, is not a complete feature in and of itself. However, I'm choosing to ship it to main for the following reasonns reasons:

- Creating new components/folders does not interfere or cause interruptions to consumers using the old components, and is relatively risk free
- Releasing it (unannounced/undocumented) allows @tsullivan to incrementally use redesign progress in his Kibana feature work and battle-test our component using production data, leading to issues (hopefully) getting caught faster

## QA

- `gh pr checkout 6904`
- `yarn storybook` (may need to `yarn` beforehand if you haven't run EUI locally in a while)
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--kibana-example
- Go to http://localhost:6006/?path=/story/euicollapsiblenavitem--edge-case-testing
- Click around / QA the various links and displays and confirm they look and behave coherently (in particular, sub-sub-item nesting)

### General checklist

- [x] Checked in both **light and dark** modes
~- [ ] Checked in **mobile**~ Responsive/mobile work isn't yet done, will be part of the next upcoming work where the `EuiCollapsibleNavBeta` component itself gets fleshed out more
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes

Changelog & docs: Skipping this for now due to beta status & until we have something we're ready for all public consumers to use. Once all components are put together, we can deprecate the old component and update docs. 
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~
~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~

Figma: See linked issue with Figma URLs - will likely need to update EUI's Figma library after this work is all over
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~