### PR TITLE
[ComboBox] Added icon option

### DIFF
--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -33,7 +33,9 @@ import Containers from './containers';
 const containersSource = require('!!raw-loader!./containers');
 
 import Colors from './colors';
+import WithIcons from './with_icons';
 const colorsSource = require('!!raw-loader!./colors');
+const withIconsSource = require('!!raw-loader!./with_icons');
 const colorsSnippet = `<EuiComboBox
   aria-label="Accessible screen reader label"
   placeholder="Select or create options"
@@ -103,6 +105,9 @@ const singleSelectionCustomOptionsSnippet = `<EuiComboBox
   onCreateOption={onCreateOption}
   onChange={onChange}
 />`;
+
+import SingleSelectionWithIcon from './single_selection_with_icon';
+const singleSelectionWithIconSource = require('!!raw-loader!./single_selection_with_icon');
 
 import DisallowCustomOptions from './disallow_custom_options';
 const disallowCustomOptionsSource = require('!!raw-loader!./disallow_custom_options');
@@ -363,6 +368,23 @@ export const ComboBoxExample = {
       demo: <Colors />,
     },
     {
+      title: 'With icons',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: withIconsSource,
+        },
+      ],
+      text: (
+        <p>
+          Useful for showing icon alongside label. Passed icon as part of option will be displayed in options and selected item.
+        </p>
+      ),
+      props: { EuiComboBox, EuiComboBoxOptionOption },
+      snippet: colorsSnippet,
+      demo: <WithIcons />,
+    },
+    {
       title: 'Option rendering',
       source: [
         {
@@ -485,6 +507,34 @@ export const ComboBoxExample = {
       props: { EuiComboBox, EuiComboBoxOptionOption },
       snippet: singleSelectionCustomOptionsSnippet,
       demo: <SingleSelectionCustomOptions />,
+    },
+    {
+      title: 'Single selection with icon',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: singleSelectionWithIconSource,
+        },
+      ],
+      text: (
+        <Fragment>
+          <p>
+            You can allow the user to select a single option and also allow the
+            creation of custom options. To do that, use the{' '}
+            <EuiCode>singleSelection</EuiCode> in conjunction with the{' '}
+            <EuiCode>onCreateOption</EuiCode> prop.
+          </p>
+          <p>
+            <strong>Note:</strong> Creating custom options might not be obvious
+            to the user, so provide help text explaining that this option is
+            available. You can also customize the custom option text by passing
+            a text to <EuiCode>customOptionText</EuiCode> prop.
+          </p>
+        </Fragment>
+      ),
+      props: { EuiComboBox, EuiComboBoxOptionOption },
+      snippet: singleSelectionCustomOptionsSnippet,
+      demo: <SingleSelectionWithIcon />,
     },
     {
       title: 'Disallowing custom options',

--- a/src-docs/src/views/combo_box/single_selection_with_icon.js
+++ b/src-docs/src/views/combo_box/single_selection_with_icon.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+
+import { EuiComboBox, EuiFormRow } from '../../../../src/components';
+
+const options = [
+  {
+    label: 'Software Developer',
+    'data-test-subj': 'softDevOption',
+    icon: 'logoSlack'
+  },
+  {
+    label: 'Mobile Developer',
+    icon: 'logoElastic'
+  },
+  {
+    label: 'Javascript Engineer',
+    icon: 'logoElastic'
+  },
+  {
+    label: 'UX Designer',
+    icon: 'logoElastic'
+  },
+];
+
+export default () => {
+  const [selectedOptions, setSelected] = useState([options[2]]);
+
+  const onChange = (selectedOptions) => {
+    // We should only get back either 0 or 1 options.
+    setSelected(selectedOptions);
+  };
+
+  const onCreateOption = (searchValue = []) => {
+    const normalizedSearchValue = searchValue.trim().toLowerCase();
+
+    if (!normalizedSearchValue) {
+      return;
+    }
+
+    const newOption = {
+      label: searchValue,
+    };
+
+    // Select the option.
+    setSelected([newOption]);
+  };
+
+  return (
+    <EuiFormRow
+      label="Your occupation"
+      helpText="Select an occupation from the list. If your occupation isn’t available, create a custom one."
+    >
+      <EuiComboBox
+        aria-label="Accessible screen reader label"
+        placeholder="Select a single option"
+        singleSelection={{ asPlainText: true }}
+        options={options}
+        selectedOptions={selectedOptions}
+        onChange={onChange}
+        onCreateOption={onCreateOption}
+        customOptionText="Add {searchValue} as your occupation"
+      />
+    </EuiFormRow>
+  );
+};

--- a/src-docs/src/views/combo_box/with_icons.js
+++ b/src-docs/src/views/combo_box/with_icons.js
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+
+import { EuiComboBox } from '../../../../src/components';
+import { DisplayToggles } from '../form_controls/display_toggles';
+
+const optionsStatic = [
+  {
+    label: 'Titan',
+    'data-test-subj': 'titanOption',
+    icon: 'logoSlack'
+  },
+  {
+    label: 'Enceladus',
+    icon: 'logoElastic'
+  },
+  {
+    label: 'Mimas',
+    icon: 'logoElastic'
+  },
+  {
+    label: 'Dione',
+    icon: 'logoElastic'
+  },
+  {
+    label: 'Iapetus',
+    icon: 'logoElastic'
+  },
+  {
+    label: 'Phoebe',
+    icon: 'logoSlack'
+  },
+];
+
+export default () => {
+  const [options, setOptions] = useState(optionsStatic);
+  const [selectedOptions, setSelected] = useState([options[0], options[1]]);
+
+  const onChange = (selectedOptions) => {
+    setSelected(selectedOptions);
+  };
+
+  const onCreateOption = (searchValue, flattenedOptions = []) => {
+    if (!searchValue) {
+      return;
+    }
+
+    const normalizedSearchValue = searchValue.trim().toLowerCase();
+
+    if (!normalizedSearchValue) {
+      return;
+    }
+
+    const newOption = {
+      label: searchValue,
+    };
+
+    // Create the option if it doesn't exist.
+    if (
+      flattenedOptions.findIndex(
+        (option) => option.label.trim().toLowerCase() === normalizedSearchValue
+      ) === -1
+    ) {
+      setOptions([...options, newOption]);
+    }
+
+    // Select the option.
+    setSelected((prevSelected) => [...prevSelected, newOption]);
+  };
+
+  return (
+    /* DisplayToggles wrapper for Docs only */
+    <DisplayToggles canDisabled={false} canReadOnly={false} canIsDisabled>
+      <EuiComboBox
+        aria-label="Accessible screen reader label"
+        placeholder="Select or create options"
+        options={options}
+        selectedOptions={selectedOptions}
+        onChange={onChange}
+        onCreateOption={onCreateOption}
+        isDisabled
+      />
+    </DisplayToggles>
+  );
+};

--- a/src/components/badge/badge.styles.ts
+++ b/src/components/badge/badge.styles.ts
@@ -127,6 +127,21 @@ export const euiBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       euiBadge__icon: css``,
       right: css`
         &:not(:only-child) {
+          ${logicalCSS('margin-right', euiTheme.size.xs)}
+        }
+      `,
+      left: css`
+        &:not(:only-child) {
+          ${logicalCSS('margin-left', euiTheme.size.xs)}
+        }
+      `,
+    },
+
+    // extra Icon
+    extraIcon: {
+      euiBadge__iconExtra: css``,
+      right: css`
+        &:not(:only-child) {
           ${logicalCSS('margin-left', euiTheme.size.xs)}
         }
       `,

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -87,6 +87,11 @@ export type EuiBadgeProps = {
   iconSide?: IconSide;
 
   /**
+   * Accepts any string from our icon library, if `iconSide` provided, will display opposite to the `iconSide`
+   */
+  extraIcon?: IconType;
+
+  /**
    * Accepts either our palette colors (primary, success ..etc) or a hex value `#FFFFFF`, `#000`.
    */
   color?: BadgeColor | string;
