### PR TITLE
[EuiAccordion] Children class cleanup 

### DIFF
--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
@@ -94,20 +94,6 @@ const accordionDisabledSource = require('!!raw-loader!./accordion_disabled');
 
 export const AccordionExample = {
   title: 'Accordion',
-  intro: (
-    <Fragment>
-      <EuiCallOut title="Take care when including flex group content within accordions">
-        <p>
-          <strong>EuiFlexGroup</strong>&apos;s negative margins can sometimes
-          create scrollbars within <strong>EuiAccordion</strong> because of the
-          overflow tricks used to hide content. If you run into this issue make
-          sure your <EuiCode>paddingSize</EuiCode> prop is large enough to
-          account for the <EuiCode>gutterSize</EuiCode> of any nested flex
-          groups.
-        </p>
-      </EuiCallOut>
-    </Fragment>
-  ),
   sections: [
     {
       title: 'Simple and unstyled',

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You can not see me.
@@ -99,7 +99,7 @@ exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You cannot see me.
@@ -153,7 +153,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You can see me.
@@ -207,7 +207,7 @@ exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`]
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You can see me.
@@ -263,7 +263,7 @@ exports[`EuiAccordion is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -315,7 +315,7 @@ exports[`EuiAccordion isDisabled is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -350,7 +350,7 @@ exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -400,7 +400,7 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -452,7 +452,7 @@ exports[`EuiAccordion props arrowProps is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -506,7 +506,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -556,7 +556,7 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -604,7 +604,7 @@ exports[`EuiAccordion props buttonElement is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -656,7 +656,7 @@ exports[`EuiAccordion props buttonProps is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -704,7 +704,7 @@ exports[`EuiAccordion props element is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -761,7 +761,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -811,7 +811,7 @@ exports[`EuiAccordion props forceState closed is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You can not see me
@@ -865,7 +865,7 @@ exports[`EuiAccordion props forceState open is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You can see me
@@ -919,7 +919,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
           You can see me.
@@ -982,7 +982,7 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__children-isLoading emotion-euiAccordion__children-isLoading"
+        class="euiAccordion__children euiAccordion__children-isLoading emotion-euiAccordion__children-isLoading"
       />
     </div>
   </div>
@@ -1041,7 +1041,7 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
   >
     <div>
       <div
-        class="euiAccordion__children-isLoading emotion-euiAccordion__children-isLoading"
+        class="euiAccordion__children euiAccordion__children-isLoading emotion-euiAccordion__children-isLoading"
       >
         <span
           aria-label="Loading"

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -33,7 +33,7 @@ import {
 import { logicalCSS } from '../../global_styling';
 
 export const PADDING_SIZES = ['none', 'xs', 's', 'm', 'l', 'xl'] as const;
-export type EuiAccordionSize = (typeof PADDING_SIZES)[number];
+export type EuiAccordionPaddingSize = (typeof PADDING_SIZES)[number];
 
 export type EuiAccordionProps = CommonProps &
   Omit<HTMLAttributes<HTMLElement>, 'id'> & {
@@ -85,7 +85,7 @@ export type EuiAccordionProps = CommonProps &
     /**
      * The padding around the exposed accordion content.
      */
-    paddingSize?: EuiAccordionSize;
+    paddingSize?: EuiAccordionPaddingSize;
     /**
      * Placement of the arrow indicator, or 'none' to hide it.
      */

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -234,7 +234,7 @@ export class EuiAccordionClass extends Component<
       className
     );
 
-    const childrenClasses = classNames({
+    const childrenClasses = classNames('euiAccordion__children', {
       'euiAccordion__children-isLoading': isLoading,
     });
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -9,7 +9,7 @@
 import React, { Component, HTMLAttributes, ReactNode } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, keysOf } from '../common';
+import { CommonProps } from '../common';
 
 import { EuiLoadingSpinner } from '../loading';
 import { EuiResizeObserver } from '../observer/resize_observer';
@@ -32,17 +32,8 @@ import {
 } from './accordion.styles';
 import { logicalCSS } from '../../global_styling';
 
-const paddingSizeToClassNameMap = {
-  none: '',
-  xs: 'euiAccordion__padding--xs',
-  s: 'euiAccordion__padding--s',
-  m: 'euiAccordion__padding--m',
-  l: 'euiAccordion__padding--l',
-  xl: 'euiAccordion__padding--xl',
-};
-
-export const PADDING_SIZES = keysOf(paddingSizeToClassNameMap);
-export type EuiAccordionSize = keyof typeof paddingSizeToClassNameMap;
+export const PADDING_SIZES = ['none', 'xs', 's', 'm', 'l', 'xl'] as const;
+export type EuiAccordionSize = (typeof PADDING_SIZES)[number];
 
 export type EuiAccordionProps = CommonProps &
   Omit<HTMLAttributes<HTMLElement>, 'id'> & {
@@ -243,11 +234,7 @@ export class EuiAccordionClass extends Component<
       className
     );
 
-    const paddingClass = paddingSize
-      ? classNames(paddingSizeToClassNameMap[paddingSize])
-      : undefined;
-
-    const childrenClasses = classNames(paddingClass, {
+    const childrenClasses = classNames({
       'euiAccordion__children-isLoading': isLoading,
     });
 
@@ -282,7 +269,7 @@ export class EuiAccordionClass extends Component<
     const cssChildrenStyles = [
       childrenStyles.euiAccordion__children,
       isLoading && childrenStyles.isLoading,
-      paddingSize === 'none' ? undefined : childrenStyles[paddingSize!],
+      paddingSize && paddingSize !== 'none' && childrenStyles[paddingSize],
     ];
 
     const childWrapperStyles = euiAccordionChildWrapperStyles(theme);

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true accepts accordion pro
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>
@@ -323,7 +323,7 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accord
   >
     <div>
       <div
-        class=" emotion-euiAccordion__children"
+        class="euiAccordion__children emotion-euiAccordion__children"
       />
     </div>
   </div>

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -528,7 +528,7 @@ exports[`EuiNotificationEvent props multiple messages are rendered 1`] = `
         >
           <div>
             <div
-              class=" emotion-euiAccordion__children"
+              class="euiAccordion__children emotion-euiAccordion__children"
             >
               <div
                 class="euiNotificationEventMessages__accordionContent"


### PR DESCRIPTION
## Summary

Removes EuiAccordion's padding class map/modifiers (`.euiAccordion__padding--[size]`) in favor of a static `.euiAccordion__children` className.

- ⚠️ Note that there are two instances of CSS references to the removed padding modifiers in Kibana that we'll have to manually convert over to referencing `.euiAccordion__children` in the next upgrade:
  - https://github.com/search?q=repo%3Aelastic%2Fkibana%20euiAccordion__padding--&type=code

This PR also incidentally renames the `EuiAccordionSize` type to a more specific `EuiAccordionPaddingSize` just for clarity, but this isn't a noteworthy change as this type is not exported at the top-most level for consumer usage.

This PR also removes a callout from the EuiAccordion docs that I noticed while QAing. The callout is no longer correct as EuiFlexGroup no longer uses negative margins (as of https://github.com/elastic/eui/pull/6270).

## QA

- Nothing user-facing should have changed or regressed as part of this PR
- [x] Confirm that https://eui.elastic.co/pr_6906/#/layout/accordion#multiple-accordions still have correctly displayed padding sizes (`-l`, etc)

### General checklist

~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~