### PR TITLE
test: convert more component unit tests using enzyme render to RTL

### DIFF
--- a/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiProgress color #885522 is rendered 1`] = `
-<div
-  class="euiProgress emotion-euiProgress-indeterminate-m-static-customColor"
-  style="color:#885522"
-/>
-`;
-
 exports[`EuiProgress color accent is rendered 1`] = `
 <div
   class="euiProgress emotion-euiProgress-indeterminate-m-static-accent"
@@ -22,6 +15,13 @@ exports[`EuiProgress color danger is rendered 1`] = `
 exports[`EuiProgress color primary is rendered 1`] = `
 <div
   class="euiProgress emotion-euiProgress-indeterminate-m-static-primary"
+/>
+`;
+
+exports[`EuiProgress color rgb(136, 85, 34) is rendered 1`] = `
+<div
+  class="euiProgress emotion-euiProgress-indeterminate-m-static-customColor"
+  style="color: rgb(136, 85, 34);"
 />
 `;
 
@@ -104,16 +104,17 @@ exports[`EuiProgress color warning is rendered 1`] = `
 `;
 
 exports[`EuiProgress has labelProps 1`] = `
-Array [
+<div>
   <div
     class="euiProgress__data emotion-euiProgress__data"
   >
     <span
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
+      title="150"
     >
       150
     </span>
-  </div>,
+  </div>
   <progress
     aria-hidden="false"
     aria-label="aria-label"
@@ -121,8 +122,8 @@ Array [
     data-test-subj="test subject string"
     max="100"
     value="50"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`EuiProgress has max 1`] = `
@@ -144,21 +145,23 @@ exports[`EuiProgress has value 1`] = `
 `;
 
 exports[`EuiProgress has valueText and label 1`] = `
-Array [
+<div>
   <div
     class="euiProgress__data emotion-euiProgress__data"
   >
     <span
       class="euiProgress__label emotion-euiProgress__label"
+      title="Label"
     >
       Label
     </span>
     <span
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
+      title="150"
     >
       150
     </span>
-  </div>,
+  </div>
   <progress
     aria-hidden="true"
     aria-label="aria-label"
@@ -166,8 +169,8 @@ Array [
     data-test-subj="test subject string"
     max="100"
     value="50"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`EuiProgress is determinate 1`] = `
@@ -222,16 +225,17 @@ exports[`EuiProgress size xs is rendered 1`] = `
 `;
 
 exports[`EuiProgress valueText is true 1`] = `
-Array [
+<div>
   <div
     class="euiProgress__data emotion-euiProgress__data"
   >
     <span
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
+      title="50%"
     >
       50%
     </span>
-  </div>,
+  </div>
   <progress
     aria-hidden="false"
     aria-label="aria-label"
@@ -239,6 +243,6 @@ Array [
     data-test-subj="test subject string"
     max="100"
     value="50"
-  />,
-]
+  />
+</div>
 `;

--- a/src/components/progress/progress.test.tsx
+++ b/src/components/progress/progress.test.tsx
@@ -7,17 +7,17 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiProgress, COLORS, SIZES } from './progress';
 
 describe('EuiProgress', () => {
   test('is rendered', () => {
-    const component = render(<EuiProgress {...requiredProps} />);
+    const { container } = render(<EuiProgress {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiProgress />);
@@ -27,37 +27,39 @@ describe('EuiProgress', () => {
   });
 
   test('has max', () => {
-    const component = render(<EuiProgress max={100} {...requiredProps} />);
+    const { container } = render(<EuiProgress max={100} {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('has value', () => {
-    const component = render(<EuiProgress value={100} {...requiredProps} />);
+    const { container } = render(
+      <EuiProgress value={100} {...requiredProps} />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is determinate', () => {
     const val = 50;
-    const component = render(
+    const { container } = render(
       <EuiProgress max={val ? 100 : undefined} value={val} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is indeterminate', () => {
     const val = undefined;
-    const component = render(
+    const { container } = render(
       <EuiProgress max={val ? 100 : undefined} value={val} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('has valueText and label', () => {
-    const component = render(
+    const { container } = render(
       <EuiProgress
         valueText="150"
         label="Label"
@@ -67,19 +69,19 @@ describe('EuiProgress', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('valueText is true', () => {
-    const component = render(
+    const { container } = render(
       <EuiProgress valueText={true} value={50} max={100} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('has labelProps', () => {
-    const component = render(
+    const { container } = render(
       <EuiProgress
         max={100}
         value={50}
@@ -89,15 +91,15 @@ describe('EuiProgress', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   describe('color', () => {
-    [...COLORS, '#885522'].forEach((color) => {
+    [...COLORS, 'rgb(136, 85, 34)'].forEach((color) => {
       test(`${color} is rendered`, () => {
-        const component = render(<EuiProgress color={color} />);
+        const { container } = render(<EuiProgress color={color} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
@@ -105,9 +107,9 @@ describe('EuiProgress', () => {
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(<EuiProgress size={size} />);
+        const { container } = render(<EuiProgress size={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiResizablePanel__content emotion-euiPanel-grow-none-transparent-euiResizablePanel__content-scrollable"
@@ -27,9 +27,9 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--plain euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-plain-euiResizablePanel__content-scrollable"
@@ -48,9 +48,9 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -67,9 +67,9 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -88,9 +88,9 @@ exports[`EuiResizableContainer can be vertical 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:100%;block-size:50%"
+    style="inline-size: 100%; block-size: 50%;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -107,9 +107,9 @@ exports[`EuiResizableContainer can be vertical 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:100%;block-size:50%"
+    style="inline-size: 100%; block-size: 50%;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -128,9 +128,9 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:33%;block-size:auto"
+    style="inline-size: 33%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -147,9 +147,9 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:33%;block-size:auto"
+    style="inline-size: 33%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -166,9 +166,9 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:33%;block-size:auto"
+    style="inline-size: 33%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -187,9 +187,9 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -206,9 +206,9 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -227,10 +227,22 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:20%;block-size:auto"
+    style="inline-size: 80%; block-size: auto;"
   >
+    <button
+      aria-label="Press to toggle this panel"
+      class="euiButtonIcon euiResizableToggleButton euiResizableToggleButton--horizontal euiResizableToggleButton--before euiResizableToggleButton--middle emotion-euiButtonIcon-xs-base-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="menuRight"
+      />
+    </button>
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable-hasCollapsibleButton"
     >
@@ -246,9 +258,9 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:80%;block-size:auto"
+    style="inline-size: 80%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -267,9 +279,9 @@ exports[`EuiResizableContainer is rendered 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -286,9 +298,9 @@ exports[`EuiResizableContainer is rendered 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:50%;block-size:auto"
+    style="inline-size: 50%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"
@@ -307,10 +319,23 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
 >
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:20%;block-size:auto"
+    style="inline-size: 80%; block-size: auto;"
   >
+    <button
+      aria-label="Press to toggle this panel"
+      class="euiButtonIcon euiResizableToggleButton euiResizableToggleButton--horizontal euiResizableToggleButton--before euiResizableToggleButton--top emotion-euiButtonIcon-xs-base-text"
+      data-test-subj="panel-toggle"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="menuRight"
+      />
+    </button>
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable-hasCollapsibleButton"
     >
@@ -326,9 +351,9 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
   />
   <div
     class="euiResizablePanel emotion-euiResizablePanel"
-    data-position="middle"
+    data-position="last"
     id="resizable-panel_generated-id"
-    style="inline-size:80%;block-size:auto"
+    style="inline-size: 80%; block-size: auto;"
   >
     <div
       class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiResizablePanel__content emotion-euiPanel-grow-none-m-transparent-euiResizablePanel__content-scrollable"

--- a/src/components/resizable_container/resizable_container.test.tsx
+++ b/src/components/resizable_container/resizable_container.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import { findTestSubject, requiredProps } from '../../test';
-import { shouldRenderCustomStyles } from '../..//test/internal';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiResizableContainer } from './resizable_container';
 import { keys } from '../../services';
@@ -28,7 +29,7 @@ describe('EuiResizableContainer', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -40,11 +41,11 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can be vertical', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps} direction="vertical">
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -56,13 +57,13 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can be controlled externally', () => {
     const panel1 = 50;
     const panel2 = 50;
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -74,11 +75,11 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can have scrollable panels', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -94,11 +95,11 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can have more than two panels', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -112,11 +113,11 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can adjust panel props', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -132,11 +133,11 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can have toggleable panels', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -152,11 +153,11 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('toggleable panels can be configurable', () => {
-    const component = render(
+    const { container } = render(
       <EuiResizableContainer {...requiredProps}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
@@ -182,7 +183,7 @@ describe('EuiResizableContainer', () => {
       </EuiResizableContainer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('on resize callbacks', () => {

--- a/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -13,10 +13,15 @@ exports[`EuiSelectable custom options with data 1`] = `
     >
       <div
         class="euiSelectableList__list"
-        style="position:relative;height:96px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+        style="position: relative; height: 96px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+        tabindex="-1"
       >
         <ul
-          style="height:96px;width:100%"
+          aria-multiselectable="true"
+          id="generated-id_listbox"
+          role="listbox"
+          style="height: 96px; width: 100%;"
+          tabindex="0"
         >
           <li
             aria-checked="false"
@@ -26,7 +31,7 @@ exports[`EuiSelectable custom options with data 1`] = `
             class="euiSelectableListItem euiSelectableListItem--paddingSmall"
             id="generated-id_listbox_option-0"
             role="option"
-            style="position:absolute;left:0;top:0;height:32px;width:100%"
+            style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
             title="Titan"
           >
             <span
@@ -40,7 +45,9 @@ exports[`EuiSelectable custom options with data 1`] = `
                 class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
               >
                 <span>
-                  VI: Titan
+                  VI
+                  : 
+                  Titan
                 </span>
               </span>
             </span>
@@ -53,7 +60,7 @@ exports[`EuiSelectable custom options with data 1`] = `
             class="euiSelectableListItem euiSelectableListItem--paddingSmall"
             id="generated-id_listbox_option-1"
             role="option"
-            style="position:absolute;left:0;top:32px;height:32px;width:100%"
+            style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
             title="Enceladus"
           >
             <span
@@ -67,7 +74,9 @@ exports[`EuiSelectable custom options with data 1`] = `
                 class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
               >
                 <span>
-                  II: Enceladus
+                  II
+                  : 
+                  Enceladus
                 </span>
               </span>
             </span>
@@ -80,7 +89,7 @@ exports[`EuiSelectable custom options with data 1`] = `
             class="euiSelectableListItem euiSelectableListItem--paddingSmall"
             id="generated-id_listbox_option-2"
             role="option"
-            style="position:absolute;left:0;top:64px;height:32px;width:100%"
+            style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
             title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
           >
             <span
@@ -94,7 +103,9 @@ exports[`EuiSelectable custom options with data 1`] = `
                 class="euiSelectableListItem__text euiSelectableListItem__text--truncate"
               >
                 <span>
-                  XVII: Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
+                  XVII
+                  : 
+                  Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
                 </span>
               </span>
             </span>
@@ -135,10 +146,15 @@ exports[`EuiSelectable errorMessage prop does not render the message when not de
     >
       <div
         class="euiSelectableList__list"
-        style="position:relative;height:96px;width:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+        style="position: relative; height: 96px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+        tabindex="-1"
       >
         <ul
-          style="height:96px;width:100%"
+          aria-multiselectable="true"
+          id="generated-id_listbox"
+          role="listbox"
+          style="height: 96px; width: 100%;"
+          tabindex="0"
         >
           <li
             aria-checked="false"
@@ -149,7 +165,7 @@ exports[`EuiSelectable errorMessage prop does not render the message when not de
             data-test-subj="titanOption"
             id="generated-id_listbox_option-0"
             role="option"
-            style="position:absolute;left:0;top:0;height:32px;width:100%"
+            style="position: absolute; left: 0px; top: 0px; height: 32px; width: 100%;"
             title="Titan"
           >
             <span
@@ -176,7 +192,7 @@ exports[`EuiSelectable errorMessage prop does not render the message when not de
             class="euiSelectableListItem euiSelectableListItem--paddingSmall"
             id="generated-id_listbox_option-1"
             role="option"
-            style="position:absolute;left:0;top:32px;height:32px;width:100%"
+            style="position: absolute; left: 0px; top: 32px; height: 32px; width: 100%;"
             title="Enceladus"
           >
             <span
@@ -203,7 +219,7 @@ exports[`EuiSelectable errorMessage prop does not render the message when not de
             class="euiSelectableListItem euiSelectableListItem--paddingSmall"
             id="generated-id_listbox_option-2"
             role="option"
-            style="position:absolute;left:0;top:64px;height:32px;width:100%"
+            style="position: absolute; left: 0px; top: 64px; height: 32px; width: 100%;"
             title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
           >
             <span
@@ -310,12 +326,6 @@ exports[`EuiSelectable search value supports inheriting initialSearchValue from 
   >
     <div
       aria-atomic="true"
-      aria-hidden="true"
-      aria-live="off"
-      role="status"
-    />
-    <div
-      aria-atomic="true"
       aria-live="polite"
       role="status"
     >
@@ -326,6 +336,12 @@ exports[`EuiSelectable search value supports inheriting initialSearchValue from 
          doesn't match any options
       </p>
     </div>
+    <div
+      aria-atomic="true"
+      aria-hidden="true"
+      aria-live="off"
+      role="status"
+    />
   </div>
   <div
     class="euiText euiSelectableMessage emotion-euiText-xs-euiTextColor-subdued"
@@ -391,7 +407,8 @@ exports[`EuiSelectable search value supports inheriting initialSearchValue from 
     class="emotion-euiScreenReaderOnly"
     id="generated-id_instructions"
   >
-     Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+     
+    Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
   </p>
 </div>
 `;

--- a/src/components/selectable/selectable.test.tsx
+++ b/src/components/selectable/selectable.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiSelectable } from './selectable';
 import { EuiSelectableOption } from './selectable_option';
@@ -42,11 +43,11 @@ describe('EuiSelectable', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSelectable options={options} {...requiredProps} id="testId" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('should not reset the activeOptionIndex nor isFocused when EuiSelectable is blurred in favour of its search/listbox', () => {
@@ -77,51 +78,55 @@ describe('EuiSelectable', () => {
 
   describe('props', () => {
     test('searchable', () => {
-      const component = render(<EuiSelectable options={options} searchable />);
+      const { container } = render(
+        <EuiSelectable options={options} searchable />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('singleSelection', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable options={options} singleSelection />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('allowExclusions', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable options={options} allowExclusions />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isLoading', () => {
-      const component = render(<EuiSelectable options={options} isLoading />);
+      const { container } = render(
+        <EuiSelectable options={options} isLoading />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('height can be forced', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable options={options} height={200} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('height can be full', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable options={options} height="full" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renderOption', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable
           options={options}
           renderOption={(option: EuiSelectableOption, searchValue?: string) => {
@@ -134,11 +139,11 @@ describe('EuiSelectable', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('listProps', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable
           options={options}
           listProps={{
@@ -149,13 +154,13 @@ describe('EuiSelectable', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('search value', () => {
     it('supports inheriting initialSearchValue from searchProps.defaultValue', () => {
-      const component = render(
+      const { container, getByTestSubject } = render(
         <EuiSelectable
           options={options}
           searchable
@@ -172,10 +177,8 @@ describe('EuiSelectable', () => {
           )}
         </EuiSelectable>
       );
-      expect(component).toMatchSnapshot();
-      expect(
-        component.find('input[data-test-subj="searchInput"]').prop('value')
-      ).toEqual('default value');
+      expect(container.firstChild).toMatchSnapshot();
+      expect(getByTestSubject('searchInput')).toHaveValue('default value');
     });
 
     it('supports controlled searchValue state from searchProps.value', () => {
@@ -255,7 +258,7 @@ describe('EuiSelectable', () => {
     });
 
     it('defaults to an empty string if no value or defaultValue is passed from searchProps', () => {
-      const component = render(
+      const { getByTestSubject } = render(
         <EuiSelectable
           options={options}
           searchable
@@ -264,9 +267,8 @@ describe('EuiSelectable', () => {
           {(_, search) => <>{search}</>}
         </EuiSelectable>
       );
-      expect(
-        component.find('input[data-test-subj="searchInput"]').prop('value')
-      ).toEqual('');
+
+      expect(getByTestSubject('searchInput')).toHaveValue('');
     });
   });
 
@@ -357,7 +359,7 @@ describe('EuiSelectable', () => {
           },
         },
       ];
-      const component = render(
+      const { container } = render(
         <EuiSelectable<WithData>
           options={options}
           renderOption={(option) => {
@@ -372,7 +374,7 @@ describe('EuiSelectable', () => {
         </EuiSelectable>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
@@ -486,27 +488,27 @@ describe('EuiSelectable', () => {
 
   describe('errorMessage prop', () => {
     it('does not render the message when not defined', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable options={options} errorMessage={null}>
           {(list) => list}
         </EuiSelectable>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('does renders the message when defined', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable options={options} errorMessage="Error!">
           {(list) => list}
         </EuiSelectable>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('can render an element as the message', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectable
           options={options}
           errorMessage={<span>Element error!</span>}
@@ -515,7 +517,7 @@ describe('EuiSelectable', () => {
         </EuiSelectable>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 

--- a/src/components/selectable/selectable_message/selectable_message.test.tsx
+++ b/src/components/selectable/selectable_message/selectable_message.test.tsx
@@ -7,21 +7,21 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiSelectableMessage } from './selectable_message';
 
 describe('EuiSelectableMessage', () => {
   test('is rendered', () => {
-    const component = render(<EuiSelectableMessage {...requiredProps} />);
+    const { container } = render(<EuiSelectableMessage {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('bordered is rendered', () => {
-    const component = render(<EuiSelectableMessage bordered={true} />);
+    const { container } = render(<EuiSelectableMessage bordered={true} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
+++ b/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
@@ -47,7 +47,8 @@ exports[`EuiSelectableTemplateSitewide is rendered 1`] = `
         class="emotion-euiScreenReaderOnly"
         id="generated-id_instructions"
       >
-         Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
       </p>
     </div>
   </div>
@@ -100,7 +101,8 @@ exports[`EuiSelectableTemplateSitewide props popoverButton is not rendered with 
         class="emotion-euiScreenReaderOnly"
         id="generated-id_instructions"
       >
-         Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
       </p>
     </div>
   </div>
@@ -189,7 +191,8 @@ exports[`EuiSelectableTemplateSitewide props popoverFooter is rendered 1`] = `
         class="emotion-euiScreenReaderOnly"
         id="generated-id_instructions"
       >
-         Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
       </p>
     </div>
   </div>
@@ -242,7 +245,8 @@ exports[`EuiSelectableTemplateSitewide props popoverProps is rendered 1`] = `
         class="emotion-euiScreenReaderOnly"
         id="generated-id_instructions"
       >
-         Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
       </p>
     </div>
   </div>
@@ -295,7 +299,8 @@ exports[`EuiSelectableTemplateSitewide props popoverTitle is rendered 1`] = `
         class="emotion-euiScreenReaderOnly"
         id="generated-id_instructions"
       >
-         Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
       </p>
     </div>
   </div>

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiSelectableTemplateSitewide } from './selectable_template_sitewide';
 import { EuiSelectableTemplateSitewideOption } from './selectable_template_sitewide_option';
@@ -81,45 +81,45 @@ describe('EuiSelectableTemplateSitewide', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSelectableTemplateSitewide options={options} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('popoverProps is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableTemplateSitewide
           options={options}
           popoverProps={{ className: 'customPopoverClass' }}
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('popoverTitle is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableTemplateSitewide
           options={options}
           popoverTitle={<>Title</>}
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('popoverFooter is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSelectableTemplateSitewide
           options={options}
           popoverFooter={<>Footer</>}
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('popoverButton', () => {
@@ -128,18 +128,18 @@ describe('EuiSelectableTemplateSitewide', () => {
       afterAll(() => 1024); // reset to jsdom's default
 
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiSelectableTemplateSitewide
             options={options}
             popoverButton={<button>Button</button>}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with popoverButtonBreakpoints m', () => {
-        const component = render(
+        const { container } = render(
           <EuiSelectableTemplateSitewide
             options={options}
             popoverButton={<button>Button</button>}
@@ -147,11 +147,11 @@ describe('EuiSelectableTemplateSitewide', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is not rendered with popoverButtonBreakpoints xs', () => {
-        const component = render(
+        const { container } = render(
           <EuiSelectableTemplateSitewide
             options={options}
             popoverButton={<button>Button</button>}
@@ -159,7 +159,7 @@ describe('EuiSelectableTemplateSitewide', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/side_nav/__snapshots__/side_nav.test.tsx.snap
+++ b/src/components/side_nav/__snapshots__/side_nav.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`EuiSideNav props items is rendered 1`] = `
         >
           <span
             class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+            title="A"
           >
             A
           </span>
@@ -131,6 +132,7 @@ exports[`EuiSideNav props items is rendered 1`] = `
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="B"
               >
                 B
               </span>
@@ -183,6 +185,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
         >
           <span
             class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+            title="A"
           >
             A
           </span>
@@ -202,6 +205,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="B"
               >
                 B
               </span>
@@ -220,6 +224,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="C"
               >
                 C
               </span>
@@ -243,6 +248,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
                 >
                   <span
                     class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                    title="D"
                   >
                     D
                   </span>
@@ -265,6 +271,7 @@ exports[`EuiSideNav props items renders items having { forceOpen: true } in open
                     >
                       <span
                         class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                        title="E"
                       >
                         E
                       </span>
@@ -302,6 +309,7 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
         >
           <span
             class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+            title="A"
           >
             A
           </span>
@@ -322,6 +330,7 @@ exports[`EuiSideNav props items renders items using a specified callback 1`] = `
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="B"
               >
                 B
               </span>
@@ -355,6 +364,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
         >
           <span
             class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+            title="A"
           >
             A
           </span>
@@ -374,6 +384,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="B"
               >
                 B
               </span>
@@ -392,6 +403,7 @@ exports[`EuiSideNav props items renders items which are links 1`] = `
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="C"
               >
                 C
               </span>
@@ -426,6 +438,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
         >
           <span
             class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+            title="A"
           >
             A
           </span>
@@ -445,6 +458,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="B"
               >
                 B
               </span>
@@ -463,6 +477,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
             >
               <span
                 class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                title="C"
               >
                 C
               </span>
@@ -485,6 +500,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
                 >
                   <span
                     class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                    title="D"
                   >
                     D
                   </span>
@@ -502,6 +518,7 @@ exports[`EuiSideNav props items renders selected item and automatically opens pa
                 >
                   <span
                     class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+                    title="E"
                   >
                     E
                   </span>

--- a/src/components/side_nav/__snapshots__/side_nav_item.test.tsx.snap
+++ b/src/components/side_nav/__snapshots__/side_nav_item.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`EuiSideNavItem can be disabled 1`] = `
     >
       <span
         class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+        title="Children"
       >
         Children
       </span>
@@ -34,6 +35,7 @@ exports[`EuiSideNavItem can be emphasized 1`] = `
     >
       <span
         class="euiSideNavItemButton__label euiSideNavItemButton__label--truncated"
+        title="Children"
       >
         Children
       </span>

--- a/src/components/side_nav/side_nav.test.tsx
+++ b/src/components/side_nav/side_nav.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiSideNav } from './side_nav';
 import { RenderItem } from './side_nav_item';
@@ -20,69 +20,71 @@ describe('EuiSideNav', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiSideNav {...requiredProps} />);
+    const { container } = render(<EuiSideNav {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('isOpenOnMobile', () => {
       test('defaults to false', () => {
-        const component = render(<EuiSideNav />);
+        const { container } = render(<EuiSideNav />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered when specified as true', () => {
-        const component = render(<EuiSideNav isOpenOnMobile />);
+        const { container } = render(<EuiSideNav isOpenOnMobile />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('mobileBreakpoints can be adjusted', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiSideNav mobileBreakpoints={['xs', 's', 'm', 'l', 'xl']} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('null is rendered', () => {
-        const component = render(<EuiSideNav mobileBreakpoints={undefined} />);
+        const { container } = render(
+          <EuiSideNav mobileBreakpoints={undefined} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('heading', () => {
       test('is rendered', () => {
-        const component = render(<EuiSideNav heading="Side Nav Heading" />);
+        const { container } = render(<EuiSideNav heading="Side Nav Heading" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is hidden with screenReaderOnly', () => {
-        const component = render(
+        const { container } = render(
           <EuiSideNav
             heading="Side Nav Heading"
             headingProps={{ screenReaderOnly: true }}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('accepts more headingProps', () => {
-        const component = render(
+        const { container } = render(
           <EuiSideNav
             heading="Side Nav Heading"
             headingProps={{ ...requiredProps, id: 'testID', element: 'h3' }}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
@@ -121,9 +123,9 @@ describe('EuiSideNav', () => {
           },
         ];
 
-        const component = render(<EuiSideNav items={sideNav} />);
+        const { container } = render(<EuiSideNav items={sideNav} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders items which are links', () => {
@@ -155,9 +157,9 @@ describe('EuiSideNav', () => {
           },
         ];
 
-        const component = render(<EuiSideNav items={sideNav} />);
+        const { container } = render(<EuiSideNav items={sideNav} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders items using a specified callback', () => {
@@ -182,11 +184,11 @@ describe('EuiSideNav', () => {
           </a>
         );
 
-        const component = render(
+        const { container } = render(
           <EuiSideNav items={sideNav} renderItem={renderItem} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders selected item and automatically opens parent items', () => {
@@ -218,9 +220,9 @@ describe('EuiSideNav', () => {
           },
         ];
 
-        const component = render(<EuiSideNav items={sideNav} />);
+        const { container } = render(<EuiSideNav items={sideNav} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders items having { forceOpen: true } in open state, and automatically opens parent items', () => {
@@ -254,9 +256,9 @@ describe('EuiSideNav', () => {
           },
         ];
 
-        const component = render(<EuiSideNav items={sideNav} />);
+        const { container } = render(<EuiSideNav items={sideNav} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/side_nav/side_nav_item.test.tsx
+++ b/src/components/side_nav/side_nav_item.test.tsx
@@ -7,97 +7,97 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiSideNavItem } from './side_nav_item';
 
 describe('EuiSideNavItem', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSideNavItem>
         <button {...requiredProps} />
       </EuiSideNavItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test("preserves child's classes", () => {
-    const component = render(
+    const { container } = render(
       <EuiSideNavItem>
         <button className="test" />
       </EuiSideNavItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can have truncation turned off', () => {
-    const component = render(
+    const { container } = render(
       <EuiSideNavItem truncate={false}>Children</EuiSideNavItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can be emphasized', () => {
-    const component = render(
+    const { container } = render(
       <EuiSideNavItem emphasize>Children</EuiSideNavItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can be disabled', () => {
-    const component = render(
+    const { container } = render(
       <EuiSideNavItem disabled>Children</EuiSideNavItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('isSelected', () => {
     test('defaults to false', () => {
-      const component = render(
+      const { container } = render(
         <EuiSideNavItem>
           <button />
         </EuiSideNavItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered when specified as true', () => {
-      const component = render(
+      const { container } = render(
         <EuiSideNavItem isSelected>
           <button />
         </EuiSideNavItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('href', () => {
     test('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSideNavItem href="#">
           <button />
         </EuiSideNavItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered with rel', () => {
-      const component = render(
+      const { container } = render(
         <EuiSideNavItem href="#" rel="noopener">
           <button />
         </EuiSideNavItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/stat/__snapshots__/stat.test.tsx.snap
+++ b/src/components/stat/__snapshots__/stat.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`EuiStat props hexcode colors are rendered 1`] = `
   <p
     aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title"
-    style="color:#EB1919"
+    style="color: rgb(235, 25, 25);"
   >
     title
   </p>
@@ -320,7 +320,7 @@ exports[`EuiStat props render with custom description element 1`] = `
   <p
     aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title"
-    style="color:#EB1919"
+    style="color: rgb(235, 25, 25);"
   >
     title
   </p>

--- a/src/components/stat/stat.test.tsx
+++ b/src/components/stat/stat.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -16,18 +16,18 @@ import { TITLE_SIZES } from '../title/title';
 
 describe('EuiStat', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiStat title="title" description="description" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiStat title="title" description="description" />);
 
   describe('props', () => {
     test('loading is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiStat
           title="title"
           description="description"
@@ -36,20 +36,20 @@ describe('EuiStat', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('title and description are reversed', () => {
-      const component = render(
+      const { container } = render(
         <EuiStat title="title" description="description" reverse />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     ALIGNMENTS.forEach((alignment) => {
       test(`${alignment} is rendered`, () => {
-        const component = render(
+        const { container } = render(
           <EuiStat
             title="title"
             description="description"
@@ -57,30 +57,30 @@ describe('EuiStat', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     COLORS.forEach((color) => {
       test(`${color} is rendered`, () => {
-        const component = render(
+        const { container } = render(
           <EuiStat title="title" description="description" titleColor={color} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('hexcode colors are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiStat title="title" description="description" titleColor="#EB1919" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('render with custom description element', () => {
-      const component = render(
+      const { container } = render(
         <EuiStat
           title="title"
           description={<div>description</div>}
@@ -89,11 +89,11 @@ describe('EuiStat', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('render with custom title element', () => {
-      const component = render(
+      const { container } = render(
         <EuiStat
           title={<div>title</div>}
           titleElement="div"
@@ -101,16 +101,16 @@ describe('EuiStat', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     TITLE_SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(
+        const { container } = render(
           <EuiStat title="title" description="description" titleSize={size} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/steps/step.test.tsx
+++ b/src/components/steps/step.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiStep } from './step';
 import { STATUS } from './step_number';
@@ -22,56 +22,56 @@ describe('EuiStep', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiStep {...requiredProps} title={'First step'}>
         <p>Do this</p>
       </EuiStep>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('headingElement', () => {
-      const component = render(
+      const { container } = render(
         <EuiStep headingElement={'h3'} title={'First step'}>
           <p>Do this</p>
         </EuiStep>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('step', () => {
-      const component = render(
+      const { container } = render(
         <EuiStep step={5} title={'First step'}>
           <p>Do this</p>
         </EuiStep>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('titleSize', () => {
-      const component = render(
+      const { container } = render(
         <EuiStep titleSize="xs" title={'First step'}>
           <p>Do this</p>
         </EuiStep>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('status', () => {
       STATUS.forEach((status) => {
         test(`${status} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiStep status={status} title={'First step'}>
               <p>Do this</p>
             </EuiStep>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/steps/step_horizontal.test.tsx
+++ b/src/components/steps/step_horizontal.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { STATUS } from './step_number';
 import { EuiStepHorizontal } from './step_horizontal';
@@ -21,58 +22,58 @@ describe('EuiStepHorizontal', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiStepHorizontal {...requiredProps} onClick={() => {}} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('step', () => {
-      const component = render(
+      const { container } = render(
         <EuiStepHorizontal step={5} onClick={() => {}} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('title', () => {
-      const component = render(
+      const { container } = render(
         <EuiStepHorizontal title={'First step'} onClick={() => {}} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('status', () => {
       STATUS.forEach((status) => {
         test(`${status} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiStepHorizontal status={status} onClick={() => {}} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
       test('disabled overrides the passed status', () => {
-        const component = render(
+        const { container } = render(
           <EuiStepHorizontal status="current" disabled onClick={() => {}} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiStepHorizontal size={size} onClick={() => {}} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/steps/step_number.test.tsx
+++ b/src/components/steps/step_number.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { STATUS, EuiStepNumber } from './step_number';
 
@@ -17,28 +17,30 @@ describe('EuiStepNumber', () => {
   shouldRenderCustomStyles(<EuiStepNumber {...requiredProps} />);
 
   test('is rendered', () => {
-    const component = render(<EuiStepNumber {...requiredProps} />);
+    const { container } = render(<EuiStepNumber {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('has titleSize', () => {
       it('is rendered', () => {
-        const component = render(<EuiStepNumber titleSize="xs" number={1} />);
+        const { container } = render(
+          <EuiStepNumber titleSize="xs" number={1} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('status', () => {
       STATUS.forEach((status) => {
         test(`${status} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiStepNumber number={1} status={status} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/steps/steps.test.tsx
+++ b/src/components/steps/steps.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiContainedStepProps, EuiSteps } from './steps';
 
@@ -33,32 +33,32 @@ describe('EuiSteps', () => {
   shouldRenderCustomStyles(<EuiSteps {...requiredProps} steps={steps} />);
 
   test('renders steps', () => {
-    const component = render(<EuiSteps {...requiredProps} steps={steps} />);
+    const { container } = render(<EuiSteps {...requiredProps} steps={steps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders steps with firstStepNumber', () => {
-    const component = render(
+    const { container } = render(
       <EuiSteps {...requiredProps} steps={steps} firstStepNumber={10} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders steps with titleSize', () => {
-    const component = render(
+    const { container } = render(
       <EuiSteps {...requiredProps} steps={steps} titleSize="xs" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders step title inside "headingElement" element', () => {
-    const component = render(
+    const { container } = render(
       <EuiSteps {...requiredProps} steps={steps} headingElement="h2" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/steps/steps_horizontal.test.tsx
+++ b/src/components/steps/steps_horizontal.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import {
   EuiStepsHorizontal,
@@ -44,10 +44,10 @@ describe('EuiStepsHorizontal', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiStepsHorizontal {...requiredProps} steps={steps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/steps/sub_steps.test.tsx
+++ b/src/components/steps/sub_steps.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiSubSteps } from './sub_steps';
 
@@ -17,8 +17,8 @@ describe('EuiSubSteps', () => {
   shouldRenderCustomStyles(<EuiSubSteps {...requiredProps} />);
 
   test('is rendered', () => {
-    const component = render(<EuiSubSteps {...requiredProps} />);
+    const { container } = render(<EuiSubSteps {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/suggest/__snapshots__/suggest.test.tsx.snap
+++ b/src/components/suggest/__snapshots__/suggest.test.tsx.snap
@@ -48,7 +48,9 @@ exports[`EuiSuggest is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -109,7 +111,9 @@ exports[`EuiSuggest props append 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -165,7 +169,9 @@ exports[`EuiSuggest props isVirtualized 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -221,7 +227,9 @@ exports[`EuiSuggest props maxHeight 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -277,7 +285,9 @@ exports[`EuiSuggest props options common 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -333,7 +343,9 @@ exports[`EuiSuggest props options standard 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -411,7 +423,9 @@ exports[`EuiSuggest props remaining EuiFieldSearch props are spread to the searc
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -476,7 +490,9 @@ exports[`EuiSuggest props status status: loading is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: loading. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: loading.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -541,7 +557,9 @@ exports[`EuiSuggest props status status: saved is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: saved. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: saved.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -597,7 +615,9 @@ exports[`EuiSuggest props status status: unchanged is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -662,7 +682,9 @@ exports[`EuiSuggest props status status: unsaved is rendered 1`] = `
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unsaved. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unsaved.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -727,7 +749,9 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: loading is r
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: loading. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: loading.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -792,7 +816,9 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: saved is ren
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: saved. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: saved.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -848,7 +874,9 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: unchanged is
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unchanged. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unchanged.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>
@@ -913,7 +941,9 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: unsaved is r
           class="emotion-euiScreenReaderOnly"
           id="generated-id_instructions"
         >
-          State: unsaved. Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+          State: unsaved.
+           
+          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
         </p>
       </div>
     </div>

--- a/src/components/suggest/suggest.test.tsx
+++ b/src/components/suggest/suggest.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiSelectable } from '../selectable';
 import { EuiSuggest, EuiSuggestionProps } from './suggest';
@@ -29,18 +30,18 @@ const sampleItems: EuiSuggestionProps[] = [
 
 describe('EuiSuggest', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSuggest {...requiredProps} suggestions={sampleItems} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('status', () => {
       ALL_STATUSES.forEach((status) => {
         test(`status: ${status} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiSuggest
               {...requiredProps}
               suggestions={sampleItems}
@@ -48,13 +49,13 @@ describe('EuiSuggest', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     test('append', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggest
           {...requiredProps}
           suggestions={sampleItems}
@@ -62,13 +63,13 @@ describe('EuiSuggest', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('tooltipContent', () => {
       ALL_STATUSES.forEach((status) => {
         test(`tooltipContent for status: ${status} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiSuggest
               {...requiredProps}
               suggestions={sampleItems}
@@ -77,13 +78,13 @@ describe('EuiSuggest', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     test('isVirtualized', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggest
           {...requiredProps}
           suggestions={sampleItems}
@@ -91,11 +92,11 @@ describe('EuiSuggest', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('maxHeight', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggest
           {...requiredProps}
           suggestions={sampleItems}
@@ -103,7 +104,7 @@ describe('EuiSuggest', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('options', () => {
@@ -116,11 +117,11 @@ describe('EuiSuggest', () => {
             labelWidth: idx === 0 ? '70' : 80,
           })
         );
-        const component = render(
+        const { container } = render(
           <EuiSuggest {...requiredProps} suggestions={_sampleItems} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('common', () => {
@@ -131,11 +132,11 @@ describe('EuiSuggest', () => {
           className: 'sampleItem',
           id: 'sampleItem',
         }));
-        const component = render(
+        const { container } = render(
           <EuiSuggest {...requiredProps} suggestions={_sampleItems} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
@@ -160,7 +161,7 @@ describe('EuiSuggest', () => {
     });
 
     test('remaining EuiFieldSearch props are spread to the search input', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggest
           {...requiredProps}
           suggestions={sampleItems}
@@ -175,7 +176,7 @@ describe('EuiSuggest', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/suggest/suggest_item.test.tsx
+++ b/src/components/suggest/suggest_item.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiSuggestItem } from './suggest_item';
 
@@ -19,11 +19,11 @@ const TYPE = {
 
 describe('EuiSuggestItem', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiSuggestItem {...requiredProps} label="Test label" type={TYPE} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });
 
@@ -36,7 +36,7 @@ describe('props', () => {
 
   describe('labelWidth is 30%', () => {
     test('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggestItem
           type={sampleItem.type}
           description={sampleItem.description}
@@ -44,13 +44,13 @@ describe('props', () => {
           labelWidth="30"
         />
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('truncate', () => {
     test('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggestItem
           type={sampleItem.type}
           description={sampleItem.description}
@@ -58,11 +58,11 @@ describe('props', () => {
           truncate
         />
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renders false', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggestItem
           type={sampleItem.type}
           description={sampleItem.description}
@@ -70,16 +70,16 @@ describe('props', () => {
           truncate={false}
         />
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('item with no description has expanded label', () => {
     test('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSuggestItem label={sampleItem.label} type={sampleItem.type} />
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/tabs/tab.test.tsx
+++ b/src/components/tabs/tab.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiTab } from './tab';
 
@@ -19,12 +20,12 @@ describe('EuiTab', () => {
   describe('props', () => {
     describe('onClick', () => {
       test('renders button', () => {
-        const component = (
+        const { container } = render(
           <EuiTab onClick={() => {}} {...requiredProps}>
             children
           </EuiTab>
         );
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is called when the button is clicked', () => {
@@ -37,55 +38,55 @@ describe('EuiTab', () => {
     });
 
     test('href renders anchor', () => {
-      const component = (
+      const { container } = render(
         <EuiTab href="/baz/bing" {...requiredProps}>
           children
         </EuiTab>
       );
-      expect(render(component)).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('disabled is rendered', () => {
-      const component = render(<EuiTab disabled>Click Me</EuiTab>);
+      const { container } = render(<EuiTab disabled>Click Me</EuiTab>);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isSelected is rendered', () => {
-      const component = (
+      const { container } = render(
         <EuiTab onClick={() => {}} isSelected>
           children
         </EuiTab>
       );
-      expect(render(component)).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('disabled and selected', () => {
-      const component = render(
+      const { container } = render(
         <EuiTab disabled isSelected>
           Click Me
         </EuiTab>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('prepend is rendered', () => {
-      const component = (
+      const { container } = render(
         <EuiTab onClick={() => {}} prepend="Prepend">
           children
         </EuiTab>
       );
-      expect(render(component)).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('append is rendered', () => {
-      const component = (
+      const { container } = render(
         <EuiTab onClick={() => {}} prepend="Append">
           children
         </EuiTab>
       );
-      expect(render(component)).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/tabs/tabbed_content/tabbed_content.test.tsx
+++ b/src/components/tabs/tabbed_content/tabbed_content.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps, findTestSubject } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiTabbedContent, AUTOFOCUS } from './tabbed_content';
 
@@ -35,10 +36,10 @@ describe('EuiTabbedContent', () => {
   shouldRenderCustomStyles(<EuiTabbedContent tabs={tabs} />);
 
   test('is rendered with required props and tabs', () => {
-    const component = render(
+    const { container } = render(
       <EuiTabbedContent {...requiredProps} tabs={tabs} />
     );
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
@@ -56,37 +57,37 @@ describe('EuiTabbedContent', () => {
 
     describe('selectedTab', () => {
       test('renders a selected tab', () => {
-        const component = render(
+        const { container } = render(
           <EuiTabbedContent selectedTab={kibanaTab} tabs={tabs} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('initialSelectedTab', () => {
       test('renders a selected tab', () => {
-        const component = render(
+        const { container } = render(
           <EuiTabbedContent initialSelectedTab={kibanaTab} tabs={tabs} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       test('can be small', () => {
-        const component = render(<EuiTabbedContent size="s" tabs={tabs} />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiTabbedContent size="s" tabs={tabs} />);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('autoFocus', () => {
       AUTOFOCUS.forEach((focusType) => {
         test(`${focusType} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiTabbedContent autoFocus={focusType} tabs={tabs} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -94,8 +95,8 @@ describe('EuiTabbedContent', () => {
 
   describe('behavior', () => {
     test("when selected tab state isn't controlled by the owner, select the first tab by default", () => {
-      const component = render(<EuiTabbedContent tabs={tabs} />);
-      expect(component).toMatchSnapshot();
+      const { container } = render(<EuiTabbedContent tabs={tabs} />);
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('when uncontrolled, the selected tab should update if it receives new content', () => {

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiTab } from './tab';
 import { EuiTabs, SIZES } from './tabs';
@@ -20,39 +20,47 @@ describe('EuiTabs', () => {
   shouldRenderCustomStyles(<EuiTabs>{children}</EuiTabs>);
 
   test('renders', () => {
-    const component = <EuiTabs {...requiredProps}>children</EuiTabs>;
+    const { container } = render(
+      <EuiTabs {...requiredProps}>children</EuiTabs>
+    );
 
-    expect(render(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
         it(`${size} renders and passes down to EuiTab children`, () => {
-          const component = render(<EuiTabs size={size}>{children}</EuiTabs>);
+          const { container } = render(
+            <EuiTabs size={size}>{children}</EuiTabs>
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('expand', () => {
       it('passes down to EuiTab children', () => {
-        const component = render(<EuiTabs expand>{children}</EuiTabs>);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiTabs expand>{children}</EuiTabs>);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('context', () => {
     it('passes down `size` and `expand` to EuiTab children regardless of nesting', () => {
-      const component = render(
+      const { container } = render(
         <EuiTabs expand size="l">
           <div>{children}</div>
         </EuiTabs>
       );
-      expect(component.find('.euiTab').attr('class')).toContain('-expand');
-      expect(component.find('.euiTab__content').attr('class')).toContain('-l');
+
+      const tab = container.querySelector('.euiTab');
+      const tabContent = container.querySelector('.euiTab__content');
+
+      expect(tab!.className).toContain('-expand');
+      expect(tabContent!.className).toContain('-l');
     });
   });
 });

--- a/src/components/token/__snapshots__/token.test.tsx.snap
+++ b/src/components/token/__snapshots__/token.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`EuiToken is rendered 1`] = `
 exports[`EuiToken props color can be a custom hex 1`] = `
 <span
   class="euiToken emotion-euiToken-circle-light-s-customColor"
-  style="color:#000000;background-color:#FF0000"
+  style="color: rgb(0, 0, 0); background-color: rgb(255, 0, 0);"
 >
   <span
     data-euiicon-type="dot"

--- a/src/components/token/token.test.tsx
+++ b/src/components/token/token.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiToken } from './token';
 import { COLORS, SHAPES, SIZES, FILLS } from './token_types';
@@ -23,18 +23,20 @@ describe('EuiToken', () => {
   shouldRenderCustomStyles(<EuiToken iconType="dot" />);
 
   test('is rendered', () => {
-    const component = render(<EuiToken iconType="dot" {...requiredProps} />);
+    const { container } = render(
+      <EuiToken iconType="dot" {...requiredProps} />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('iconType as EuiTokenMapType', () => {
       tokenTypes.forEach((type) => {
         test(`${type} is rendered`, () => {
-          const component = render(<EuiToken iconType={type} />);
+          const { container } = render(<EuiToken iconType={type} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -42,9 +44,11 @@ describe('EuiToken', () => {
     describe('shape', () => {
       SHAPES.forEach((shape) => {
         test(`${shape} is rendered`, () => {
-          const component = render(<EuiToken iconType="dot" shape={shape} />);
+          const { container } = render(
+            <EuiToken iconType="dot" shape={shape} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -52,27 +56,31 @@ describe('EuiToken', () => {
     describe('color', () => {
       tokenColors.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiToken iconType="dot" color={color} />);
+          const { container } = render(
+            <EuiToken iconType="dot" color={color} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
       test('can be a custom hex', () => {
-        const component = render(<EuiToken iconType="dot" color="#FF0000" />);
+        const { container } = render(
+          <EuiToken iconType="dot" color="#FF0000" />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       SIZES.forEach((tokenSize) => {
         test(`${tokenSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiToken iconType="dot" size={tokenSize} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -80,9 +88,9 @@ describe('EuiToken', () => {
     describe('fill', () => {
       FILLS.forEach((fill) => {
         test(`${fill} is rendered`, () => {
-          const component = render(<EuiToken iconType="dot" fill={fill} />);
+          const { container } = render(<EuiToken iconType="dot" fill={fill} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });


### PR DESCRIPTION
## Summary

This PR converts `EuiToken`, `EuiTabs`, `EuiSuggest`, `EuiSteps`, `EuiStat`, `EuiSideNav`, `EuiSelectable`, `EuiResizeableContainer` and `EuiProgress` unit tests using Enzyme's render() function to RTL render() counterpart to reduce our tech debt.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
