### PR TITLE
test: convert EuiForm unit tests using enzyme render to RTL

### DIFF
--- a/src/components/form/checkbox/__snapshots__/checkbox_group.test.tsx.snap
+++ b/src/components/form/checkbox/__snapshots__/checkbox_group.test.tsx.snap
@@ -2,51 +2,33 @@
 
 exports[`EuiCheckboxGroup (mocked checkbox) disabled is rendered 1`] = `
 <div>
-  <eui_checkbox
-    checked=""
-    class="euiCheckboxGroup__item"
-    disabled=""
-    id="1"
-    label="kibana"
+  <div
+    data-eui-checkbox=""
   />
-  <eui_checkbox
-    class="euiCheckboxGroup__item"
-    disabled=""
-    id="2"
-    label="elastic"
+  <div
+    data-eui-checkbox=""
   />
 </div>
 `;
 
 exports[`EuiCheckboxGroup (mocked checkbox) idToSelectedMap is rendered 1`] = `
 <div>
-  <eui_checkbox
-    checked=""
-    class="euiCheckboxGroup__item"
-    id="1"
-    label="kibana"
+  <div
+    data-eui-checkbox=""
   />
-  <eui_checkbox
-    class="euiCheckboxGroup__item"
-    id="2"
-    label="elastic"
+  <div
+    data-eui-checkbox=""
   />
 </div>
 `;
 
 exports[`EuiCheckboxGroup (mocked checkbox) individual disabled is rendered 1`] = `
 <div>
-  <eui_checkbox
-    checked=""
-    class="euiCheckboxGroup__item"
-    disabled=""
-    id="1"
-    label="kibana"
+  <div
+    data-eui-checkbox=""
   />
-  <eui_checkbox
-    class="euiCheckboxGroup__item"
-    id="2"
-    label="elastic"
+  <div
+    data-eui-checkbox=""
   />
 </div>
 `;
@@ -71,15 +53,11 @@ exports[`EuiCheckboxGroup (mocked checkbox) legend is rendered 1`] = `
 
 exports[`EuiCheckboxGroup (mocked checkbox) options are rendered 1`] = `
 <div>
-  <eui_checkbox
-    class="euiCheckboxGroup__item"
-    id="1"
-    label="kibana"
+  <div
+    data-eui-checkbox=""
   />
-  <eui_checkbox
-    class="euiCheckboxGroup__item"
-    id="2"
-    label="elastic"
+  <div
+    data-eui-checkbox=""
   />
 </div>
 `;

--- a/src/components/form/checkbox/checkbox.test.tsx
+++ b/src/components/form/checkbox/checkbox.test.tsx
@@ -7,13 +7,13 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import {
   requiredProps,
   startThrowingReactWarnings,
   stopThrowingReactWarnings,
 } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiCheckbox, TYPES } from './checkbox';
 
@@ -43,32 +43,32 @@ describe('EuiCheckbox', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckbox id="id" onChange={() => {}} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('check is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiCheckbox {...checkboxRequiredProps} checked />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('label is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiCheckbox {...checkboxRequiredProps} label={<span>Label</span>} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('labelProps is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiCheckbox
           {...checkboxRequiredProps}
           label="Label"
@@ -76,27 +76,27 @@ describe('EuiCheckbox', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
     describe('type', () => {
       TYPES.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiCheckbox {...checkboxRequiredProps} type={value} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('disabled', () => {
       test('disabled is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCheckbox {...checkboxRequiredProps} disabled />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/form/checkbox/checkbox_group.test.tsx
+++ b/src/components/form/checkbox/checkbox_group.test.tsx
@@ -7,12 +7,14 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiCheckboxGroup } from './checkbox_group';
 
-jest.mock('./checkbox', () => ({ EuiCheckbox: 'eui_checkbox' }));
+jest.mock('./checkbox', () => ({
+  EuiCheckbox: () => <div data-eui-checkbox="" />,
+}));
 
 const checkboxGroupRequiredProps = {
   options: [],
@@ -22,15 +24,15 @@ const checkboxGroupRequiredProps = {
 
 describe('EuiCheckboxGroup (mocked checkbox)', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckboxGroup {...checkboxGroupRequiredProps} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('options are rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckboxGroup
         {...checkboxGroupRequiredProps}
         options={[
@@ -40,11 +42,11 @@ describe('EuiCheckboxGroup (mocked checkbox)', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('idToSelectedMap is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckboxGroup
         {...checkboxGroupRequiredProps}
         options={[
@@ -58,11 +60,11 @@ describe('EuiCheckboxGroup (mocked checkbox)', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('disabled is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckboxGroup
         {...checkboxGroupRequiredProps}
         options={[
@@ -77,11 +79,11 @@ describe('EuiCheckboxGroup (mocked checkbox)', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('individual disabled is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckboxGroup
         {...checkboxGroupRequiredProps}
         options={[
@@ -95,11 +97,11 @@ describe('EuiCheckboxGroup (mocked checkbox)', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('legend is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckboxGroup
         {...checkboxGroupRequiredProps}
         legend={{
@@ -108,6 +110,6 @@ describe('EuiCheckboxGroup (mocked checkbox)', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/form/field_password/__snapshots__/field_password.test.tsx.snap
+++ b/src/components/form/field_password/__snapshots__/field_password.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`EuiFieldPassword props compressed is rendered 1`] = `
       <input
         class="euiFieldPassword euiFieldPassword--compressed"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -90,6 +91,7 @@ exports[`EuiFieldPassword props dual dual type also renders append 1`] = `
       <input
         class="euiFieldPassword euiFieldPassword--inGroup euiFieldPassword--withToggle"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -143,6 +145,7 @@ exports[`EuiFieldPassword props dual dualToggleProps is rendered 1`] = `
       <input
         class="euiFieldPassword euiFieldPassword--inGroup euiFieldPassword--withToggle"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -187,6 +190,7 @@ exports[`EuiFieldPassword props fullWidth is rendered 1`] = `
       <input
         class="euiFieldPassword euiFieldPassword--fullWidth"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -219,6 +223,7 @@ exports[`EuiFieldPassword props isInvalid is rendered 1`] = `
       <input
         class="euiFieldPassword euiFormControlLayout--1icons"
         type="password"
+        value=""
       />
     </eui-validatable-control>
     <div
