### PR TITLE
[Emotion] Add Emotion theming support

### DIFF
--- a/src-docs/src/views/theme/consuming_emotion_theme.tsx
+++ b/src-docs/src/views/theme/consuming_emotion_theme.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ThemeProvider, css } from '@emotion/react';
+import { EuiIcon, EuiText } from '../../../../src';
+
+export default () => {
+  return (
+    <EuiText>
+      <p
+        css={({ euiTheme }) => css`
+          background-color: ${euiTheme.colors.lightestShade};
+          padding: ${euiTheme.size.l};
+        `}
+      >
+        <EuiIcon
+          type="faceHappy"
+          // The current `colorMode` is also available in the passed Emotion theme
+          // which may be useful for certain conditional styles
+          css={({ euiTheme, colorMode }) => ({
+            color:
+              colorMode === 'LIGHT'
+                ? euiTheme.colors.primary
+                : euiTheme.colors.accent,
+          })}
+        />{' '}
+        This box sets its icon color, background color, and padding via Emotion
+        theme context
+      </p>
+
+      <ThemeProvider
+        theme={{
+          // @ts-ignore - if providing your own Emotion theme, create your own emotion.d.ts - see https://emotion.sh/docs/typescript#define-a-theme
+          brandColor: 'pink',
+          backgroundColor: 'black',
+          padding: '1rem',
+        }}
+      >
+        <p
+          css={(theme: any) => css`
+            color: ${theme.brandColor};
+            background-color: ${theme.backgroundColor};
+            padding: ${theme.padding};
+          `}
+        >
+          This box sets its own Emotion ThemeProvider and theme variables
+        </p>
+      </ThemeProvider>
+    </EuiText>
+  );
+};

--- a/src-docs/src/views/theme/theme_example.js
+++ b/src-docs/src/views/theme/theme_example.js
@@ -12,6 +12,9 @@ const consumingSource = require('!!raw-loader!./consuming');
 import { ConsumingHOC } from './consuming_hoc';
 const consumingHOCSource = require('!!raw-loader!./consuming_hoc');
 
+import ConsumingEmotionTheme from './consuming_emotion_theme';
+const consumingEmotionThemeSource = require('!!raw-loader!./consuming_emotion_theme');
+
 import OverrideSimple from './override_simple';
 const overrideSimpleSource = require('!!raw-loader!./override_simple');
 
@@ -153,6 +156,36 @@ export const ThemeExample = {
         </>
       ),
       demo: <ConsumingHOC />,
