### PR TITLE
test: React 18 act() adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "@svgr/core": "8.0.0",
     "@svgr/plugin-jsx": "^8.0.1",
     "@svgr/plugin-svgo": "^8.0.1",
-    "@testing-library/dom": "^8.12.0",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^14.0.0",
     "@testing-library/react-16-17": "npm:@testing-library/react@^12.1.5",

--- a/src/components/accessibility/skip_link/skip_link.test.tsx
+++ b/src/components/accessibility/skip_link/skip_link.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test';
 

--- a/src/components/button/button_empty/button_empty.test.tsx
+++ b/src/components/button/button_empty/button_empty.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';

--- a/src/components/button/button_icon/button_icon.test.tsx
+++ b/src/components/button/button_icon/button_icon.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -9,7 +9,7 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { mount, render, shallow } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiCodeBlock, FONT_SIZES, PADDING_SIZES } from './code_block';

--- a/src/components/code/code_block_annotations.test.tsx
+++ b/src/components/code/code_block_annotations.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render, waitForEuiPopoverOpen } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test';

--- a/src/components/color_picker/color_picker.test.tsx
+++ b/src/components/color_picker/color_picker.test.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { render, mount } from 'enzyme';
+import { act } from '@testing-library/react';
 
 import { EuiColorPicker } from './color_picker';
 import { VISUALIZATION_COLORS, keys } from '../../services';