@@ -111,6 +116,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   color = 'default',
   iconType,
   iconSide = 'left',
+  extraIcon,
   className,
   isDisabled: _isDisabled,
   onClick,
@@ -249,6 +255,19 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
     }
   }
 
+  let extraIconNode: ReactNode = null;
+  if (extraIcon) {
+    extraIconNode = (
+      <EuiIcon
+        type={extraIcon}
+        size={children ? 's' : 'm'}
+        className="euiBadge__iconExtra"
+        css={iconCssStyles}
+        color="inherit" // forces the icon to inherit its parent color
+      />
+    );
+  }
+
   if (onClick && !onClickAriaLabel) {
     console.warn(
       'When passing onClick to EuiBadge, you must also provide onClickAriaLabel'
@@ -258,12 +277,14 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   const content = (
     <span className="euiBadge__content" css={styles.euiBadge__content}>
       {iconSide === 'left' && optionalIcon}
+      {(!iconSide || iconSide === 'right') && extraIconNode}
       {children && (
         <span className="euiBadge__text" css={textCssStyles}>
           {children}
         </span>
       )}
       {iconSide === 'right' && optionalIcon}
+      {iconSide === 'left' && extraIconNode}
     </span>
   );
 
@@ -272,6 +293,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
       <span className={classes} css={cssStyles} style={customColorStyles}>
         <span className="euiBadge__content" css={styles.euiBadge__content}>
           {iconSide === 'left' && optionalIcon}
+          {(!iconSide || iconSide === 'right') && extraIconNode}
           <EuiInnerText>
             {(ref, innerText) => (
               <Element
@@ -289,6 +311,7 @@ export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
             )}
           </EuiInnerText>
           {iconSide === 'right' && optionalIcon}
+          {iconSide === 'left' && extraIconNode}
         </span>
       </span>
     ) : (

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -32,4 +32,7 @@
     vertical-align: middle;
     display: inline-block;
   }
+  &--icon{
+    margin-right: $euiSizeXS;
+  }
 }

