### PR TITLE
[EuiLink] Remove unnecessary `!important` from styles

### DIFF
--- a/src/components/link/link.styles.ts
+++ b/src/components/link/link.styles.ts
@@ -18,12 +18,6 @@ const _colorCSS = (color: string) => {
   return `
     color: ${color};
 
-    &:hover,
-    &:focus,
-    &:target {
-      text-decoration: underline;
-    }
-
     &:target {
       color: darken(${color}, 10%);
     }
@@ -39,7 +33,7 @@ export const euiLinkHoverCSS = () => {
 export const euiLinkFocusCSS = (euiTheme: UseEuiTheme['euiTheme']) => {
   return `
     text-decoration: underline;
-    text-decoration-thickness: ${euiTheme.border.width.thick} !important;
+    text-decoration-thickness: ${euiTheme.border.width.thick};
   `;
 };
 


### PR DESCRIPTION
## Summary

I noticed this minor annoyance while trying to override some default link styling for the new EuiCollapsibleNav work and wanted to fix it separately (so I wouldn't have to introduce yet more `!important`s to the codebase).

- the `!important` appeared to be set because the `text-decoration: underline` in `_colorCSS` was overriding it
- `_colorCSS` should only be in charge of colors in any case and not hover/focus states, so removing that unnecessary CSS means we can remove the `!important`

## QA

- Go to https://eui.elastic.co/pr_6905/#/navigation/link#coloring-links
- [x] Tab to the links and confirm they still have an underline, and the underline when tabbed is slightly thicker than on just hover

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~ - I'm skipping a changelog on this as this is a technical detail unlikely to meaningfully affect consumers