### PR TITLE
[CHORE] Adding a temp Jenkins env variable for the migration.

### DIFF
--- a/.ci/jobs/elastic+eui+deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+deploy-docs.yml
@@ -20,8 +20,9 @@
           export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
           export GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
           export GITHUB_TOKEN=$(vault read -field=github_token secret/kibana-issues/dev/kibanamachine)
+          export JENKINS_CI="true"
           unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
 
           # Run EUI build/deploy script, set in the template parameter
-          # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, GITHUB_TOKEN
+          # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, GITHUB_TOKEN, JENKINS_CI
           ./scripts/deploy/deploy_docs

--- a/.ci/jobs/elastic+eui+pull-request-deploy-docs.yml
+++ b/.ci/jobs/elastic+eui+pull-request-deploy-docs.yml
@@ -24,8 +24,9 @@
           export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
           export GCE_ACCOUNT=$(vault read -field=value $VAULT_ACCOUNT)
           export GITHUB_TOKEN=$(vault read -field=github_token secret/kibana-issues/dev/kibanamachine)
+          export JENKINS_CI="true"
           unset VAULT_ROLE_ID VAULT_SECRET_ID VAULT_ADDR VAULT_TOKEN VAULT_ACCOUNT
 
           # Run EUI build/deploy script, set in the template parameter
-          # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, GITHUB_TOKEN
+          # Expects env: GPROJECT, GCE_ACCOUNT, GIT_BRANCH, GITHUB_TOKEN, JENKINS_CI
           ./scripts/deploy/deploy_docs


### PR DESCRIPTION
## Summary

I need a reliable way to differentiate the Jenkins and Buildkite CI environments during the migration. There's not a good Jenkins CI environment variable I can key off, so I'm adding one for the very short term.

https://github.com/elastic/eui/pull/6947 is blocked by this PR.

## QA

All QA will be done on the Jenkins CI environment to ensure this variable was added.