### PR TITLE
[EuiResizableCollapseButton] Fix icon colors

### DIFF
--- a/src/components/resizable_container/_resizable_collapse_button.scss
+++ b/src/components/resizable_container/_resizable_collapse_button.scss
@@ -16,6 +16,7 @@
   animation: none !important; // stylelint-disable-line declaration-no-important
   // Remove transition from EuiButtonIcon because of the custom transforms
   transition-property: background, box-shadow;
+  background: $euiColorEmptyShade;
 
   &:focus {
     @include euiSlightShadowHover;

--- a/src/components/resizable_container/resizable_collapse_button.tsx
+++ b/src/components/resizable_container/resizable_collapse_button.tsx
@@ -80,8 +80,8 @@ export const EuiResizableCollapseButton: FunctionComponent<
 
   return (
     <EuiButtonIcon
-      display={isCollapsed ? 'empty' : 'fill'}
-      color={isCollapsed ? 'text' : 'ghost'}
+      display={isCollapsed ? 'empty' : 'base'}
+      color="text"
       {...rest}
       className={classes}
       iconType={isCollapsed ? COLLAPSED_ICON : NOT_COLLAPSED_ICON}

--- a/upcoming_changelogs/6926.md
+++ b/upcoming_changelogs/6926.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed visual appearance of collapse buttons on collapsible `EuiResizablePanel`s
+


### PR DESCRIPTION
## Summary

I randomly noticed this while answering a support question today - the icon colors on `EuiResizablePanel`'s collapse button are incorrect after `EuiButtonIcon`'s Emotion conversion. 😬 

Assigning this PR to either Andrea (showing as last person who touched the component), or anyone on the EUI team, whoever gets to this first.

### [Pre-Emotion](https://eui.elastic.co/v60.0.0/#/layout/resizable-container#collapsible-resizable-panels)
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/9ee8c536-9964-4ae6-875f-ce842fed5a07">

### [Post-Emotion](https://eui.elastic.co/v83.1.0/#/layout/resizable-container#collapsible-resizable-panels)
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/ff5bb7c9-6e2e-4a33-9c04-337337ae18aa">

### [Fixed](https://eui.elastic.co/pr_6926/#/layout/resizable-container#collapsible-resizable-panels)
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/34e5a0ec-4e47-4460-a0cc-97cdd5a131d6">

## QA

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
