### PR TITLE
[EuiFocusTrap] Default to not trapping focus across iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   },
   "resolutions": {
     "**/prismjs": "1.27.0",
-    "**/react": "^17.0.0"
+    "**/react": "^17.0.0",
+    "react-focus-lock": "^2.9.5"
   },
   "pre-commit": [
     "test-staged"
@@ -81,7 +82,7 @@
     "react-beautiful-dnd": "^13.1.0",
     "react-dropzone": "^11.5.3",
     "react-element-to-jsx-string": "^14.3.4",
-    "react-focus-on": "^3.9.0",
+    "react-focus-on": "^3.9.1",
     "react-input-autosize": "^3.0.0",
     "react-is": "^17.0.2",
     "react-remove-scroll-bar": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-beautiful-dnd": "^13.1.0",
     "react-dropzone": "^11.5.3",
     "react-element-to-jsx-string": "^14.3.4",
-    "react-focus-on": "^3.7.0",
+    "react-focus-on": "^3.9.0",
     "react-input-autosize": "^3.0.0",
     "react-is": "^17.0.2",
     "react-remove-scroll-bar": "^2.3.4",

--- a/src-docs/src/views/focus_trap/focus_trap_example.js
+++ b/src-docs/src/views/focus_trap/focus_trap_example.js
@@ -18,7 +18,7 @@ export const FocusTrapExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             Use <strong>EuiFocusTrap</strong> to prevent keyboard-initiated
             focus from leaving a defined area. Temporary flows and UX escapes
@@ -37,15 +37,21 @@ export const FocusTrapExample = {
             <strong>EuiFocusTrap</strong> will maintain the tab order expected
             by users.
           </p>
-          <p>
-            Use <EuiCode>clickOutsideDisables</EuiCode> to disable the focus
-            trap when the user clicks outside the trap.
-          </p>
-          <p>
-            Use <EuiCode>noIsolation=false</EuiCode> when pointer events on
-            outside elements should be disallowed.
-          </p>
-        </React.Fragment>
+          <ul>
+            <li>
+              Use <EuiCode>clickOutsideDisables</EuiCode> to disable the focus
+              trap when the user clicks outside the trap.
+            </li>
+            <li>
+              Use <EuiCode>noIsolation=false</EuiCode> when pointer events on
+              outside elements should be disallowed.
+            </li>
+            <li>
+              Use <EuiCode>crossFrame=true</EuiCode> when focus should not be
+              allowed on other iframes on the page.
+            </li>
+          </ul>
+        </>
       ),
       props: { EuiFocusTrap },
       demo: <FocusTrap />,

--- a/src/components/focus_trap/focus_trap.stories.tsx
+++ b/src/components/focus_trap/focus_trap.stories.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+
+import { EuiButton } from '../button';
+import { EuiFieldText } from '../form';
+import { EuiSpacer } from '../spacer';
+import { EuiPanel } from '../panel';
+
+import { EuiFocusTrap, EuiFocusTrapProps } from './focus_trap';
+
+const meta: Meta<EuiFocusTrapProps> = {
+  title: 'EuiFocusTrap',
+  // @ts-ignore This still works for Storybook controls, even though Typescript complains
+  component: EuiFocusTrap,
+  argTypes: {
+    crossFrame: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiFocusTrapProps>;
+
+const StatefulFocusTrap = (props: Partial<EuiFocusTrapProps>) => {
+  const [disabled, setDisabled] = useState(props.disabled);
+  return (
+    <>
+      <EuiButton size="s" onClick={() => setDisabled(!disabled)}>
+        Toggle focus trap
+      </EuiButton>
+      <EuiSpacer />
+      <EuiPanel>
+        <EuiFocusTrap {...props} disabled={disabled}>
+          Focus trap is currently {disabled ? 'disabled' : 'enabled'}
+          <EuiFieldText />
+          <EuiButton size="s">Button inside focus trap</EuiButton>
+        </EuiFocusTrap>
+      </EuiPanel>
+    </>
+  );
+};
+
+export const Playground: Story = {
+  render: ({ ...args }) => <StatefulFocusTrap {...args} />,
+  args: {
+    disabled: true,
+  },
+};
+
+export const Iframe: Story = {
+  render: ({ ...args }) => (
+    <>
+      <EuiFieldText placeholder="Focusable item outside iframe" />
+      <EuiSpacer />
+      <EuiPanel>
+        Iframe content
+        <iframe
+          title="crossFrame test"
+          src={`/iframe.html?id=euifocustrap--playground&crossFrame=${args.crossFrame}`}
+          style={{ width: '100%', height: 200 }}
+          sandbox="allow-forms allow-modals allow-popups allow-same-origin allow-scripts allow-downloads allow-storage-access-by-user-activation"
+        />
+      </EuiPanel>
+    </>
+  ),
+  args: { disabled: true, crossFrame: false },
+};

--- a/src/components/focus_trap/focus_trap.tsx
+++ b/src/components/focus_trap/focus_trap.tsx
@@ -56,6 +56,7 @@ export class EuiFocusTrap extends Component<EuiFocusTrapProps, State> {
     returnFocus: true,
     noIsolation: true,
     scrollLock: false,
+    crossFrame: false,
     gapMode: 'padding', // EUI defaults to padding because Kibana's body/layout CSS ignores `margin`
   };
 

--- a/upcoming_changelogs/6908.md
+++ b/upcoming_changelogs/6908.md
@@ -1,0 +1,6 @@
+- `EuiFocusTrap` now supports configuring cross-iframe focus trapping via the `crossFrame` prop
+
+**Breaking changes**
+
+- `EuiFocusTrap` now defaults to *not* trapping focus across iframes
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -9588,10 +9588,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-lock@^0.11.2:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.3.tgz#c094e8f109d780f56038abdeec79328fd56b627f"
-  integrity sha512-4n0pYcPTa/uI7Q66BZna61nRT7lDhnuJ9PJr6wiDjx4uStg491ks41y7uOG+s0umaaa+hulNKSldU9aTg9/yVg==
+focus-lock@^0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.6.tgz#e8821e21d218f03e100f7dc27b733f9c4f61e683"
+  integrity sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==
   dependencies:
     tslib "^2.0.3"
 
@@ -16502,26 +16502,26 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@^2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.2.tgz#a57dfd7c493e5a030d87f161c96ffd082bd920f2"
-  integrity sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==
+react-focus-lock@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.4.tgz#4753f6dcd167c39050c9d84f9c63c71b3ff8462e"
+  integrity sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.11.2"
+    focus-lock "^0.11.6"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-focus-on@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.7.0.tgz#bf782b51483d52d1d336b7b09cb864897af26cdf"
-  integrity sha512-TsCnbJr4qjqFatJ4U1N8qGSZH+FUzxJ5mJ5ta7TY2YnDmUbGGmcvZMTZgGjQ1fl6vlztsMyg6YyZlPAeeIhEUg==
+react-focus-on@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.9.0.tgz#0e1b7ea898365f1e7b63455c869153426725a9db"
+  integrity sha512-4HA8zeMgK5hzR7ffXr/ser3cY3XJBIU1Z8eZI9r3lunMDxIZ5/m9Q2YaHq1I0NFzev1nFsMERZX/JovTYk+GtQ==
   dependencies:
     aria-hidden "^1.2.2"
-    react-focus-lock "^2.9.2"
-    react-remove-scroll "^2.5.5"
+    react-focus-lock "^2.9.4"
+    react-remove-scroll "^2.5.6"
     react-style-singleton "^2.2.0"
     tslib "^2.3.1"
     use-callback-ref "^1.3.0"
@@ -16581,7 +16581,7 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.4:
+react-remove-scroll-bar@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
   integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
@@ -16589,12 +16589,12 @@ react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.4:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
-  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+react-remove-scroll@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz#7510b8079e9c7eebe00e65a33daaa3aa29a10336"
+  integrity sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==
   dependencies:
-    react-remove-scroll-bar "^2.3.3"
+    react-remove-scroll-bar "^2.3.4"
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16502,10 +16502,10 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@^2.9.4:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.4.tgz#4753f6dcd167c39050c9d84f9c63c71b3ff8462e"
-  integrity sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==
+react-focus-lock@2.9.5, react-focus-lock@^2.9.4:
+  version "2.9.5"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.5.tgz#8a82f4f0128cccc27b9e77a4472e8a22f1b52189"
+  integrity sha512-h6vrdgUbsH2HeD5I7I3Cx1PPrmwGuKYICS+kB9m+32X/9xHRrAbxgvaBpG7BFBN9h3tO+C3qX1QAVESmi4CiIA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     focus-lock "^0.11.6"
@@ -16514,10 +16514,10 @@ react-focus-lock@^2.9.4:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-focus-on@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.9.0.tgz#0e1b7ea898365f1e7b63455c869153426725a9db"
-  integrity sha512-4HA8zeMgK5hzR7ffXr/ser3cY3XJBIU1Z8eZI9r3lunMDxIZ5/m9Q2YaHq1I0NFzev1nFsMERZX/JovTYk+GtQ==
+react-focus-on@^3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.9.1.tgz#449a34ebb487c458d9d5526a74214c408544cfec"
+  integrity sha512-IYo2j4mgNpZEJNv+/XzZs3S3xhJbR+AFop092h4OMW7sbFpIMVWxp/Z61V/gfpsgOi7VnoSFXP2bfOWWkjjtOw==
   dependencies:
     aria-hidden "^1.2.2"
     react-focus-lock "^2.9.4"


### PR DESCRIPTION
## Summary

Upgrades to latest `react-focus-on` which allows setting `crossFrame=false` (https://github.com/theKashey/react-focus-on/issues/72).

Example of previous cross frame behavior:

- Go to https://codesandbox.io/s/qzf8zp?file=/demo.js
- Click the "Show flyout" button
- Click into the code panel/frame and try to type. Notice that it won't let you (at first at least, it may intermittently work if you click enough but the first click+type never does)

## QA

I wasn't able to test this working behavior locally for whatever bizarre reason, so I did a pre-release RC and created a demo CodeSandbox with the RC:

- Go to https://codesandbox.io/s/red-grass-zqrgvj?file=/demo.js
- Click the blank EuiFieldText and tab back and forth, confirm tabbing is trapped and does not go down to the console
- [x] Click into the code editor panel and try to type. Confirm it allows you to immediately
- [x] Clicking the "Toggle crossFrame" button and trying to type in the code editor should have the old non-working behavior

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - ⚠️  This doesn't work as well in Safari as it does Chrome/FF, but I'm not sure there's anything we can do about that 😖 I opened an issue for it to see if others can repro: https://github.com/theKashey/react-focus-lock/issues/249 
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- ~[ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
   - Our props table appears to exclude ReactFocusOn's props, so I documented the behavior manually instead
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - Honestly, I couldn't figure out an easy and non-headache-y way to test iframes via Cypress (and Jest would be right out for multiple reasons). Since EUI iframe usage is a bit of an edge case and the core behavior should theoretically be managed by `react-focus-on`, not us, I'm opting to skip writing a test for this 🤷 
    - If we absolutely had to, I think I'd personally suggest writing an actual E2E (not Cypress) smoke test for a CodeSandbox demo.
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately