### PR TITLE
test: convert EuiPage and EuiPageTemplate unit tests using enzyme render to RTL

### DIFF
--- a/src/components/page/__snapshots__/page.test.tsx.snap
+++ b/src/components/page/__snapshots__/page.test.tsx.snap
@@ -59,20 +59,20 @@ exports[`EuiPage paddingSize xs is rendered 1`] = `
 exports[`EuiPage restrict width can be set to a custom number 1`] = `
 <div
   class="euiPage emotion-euiPage-row-grow-restrictWidth"
-  style="max-width:1024px"
+  style="max-width: 1024px;"
 />
 `;
 
 exports[`EuiPage restrict width can be set to a custom value and does not override custom style 1`] = `
 <div
   class="euiPage emotion-euiPage-row-grow-restrictWidth"
-  style="color:red;max-width:24rem"
+  style="color: red; max-width: 24rem;"
 />
 `;
 
 exports[`EuiPage restrict width can be set to a default 1`] = `
 <div
   class="euiPage emotion-euiPage-row-grow-restrictWidth"
-  style="max-width:1200px"
+  style="max-width: 1200px;"
 />
 `;

--- a/src/components/page/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page/__snapshots__/page_template.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiPageTemplate_Deprecated fullHeight is rendered with noscroll 1`] = `
 <div
   class="euiPage euiPageTemplate eui-fullHeight emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody eui-fullHeight emotion-euiPageBody"
@@ -31,7 +31,7 @@ exports[`EuiPageTemplate_Deprecated fullHeight is rendered with noscroll 1`] = `
 exports[`EuiPageTemplate_Deprecated fullHeight is rendered with true 1`] = `
 <div
   class="euiPage euiPageTemplate eui-fullHeight emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody eui-fullHeight emotion-euiPageBody"
@@ -61,7 +61,7 @@ exports[`EuiPageTemplate_Deprecated is rendered 1`] = `
   aria-label="aria-label"
   class="euiPage euiPageTemplate testClass1 testClass2 emotion-euiPage-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -81,7 +81,7 @@ exports[`EuiPageTemplate_Deprecated is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated restrict width can be set to a custom number 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -92,7 +92,7 @@ exports[`EuiPageTemplate_Deprecated restrict width can be set to a custom number
     >
       <div
         class="euiPageContentBody euiPageContentBody--paddingLarge euiPageContentBody--restrictWidth-custom"
-        style="max-width:1024px"
+        style="max-width: 1024px;"
       />
     </div>
   </div>