--- a/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -12,6 +12,7 @@ import React, {
   FocusEventHandler,
   KeyboardEventHandler,
   RefCallback,
+  ReactNode,
 } from 'react';
 import classNames from 'classnames';
 import AutosizeInput from 'react-input-autosize';
@@ -57,6 +58,7 @@ export interface EuiComboBoxInputProps<T> extends CommonProps {
   rootId: ReturnType<typeof htmlIdGenerator>;
   searchValue: string;
   selectedOptions: Array<EuiComboBoxOptionOption<T>>;
+  renderPill?: (option: EuiComboBoxOptionOption<T>) => ReactNode;
   singleSelection?: boolean | EuiComboBoxSingleSelectionShape;
   toggleButtonRef?: RefCallback<HTMLButtonElement | HTMLSpanElement>;
   updatePosition: UpdatePositionHandler;

--- a/src/components/combo_box/combo_box_input/combo_box_pill.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_pill.tsx
@@ -13,6 +13,7 @@ import { EuiBadge } from '../../badge';
 import { EuiI18n } from '../../i18n';
 import { EuiComboBoxOptionOption, OptionHandler } from '../types';
 import { CommonProps } from '../../common';
+import { EuiIcon } from '../../icon';
 
 export interface EuiComboBoxPillProps<T> extends CommonProps {
   asPlainText?: boolean;
@@ -79,6 +80,7 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
               iconOnClickAriaLabel={removeSelection}
               iconSide="right"
               iconType="cross"
+              extraIcon={option.icon}
               title={children}
               {...onClickProps}
               {...rest}
@@ -93,6 +95,13 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
     if (asPlainText) {
       return (
         <span className={classes} {...rest}>
+          {option.icon && (
+            <EuiIcon
+              className="euiComboBoxPill--icon"
+              type={option.icon}
+              size="s"
+            />
+          )}
           {children}
         </span>
       );

--- a/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_option.scss
@@ -26,6 +26,7 @@
       text-decoration: none;
     }
   }
+
 }
 
 .euiComboBoxOption__contentWrapper {
@@ -40,6 +41,11 @@
   .euiComboBoxOption__enterBadge {
     align-self: center;
     margin-left: $euiSizeXS;
+  }
+
+  .euiComboBoxOption__icon {
+    align-self: center;
+    margin-right: $euiSizeXS;
   }
 }
 

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -41,6 +41,7 @@ import {
 import { CommonProps } from '../../common';
 import { EuiBadge } from '../../badge';
 import { EuiPopoverPanel } from '../../popover/popover_panel';
+import { EuiIcon } from '../../icon';
 
 const OPTION_CONTENT_CLASSNAME = 'euiComboBoxOption__content';
 
@@ -84,6 +85,7 @@ export type EuiComboBoxOptionsListProps<T> = CommonProps &
       searchValue: string,
       OPTION_CONTENT_CLASSNAME: string
     ) => ReactNode;
+    renderPill?: (option: EuiComboBoxOptionOption<T>) => ReactNode;
     rootId: ReturnType<typeof htmlIdGenerator>;
     rowHeight: number;
     scrollToIndex?: number;
@@ -268,13 +270,22 @@ export class EuiComboBoxOptionsList<T> extends Component<
               )}
             </span>
           ) : (
-            <EuiHighlight
-              search={searchValue}
-              strict={this.props.isCaseSensitive}
-              className={OPTION_CONTENT_CLASSNAME}
-            >
-              {label}
-            </EuiHighlight>
+            <>
+              {option.icon && (
+                <EuiIcon
+                  className="euiComboBoxOption__icon"
+                  type={option.icon}
+                  size="s"
+                />
+              )}
+              <EuiHighlight
+                search={searchValue}
+                strict={this.props.isCaseSensitive}
+                className={OPTION_CONTENT_CLASSNAME}
+              >
+                {label}
+              </EuiHighlight>
+            </>
           )}
           {optionIsFocused && !optionIsDisabled ? hitEnterBadge : null}
         </span>

--- a/src/components/combo_box/types.ts
+++ b/src/components/combo_box/types.ts
@@ -8,6 +8,7 @@
 
 import { ButtonHTMLAttributes } from 'react';
 import { CommonProps } from '../common';
+import { IconType } from '../icon';
 
 // note similarity to `Option` in `components/selectable/types.tsx`
 export interface EuiComboBoxOptionOption<
@@ -19,6 +20,7 @@ export interface EuiComboBoxOptionOption<
   key?: string;
   options?: Array<EuiComboBoxOptionOption<T>>;
   value?: T;
+  icon?: IconType;
 }
 
 export type UpdatePositionHandler = (


### PR DESCRIPTION
## Summary

Users can pass icon property as part of option and it will be displayed both in list and also in selected values in input box.

Will add tests once i get bit of design feedback. 

<img width="1322" alt="image" src="https://github.com/elastic/eui/assets/3505601/8ea7f6fd-5f02-4992-935a-60ffbe456d52">

<img width="1451" alt="image" src="https://github.com/elastic/eui/assets/3505601/8fa3407c-57f6-4608-9af7-07a13b36a52f">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
