### PR TITLE
test: enhance emotion serializer on React 18 to remove random values in class names

### DIFF
--- a/scripts/jest/setup/emotion.js
+++ b/scripts/jest/setup/emotion.js
@@ -1,9 +1,51 @@
-import { createSerializer, matchers } from "@emotion/jest";
-import { replaceEmotionPrefix } from '../../../src/test'
+import { createSerializer, matchers } from '@emotion/jest';
+import { replaceEmotionPrefix } from '../../../src/test';
 
 expect.extend(matchers);
 
-module.exports = createSerializer({
+const emotionSerializer = createSerializer({
   classNameReplacer: replaceEmotionPrefix,
   includeStyles: false,
 });
+
+function replaceNodeClasses(node) {
+  if (node.attribs && node.attribs.class) {
+    node.attribs.class = node.attribs.class
+      .split(' ')
+      .map((className) => replaceEmotionPrefix(className))
+      .join(' ');
+  }
+
+  if (node.children) {
+    node.children.forEach((childNode) => replaceNodeClasses(childNode));
+  }
+}
+
+// Emotion serializer looks up for class name prefixes in <style> data-emotion
+// attribute values. Sometimes the style elements are not available
+// in the document when running Enzyme with the hacky React 18 adapter,
+// but the serialize function is still being called. We need to find the emotion
+// class names manually and replace them using the replaceEmotionPrefix()
+// function used in earlier versions of React.
+export default {
+  serialize: (val, config, indentation, depth, refs, printer) => {
+    if (
+      val &&
+      val.node &&
+      val.node.type === 'tag' &&
+      (val.node.attribs || val.node.children)
+    ) {
+      replaceNodeClasses(val.node);
+    }
+
+    return emotionSerializer.serialize(
+      val,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer
+    );
+  },
+  test: emotionSerializer.test,
+};


### PR DESCRIPTION
## Summary

This PR extends the scope of our emotion serializer to replace random emotion prefixes with `emotion` for `class` attributes in DOM snapshots. It is necessary to work with React 18 and is backwards compatible.

## QA

1. Checkout this branch
2. Run `yarn` to ensure modules are up to date
3. Run `REACT_VERSION=17 yarn test-unit` and verify all tests are passing
4. Run `yarn test-unit` and verify that all snapshots are passing and there are no failed tests caused by mismatched `class` attribute. It is expected for some other tests to fail.
  Please note that jest will never finish due to `EuiIcon` unit tests running indefinitely on React 18.