@@ -102,7 +102,7 @@ exports[`EuiPageTemplate_Deprecated restrict width can be set to a custom number
 exports[`EuiPageTemplate_Deprecated restrict width can be turned off 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -122,11 +122,11 @@ exports[`EuiPageTemplate_Deprecated restrict width can be turned off 1`] = `
 exports[`EuiPageTemplate_Deprecated template centeredBody is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -147,13 +147,13 @@ exports[`EuiPageTemplate_Deprecated template centeredBody is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
     class="euiPageBody testClass1 testClass2 emotion-euiPageBody-restrictWidth-euiTestCss"
     data-test-subj="test subject string"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -174,11 +174,11 @@ exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageB
 exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageContentBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -201,11 +201,11 @@ exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageC
 exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageContentProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -228,11 +228,11 @@ exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageC
 exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageHeader 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <header
       aria-label="aria-label"
@@ -271,11 +271,11 @@ exports[`EuiPageTemplate_Deprecated template centeredBody is rendered with pageH
 exports[`EuiPageTemplate_Deprecated template centeredBody minHeight is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:40vh"
+  style="min-height: 40vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -296,11 +296,11 @@ exports[`EuiPageTemplate_Deprecated template centeredBody minHeight is rendered 
 exports[`EuiPageTemplate_Deprecated template centeredBody paddingSize is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -321,11 +321,11 @@ exports[`EuiPageTemplate_Deprecated template centeredBody paddingSize is rendere
 exports[`EuiPageTemplate_Deprecated template centeredBody style is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px;max-height:100vh"
+  style="min-height: 460px; max-height: 100vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPageBody emotion-euiPageBody"
@@ -346,7 +346,7 @@ exports[`EuiPageTemplate_Deprecated template centeredBody style is rendered 1`] 
 exports[`EuiPageTemplate_Deprecated template centeredBody with pageSideBar is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageSideBar euiPageSideBar--paddingLarge euiPageSideBar--sticky"
@@ -371,7 +371,7 @@ exports[`EuiPageTemplate_Deprecated template centeredBody with pageSideBar is re
 exports[`EuiPageTemplate_Deprecated template centeredBody with pageSideBar is rendered with pageSideBarProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
@@ -398,14 +398,14 @@ exports[`EuiPageTemplate_Deprecated template centeredBody with pageSideBar is re
 exports[`EuiPageTemplate_Deprecated template centeredContent is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPanel--paddingLarge euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-l-subdued"
@@ -423,7 +423,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pageBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
@@ -432,7 +432,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPanel--paddingLarge euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-l-subdued"
@@ -450,14 +450,14 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
 exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pageContentBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPanel--paddingLarge euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-l-subdued"
@@ -477,14 +477,14 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
 exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pageContentProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         aria-label="aria-label"
@@ -504,7 +504,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
 exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pageHeader 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -517,7 +517,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
     >
       <div
         class="euiPageHeaderContent emotion-euiPageHeaderContent-l"
-        style="max-width:1200px"
+        style="max-width: 1200px;"
       >
         <div
           class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
@@ -530,7 +530,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
     </header>
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPanel--paddingLarge euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-l-subdued"
@@ -548,14 +548,14 @@ exports[`EuiPageTemplate_Deprecated template centeredContent is rendered with pa
 exports[`EuiPageTemplate_Deprecated template centeredContent minHeight is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:40vh"
+  style="min-height: 40vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPanel--paddingLarge euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-l-subdued"
@@ -573,14 +573,14 @@ exports[`EuiPageTemplate_Deprecated template centeredContent minHeight is render
 exports[`EuiPageTemplate_Deprecated template centeredContent paddingSize is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
   >
     <div
       class="euiPanel euiPanel--plain euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-subdued"
@@ -598,14 +598,14 @@ exports[`EuiPageTemplate_Deprecated template centeredContent paddingSize is rend
 exports[`EuiPageTemplate_Deprecated template centeredContent style is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px;max-height:100vh"
+  style="min-height: 460px; max-height: 100vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingLarge euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-l-plain"
-      style="display:flex"
+      style="display: flex;"
     >
       <div
         class="euiPanel euiPanel--subdued euiPanel--paddingLarge euiPageContent euiPageContent--verticalCenter euiPageContent--horizontalCenter emotion-euiPanel-grow-m-l-subdued"
@@ -623,7 +623,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent style is rendered 1
 exports[`EuiPageTemplate_Deprecated template centeredContent with pageSideBar is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageSideBar euiPageSideBar--paddingLarge euiPageSideBar--sticky"
@@ -648,7 +648,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent with pageSideBar is
 exports[`EuiPageTemplate_Deprecated template centeredContent with pageSideBar is rendered with pageSideBarProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
@@ -675,7 +675,7 @@ exports[`EuiPageTemplate_Deprecated template centeredContent with pageSideBar is
 exports[`EuiPageTemplate_Deprecated template default is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -695,7 +695,7 @@ exports[`EuiPageTemplate_Deprecated template default is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template default is rendered with pageBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
@@ -717,7 +717,7 @@ exports[`EuiPageTemplate_Deprecated template default is rendered with pageBodyPr
 exports[`EuiPageTemplate_Deprecated template default is rendered with pageContentBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -739,7 +739,7 @@ exports[`EuiPageTemplate_Deprecated template default is rendered with pageConten
 exports[`EuiPageTemplate_Deprecated template default is rendered with pageContentProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -761,7 +761,7 @@ exports[`EuiPageTemplate_Deprecated template default is rendered with pageConten
 exports[`EuiPageTemplate_Deprecated template default is rendered with pageHeader 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -774,7 +774,7 @@ exports[`EuiPageTemplate_Deprecated template default is rendered with pageHeader
     >
       <div
         class="euiPageHeaderContent emotion-euiPageHeaderContent-l"
-        style="max-width:1200px"
+        style="max-width: 1200px;"
       >
         <div
           class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
@@ -800,7 +800,7 @@ exports[`EuiPageTemplate_Deprecated template default is rendered with pageHeader
 exports[`EuiPageTemplate_Deprecated template default minHeight is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:40vh"
+  style="min-height: 40vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -820,7 +820,7 @@ exports[`EuiPageTemplate_Deprecated template default minHeight is rendered 1`] =
 exports[`EuiPageTemplate_Deprecated template default paddingSize is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -840,7 +840,7 @@ exports[`EuiPageTemplate_Deprecated template default paddingSize is rendered 1`]
 exports[`EuiPageTemplate_Deprecated template default style is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px;max-height:100vh"
+  style="min-height: 460px; max-height: 100vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -860,7 +860,7 @@ exports[`EuiPageTemplate_Deprecated template default style is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template default with pageSideBar is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageSideBar euiPageSideBar--paddingLarge euiPageSideBar--sticky"
@@ -889,7 +889,7 @@ exports[`EuiPageTemplate_Deprecated template default with pageSideBar is rendere
 exports[`EuiPageTemplate_Deprecated template default with pageSideBar is rendered with pageSideBarProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
@@ -920,11 +920,11 @@ exports[`EuiPageTemplate_Deprecated template default with pageSideBar is rendere
 exports[`EuiPageTemplate_Deprecated template empty is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-transparent"
@@ -941,13 +941,13 @@ exports[`EuiPageTemplate_Deprecated template empty is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template empty is rendered with pageBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
     class="euiPageBody testClass1 testClass2 emotion-euiPageBody-restrictWidth-euiTestCss"
     data-test-subj="test subject string"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-transparent"
@@ -964,11 +964,11 @@ exports[`EuiPageTemplate_Deprecated template empty is rendered with pageBodyProp
 exports[`EuiPageTemplate_Deprecated template empty is rendered with pageContentBodyProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-transparent"
@@ -987,11 +987,11 @@ exports[`EuiPageTemplate_Deprecated template empty is rendered with pageContentB
 exports[`EuiPageTemplate_Deprecated template empty is rendered with pageContentProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       aria-label="aria-label"
@@ -1010,11 +1010,11 @@ exports[`EuiPageTemplate_Deprecated template empty is rendered with pageContentP
 exports[`EuiPageTemplate_Deprecated template empty is rendered with pageHeader 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <header
       aria-label="aria-label"
@@ -1049,11 +1049,11 @@ exports[`EuiPageTemplate_Deprecated template empty is rendered with pageHeader 1
 exports[`EuiPageTemplate_Deprecated template empty minHeight is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:40vh"
+  style="min-height: 40vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-transparent"
@@ -1070,11 +1070,11 @@ exports[`EuiPageTemplate_Deprecated template empty minHeight is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template empty paddingSize is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-transparent"
@@ -1091,11 +1091,11 @@ exports[`EuiPageTemplate_Deprecated template empty paddingSize is rendered 1`] =
 exports[`EuiPageTemplate_Deprecated template empty style is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow-l"
-  style="min-height:460px;max-height:100vh"
+  style="min-height: 460px; max-height: 100vh;"
 >
   <div
     class="euiPageBody emotion-euiPageBody-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPageContent euiPageContent--borderRadiusNone emotion-euiPanel-grow-none-transparent"
@@ -1112,7 +1112,7 @@ exports[`EuiPageTemplate_Deprecated template empty style is rendered 1`] = `
 exports[`EuiPageTemplate_Deprecated template empty with pageSideBar is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageSideBar euiPageSideBar--paddingLarge euiPageSideBar--sticky"
@@ -1137,7 +1137,7 @@ exports[`EuiPageTemplate_Deprecated template empty with pageSideBar is rendered 
 exports[`EuiPageTemplate_Deprecated template empty with pageSideBar is rendered with pageSideBarProps 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     aria-label="aria-label"
@@ -1164,7 +1164,7 @@ exports[`EuiPageTemplate_Deprecated template empty with pageSideBar is rendered 
 exports[`EuiPageTemplate_Deprecated with bottomBar is rendered 1`] = `
 <div
   class="euiPage euiPageTemplate emotion-euiPage-row-grow"
-  style="min-height:460px"
+  style="min-height: 460px;"
 >
   <div
     class="euiPageBody emotion-euiPageBody"
@@ -1179,8 +1179,8 @@ exports[`EuiPageTemplate_Deprecated with bottomBar is rendered 1`] = `
     </div>
     <section
       aria-label="Page level controls"
-      class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky"
-      style="left:0;right:0;bottom:0"
+      class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-euiColorMode-dark-colorClassName"
+      style="left: 0px; right: 0px; bottom: 0px;"
     >
       <h2
         class="emotion-euiScreenReaderOnly"

--- a/src/components/page/page.test.tsx
+++ b/src/components/page/page.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
-import { shouldRenderCustomStyles } from '../../test/internal';
 import { PADDING_SIZES } from '../../global_styling';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPage } from './page';
 
@@ -18,56 +18,56 @@ describe('EuiPage', () => {
   shouldRenderCustomStyles(<EuiPage />);
 
   test('is rendered', () => {
-    const component = render(<EuiPage {...requiredProps} />);
+    const { container } = render(<EuiPage {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPage paddingSize={size} />);
+        const { container } = render(<EuiPage paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('grow', () => {
     test('can be false', () => {
-      const component = render(<EuiPage grow={false} />);
+      const { container } = render(<EuiPage grow={false} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('direction', () => {
     test('can be row', () => {
-      const component = render(<EuiPage direction="row" />);
+      const { container } = render(<EuiPage direction="row" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('restrict width', () => {
     test('can be set to a default', () => {
-      const component = render(<EuiPage restrictWidth={true} />);
+      const { container } = render(<EuiPage restrictWidth={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom number', () => {
-      const component = render(<EuiPage restrictWidth={1024} />);
+      const { container } = render(<EuiPage restrictWidth={1024} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom value and does not override custom style', () => {
-      const component = render(
+      const { container } = render(
         <EuiPage restrictWidth="24rem" style={{ color: 'red ' }} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/page/page_body/__snapshots__/page_body.test.tsx.snap
+++ b/src/components/page/page_body/__snapshots__/page_body.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`EuiPageBody restrict width can be set to a custom number 1`] = `
   aria-label="aria-label"
   class="euiPageBody testClass1 testClass2 emotion-euiPageBody-restrictWidth-euiTestCss"
   data-test-subj="test subject string"
-  style="max-width:1024px"
+  style="max-width: 1024px;"
 />
 `;
 
@@ -70,7 +70,7 @@ exports[`EuiPageBody restrict width can be set to a custom value and measurement
   aria-label="aria-label"
   class="euiPageBody testClass1 testClass2 emotion-euiPageBody-restrictWidth-euiTestCss"
   data-test-subj="test subject string"
-  style="max-width:24rem"
+  style="max-width: 24rem;"
 />
 `;
 
@@ -79,6 +79,6 @@ exports[`EuiPageBody restrict width can be set to a default 1`] = `
   aria-label="aria-label"
   class="euiPageBody testClass1 testClass2 emotion-euiPageBody-restrictWidth-euiTestCss"
   data-test-subj="test subject string"
-  style="max-width:1200px"
+  style="max-width: 1200px;"
 />
 `;

--- a/src/components/page/page_body/page_body.test.tsx
+++ b/src/components/page/page_body/page_body.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
-import { shouldRenderCustomStyles } from '../../../test/internal';
 import { PADDING_SIZES } from '../../../global_styling';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageBody } from './page_body';
 
@@ -21,60 +21,60 @@ describe('EuiPageBody', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiPageBody {...requiredProps} />);
+    const { container } = render(<EuiPageBody {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageBody paddingSize={size} />);
+        const { container } = render(<EuiPageBody paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('panelled', () => {
     test('can be set to true', () => {
-      const component = render(<EuiPageBody panelled={true} />);
+      const { container } = render(<EuiPageBody panelled={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('also accepts panelProps', () => {
-      const component = render(
+      const { container } = render(
         <EuiPageBody panelled={true} panelProps={{ color: 'subdued' }} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('restrict width', () => {
     test('can be set to a default', () => {
-      const component = render(
+      const { container } = render(
         <EuiPageBody {...requiredProps} restrictWidth={true} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom number', () => {
-      const component = render(
+      const { container } = render(
         <EuiPageBody {...requiredProps} restrictWidth={1024} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom value and measurement', () => {
-      const component = render(
+      const { container } = render(
         <EuiPageBody {...requiredProps} restrictWidth="24rem" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/page/page_content/__snapshots__/page_content_body.test.tsx.snap
+++ b/src/components/page/page_content/__snapshots__/page_content_body.test.tsx.snap
@@ -35,14 +35,14 @@ exports[`EuiPageContentBody paddingSize s is rendered 1`] = `
 exports[`EuiPageContentBody restrict width can be set to a custom number 1`] = `
 <div
   class="euiPageContentBody euiPageContentBody--restrictWidth-custom"
-  style="max-width:1024px"
+  style="max-width: 1024px;"
 />
 `;
 
 exports[`EuiPageContentBody restrict width can be set to a custom value and does not override custom style 1`] = `
 <div
   class="euiPageContentBody euiPageContentBody--restrictWidth-custom"
-  style="color:red;max-width:24rem"
+  style="color: red; max-width: 24rem;"
 />
 `;
 

--- a/src/components/page/page_content/page_content.test.tsx
+++ b/src/components/page/page_content/page_content.test.tsx
@@ -7,38 +7,40 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageContent_Deprecated as EuiPageContent } from './page_content';
 
 describe('EuiPageContent', () => {
   test('is rendered', () => {
-    const component = render(<EuiPageContent {...requiredProps} />);
+    const { container } = render(<EuiPageContent {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('verticalPosition is rendered', () => {
-    const component = render(<EuiPageContent verticalPosition="center" />);
+    const { container } = render(<EuiPageContent verticalPosition="center" />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('horizontalPosition is rendered', () => {
-    const component = render(<EuiPageContent horizontalPosition="center" />);
+    const { container } = render(
+      <EuiPageContent horizontalPosition="center" />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('role can be removed', () => {
-    const component = render(<EuiPageContent role={null} />);
+    const { container } = render(<EuiPageContent role={null} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('accepts panel props', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageContent
         borderRadius="none"
         hasShadow={false}
@@ -46,6 +48,6 @@ describe('EuiPageContent', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/page/page_content/page_content_body.test.tsx
+++ b/src/components/page/page_content/page_content_body.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import {
   EuiPageContentBody_Deprecated as EuiPageContentBody,
@@ -17,40 +17,40 @@ import {
 
 describe('EuiPageContentBody', () => {
   test('is rendered', () => {
-    const component = render(<EuiPageContentBody {...requiredProps} />);
+    const { container } = render(<EuiPageContentBody {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageContentBody paddingSize={size} />);
+        const { container } = render(<EuiPageContentBody paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('restrict width', () => {
     test('can be set to a default', () => {
-      const component = render(<EuiPageContentBody restrictWidth={true} />);
+      const { container } = render(<EuiPageContentBody restrictWidth={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom number', () => {
-      const component = render(<EuiPageContentBody restrictWidth={1024} />);
+      const { container } = render(<EuiPageContentBody restrictWidth={1024} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom value and does not override custom style', () => {
-      const component = render(
+      const { container } = render(
         <EuiPageContentBody restrictWidth="24rem" style={{ color: 'red ' }} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/page/page_content/page_content_header.test.tsx
+++ b/src/components/page/page_content/page_content_header.test.tsx
@@ -7,15 +7,15 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageContentHeader_Deprecated as EuiPageContentHeader } from './page_content_header';
 
 describe('EuiPageContentHeader', () => {
   test('is rendered', () => {
-    const component = render(<EuiPageContentHeader {...requiredProps} />);
+    const { container } = render(<EuiPageContentHeader {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/page/page_content/page_content_header_section.test.tsx
+++ b/src/components/page/page_content/page_content_header_section.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageContentHeaderSection_Deprecated as EuiPageContentHeaderSection } from './page_content_header_section';
 
 describe('EuiPageContentHeaderSection', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageContentHeaderSection {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -262,6 +262,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
             data-test-subj="breadcrumbsAnimals"
             href="#"
             rel="noreferrer"
+            title="Animals"
           >
             Animals
           </a>
@@ -273,6 +274,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           <span
             aria-current="page"
             class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+            title="Edit"
           >
             Edit
           </span>
@@ -428,7 +430,7 @@ exports[`EuiPageHeader props restrictWidth is rendered as custom 1`] = `
 >
   <div
     class="euiPageHeaderContent emotion-euiPageHeaderContent"
-    style="max-width:100px"
+    style="max-width: 100px;"
   >
     <div
       class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"
@@ -447,7 +449,7 @@ exports[`EuiPageHeader props restrictWidth is rendered as true 1`] = `
 >
   <div
     class="euiPageHeaderContent emotion-euiPageHeaderContent"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiFlexGroup euiPageHeaderContent__top emotion-euiFlexGroup-responsive-l-flexStart-stretch-row"

--- a/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -205,6 +205,7 @@ exports[`EuiPageHeaderContent props breadcrumbs is rendered 1`] = `
           data-test-subj="breadcrumbsAnimals"
           href="#"
           rel="noreferrer"
+          title="Animals"
         >
           Animals
         </a>
@@ -216,6 +217,7 @@ exports[`EuiPageHeaderContent props breadcrumbs is rendered 1`] = `
         <span
           aria-current="page"
           class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+          title="Edit"
         >
           Edit
         </span>

--- a/src/components/page/page_header/page_header.test.tsx
+++ b/src/components/page/page_header/page_header.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageHeader, EuiPageHeaderProps } from './page_header';
 import { ALIGN_ITEMS } from './page_header_content';
@@ -48,17 +48,17 @@ export const rightSideItems: EuiPageHeaderProps['rightSideItems'] = [
 
 describe('EuiPageHeader', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageHeader {...requiredProps}>Anything</EuiPageHeader>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('page content props are passed down', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeader
             pageTitle="Page title"
             pageTitleProps={requiredProps}
@@ -76,14 +76,14 @@ describe('EuiPageHeader', () => {
           </EuiPageHeader>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('alignItems', () => {
       ALIGN_ITEMS.forEach((alignment) => {
         it(`${alignment} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiPageHeader
               pageTitle="Page title"
               rightSideItems={rightSideItems}
@@ -91,50 +91,52 @@ describe('EuiPageHeader', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('responsive', () => {
       test('is rendered as false', () => {
-        const component = render(<EuiPageHeader responsive={false} />);
+        const { container } = render(<EuiPageHeader responsive={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered as reverse', () => {
-        const component = render(<EuiPageHeader responsive={'reverse'} />);
+        const { container } = render(<EuiPageHeader responsive={'reverse'} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('restrictWidth', () => {
       test('is rendered as true', () => {
-        const component = render(<EuiPageHeader restrictWidth={true} />);
+        const { container } = render(<EuiPageHeader restrictWidth={true} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered as custom', () => {
-        const component = render(<EuiPageHeader restrictWidth={100} />);
+        const { container } = render(<EuiPageHeader restrictWidth={100} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('bottomBorder', () => {
       test('is rendered as true', () => {
-        const component = render(<EuiPageHeader bottomBorder={true} />);
+        const { container } = render(<EuiPageHeader bottomBorder={true} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered as extended', () => {
-        const component = render(<EuiPageHeader bottomBorder={'extended'} />);
+        const { container } = render(
+          <EuiPageHeader bottomBorder={'extended'} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page/page_header/page_header_content.test.tsx
+++ b/src/components/page/page_header/page_header_content.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import {
   ALIGN_ITEMS,
@@ -71,42 +71,42 @@ describe('EuiPageHeaderContent', () => {
   );
 
   test('is rendered', () => {
-    const component = render(<EuiPageHeaderContent {...requiredProps} />);
+    const { container } = render(<EuiPageHeaderContent {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('pageTitle', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent pageTitle="Page title" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with pageTitleProps', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent
             pageTitle="Page title"
             pageTitleProps={requiredProps}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with icon', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent pageTitle="Page title" iconType="logoKibana" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with icon and iconProps', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent
             pageTitle="Page title"
             iconType="logoKibana"
@@ -114,72 +114,72 @@ describe('EuiPageHeaderContent', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('tabs', () => {
       test('is rendered', () => {
-        const component = render(<EuiPageHeaderContent tabs={tabs} />);
+        const { container } = render(<EuiPageHeaderContent tabs={tabs} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with tabsProps', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent tabs={tabs} tabsProps={requiredProps} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('breadcrumbs', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent
             breadcrumbs={breadcrumbs}
             breadcrumbProps={requiredProps}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('children', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent>
             <p>Anything</p>
           </EuiPageHeaderContent>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('description', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent description="Description" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('rightSideItems', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent rightSideItems={rightSideItems} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with rightSideGroupProps', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent
             rightSideItems={rightSideItems}
             rightSideGroupProps={{
@@ -190,21 +190,21 @@ describe('EuiPageHeaderContent', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('children', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent>Child</EuiPageHeaderContent>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered even if content props are passed', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent
             pageTitle="Page title"
             tabs={tabs}
@@ -214,14 +214,14 @@ describe('EuiPageHeaderContent', () => {
           </EuiPageHeaderContent>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('alignItems', () => {
       ALIGN_ITEMS.forEach((alignment) => {
         it(`${alignment} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiPageHeaderContent
               pageTitle="Page title"
               rightSideItems={rightSideItems}
@@ -229,24 +229,26 @@ describe('EuiPageHeaderContent', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('responsive', () => {
       test('is rendered as false', () => {
-        const component = render(<EuiPageHeaderContent responsive={false} />);
+        const { container } = render(
+          <EuiPageHeaderContent responsive={false} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered as reverse', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageHeaderContent responsive={'reverse'} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page/page_header/page_header_section.test.tsx
+++ b/src/components/page/page_header/page_header_section.test.tsx
@@ -7,15 +7,15 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageHeaderSection } from './page_header_section';
 
 describe('EuiPageHeaderSection', () => {
   test('is rendered', () => {
-    const component = render(<EuiPageHeaderSection {...requiredProps} />);
+    const { container } = render(<EuiPageHeaderSection {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/page/page_section/__snapshots__/page_section.test.tsx.snap
+++ b/src/components/page/page_section/__snapshots__/page_section.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`EuiPageSection props restrictWidth can be custom 1`] = `
 >
   <div
     class="emotion-euiPageSection__content-l-restrictWidth"
-    style="max-width:1000px"
+    style="max-width: 1000px;"
   />
 </section>
 `;
@@ -257,7 +257,7 @@ exports[`EuiPageSection props restrictWidth can be true 1`] = `
 >
   <div
     class="emotion-euiPageSection__content-l-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   />
 </section>
 `;

--- a/src/components/page/page_section/page_section.test.tsx
+++ b/src/components/page/page_section/page_section.test.tsx
@@ -8,13 +8,13 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
+import { PADDING_SIZES, BACKGROUND_COLORS } from '../../../global_styling';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageSection } from './page_section';
 import { ALIGNMENTS } from './page_section.styles';
-import { PADDING_SIZES, BACKGROUND_COLORS } from '../../../global_styling';
 
 describe('EuiPageSection', () => {
   shouldRenderCustomStyles(<EuiPageSection />, {
@@ -22,14 +22,14 @@ describe('EuiPageSection', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiPageSection {...requiredProps} />);
+    const { container } = render(<EuiPageSection {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('component', () => {
-      const component = render(
+      const { container } = render(
         <main>
           <EuiPageSection />
           <EuiPageSection component="div" />
@@ -37,45 +37,47 @@ describe('EuiPageSection', () => {
         </main>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('restrictWidth', () => {
       test('can be true', () => {
-        const component = render(<EuiPageSection restrictWidth />);
+        const { container } = render(<EuiPageSection restrictWidth />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('can be custom', () => {
-        const component = render(<EuiPageSection restrictWidth={1000} />);
+        const { container } = render(<EuiPageSection restrictWidth={1000} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('bottomBorder', () => {
       test('can be true', () => {
-        const component = render(<EuiPageSection bottomBorder />);
+        const { container } = render(<EuiPageSection bottomBorder />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('grow', () => {
       test('can be true', () => {
-        const component = render(<EuiPageSection grow />);
+        const { container } = render(<EuiPageSection grow />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('alignment', () => {
       ALIGNMENTS.forEach((alignment) => {
         test(`${alignment} is rendered`, () => {
-          const component = render(<EuiPageSection alignment={alignment} />);
+          const { container } = render(
+            <EuiPageSection alignment={alignment} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -83,9 +85,9 @@ describe('EuiPageSection', () => {
     describe('color', () => {
       BACKGROUND_COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiPageSection color={color} />);
+          const { container } = render(<EuiPageSection color={color} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -93,27 +95,29 @@ describe('EuiPageSection', () => {
     describe('paddingSize', () => {
       PADDING_SIZES.forEach((padding) => {
         test(`${padding} is rendered`, () => {
-          const component = render(<EuiPageSection paddingSize={padding} />);
+          const { container } = render(
+            <EuiPageSection paddingSize={padding} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('contentProps', () => {
       test('are passed down', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageSection contentProps={requiredProps} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   // Regression test for recurring bug / unintuitive Emotion behavior
   it('correctly merges `css` passed to `contentProps`', () => {
-    const component = render(
+    const { getByTestSubject } = render(
       <EuiPageSection
         contentProps={{
           css: css`
@@ -123,14 +127,14 @@ describe('EuiPageSection', () => {
         }}
       />
     );
-    const content = component.find('[data-test-subj="content"]');
+    const content = getByTestSubject('content');
     expect(content).toMatchInlineSnapshot(`
       <div
         class="emotion-euiPageSection__content-l-css"
         data-test-subj="content"
       />
     `);
-    expect(content.attr('class')).toContain('euiPageSection__content'); // Preserves our CSS
-    expect(content.attr('class').endsWith('-css')).toBeTruthy(); // Concatenates custom CSS
+    expect(content.className).toContain('euiPageSection__content'); // Preserves our CSS
+    expect(content.className.endsWith('-css')).toBeTruthy(); // Concatenates custom CSS
   });
 });

--- a/src/components/page/page_side_bar/page_side_bar.test.tsx
+++ b/src/components/page/page_side_bar/page_side_bar.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import {
   EuiPageSideBar_Deprecated as EuiPageSideBar,
@@ -17,23 +17,23 @@ import {
 
 describe('EuiPageSideBar', () => {
   test('is rendered', () => {
-    const component = render(<EuiPageSideBar {...requiredProps} />);
+    const { container } = render(<EuiPageSideBar {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('sticky is rendered', () => {
-    const component = render(<EuiPageSideBar sticky />);
+    const { container } = render(<EuiPageSideBar sticky />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageSideBar paddingSize={size} />);
+        const { container } = render(<EuiPageSideBar paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page/page_sidebar/__snapshots__/page_sidebar.test.tsx.snap
+++ b/src/components/page/page_sidebar/__snapshots__/page_sidebar.test.tsx.snap
@@ -5,62 +5,62 @@ exports[`EuiPageSidebar is rendered 1`] = `
   aria-label="aria-label"
   class="testClass1 testClass2 emotion-euiPageSidebar-euiTestCss"
   data-test-subj="test subject string"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar minWidth is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar"
-  style="min-inline-size:400px"
+  style="min-inline-size: 400px;"
 />
 `;
 
 exports[`EuiPageSidebar paddingSize l is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar-l"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar paddingSize m is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar-m"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar paddingSize none is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar paddingSize s is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar-s"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar paddingSize xl is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar-xl"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar paddingSize xs is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar-xs"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px;"
 />
 `;
 
 exports[`EuiPageSidebar sticky is rendered 1`] = `
 <div
   class="emotion-euiPageSidebar-sticky"
-  style="min-inline-size:248px"
+  style="min-inline-size: 248px; inset-block-start: 100px; max-block-size: calc(100vh - 100px);"
 />
 `;

--- a/src/components/page/page_sidebar/page_sidebar.test.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.test.tsx
@@ -7,10 +7,11 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
-import { shouldRenderCustomStyles } from '../../../test/internal';
+import { mount } from 'enzyme';
 import { PADDING_SIZES } from '../../../global_styling';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPageSidebar } from './page_sidebar';
 
@@ -18,29 +19,29 @@ describe('EuiPageSidebar', () => {
   shouldRenderCustomStyles(<EuiPageSidebar />);
 
   test('is rendered', () => {
-    const component = render(<EuiPageSidebar {...requiredProps} />);
+    const { container } = render(<EuiPageSidebar {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('minWidth is rendered', () => {
-    const component = render(<EuiPageSidebar minWidth={400} />);
+    const { container } = render(<EuiPageSidebar minWidth={400} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('sticky is rendered', () => {
-    const component = render(<EuiPageSidebar sticky={{ offset: 100 }} />);
+    const { container } = render(<EuiPageSidebar sticky={{ offset: 100 }} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageSidebar paddingSize={size} />);
+        const { container } = render(<EuiPageSidebar paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page/page_template.test.tsx
+++ b/src/components/page/page_template.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import {
   EuiPageTemplate_Deprecated as EuiPageTemplate,
@@ -17,22 +17,22 @@ import {
 
 describe('EuiPageTemplate_Deprecated', () => {
   test('is rendered', () => {
-    const component = render(<EuiPageTemplate {...requiredProps} />);
+    const { container } = render(<EuiPageTemplate {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('restrict width', () => {
     test('can be turned off', () => {
-      const component = render(<EuiPageTemplate restrictWidth={false} />);
+      const { container } = render(<EuiPageTemplate restrictWidth={false} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom number', () => {
-      const component = render(<EuiPageTemplate restrictWidth={1024} />);
+      const { container } = render(<EuiPageTemplate restrictWidth={1024} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
@@ -40,49 +40,49 @@ describe('EuiPageTemplate_Deprecated', () => {
     TEMPLATES.forEach((template) => {
       describe(`${template}`, () => {
         it('is rendered', () => {
-          const component = render(<EuiPageTemplate template={template} />);
+          const { container } = render(<EuiPageTemplate template={template} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         it('paddingSize is rendered', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate template={template} paddingSize="none" />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         it('minHeight is rendered', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate template={template} minHeight="40vh" />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         it('style is rendered', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate
               template={template}
               style={{ maxHeight: '100vh' }}
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         describe('with pageSideBar', () => {
           test('is rendered', () => {
-            const component = render(
+            const { container } = render(
               <EuiPageTemplate template={template} pageSideBar="Side Bar" />
             );
 
-            expect(component).toMatchSnapshot();
+            expect(container.firstChild).toMatchSnapshot();
           });
 
           test('is rendered with pageSideBarProps', () => {
-            const component = render(
+            const { container } = render(
               <EuiPageTemplate
                 template={template}
                 pageSideBar="Side Bar"
@@ -90,12 +90,12 @@ describe('EuiPageTemplate_Deprecated', () => {
               />
             );
 
-            expect(component).toMatchSnapshot();
+            expect(container.firstChild).toMatchSnapshot();
           });
         });
 
         test('is rendered with pageHeader', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate
               template={template}
               pageHeader={{
@@ -105,40 +105,40 @@ describe('EuiPageTemplate_Deprecated', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         test('is rendered with pageBodyProps', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate
               template={template}
               pageBodyProps={requiredProps}
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         test('is rendered with pageContentProps', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate
               template={template}
               pageContentProps={requiredProps}
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
 
         test('is rendered with pageContentBodyProps', () => {
-          const component = render(
+          const { container } = render(
             <EuiPageTemplate
               template={template}
               pageContentBodyProps={requiredProps}
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -146,28 +146,28 @@ describe('EuiPageTemplate_Deprecated', () => {
 
   describe('with bottomBar', () => {
     test('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiPageTemplate
           bottomBar="Bottom Bar"
           bottomBarProps={{ paddingSize: 'none' }}
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('fullHeight', () => {
     test('is rendered with true', () => {
-      const component = render(<EuiPageTemplate fullHeight={true} />);
+      const { container } = render(<EuiPageTemplate fullHeight={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered with noscroll', () => {
-      const component = render(<EuiPageTemplate fullHeight={'noscroll'} />);
+      const { container } = render(<EuiPageTemplate fullHeight={'noscroll'} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiPageTemplate _EuiPageInnerProps is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <div
     class="customClassName emotion-euiPageInner-left"
@@ -15,7 +15,7 @@ exports[`EuiPageTemplate _EuiPageInnerProps is rendered 1`] = `
 exports[`EuiPageTemplate _EuiPageOuterProps is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-column-grow"
-  style="min-block-size:460px"
+  style="min-block-size: 460px; padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -27,7 +27,7 @@ exports[`EuiPageTemplate _EuiPageOuterProps is rendered 1`] = `
 exports[`EuiPageTemplate bottomBorder is rendered as extended 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -39,7 +39,7 @@ exports[`EuiPageTemplate bottomBorder is rendered as extended 1`] = `
 exports[`EuiPageTemplate bottomBorder is rendered as true 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -53,15 +53,15 @@ exports[`EuiPageTemplate children detects sidebars and does not place them in th
   aria-label="aria-label"
   class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <div
     class="emotion-euiPageSidebar-l"
-    style="min-inline-size:248px"
+    style="min-inline-size: 248px;"
   />
   <div
-    class="emotion-euiPageSidebar-l-component"
-    style="min-inline-size:248px"
+    class="emotion-euiPageSidebar-l"
+    style="min-inline-size: 248px;"
   />
   <main
     class="emotion-euiPageInner-panelled-left"
@@ -75,7 +75,7 @@ exports[`EuiPageTemplate children renders all other types within the main EuiPag
   aria-label="aria-label"
   class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -99,7 +99,7 @@ exports[`EuiPageTemplate children renders all other types within the main EuiPag
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
-        style="max-width:1200px"
+        style="max-width: 1200px;"
       >
         B
       </div>
@@ -116,7 +116,7 @@ exports[`EuiPageTemplate is rendered 1`] = `
   aria-label="aria-label"
   class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -128,7 +128,7 @@ exports[`EuiPageTemplate is rendered 1`] = `
 exports[`EuiPageTemplate minHeight is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(40vh, 100vh)"
+  style="min-block-size: max(40vh, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -140,7 +140,7 @@ exports[`EuiPageTemplate minHeight is rendered 1`] = `
 exports[`EuiPageTemplate offset is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh);padding-block-start:100px"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 100px;"
 >
   <main
     class="emotion-euiPageInner"
@@ -152,7 +152,7 @@ exports[`EuiPageTemplate offset is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize l is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -164,7 +164,7 @@ exports[`EuiPageTemplate paddingSize l is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize m is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -176,7 +176,7 @@ exports[`EuiPageTemplate paddingSize m is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize none is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -188,7 +188,7 @@ exports[`EuiPageTemplate paddingSize none is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize s is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -200,7 +200,7 @@ exports[`EuiPageTemplate paddingSize s is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize xl is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -212,7 +212,7 @@ exports[`EuiPageTemplate paddingSize xl is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize xs is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -224,7 +224,7 @@ exports[`EuiPageTemplate paddingSize xs is rendered 1`] = `
 exports[`EuiPageTemplate restrict width can be set to a custom number 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -236,7 +236,7 @@ exports[`EuiPageTemplate restrict width can be set to a custom number 1`] = `
 exports[`EuiPageTemplate restrict width can be set to a custom value and measurement 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"
@@ -248,7 +248,7 @@ exports[`EuiPageTemplate restrict width can be set to a custom value and measure
 exports[`EuiPageTemplate restrict width can be set to a default 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size:max(460px, 100vh)"
+  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
 >
   <main
     class="emotion-euiPageInner"

--- a/src/components/page_template/bottom_bar/__snapshots__/page_bottom_bar.test.tsx.snap
+++ b/src/components/page_template/bottom_bar/__snapshots__/page_bottom_bar.test.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`_EuiPageBottomBar is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="aria-label"
-    class="euiBottomBar euiBottomBar--sticky testClass1 testClass2 emotion-euiBottomBar-sticky-bar-euiTestCss"
+    class="euiBottomBar euiBottomBar--sticky testClass1 testClass2 emotion-euiBottomBar-sticky-bar-euiTestCss-euiColorMode-dark-colorClassName"
     data-test-subj="test subject string"
-    style="left:0;right:0;bottom:0"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -20,22 +20,22 @@ Array [
         class="emotion-euiPageSection__content-l"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar paddingSize l is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -49,22 +49,22 @@ Array [
         class="emotion-euiPageSection__content-l"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar paddingSize m is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -78,22 +78,22 @@ Array [
         class="emotion-euiPageSection__content-m"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar paddingSize none is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -107,22 +107,22 @@ Array [
         class="emotion-euiPageSection__content"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar paddingSize s is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -136,22 +136,22 @@ Array [
         class="emotion-euiPageSection__content-s"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar paddingSize xl is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -165,22 +165,22 @@ Array [
         class="emotion-euiPageSection__content-xl"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar paddingSize xs is rendered 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -194,22 +194,22 @@ Array [
         class="emotion-euiPageSection__content-xs"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar restrict width can be set to a custom number 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -221,25 +221,25 @@ Array [
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
-        style="max-width:1024px"
+        style="max-width: 1024px;"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar restrict width can be set to a custom value and measurement 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -251,25 +251,25 @@ Array [
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
-        style="max-width:24rem"
+        style="max-width: 24rem;"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`_EuiPageBottomBar restrict width can be set to a default 1`] = `
-Array [
+<div>
   <section
     aria-label="Page level controls"
-    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar"
-    style="left:0;right:0;bottom:0"
+    class="euiBottomBar euiBottomBar--sticky emotion-euiBottomBar-sticky-bar-euiColorMode-dark-colorClassName"
+    style="left: 0px; right: 0px; bottom: 0px;"
   >
     <h2
       class="emotion-euiScreenReaderOnly"
@@ -281,15 +281,15 @@ Array [
     >
       <div
         class="emotion-euiPageSection__content-l-restrictWidth"
-        style="max-width:1200px"
+        style="max-width: 1200px;"
       />
     </section>
-  </section>,
+  </section>
   <p
     aria-live="assertive"
     class="emotion-euiScreenReaderOnly"
   >
     There is a new region landmark with page level controls at the end of the document.
-  </p>,
-]
+  </p>
+</div>
 `;

--- a/src/components/page_template/bottom_bar/page_bottom_bar.test.tsx
+++ b/src/components/page_template/bottom_bar/page_bottom_bar.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
-import { shouldRenderCustomStyles } from '../../../test/internal';
 import { PADDING_SIZES } from '../../../global_styling';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { _EuiPageBottomBar as EuiPageBottomBar } from './page_bottom_bar';
 
@@ -18,37 +18,37 @@ describe('_EuiPageBottomBar', () => {
   shouldRenderCustomStyles(<EuiPageBottomBar />);
 
   test('is rendered', () => {
-    const component = render(<EuiPageBottomBar {...requiredProps} />);
+    const { container } = render(<EuiPageBottomBar {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   describe('restrict width', () => {
     test('can be set to a default', () => {
-      const component = render(<EuiPageBottomBar restrictWidth={true} />);
+      const { container } = render(<EuiPageBottomBar restrictWidth={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('can be set to a custom number', () => {
-      const component = render(<EuiPageBottomBar restrictWidth={1024} />);
+      const { container } = render(<EuiPageBottomBar restrictWidth={1024} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     test('can be set to a custom value and measurement', () => {
-      const component = render(<EuiPageBottomBar restrictWidth="24rem" />);
+      const { container } = render(<EuiPageBottomBar restrictWidth="24rem" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageBottomBar paddingSize={size} />);
+        const { container } = render(<EuiPageBottomBar paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page_template/empty_prompt/__snapshots__/page_empty_prompt.test.tsx.snap
+++ b/src/components/page_template/empty_prompt/__snapshots__/page_empty_prompt.test.tsx.snap
@@ -359,7 +359,7 @@ exports[`_EuiPageEmptyPrompt restrict width can be set to a custom number 1`] = 
 >
   <div
     class="emotion-euiPageSection__content-l-center-restrictWidth"
-    style="max-width:1024px"
+    style="max-width: 1024px;"
   >
     <div
       class="euiPanel euiPanel--plain euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge emotion-euiPanel-m-plain-hasShadow"
@@ -386,7 +386,7 @@ exports[`_EuiPageEmptyPrompt restrict width can be set to a custom value and mea
 >
   <div
     class="emotion-euiPageSection__content-l-center-restrictWidth"
-    style="max-width:24rem"
+    style="max-width: 24rem;"
   >
     <div
       class="euiPanel euiPanel--plain euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge emotion-euiPanel-m-plain-hasShadow"
@@ -413,7 +413,7 @@ exports[`_EuiPageEmptyPrompt restrict width can be set to a default 1`] = `
 >
   <div
     class="emotion-euiPageSection__content-l-center-restrictWidth"
-    style="max-width:1200px"
+    style="max-width: 1200px;"
   >
     <div
       class="euiPanel euiPanel--plain euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge emotion-euiPanel-m-plain-hasShadow"

--- a/src/components/page_template/empty_prompt/page_empty_prompt.test.tsx
+++ b/src/components/page_template/empty_prompt/page_empty_prompt.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
-import { shouldRenderCustomStyles } from '../../../test/internal';
 import { PADDING_SIZES } from '../../../global_styling';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { _EuiPageEmptyPrompt as EuiPageEmptyPrompt } from './page_empty_prompt';
 
@@ -18,54 +18,56 @@ describe('_EuiPageEmptyPrompt', () => {
   shouldRenderCustomStyles(<EuiPageEmptyPrompt />);
 
   test('is rendered', () => {
-    const component = render(<EuiPageEmptyPrompt {...requiredProps} />);
-    expect(component).toMatchSnapshot();
+    const { container } = render(<EuiPageEmptyPrompt {...requiredProps} />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('EuiPageSectionProps is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageEmptyPrompt grow={false} alignment="horizontalCenter" />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('EuiEmptyPromptProps is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageEmptyPrompt
         footer="Footer"
         iconType="warning"
         layout="horizontal"
       />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('restrict width', () => {
     test('can be set to a default', () => {
-      const component = render(<EuiPageEmptyPrompt restrictWidth={true} />);
-      expect(component).toMatchSnapshot();
+      const { container } = render(<EuiPageEmptyPrompt restrictWidth={true} />);
+      expect(container.firstChild).toMatchSnapshot();
     });
     test('can be set to a custom number', () => {
-      const component = render(<EuiPageEmptyPrompt restrictWidth={1024} />);
-      expect(component).toMatchSnapshot();
+      const { container } = render(<EuiPageEmptyPrompt restrictWidth={1024} />);
+      expect(container.firstChild).toMatchSnapshot();
     });
     test('can be set to a custom value and measurement', () => {
-      const component = render(<EuiPageEmptyPrompt restrictWidth="24rem" />);
-      expect(component).toMatchSnapshot();
+      const { container } = render(
+        <EuiPageEmptyPrompt restrictWidth="24rem" />
+      );
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('panelled is true', () => {
     describe('and color', () => {
       test('is not defined, then the prompt is subdued', () => {
-        const component = render(<EuiPageEmptyPrompt panelled />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiPageEmptyPrompt panelled />);
+        expect(container.firstChild).toMatchSnapshot();
       });
       test('is defined, then the prompt inherits the color', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageEmptyPrompt panelled color="accent" />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
@@ -73,14 +75,14 @@ describe('_EuiPageEmptyPrompt', () => {
   describe('panelled is false', () => {
     describe('and color', () => {
       test('is not defined, then the prompt is plain', () => {
-        const component = render(<EuiPageEmptyPrompt panelled={false} />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiPageEmptyPrompt panelled={false} />);
+        expect(container.firstChild).toMatchSnapshot();
       });
       test('is defined, then the prompt inherits the color', () => {
-        const component = render(
+        const { container } = render(
           <EuiPageEmptyPrompt panelled={false} color="warning" />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
@@ -88,8 +90,8 @@ describe('_EuiPageEmptyPrompt', () => {
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageEmptyPrompt paddingSize={size} />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiPageEmptyPrompt paddingSize={size} />);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page_template/inner/__snapshots__/page_inner.test.tsx.snap
+++ b/src/components/page_template/inner/__snapshots__/page_inner.test.tsx.snap
@@ -13,14 +13,14 @@ exports[`_EuiPageInner component renders HTML tag strings 1`] = `
 `;
 
 exports[`_EuiPageInner component renders custom React components 1`] = `
-Array [
+<div>
   <div>
     hello
-  </div>,
+  </div>
   <div>
     world
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`_EuiPageInner is rendered 1`] = `

--- a/src/components/page_template/inner/page_inner.test.tsx
+++ b/src/components/page_template/inner/page_inner.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { PADDING_SIZES } from '../../../global_styling';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { _EuiPageInner as EuiPageInner } from './page_inner';
 
@@ -18,28 +18,28 @@ describe('_EuiPageInner', () => {
   shouldRenderCustomStyles(<EuiPageInner />);
 
   test('is rendered', () => {
-    const component = render(<EuiPageInner {...requiredProps} />);
+    const { container } = render(<EuiPageInner {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('panelled is rendered', () => {
-    const component = render(<EuiPageInner panelled={true} />);
+    const { container } = render(<EuiPageInner panelled={true} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('border is rendered', () => {
-    const component = render(<EuiPageInner border={true} />);
+    const { container } = render(<EuiPageInner border={true} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('component', () => {
     it('renders HTML tag strings', () => {
-      const component = render(<EuiPageInner component="div" />);
+      const { container } = render(<EuiPageInner component="div" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('renders custom React components', () => {
@@ -47,22 +47,22 @@ describe('_EuiPageInner', () => {
         <div>{test ? 'hello' : 'world'}</div>
       );
 
-      const component = render(
+      const { container } = render(
         <>
           <EuiPageInner component={TestComponent} test />
           <EuiPageInner component={TestComponent} />
         </>
       );
-      expect(component).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageInner paddingSize={size} />);
+        const { container } = render(<EuiPageInner paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/page_template/outer/page_outer.test.tsx
+++ b/src/components/page_template/outer/page_outer.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { _EuiPageOuter as EuiPageOuter } from './page_outer';
 
@@ -17,24 +17,24 @@ describe('_EuiPageOuter', () => {
   shouldRenderCustomStyles(<EuiPageOuter />);
 
   test('is rendered', () => {
-    const component = render(<EuiPageOuter {...requiredProps} />);
+    const { container } = render(<EuiPageOuter {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('grow', () => {
     test('can be false', () => {
-      const component = render(<EuiPageOuter grow={false} />);
+      const { container } = render(<EuiPageOuter grow={false} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('direction', () => {
     test('can be row', () => {
-      const component = render(<EuiPageOuter direction="row" />);
+      const { container } = render(<EuiPageOuter direction="row" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/page_template/page_template.test.tsx
+++ b/src/components/page_template/page_template.test.tsx
@@ -8,10 +8,10 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
-import { shouldRenderCustomStyles } from '../../test/internal';
 import { PADDING_SIZES } from '../../global_styling';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPageTemplate } from './page_template';
 
@@ -19,21 +19,21 @@ describe('EuiPageTemplate', () => {
   shouldRenderCustomStyles(<EuiPageTemplate />, { childProps: ['mainProps'] });
 
   test('is rendered', () => {
-    const component = render(<EuiPageTemplate {...requiredProps} />);
+    const { container } = render(<EuiPageTemplate {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('_EuiPageOuterProps is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageTemplate grow={false} direction="column" responsive={[]} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('_EuiPageInnerProps is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPageTemplate
         component="div"
         contentBorder={true}
@@ -42,68 +42,70 @@ describe('EuiPageTemplate', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('restrict width', () => {
     test('can be set to a default', () => {
-      const component = render(<EuiPageTemplate restrictWidth={true} />);
+      const { container } = render(<EuiPageTemplate restrictWidth={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom number', () => {
-      const component = render(<EuiPageTemplate restrictWidth={1024} />);
+      const { container } = render(<EuiPageTemplate restrictWidth={1024} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be set to a custom value and measurement', () => {
-      const component = render(<EuiPageTemplate restrictWidth="24rem" />);
+      const { container } = render(<EuiPageTemplate restrictWidth="24rem" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('bottomBorder', () => {
     test('is rendered as true', () => {
-      const component = render(<EuiPageTemplate bottomBorder={true} />);
+      const { container } = render(<EuiPageTemplate bottomBorder={true} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered as extended', () => {
-      const component = render(<EuiPageTemplate bottomBorder={'extended'} />);
+      const { container } = render(
+        <EuiPageTemplate bottomBorder={'extended'} />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('minHeight is rendered', () => {
-    const component = render(<EuiPageTemplate minHeight={'40vh'} />);
+    const { container } = render(<EuiPageTemplate minHeight={'40vh'} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('offset is rendered', () => {
-    const component = render(<EuiPageTemplate offset={100} />);
+    const { container } = render(<EuiPageTemplate offset={100} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('paddingSize', () => {
     PADDING_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiPageTemplate paddingSize={size} />);
+        const { container } = render(<EuiPageTemplate paddingSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('children', () => {
     it('detects sidebars and does not place them in the main EuiPageInner', () => {
-      const component = render(
+      const { container, getByRole } = render(
         <EuiPageTemplate {...requiredProps}>
           <EuiPageTemplate.Sidebar />
           <EuiPageTemplate.Sidebar
@@ -113,20 +115,20 @@ describe('EuiPageTemplate', () => {
           />
         </EuiPageTemplate>
       );
-      expect(component).toMatchSnapshot();
-      expect(component.find('main').children()).toHaveLength(0);
+      expect(container.firstChild).toMatchSnapshot();
+      expect(getByRole('main').childElementCount).toEqual(0);
     });
 
     it('renders all other types within the main EuiPageInner', () => {
-      const component = render(
+      const { container, getByRole } = render(
         <EuiPageTemplate {...requiredProps}>
           <EuiPageTemplate.Header>A</EuiPageTemplate.Header>
           <EuiPageTemplate.Section>B</EuiPageTemplate.Section>
           <section>C</section>
         </EuiPageTemplate>
       );
-      expect(component).toMatchSnapshot();
-      expect(component.find('main').children()).toHaveLength(3);
+      expect(container.firstChild).toMatchSnapshot();
+      expect(getByRole('main').childElementCount).toEqual(3);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR converts `EuiPage` and `EuiPageTemplate` unit tests using Enzyme's render() function to RTL render() counterpart to reduce our tech debt.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