@@ -257,6 +262,7 @@ exports[`EuiFieldPassword props isLoading is rendered 1`] = `
       <input
         class="euiFieldPassword euiFormControlLayout--1icons euiFieldPassword-isLoading"
         type="password"
+        value=""
       />
     </eui-validatable-control>
     <div
@@ -301,6 +307,7 @@ exports[`EuiFieldPassword props prepend and append is rendered 1`] = `
       <input
         class="euiFieldPassword euiFieldPassword--inGroup"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -336,6 +343,7 @@ exports[`EuiFieldPassword props type dual is rendered 1`] = `
       <input
         class="euiFieldPassword euiFieldPassword--inGroup euiFieldPassword--withToggle"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -379,6 +387,7 @@ exports[`EuiFieldPassword props type password is rendered 1`] = `
       <input
         class="euiFieldPassword"
         type="password"
+        value=""
       />
     </eui-validatable-control>
   </div>
@@ -409,6 +418,7 @@ exports[`EuiFieldPassword props type text is rendered 1`] = `
       <input
         class="euiFieldPassword"
         type="text"
+        value=""
       />
     </eui-validatable-control>
   </div>

--- a/src/components/form/field_password/field_password.test.tsx
+++ b/src/components/form/field_password/field_password.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
+import { mount } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiFieldPassword, EuiFieldPasswordProps } from './field_password';
@@ -30,7 +31,7 @@ describe('EuiFieldPassword', () => {
   });
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFieldPassword
         name="elastic"
         id="1"
@@ -41,70 +42,70 @@ describe('EuiFieldPassword', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('isInvalid is rendered', () => {
-      const component = render(<EuiFieldPassword isInvalid />);
+      const { container } = render(<EuiFieldPassword isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('fullWidth is rendered', () => {
-      const component = render(<EuiFieldPassword fullWidth />);
+      const { container } = render(<EuiFieldPassword fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isLoading is rendered', () => {
-      const component = render(<EuiFieldPassword isLoading />);
+      const { container } = render(<EuiFieldPassword isLoading />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('prepend and append is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFieldPassword prepend="String" append="String" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('compressed is rendered', () => {
-      const component = render(<EuiFieldPassword compressed />);
+      const { container } = render(<EuiFieldPassword compressed />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('type', () => {
       TYPES.forEach((type) => {
         test(`${type} is rendered`, () => {
-          const component = render(<EuiFieldPassword type={type} />);
+          const { container } = render(<EuiFieldPassword type={type} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('dual', () => {
       test('dualToggleProps is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiFieldPassword type="dual" dualToggleProps={requiredProps} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('dual type also renders append', () => {
-        const component = render(
+        const { container } = render(
           <EuiFieldPassword
             type="dual"
             append={['String', <span>Span</span>]}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('dual does not mutate the append array prop', () => {
@@ -144,21 +145,14 @@ describe('EuiFieldPassword', () => {
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiFieldPassword />
         </EuiForm>
       );
 
-      if (
-        !component
-          .find('.euiFieldPassword')
-          .hasClass('euiFieldPassword--fullWidth')
-      ) {
-        throw new Error(
-          'expected EuiFieldPassword to inherit fullWidth from EuiForm'
-        );
-      }
+      const input = container.querySelector('.euiFieldPassword');
+      expect(input).toHaveClass('euiFieldPassword--fullWidth');
     });
   });
 });

--- a/src/components/form/field_search/field_search.test.tsx
+++ b/src/components/form/field_search/field_search.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiFieldSearch } from './field_search';
@@ -22,7 +22,7 @@ jest.mock('../validatable_control', () => ({
 
 describe('EuiFieldSearch', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFieldSearch
         name="elastic"
         id="1"
@@ -33,72 +33,67 @@ describe('EuiFieldSearch', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('isInvalid is rendered', () => {
-      const component = render(<EuiFieldSearch isInvalid />);
+      const { container } = render(<EuiFieldSearch isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('fullWidth is rendered', () => {
-      const component = render(<EuiFieldSearch fullWidth />);
+      const { container } = render(<EuiFieldSearch fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isLoading is rendered', () => {
-      const component = render(<EuiFieldSearch isLoading />);
+      const { container } = render(<EuiFieldSearch isLoading />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('isClearable', () => {
       test('is accepted', () => {
-        const component = render(<EuiFieldSearch isClearable />);
+        const { container } = render(<EuiFieldSearch isClearable />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered when a value exists', () => {
-        const component = render(
+        const { container } = render(
           <EuiFieldSearch isClearable defaultValue="Hello" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('prepend is rendered', () => {
-      const component = render(<EuiFieldSearch prepend="Prepend" />);
+      const { container } = render(<EuiFieldSearch prepend="Prepend" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('append is rendered', () => {
-      const component = render(<EuiFieldSearch prepend="Append" />);
+      const { container } = render(<EuiFieldSearch prepend="Append" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiFieldSearch />
         </EuiForm>
       );
 
-      if (
-        !component.find('.euiFieldSearch').hasClass('euiFieldSearch--fullWidth')
-      ) {
-        throw new Error(
-          'expected EuiFieldSearch to inherit fullWidth from EuiForm'
-        );
-      }
+      const input = container.querySelector('.euiFieldSearch');
+      expect(input).toHaveClass('euiFieldSearch--fullWidth');
     });
   });
 });

--- a/src/components/form/field_text/__snapshots__/field_text.test.tsx.snap
+++ b/src/components/form/field_text/__snapshots__/field_text.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`EuiFieldText props controlOnly is rendered 1`] = `
   <input
     class="euiFieldText"
     type="text"
+    value=""
   />
 </eui-validatable-control>
 `;
@@ -38,6 +39,7 @@ exports[`EuiFieldText props fullWidth is rendered 1`] = `
     <input
       class="euiFieldText euiFieldText--fullWidth"
       type="text"
+      value=""
     />
   </eui-validatable-control>
 </eui-form-control-layout>
@@ -54,6 +56,7 @@ exports[`EuiFieldText props isInvalid is rendered 1`] = `
     <input
       class="euiFieldText euiFormControlLayout--1icons"
       type="text"
+      value=""
     />
   </eui-validatable-control>
 </eui-form-control-layout>
@@ -68,6 +71,7 @@ exports[`EuiFieldText props isLoading is rendered 1`] = `
     <input
       class="euiFieldText euiFormControlLayout--1icons euiFieldText-isLoading"
       type="text"
+      value=""
     />
   </eui-validatable-control>
 </eui-form-control-layout>