+    },
+    {
+      title: "Consuming with Emotion's theming",
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: consumingEmotionThemeSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            <strong>EuiThemeProvider</strong> by default sets an{' '}
+            <EuiLink href="https://emotion.sh/docs/theming" target="_blank">
+              Emotion theme context
+            </EuiLink>{' '}
+            with the results of <strong>useEuiTheme()</strong>. This is a
+            syntactical sugar convenience that allows you to take advantage of
+            Emotion's <EuiCode>styled</EuiCode> syntax, or use a function in the{' '}
+            <EuiCode>css</EuiCode> prop.
+          </p>
+          <p>
+            If you prefer to use or access your own custom Emotion theme, you
+            can completely override EUI's passed theme at any time with your own{' '}
+            <EuiCode>ThemeProvider</EuiCode> - see the second box below for an
+            example.
+          </p>
+        </>
+      ),
+      demo: <ConsumingEmotionTheme />,
     },
     {
       title: 'Simple instance overrides',

--- a/src/custom_typings/emotion.d.ts
+++ b/src/custom_typings/emotion.d.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import '@emotion/react';
+import { UseEuiTheme } from '../services/theme';
+
+/**
+ * @see https://emotion.sh/docs/typescript#define-a-theme
+ */
+declare module '@emotion/react' {
+  export interface Theme extends UseEuiTheme {}
+}

--- a/src/services/theme/emotion.test.tsx
+++ b/src/services/theme/emotion.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { ThemeProvider } from '@emotion/react';
+import { render } from '../../test/rtl';
+
+import { EuiTextColor } from '../../components/text';
+import { EuiEmotionThemeProvider } from './emotion';
+
+describe('EuiEmotionThemeProvider', () => {
+  it("allows consumers to use Emotion's theme context by default", () => {
+    const { container, getByTestSubject } = render(
+      <EuiEmotionThemeProvider>
+        <div
+          css={({ euiTheme }) => ({ color: euiTheme.colors.primary })}
+          data-test-subj="consumer"
+        >
+          hello world
+        </div>
+      </EuiEmotionThemeProvider>
+    );
+
+    expect(getByTestSubject('consumer')).toHaveStyleRule('color', '#07C');
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="css-cs4x42"
+        data-test-subj="consumer"
+      >
+        hello world
+      </div>
+    `);
+  });
+
+  it("allows consumers to override EUI's ThemeProvider with their own theme", () => {
+    const customTheme = {
+      brandColor: 'pink',
+    };
+
+    const { container, getByTestSubject } = render(
+      <EuiEmotionThemeProvider>
+        {/* @ts-ignore - consumers would set their own emotion.d.ts */}
+        <ThemeProvider theme={customTheme}>
+          <div
+            css={(theme: any) => ({ color: theme.brandColor })}
+            data-test-subj="consumer"
+          >
+            hello
+          </div>
+          {/* Custom Emotion themes should not break EUI's own Emotion styles */}
+          <EuiTextColor color="accent" data-test-subj="eui">
+            world
+          </EuiTextColor>
+        </ThemeProvider>
+      </EuiEmotionThemeProvider>
+    );
+
+    expect(getByTestSubject('consumer')).toHaveStyleRule('color', 'pink');
+    expect(getByTestSubject('eui')).toHaveStyleRule('color', '#ba3d76');
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="css-18ry2co"
+          data-test-subj="consumer"
+        >
+          hello
+        </div>
+        <span
+          class="emotion-euiTextColor-accent"
+          data-test-subj="eui"
+        >
+          world
+        </span>
+      </div>
+    `);
+  });
+});

--- a/src/services/theme/emotion.tsx
+++ b/src/services/theme/emotion.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+import { ThemeProvider } from '@emotion/react';
+
+import { useEuiTheme } from './hooks';
+
+/**
+ * @see https://emotion.sh/docs/theming
+ */
+export const EuiEmotionThemeProvider: FunctionComponent<
+  PropsWithChildren<{}>
+> = ({ children }) => {
+  const euiThemeContext = useEuiTheme();
+  return <ThemeProvider theme={euiThemeContext}>{children}</ThemeProvider>;
+};

--- a/src/services/theme/emotion.tsx
+++ b/src/services/theme/emotion.tsx
@@ -13,6 +13,12 @@ import { useEuiTheme } from './hooks';
 
 /**
  * @see https://emotion.sh/docs/theming
+ * This Emotion theme provider is added for *consumer usage* & convenience only.
+ *
+ * EUI itself should stick to using our own context/`useEuiTheme` internally
+ * instead of Emotion's shorthand `css={theme => {}}` API. This is in case
+ * consumers to set their own theme via <ThemeProvider>; EUI's styles should
+ * continue working as-is.
  */
 export const EuiEmotionThemeProvider: FunctionComponent<
   PropsWithChildren<{}>

--- a/src/services/theme/emotion.tsx
+++ b/src/services/theme/emotion.tsx
@@ -15,10 +15,10 @@ import { useEuiTheme } from './hooks';
  * @see https://emotion.sh/docs/theming
  * This Emotion theme provider is added for *consumer usage* & convenience only.
  *