@@ -190,15 +191,29 @@ test('popover color selector is hidden when the ESC key pressed', async () => {
     />
   );
 
-  findTestSubject(colorPicker, 'euiColorPickerAnchor').simulate('click');
-  await sleep();
-  findTestSubject(colorPicker, 'euiColorPickerAnchor').simulate('keydown', {
-    key: keys.ENTER,
+  await act(
+    async () =>
+      await findTestSubject(colorPicker, 'euiColorPickerAnchor').simulate(
+        'click'
+      )
+  );
+
+  await act(() => sleep());
+
+  act(() => {
+    findTestSubject(colorPicker, 'euiColorPickerAnchor').simulate('keydown', {
+      key: keys.ENTER,
+    });
   });
-  await sleep();
-  findTestSubject(colorPicker, 'euiColorPickerPopover').simulate('keydown', {
-    key: keys.ESCAPE,
+
+  await act(() => sleep());
+
+  act(() => {
+    findTestSubject(colorPicker, 'euiColorPickerPopover').simulate('keydown', {
+      key: keys.ESCAPE,
+    });
   });
+
   // Portal removal not working with Jest. The blur handler is called just before the portal would be removed.
   expect(onBlurHandler).toBeCalled();
 });

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -8,6 +8,7 @@
 
 import React, { ReactNode } from 'react';
 import { shallow, render, mount } from 'enzyme';
+import { act } from '@testing-library/react';
 import {
   requiredProps,
   findTestSubject,
@@ -89,7 +90,9 @@ describe('props', () => {
       />
     );
 
-    component.setState({ isListOpen: true });
+    act(() => {
+      component.setState({ isListOpen: true });
+    });
     expect(takeMountedSnapshot(component)).toMatchSnapshot();
   });
 
@@ -282,10 +285,16 @@ describe('behavior', () => {
         />
       );
 
-      component.setState({ searchValue: 'foo' });
-      const searchInput = findTestSubject(component, 'comboBoxSearchInput');
-      searchInput.simulate('focus');
-      searchInput.simulate('keyDown', { key: comboBoxKeys.ENTER });
+      act(() => {
+        component.setState({ searchValue: 'foo' });
+      });
+
+      act(() => {
+        const searchInput = findTestSubject(component, 'comboBoxSearchInput');
+        searchInput.simulate('focus');
+        searchInput.simulate('keyDown', { key: comboBoxKeys.ENTER });
+      });
+
       expect(onCreateOptionHandler).toHaveBeenCalledTimes(1);
       expect(onCreateOptionHandler).toHaveBeenNthCalledWith(1, 'foo', options);
     });
@@ -344,15 +353,20 @@ describe('behavior', () => {
         />
       );
 
-      component.setState({ searchValue: 'foo' });
       const searchInput = findTestSubject(component, 'comboBoxSearchInput');
-      searchInput.simulate('focus');
 
-      const searchInputNode = searchInput.getDOMNode();
-      // React doesn't support `focusout` so we have to manually trigger it
-      searchInputNode.dispatchEvent(
-        new FocusEvent('focusout', { bubbles: true })
-      );
+      act(() => {
+        component.setState({ searchValue: 'foo' });
+        searchInput.simulate('focus');
+      });
+
+      act(() => {
+        const searchInputNode = searchInput.getDOMNode();
+        // React doesn't support `focusout` so we have to manually trigger it
+        searchInputNode.dispatchEvent(
+          new FocusEvent('focusout', { bubbles: true })
+        );
+      });
 
       expect(onCreateOptionHandler).toHaveBeenCalledTimes(1);
       expect(onCreateOptionHandler).toHaveBeenNthCalledWith(1, 'foo', options);

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -7,11 +7,11 @@
  */
 
 import React from 'react';
+import { act } from '@testing-library/react';
 import { render, mount } from 'enzyme';
 import { requiredProps, takeMountedSnapshot } from '../../test';
 
 import { EuiContextMenu, SIZES } from './context_menu';
-import { setTimeout } from 'timers';
 
 const panel3 = {
   id: 3,
@@ -64,9 +64,7 @@ const panel0 = {
 const panels = [panel0, panel1, panel2, panel3];
 
 export const tick = (ms = 0) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+  act(() => new Promise((resolve) => setTimeout(resolve, ms)));
 
 describe('EuiContextMenu', () => {
   test('is rendered', () => {

--- a/src/components/datagrid/body/data_grid_body_custom.test.tsx
+++ b/src/components/datagrid/body/data_grid_body_custom.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useEffect } from 'react';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 
 import { EuiDataGridProps } from '../data_grid_types';

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { act } from '@testing-library/react';
 import { mount, render, ReactWrapper } from 'enzyme';
 import { keys } from '../../../services';
 import { RowHeightUtils } from '../utils/__mocks__/row_heights';
@@ -79,7 +80,9 @@ describe('EuiDataGridCell', () => {
         }}
       />
     );
-    component.setState({ enableInteractions: true });
+    act(() => {
+      component.setState({ enableInteractions: true });
+    });
 
     const getCellActions = () => component.find('EuiDataGridCellActions');
     expect(getCellActions()).toHaveLength(1);
@@ -174,19 +177,29 @@ describe('EuiDataGridCell', () => {
 
       describe('when state changes:', () => {
         it('cellProps', () => {
-          component.setState({ cellProps: {} });
+          act(() => {
+            component.setState({ cellProps: {} });
+          });
         });
         it('isEntered', () => {
-          component.setState({ isEntered: true });
+          act(() => {
+            component.setState({ isEntered: true });
+          });
         });
         it('isFocused', () => {
-          component.setState({ isFocused: true });
+          act(() => {
+            component.setState({ isFocused: true });
+          });
         });
         it('enableInteractions', () => {
-          component.setState({ enableInteractions: true });
+          act(() => {
+            component.setState({ enableInteractions: true });
+          });
         });
         it('disableCellTabIndex', () => {
-          component.setState({ disableCellTabIndex: true });
+          act(() => {
+            component.setState({ disableCellTabIndex: true });
+          });
         });
       });
     });

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { mount } from 'enzyme';
 
 import { keys } from '../../../../services';

--- a/src/components/datagrid/body/header/header_is_interactive.test.ts
+++ b/src/components/datagrid/body/header/header_is_interactive.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { testCustomHook } from '../../../../test/internal';
 import { useHeaderIsInteractive } from './header_is_interactive';
 

--- a/src/components/datagrid/controls/column_selector.test.tsx
+++ b/src/components/datagrid/controls/column_selector.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { shallow, mount, ReactWrapper } from 'enzyme';
 import { findTestSubject, testByReactVersion } from '../../../test';
 

--- a/src/components/datagrid/controls/column_sorting.test.tsx
+++ b/src/components/datagrid/controls/column_sorting.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { mount, ReactWrapper } from 'enzyme';
 import { findTestSubject, testByReactVersion } from '../../../test';
 

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { shallow, mount, ShallowWrapper, ReactWrapper } from 'enzyme';
 import { testCustomHook } from '../../../test/internal';
 

--- a/src/components/datagrid/controls/fullscreen_selector.test.tsx
+++ b/src/components/datagrid/controls/fullscreen_selector.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { shallow } from 'enzyme';
 import { keys } from '../../../services';
 import { testCustomHook } from '../../../test/internal';

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -13,7 +13,7 @@ import { EuiDataGridProps } from './data_grid_types';
 import { findTestSubject, requiredProps } from '../../test';
 import { EuiDataGridColumnResizer } from './body/header/data_grid_column_resizer';
 import { keys } from '../../services';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 // Mock the cell popover (TODO: Move failing tests to Cypress and remove need for mock?)
 jest.mock('../popover', () => ({
@@ -91,12 +91,15 @@ function resizeColumn(
   const firstResizer = datagrid
     .find(`EuiDataGridColumnResizer[columnId="${columnId}"]`)
     .instance() as EuiDataGridColumnResizer;
-  firstResizer.onMouseDown({
-    pageX: originalWidth,
-    stopPropagation: () => {},
-    preventDefault: () => {},
-  } as React.MouseEvent<HTMLDivElement>);
-  firstResizer.onMouseMove({ pageX: columnWidth });
+
+  act(() => {
+    firstResizer.onMouseDown({
+      pageX: originalWidth,
+      stopPropagation: () => {},
+      preventDefault: () => {},
+    } as React.MouseEvent<HTMLDivElement>);
+  });
+  act(() => firstResizer.onMouseMove({ pageX: columnWidth }));
   act(() => firstResizer.onMouseUp());
 
   datagrid.update();
@@ -1171,18 +1174,25 @@ describe('EuiDataGrid', () => {
         ['2'],
       ]);
 
-      findTestSubject(component, 'tablePaginationPopoverButton').simulate(
-        'click'
+      act(() => {
+        findTestSubject(component, 'tablePaginationPopoverButton').simulate(
+          'click'
+        );
+      });
+
+      const rowButtons: NodeListOf<HTMLButtonElement> = document.body.querySelectorAll(
+        '.euiContextMenuItem'
       );
-      const rowButtons: NodeListOf<HTMLButtonElement> =
-        document.body.querySelectorAll('.euiContextMenuItem');
       expect(
         Array.prototype.map.call(
           rowButtons,
           (button: HTMLDivElement) => button.textContent || ''
         )
       ).toEqual(['3 rows', '6 rows', '10 rows']);
-      rowButtons[1].click();
+
+      act(() => {
+        rowButtons[1].click();
+      });
 
       expect(
         component.props().pagination.onChangeItemsPerPage
@@ -1240,18 +1250,22 @@ describe('EuiDataGrid', () => {
           />
         );
 
-        const originalCellWidths = extractColumnWidths(component);
-        expect(originalCellWidths).toEqual({
-          'Column 1': 100,
-          'Column 2': 100,
+        act(() => {
+          const originalCellWidths = extractColumnWidths(component);
+          expect(originalCellWidths).toEqual({
+            'Column 1': 100,
+            'Column 2': 100,
+          });
         });
 
         resizeColumn(component, 'Column 1', 150);
 
-        const updatedCellWidths = extractColumnWidths(component);
-        expect(updatedCellWidths).toEqual({
-          'Column 1': 150,
-          'Column 2': 100,
+        act(() => {
+          const updatedCellWidths = extractColumnWidths(component);
+          expect(updatedCellWidths).toEqual({
+            'Column 1': 150,
+            'Column 2': 100,
+          });
         });
       });
 
@@ -2173,9 +2187,11 @@ describe('EuiDataGrid', () => {
       expect(findTestSubject(component, 'alertAction').exists()).toBe(false);
       expect(findTestSubject(component, 'happyAction').exists()).toBe(false);
 
-      findTestSubject(component, 'dataGridRowCell').at(1).prop('onMouseEnter')!(
-        {} as React.MouseEvent
-      );
+      act(() => {
+        findTestSubject(component, 'dataGridRowCell')
+          .at(1)
+          .prop('onMouseEnter')!({} as React.MouseEvent);
+      });
 
       component.update();
 

--- a/src/components/datagrid/utils/col_widths.test.ts
+++ b/src/components/datagrid/utils/col_widths.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { testCustomHook } from '../../../test/internal';
 import {
   useDefaultColumnWidth,

--- a/src/components/datagrid/utils/focus.test.tsx
+++ b/src/components/datagrid/utils/focus.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { mount } from 'enzyme';
 import { keys } from '../../../services';
 import { testCustomHook } from '../../../test/internal';

--- a/src/components/datagrid/utils/row_heights.test.ts
+++ b/src/components/datagrid/utils/row_heights.test.ts
@@ -7,7 +7,7 @@
  */
 
 import type { MutableRefObject } from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { startingStyles } from '../controls';
 import type { ImperativeGridApi } from '../data_grid_types';

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';

--- a/src/components/delay_hide/delay_hide.test.tsx
+++ b/src/components/delay_hide/delay_hide.test.tsx
@@ -8,7 +8,11 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { act } from '@testing-library/react';
 import { EuiDelayHide } from './index';
+
+const actAdvanceTimersByTime = (time: number) =>
+  act(() => jest.advanceTimersByTime(time));
 
 describe('when EuiDelayHide is visible initially', () => {
   function getWrapper() {
@@ -27,14 +31,14 @@ describe('when EuiDelayHide is visible initially', () => {
   test('it should be visible after 900ms', () => {
     const wrapper = getWrapper();
     wrapper.setProps({ hide: true });
-    jest.advanceTimersByTime(900);
+    actAdvanceTimersByTime(900);
     expect(wrapper.html()).toEqual('<div>Hello World</div>');
   });
 
   test('it should be hidden after 1100ms', () => {
     const wrapper = getWrapper();
     wrapper.setProps({ hide: true });
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
     wrapper.setProps({});
     expect(wrapper.html()).toEqual(null);
   });
@@ -43,14 +47,14 @@ describe('when EuiDelayHide is visible initially', () => {
     const wrapper = getWrapper();
     wrapper.setProps({ hide: true });
     wrapper.setProps({ hide: false });
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
     expect(wrapper.html()).toEqual('<div>Hello World</div>');
   });
 
   test('it should hide immediately after prop change, if it has been displayed for 1100ms', () => {
     const wrapper = getWrapper();
     const currentTime = Date.now();
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
     jest.spyOn(Date, 'now').mockReturnValue(currentTime + 1100);
     expect(wrapper.html()).toEqual('<div>Hello World</div>');
 
@@ -67,10 +71,10 @@ describe('when EuiDelayHide parent updates', () => {
     );
 
     wrapper.setProps({ hide: false });
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
     wrapper.setProps({}); // simulate parent component re-rendering
     wrapper.setProps({ hide: true });
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
 
     expect(wrapper.html()).toEqual(null);
   });
@@ -99,11 +103,11 @@ describe('when EuiDelayHide is hidden initially', () => {
     const wrapper = getWrapper();
     wrapper.setProps({ hide: false });
     wrapper.setProps({ hide: true });
-    jest.advanceTimersByTime(900);
+    actAdvanceTimersByTime(900);
 
     expect(wrapper.html()).toEqual('<div>Hello World</div>');
 
-    jest.advanceTimersByTime(200);
+    actAdvanceTimersByTime(200);
     wrapper.setProps({});
     expect(wrapper.html()).toEqual(null);
   });
@@ -136,7 +140,7 @@ describe('when EuiDelayHide is visible initially and has a minimumDuration of 20
 
   test('it should be hidden after 2100ms', () => {
     const wrapper = getWrapper();
-    jest.advanceTimersByTime(2100);
+    actAdvanceTimersByTime(2100);
     wrapper.setProps({});
     expect(wrapper.html()).toEqual(null);
   });
@@ -150,15 +154,15 @@ describe('when EuiDelayHide has been visible and become hidden', () => {
     );
 
     wrapper.setProps({ hide: false });
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
     wrapper.setProps({ hide: true });
-    jest.advanceTimersByTime(100);
+    actAdvanceTimersByTime(100);
     wrapper.setProps({ hide: false });
     wrapper.setProps({ hide: true });
 
     expect(wrapper.html()).toEqual('<div>Hello World</div>');
 
-    jest.advanceTimersByTime(1100);
+    actAdvanceTimersByTime(1100);
     wrapper.setProps({});
 
     expect(wrapper.html()).toEqual(null);

--- a/src/components/form/range/dual_range.test.tsx
+++ b/src/components/form/range/dual_range.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useEffect, useRef } from 'react';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 import { render, screen } from '../../../test/rtl';

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent } from '@testing-library/react';
 import { render, screen } from '../../test/rtl';
 import { requiredProps as commonProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';

--- a/src/components/inner_text/inner_text.test.tsx
+++ b/src/components/inner_text/inner_text.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { render, mount } from 'enzyme';
 import { findTestSubject, requiredProps } from '../../test';
 

--- a/src/components/observer/resize_observer/resize_observer.test.tsx
+++ b/src/components/observer/resize_observer/resize_observer.test.tsx
@@ -10,7 +10,7 @@ import React, { FunctionComponent, PropsWithChildren, useState } from 'react';
 import { mount } from 'enzyme';
 import { EuiResizeObserver, useResizeObserver } from './resize_observer';
 import { sleep } from '../../../test';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 export async function waitforResizeObserver(period = 30) {
   // `period` defaults to 30 because its the delay used by the ResizeObserver polyfill

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -8,6 +8,7 @@
 
 import React, { ReactNode } from 'react';
 import { render, mount } from 'enzyme';
+import { act } from '@testing-library/react';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { EuiFocusTrap } from '../';
@@ -20,6 +21,9 @@ import {
 } from './popover';
 
 import { keys } from '../../services';
+
+const actAdvanceTimersByTime = (time: number) =>
+  act(() => jest.advanceTimersByTime(time));
 
 jest.mock('../portal', () => ({
   EuiPortal: ({ children }: { children: ReactNode }) => children,
@@ -479,7 +483,7 @@ describe('EuiPopover', () => {
 
       // execute any pending timeouts or animation frame callbacks
       // and validate the timeout/rAF clearing done by EuiPopover
-      jest.advanceTimersByTime(300);
+      actAdvanceTimersByTime(300);
     });
   });
 
@@ -513,7 +517,7 @@ describe('EuiPopover', () => {
       );
       component.find(EuiFocusTrap).invoke('onEscapeKey')!(mockEvent);
       component.setProps({ isOpen: false });
-      jest.advanceTimersByTime(closingTransitionTime);
+      actAdvanceTimersByTime(closingTransitionTime);
 
       expect(closePopover).toHaveBeenCalled();
       expect(document.activeElement).toEqual(toggleButtonEl.current);
@@ -538,7 +542,7 @@ describe('EuiPopover', () => {
       );
       component.find(EuiFocusTrap).invoke('onEscapeKey')!(mockEvent);
       component.setProps({ isOpen: false });
-      jest.advanceTimersByTime(closingTransitionTime);
+      actAdvanceTimersByTime(closingTransitionTime);
 
       expect(closePopover).toHaveBeenCalled();
       expect(document.activeElement).toEqual(toggleButtonEl.current);
@@ -558,7 +562,8 @@ describe('EuiPopover', () => {
       );
       component.find(EuiFocusTrap).invoke('onEscapeKey')!(mockEvent);
       component.setProps({ isOpen: false });
-      jest.advanceTimersByTime(closingTransitionTime);
+
+      actAdvanceTimersByTime(closingTransitionTime);
 
       expect(closePopover).toHaveBeenCalled();
       expect(document.activeElement).not.toEqual(toggleDivEl.current);

--- a/src/components/search_bar/search_bar.test.tsx
+++ b/src/components/search_bar/search_bar.test.tsx
@@ -58,7 +58,7 @@ describe('SearchBar', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('render - provided query, filters', () => {
+  test('render - provided query, filters', async () => {
     const filters: SearchFilterConfig[] = [
       {
         type: 'is',
@@ -80,7 +80,10 @@ describe('SearchBar', () => {
       onChange: () => {},
     };
 
-    const { container } = render(<EuiSearchBar {...props} />);
+    const { container, findByTitle } = render(<EuiSearchBar {...props} />);
+
+    // Wait for FieldValueSelectionFilter to finish updating its state on init
+    await findByTitle('Tag');
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/search_bar/search_bar.test.tsx
+++ b/src/components/search_bar/search_bar.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useState } from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { mount } from 'enzyme';
 
 import { render } from '../../test/rtl';

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { act } from '@testing-library/react';
 import { mount, render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
@@ -61,10 +62,13 @@ describe('EuiSelectable', () => {
       </EuiSelectable>
     );
 
-    component.setState({
-      activeOptionIndex: 0,
-      isFocused: true,
+    act(() => {
+      component.setState({
+        activeOptionIndex: 0,
+        isFocused: true,
+      });
     });
+
     expect(component.state()).toMatchSnapshot();
 
     const listBox = component.find('div.euiSelectableList__list').getDOMNode();

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { render, mount } from 'enzyme';
 import { requiredProps, findTestSubject } from '../../test';
 

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -8,7 +8,7 @@
 
 import React, { useRef } from 'react';
 import { mount } from 'enzyme';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import {
   render,
   waitForEuiToolTipVisible,
@@ -97,8 +97,10 @@ describe('EuiToolTip', () => {
     );
 
     const trigger = findTestSubject(component, 'trigger');
-    trigger.simulate('focus');
-    jest.runAllTimers(); // wait for showToolTip setTimeout
+    act(() => {
+      trigger.simulate('focus');
+      jest.runAllTimers(); // wait for showToolTip setTimeout
+    });
 
     expect(
       document.querySelectorAll('[data-test-subj="tooltip"]')[1]

--- a/src/services/hooks/useForceRender.test.tsx
+++ b/src/services/hooks/useForceRender.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useImperativeHandle, createRef, forwardRef } from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { mount } from 'enzyme';
 import { useForceRender } from './useForceRender';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4287,20 +4287,6 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
-"@testing-library/dom@^8.12.0":
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
-  integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.4.4"
-    pretty-format "^27.0.2"
-
 "@testing-library/dom@^9.0.0":
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.1.tgz#8094f560e9389fb973fe957af41bf766937a9ee9"
@@ -4380,11 +4366,6 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
-
-"@types/aria-query@^4.2.0":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
-  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/aria-query@^5.0.1":
   version "5.0.1"


### PR DESCRIPTION
## Summary

This PR adds act() wrappers in a few places to ensure correct execution when running on React 18 and earlier versions.

## QA

1. Checkout this branch locally
2. Run `yarn` to install dependencies
3. Run `REACT_VERSION=17 yarn test-unit` and ensure there's `Running tests on React v17` printed out and there are no failing tests
4. Run `yarn test-unit` and confirm `Running tests on React v18` is printed out and there are some failing tests, but none are caused by `act()` warnings.