@@ -83,6 +87,7 @@ exports[`EuiFieldText props readOnly is rendered 1`] = `
       class="euiFieldText"
       readonly=""
       type="text"
+      value=""
     />
   </eui-validatable-control>
 </eui-form-control-layout>

--- a/src/components/form/field_text/field_text.test.tsx
+++ b/src/components/form/field_text/field_text.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiFieldText } from './field_text';
@@ -26,7 +26,7 @@ jest.mock('../validatable_control', () => ({
 
 describe('EuiFieldText', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFieldText
         name="elastic"
         id="1"
@@ -39,56 +39,51 @@ describe('EuiFieldText', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('isInvalid is rendered', () => {
-      const component = render(<EuiFieldText isInvalid />);
+      const { container } = render(<EuiFieldText isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('fullWidth is rendered', () => {
-      const component = render(<EuiFieldText fullWidth />);
+      const { container } = render(<EuiFieldText fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('readOnly is rendered', () => {
-      const component = render(<EuiFieldText readOnly />);
+      const { container } = render(<EuiFieldText readOnly />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isLoading is rendered', () => {
-      const component = render(<EuiFieldText isLoading />);
+      const { container } = render(<EuiFieldText isLoading />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('controlOnly is rendered', () => {
-      const component = render(<EuiFieldText controlOnly />);
+      const { container } = render(<EuiFieldText controlOnly />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { getByRole } = render(
         <EuiForm fullWidth>
           <EuiFieldText />
         </EuiForm>
       );
 
-      if (
-        !component.find('.euiFieldText').hasClass('euiFieldText--fullWidth')
-      ) {
-        throw new Error(
-          'expected EuiFieldText to inherit fullWidth from EuiForm'
-        );
-      }
+      const input = getByRole('textbox');
+      expect(input).toHaveClass('euiFieldText--fullWidth');
     });
   });
 });

--- a/src/components/form/file_picker/file_picker.test.tsx
+++ b/src/components/form/file_picker/file_picker.test.tsx
@@ -7,34 +7,29 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiFilePicker } from './file_picker';
 
 describe('EuiFilePicker', () => {
   test('is rendered', () => {
-    const component = render(<EuiFilePicker {...requiredProps} />);
+    const { container } = render(<EuiFilePicker {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiFilePicker />
         </EuiForm>
       );
 
-      if (
-        !component.find('.euiFilePicker').hasClass('euiFilePicker--fullWidth')
-      ) {
-        throw new Error(
-          'expected EuiFilePicker to inherit fullWidth from EuiForm'
-        );
-      }
+      const filePicker = container.querySelector('.euiFilePicker');
+      expect(filePicker).toHaveClass('euiFilePicker--fullWidth');
     });
   });
 });

--- a/src/components/form/form.test.tsx
+++ b/src/components/form/form.test.tsx
@@ -7,30 +7,32 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiForm } from './form';
 
 describe('EuiForm', () => {
   test('is rendered', () => {
-    const component = render(<EuiForm {...requiredProps} />);
+    const { container } = render(<EuiForm {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders a form element', () => {
-    const component = render(<EuiForm {...requiredProps} component="form" />);
+    const { container } = render(
+      <EuiForm {...requiredProps} component="form" />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
   test('renders with error callout when isInvalid is "true"', () => {
-    const component = render(<EuiForm {...requiredProps} isInvalid />);
+    const { container } = render(<EuiForm {...requiredProps} isInvalid />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
   test('renders with error callout when isInvalid is "true" and has one error', () => {
-    const component = render(
+    const { container } = render(
       <EuiForm
         {...requiredProps}
         isInvalid
@@ -38,10 +40,10 @@ describe('EuiForm', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
   test('renders with error callout when isInvalid is "true" and has multiple errors', () => {
-    const component = render(
+    const { container } = render(
       <EuiForm
         {...requiredProps}
         isInvalid
@@ -52,13 +54,13 @@ describe('EuiForm', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
   test('renders without error callout when invalidCallout is "none"', () => {
-    const component = render(
+    const { container } = render(
       <EuiForm {...requiredProps} isInvalid invalidCallout="none" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/form/form_control_layout/form_control_layout.test.tsx
+++ b/src/components/form/form_control_layout/form_control_layout.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { findTestSubject, requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiFormControlLayout } from './form_control_layout';
@@ -22,22 +23,22 @@ jest.mock('../../', () => ({
 
 describe('EuiFormControlLayout', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayout {...requiredProps}>
         <input />
       </EuiFormControlLayout>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('icon', () => {
       describe('is rendered', () => {
         test('as a string', () => {
-          const component = render(<EuiFormControlLayout icon="error" />);
+          const { container } = render(<EuiFormControlLayout icon="error" />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         test('as an object', () => {
@@ -47,9 +48,9 @@ describe('EuiFormControlLayout', () => {
             'data-test-subj': 'myIcon',
           };
 
-          const component = render(<EuiFormControlLayout icon={icon} />);
+          const { container } = render(<EuiFormControlLayout icon={icon} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
@@ -61,9 +62,9 @@ describe('EuiFormControlLayout', () => {
               side,
             };
 
-            const component = render(<EuiFormControlLayout icon={icon} />);
+            const { container } = render(<EuiFormControlLayout icon={icon} />);
 
-            expect(component).toMatchSnapshot();
+            expect(container.firstChild).toMatchSnapshot();
           });
         });
       });
@@ -94,9 +95,9 @@ describe('EuiFormControlLayout', () => {
             'data-test-subj': 'clearButton',
           };
 
-          const component = render(<EuiFormControlLayout clear={clear} />);
+          const { container } = render(<EuiFormControlLayout clear={clear} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         test('is called when clicked', () => {
@@ -115,25 +116,25 @@ describe('EuiFormControlLayout', () => {
     });
 
     test('isLoading is rendered', () => {
-      const component = render(<EuiFormControlLayout isLoading />);
+      const { container } = render(<EuiFormControlLayout isLoading />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isInvalid is rendered', () => {
-      const component = render(<EuiFormControlLayout isInvalid />);
+      const { container } = render(<EuiFormControlLayout isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isDropdown is rendered', () => {
-      const component = render(<EuiFormControlLayout isDropdown />);
+      const { container } = render(<EuiFormControlLayout isDropdown />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('iconsPosition', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormControlLayout
           iconsPosition="static"
           icon="calendar"
@@ -143,12 +144,12 @@ describe('EuiFormControlLayout', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('compressed', () => {
       it('renders small-sized icon, clear button, and loading spinner', () => {
-        const component = render(
+        const { container } = render(
           <EuiFormControlLayout
             compressed
             icon={{ type: 'error' }}
@@ -157,92 +158,87 @@ describe('EuiFormControlLayout', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('fullWidth is rendered', () => {
-      const component = render(<EuiFormControlLayout fullWidth />);
+      const { container } = render(<EuiFormControlLayout fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('readOnly is rendered', () => {
-      const component = render(<EuiFormControlLayout readOnly />);
+      const { container } = render(<EuiFormControlLayout readOnly />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('one prepend node is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormControlLayout prepend={<span>1</span>} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('one prepend node is rendered with className', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormControlLayout prepend={<span className="myClass">1</span>} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('one prepend string is rendered', () => {
-      const component = render(<EuiFormControlLayout prepend="1" />);
+      const { container } = render(<EuiFormControlLayout prepend="1" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('one append node is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormControlLayout append={<span>1</span>} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('one append string is rendered', () => {
-      const component = render(<EuiFormControlLayout append="1" />);
+      const { container } = render(<EuiFormControlLayout append="1" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('multiple prepends are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormControlLayout prepend={[<span>1</span>, <span>2</span>]} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('multiple appends are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormControlLayout append={[<span>1</span>, <span>2</span>]} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { baseElement } = render(
         <EuiForm fullWidth>
           <EuiFormControlLayout />
         </EuiForm>
       );
 
-      if (
-        !component
-          .find('.euiFormControlLayout')
-          .hasClass('euiFormControlLayout--fullWidth')
-      ) {
-        throw new Error(
-          'expected EuiFormControlLayout to inherit fullWidth from EuiForm'
-        );
-      }
+      const layout = baseElement.querySelector('.euiFormControlLayout');
+
+      expect(layout).toBeDefined();
+      expect(layout).toHaveClass('euiFormControlLayout--fullWidth');
     });
   });
 });

--- a/src/components/form/form_control_layout/form_control_layout_clear_button.test.tsx
+++ b/src/components/form/form_control_layout/form_control_layout_clear_button.test.tsx
@@ -7,27 +7,27 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { EuiFormControlLayoutClearButton } from './form_control_layout_clear_button';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
+import { EuiFormControlLayoutClearButton } from './form_control_layout_clear_button';
 
 describe('EuiFormControlLayoutClearButton', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayoutClearButton
         onClick={() => null}
         {...requiredProps}
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayoutClearButton onClick={() => null} size="s" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/form/form_control_layout/form_control_layout_custom_icon.test.tsx
+++ b/src/components/form/form_control_layout/form_control_layout_custom_icon.test.tsx
@@ -7,45 +7,45 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 import {
   EuiFormControlLayoutCustomIcon,
   EuiFormControlLayoutCustomIconProps,
 } from './form_control_layout_custom_icon';
-import { requiredProps } from '../../../test';
 
 describe('EuiFormControlLayoutCustomIcon', () => {
   test('is rendered as button', () => {
     const props: EuiFormControlLayoutCustomIconProps = {
       onClick: () => null,
       type: 'error',
-      iconRef: 'icon',
+      iconRef: jest.fn(),
       color: 'danger',
     };
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayoutCustomIcon {...props} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered as span', () => {
     const props: EuiFormControlLayoutCustomIconProps = {
       type: 'error',
-      iconRef: 'icon',
+      iconRef: jest.fn(),
     };
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayoutCustomIcon {...props} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('size is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayoutCustomIcon type="warning" size="s" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/form/form_control_layout/form_control_layout_delimited.test.tsx
+++ b/src/components/form/form_control_layout/form_control_layout_delimited.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiFormControlLayoutDelimited } from './form_control_layout_delimited';
@@ -15,7 +15,7 @@ import { EuiIcon } from '../../icon';
 
 describe('EuiFormControlLayoutDelimited', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormControlLayoutDelimited
         startControl={<span>start</span>}
         endControl={<span>end</span>}
@@ -23,14 +23,14 @@ describe('EuiFormControlLayoutDelimited', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('delimiter', () => {
       describe('is rendered', () => {
         test('as a string', () => {
-          const component = render(
+          const { container } = render(
             <EuiFormControlLayoutDelimited
               startControl={<span>start</span>}
               endControl={<span>end</span>}
@@ -38,13 +38,13 @@ describe('EuiFormControlLayoutDelimited', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         test('as a node', () => {
           const icon = <EuiIcon type="error" />;
 
-          const component = render(
+          const { container } = render(
             <EuiFormControlLayoutDelimited
               startControl={<span>start</span>}
               endControl={<span>end</span>}
@@ -52,7 +52,7 @@ describe('EuiFormControlLayoutDelimited', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/form/form_error_text/form_error_text.test.tsx
+++ b/src/components/form/form_error_text/form_error_text.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiFormErrorText } from './form_error_text';
 
 describe('EuiFormErrorText', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormErrorText {...requiredProps}>This is an error.</EuiFormErrorText>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/form/form_fieldset/form_fieldset.test.tsx
+++ b/src/components/form/form_fieldset/form_fieldset.test.tsx
@@ -7,31 +7,31 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiFormFieldset } from './form_fieldset';
 
 describe('EuiFormFieldset', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormFieldset {...requiredProps}>
         <input />
       </EuiFormFieldset>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('legend is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormFieldset legend={{ children: 'Legend' }}>
           <input />
         </EuiFormFieldset>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/form/form_fieldset/form_legend.test.tsx
+++ b/src/components/form/form_fieldset/form_legend.test.tsx
@@ -7,35 +7,35 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiFormLegend } from './form_legend';
 
 describe('EuiFormLegend', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormLegend {...requiredProps}>Legend</EuiFormLegend>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('hidden is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormLegend display="hidden">Legend</EuiFormLegend>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('compressed is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormLegend compressed>Legend</EuiFormLegend>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/form/form_help_text/form_help_text.test.tsx
+++ b/src/components/form/form_help_text/form_help_text.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiFormHelpText } from './form_help_text';
 
 describe('EuiFormHelpText', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormHelpText {...requiredProps}>This is help text.</EuiFormHelpText>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/form/form_label/form_label.test.tsx
+++ b/src/components/form/form_label/form_label.test.tsx
@@ -7,49 +7,49 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiFormLabel } from './form_label';
 
 describe('EuiFormLabel', () => {
   test('is rendered', () => {
-    const component = render(<EuiFormLabel {...requiredProps} />);
+    const { container } = render(<EuiFormLabel {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('isFocused is rendered', () => {
-      const component = render(<EuiFormLabel isFocused />);
+      const { container } = render(<EuiFormLabel isFocused />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isInvalid is rendered', () => {
-      const component = render(<EuiFormLabel isInvalid />);
+      const { container } = render(<EuiFormLabel isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('isDisabled', () => {
       test('is rendered', () => {
-        const component = render(<EuiFormLabel isDisabled />);
+        const { container } = render(<EuiFormLabel isDisabled />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is still disabled with for attribute', () => {
-        const component = render(<EuiFormLabel isDisabled htmlFor="" />);
+        const { container } = render(<EuiFormLabel isDisabled htmlFor="" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('type can be changed to legend', () => {
-      const component = render(<EuiFormLabel type="legend" />);
+      const { container } = render(<EuiFormLabel type="legend" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/form/form_row/__snapshots__/form_row.test.tsx.snap
+++ b/src/components/form/form_row/__snapshots__/form_row.test.tsx.snap
@@ -553,7 +553,8 @@ exports[`EuiFormRow props label append is rendered 1`] = `
     >
       label
     </label>
