### PR TITLE
build: log CURRENT_RELEASE and GIT_BRANCH in deploy_docs script

### DIFF
--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -118,6 +118,9 @@ else
     max_age="604800"
     publish_to_bucket
 
+    echo "Current release: $CURRENT_RELEASE"
+    echo "Git branch: $GIT_BRANCH"
+
     # if this is the highest release number to date, also publish the docs to the
     # root directory
     if [[ "v$CURRENT_RELEASE" == "$GIT_BRANCH" ]]; then


### PR DESCRIPTION
## Summary

Our Jenkins deployment job seems to be working differently than before and we can't figure out the exact reason why. This PR prints CURRENT_RELEASE and GIT_BRANCH environment variables that'll allow us understand where the issue is coming from.

## QA

Note: **do not run the `deploy_docs` script locally**, especially if you're authenticated with Google Cloud.

1. Check the updated code and make sure there are no syntax errors