### PR TITLE
[EuiTab] Fix prepend/append elements not inheriting selected colors + misc CSS cleanup

### DIFF
--- a/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -337,7 +337,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
               type="button"
             >
               <span
-                class="euiTab__content emotion-euiTab__content-l-selected"
+                class="euiTab__content emotion-euiTab__content-l"
               >
                 Tab 1
               </span>

--- a/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -297,7 +297,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
             type="button"
           >
             <span
-              class="euiTab__content emotion-euiTab__content-l-selected"
+              class="euiTab__content emotion-euiTab__content-l"
             >
               Tab 1
             </span>
@@ -586,7 +586,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content emotion-euiTab__content-xl-selected"
+            class="euiTab__content emotion-euiTab__content-xl"
           >
             Tab 1
           </span>
@@ -637,7 +637,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content emotion-euiTab__content-xl-selected"
+            class="euiTab__content emotion-euiTab__content-xl"
           >
             Tab 1
           </span>

--- a/src/components/tabs/__snapshots__/tab.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tab.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`EuiTab props disabled and selected 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m-selected-disabled"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     Click Me
   </span>
@@ -45,7 +45,7 @@ exports[`EuiTab props disabled is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m-disabled"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     Click Me
   </span>
@@ -78,7 +78,7 @@ exports[`EuiTab props isSelected is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m-selected"
+    class="euiTab__content emotion-euiTab__content-m"
   >
     children
   </span>

--- a/src/components/tabs/tab.styles.ts
+++ b/src/components/tabs/tab.styles.ts
@@ -26,7 +26,6 @@ export const euiTabStyles = ({ euiTheme }: UseEuiTheme) => {
       color: ${euiTheme.colors.title};
 
       &:focus {
-        background-color: transparent;
         outline-offset: -${euiTheme.focus.width};
       }
     `,
@@ -58,10 +57,6 @@ export const euiTabContentStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     euiTab__content: css`
       font-weight: ${euiTheme.font.weight[euiTheme.font.title.weight]};
-
-      &:hover {
-        text-decoration: none;
-      }
     `,
     // sizes
     s: css`

--- a/src/components/tabs/tab.styles.ts
+++ b/src/components/tabs/tab.styles.ts
@@ -36,6 +36,7 @@ export const euiTabStyles = ({ euiTheme }: UseEuiTheme) => {
     `,
     selected: css`
       box-shadow: inset 0 -${euiTheme.border.width.thick} 0 ${euiTheme.colors.primary};
+      color: ${euiTheme.colors.primaryText};
     `,
     disabled: {
       disabled: css`

--- a/src/components/tabs/tab.styles.ts
+++ b/src/components/tabs/tab.styles.ts
@@ -7,9 +7,8 @@
  */
 
 import { css } from '@emotion/react';
-import { logicalCSS, mathWithUnits } from '../../global_styling';
+import { logicalCSS, mathWithUnits, euiFontSize } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
-import { euiTitle } from '../title/title.styles';
 
 export const euiTabStyles = ({ euiTheme }: UseEuiTheme) => {
   return {
@@ -18,10 +17,13 @@ export const euiTabStyles = ({ euiTheme }: UseEuiTheme) => {
       cursor: pointer;
       flex-direction: row;
       align-items: center;
-      font-weight: ${euiTheme.font.weight.semiBold};
       gap: ${euiTheme.size.s};
       ${logicalCSS('padding-vertical', 0)}
       ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
+
+      /* Font-weight used by append/prepend nodes - the tab title receives a heavier weight */
+      font-weight: ${euiTheme.font.weight.semiBold};
+      color: ${euiTheme.colors.title};
 
       &:focus {
         background-color: transparent;
@@ -55,39 +57,34 @@ export const euiTabContentStyles = (euiThemeContext: UseEuiTheme) => {
 
   return {
     euiTab__content: css`
+      font-weight: ${euiTheme.font.weight[euiTheme.font.title.weight]};
+
       &:hover {
         text-decoration: none;
       }
     `,
     // sizes
     s: css`
-      ${euiTitle(euiThemeContext, 'xxxs')}
+      font-size: ${euiFontSize(euiThemeContext, 'xs').fontSize};
       line-height: ${euiTheme.size.xl};
     `,
     m: css`
-      ${euiTitle(euiThemeContext, 'xxs')}
+      font-size: ${euiFontSize(euiThemeContext, 's').fontSize};
       line-height: ${euiTheme.size.xxl};
     `,
     l: css`
-      ${euiTitle(euiThemeContext, 'xs')}
+      font-size: ${euiFontSize(euiThemeContext, 'm').fontSize};
       line-height: ${mathWithUnits(
         [euiTheme.size.xl, euiTheme.size.s],
         (x, y) => x + y
       )};
     `,
     xl: css`
-      ${euiTitle(euiThemeContext, 's')}
+      font-size: ${euiFontSize(euiThemeContext, 'l').fontSize};
       line-height: ${mathWithUnits(
         [euiTheme.size.xxxl, euiTheme.size.s],
         (x, y) => x + y
       )};
-    `,
-    // variations
-    selected: css`
-      color: ${euiTheme.colors.primaryText};
-    `,
-    disabled: css`
-      color: ${euiTheme.colors.disabledText};
     `,
   };
 };

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -84,8 +84,6 @@ export const EuiTab: FunctionComponent<Props> = ({
   const cssTabContentStyles = [
     tabContentStyles.euiTab__content,
     size && tabContentStyles[size],
-    isSelected && tabContentStyles.selected,
-    disabled && tabContentStyles.disabled,
   ];
 
   const prependNode = prepend && (

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -95,7 +95,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -139,7 +139,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -199,7 +199,7 @@ exports[`EuiTabbedContent props autoFocus initial is rendered 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -259,7 +259,7 @@ exports[`EuiTabbedContent props autoFocus selected is rendered 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -339,7 +339,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -399,7 +399,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m-selected"
+        class="euiTab__content emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -439,7 +439,7 @@ exports[`EuiTabbedContent props size can be small 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-s-selected"
+        class="euiTab__content emotion-euiTab__content-s"
       >
         Elasticsearch
       </span>

--- a/upcoming_changelogs/6938.md
+++ b/upcoming_changelogs/6938.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiTab` not correctly passing selection color state to `prepend` and `append` children
+


### PR DESCRIPTION
## Summary

fixes https://github.com/elastic/eui/issues/6935

Pre-Emotion conversion (#6311), icons used within the `prepend`/`append` props of `EuiTab` correctly inherited the selected primary color (go to https://eui.elastic.co/v60.0.0/#/navigation/tabs#tabbed-content and click the hydrogen tab).

This PR correctly sets the selected text color of all children of `EuiTab`, and incidentally cleans up CSS, reducing unnecessary overrides and removing some CSS that isn't doing anything (I recommend [following along by commit](https://github.com/elastic/eui/pull/6938/commits)).

## QA

- Go to https://eui.elastic.co/pr_6938/#/navigation/tabs#tabbed-content
- Click the `Hydrogen` tab
- [x] Confirm the icon changes to blue alongside the tab text
- Regression testing
  - [x] In the first/top example on the page, confirm the disabled tab with an icon are both the same disabled color
  - [x] In the playground, confirm the different tab sizes are still the same as production

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~** - mostly just updating snapshots
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