- * EUI itself should stick to using our own context/`useEuiTheme` internally
- * instead of Emotion's shorthand `css={theme => {}}` API. This is in case
- * consumers to set their own theme via <ThemeProvider>; EUI's styles should
- * continue working as-is.
+ * EUI should stick to using our own context/`useEuiTheme` internally
+ * instead of Emotion's shorthand `css={theme => {}}` API. If consumers
+ * set their own theme via <ThemeProvider>; EUI's styles should continue
+ * working as-is.
  */
 export const EuiEmotionThemeProvider: FunctionComponent<
   PropsWithChildren<{}>

--- a/src/services/theme/hooks.test.tsx
+++ b/src/services/theme/hooks.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { render } from '@testing-library/react';
 
-import { setEuiDevProviderWarning } from './provider';
+import { setEuiDevProviderWarning } from './warning';
 import {
   useEuiTheme,
   UseEuiTheme,

--- a/src/services/theme/hooks.tsx
+++ b/src/services/theme/hooks.tsx
@@ -14,7 +14,7 @@ import {
   EuiColorModeContext,
   defaultComputedTheme,
 } from './context';
-import { getEuiDevProviderWarning } from './provider';
+import { getEuiDevProviderWarning } from './warning';
 import {
   EuiThemeColorModeStandard,
   EuiThemeModifications,

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -16,11 +16,8 @@ export {
 export type { UseEuiTheme, WithEuiThemeProps } from './hooks';
 export { useEuiTheme, withEuiTheme, RenderWithEuiTheme } from './hooks';
 export type { EuiThemeProviderProps } from './provider';
-export {
-  EuiThemeProvider,
-  getEuiDevProviderWarning,
-  setEuiDevProviderWarning,
-} from './provider';
+export { EuiThemeProvider } from './provider';
+export { getEuiDevProviderWarning, setEuiDevProviderWarning } from './warning';
 export {
   buildTheme,
   computed,

--- a/src/services/theme/provider.tsx
+++ b/src/services/theme/provider.tsx
@@ -28,6 +28,7 @@ import {
   EuiModificationsContext,
   EuiColorModeContext,
 } from './context';
+import { EuiEmotionThemeProvider } from './emotion';
 import { buildTheme, getColorMode, getComputed, mergeDeep } from './utils';
 import {
   EuiThemeColorMode,
@@ -184,7 +185,9 @@ export const EuiThemeProvider = <T extends {} = {}>({
         <EuiModificationsContext.Provider value={modifications}>
           <EuiThemeContext.Provider value={theme}>
             <EuiNestedThemeContext.Provider value={nestedThemeContext}>
-              {renderedChildren}
+              <EuiEmotionThemeProvider>
+                {renderedChildren}
+              </EuiEmotionThemeProvider>
             </EuiNestedThemeContext.Provider>
           </EuiThemeContext.Provider>
         </EuiModificationsContext.Provider>

--- a/src/services/theme/provider.tsx
+++ b/src/services/theme/provider.tsx
@@ -36,12 +36,6 @@ import {
   EuiThemeModifications,
 } from './types';
 
-type LEVELS = 'log' | 'warn' | 'error';
-let providerWarning: LEVELS | undefined = undefined;
-export const setEuiDevProviderWarning = (level: LEVELS | undefined) =>
-  (providerWarning = level);
-export const getEuiDevProviderWarning = () => providerWarning;
-
 export interface EuiThemeProviderProps<T> {
   theme?: EuiThemeSystem<T>;
   colorMode?: EuiThemeColorMode;

--- a/src/services/theme/warning.ts
+++ b/src/services/theme/warning.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+type LEVELS = 'log' | 'warn' | 'error';
+
+let providerWarning: LEVELS | undefined = undefined;
+
+export const setEuiDevProviderWarning = (level: LEVELS | undefined) =>
+  (providerWarning = level);
+
+export const getEuiDevProviderWarning = () => providerWarning;

--- a/upcoming_changelogs/6913.md
+++ b/upcoming_changelogs/6913.md
@@ -1,0 +1,2 @@
+- Updated `EuiThemeProvider` to set an Emotion theme context that returns the values of `useEuiTheme()`
+

--- a/wiki/contributing-to-eui/developing/writing-styles-with-emotion.md
+++ b/wiki/contributing-to-eui/developing/writing-styles-with-emotion.md
@@ -545,3 +545,11 @@ Emotion provides its own `createElement` function; existing uses of `import {cre
 Unfortunately, a limitation of the CSS-in-JS syntax parser we're using is that `//` comments throw this error (see https://github.com/hudochenkov/postcss-styled-syntax#known-issues).
 
 You must convert all `//` comments to standard CSS `/* */` comments instead.
+
+### Should I use Emotion's `css={theme => {}}` API?
+
+No. The [Emotion theme context](https://emotion.sh/docs/theming) that we include by default in `EuiThemeProvider` is intended for **consumer usage** and convenience, particularly with the goal of making adoption by Kibana devs easier.
+
+It is not intended for internal EUI usage, primarily because it can be too easily overridden by consumers who want to use their own custom Emotion theme vars and set their own `<ThemeProvider>`. If this happens, and we're relying on Emotion's theme context, all of EUI's styles will break.
+
+When you're styling EUI components internally, you should use only EUI's theme context/`useEuiTheme()`, and not on Emotion's theme context (i.e., do not use the `css={theme => {}}` API).


### PR DESCRIPTION
## Summary

See https://emotion.sh/docs/theming

This work will support:

- Consumers who are used to `styled.` CSS-in-JS syntax, particularly the ability to use `(props) => props.theme.var` (which Kibana has multiple uses of across their codebase)
- Consumers who want to use the `css={}` prop without needing to import or call `useEuiTheme()` separately, e.g. `css={theme => ({ color: theme.euiTheme.colors.primary })`

<details><summary>Resolved questions</summary>

**Questions resolved in comment below: https://github.com/elastic/eui/pull/6913#issuecomment-1626384082**

Questions to answer:

- It's not clear to me why Greg/Caroline never mentioned Emotion theming or made use of Emotion's `ThemeProvider` before this. Was it intentional to avoid conflicts with other Emotion themes? Did they simply just not realize it was an option?
  - I went digging through our issues/discussions as well as the old weekly sync docs for CSS-in-JS, and found literally no mention of Emotion's `ThemeProvider` by Greg or Caroline :(
  - The only relevant discussion I found was https://github.com/elastic/eui/discussions/5351, opened by a non-EUI dev
- **Should we consider updating all current instances of EUI to make use of this new API?**
  - The slightly nicer syntactical sugar is probably the primary benefit? 🤷 
- The one major downside I see to this is that consumers who use other Emotion themes other than EUI's may prefer to use their own `theme` prop and not use ours 🤷 
  - Should we add in some sort of configuration that allows turning off `EuiEmotionThemeProvider` to support consumers using their own emotion `ThemeProvider`?
  - CAVEAT: If we switch EUI's own CSS-in-JS Emotion to use the new Emotion theme context, and we also allow turning off the theme wrapper, we break our own styles
  - THOUGHT: We're passing the full `{ euiTheme, colorMode, modify }` obj to Emotion's `theme` prop so in theory consumers could add their own custom theme vars to `modify` instead. Or alternatively, they can "override" Emotion's theme with `<EuiThemeProvider><ThemeProvider theme={consumerTheme}>`.... ooh, but then we run into shenanigans where EUI can potentially no longer trust Emotion's context to have the theme vars we need for EUI's components.
</details>

## QA

- Go to https://eui.elastic.co/pr_6913/#/theming/theme-provider#consuming-with-emotions-theming to see the working CSS output
- Toggle between light and dark mode to see working conditional CSS (in first box, not second)

### General checklist

- [x] Checked in both **light and dark** modes
- ~[ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
   - This is not configurable by prop, although we could expand `EuiThemeProvider` to be if necessary / if people request it in the future
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **breaking changes** and labeled appropriately
    - This could technically be considered a breaking change, but I'm going to mark it as just a feature for now, unless folks think otherwise
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~