### PR TITLE
test: convert simple component tests using enzyme render() tests to RTL

### DIFF
--- a/scripts/jest/setup/throw_on_console_error.js
+++ b/scripts/jest/setup/throw_on_console_error.js
@@ -26,5 +26,18 @@ console.error = (message, ...rest) => {
     return;
   }
 
+  // Print React validateDOMNesting warning as a console.warn instead
+  // of throwing an error.
+  // TODO: Remove when edge-case DOM nesting is fixed in all components
+  if (
+    typeof message === 'string' &&
+    message.startsWith(
+      'Warning: validateDOMNesting(...): %s cannot appear as a child of <%s>'
+    )
+  ) {
+    console.warn(message, ...rest);
+    return;
+  }
+
   throw new Error(format(message, ...rest));
 };

--- a/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
+++ b/src/components/aspect_ratio/__snapshots__/aspect_ratio.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiAspectRatio allows overriding with custom styles 1`] = `
   frameborder="0"
   height="315"
   src="https://www.youtube.com/embed/yJarWSLRM24"
-  style="aspect-ratio:9 / 4;height:300px;width:100%;margin:2em"
+  style="height: 300px; width: 100%; margin: 2em;"
   title="Elastic is a search company"
   width="560"
 />
@@ -24,7 +24,7 @@ exports[`EuiAspectRatio is rendered 1`] = `
   frameborder="0"
   height="315"
   src="https://www.youtube.com/embed/yJarWSLRM24"
-  style="aspect-ratio:9 / 4;height:auto;width:100%"
+  style="height: auto; width: 100%;"
   title="Elastic is a search company"
   width="560"
 />
@@ -40,7 +40,7 @@ exports[`EuiAspectRatio props maxWidth is rendered 1`] = `
   frameborder="0"
   height="315"
   src="https://www.youtube.com/embed/yJarWSLRM24"
-  style="aspect-ratio:9 / 16;height:auto;width:100%;max-width:500px"
+  style="height: auto; width: 100%; max-width: 500px;"
   title="Elastic is a search company"
   width="560"
 />

