### PR TITLE
[Emotion] Further enhance `shouldRenderCustomStyles`

### DIFF
--- a/src/components/card/checkable_card/checkable_card.test.tsx
+++ b/src/components/card/checkable_card/checkable_card.test.tsx
@@ -30,7 +30,15 @@ describe('EuiCheckableCard', () => {
 
   shouldRenderCustomStyles(
     <EuiCheckableCard {...checkablePanelRequiredProps} />,
-    { skipStyles: true } // `style` goes with ...rest onto the child check/radio input
+    { skip: { style: true } }
+  );
+  // `style` goes with ...rest onto the child check/radio input, unlike className/css
+  shouldRenderCustomStyles(
+    <EuiCheckableCard {...checkablePanelRequiredProps} />,
+    {
+      targetSelector: '.euiRadio',
+      skip: { className: true, css: true },
+    }
   );
 
   test('renders panel props', () => {

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -33,11 +33,11 @@ const findInternalInstance = (
 
 describe('EuiSuperDatePicker', () => {
   shouldRenderCustomStyles(<EuiSuperDatePicker onTimeChange={noop} />, {
-    skipStyles: true,
+    skip: { style: true },
   });
   shouldRenderCustomStyles(<EuiSuperDatePicker onTimeChange={noop} />, {
     childProps: ['updateButtonProps'],
-    skipParentTest: true,
+    skip: { parentTest: true },
   });
 
   it('renders', () => {

--- a/src/components/date_picker/super_date_picker/super_update_button.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_update_button.test.tsx
@@ -29,7 +29,7 @@ describe('EuiSuperUpdateButton', () => {
     />,
     {
       childProps: ['toolTipProps'],
-      skipParentTest: true,
+      skip: { parentTest: true },
       renderCallback: async ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
         await waitForEuiToolTipVisible();

--- a/src/components/form/checkbox/checkbox.test.tsx
+++ b/src/components/form/checkbox/checkbox.test.tsx
@@ -32,7 +32,10 @@ describe('EuiCheckbox', () => {
   );
   shouldRenderCustomStyles(
     <EuiCheckbox {...checkboxRequiredProps} label="test" />,
-    { childProps: ['labelProps'], skipParentTest: true }
+    {
+      childProps: ['labelProps'],
+      skip: { parentTest: true },
+    }
   );
 
   test('is rendered', () => {

--- a/src/components/form/checkbox/checkbox.test.tsx
+++ b/src/components/form/checkbox/checkbox.test.tsx
@@ -26,10 +26,14 @@ const checkboxRequiredProps = {
 };
 
 describe('EuiCheckbox', () => {
-  shouldRenderCustomStyles(
-    <EuiCheckbox {...checkboxRequiredProps} />,
-    { skipStyles: true } // styles get applied to the nested input, not to the className wrapper
-  );
+  shouldRenderCustomStyles(<EuiCheckbox {...checkboxRequiredProps} />, {
+    skip: { style: true },
+  });
+  // styles get applied to the nested input, not to the className wrapper
+  shouldRenderCustomStyles(<EuiCheckbox {...checkboxRequiredProps} />, {
+    targetSelector: '.euiCheckbox__input',
+    skip: { className: true, css: true },
+  });
   shouldRenderCustomStyles(
     <EuiCheckbox {...checkboxRequiredProps} label="test" />,
     {

--- a/src/components/form/range/dual_range.test.tsx
+++ b/src/components/form/range/dual_range.test.tsx
@@ -23,10 +23,14 @@ const props = {
 };
 
 describe('EuiDualRange', () => {
-  shouldRenderCustomStyles(
-    <EuiDualRange name="name" id="id" {...props} {...requiredProps} />,
-    { skipStyles: true } // style is in ...rest and is spread to a different location than className/css
-  );
+  shouldRenderCustomStyles(<EuiDualRange {...props} {...requiredProps} />, {
+    skip: { style: true },
+  });
+  // style is in ...rest and is spread to a different location than className/css
+  shouldRenderCustomStyles(<EuiDualRange {...props} {...requiredProps} />, {
+    targetSelector: '.euiRangeSlider',
+    skip: { className: true, css: true },
+  });
 
   test('is rendered', () => {
     const component = render(

--- a/src/components/form/range/range.test.tsx
+++ b/src/components/form/range/range.test.tsx
@@ -21,16 +21,14 @@ const props = {
 };
 
 describe('EuiRange', () => {
-  shouldRenderCustomStyles(
-    <EuiRange
-      name="name"
-      id="id"
-      onChange={() => {}}
-      {...props}
-      {...requiredProps}
-    />,
-    { skipStyles: true } // style is in ...rest and is spread to a different location than className/css
-  );
+  shouldRenderCustomStyles(<EuiRange {...props} {...requiredProps} />, {
+    skip: { style: true },
+  });
+  // style is in ...rest and is spread to a different location than className/css
+  shouldRenderCustomStyles(<EuiRange {...props} {...requiredProps} />, {
+    targetSelector: '.euiRangeSlider',
+    skip: { className: true, css: true },
+  });
 
   test('is rendered', () => {
     const component = render(

--- a/src/components/form/switch/switch.test.tsx
+++ b/src/components/form/switch/switch.test.tsx
@@ -21,7 +21,12 @@ const props = {
 
 describe('EuiSwitch', () => {
   shouldRenderCustomStyles(<EuiSwitch {...props} />, {
-    skipStyles: true, // styles are applied to the nested button instead of the className wrapper
+    skip: { style: true },
+  });
+  // styles are applied to the nested button instead of the className wrapper
+  shouldRenderCustomStyles(<EuiSwitch {...props} />, {
+    targetSelector: '.euiSwitch__button',
+    skip: { className: true, css: true },
   });
   shouldRenderCustomStyles(<EuiSwitch {...props} />, {
     childProps: ['labelProps'],

--- a/src/components/form/switch/switch.test.tsx
+++ b/src/components/form/switch/switch.test.tsx
@@ -25,7 +25,7 @@ describe('EuiSwitch', () => {
   });
   shouldRenderCustomStyles(<EuiSwitch {...props} />, {
     childProps: ['labelProps'],
-    skipParentTest: true,
+    skip: { parentTest: true },
   });
 
   test('is rendered', () => {

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -19,7 +19,7 @@ describe('EuiHeader', () => {
     <EuiHeader sections={[{ breadcrumbs: [{ text: 'test' }] }]} />,
     {
       childProps: ['sections[0].breadcrumbProps'],
-      skipParentTest: true,
+      skip: { parentTest: true },
     }
   );
 

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -26,7 +26,7 @@ describe('EuiImage', () => {
     childProps: ['wrapperProps'],
   });
   shouldRenderCustomStyles(<EuiImage allowFullScreen {...requiredProps} />, {
-    skipParentTest: true,
+    skip: { parentTest: true },
     childProps: ['wrapperProps'],
     targetSelector: '.euiImageFullScreenWrapper',
     renderCallback: ({ getByTestSubject }) => {

--- a/src/components/key_pad_menu/key_pad_menu.test.tsx
+++ b/src/components/key_pad_menu/key_pad_menu.test.tsx
@@ -17,7 +17,7 @@ describe('EuiKeyPadMenu', () => {
   shouldRenderCustomStyles(<EuiKeyPadMenu />);
   shouldRenderCustomStyles(<EuiKeyPadMenu checkable={{ legend: 'test' }} />, {
     childProps: ['checkable.legendProps'],
-    skipParentTest: true,
+    skip: { parentTest: true },
   });
 
   test('is rendered', () => {

--- a/src/components/key_pad_menu/key_pad_menu_item.test.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.test.tsx
@@ -28,7 +28,7 @@ describe('EuiKeyPadMenuItem', () => {
       Test
     </EuiKeyPadMenuItem>,
     {
-      skipParentTest: true,
+      skip: { parentTest: true },
       childProps: ['betaBadgeTooltipProps'],
       renderCallback: async ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));

--- a/src/components/list_group/list_group_item.test.tsx
+++ b/src/components/list_group/list_group_item.test.tsx
@@ -15,7 +15,12 @@ import { EuiListGroupItem, SIZES, COLORS } from './list_group_item';
 
 describe('EuiListGroupItem', () => {
   shouldRenderCustomStyles(<EuiListGroupItem label="Label" />, {
-    skipStyles: true, // the styles end up on the inner child
+    skip: { style: true },
+  });
+  // the styles end up on the inner child
+  shouldRenderCustomStyles(<EuiListGroupItem label="Label" />, {
+    targetSelector: '.euiListGroupItem__text',
+    skip: { className: true, css: true },
   });
   shouldRenderCustomStyles(
     <EuiListGroupItem

--- a/src/components/list_group/list_group_item.test.tsx
+++ b/src/components/list_group/list_group_item.test.tsx
@@ -25,7 +25,7 @@ describe('EuiListGroupItem', () => {
     />,
     {
       childProps: ['iconProps', 'extraAction'],
-      skipParentTest: true,
+      skip: { parentTest: true },
     }
   );
 

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -34,7 +34,13 @@ describe('EuiPopover', () => {
   );
   shouldRenderCustomStyles(
     <EuiPopover button={<button />} closePopover={() => {}} isOpen />,
-    { childProps: ['panelProps'], skipStyles: true, skipParentTest: true }
+    {
+      childProps: ['panelProps'],
+      skip: {
+        parentTest: true,
+        style: true, // EuiPopoverPanel does not allow custom `style`s
+      },
+    }
   );
 
   test('is rendered', () => {

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -23,7 +23,7 @@ describe('EuiProgress', () => {
   shouldRenderCustomStyles(<EuiProgress />);
   shouldRenderCustomStyles(<EuiProgress max={100} label="Test" />, {
     childProps: ['labelProps'],
-    skipParentTest: true,
+    skip: { parentTest: true },
   });
 
   test('has max', () => {

--- a/src/components/resizable_container/resizable_panel.test.tsx
+++ b/src/components/resizable_container/resizable_panel.test.tsx
@@ -27,7 +27,11 @@ describe('EuiResizablePanel', () => {
   });
   shouldRenderCustomStyles(
     <EuiResizablePanel wrapperPadding="s">Test</EuiResizablePanel>,
-    { wrapper, childProps: ['wrapperProps'], skipParentTest: true }
+    {
+      wrapper,
+      childProps: ['wrapperProps'],
+      skip: { parentTest: true },
+    }
   );
 
   it('renders', () => {

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -42,7 +42,13 @@ describe('EuiTourStep', () => {
     <EuiTourStep {...config} {...steps[0]} isStepOpen>
       <span>Test</span>
     </EuiTourStep>,
-    { childProps: ['panelProps'], skipStyles: true, skipParentTest: true }
+    {
+      childProps: ['panelProps'],
+      skip: {
+        parentTest: true,
+        style: true, // EuiPopoverPanel does not allow custom `style`s
+      },
+    }
   );
 
   test('is rendered', () => {


### PR DESCRIPTION
## Summary

This is some final extra/optional work on top of #6896 - I didn't want to include it in the above PR as that was was big enough as it was. I recommend [reviewing by commit](https://github.com/elastic/eui/pull/6907/commits) and [turning off whitespace diffs](https://github.com/elastic/eui/pull/6907/files?w=1).

- Removes `skipStyles` API - now uses `skip: { style: true }`
- Removes `skipParentTest` API, now uses `skip: { parentTest: true }`
- Adds a new `skip` API which allows for granular skipping, e.g. `skip: { css: true }`
- Updates all tests using the old APIs (particularly ones that were skipping styles due to `...rest` spread - add tests that actually checks that consumer styles are correctly applied)

## QA

### General checklist

N/A, internal dev/tech debt only