### PR TITLE
feature: EuiDataGrid type improvements to support React 18

### DIFF
--- a/scripts/babel/proptypes-from-ts-props/index.js
+++ b/scripts/babel/proptypes-from-ts-props/index.js
@@ -10,7 +10,7 @@ function stripTypeScript(filename, ast) {
   return babelCore.transform(babelCore.transformFromAst(ast).code, {
     filename: filename,
     babelrc: false,
-    presets: ['@babel/typescript'],
+    presets: [['@babel/typescript', { allowDeclareFields: true }]],
   }).code;
 }
 

--- a/src-docs/src/views/datagrid/advanced/custom_renderer.tsx
+++ b/src-docs/src/views/datagrid/advanced/custom_renderer.tsx
@@ -16,6 +16,9 @@ import {
   EuiSpacer,
   useEuiTheme,
   logicalCSS,
+  EuiDataGridPaginationProps,
+  EuiDataGridSorting,
+  EuiDataGridColumnSortingConfig,
 } from '../../../../../src';
 
 const raw_data: Array<{ [key: string]: string }> = [];
@@ -166,16 +169,16 @@ export default () => {
 
   // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
-  const onChangePage = useCallback((pageIndex) => {
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>((pageIndex) => {
     setPagination((pagination) => ({ ...pagination, pageIndex }));
   }, []);
-  const onChangePageSize = useCallback((pageSize) => {
+  const onChangePageSize = useCallback<EuiDataGridPaginationProps['onChangeItemsPerPage']>((pageSize) => {
     setPagination((pagination) => ({ ...pagination, pageSize }));
   }, []);
 
   // Sorting
-  const [sortingColumns, setSortingColumns] = useState([]);
-  const onSort = useCallback((sortingColumns) => {
+  const [sortingColumns, setSortingColumns] = useState<EuiDataGridColumnSortingConfig[]>([]);
+  const onSort = useCallback<EuiDataGridSorting['onSort']>((sortingColumns) => {
     setSortingColumns(sortingColumns);
   }, []);
 

--- a/src-docs/src/views/datagrid/advanced/ref.tsx
+++ b/src-docs/src/views/datagrid/advanced/ref.tsx
@@ -16,6 +16,10 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiText,
+  EuiDataGridColumnCellAction,
+  EuiDataGridColumnSortingConfig,
+  EuiDataGridPaginationProps,
+  EuiDataGridSorting,
 } from '../../../../../src';
 
 const raw_data: Array<{ [key: string]: string }> = [];
@@ -105,16 +109,23 @@ export default () => {
 
   // Pagination
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
-  const onChangePage = useCallback((pageIndex) => {
-    setPagination((pagination) => ({ ...pagination, pageIndex }));
-  }, []);
-  const onChangePageSize = useCallback((pageSize) => {
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
+    (pageIndex) => {
+      setPagination((pagination) => ({ ...pagination, pageIndex }));
+    },
+    []
+  );
+  const onChangePageSize = useCallback<
+    EuiDataGridPaginationProps['onChangeItemsPerPage']
+  >((pageSize) => {
     setPagination((pagination) => ({ ...pagination, pageSize }));
   }, []);
 
   // Sorting
-  const [sortingColumns, setSortingColumns] = useState([]);
-  const onSort = useCallback((sortingColumns) => {
+  const [sortingColumns, setSortingColumns] = useState<
+    EuiDataGridColumnSortingConfig[]
+  >([]);
+  const onSort = useCallback<EuiDataGridSorting['onSort']>((sortingColumns) => {
     setSortingColumns(sortingColumns);
   }, []);
 

--- a/src-docs/src/views/datagrid/advanced/ref.tsx
+++ b/src-docs/src/views/datagrid/advanced/ref.tsx
@@ -48,13 +48,16 @@ export default () => {
     dataGridRef.current!.setFocusedCell(lastFocusedCell); // Set the data grid focus back to the cell that opened the modal
   }, [lastFocusedCell]);
 
-  const showModal = useCallback(({ rowIndex, colIndex }) => {
-    setIsModalVisible(true);
-    dataGridRef.current!.closeCellPopover(); // Close any open cell popovers
-    setLastFocusedCell({ rowIndex, colIndex }); // Store the cell that opened this modal
-  }, []);
+  const showModal = useCallback(
+    ({ rowIndex, colIndex }: { rowIndex: number; colIndex: number }) => {
+      setIsModalVisible(true);
+      dataGridRef.current!.closeCellPopover(); // Close any open cell popovers
+      setLastFocusedCell({ rowIndex, colIndex }); // Store the cell that opened this modal
+    },
+    []
+  );
 
-  const openModalAction = useCallback(
+  const openModalAction = useCallback<EuiDataGridColumnCellAction>(
     ({ Component, rowIndex, colIndex }) => {
       return (
         <Component

--- a/src-docs/src/views/datagrid/styling/row_height_auto.tsx
+++ b/src-docs/src/views/datagrid/styling/row_height_auto.tsx
@@ -18,6 +18,9 @@ import {
   EuiText,
   EuiSpacer,
   formatDate,
+  EuiDataGridSorting,
+  EuiDataGridColumnSortingConfig,
+  EuiDataGridPaginationProps,
 } from '../../../../../src';
 
 interface DataShape {
@@ -146,15 +149,19 @@ export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
 
   // Sorting
-  const [sortingColumns, setSortingColumns] = useState([]);
-  const onSort = useCallback(
+  const [sortingColumns, setSortingColumns] = useState<
+    EuiDataGridColumnSortingConfig[]
+  >([]);
+  const onSort = useCallback<EuiDataGridSorting['onSort']>(
     (sortingColumns) => {
       setSortingColumns(sortingColumns);
     },
     [setSortingColumns]
   );
 
-  const onChangeItemsPerPage = useCallback(
+  const onChangeItemsPerPage = useCallback<
+    EuiDataGridPaginationProps['onChangeItemsPerPage']
+  >(
     (pageSize) =>
       setPagination((pagination) => ({
         ...pagination,
@@ -164,7 +171,7 @@ export default () => {
     [setPagination]
   );
 
-  const onChangePage = useCallback(
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
     [setPagination]

--- a/src-docs/src/views/datagrid/styling/row_height_fixed.tsx
+++ b/src-docs/src/views/datagrid/styling/row_height_fixed.tsx
@@ -18,6 +18,9 @@ import {
   EuiText,
   EuiSpacer,
   formatDate,
+  EuiDataGridSorting,
+  EuiDataGridColumnSortingConfig,
+  EuiDataGridPaginationProps,
 } from '../../../../../src';
 
 interface DataShape {
@@ -146,15 +149,15 @@ export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
 
   // Sorting
-  const [sortingColumns, setSortingColumns] = useState([]);
-  const onSort = useCallback(
+  const [sortingColumns, setSortingColumns] = useState<EuiDataGridColumnSortingConfig[]>([]);
+  const onSort = useCallback<EuiDataGridSorting['onSort']>(
     (sortingColumns) => {
       setSortingColumns(sortingColumns);
     },
     [setSortingColumns]
   );
 
-  const onChangeItemsPerPage = useCallback(
+  const onChangeItemsPerPage = useCallback<EuiDataGridPaginationProps['onChangeItemsPerPage']>(
     (pageSize) =>
       setPagination((pagination) => ({
         ...pagination,
@@ -164,7 +167,7 @@ export default () => {
     [setPagination]
   );
 
-  const onChangePage = useCallback(
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
     [setPagination]

--- a/src-docs/src/views/datagrid/styling/row_line_height.tsx
+++ b/src-docs/src/views/datagrid/styling/row_line_height.tsx
@@ -8,7 +8,14 @@ import React, {
 } from 'react';
 import githubData from '../_row_auto_height_data.json';
 
-import { EuiDataGrid, EuiDataGridProps, formatDate } from '../../../../../src';
+import {
+  EuiDataGrid,
+  EuiDataGridColumnSortingConfig,
+  EuiDataGridPaginationProps,
+  EuiDataGridProps,
+  EuiDataGridSorting,
+  formatDate,
+} from '../../../../../src';
 
 interface DataShape {
   html_url: string;
@@ -96,15 +103,19 @@ export default () => {
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
 
   // Sorting
-  const [sortingColumns, setSortingColumns] = useState([]);
-  const onSort = useCallback(
+  const [sortingColumns, setSortingColumns] = useState<
+    EuiDataGridColumnSortingConfig[]
+  >([]);
+  const onSort = useCallback<EuiDataGridSorting['onSort']>(
     (sortingColumns) => {
       setSortingColumns(sortingColumns);
     },
     [setSortingColumns]
   );
 
-  const onChangeItemsPerPage = useCallback(
+  const onChangeItemsPerPage = useCallback<
+    EuiDataGridPaginationProps['onChangeItemsPerPage']
+  >(
     (pageSize) =>
       setPagination((pagination) => ({
         ...pagination,
@@ -114,7 +125,7 @@ export default () => {
     [setPagination]
   );
 
-  const onChangePage = useCallback(
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
     [setPagination]

--- a/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
+++ b/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
@@ -16,6 +16,7 @@ import {
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiPopover,
+  EuiDataGridPaginationProps,
 } from '../../../../../src';
 
 const columns = [
@@ -94,12 +95,14 @@ export default () => {
     columns.map(({ id }) => id)
   );
 
-  const setPageIndex = useCallback(
+  const setPageIndex = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
     []
   );
-  const setPageSize = useCallback(
+  const setPageSize = useCallback<
+    EuiDataGridPaginationProps['onChangeItemsPerPage']
+  >(
     (pageSize) =>
       setPagination((pagination) => ({
         ...pagination,

--- a/src/components/datagrid/body/data_grid_body_custom.tsx
+++ b/src/components/datagrid/body/data_grid_body_custom.tsx
@@ -19,6 +19,7 @@ import { useRowHeightUtils, useDefaultRowHeight } from '../utils/row_heights';
 
 import {
   EuiDataGridBodyProps,
+  EuiDataGridCustomBodyProps,
   EuiDataGridSetCustomGridBodyProps,
 } from '../data_grid_types';
 import { useDataGridHeader } from './header';
@@ -140,7 +141,7 @@ export const EuiDataGridBodyCustomRender: FunctionComponent<
     rowHeightUtils,
   };
 
-  const _Cell = useCallback(
+  const _Cell = useCallback<EuiDataGridCustomBodyProps['Cell']>(
     ({ colIndex, visibleRowIndex, ...rest }) => {
       const style = {
         height: rowHeightUtils.isAutoHeight(visibleRowIndex, rowHeightsOptions)

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -9,6 +9,7 @@
 import classNames from 'classnames';
 import React, {
   Component,
+  ContextType,
   createRef,
   FocusEvent,
   FunctionComponent,
@@ -143,6 +144,7 @@ export class EuiDataGridCell extends Component<
   style = null;
 
   static contextType = DataGridFocusContext;
+  declare context: ContextType<typeof DataGridFocusContext>;
 
   getInteractables = () => {
     const tabbingRef = this.cellContentsRef;

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -46,7 +46,9 @@ export const useCellPopover = (): {
   >({});
 
   const closeCellPopover = useCallback(() => setPopoverIsOpen(false), []);
-  const openCellPopover = useCallback(
+  const openCellPopover = useCallback<
+    DataGridCellPopoverContextShape['openCellPopover']
+  >(
     ({ rowIndex, colIndex }) => {
       // Prevent popover DOM issues when re-opening the same popover
       if (

--- a/src/components/datagrid/body/data_grid_row_manager.ts
+++ b/src/components/datagrid/body/data_grid_row_manager.ts
@@ -18,7 +18,7 @@ export const useRowManager = ({
 }): EuiDataGridRowManager => {
   const rowIdToElements = useRef(new Map<number, HTMLDivElement>());
 
-  const getRow = useCallback(
+  const getRow = useCallback<EuiDataGridRowManager['getRow']>(
     ({ rowIndex, visibleRowIndex, top, height }) => {
       let rowElement = rowIdToElements.current.get(rowIndex);
 

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -314,7 +314,7 @@ export const useSortingUtils = ({
 export const usePopoverArrowNavigation = () => {
   const popoverPanelRef = useRef<HTMLElement | null>(null);
   const actionsRef = useRef<FocusableElement[] | undefined>(undefined);
-  const panelRef = useCallback((ref) => {
+  const panelRef = useCallback((ref: HTMLElement | null) => {
     popoverPanelRef.current = ref;
     actionsRef.current = ref ? tabbable(ref) : undefined;
   }, []);

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import { shallow, mount, ShallowWrapper, ReactWrapper } from 'enzyme';
 import { testCustomHook } from '../../../test/internal';
 
@@ -310,10 +310,19 @@ describe('useDataGridDisplaySelector', () => {
           component
             .find('input[type="range"][data-test-subj="lineCountNumber"]')
             .prop('value');
-        const setLineCountNumber = (component: ReactWrapper, number: number) =>
-          component
-            .find('input[type="range"][data-test-subj="lineCountNumber"]')
-            .simulate('change', { target: { value: number } });
+        const setLineCountNumber = (
+          component: ReactWrapper,
+          number: number
+        ) => {
+          const input = component.find(
+            'input[type="range"][data-test-subj="lineCountNumber"]'
+          );
+
+          // enzyme simulate() doesn't handle event.currentTarget updates well
+          // https://github.com/enzymejs/enzyme/issues/218
+          (input.getDOMNode() as HTMLInputElement).value = number.toString();
+          input.simulate('change');
+        };
 
         it('conditionally displays a line count number input when the lineCount button is selected', () => {
           const component = mount(<MockComponent />);
@@ -357,7 +366,11 @@ describe('useDataGridDisplaySelector', () => {
           );
           openPopover(component);
 
-          setLineCountNumber(component, 3);
+          act(() => {
+            setLineCountNumber(component, 3);
+          });
+          component.update();
+
           expect(getLineCountNumber(component)).toEqual(3);
         });
 

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -18,7 +18,7 @@ import { useUpdateEffect } from '../../../services';
 import { EuiI18n, useEuiI18n } from '../../i18n';
 import { EuiPopover, EuiPopoverFooter } from '../../popover';
 import { EuiButtonIcon, EuiButtonGroup, EuiButtonEmpty } from '../../button';
-import { EuiFormRow, EuiRange } from '../../form';
+import { EuiFormRow, EuiRange, EuiRangeProps } from '../../form';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiToolTip } from '../../tool_tip';
 
@@ -137,8 +137,12 @@ export const useDataGridDisplaySelector = (
     },
     [lineCount]
   );
-  const setLineCountHeight = useCallback((event) => {
-    const newLineCount = Number(event.target.value);
+  const setLineCountHeight = useCallback<
+    NonNullable<EuiRangeProps['onChange']>
+  >((event) => {
+    if (!event.target) return;
+
+    const newLineCount = Number((event.target as HTMLInputElement).value);
     if (newLineCount < 1) return; // Don't let users set a 0 or negative line count
 
     setLineCount(newLineCount);

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -140,9 +140,9 @@ export const useDataGridDisplaySelector = (
   const setLineCountHeight = useCallback<
     NonNullable<EuiRangeProps['onChange']>
   >((event) => {
-    if (!event.target) return;
+    if (!event.currentTarget) return;
 
-    const newLineCount = Number((event.target as HTMLInputElement).value);
+    const newLineCount = Number(event.currentTarget.value);
     if (newLineCount < 1) return; // Don't let users set a 0 or negative line count
 
     setLineCount(newLineCount);

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -18,6 +18,7 @@ import {
   Ref,
   Component,
   PropsWithChildren,
+  ComponentClass,
 } from 'react';
 import {
   VariableSizeGridProps,
@@ -582,8 +583,8 @@ export interface EuiDataGridCellProps {
   className?: string;
   popoverContext: DataGridCellPopoverContextShape;
   renderCellValue:
-    | JSXElementConstructor<EuiDataGridCellValueElementProps>
-    | ((props: EuiDataGridCellValueElementProps) => ReactNode);
+    | ((props: EuiDataGridCellValueElementProps) => ReactNode)
+    | ComponentClass<EuiDataGridCellValueElementProps>;
   renderCellPopover?:
     | JSXElementConstructor<EuiDataGridCellPopoverElementProps>
     | ((props: EuiDataGridCellPopoverElementProps) => ReactNode);

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -936,18 +936,20 @@ export interface EuiDataGridPaginationProps {
   onChangePage: (pageIndex: number) => void;
 }
 
+export interface EuiDataGridColumnSortingConfig {
+  id: string;
+  direction: 'asc' | 'desc';
+}
+
 export interface EuiDataGridSorting {
   /**
    * A function that receives updated column sort details in response to user interactions in the toolbar controls
    */
-  onSort: (columns: EuiDataGridSorting['columns']) => void;
+  onSort: (columns: EuiDataGridColumnSortingConfig[]) => void;
   /**
    * An array of the column ids currently being sorted and their sort direction. The array order determines the sort order. `{ id: 'A'; direction: 'asc' }`
    */
-  columns: Array<{
-    id: string;
-    direction: 'asc' | 'desc';
-  }>;
+  columns: EuiDataGridColumnSortingConfig[];
 }
 
 export interface EuiDataGridInMemory {

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -705,9 +705,9 @@ export interface EuiDataGridColumn {
   visibleCellActions?: number;
 }
 
-export type EuiDataGridColumnCellAction =
-  | JSXElementConstructor<EuiDataGridColumnCellActionProps>
-  | ((props: EuiDataGridColumnCellActionProps) => ReactNode);
+export type EuiDataGridColumnCellAction = (
+  props: EuiDataGridColumnCellActionProps
+) => ReactNode;
 
 export interface EuiDataGridColumnActions {
   /**

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -706,9 +706,8 @@ export interface EuiDataGridColumn {
   visibleCellActions?: number;
 }
 
-export type EuiDataGridColumnCellAction = (
-  props: EuiDataGridColumnCellActionProps
-) => ReactNode;
+export type EuiDataGridColumnCellAction =
+  ComponentType<EuiDataGridColumnCellActionProps>;
 
 export interface EuiDataGridColumnActions {
   /**

--- a/src/components/datagrid/utils/data_grid_pagination.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.tsx
@@ -9,7 +9,10 @@
 import React, { useCallback, useContext } from 'react';
 import { useEuiI18n } from '../../i18n'; // Note: this file must be named data_grid_pagination to match i18n tokens
 import { EuiTablePagination } from '../../table/table_pagination';
-import { EuiDataGridPaginationRendererProps } from '../data_grid_types';
+import {
+  EuiDataGridPaginationProps,
+  EuiDataGridPaginationRendererProps,
+} from '../data_grid_types';
 import { DataGridFocusContext } from './focus';
 
 export const EuiDataGridPaginationRenderer = ({
@@ -34,7 +37,7 @@ export const EuiDataGridPaginationRenderer = ({
 
   // Focus the first data cell & scroll back to the top of the grid whenever paginating to a new page
   const { setFocusedCell } = useContext(DataGridFocusContext);
-  const onChangePage = useCallback(
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) => {
       _onChangePage(pageIndex);
       setFocusedCell([0, 0]);

--- a/src/components/datagrid/utils/in_memory.tsx
+++ b/src/components/datagrid/utils/in_memory.tsx
@@ -47,7 +47,7 @@ export const useInMemoryValues = (
   const _inMemoryValues = useRef<EuiDataGridInMemoryValues>({});
   const [inMemoryValuesVersion, setInMemoryValuesVersion] = useState(0);
 
-  const inMemoryValues = useMemo(
+  const inMemoryValues = useMemo<EuiDataGridInMemoryValues>(
     () => ({ ..._inMemoryValues.current }),
     [inMemoryValuesVersion] // eslint-disable-line react-hooks/exhaustive-deps
   );

--- a/src/components/datagrid/utils/in_memory.tsx
+++ b/src/components/datagrid/utils/in_memory.tsx
@@ -33,7 +33,7 @@ export const useInMemoryValues = (
   rowCount: number
 ): [
   EuiDataGridInMemoryValues,
-  (rowIndex: number, columnId: string, value: string) => void
+  EuiDataGridInMemoryRendererProps['onCellRender']
 ] => {
   /**
    * For performance, `onCellRender` below mutates the inMemoryValues object
@@ -52,7 +52,9 @@ export const useInMemoryValues = (
     [inMemoryValuesVersion] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
-  const onCellRender = useCallback((rowIndex, columnId, value) => {
+  const onCellRender = useCallback<
+    EuiDataGridInMemoryRendererProps['onCellRender']
+  >((rowIndex, columnId, value) => {
     const nextInMemoryValues = _inMemoryValues.current;
     nextInMemoryValues[rowIndex] = nextInMemoryValues[rowIndex] || {};
     if (nextInMemoryValues[rowIndex][columnId] !== value) {

--- a/src/components/datagrid/utils/ref.ts
+++ b/src/components/datagrid/utils/ref.ts
@@ -50,7 +50,7 @@ export const useImperativeGridRef = ({
   // the targeted cell is valid or in view (unlike our internal state, where
   // both of those states can be guaranteed), so we need to do some extra
   // checks here to make sure the grid automatically handles all cells
-  const setFocusedCell = useCallback(
+  const setFocusedCell = useCallback<EuiDataGridRefProps['setFocusedCell']>(
     ({ rowIndex, colIndex }) => {
       checkCellExists({ rowIndex, colIndex });
       const visibleRowIndex = findVisibleRowIndex(rowIndex);
@@ -67,7 +67,7 @@ export const useImperativeGridRef = ({
   // the targeted cell is valid or in view (unlike our internal state, where
   // both of those states can be guaranteed), so we need to do some extra
   // checks here to make sure the grid automatically handles all cells
-  const openCellPopover = useCallback(
+  const openCellPopover = useCallback<EuiDataGridRefProps['openCellPopover']>(
     ({ rowIndex, colIndex }) => {
       checkCellExists({ rowIndex, colIndex });
       const visibleRowIndex = findVisibleRowIndex(rowIndex);

--- a/src/components/datagrid/utils/ref.ts
+++ b/src/components/datagrid/utils/ref.ts
@@ -114,7 +114,7 @@ export const useImperativeGridRef = ({
  */
 export const useCellLocationCheck = (rowCount: number, colCount: number) => {
   const checkCellExists = useCallback(
-    ({ rowIndex, colIndex }) => {
+    ({ rowIndex, colIndex }: { rowIndex: number; colIndex: number }) => {
       if (rowIndex >= rowCount || rowIndex < 0) {
         throw new Error(
           `Row ${rowIndex} is not a valid row. The maximum visible row index is ${


### PR DESCRIPTION
## Summary

`@types/react` for React 18 introduced a few breaking changes, primarily in the automatic type inference area. Specifically, type inference for `useCallback` when passing to typed props is broken in TS version we're using (it should be fixed in v5.2 by [this PR](https://github.com/microsoft/TypeScript/pull/49707) and possibly more), but we're not there yet and the upgrade isn't straightforward.

React 17 apps using EUI won't be affected by these changes and React 18 apps will work as before depending on the TypeScript version they're running on.

There are also a few small fixes to ensure safe typing in other EuiDataGrid places.

Please pay attention to the `JSXElementConstructor` changes as it's the one that may cause the most trouble. I made sure the old and new types resolve to almost the same thing, but `JSXElementConstructor` had to be replaced as it breaks prop type inference when used and creates strange issues throughout our codebase when using `@types/react` v18. Overall, I think we should standardize whether we accept react elements or components in props in order to make sure we're rendering allowed input types correctly and not just casting the values to either of these in our render functions.

## QA

1. Checkout this branch
2. Run `yarn`
3. Run `yarn tsc --noEmit` and confirm there are no errors in `src/components/datagrid`

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
