### PR TITLE
[EuiCombobox]: Added a rule to reset margin on compressed plain text pills.

### DIFF
--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -18,7 +18,7 @@
   }
 
   .euiComboBox--compressed &--plainText {
-    margin: $euiSizeXS $euiSizeXS 0 0;
+    margin-top: $euiSizeXS;
   }
 
   &--plainText {

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -17,6 +17,10 @@
     margin: ($euiSizeXS + 1px) $euiSizeXS 0 0;
   }
 
+  .euiComboBox--compressed &--plainText {
+    margin: $euiSizeXS $euiSizeXS 0 0;
+  }
+
   &--plainText {
     @include euiFont;
     @include euiTextTruncate;

--- a/upcoming_changelogs/6910.md
+++ b/upcoming_changelogs/6910.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed `EuiCombobox` compressed plain text pill display
+- Fixed `EuiCombobox` compressed plain text display

--- a/upcoming_changelogs/6910.md
+++ b/upcoming_changelogs/6910.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiCombobox` compressed plain text pill display


### PR DESCRIPTION
## Summary
@andreadelrio identified a bug where the compressed `EuiCombox` plain text pills were not aligned vertically. I added a rule to target these pills specifically and adjust the vertical margin.

PR closes #6899. 

## QA
<img width="737" alt="Screen Shot 2023-07-06 at 12 05 32 PM" src="https://github.com/elastic/eui/assets/934879/9a293282-ee5e-436c-894f-98e9190af432">

---
<img width="699" alt="Screen Shot 2023-07-06 at 12 05 26 PM" src="https://github.com/elastic/eui/assets/934879/9725baff-5f46-43fe-8eff-af4515a3489b">



### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
- [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~~
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] ~~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~~
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