-     append
+     
+    append
   </div>
   <div
     class="euiFormRow__fieldWrapper"

--- a/src/components/form/form_row/form_row.test.tsx
+++ b/src/components/form/form_row/form_row.test.tsx
@@ -7,21 +7,22 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiFormRow, DISPLAYS } from './form_row';
 
 describe('EuiFormRow', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFormRow {...requiredProps}>
         <input />
       </EuiFormRow>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('ties together parts for accessibility', () => {
@@ -59,167 +60,167 @@ describe('EuiFormRow', () => {
 
   describe('props', () => {
     test('label is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow label="label">
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('label append is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow label="label" labelAppend="append">
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('label renders as a legend and subsquently a fieldset wrapper', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow label="label" labelType="legend">
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('describedByIds is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow describedByIds={['generated-id-additional']}>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('id is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow id="id">
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isInvalid is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow isInvalid label="label">
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('error as string is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow error="Error" isInvalid={true}>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('error as array is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow error={['Error', 'Error2']} isInvalid={true}>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('error is not rendered if isInvalid is false', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow error={['Error']} isInvalid={false}>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('helpText is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow helpText={<span>This is help text.</span>}>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('hasEmptyLabelSpace is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow hasEmptyLabelSpace>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('fullWidth is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiFormRow fullWidth>
           <input />
         </EuiFormRow>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('isDisabled', () => {
       test('is passed as disabled to child', () => {
-        const component = render(
+        const { container } = render(
           <EuiFormRow isDisabled>
             <input />
           </EuiFormRow>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test("allows a child's disabled to override", () => {
-        const component = render(
+        const { container } = render(
           <EuiFormRow isDisabled>
             <input disabled={false} />
           </EuiFormRow>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('allows a child to still be disabled manually', () => {
-        const component = render(
+        const { container } = render(
           <EuiFormRow>
             <input disabled />
           </EuiFormRow>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('display type', () => {
       DISPLAYS.forEach((display) => {
         test(`${display} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiFormRow display={display}>
               <input />
             </EuiFormRow>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -297,7 +298,7 @@ describe('EuiFormRow', () => {
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiFormRow label={<span>Label</span>}>
             <input />
@@ -305,11 +306,8 @@ describe('EuiFormRow', () => {
         </EuiForm>
       );
 
-      if (!component.find('.euiFormRow').hasClass('euiFormRow--fullWidth')) {
-        throw new Error(
-          'expected EuiFormRow to inherit fullWidth from EuiForm'
-        );
-      }
+      const row = container.querySelector('.euiFormRow');
+      expect(row).toHaveClass('euiFormRow--fullWidth');
     });
   });
 });

--- a/src/components/form/radio/__snapshots__/radio.test.tsx.snap
+++ b/src/components/form/radio/__snapshots__/radio.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`EuiRadio is rendered 1`] = `
     class="euiRadio__input"
     id="id"
     type="radio"
+    value=""
   />
   <div
     class="euiRadio__circle"
@@ -26,6 +27,7 @@ exports[`EuiRadio props checked is rendered 1`] = `
     class="euiRadio__input"
     id="id"
     type="radio"
+    value=""
   />
   <div
     class="euiRadio__circle"
@@ -42,6 +44,7 @@ exports[`EuiRadio props disabled is rendered 1`] = `
     disabled=""
     id="id"
     type="radio"
+    value=""
   />
   <div
     class="euiRadio__circle"
@@ -57,6 +60,7 @@ exports[`EuiRadio props label is rendered 1`] = `
     class="euiRadio__input"
     id="id"
     type="radio"
+    value=""
   />
   <div
     class="euiRadio__circle"
@@ -80,6 +84,7 @@ exports[`EuiRadio props labelProps is rendered 1`] = `
     class="euiRadio__input"
     id="id"
     type="radio"
+    value=""
   />
   <div
     class="euiRadio__circle"

--- a/src/components/form/radio/__snapshots__/radio_group.test.tsx.snap
+++ b/src/components/form/radio/__snapshots__/radio_group.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`EuiRadioGroup props idSelected is rendered 1`] = `
       class="euiRadio__input"
       id="1"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -36,6 +37,7 @@ exports[`EuiRadioGroup props idSelected is rendered 1`] = `
       class="euiRadio__input"
       id="2"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -64,6 +66,7 @@ exports[`EuiRadioGroup props legend is rendered 1`] = `
       class="euiRadio__input"
       id="1"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -82,6 +85,7 @@ exports[`EuiRadioGroup props legend is rendered 1`] = `
       class="euiRadio__input"
       id="2"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -106,6 +110,7 @@ exports[`EuiRadioGroup props name is propagated to radios 1`] = `
       id="1"
       name="radiogroupname"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -125,6 +130,7 @@ exports[`EuiRadioGroup props name is propagated to radios 1`] = `
       id="2"
       name="radiogroupname"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -148,6 +154,7 @@ exports[`EuiRadioGroup props options are rendered 1`] = `
       class="euiRadio__input"
       id="1"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"
@@ -167,6 +174,7 @@ exports[`EuiRadioGroup props options are rendered 1`] = `
       disabled=""
       id="2"
       type="radio"
+      value=""
     />
     <div
       class="euiRadio__circle"

--- a/src/components/form/radio/radio.test.tsx
+++ b/src/components/form/radio/radio.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiRadio } from './radio';
 
@@ -20,48 +20,48 @@ describe('EuiRadio', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiRadio id="id" onChange={() => {}} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('checked is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadio id="id" onChange={() => {}} checked />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('label is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadio id="id" onChange={() => {}} label={<span>Label</span>} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('value is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadio id="id" onChange={() => {}} value={'bobbins'} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('disabled is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadio id="id" onChange={() => {}} disabled />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('labelProps is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadio
           id="id"
           onChange={() => {}}
@@ -70,7 +70,7 @@ describe('EuiRadio', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/form/radio/radio_group.test.tsx
+++ b/src/components/form/radio/radio_group.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiRadioGroup } from './radio_group';
 
@@ -16,16 +17,16 @@ jest.mock('../radio', () => ({ EuiRadio: 'eui_radio' }));
 
 describe('EuiRadioGroup', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiRadioGroup {...requiredProps} options={[]} onChange={() => {}} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('options are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadioGroup
           options={[
             { id: '1', label: 'Option #1' },
@@ -35,11 +36,11 @@ describe('EuiRadioGroup', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('name is propagated to radios', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadioGroup
           name="radiogroupname"
           options={[
@@ -50,11 +51,11 @@ describe('EuiRadioGroup', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('idSelected is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadioGroup
           options={[
             { id: '1', label: 'Option #1' },
@@ -65,11 +66,11 @@ describe('EuiRadioGroup', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('value is propagated to radios', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadioGroup
           name="radiogroupname"
           options={[
@@ -80,11 +81,11 @@ describe('EuiRadioGroup', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('legend is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiRadioGroup
           options={[
             { id: '1', label: 'Option #1' },
@@ -97,7 +98,7 @@ describe('EuiRadioGroup', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 

--- a/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`EuiRange allows value prop to accept a number 1`] = `
     >
       <output
         class="euiRangeTooltip__value emotion-euiRangeTooltip__value-right"
-        style="inset-inline-start:8%"
+        style="inset-inline-start: 8%;"
       >
         8
       </output>
@@ -140,7 +140,7 @@ exports[`EuiRange props custom ticks should render 1`] = `
     >
       <button
         class="euiRangeTick emotion-euiRangeTick-isCustom-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(-Infinity% + 8px)"
+        style="inset-inline-start: calc(-Infinity% + 8px);"
         tabindex="-1"
         title="20kb"
         type="button"
@@ -150,7 +150,7 @@ exports[`EuiRange props custom ticks should render 1`] = `
       </button>
       <button
         class="euiRangeTick emotion-euiRangeTick-isCustom-isMax-regular"
-        style="inset-inline-end:0%;margin-inline-end:-1.25em"
+        style="inset-inline-end: 0%; margin-inline-end: -1.25em;"
         tabindex="-1"
         title="100kb"
         type="button"
@@ -159,7 +159,7 @@ exports[`EuiRange props custom ticks should render 1`] = `
         <span
           aria-hidden="true"
           class="euiRangeTick__pseudo emotion-euiRangeTick__pseudo"
-          style="margin-inline-end:calc(1.25em + 4px)"
+          style="margin-inline-end: calc(1.25em + 4px);"
         />
         100kb
       </button>
@@ -263,7 +263,7 @@ exports[`EuiRange props input should render 1`] = `
         min="0"
         name="name"
         step="1"
-        style="inline-size:calc(12px + 1ch + 2em + 0px)"
+        style="inline-size: calc(12px + 1ch + 2em + 0px);"
         type="number"
         value="8"
       />
@@ -317,11 +317,11 @@ exports[`EuiRange props levels should render 1`] = `
     >
       <span
         class="euiRangeLevel emotion-euiRangeLevel-danger"
-        style="inset-inline-start:calc(0% + 0px);inset-inline-end:calc(100% - 0px)"
+        style="inset-inline-start: calc(0% + 0px); inset-inline-end: calc(100% - 0px);"
       />
       <span
         class="euiRangeLevel emotion-euiRangeLevel-success"
-        style="inset-inline-start:calc(0% + 0px);inset-inline-end:calc(100% - 0px)"
+        style="inset-inline-start: calc(0% + 0px); inset-inline-end: calc(100% - 0px);"
       />
     </div>
     <input
@@ -331,7 +331,7 @@ exports[`EuiRange props levels should render 1`] = `
       max="100"
       min="0"
       step="1"
-      style="color:#BD271E"
+      style="color: rgb(189, 39, 30);"
       type="range"
       value="20"
     />
@@ -404,7 +404,7 @@ exports[`EuiRange props range should render 1`] = `
     >
       <div
         class="euiRangeHighlight__progress emotion-euiRangeHighlight__progress"
-        style="margin-inline-start:0%;inline-size:8%"
+        style="margin-inline-start: 0%; inline-size: 8%;"
       />
     </div>
   </div>
@@ -457,8 +457,9 @@ exports[`EuiRange props ticks should render 1`] = `
     >
       <button
         class="euiRangeTick emotion-euiRangeTick-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(NaN% + 8px);max-inline-size:16.666666666666664%"
+        style="inset-inline-start: calc(NaN% + 8px); max-inline-size: 16.666666666666664%;"
         tabindex="-1"
+        title="0"
         type="button"
         value="0"
       >
@@ -466,8 +467,9 @@ exports[`EuiRange props ticks should render 1`] = `
       </button>
       <button
         class="euiRangeTick emotion-euiRangeTick-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(-Infinity% + 8px);max-inline-size:16.666666666666664%"
+        style="inset-inline-start: calc(-Infinity% + 8px); max-inline-size: 16.666666666666664%;"
         tabindex="-1"
+        title="20"
         type="button"
         value="20"
       >
@@ -475,8 +477,9 @@ exports[`EuiRange props ticks should render 1`] = `
       </button>
       <button
         class="euiRangeTick emotion-euiRangeTick-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(-Infinity% + 8px);max-inline-size:16.666666666666664%"
+        style="inset-inline-start: calc(-Infinity% + 8px); max-inline-size: 16.666666666666664%;"
         tabindex="-1"
+        title="40"
         type="button"
         value="40"
       >
@@ -484,8 +487,9 @@ exports[`EuiRange props ticks should render 1`] = `
       </button>
       <button
         class="euiRangeTick emotion-euiRangeTick-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(-Infinity% + 8px);max-inline-size:16.666666666666664%"
+        style="inset-inline-start: calc(-Infinity% + 8px); max-inline-size: 16.666666666666664%;"
         tabindex="-1"
+        title="60"
         type="button"
         value="60"
       >
@@ -493,8 +497,9 @@ exports[`EuiRange props ticks should render 1`] = `
       </button>
       <button
         class="euiRangeTick emotion-euiRangeTick-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(-Infinity% + 8px);max-inline-size:16.666666666666664%"
+        style="inset-inline-start: calc(-Infinity% + 8px); max-inline-size: 16.666666666666664%;"
         tabindex="-1"
+        title="80"
         type="button"
         value="80"
       >
@@ -502,8 +507,9 @@ exports[`EuiRange props ticks should render 1`] = `
       </button>
       <button
         class="euiRangeTick emotion-euiRangeTick-hasPseudoTickMark-regular"
-        style="inset-inline-start:calc(-Infinity% + 8px);max-inline-size:16.666666666666664%"
+        style="inset-inline-start: calc(-Infinity% + 8px); max-inline-size: 16.666666666666664%;"
         tabindex="-1"
+        title="100"
         type="button"
         value="100"
       >
@@ -547,9 +553,11 @@ exports[`EuiRange props value should render 1`] = `
     >
       <output
         class="euiRangeTooltip__value emotion-euiRangeTooltip__value-left"
-        style="inset-inline-end:0%"
+        style="inset-inline-end: 0%;"
       >
-        before200after
+        before
+        200
+        after
       </output>
     </div>
   </div>

--- a/src/components/form/range/range.test.tsx
+++ b/src/components/form/range/range.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiRange } from './range';
@@ -31,7 +31,7 @@ describe('EuiRange', () => {
   });
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiRange
         name="name"
         id="id"
@@ -41,44 +41,44 @@ describe('EuiRange', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('disabled should render', () => {
-      const component = render(<EuiRange {...props} disabled />);
+      const { container } = render(<EuiRange {...props} disabled />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('fullWidth should render', () => {
-      const component = render(<EuiRange {...props} fullWidth />);
+      const { container } = render(<EuiRange {...props} fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('compressed should render', () => {
-      const component = render(<EuiRange {...props} compressed />);
+      const { container } = render(<EuiRange {...props} compressed />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('labels should render', () => {
-      const component = render(<EuiRange {...props} showLabels />);
+      const { container } = render(<EuiRange {...props} showLabels />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('ticks should render', () => {
-      const component = render(
+      const { container } = render(
         <EuiRange {...props} showTicks tickInterval={20} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('custom ticks should render', () => {
-      const component = render(
+      const { container } = render(
         <EuiRange
           {...props}
           showTicks
@@ -89,18 +89,18 @@ describe('EuiRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('range should render', () => {
-      const component = render(<EuiRange {...props} showRange />);
+      const { container } = render(<EuiRange {...props} showRange />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('value should render', () => {
       const { value, ...localProps } = props;
-      const component = render(
+      const { container } = render(
         <EuiRange
           value="200"
           showValue
@@ -110,11 +110,11 @@ describe('EuiRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('input should render', () => {
-      const component = render(
+      const { container } = render(
         <EuiRange
           name="name"
           id="id"
@@ -125,11 +125,11 @@ describe('EuiRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('slider should display in popover', () => {
-      const component = render(
+      const { container } = render(
         <EuiRange
           name="name"
           id="id"
@@ -140,11 +140,11 @@ describe('EuiRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('loading should display when showInput="inputWithPopover"', () => {
-      const component = render(
+      const { container } = render(
         <EuiRange
           name="name"
           id="id"
@@ -156,11 +156,11 @@ describe('EuiRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('levels should render', () => {
-      const component = render(
+      const { container } = render(
         <EuiRange
           levels={[
             {
@@ -180,37 +180,37 @@ describe('EuiRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('allows value prop to accept a number', () => {
     const { value, ...localProps } = props;
-    const component = render(
+    const { container } = render(
       <EuiRange value={8} onChange={() => {}} showValue {...localProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('allows value prop to accept empty string', () => {
     const { value, ...localProps } = props;
-    const component = render(
+    const { container } = render(
       <EuiRange value={''} onChange={() => {}} {...localProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiRange value={20} min={0} max={100} />
         </EuiForm>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/form/select/__snapshots__/select.test.tsx.snap
+++ b/src/components/form/select/__snapshots__/select.test.tsx.snap
@@ -133,7 +133,6 @@ exports[`EuiSelect props value option is rendered 1`] = `
       class="euiSelect euiFormControlLayout--1icons"
     >
       <option
-        selected=""
         value="1"
       >
         Option #1

--- a/src/components/form/select/select.test.tsx
+++ b/src/components/form/select/select.test.tsx
@@ -8,8 +8,9 @@
 /* eslint-disable no-irregular-whitespace */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiSelect } from './select';
@@ -23,16 +24,16 @@ jest.mock('../validatable_control', () => ({
 
 describe('EuiSelect', () => {
   it('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSelect id="id" name="name" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     it('options are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelect
           options={[
             { value: '1', text: 'Option #1' },
@@ -41,29 +42,29 @@ describe('EuiSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('isInvalid is rendered', () => {
-      const component = render(<EuiSelect isInvalid />);
+      const { container } = render(<EuiSelect isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('fullWidth is rendered', () => {
-      const component = render(<EuiSelect fullWidth />);
+      const { container } = render(<EuiSelect fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('isLoading is rendered', () => {
-      const component = render(<EuiSelect isLoading />);
+      const { container } = render(<EuiSelect isLoading />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('disabled options are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelect
           options={[
             { value: '1', text: 'Option #1', disabled: false },
@@ -72,11 +73,11 @@ describe('EuiSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('value option is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelect
           options={[
             { value: '1', text: 'Option #1' },
@@ -87,7 +88,7 @@ describe('EuiSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
@@ -157,15 +158,14 @@ describe('EuiSelect', () => {
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiSelect />
         </EuiForm>
       );
 
-      if (!component.find('.euiSelect').hasClass('euiSelect--fullWidth')) {
-        throw new Error('expected EuiSelect to inherit fullWidth from EuiForm');
-      }
+      const select = container.querySelector('.euiSelect');
+      expect(select).toHaveClass('euiSelect--fullWidth');
     });
   });
 });

--- a/src/components/form/super_select/__snapshots__/super_select_control.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select_control.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiSuperSelectControl is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -33,16 +33,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props compressed is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout euiFormControlLayout--compressed"
   >
@@ -68,16 +68,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props disabled options are rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -103,16 +103,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props empty value option is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -138,16 +138,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props fullWidth is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout euiFormControlLayout--fullWidth"
   >
@@ -173,16 +173,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props isInvalid is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -212,16 +212,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props isLoading is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -252,16 +252,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props placeholder is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value=""
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -293,16 +293,16 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`EuiSuperSelectControl props value option is rendered 1`] = `
-Array [
+<div>
   <input
     type="hidden"
     value="1"
-  />,
+  />
   <div
     class="euiFormControlLayout"
   >
@@ -330,6 +330,6 @@ Array [
         </span>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/src/components/form/super_select/super_select.test.tsx
+++ b/src/components/form/super_select/super_select.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps, takeMountedSnapshot } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiSuperSelect } from './super_select';
 
@@ -29,7 +30,7 @@ describe('EuiSuperSelect', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSuperSelect
         {...requiredProps}
         options={options}
@@ -37,12 +38,12 @@ describe('EuiSuperSelect', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('fullWidth is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelect
           {...requiredProps}
           options={options}
@@ -51,11 +52,11 @@ describe('EuiSuperSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('compressed is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelect
           {...requiredProps}
           options={options}
@@ -64,11 +65,11 @@ describe('EuiSuperSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered with a prepend and append', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelect
           {...requiredProps}
           options={options}
@@ -78,11 +79,11 @@ describe('EuiSuperSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('select component is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelect
           options={[
             { value: '1', inputDisplay: 'Option #1' },
@@ -92,7 +93,7 @@ describe('EuiSuperSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('options are rendered when select is open', () => {
@@ -110,7 +111,7 @@ describe('EuiSuperSelect', () => {
     });
 
     test('valueSelected is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelect
           options={options}
           valueOfSelected="2"
@@ -118,7 +119,7 @@ describe('EuiSuperSelect', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('custom display is propagated to dropdown', () => {

--- a/src/components/form/super_select/super_select_control.test.tsx
+++ b/src/components/form/super_select/super_select_control.test.tsx
@@ -7,46 +7,46 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiSuperSelectControl } from './super_select_control';
 
 describe('EuiSuperSelectControl', () => {
   test('is rendered', () => {
-    const component = render(<EuiSuperSelectControl {...requiredProps} />);
+    const { container } = render(<EuiSuperSelectControl {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('fullWidth is rendered', () => {
-      const component = render(<EuiSuperSelectControl fullWidth />);
+      const { container } = render(<EuiSuperSelectControl fullWidth />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('compressed is rendered', () => {
-      const component = render(<EuiSuperSelectControl compressed />);
+      const { container } = render(<EuiSuperSelectControl compressed />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('isLoading is rendered', () => {
-      const component = render(<EuiSuperSelectControl isLoading />);
+      const { container } = render(<EuiSuperSelectControl isLoading />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('isInvalid is rendered', () => {
-      const component = render(<EuiSuperSelectControl isInvalid />);
+      const { container } = render(<EuiSuperSelectControl isInvalid />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('disabled options are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelectControl
           options={[
             { value: '1', inputDisplay: 'Option #1', disabled: false },
@@ -55,11 +55,11 @@ describe('EuiSuperSelectControl', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('value option is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelectControl
           options={[
             { value: '1', inputDisplay: 'Option #1' },
@@ -70,12 +70,12 @@ describe('EuiSuperSelectControl', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('empty value option is rendered', () => {
       const value = undefined;
-      const component = render(
+      const { container } = render(
         <EuiSuperSelectControl
           options={[
             { value: '1', inputDisplay: 'Option #1' },
@@ -86,11 +86,11 @@ describe('EuiSuperSelectControl', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('placeholder is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuperSelectControl
           options={[
             { value: '1', inputDisplay: 'Option #1' },
@@ -101,30 +101,25 @@ describe('EuiSuperSelectControl', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
-      expect(
-        component.find('.euiSuperSelectControl__placeholder')
-      ).toBeTruthy();
+      expect(container).toMatchSnapshot();
+      const placeholder = container.querySelector(
+        '.euiSuperSelectControl__placeholder'
+      );
+
+      expect(placeholder).toBeInTheDocument();
     });
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiSuperSelectControl />
         </EuiForm>
       );
 
-      if (
-        !component
-          .find('.euiSuperSelectControl')
-          .hasClass('euiSuperSelectControl--fullWidth')
-      ) {
-        throw new Error(
-          'expected EuiSuperSelectControl to inherit fullWidth from EuiForm'
-        );
-      }
+      const control = container.querySelector('.euiSuperSelectControl');
+      expect(control).toHaveClass('euiSuperSelectControl--fullWidth');
     });
   });
 });

--- a/src/components/form/switch/switch.test.tsx
+++ b/src/components/form/switch/switch.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiSwitch } from './switch';
 
@@ -34,25 +34,25 @@ describe('EuiSwitch', () => {
   });
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSwitch id="test" {...props} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('assigns automatically generated ID to label', () => {
-    const component = render(<EuiSwitch {...props} />);
+    const { container } = render(<EuiSwitch {...props} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
   describe('labelProps', () => {
     it('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSwitch {...props} labelProps={requiredProps} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/form/text_area/text_area.test.tsx
+++ b/src/components/form/text_area/text_area.test.tsx
@@ -7,32 +7,29 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import { EuiTextArea } from './text_area';
 
 describe('EuiTextArea', () => {
   test('is rendered', () => {
-    const component = render(<EuiTextArea {...requiredProps} />);
+    const { container } = render(<EuiTextArea {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('inherits', () => {
     test('fullWidth from <EuiForm />', () => {
-      const component = render(
+      const { container } = render(
         <EuiForm fullWidth>
           <EuiTextArea />
         </EuiForm>
       );
 
-      if (!component.find('.euiTextArea').hasClass('euiTextArea--fullWidth')) {
-        throw new Error(
-          'expected EuiTextArea to inherit fullWidth from EuiForm'
-        );
-      }
+      const element = container.querySelector('.euiTextArea');
+      expect(element).toHaveClass('euiTextArea--fullWidth');
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR converts `EuiForm` unit tests using Enzyme's render() function to RTL render() counterpart to reduce our tech debt.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
