### PR TITLE
[EuiProvider] Set up `componentDefaults` prop, context, & documentation

### DIFF
--- a/src-docs/src/components/guide_page/_guide_page.scss
+++ b/src-docs/src/components/guide_page/_guide_page.scss
@@ -42,12 +42,9 @@
   }
 
   .guideSideNav__itemBadge {
-    margin-inline: $euiSizeXS;
-  }
-
-  // Shift the margin on the badge when selected and the dropdown arrow no longer shows
-  .euiSideNavItemButton-isSelected .guideSideNav__itemBadge {
-    margin-right: 0;
+    margin-inline-start: $euiSizeXS;
+    // Decrease distance from right side to allow for longer titles and sub-items
+    margin-inline-end: -$euiSizeS;
   }
 }
 

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -41,6 +41,24 @@ export class GuidePageChrome extends Component {
     });
   };
 
+  renderSideNavBadge = ({ isBeta, isNew }) => {
+    if (isBeta) {
+      return (
+        <EuiBadge color="warning" className="guideSideNav__itemBadge">
+          BETA
+        </EuiBadge>
+      );
+    }
+    if (isNew) {
+      return (
+        <EuiBadge color="accent" className="guideSideNav__itemBadge">
+          NEW
+        </EuiBadge>
+      );
+    }
+    return undefined;
+  };
+
   scrollNavSectionIntoView = () => {
     // wait a bit for react to blow away and re-create the DOM
     // then scroll the selected nav section into view
@@ -80,7 +98,7 @@ export class GuidePageChrome extends Component {
       return;
     }
 
-    return subSectionsWithTitles.map(({ title, sections }) => {
+    return subSectionsWithTitles.map(({ title, isBeta, isNew, sections }) => {
       const id = slugify(title);
 
       const subSectionHref = `${href}/${id}`;
@@ -115,6 +133,7 @@ export class GuidePageChrome extends Component {
           : '',
         items: subItems,
         forceOpen: !!searchTerm || isCurrentlyOpenSubSection,
+        icon: this.renderSideNavBadge({ isBeta, isNew }),
       };
     });
   };
@@ -146,16 +165,6 @@ export class GuidePageChrome extends Component {
 
         const href = `#/${path}`;
 
-        const badge = isBeta ? (
-          <EuiBadge color="warning" className="guideSideNav__itemBadge">
-            BETA
-          </EuiBadge>
-        ) : isNew ? (
-          <EuiBadge color="accent" className="guideSideNav__itemBadge">
-            NEW
-          </EuiBadge>
-        ) : undefined;
-
         let visibleName = name;
         if (searchTerm) {
           visibleName = (
@@ -176,7 +185,7 @@ export class GuidePageChrome extends Component {
           isSelected: item.path === this.props.currentRoute.path,
           forceOpen: !!(searchTerm && hasMatchingSubItem),
           className: 'guideSideNav__item',
-          icon: badge,
+          icon: this.renderSideNavBadge({ isBeta, isNew }),
         };
       });
 

--- a/src-docs/src/components/guide_section/guide_section.tsx
+++ b/src-docs/src/components/guide_section/guide_section.tsx
@@ -35,6 +35,8 @@ export interface GuideSectionProps
     > {
   id?: string;
   title?: string;
+  isBeta?: boolean;
+  isNew?: boolean;
   text?: ReactNode;
   source?: any[];
   demo?: ReactNode;
@@ -83,6 +85,8 @@ export const GuideSectionCodeTypesMap = {
 export const GuideSection: FunctionComponent<GuideSectionProps> = ({
   id,
   title,
+  isBeta,
+  isNew,
   text,
   demo,
   fullScreen,
@@ -210,7 +214,13 @@ export const GuideSection: FunctionComponent<GuideSectionProps> = ({
       className={classNames('guideSection', className)}
     >
       <EuiSpacer size={(color || title) && isLargeBreakpoint ? 'xxl' : 'xs'} />
-      <GuideSectionExampleText title={title} id={id} wrapText={wrapText}>
+      <GuideSectionExampleText
+        title={title}
+        id={id}
+        isBeta={isBeta}
+        isNew={isNew}
+        wrapText={wrapText}
+      >
         {text}
       </GuideSectionExampleText>
 

--- a/src-docs/src/components/guide_section/guide_section_parts/guide_section_text.tsx
+++ b/src-docs/src/components/guide_section/guide_section_parts/guide_section_text.tsx
@@ -1,27 +1,40 @@
 import React, { FunctionComponent, ReactNode } from 'react';
-import { EuiSpacer } from '../../../../../src/components/spacer';
-import { EuiTitle } from '../../../../../src/components/title';
-import { EuiText } from '../../../../../src/components/text';
+
+import {
+  EuiSpacer,
+  EuiTitle,
+  EuiText,
+  EuiBetaBadge,
+} from '../../../../../src/components';
 
 export const LANGUAGES = ['javascript', 'html'] as const;
 
 type GuideSectionExampleText = {
   title?: ReactNode;
   id?: string;
+  isBeta?: boolean;
+  isNew?: boolean;
   children?: ReactNode;
   wrapText?: boolean;
 };
 
 export const GuideSectionExampleText: FunctionComponent<
   GuideSectionExampleText
-> = ({ title, id, children, wrapText = true }) => {
+> = ({ title, id, isBeta, isNew, children, wrapText = true }) => {
   let titleNode;
 
   if (title) {
+    const badge = (isBeta || isNew) && (
+      <EuiBetaBadge label={isBeta ? 'Beta' : 'New'} color="accent" size="s" />
+    );
+
     titleNode = (
       <>
         <EuiTitle>
-          <h2 id={id}>{title}</h2>
+          <h2 id={id}>
+            {title}
+            {badge && <>&emsp;{badge}</>}
+          </h2>
         </EuiTitle>
         <EuiSpacer size="m" />
       </>

--- a/src-docs/src/views/guidelines/getting_started/getting_started.js
+++ b/src-docs/src/views/guidelines/getting_started/getting_started.js
@@ -7,6 +7,7 @@ import { AppSetup } from './_app_setup';
 import { Tokens } from './_tokens';
 import { Customizing } from './_customizing';
 import { ThemeNotice } from '../../../views/theme/_components/_theme_notice.tsx';
+import { euiProviderComponentDefaultsSnippet } from '../../provider/provider_component_defaults';
 
 export const GettingStarted = {
   title: 'Getting started',
@@ -264,6 +265,30 @@ import { findByTestSubject, render, screen } from '@elastic/eui/lib/test/rtl'; /
           <p>Renders as:</p>
           <EuiCodeBlock language="html" isCopyable fontSize="m">
             {'<button class="euiButton myCustomClass__button" />'}
+          </EuiCodeBlock>
+        </>
+      ),
+    },
+    {
+      title: 'Customizing component defaults',
+      wrapText: false,
+      text: (
+        <>
+          <EuiText grow={false}>
+            <p>
+              While all props can be individually customized via props, some
+              components can have their default props customized globally via{' '}
+              <strong>EuiProvider's</strong>{' '}
+              <EuiCode>componentDefaults</EuiCode> API.{' '}
+              <Link to="/utilities/provider#component-defaults">
+                Read more in EuiProvider's documentation
+              </Link>
+              .
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiCodeBlock language="jsx" isCopyable fontSize="m">
+            {euiProviderComponentDefaultsSnippet}
           </EuiCodeBlock>
         </>
       ),

--- a/src-docs/src/views/provider/provider_component_defaults.tsx
+++ b/src-docs/src/views/provider/provider_component_defaults.tsx
@@ -1,0 +1,22 @@
+import React, { FunctionComponent } from 'react';
+
+import { EuiComponentDefaults } from '../../../../src/components/provider/component_defaults';
+
+// Used to generate a "component" that is parsed for its types
+// and used to generate a prop table
+export const EuiComponentDefaultsProps: FunctionComponent<
+  EuiComponentDefaults
+> = () => <></>;
+
+// Used by both getting started and EuiProvider component documentation pages
+// Exported in one place for DRYness
+export const euiProviderComponentDefaultsSnippet = `<EuiProvider
+  componentDefaults={{
+    EuiTablePagination: { itemsPerPage: 20, },
+    EuiFocusTrap: { crossFrame: true },
+    EuiPortal: { insert },
+  }}
+>
+  <App />
+</EuiProvider>
+`;

--- a/src-docs/src/views/provider/provider_example.js
+++ b/src-docs/src/views/provider/provider_example.js
@@ -139,6 +139,7 @@ export const ProviderExample = {
     },
     {
       title: 'Component defaults',
+      isBeta: true,
       text: (
         <EuiText>
           <EuiCallOut title="Beta status" iconType="beta">

--- a/src-docs/src/views/provider/provider_example.js
+++ b/src-docs/src/views/provider/provider_example.js
@@ -8,12 +8,17 @@ import {
   EuiCodeBlock,
   EuiLink,
   EuiSpacer,
+  EuiCallOut,
 } from '../../../../src/components';
 
 import { GuideSectionPropsTable } from '../../components/guide_section/guide_section_parts/guide_section_props_table';
 
 import Setup from './provider_setup';
 import GlobalStyles from './provider_styles';
+import {
+  EuiComponentDefaultsProps,
+  euiProviderComponentDefaultsSnippet,
+} from './provider_component_defaults';
 
 export const ProviderExample = {
   title: 'Provider',
@@ -21,8 +26,7 @@ export const ProviderExample = {
     <EuiText>
       <p>
         <strong>EuiProvider</strong> contains all necessary context providers
-        required for full functionality and styling of EUI. It currently
-        includes the{' '}
+        required for full functionality and styling of EUI. It includes{' '}
         <Link to="/theming/theme-provider">
           <strong>EuiThemeProvider</strong>
         </Link>{' '}
@@ -130,6 +134,65 @@ export const ProviderExample = {
             library, so you will need to add it to your application
             dependencies.
           </p>
+        </EuiText>
+      ),
+    },
+    {
+      title: 'Component defaults',
+      text: (
+        <EuiText>
+          <EuiCallOut title="Beta status" iconType="beta">
+            <p>
+              This functionality is still currently in beta, and the list of
+              components as well as defaults that EUI will be supporting is
+              still under consideration. If you have a component you would like
+              to see added, feel free to{' '}
+              <EuiLink
+                href="https://github.com/elastic/eui/discussions/6922"
+                target="_blank"
+              >
+                discuss that request in EUI's GitHub repo
+              </EuiLink>
+              .
+            </p>
+          </EuiCallOut>
+          <EuiSpacer />
+
+          <p>
+            All EUI components ship with a set of baseline defaults that can
+            usually be configured via props. For example,{' '}
+            <Link to="/utilities/focus-trap">
+              <strong>EuiFocusTrap</strong>
+            </Link>{' '}
+            defaults to <EuiCode>crossFrame={'{false}'}</EuiCode> - i.e., it
+            does not trap focus between iframes. If you wanted to change that
+            behavior in your app across all instances of{' '}
+            <strong>EuiFocusTrap</strong>, you would be stuck manually passing
+            that prop over and over again, including in higher-level components
+            (like modals, popovers, and flyouts) that utilize focus traps.
+          </p>
+          <p>
+            <strong>EuiProvider</strong> allows overriding some component
+            defaults across all component usages globally via the{' '}
+            <EuiCode>componentDefaults</EuiCode> prop like so:
+          </p>
+
+          <EuiCodeBlock language="jsx" isCopyable fontSize="m">
+            {euiProviderComponentDefaultsSnippet}
+          </EuiCodeBlock>
+
+          <p>
+            The above example would override EUI's default table pagination size
+            (50) across all usages of EUI tables and data grids, all EUI focus
+            traps would trap focus even from iframes, and all EUI portals would
+            be inserted at a specified position (instead of the end of the
+            document body).
+          </p>
+          <p>
+            The current list of supported components and the prop defaults they
+            accept are:
+          </p>
+          <GuideSectionPropsTable component={EuiComponentDefaultsProps} />
         </EuiText>
       ),
     },

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -37,7 +37,14 @@ export interface EuiPortalProps {
    * ReactNode to render as this component's content
    */
   children: ReactNode;
+  /**
+   * If not specified, `EuiPortal` will insert itself
+   * into the end of the `document.body` by default
+   */
   insert?: { sibling: HTMLElement; position: 'before' | 'after' };
+  /**
+   * Optional ref callback
+   */
   portalRef?: (ref: HTMLDivElement | null) => void;
 }
 

--- a/src/components/provider/component_defaults/component_defaults.test.tsx
+++ b/src/components/provider/component_defaults/component_defaults.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import {
+  EuiComponentDefaultsProvider,
+  useEuiComponentDefaults,
+} from './component_defaults';
+
+describe('EuiComponentDefaultsProvider', () => {
+  it('sets up context that allows accessing the passed `componentDefaults` from anywhere', () => {
+    const wrapper = ({ children }: PropsWithChildren<{}>) => (
+      <EuiComponentDefaultsProvider
+        componentDefaults={{
+          EuiPortal: {
+            insert: {
+              sibling: document.createElement('div'),
+              position: 'before',
+            },
+          },
+        }}
+      >
+        {children}
+      </EuiComponentDefaultsProvider>
+    );
+    const { result } = renderHook(useEuiComponentDefaults, { wrapper });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "EuiPortal": Object {
+          "insert": Object {
+            "position": "before",
+            "sibling": <div />,
+          },
+        },
+      }
+    `);
+  });
+
+  // NOTE: Components are in charge of their own testing to ensure that the props
+  // coming from `useEuiComponentDefaults()` were properly applied. This file
+  // is simply a very light wrapper that carries prop data.
+});

--- a/src/components/provider/component_defaults/component_defaults.tsx
+++ b/src/components/provider/component_defaults/component_defaults.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { createContext, useContext, FunctionComponent } from 'react';
+
+import { EuiPortalProps } from '../../portal';
+
+export type EuiComponentDefaults = {
+  /**
+   * Provide a global setting for EuiPortal's default insertion position.
+   */
+  EuiPortal?: { insert: EuiPortalProps['insert'] };
+  /**
+   * TODO
+   */
+  EuiFocusTrap?: unknown;
+  /**
+   * TODO
+   */
+  EuiPagination?: unknown;
+};
+
+// Declaring as a static const for reference integrity/reducing rerenders
+const emptyDefaults = {};
+
+/*
+ * Context
+ */
+export const EuiComponentDefaultsContext =
+  createContext<EuiComponentDefaults>(emptyDefaults);
+
+/*
+ * Component
+ */
+export const EuiComponentDefaultsProvider: FunctionComponent<{
+  componentDefaults?: EuiComponentDefaults;
+}> = ({ componentDefaults = emptyDefaults, children }) => {
+  return (
+    <EuiComponentDefaultsContext.Provider value={componentDefaults}>
+      {children}
+    </EuiComponentDefaultsContext.Provider>
+  );
+};
+
+/*
+ * Hook
+ */
+export const useEuiComponentDefaults = () => {
+  return useContext(EuiComponentDefaultsContext);
+};

--- a/src/components/provider/component_defaults/index.ts
+++ b/src/components/provider/component_defaults/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export * from './component_defaults';

--- a/upcoming_changelogs/6923.md
+++ b/upcoming_changelogs/6923.md
@@ -1,0 +1,1 @@
+- Added beta `componentDefaults` prop to `EuiProvider`, which will allow configuring certain default props globally. This list of components and defaults is still under consideration.


### PR DESCRIPTION
⚠️ Please be aware this work is merging into a **feature branch** (in order to avoid non-valid documentation in main). This initial PR sets up some basic infrastructure and initial documentation, but the actual behavior is not yet wired up (i.e., will not work as promised in the docs example). I'm planning on opening individual PRs for each component that we plan to support defaults for initially (at least portals, pagination, and focus trap as a bonus).

## Summary

<img width="1503" alt="" src="https://github.com/elastic/eui/assets/549407/51743347-0a81-40e5-9fc1-f49d61ed4985">

This PR sets up the prop, context, and documentation for an `<EuiProvider componentDefaults={}>` API that be used so that certain components (to be discussed) can have various settings configured at a global level instead of needing to be set on every instance.

I recommend following along [by commit](https://github.com/elastic/eui/pull/6923/commits) for review, as the last commit adds some nice-to-have (but not required) logic for adding badges to sub-sections of pages.

## QA

- Go to https://eui.elastic.co/pr_6923/#/guidelines/getting-started#customizing-component-defaults and confirm the copy and link make sense to you
- Go to https://eui.elastic.co/pr_6923/#/utilities/provider#component-defaults and confirm the copy and documentation make sense to you as a developer

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
