### PR TITLE
[EuiPopover][EuiInputPopover] Allow more control via `focusTrapProps`

### DIFF
--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -46,6 +46,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   children,
   className,
   disableFocusTrap = false,
+  focusTrapProps,
   input,
   fullWidth = false,
   onPanelResize,
@@ -123,7 +124,11 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
       className={classes}
       {...props}
     >
-      <EuiFocusTrap clickOutsideDisables={true} disabled={disableFocusTrap}>
+      <EuiFocusTrap
+        clickOutsideDisables={true}
+        disabled={disableFocusTrap}
+        {...focusTrapProps}
+      >
         <div onKeyDown={onKeyDown}>{children}</div>
       </EuiFocusTrap>
     </EuiPopover>

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -103,14 +103,7 @@ export interface EuiPopoverProps extends CommonProps {
   /**
    * Object of props passed to EuiFocusTrap
    */
-  focusTrapProps?: Pick<
-    EuiFocusTrapProps,
-    | 'clickOutsideDisables'
-    | 'onClickOutside'
-    | 'noIsolation'
-    | 'scrollLock'
-    | 'shards'
-  >;
+  focusTrapProps?: Partial<EuiFocusTrapProps>;
   /**
    * Show arrow indicating to originating button
    */
@@ -703,7 +696,6 @@ export class EuiPopover extends Component<Props, State> {
           <EuiFocusTrap
             clickOutsideDisables={true}
             onClickOutside={this.onClickOutside}
-            {...focusTrapProps}
             returnFocus={returnFocus} // Ignore temporary state of indecisive focus
             initialFocus={initialFocus}
             onDeactivation={onTrapDeactivation}
@@ -711,6 +703,7 @@ export class EuiPopover extends Component<Props, State> {
             disabled={
               !ownFocus || !this.state.isOpenStable || this.state.isClosing
             }
+            {...focusTrapProps}
           >
             <EuiPopoverPanel
               {...(panelProps as EuiPopoverPanelProps)}

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -20,7 +20,6 @@ import { focusable } from 'tabbable';
 
 import { CommonProps, NoArgCallback } from '../common';
 import { FocusTarget, EuiFocusTrap, EuiFocusTrapProps } from '../focus_trap';
-import { ReactFocusOnProps } from 'react-focus-on/dist/es5/types';
 
 import {
   cascadingMenuKeys,
@@ -174,10 +173,6 @@ export interface EuiPopoverProps extends CommonProps {
    * component; pass `zIndex` to override
    */
   zIndex?: number;
-  /**
-   * Function callback for when the focus trap is deactivated
-   */
-  onTrapDeactivation?: ReactFocusOnProps['onDeactivation'];
   /**
    * Distance away from the anchor that the popover will render
    */
@@ -620,7 +615,6 @@ export class EuiPopover extends Component<Props, State> {
       display,
       offset,
       onPositionChange,
-      onTrapDeactivation,
       buffer,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
@@ -698,7 +692,6 @@ export class EuiPopover extends Component<Props, State> {
             onClickOutside={this.onClickOutside}
             returnFocus={returnFocus} // Ignore temporary state of indecisive focus
             initialFocus={initialFocus}
-            onDeactivation={onTrapDeactivation}
             onEscapeKey={this.onEscapeKey}
             disabled={
               !ownFocus || !this.state.isOpenStable || this.state.isClosing

--- a/upcoming_changelogs/6955.md
+++ b/upcoming_changelogs/6955.md
@@ -1,5 +1,9 @@
 - Updated `EuiPopover` to allow consumer control of all `focusTrapProps`
 
+**Bug fixes**
+
+- Fixed `EuiInputPopover` to allow consumer control of its focus trap via `focusTrapProps`
+
 **Breaking changes**
 
 - Removed `onTrapDeactivation` prop from `EuiPopover`. Use `focusTrapProps.onDeactivation` instead

--- a/upcoming_changelogs/6955.md
+++ b/upcoming_changelogs/6955.md
@@ -1,0 +1,6 @@
+- Updated `EuiPopover` to allow consumer control of all `focusTrapProps`
+
+**Breaking changes**
+
+- Removed `onTrapDeactivation` prop from `EuiPopover`. Use `focusTrapProps.onDeactivation` instead
+


### PR DESCRIPTION
## Summary

@Heenawter is working on a custom `EuiSelectable` component that has a filter dropdown/popover selection menu in between the search box and the listbox. This filter popover has special custom focus behavior that returns focus to the searchbox after filter select, and not to the toggling popover button.

The solution their usage needs is something like this:

```tsx
<EuiPopover
  closePopover={}
  focusTrapProps={{
    returnFocus: false,
    onEscapeKey: // custom callback closing the popover and focusing the searchbox
    onDeactivation: // custom callback focusing the searchbox
  }}
/>
```

Unfortunately EuiPopover's default focus return behavior is getting in the way of their custom focus behavior. We should loosen the spread behavior of `focusTrapProps` to allow consumers to control focus UX as needed.

### Breaking change

This PR also incidentally removes a prop (`onTrapDeactivation`) that is completely unused in EUI and Kibana (as well as untested and undocumented in EUI) that is duplicative of `focusTrapProps` behavior. I've opinionatedly left in other semi-duplicative focus trap props such as `initialFocus` and `ownFocus` because those have actual documentation in EUI as well as usages in Kibana.

## QA

Mostly regression testing to ensure past behavior works as before; @Heenawter has QA'd that new behavior works in her app.

- [x] Confirm [`EuiInputPopover`](https://eui.elastic.co/pr_6955/#/layout/popover#popover-attached-to-input-element) continues to focus trap & dismiss its focus trap the same as [on production](https://elastic.github.io/eui/#/layout/popover#popover-attached-to-input-element)
- [x] Confirm the basic `EuiPopover` examples continue to focus trap & dismiss its focus trap as on prod
- [x] Confirm the [focus examples](https://eui.elastic.co/pr_6955/#/layout/popover#setting-an-initial-focus) on EuiPopover's docs pages work the same as [on prod](https://elastic.github.io/eui/#/layout/popover#setting-an-initial-focus)

### General checklist

- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - No `onTrapDeactivation` docs, and IMO the concept of `focusTrapProps` is self-evident and already documented in its props
    - ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ - also skipped because no meaningful logic other than basic spread behavior was changed, which should also be self-evident
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately


~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~