--- a/src/components/aspect_ratio/aspect_ratio.test.tsx
+++ b/src/components/aspect_ratio/aspect_ratio.test.tsx
@@ -7,14 +7,14 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 
 import { EuiAspectRatio } from './aspect_ratio';
 
 describe('EuiAspectRatio', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiAspectRatio height={4} width={9} {...requiredProps}>
         <iframe
           title="Elastic is a search company"
@@ -28,11 +28,11 @@ describe('EuiAspectRatio', () => {
       </EuiAspectRatio>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('allows overriding with custom styles', () => {
-    const component = render(
+    const { container } = render(
       <EuiAspectRatio
         height={4}
         width={9}
@@ -50,13 +50,13 @@ describe('EuiAspectRatio', () => {
       </EuiAspectRatio>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('maxWidth', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAspectRatio
             height={16}
             width={9}
@@ -75,7 +75,7 @@ describe('EuiAspectRatio', () => {
           </EuiAspectRatio>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -7,7 +7,8 @@
  */
 
 import React, { FocusEvent } from 'react';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
+import { render } from '../../test/rtl';
 import { CollapsedItemActions } from './collapsed_item_actions';
 import { Action } from './action_types';
 
@@ -33,9 +34,9 @@ describe('CollapsedItemActions', () => {
       onBlur: () => {},
     };
 
-    const component = render(<CollapsedItemActions {...props} />);
+    const { container } = render(<CollapsedItemActions {...props} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('render with href and _target provided', () => {

--- a/src/components/beacon/__snapshots__/beacon.test.tsx.snap
+++ b/src/components/beacon/__snapshots__/beacon.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`EuiBeacon is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-success-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -14,7 +14,7 @@ exports[`EuiBeacon props color accent is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-accent-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -23,7 +23,7 @@ exports[`EuiBeacon props color danger is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-danger-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -32,7 +32,7 @@ exports[`EuiBeacon props color primary is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-primary-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -41,7 +41,7 @@ exports[`EuiBeacon props color subdued is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-subdued-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -50,7 +50,7 @@ exports[`EuiBeacon props color success is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-success-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -59,7 +59,7 @@ exports[`EuiBeacon props color warning is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-warning-euiTestCss"
   data-test-subj="test subject string"
-  style="height:12px;width:12px"
+  style="height: 12px; width: 12px;"
 />
 `;
 
@@ -68,6 +68,6 @@ exports[`EuiBeacon props size accepts size 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-success-euiTestCss"
   data-test-subj="test subject string"
-  style="height:14px;width:14px"
+  style="height: 14px; width: 14px;"
 />
 `;

--- a/src/components/beacon/beacon.test.tsx
+++ b/src/components/beacon/beacon.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiBeacon, COLORS } from './beacon';
 
@@ -17,28 +17,30 @@ describe('EuiBeacon', () => {
   shouldRenderCustomStyles(<EuiBeacon />);
 
   test('is rendered', () => {
-    const component = render(<EuiBeacon {...requiredProps} />);
+    const { container } = render(<EuiBeacon {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         it(`${color} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiBeacon color={color} {...requiredProps} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
     describe('size', () => {
       it('accepts size', () => {
-        const component = render(<EuiBeacon size={14} {...requiredProps} />);
+        const { container } = render(
+          <EuiBeacon size={14} {...requiredProps} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/call_out/call_out.test.tsx
+++ b/src/components/call_out/call_out.test.tsx
@@ -7,45 +7,45 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiCallOut, COLORS, HEADINGS } from './call_out';
 
 describe('EuiCallOut', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCallOut {...requiredProps}>Content</EuiCallOut>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('title', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCallOut title="Title">Content</EuiCallOut>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('iconType', () => {
       it('is rendered', () => {
-        const component = render(<EuiCallOut iconType="user" />);
+        const { container } = render(<EuiCallOut iconType="user" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiCallOut color={color} />);
+          const { container } = render(<EuiCallOut color={color} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -53,9 +53,9 @@ describe('EuiCallOut', () => {
     describe('heading', () => {
       HEADINGS.forEach((heading) => {
         test(`${heading} is rendered`, () => {
-          const component = render(<EuiCallOut heading={heading} />);
+          const { container } = render(<EuiCallOut heading={heading} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`EuiComboBox is rendered 1`] = `
       >
         <div
           class="euiComboBox__input"
-          style="font-size:14px;display:inline-block"
+          style="font-size: 14px; display: inline-block;"
         >
           <input
             aria-autocomplete="list"
@@ -29,11 +29,11 @@ exports[`EuiComboBox is rendered 1`] = `
             data-test-subj="comboBoxSearchInput"
             id="generated-id__eui-combobox-id"
             role="combobox"
-            style="box-sizing:content-box;width:1px"
+            style="box-sizing: content-box; width: 2px;"
             value=""
           />
           <div
-            style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
+            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-size: 14px; font-family: 'Inter',BlinkMacSystemFont,Helvetica,Arial,sans-serif; font-weight: 400; letter-spacing: normal; text-transform: none;"
           />
         </div>
       </div>

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -7,7 +7,8 @@
  */
 
 import React, { ReactNode } from 'react';
-import { shallow, render, mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
+import { render } from '../../test/rtl';
 import {
   requiredProps,
   findTestSubject,
@@ -63,9 +64,9 @@ const options: TitanOption[] = [
 
 describe('EuiComboBox', () => {
   test('is rendered', () => {
-    const component = render(<EuiComboBox {...requiredProps} />);
+    const { container } = render(<EuiComboBox {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('supports thousands of options in an options group', () => {

--- a/src/components/comment_list/comment.test.tsx
+++ b/src/components/comment_list/comment.test.tsx
@@ -7,11 +7,11 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiComment } from './comment';
-import { shouldRenderCustomStyles } from '../../test/internal';
 
 describe('EuiComment', () => {
   shouldRenderCustomStyles(
@@ -19,52 +19,52 @@ describe('EuiComment', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiComment username="someuser" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('timestamp', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiComment timestamp="21 days ago" username="someuser" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('event', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiComment username="someuser" event="commented" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   test('renders a body', () => {
-    const component = render(
+    const { container } = render(
       <EuiComment username="someuser">
         <p>This is the body.</p>
       </EuiComment>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders a timeline icon', () => {
-    const component = render(
+    const { container } = render(
       <EuiComment username="someuser" timelineAvatar="dot">
         <p>This is the body.</p>
       </EuiComment>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/comment_list/comment_event.test.tsx
+++ b/src/components/comment_list/comment_event.test.tsx
@@ -7,46 +7,46 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiCommentEvent } from './comment_event';
 
 describe('EuiCommentEvent', () => {
   test('is rendered with custom content', () => {
-    const component = render(
+    const { container } = render(
       <EuiCommentEvent username="someuser" {...requiredProps}>
         <p>Some custom content</p>
       </EuiCommentEvent>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('timestamp', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCommentEvent timestamp="21 days ago" username="someuser" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('event', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCommentEvent event="commented" username="someuser" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('eventIcon and eventIconAriaLabel', () => {
       it('are rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCommentEvent
             username="someuser"
             eventIcon="pencil"
@@ -54,17 +54,17 @@ describe('EuiCommentEvent', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('eventColor', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCommentEvent username="someuser" eventColor="danger" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/comment_list/comment_list.test.tsx
+++ b/src/components/comment_list/comment_list.test.tsx
@@ -7,11 +7,11 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiCommentList } from './comment_list';
-import { shouldRenderCustomStyles } from '../../test/internal';
 import { GUTTER_SIZES } from '../timeline/timeline';
 
 const comments = [
@@ -26,22 +26,22 @@ describe('EuiCommentList', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCommentList comments={comments} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('gutterSize', () => {
       GUTTER_SIZES.forEach((gutterSize) => {
         test(`${gutterSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiCommentList comments={comments} gutterSize={gutterSize} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/comment_list/comment_timeline.test.tsx
+++ b/src/components/comment_list/comment_timeline.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { EuiCommentTimeline } from './comment_timeline';
 import { EuiAvatar } from '../avatar';
 
@@ -15,19 +15,21 @@ describe('EuiCommentTimeline', () => {
   describe('props', () => {
     describe('timelineAvatar', () => {
       it('defaults to an avatar with a `userAvatar` icon', () => {
-        const component = render(<EuiCommentTimeline />);
+        const { container } = render(<EuiCommentTimeline />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('is rendered with a string', () => {
-        const component = render(<EuiCommentTimeline timelineAvatar="dot" />);
+        const { container } = render(
+          <EuiCommentTimeline timelineAvatar="dot" />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('is rendered with a ReactNode', () => {
-        const component = render(
+        const { container } = render(
           <EuiCommentTimeline
             timelineAvatar={
               <EuiAvatar
@@ -39,18 +41,18 @@ describe('EuiCommentTimeline', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('is rendered with timelineAvatarAriaLabel', () => {
-        const component = render(
+        const { container } = render(
           <EuiCommentTimeline
             timelineAvatar="dot"
             timelineAvatarAriaLabel="timelineAvatarAriaLabel"
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
+++ b/src/components/control_bar/__snapshots__/control_bar.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiControlBar is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="aria-label"
     class="euiControlBar testClass1 testClass2 emotion-euiTestCss euiControlBar--large euiControlBar--fixed"
     data-test-subj="test subject string"
-    style="left:0;right:0"
+    style="left: 0px; right: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -29,6 +29,7 @@ Array [
           >
             <span
               class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+              title="src"
             >
               src
             </span>
@@ -40,6 +41,7 @@ Array [
             <span
               aria-current="page"
               class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+              title="components"
             >
               components
             </span>
@@ -47,7 +49,7 @@ Array [
         </ol>
       </nav>
       <button
-        class="euiButton euiControlBar__button emotion-euiButtonDisplay-s-defaultMinWidth-base-text"
+        class="euiButton euiControlBar__button emotion-euiButtonDisplay-s-defaultMinWidth-base-text-euiColorMode-dark-colorClassName"
         data-test-subj="dts"
         type="button"
       >
@@ -85,14 +87,14 @@ Array [
         Flight 815
       </button>
     </div>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`EuiControlBar props leftOffset is rendered 1`] = `

--- a/src/components/control_bar/control_bar.test.tsx
+++ b/src/components/control_bar/control_bar.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React, { ReactNode } from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { EuiControlBar, Control } from './control_bar';
 
@@ -69,10 +70,10 @@ const controls: Control[] = [
 
 describe('EuiControlBar', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiControlBar controls={controls} {...requiredProps} />
     );
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   describe('props', () => {

--- a/src/components/facet/__snapshots__/facet_button.test.tsx.snap
+++ b/src/components/facet/__snapshots__/facet_button.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`EuiFacetButton is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text emotion-euiFacetButton__text-unSelected"
+      data-text="Content"
     >
       Content
     </span>
@@ -23,6 +24,7 @@ exports[`EuiFacetButton is rendered 1`] = `
 exports[`EuiFacetButton props icon is rendered 1`] = `
 <button
   class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton"
+  title="Content"
   type="button"
 >
   <span
@@ -34,6 +36,7 @@ exports[`EuiFacetButton props icon is rendered 1`] = `
     />
     <span
       class="euiFacetButton__text emotion-euiFacetButton__text-unSelected"
+      data-text="Content"
     >
       Content
     </span>
@@ -45,6 +48,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
 <button
   class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiFacetButton"
   disabled=""
+  title="Content"
   type="button"
 >
   <span
@@ -57,6 +61,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
     />
     <span
       class="euiFacetButton__text emotion-euiFacetButton__text-unSelected"
+      data-text="Content"
     >
       Content
     </span>
@@ -73,6 +78,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
 <button
   class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiFacetButton"
   disabled=""
+  title="Content"
   type="button"
 >
   <span
@@ -80,6 +86,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text emotion-euiFacetButton__text-unSelected"
+      data-text="Content"
     >
       Content
     </span>
@@ -95,6 +102,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
 exports[`EuiFacetButton props isSelected is rendered 1`] = `
 <button
   class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton"
+  title="Content"
   type="button"
 >
   <span
@@ -102,6 +110,7 @@ exports[`EuiFacetButton props isSelected is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text emotion-euiFacetButton__text-isSelected"
+      data-text="Content"
     >
       Content
     </span>
@@ -112,6 +121,7 @@ exports[`EuiFacetButton props isSelected is rendered 1`] = `
 exports[`EuiFacetButton props quantity is rendered 1`] = `
 <button
   class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton"
+  title="Content"
   type="button"
 >
   <span
@@ -119,6 +129,7 @@ exports[`EuiFacetButton props quantity is rendered 1`] = `
   >
     <span
       class="euiFacetButton__text emotion-euiFacetButton__text-unSelected"
+      data-text="Content"
     >
       Content
     </span>

--- a/src/components/facet/facet_button.test.tsx
+++ b/src/components/facet/facet_button.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiFacetButton } from './facet_button';
 import { EuiIcon } from '../icon';
@@ -18,17 +19,17 @@ describe('EuiFacetButton', () => {
   shouldRenderCustomStyles(<EuiFacetButton>Content</EuiFacetButton>);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFacetButton {...requiredProps}>Content</EuiFacetButton>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('isDisabled', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiFacetButton
             isDisabled
             quantity={6}
@@ -38,47 +39,47 @@ describe('EuiFacetButton', () => {
           </EuiFacetButton>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isLoading', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiFacetButton isLoading>Content</EuiFacetButton>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isSelected', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiFacetButton isSelected>Content</EuiFacetButton>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('quantity', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiFacetButton quantity={60}>Content</EuiFacetButton>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('icon', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiFacetButton icon={<EuiIcon type="dot" />}>Content</EuiFacetButton>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 

--- a/src/components/facet/facet_group.test.tsx
+++ b/src/components/facet/facet_group.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { EuiFacetGroup, LAYOUTS, GUTTER_SIZES } from './facet_group';
 import { shouldRenderCustomStyles } from '../../test/internal';
@@ -17,18 +17,18 @@ describe('EuiFacetGroup', () => {
   shouldRenderCustomStyles(<EuiFacetGroup>Content</EuiFacetGroup>);
 
   test('is rendered', () => {
-    const component = render(<EuiFacetGroup {...requiredProps} />);
+    const { container } = render(<EuiFacetGroup {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('layout', () => {
       LAYOUTS.forEach((layout) => {
         test(`${layout} is rendered`, () => {
-          const component = render(<EuiFacetGroup layout={layout} />);
+          const { container } = render(<EuiFacetGroup layout={layout} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -36,9 +36,9 @@ describe('EuiFacetGroup', () => {
     describe('gutterSize', () => {
       GUTTER_SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(<EuiFacetGroup gutterSize={size} />);
+          const { container } = render(<EuiFacetGroup gutterSize={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/filter_group/filter_select_item.test.tsx
+++ b/src/components/filter_group/filter_select_item.test.tsx
@@ -7,15 +7,15 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 
 import { EuiFilterSelectItem } from './filter_select_item';
 
 describe('EuiFilterSelectItem', () => {
   test('is rendered', () => {
-    const component = render(<EuiFilterSelectItem {...requiredProps} />);
+    const { container } = render(<EuiFilterSelectItem {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/flyout/flyout_body.test.tsx
+++ b/src/components/flyout/flyout_body.test.tsx
@@ -7,15 +7,15 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiFlyoutBody } from './flyout_body';
 
 describe('EuiFlyoutBody', () => {
   test('is rendered', () => {
-    const component = render(<EuiFlyoutBody {...requiredProps} />);
+    const { container } = render(<EuiFlyoutBody {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/flyout/flyout_footer.test.tsx
+++ b/src/components/flyout/flyout_footer.test.tsx
@@ -7,15 +7,15 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiFlyoutFooter } from './flyout_footer';
 
 describe('EuiFlyoutFooter', () => {
   test('is rendered', () => {
-    const component = render(<EuiFlyoutFooter {...requiredProps} />);
+    const { container } = render(<EuiFlyoutFooter {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/flyout/flyout_header.test.tsx
+++ b/src/components/flyout/flyout_header.test.tsx
@@ -7,23 +7,23 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiFlyoutHeader } from './flyout_header';
 
 describe('EuiFlyoutHeader', () => {
   test('is rendered', () => {
-    const component = render(<EuiFlyoutHeader {...requiredProps} />);
+    const { container } = render(<EuiFlyoutHeader {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('border is rendered', () => {
-      const component = render(<EuiFlyoutHeader hasBorder />);
+      const { container } = render(<EuiFlyoutHeader hasBorder />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/focus_trap/__snapshots__/focus_trap.test.tsx.snap
+++ b/src/components/focus_trap/__snapshots__/focus_trap.test.tsx.snap
@@ -1,45 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiFocusTrap accepts className and style 1`] = `
-Array [
+<div>
   <div
     data-focus-guard="true"
-    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-    tabindex="-1"
-  />,
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
   <div
     class="testing"
-    data-focus-lock-disabled="disabled"
-    style="height:100%"
+    data-focus-lock-disabled="false"
+    style="height: 100%;"
   >
     <div />
-  </div>,
+  </div>
   <div
     data-focus-guard="true"
-    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
-    tabindex="-1"
-  />,
-]
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+</div>
 `;
 
 exports[`EuiFocusTrap can be disabled 1`] = `
-Array [
+<div>
   <div
     data-focus-guard="true"
-    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
     tabindex="-1"
-  />,
+  />
   <div
     data-focus-lock-disabled="disabled"
   >
     <div />
-  </div>,
+  </div>
   <div
     data-focus-guard="true"
-    style="width:1px;height:0px;padding:0;overflow:hidden;position:fixed;top:1px;left:1px"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
     tabindex="-1"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`EuiFocusTrap is rendered 1`] = `

--- a/src/components/focus_trap/focus_trap.test.tsx
+++ b/src/components/focus_trap/focus_trap.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React, { EventHandler } from 'react';
-import { render, mount } from 'enzyme';
-
+import { mount } from 'enzyme';
+import { render } from '../../test/rtl';
 import { findTestSubject, takeMountedSnapshot } from '../../test';
 
 import { EuiEvent } from '../outside_click_detector/outside_click_detector';
@@ -29,23 +29,23 @@ describe('EuiFocusTrap', () => {
   });
 
   test('can be disabled', () => {
-    const component = render(
+    const { container } = render(
       <EuiFocusTrap disabled>
         <div />
       </EuiFocusTrap>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('accepts className and style', () => {
-    const component = render(
+    const { container } = render(
       <EuiFocusTrap className="testing" style={{ height: '100%' }}>
         <div />
       </EuiFocusTrap>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   describe('behavior', () => {

--- a/src/components/health/health.test.tsx
+++ b/src/components/health/health.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { COLORS } from '../icon/icon';
 import { EuiHealth, TEXT_SIZES } from './health';
 
 describe('EuiHealth', () => {
   test('is rendered', () => {
-    const component = render(<EuiHealth {...requiredProps} />);
+    const { container } = render(<EuiHealth {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiHealth />);
@@ -26,11 +26,11 @@ describe('EuiHealth', () => {
     describe('textSize', () => {
       TEXT_SIZES.forEach((textSize: any) => {
         test(`${textSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiHealth textSize={textSize} color="success" />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -38,9 +38,9 @@ describe('EuiHealth', () => {
     describe('color', () => {
       [...COLORS, '#000000'].forEach((color) => {
         it(`${color} is rendered`, () => {
-          const component = render(<EuiHealth color={color} />);
+          const { container } = render(<EuiHealth color={color} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/highlight/__snapshots__/highlight.test.tsx.snap
+++ b/src/components/highlight/__snapshots__/highlight.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`EuiHighlight behavior matching hasScreenReaderHelpText can be false 1`]
 
 exports[`EuiHighlight behavior matching only applies to first match 1`] = `
 <span>
+  
   <mark
     class="euiMark emotion-euiMark-hasScreenReaderHelpText"
   >

--- a/src/components/highlight/highlight.test.tsx
+++ b/src/components/highlight/highlight.test.tsx
@@ -7,44 +7,44 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { EuiHighlight } from './highlight';
 
 describe('EuiHighlight', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiHighlight {...requiredProps} search="">
         value
       </EuiHighlight>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('behavior', () => {
     describe('matching', () => {
       test('only applies to first match', () => {
-        const component = render(
+        const { container } = render(
           <EuiHighlight search="match">match match match</EuiHighlight>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('applies to all matches', () => {
-        const component = render(
+        const { container } = render(
           <EuiHighlight search="match" highlightAll>
             match match match
           </EuiHighlight>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('hasScreenReaderHelpText can be false', () => {
-        const component = render(
+        const { container } = render(
           <EuiHighlight
             search="match"
             highlightAll
@@ -54,29 +54,29 @@ describe('EuiHighlight', () => {
           </EuiHighlight>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('loose matching', () => {
       test('matches strings with different casing', () => {
-        const component = render(
+        const { container } = render(
           <EuiHighlight search="CASE">different case match</EuiHighlight>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('strict matching', () => {
       test("doesn't match strings with different casing", () => {
-        const component = render(
+        const { container } = render(
           <EuiHighlight search="CASE" strict>
             different case match
           </EuiHighlight>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/horizontal_rule/horizontal_rule.test.tsx
+++ b/src/components/horizontal_rule/horizontal_rule.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 import { EuiHorizontalRule } from './horizontal_rule';
 
 describe('EuiHorizontalRule', () => {
   shouldRenderCustomStyles(<EuiHorizontalRule {...requiredProps} />);
 
   test('is rendered', () => {
-    const component = render(<EuiHorizontalRule {...requiredProps} />);
+    const { container } = render(<EuiHorizontalRule {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/inner_text/__snapshots__/inner_text.test.tsx.snap
+++ b/src/components/inner_text/__snapshots__/inner_text.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiInnerText is rendered 1`] = `
-<span>
+<span
+  title="Test"
+>
   Test
 </span>
 `;

--- a/src/components/inner_text/inner_text.test.tsx
+++ b/src/components/inner_text/inner_text.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { act } from 'react-dom/test-utils';
-import { render, mount } from 'enzyme';
+import { act } from '@testing-library/react';
+import { mount } from 'enzyme';
 import { findTestSubject, requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { useInnerText, EuiInnerText } from './inner_text';
 import { EuiBadge } from '../badge';
@@ -126,7 +127,7 @@ describe('useInnerText', () => {
 
 describe('EuiInnerText', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiInnerText {...requiredProps}>
         {(ref, innerText) => (
           <span ref={ref} title={innerText}>
@@ -136,7 +137,7 @@ describe('EuiInnerText', () => {
       </EuiInnerText>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('uses innerText', () => {

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -7,84 +7,87 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 import { EuiLink, COLORS } from './link';
 
 describe('EuiLink', () => {
   COLORS.forEach((color) => {
     test(`${color} is rendered`, () => {
-      const component = render(<EuiLink color={color} />);
-      expect(component).toMatchSnapshot();
+      const { container } = render(<EuiLink color={color} />);
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   shouldRenderCustomStyles(<EuiLink />);
 
   test('it supports both href and onClick', () => {
-    const component = render(<EuiLink href="/imalink" onClick={() => null} />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(
+      <EuiLink href="/imalink" onClick={() => null} />
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('it passes the default props through', () => {
-    const component = render(<EuiLink {...requiredProps} />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiLink {...requiredProps} />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('supports children', () => {
-    const component = render(
+    const { container } = render(
       <EuiLink href="#">
         <span>Hiya!!!</span>
       </EuiLink>
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('it is an external link', () => {
-    const component = render(<EuiLink external href="/baz/bing" />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiLink external href="/baz/bing" />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('supports href', () => {
-    const component = render(<EuiLink href="/baz/bing" />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiLink href="/baz/bing" />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('supports target', () => {
-    const component = render(<EuiLink href="#" target="_blank" />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiLink href="#" target="_blank" />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('allows for target and external to be controlled independently', () => {
-    const component = render(
+    const { container } = render(
       <EuiLink href="#" target="_blank" external={false} />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('supports rel', () => {
-    const component = render(<EuiLink href="hoi" rel="stylesheet" />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiLink href="hoi" rel="stylesheet" />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('supports disabled', () => {
-    const component = render(
+    const { container } = render(
       <EuiLink disabled onClick={() => 'hello, world!'} />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('if href is not specified, it renders a button of type=button', () => {
-    const component = render(<EuiLink />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiLink />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('button respects the type property', () => {
-    const component = render(
+    const { container } = render(
       <EuiLink type="submit" onClick={() => 'hello, world!'} />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onClick fires for buttons', () => {

--- a/src/components/mark/mark.test.tsx
+++ b/src/components/mark/mark.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiMark } from './mark';
 
@@ -17,30 +17,36 @@ describe('EuiMark', () => {
   shouldRenderCustomStyles(<EuiMark>Marked</EuiMark>);
 
   test('is rendered', () => {
-    expect(
-      render(<EuiMark {...requiredProps}>Marked</EuiMark>)
-    ).toMatchSnapshot();
+    const { container } = render(<EuiMark {...requiredProps}>Marked</EuiMark>);
+
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('No screen reader helper text', () => {
     test('is rendered without CSS :before', () => {
-      expect(
-        render(
-          <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
-            Marked
-          </EuiMark>
-        )
-      ).not.toHaveStyleRule('content', "' [highlight start] '");
+      const { container } = render(
+        <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
+          Marked
+        </EuiMark>
+      );
+
+      expect(container.firstChild).not.toHaveStyleRule(
+        'content',
+        "' [highlight start] '"
+      );
     });
 
     test('is rendered without CSS :after', () => {
-      expect(
-        render(
-          <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
-            Marked
-          </EuiMark>
-        )
-      ).not.toHaveStyleRule('content', "' [highlight end] '");
+      const { container } = render(
+        <EuiMark hasScreenReaderHelpText={false} {...requiredProps}>
+          Marked
+        </EuiMark>
+      );
+
+      expect(container.firstChild).not.toHaveStyleRule(
+        'content',
+        "' [highlight end] '"
+      );
     });
   });
 });

--- a/src/components/modal/modal_body.test.tsx
+++ b/src/components/modal/modal_body.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiModalBody } from './modal_body';
 
@@ -17,7 +17,9 @@ describe('EuiModalBody', () => {
   shouldRenderCustomStyles(<EuiModalBody>children</EuiModalBody>);
 
   test('is rendered', () => {
-    const component = <EuiModalBody {...requiredProps}>children</EuiModalBody>;
-    expect(render(component)).toMatchSnapshot();
+    const { container } = render(
+      <EuiModalBody {...requiredProps}>children</EuiModalBody>
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/modal/modal_footer.test.tsx
+++ b/src/components/modal/modal_footer.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiModalFooter } from './modal_footer';
 
@@ -17,9 +17,9 @@ describe('EuiModalFooter', () => {
   shouldRenderCustomStyles(<EuiModalFooter>children</EuiModalFooter>);
 
   test('is rendered', () => {
-    const component = (
+    const { container } = render(
       <EuiModalFooter {...requiredProps}>children</EuiModalFooter>
     );
-    expect(render(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/modal/modal_header.test.tsx
+++ b/src/components/modal/modal_header.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiModalHeader } from './modal_header';
 
@@ -17,9 +17,9 @@ describe('EuiModalHeader', () => {
   shouldRenderCustomStyles(<EuiModalHeader>children</EuiModalHeader>);
 
   test('is rendered', () => {
-    const component = (
+    const { container } = render(
       <EuiModalHeader {...requiredProps}>children</EuiModalHeader>
     );
-    expect(render(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/outside_click_detector/outside_click_detector.test.tsx
+++ b/src/components/outside_click_detector/outside_click_detector.test.tsx
@@ -7,7 +7,8 @@
  */
 
 import React, { EventHandler, MouseEvent as ReactMouseEvent } from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { EuiOutsideClickDetector, EuiEvent } from './outside_click_detector';
 
@@ -17,13 +18,13 @@ jest.mock('./../../services/accessibility', () => {
 
 describe('EuiOutsideClickDetector', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiOutsideClickDetector onOutsideClick={() => {}}>
         <div />
       </EuiOutsideClickDetector>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('behavior', () => {

--- a/src/components/pagination/pagination.test.tsx
+++ b/src/components/pagination/pagination.test.tsx
@@ -7,76 +7,78 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPagination } from './pagination';
 
 describe('EuiPagination', () => {
   test('is rendered', () => {
-    const component = render(<EuiPagination {...requiredProps} />);
+    const { container } = render(<EuiPagination {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('pageCount', () => {
       test('is rendered', () => {
-        const component = render(<EuiPagination pageCount={10} />);
+        const { container } = render(<EuiPagination pageCount={10} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('can be 0', () => {
-        const component = render(<EuiPagination pageCount={0} />);
+        const { container } = render(<EuiPagination pageCount={0} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('activePage', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPagination activePage={5} pageCount={10} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('can be -1', () => {
-        const component = render(
+        const { container } = render(
           <EuiPagination pageCount={0} activePage={-1} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('compressed', () => {
       test('is rendered', () => {
-        const component = render(<EuiPagination compressed />);
+        const { container } = render(<EuiPagination compressed />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('aria-controls is rendered', () => {
-      const component = render(<EuiPagination aria-controls={'idOfTable'} />);
+      const { container } = render(
+        <EuiPagination aria-controls={'idOfTable'} />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('responsive', () => {
       test('can be false', () => {
-        const component = render(<EuiPagination responsive={false} />);
+        const { container } = render(<EuiPagination responsive={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('can be customized', () => {
-        const component = render(<EuiPagination responsive={['xs']} />);
+        const { container } = render(<EuiPagination responsive={['xs']} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/pagination/pagination_button.test.tsx
+++ b/src/components/pagination/pagination_button.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPaginationButton } from './pagination_button';
 
 describe('EuiPaginationButton', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPaginationButton pageIndex={1} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/responsive/hide_for.test.tsx
+++ b/src/components/responsive/hide_for.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { EuiHideForBreakpoints, EuiHideFor } from './hide_for';
 
@@ -19,54 +19,54 @@ describe('EuiHideFor', () => {
   afterAll(() => 1024); // reset to jsdom's default
 
   test('renders', () => {
-    const component = render(
+    const { container } = render(
       <EuiHideFor sizes={['s']}>
         <span>Child</span>
       </EuiHideFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   BREAKPOINTS.forEach((size) => {
     test(`${size} is rendered`, () => {
-      const component = render(
+      const { container } = render(
         <EuiHideFor sizes={[size]}>
           <span>Child</span>
         </EuiHideFor>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('renders for multiple breakpoints', () => {
-    const component = render(
+    const { container } = render(
       <EuiHideFor sizes={['s', 'l']}>
         <span>Child</span>
       </EuiHideFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders for "none"', () => {
-    const component = render(
+    const { container } = render(
       <EuiHideFor sizes={'none'}>
         <span>Child</span>
       </EuiHideFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('never renders for "all"', () => {
-    const component = render(
+    const { container } = render(
       <EuiHideFor sizes={'all'}>
         <span>Child</span>
       </EuiHideFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/responsive/show_for.test.tsx
+++ b/src/components/responsive/show_for.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { EuiShowForBreakpoints, EuiShowFor } from './show_for';
 
@@ -19,54 +19,54 @@ describe('EuiShowFor', () => {
   afterAll(() => 1024); // reset to jsdom's default
 
   test('renders', () => {
-    const component = render(
+    const { container } = render(
       <EuiShowFor sizes={['s']}>
         <span>Child</span>
       </EuiShowFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   BREAKPOINTS.forEach((size) => {
     test(`${size} is rendered`, () => {
-      const component = render(
+      const { container } = render(
         <EuiShowFor sizes={[size]}>
           <span>Child</span>
         </EuiShowFor>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('renders for multiple breakpoints', () => {
-    const component = render(
+    const { container } = render(
       <EuiShowFor sizes={['s', 'l']}>
         <span>Child</span>
       </EuiShowFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders for "all"', () => {
-    const component = render(
+    const { container } = render(
       <EuiShowFor sizes={'all'}>
         <span>Child</span>
       </EuiShowFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('never renders for "none"', () => {
-    const component = render(
+    const { container } = render(
       <EuiShowFor sizes={'none'}>
         <span>Child</span>
       </EuiShowFor>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/spacer/spacer.test.tsx
+++ b/src/components/spacer/spacer.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiSpacer } from './spacer';
 
 describe('EuiSpacer', () => {
   test('is rendered', () => {
-    const component = render(<EuiSpacer {...requiredProps} />);
+    const { container } = render(<EuiSpacer {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiSpacer />);

--- a/src/components/text/__snapshots__/text.test.tsx.snap
+++ b/src/components/text/__snapshots__/text.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`EuiText props style 1`] = `
   aria-label="aria-label"
   class="euiText testClass1 testClass2 emotion-euiText-m-euiTextColor-customColor-euiTestCss"
   data-test-subj="test subject string"
-  style="background-color:#000;color:#fff"
+  style="background-color: rgb(0, 0, 0); color: rgb(255, 255, 255);"
 >
   <p>
     Content

--- a/src/components/text/__snapshots__/text_color.test.tsx.snap
+++ b/src/components/text/__snapshots__/text_color.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`EuiTextColor props cloneElement is rendered 1`] = `
 exports[`EuiTextColor props color is rendered with custom color 1`] = `
 <span
   class="emotion-euiTextColor-customColor"
-  style="color:#ff0000"
+  style="color: rgb(255, 0, 0);"
 >
   <p>
     Content

--- a/src/components/text/text.test.tsx
+++ b/src/components/text/text.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -15,13 +15,13 @@ import { EuiText } from './text';
 
 describe('EuiText', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiText {...requiredProps}>
         <p>Content</p>
       </EuiText>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiText size="s" color="#fff" />);
@@ -31,28 +31,28 @@ describe('EuiText', () => {
   describe('props', () => {
     describe('grow', () => {
       test('false', () => {
-        const component = render(
+        const { container } = render(
           <EuiText {...requiredProps} grow={false}>
             <p>Content</p>
           </EuiText>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('color & align', () => {
-      const component = render(
+      const { container } = render(
         <EuiText {...requiredProps} color="danger" textAlign="center">
           <p>Content</p>
         </EuiText>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('style', () => {
-      const component = render(
+      const { container } = render(
         <EuiText
           {...requiredProps}
           color="#fff"
@@ -62,7 +62,7 @@ describe('EuiText', () => {
         </EuiText>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/text/text_align.test.tsx
+++ b/src/components/text/text_align.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiTextAlign, ALIGNMENTS } from './text_align';
 
 describe('EuiTextAlign', () => {
   test('is rendered', () => {
-    const component = render(<EuiTextAlign {...requiredProps} />);
+    const { container } = render(<EuiTextAlign {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(
@@ -30,22 +30,22 @@ describe('EuiTextAlign', () => {
     describe('direction', () => {
       ALIGNMENTS.forEach((direction) => {
         test(`${direction} is rendered`, () => {
-          const component = render(<EuiTextAlign textAlign={direction} />);
+          const { container } = render(<EuiTextAlign textAlign={direction} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('cloneElement', () => {
       test('cloneElement', () => {
-        const component = render(
+        const { container } = render(
           <EuiTextAlign cloneElement>
             <p>Content</p>
           </EuiTextAlign>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       shouldRenderCustomStyles(<EuiTextAlign cloneElement textAlign="right" />);

--- a/src/components/text/text_color.test.tsx
+++ b/src/components/text/text_color.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiTextColor } from './text_color';
 
 describe('EuiTextColor', () => {
   test('is rendered', () => {
-    const component = render(<EuiTextColor {...requiredProps} />);
+    const { container } = render(<EuiTextColor {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiTextColor color="#fff" />);
@@ -25,35 +25,35 @@ describe('EuiTextColor', () => {
   describe('props', () => {
     describe('color', () => {
       test('is rendered with named color', () => {
-        const component = render(
+        const { container } = render(
           <EuiTextColor color="warning">
             <p>Content</p>
           </EuiTextColor>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with custom color', () => {
-        const component = render(
+        const { container } = render(
           <EuiTextColor color="#ff0000">
             <p>Content</p>
           </EuiTextColor>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('cloneElement', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiTextColor cloneElement>
             <p>Content</p>
           </EuiTextColor>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       shouldRenderCustomStyles(

--- a/src/components/text_diff/text-diff.test.tsx
+++ b/src/components/text_diff/text-diff.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { useEuiTextDiff } from './text_diff';
 const beforeText =
@@ -25,9 +25,9 @@ describe('useEuiTextDiff', () => {
       })[0];
       return <>{renderedComponent}</>;
     };
-    const component = render(<Element />);
+    const { container } = render(<Element />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
@@ -44,9 +44,9 @@ describe('useEuiTextDiff', () => {
           })[0];
           return <>{renderedComponent}</>;
         };
-        const component = render(<Element />);
+        const { container } = render(<Element />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/timeline/timeline.test.tsx
+++ b/src/components/timeline/timeline.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { EuiAvatar } from '../avatar';
 import { EuiTimeline, EuiTimelineProps, GUTTER_SIZES } from './timeline';
 
@@ -34,20 +34,20 @@ const items: EuiTimelineProps['items'] = [
 
 describe('EuiTimeline', () => {
   test('is rendered with items', () => {
-    const component = render(<EuiTimeline items={items} />);
+    const { container } = render(<EuiTimeline items={items} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('gutterSize', () => {
       GUTTER_SIZES.forEach((gutterSize) => {
         test(`${gutterSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiTimeline items={items} gutterSize={gutterSize} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/timeline/timeline_item.test.tsx
+++ b/src/components/timeline/timeline_item.test.tsx
@@ -7,48 +7,48 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { EuiAvatar } from '../avatar';
 import { EuiTimelineItem, VERTICAL_ALIGN } from './timeline_item';
 
 describe('EuiTimelineItem', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiTimelineItem icon="dot">
         <p>I&apos;m the children</p>
       </EuiTimelineItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('verticalAlign', () => {
       VERTICAL_ALIGN.forEach((alignment) => {
         test(`${alignment} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiTimelineItem icon="dot" verticalAlign={alignment}>
               <p>I&apos;m the children</p>
             </EuiTimelineItem>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     test('iconAriaLabel is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiTimelineItem icon="dot" iconAriaLabel="icon aria label">
           <p>I&apos;m the children</p>
         </EuiTimelineItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('EuiAvatar is passed as an icon', () => {
-      const component = render(
+      const { container } = render(
         <EuiTimelineItem
           icon={<EuiAvatar name="dot" iconType="dot" color="subdued" />}
         >
@@ -56,7 +56,7 @@ describe('EuiTimelineItem', () => {
         </EuiTimelineItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/title/title.test.tsx
+++ b/src/components/title/title.test.tsx
@@ -7,21 +7,21 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiTitle } from './title';
 
 describe('EuiTitle', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiTitle {...requiredProps}>
         <h1>Title</h1>
       </EuiTitle>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(
@@ -31,12 +31,12 @@ describe('EuiTitle', () => {
   );
 
   test('renders children element className', () => {
-    const component = render(
+    const { container } = render(
       <EuiTitle {...requiredProps}>
         <h1 className="test">Title</h1>
       </EuiTitle>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { render, mount } from 'enzyme';
+import { act } from '@testing-library/react';
+import { mount } from 'enzyme';
 import { requiredProps, findTestSubject } from '../../test';
+import { render } from '../../test/rtl';
 
 import {
   EuiGlobalToastList,
@@ -21,7 +22,7 @@ jest.useFakeTimers();
 
 describe('EuiGlobalToastList', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiGlobalToastList
         {...requiredProps}
         dismissToast={() => {}}
@@ -29,7 +30,7 @@ describe('EuiGlobalToastList', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
@@ -54,7 +55,7 @@ describe('EuiGlobalToastList', () => {
           },
         ];
 
-        const component = render(
+        const { container } = render(
           <EuiGlobalToastList
             toasts={toasts}
             dismissToast={() => {}}
@@ -62,7 +63,7 @@ describe('EuiGlobalToastList', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
@@ -87,7 +88,7 @@ describe('EuiGlobalToastList', () => {
           },
         ];
 
-        const component = render(
+        const { container } = render(
           <EuiGlobalToastList
             toasts={toasts}
             dismissToast={() => {}}
@@ -95,7 +96,7 @@ describe('EuiGlobalToastList', () => {
             side="left"
           />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 

--- a/src/components/toast/global_toast_list_item.test.tsx
+++ b/src/components/toast/global_toast_list_item.test.tsx
@@ -7,18 +7,18 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { EuiGlobalToastListItem } from './global_toast_list_item';
 
 describe('EuiGlobalToastListItem', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiGlobalToastListItem>
         <div>Hi</div>
       </EuiGlobalToastListItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/toast/toast.test.tsx
+++ b/src/components/toast/toast.test.tsx
@@ -7,43 +7,48 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { findTestSubject, requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { COLORS, EuiToast } from './toast';
 
 describe('EuiToast', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiToast {...requiredProps} title="test title">
         <p>Hi</p>
       </EuiToast>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('Props', () => {
     describe('title', () => {
       test('is rendered', () => {
-        const component = <EuiToast title="toast title" />;
-        expect(render(component)).toMatchSnapshot();
+        const { container } = render(<EuiToast title="toast title" />);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = <EuiToast color={color} title="test title" />;
-          expect(render(component)).toMatchSnapshot();
+          const { container } = render(
+            <EuiToast color={color} title="test title" />
+          );
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('iconType', () => {
       test('is rendered', () => {
-        const component = <EuiToast iconType="user" title="test title" />;
-        expect(render(component)).toMatchSnapshot();
+        const { container } = render(
+          <EuiToast iconType="user" title="test title" />
+        );
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 

--- a/src/components/tool_tip/icon_tip.test.tsx
+++ b/src/components/tool_tip/icon_tip.test.tsx
@@ -7,10 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { fireEvent } from '@testing-library/react';
-import { waitForEuiToolTipVisible } from '../../test/rtl';
 import { requiredProps } from '../../test';
+import { render, waitForEuiToolTipVisible } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiIconTip } from './icon_tip';
@@ -28,41 +27,41 @@ describe('EuiIconTip', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiIconTip title="title" id="id" content="content" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('type', () => {
       test('is rendered as the icon', () => {
-        const component = render(
+        const { container } = render(
           <EuiIconTip type="warning" id="id" content="content" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('color', () => {
       test('is rendered as the icon color', () => {
-        const component = render(
+        const { container } = render(
           <EuiIconTip color="warning" id="id" content="content" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       test('is rendered as the icon size', () => {
-        const component = render(
+        const { container } = render(
           <EuiIconTip size="xl" id="id" content="content" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/tool_tip/tool_tip_popover.test.tsx
+++ b/src/components/tool_tip/tool_tip_popover.test.tsx
@@ -7,16 +7,16 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { EuiToolTipPopover } from './tool_tip_popover';
 
 describe('EuiToolTipPopover', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiToolTipPopover positionToolTip={() => {}} {...requiredProps} />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/tour/tour_step_indicator.test.tsx
+++ b/src/components/tour/tour_step_indicator.test.tsx
@@ -7,33 +7,33 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiTourStepIndicator } from './tour_step_indicator';
 
 describe('EuiTourStepIndicator', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiTourStepIndicator number={1} status="active" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can be complete', () => {
-    const component = render(
+    const { container } = render(
       <EuiTourStepIndicator number={1} status="complete" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can be incomplete', () => {
-    const component = render(
+    const { container } = render(
       <EuiTourStepIndicator number={1} status="incomplete" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/tree_view/tree_view.test.tsx
+++ b/src/components/tree_view/tree_view.test.tsx
@@ -9,8 +9,9 @@
 import React from 'react';
 import { EuiIcon } from '../icon';
 import { EuiToken } from '../token';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiTreeView } from './tree_view';
 
@@ -74,9 +75,11 @@ const items = [
 
 describe('EuiTreeView', () => {
   test('is rendered', () => {
-    const component = render(<EuiTreeView items={items} {...requiredProps} />);
+    const { container } = render(
+      <EuiTreeView items={items} {...requiredProps} />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('length of open items', () => {


### PR DESCRIPTION
## Summary

This PR converts a bunch of unit tests using Enzyme's `render()` function to RTL `render()` counterpart to reduce our tech debt.

As you can see there's also a new `validateDOMNesting` conditional in `throw_on_console_error` to warn about semantically incorrect nesting but not panic by throwing an error as it did before. This change needs to exist until we fix our test cases to always use a valid DOM structure when testing as well as any runtime DOM nesting errors we may have inside EUI components.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**