### PR TITLE
test: convert even more component unit tests using enzyme render to RTL

### DIFF
--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -417,6 +417,7 @@ exports[`props option.prepend & option.append renders in pills 1`] = `
 Array [
   <span
     class="euiBadge euiComboBoxPill emotion-euiBadge-hollow"
+    data-test-subj="euiComboBoxPill"
     title="1"
   >
     <span
@@ -428,7 +429,11 @@ Array [
         <span
           class="euiComboBoxPill__prepend"
         >
-          Pre
+          <span
+            data-test-subj="prepend"
+          >
+            Pre
+          </span>
         </span>
         1
       </span>
@@ -448,6 +453,7 @@ Array [
   </span>,
   <span
     class="euiBadge euiComboBoxPill emotion-euiBadge-hollow"
+    data-test-subj="euiComboBoxPill"
     title="2"
   >
     <span
@@ -460,7 +466,11 @@ Array [
         <span
           class="euiComboBoxPill__append"
         >
-          Post
+          <span
+            data-test-subj="append"
+          >
+            Post
+          </span>
         </span>
       </span>
       <button
@@ -483,11 +493,16 @@ Array [
 exports[`props option.prepend & option.append renders in single selection 1`] = `
 <span
   class="euiComboBoxPill euiComboBoxPill--plainText"
+  data-test-subj="euiComboBoxPill"
 >
   <span
     class="euiComboBoxPill__prepend"
   >
-    Pre
+    <span
+      data-test-subj="prepend"
+    >
+      Pre
+    </span>
   </span>
   1
 </span>
@@ -535,7 +550,11 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
                 <span
                   class="euiComboBoxOption__prepend"
                 >
-                  Pre
+                  <span
+                    data-test-subj="prepend"
+                  >
+                    Pre
+                  </span>
                 </span>
                 <span
                   class="euiComboBoxOption__content"
@@ -572,7 +591,11 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
                 <span
                   class="euiComboBoxOption__append"
                 >
-                  Post
+                  <span
+                    data-test-subj="append"
+                  >
+                    Post
+                  </span>
                 </span>
               </span>
             </span>

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -119,18 +119,18 @@ describe('props', () => {
 
   describe('option.prepend & option.append', () => {
     const options = [
-      { label: '1', prepend: 'Pre' },
-      { label: '2', append: 'Post' },
+      { label: '1', prepend: <span data-test-subj="prepend">Pre</span> },
+      { label: '2', append: <span data-test-subj="append">Post</span> },
     ];
 
     test('renders in pills', () => {
-      const component = render(
+      const { getByTestSubject, getAllByTestSubject } = render(
         <EuiComboBox options={options} selectedOptions={options} />
       );
 
-      expect(component.find('.euiComboBoxPill__prepend')).toHaveLength(1);
-      expect(component.find('.euiComboBoxPill__append')).toHaveLength(1);
-      expect(component.find('.euiComboBoxPill')).toMatchSnapshot();
+      expect(getByTestSubject('prepend')).toBeInTheDocument();
+      expect(getByTestSubject('append')).toBeInTheDocument();
+      expect(getAllByTestSubject('euiComboBoxPill')).toMatchSnapshot();
     });
 
     test('renders in the options dropdown', () => {
@@ -146,14 +146,15 @@ describe('props', () => {
     });
 
     test('renders in single selection', () => {
-      const component = render(
+      const { getByTestSubject } = render(
         <EuiComboBox
           options={options}
           selectedOptions={[options[0]]}
           singleSelection={{ asPlainText: true }}
         />
       );
-      expect(component.find('.euiComboBoxPill')).toMatchSnapshot();
+
+      expect(getByTestSubject('euiComboBoxPill')).toMatchSnapshot();
     });
   });
 

--- a/src/components/combo_box/combo_box_input/combo_box_pill.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_pill.tsx
@@ -89,6 +89,7 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
             <EuiBadge
               className={classes}
               color={color}
+              data-test-subj="euiComboBoxPill"
               iconOnClick={this.onCloseButtonClick}
               iconOnClickAriaLabel={removeSelection}
               iconSide="right"
@@ -106,7 +107,7 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
 
     if (asPlainText) {
       return (
-        <span className={classes} {...rest}>
+        <span className={classes} data-test-subj="euiComboBoxPill" {...rest}>
           {content}
         </span>
       );
@@ -116,6 +117,7 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
       <EuiBadge
         className={classes}
         color={color}
+        data-test-subj="euiComboBoxPill"
         title={children}
         {...rest}
         {...onClickProps}

--- a/src/components/header/header_alert/__snapshots__/header_alert.test.tsx.snap
+++ b/src/components/header/header_alert/__snapshots__/header_alert.test.tsx.snap
@@ -128,10 +128,11 @@ exports[`EuiHeaderAlert renders title as an element 1`] = `
   <h3
     class="euiHeaderAlert__title"
     id="generated-id-title"
-  />
-  <h2>
-    Circumambulate the city
-  </h2>
+  >
+    <span>
+      Circumambulate the city
+    </span>
+  </h3>
   <div
     class="euiHeaderAlert__text"
   />

--- a/src/components/header/header_alert/header_alert.test.tsx
+++ b/src/components/header/header_alert/header_alert.test.tsx
@@ -7,23 +7,23 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiHeaderAlert } from './header_alert';
 
 describe('EuiHeaderAlert', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiHeaderAlert {...requiredProps} title="title" date="date" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders action', () => {
     const action = <button>Quietly take to the ship</button>;
-    const component = render(
+    const { container } = render(
       <EuiHeaderAlert
         {...requiredProps}
         title="title"
@@ -32,24 +32,24 @@ describe('EuiHeaderAlert', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders title as an element', () => {
-    const title = <h2>Circumambulate the city</h2>;
-    const component = render(
+    const title = <span>Circumambulate the city</span>;
+    const { container } = render(
       <EuiHeaderAlert {...requiredProps} date="date" title={title} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders date as an element', () => {
     const date = <h2>October 18, 1851</h2>;
-    const component = render(
+    const { container } = render(
       <EuiHeaderAlert {...requiredProps} title="shazm" date={date} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/header/header_links/header_link.test.tsx
+++ b/src/components/header/header_links/header_link.test.tsx
@@ -7,27 +7,27 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiHeaderLink } from './header_link';
 
 describe('EuiHeaderLink', () => {
   test('is rendered', () => {
-    const component = render(<EuiHeaderLink {...requiredProps} />);
+    const { container } = render(<EuiHeaderLink {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered as active', () => {
-    const component = render(<EuiHeaderLink isActive />);
+    const { container } = render(<EuiHeaderLink isActive />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can render as specific color', () => {
-    const component = render(<EuiHeaderLink color="danger" />);
+    const { container } = render(<EuiHeaderLink color="danger" />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/header/header_links/header_links.test.tsx
+++ b/src/components/header/header_links/header_links.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiHeaderLinks, GUTTER_SIZES } from './header_links';
 
@@ -19,24 +19,26 @@ describe('EuiHeaderLinks', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiHeaderLinks {...requiredProps} />);
+    const { container } = render(<EuiHeaderLinks {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('gutterSize', () => {
     GUTTER_SIZES.forEach((gutterSize) => {
       test(`${gutterSize} is rendered`, () => {
-        const component = render(<EuiHeaderLinks gutterSize={gutterSize} />);
+        const { container } = render(
+          <EuiHeaderLinks gutterSize={gutterSize} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('popover props', () => {
     test('is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiHeaderLinks
           popoverBreakpoints={['xs', 's', 'm', 'l', 'xl']}
           popoverButtonProps={{
@@ -47,13 +49,15 @@ describe('EuiHeaderLinks', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is never rendered with "none"', () => {
-      const component = render(<EuiHeaderLinks popoverBreakpoints={'none'} />);
+      const { container } = render(
+        <EuiHeaderLinks popoverBreakpoints={'none'} />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/header/header_section/__snapshots__/header_section.test.tsx.snap
+++ b/src/components/header/header_section/__snapshots__/header_section.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`EuiHeaderSection is rendered 1`] = `
 exports[`EuiHeaderSection renders optional params 1`] = `
 <div
   class="euiHeaderSection euiHeaderSection--dontGrow euiHeaderSection--left"
-  style="color:blue"
+  style="color: blue;"
 >
   <span>
     Some years ago never mind how long precisely...

--- a/src/components/header/header_section/header_section.test.tsx
+++ b/src/components/header/header_section/header_section.test.tsx
@@ -7,53 +7,53 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiHeaderSection } from './header_section';
 
 describe('EuiHeaderSection', () => {
   test('is rendered', () => {
-    const component = render(<EuiHeaderSection {...requiredProps} />);
+    const { container } = render(<EuiHeaderSection {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders optional params', () => {
-    const component = render(
+    const { container } = render(
       <EuiHeaderSection style={{ color: 'blue' }}>
         <span>Some years ago never mind how long precisely...</span>
       </EuiHeaderSection>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('grow', () => {
     test('defaults to false', () => {
-      const component = render(<EuiHeaderSection />);
+      const { container } = render(<EuiHeaderSection />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renders true', () => {
-      const component = render(<EuiHeaderSection grow />);
+      const { container } = render(<EuiHeaderSection grow />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('side', () => {
     test('defaults to left', () => {
-      const component = render(<EuiHeaderSection />);
+      const { container } = render(<EuiHeaderSection />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renders right', () => {
-      const component = render(<EuiHeaderSection side="right" />);
+      const { container } = render(<EuiHeaderSection side="right" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/header/header_section/header_section_item.test.tsx
+++ b/src/components/header/header_section/header_section_item.test.tsx
@@ -7,47 +7,47 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiHeaderSectionItem } from './header_section_item';
 
 describe('EuiHeaderSectionItem', () => {
   test('is rendered', () => {
-    const component = render(<EuiHeaderSectionItem {...requiredProps} />);
+    const { container } = render(<EuiHeaderSectionItem {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders children', () => {
-    const component = render(
+    const { container } = render(
       <EuiHeaderSectionItem>
         <span>Call me Ishmael.</span>
       </EuiHeaderSectionItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('border', () => {
     test('defaults to left', () => {
-      const component = render(
+      const { container } = render(
         <EuiHeaderSectionItem>
           <span>Left is default</span>
         </EuiHeaderSectionItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renders right', () => {
-      const component = render(
+      const { container } = render(
         <EuiHeaderSectionItem border="right">
           <span>Right section</span>
         </EuiHeaderSectionItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/header/header_section/header_section_item_button.test.tsx
+++ b/src/components/header/header_section/header_section_item_button.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
-import { mount, render, shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import {
   EuiHeaderSectionItemButton,
@@ -17,51 +18,55 @@ import {
 
 describe('EuiHeaderSectionItemButton', () => {
   test('is rendered', () => {
-    const component = render(<EuiHeaderSectionItemButton {...requiredProps} />);
+    const { container } = render(
+      <EuiHeaderSectionItemButton {...requiredProps} />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders children', () => {
-    const component = render(
+    const { container } = render(
       <EuiHeaderSectionItemButton>
         <span>Ahoy!</span>
       </EuiHeaderSectionItemButton>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders a link', () => {
-    const component = render(<EuiHeaderSectionItemButton href="#" />);
+    const { container } = render(<EuiHeaderSectionItemButton href="#" />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('renders notification', () => {
     test('as a badge', () => {
-      const component = render(<EuiHeaderSectionItemButton notification="1" />);
+      const { container } = render(
+        <EuiHeaderSectionItemButton notification="1" />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('as a dot', () => {
-      const component = render(
+      const { container } = render(
         <EuiHeaderSectionItemButton notification={true} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('color', () => {
-      const component = render(
+      const { container } = render(
         <EuiHeaderSectionItemButton
           notification="1"
           notificationColor="subdued"
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 

--- a/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
+++ b/src/components/key_pad_menu/__snapshots__/key_pad_menu_item.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`EuiKeyPadMenuItem checkable renders as radio 1`] = `
         id="generated-id"
         name="single"
         type="radio"
+        value=""
       />
       <div
         class="euiRadio__circle"

--- a/src/components/key_pad_menu/key_pad_menu.test.tsx
+++ b/src/components/key_pad_menu/key_pad_menu.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiKeyPadMenu } from './key_pad_menu';
 
@@ -21,34 +21,34 @@ describe('EuiKeyPadMenu', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiKeyPadMenu {...requiredProps} />);
+    const { container } = render(<EuiKeyPadMenu {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('checkable', () => {
     test('is rendered as a fieldset when true', () => {
-      const component = render(<EuiKeyPadMenu checkable />);
+      const { container } = render(<EuiKeyPadMenu checkable />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered as with a legend', () => {
-      const component = render(
+      const { container } = render(
         <EuiKeyPadMenu
           checkable={{ legend: 'Legend', legendProps: requiredProps }}
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered as with an ariaLegend', () => {
-      const component = render(
+      const { container } = render(
         <EuiKeyPadMenu checkable={{ ariaLegend: 'Aria legend' }} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/key_pad_menu/key_pad_menu_item.test.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { fireEvent } from '@testing-library/react';
-import { waitForEuiToolTipVisible } from '../../test/rtl';
+import { render, waitForEuiToolTipVisible } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -38,77 +38,77 @@ describe('EuiKeyPadMenuItem', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiKeyPadMenuItem label="Label" {...requiredProps}>
         Icon
       </EuiKeyPadMenuItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('isDisabled', () => {
       test('renders with href', () => {
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem isDisabled label="Label" href="#">
             Icon
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders with onClick', () => {
         const onClickHandler = jest.fn();
 
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem isDisabled label="Label" onClick={onClickHandler}>
             Icon
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isSelected', () => {
       test('renders with href', () => {
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem isSelected label="Label" href="#">
             Icon
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders with onClick', () => {
         const onClickHandler = jest.fn();
 
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem isSelected label="Label" onClick={onClickHandler}>
             Icon
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('betaBadge', () => {
       test('renders', () => {
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem betaBadgeLabel="Beta" label="Label">
             Icon
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders with betaBadgeIconType', () => {
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem
             betaBadgeLabel="Beta"
             betaBadgeIconType="bolt"
@@ -118,11 +118,11 @@ describe('EuiKeyPadMenuItem', () => {
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders with betaBadgeTooltipContent', () => {
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem
             betaBadgeLabel="Beta"
             betaBadgeTooltipContent="Content"
@@ -132,11 +132,11 @@ describe('EuiKeyPadMenuItem', () => {
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders extra betaBadgeTooltipProps', () => {
-        const component = render(
+        const { container } = render(
           <EuiKeyPadMenuItem
             betaBadgeLabel="Beta"
             betaBadgeTooltipContent="Content"
@@ -147,41 +147,41 @@ describe('EuiKeyPadMenuItem', () => {
           </EuiKeyPadMenuItem>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   test('renders href', () => {
-    const component = render(
+    const { container } = render(
       <EuiKeyPadMenuItem label="Label" href="#">
         Icon
       </EuiKeyPadMenuItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders href with rel', () => {
-    const component = render(
+    const { container } = render(
       <EuiKeyPadMenuItem label="Label" href="#" rel="noreferrer">
         Icon
       </EuiKeyPadMenuItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders button', () => {
     const onClickHandler = jest.fn();
 
-    const component = render(
+    const { container } = render(
       <EuiKeyPadMenuItem label="Label" onClick={onClickHandler}>
         Icon
       </EuiKeyPadMenuItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test("onClick isn't called upon instantiation", () => {
@@ -212,7 +212,7 @@ describe('EuiKeyPadMenuItem', () => {
 
   describe('checkable', () => {
     test('renders as radio', () => {
-      const component = render(
+      const { container } = render(
         <EuiKeyPadMenuItem
           onChange={() => {}}
           name="single"
@@ -223,17 +223,17 @@ describe('EuiKeyPadMenuItem', () => {
         </EuiKeyPadMenuItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renders as checkbox', () => {
-      const component = render(
+      const { container } = render(
         <EuiKeyPadMenuItem onChange={() => {}} checkable="multi" label="Label">
           Icon
         </EuiKeyPadMenuItem>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/list_group/__snapshots__/list_group.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group.test.tsx.snap
@@ -245,14 +245,14 @@ exports[`EuiListGroup props gutter size s is rendered 1`] = `
 exports[`EuiListGroup props maxWidth as a number is rendered 1`] = `
 <ul
   class="euiListGroup emotion-euiListGroup-s"
-  style="max-inline-size:300px"
+  style="max-inline-size: 300px;"
 />
 `;
 
 exports[`EuiListGroup props maxWidth as a string is rendered 1`] = `
 <ul
   class="euiListGroup emotion-euiListGroup-s"
-  style="max-inline-size:20em"
+  style="max-inline-size: 20em;"
 />
 `;
 

--- a/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
@@ -352,7 +352,7 @@ exports[`EuiListGroupItem props style is rendered 1`] = `
 >
   <span
     class="euiListGroupItem__text emotion-euiListGroupItem__inner-m-text"
-    style="color:red"
+    style="color: red;"
   >
     <span
       class="euiListGroupItem__label emotion-euiListGroupItem__label-truncate"

--- a/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
@@ -278,6 +278,26 @@ exports[`EuiListGroupItem props onClick is rendered 1`] = `
 </li>
 `;
 
+exports[`EuiListGroupItem props showToolTip is rendered 1`] = `
+<li
+  class="euiListGroupItem emotion-euiListGroupItem-m"
+>
+  <span
+    class="euiToolTipAnchor euiListGroupItem__tooltip emotion-euiToolTipAnchor-inlineBlock-euiListGroupItem__tooltip"
+  >
+    <span
+      class="euiListGroupItem__text emotion-euiListGroupItem__inner-m-text"
+    >
+      <span
+        class="euiListGroupItem__label emotion-euiListGroupItem__label-truncate"
+      >
+        Label
+      </span>
+    </span>
+  </span>
+</li>
+`;
+
 exports[`EuiListGroupItem props size l is rendered 1`] = `
 <li
   class="euiListGroupItem emotion-euiListGroupItem-l"

--- a/src/components/list_group/list_group.test.tsx
+++ b/src/components/list_group/list_group.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiListGroup, GUTTER_SIZES } from './list_group';
 import { EuiListGroupItemProps } from './list_group_item';
@@ -48,85 +48,85 @@ describe('EuiListGroup', () => {
   shouldRenderCustomStyles(<EuiListGroup {...requiredProps} />);
 
   test('is rendered', () => {
-    const component = render(<EuiListGroup {...requiredProps} />);
+    const { container } = render(<EuiListGroup {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('listItems', () => {
     test('is rendered', () => {
-      const component = render(<EuiListGroup listItems={someListItems} />);
+      const { container } = render(<EuiListGroup listItems={someListItems} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered with color', () => {
-      const component = render(
+      const { container } = render(
         <EuiListGroup color="primary" listItems={someListItems} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('is rendered with size', () => {
-      const component = render(<EuiListGroup color="primary" size="xs" />);
+      const { container } = render(<EuiListGroup color="primary" size="xs" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   describe('props', () => {
     test('bordered is rendered', () => {
-      const component = render(<EuiListGroup bordered />);
+      const { container } = render(<EuiListGroup bordered />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('flush is rendered', () => {
-      const component = render(<EuiListGroup flush />);
+      const { container } = render(<EuiListGroup flush />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('showToolTips is rendered', () => {
-      const component = render(<EuiListGroup showToolTips />);
+      const { container } = render(<EuiListGroup showToolTips />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('wrapText is rendered', () => {
-      const component = render(<EuiListGroup wrapText />);
+      const { container } = render(<EuiListGroup wrapText />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('gutter size', () => {
       GUTTER_SIZES.forEach((gutter) => {
         test(`${gutter} is rendered`, () => {
-          const component = render(<EuiListGroup gutterSize={gutter} />);
+          const { container } = render(<EuiListGroup gutterSize={gutter} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('maxWidth', () => {
       test('as true is rendered', () => {
-        const component = render(<EuiListGroup maxWidth={true} />);
+        const { container } = render(<EuiListGroup maxWidth={true} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('as a number is rendered', () => {
-        const component = render(<EuiListGroup maxWidth={300} />);
+        const { container } = render(<EuiListGroup maxWidth={300} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('as a string is rendered', () => {
-        const component = render(<EuiListGroup maxWidth="20em" />);
+        const { container } = render(<EuiListGroup maxWidth="20em" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/list_group/list_group_item.test.tsx
+++ b/src/components/list_group/list_group_item.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiListGroupItem, SIZES, COLORS } from './list_group_item';
 
@@ -35,22 +35,22 @@ describe('EuiListGroupItem', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiListGroupItem label="Label" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiListGroupItem label="Label" size={size} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -58,73 +58,79 @@ describe('EuiListGroupItem', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiListGroupItem label="Label" color={color} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('isActive', () => {
       test('is rendered', () => {
-        const component = render(<EuiListGroupItem label="Label" isActive />);
+        const { container } = render(
+          <EuiListGroupItem label="Label" isActive />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isDisabled', () => {
       test('is rendered', () => {
-        const component = render(<EuiListGroupItem label="Label" isDisabled />);
+        const { container } = render(
+          <EuiListGroupItem label="Label" isDisabled />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('iconType', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem label="Label" iconType="empty" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('icon', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem label="Label" icon={<span />} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     // TODO: This keeps re-rendering differently because of fake id creation
     // describe('showToolTip', () => {
     //   test('is rendered', () => {
-    //     const component = render(
+    //     const { container } = render(
     //       <EuiListGroupItem label="Label" showToolTip />
     //     );
 
-    //     expect(component).toMatchSnapshot();
+    //     expect(container.firstChild).toMatchSnapshot();
     //   });
     // });
 
     describe('wrapText', () => {
       test('is rendered', () => {
-        const component = render(<EuiListGroupItem label="Label" wrapText />);
+        const { container } = render(
+          <EuiListGroupItem label="Label" wrapText />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('extraAction', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem
             label="Label"
             extraAction={{
@@ -135,11 +141,11 @@ describe('EuiListGroupItem', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('can be disabled', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem
             label="Label"
             extraAction={{
@@ -150,71 +156,73 @@ describe('EuiListGroupItem', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('href', () => {
       test('is rendered', () => {
-        const component = render(<EuiListGroupItem label="Label" href="#" />);
+        const { container } = render(
+          <EuiListGroupItem label="Label" href="#" />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with rel', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem label="Label" href="#" rel="noreferrer" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('onClick', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem label="Label" onClick={() => {}} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('href and onClick', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem label="" onClick={() => {}} href="#" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('style', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiListGroupItem label="" style={{ color: 'red' }} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   test('renders a disabled button even if provided an href', () => {
-    const component = render(
+    const { container } = render(
       <EuiListGroupItem label="Label" isDisabled href="#" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders a disabled button even if provided an href', () => {
-    const component = render(
+    const { container } = render(
       <EuiListGroupItem label="Label" isDisabled href="#" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('throws a warning', () => {
@@ -233,7 +241,7 @@ describe('EuiListGroupItem', () => {
     });
 
     test('if both iconType and icon are provided but still renders', () => {
-      const component = render(
+      const { container } = render(
         <EuiListGroupItem label="" iconType="empty" icon={<span />} />
       );
 
@@ -241,7 +249,7 @@ describe('EuiListGroupItem', () => {
       expect(consoleStub.mock.calls[0][0]).toMatch(
         '`iconType` and `icon` were passed'
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/list_group/list_group_item.test.tsx
+++ b/src/components/list_group/list_group_item.test.tsx
@@ -107,16 +107,15 @@ describe('EuiListGroupItem', () => {
       });
     });
 
-    // TODO: This keeps re-rendering differently because of fake id creation
-    // describe('showToolTip', () => {
-    //   test('is rendered', () => {
-    //     const { container } = render(
-    //       <EuiListGroupItem label="Label" showToolTip />
-    //     );
+    describe('showToolTip', () => {
+      test('is rendered', () => {
+        const { container } = render(
+          <EuiListGroupItem label="Label" showToolTip />
+        );
 
-    //     expect(container.firstChild).toMatchSnapshot();
-    //   });
-    // });
+        expect(container.firstChild).toMatchSnapshot();
+      });
+    });
 
     describe('wrapText', () => {
       test('is rendered', () => {

--- a/src/components/list_group/list_group_item_extra_action.test.tsx
+++ b/src/components/list_group/list_group_item_extra_action.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiListGroupItemExtraAction } from './list_group_item_extra_action';
 
@@ -22,44 +22,44 @@ describe('EuiListGroupItem', () => {
   shouldRenderCustomStyles(<EuiListGroupItemExtraAction iconType="star" />);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiListGroupItemExtraAction {...requiredProps} iconType="star" />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('alwaysShow', () => {
-      const component = render(
+      const { container } = render(
         <EuiListGroupItemExtraAction {...props} alwaysShow />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('color', () => {
-      const component = render(
+      const { container } = render(
         <EuiListGroupItemExtraAction {...props} color="accent" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isDisabled', () => {
-      const component = render(
+      const { container } = render(
         <EuiListGroupItemExtraAction {...props} isDisabled />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('parentIsDisabled', () => {
-      const component = render(
+      const { container } = render(
         <EuiListGroupItemExtraAction {...props} parentIsDisabled />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/list_group/pinnable_list_group/pinnable_list_group.test.tsx
+++ b/src/components/list_group/pinnable_list_group/pinnable_list_group.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import {
   EuiPinnableListGroup,
@@ -62,7 +62,7 @@ describe('EuiPinnableListGroup', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPinnableListGroup
         {...requiredProps}
         listItems={someListItems}
@@ -70,11 +70,11 @@ describe('EuiPinnableListGroup', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('can have custom pin icon titles', () => {
-    const component = render(
+    const { container } = render(
       <EuiPinnableListGroup
         {...requiredProps}
         listItems={someListItems}
@@ -88,6 +88,6 @@ describe('EuiPinnableListGroup', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
@@ -1,26 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiLoadingSpinner custom colors 1`] = `
-Array [
+<div>
   <span
     aria-label="Loading"
     class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
     role="progressbar"
-    style="border-color:#07C white white white"
-  />,
+    style="border-color: #07c white white white;"
+  />
   <span
     aria-label="Loading"
     class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
     role="progressbar"
-    style="border-color:black #D3DAE6 #D3DAE6 #D3DAE6"
-  />,
+    style="border-color: black #d3dae6 #d3dae6 #d3dae6;"
+  />
   <span
     aria-label="Loading"
     class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
     role="progressbar"
-    style="color:red;border-color:black white white white"
-  />,
-]
+    style="color: red; border-color: black white white white;"
+  />
+</div>
 `;
 
 exports[`EuiLoadingSpinner is rendered 1`] = `

--- a/src/components/loading/loading_chart.test.tsx
+++ b/src/components/loading/loading_chart.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiLoadingChart, SIZES } from './loading_chart';
 
@@ -17,23 +17,23 @@ describe('EuiLoadingChart', () => {
   shouldRenderCustomStyles(<EuiLoadingChart />);
 
   test('is rendered', () => {
-    const component = render(<EuiLoadingChart {...requiredProps} />);
+    const { container } = render(<EuiLoadingChart {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('mono is rendered', () => {
-    const component = render(<EuiLoadingChart mono />);
+    const { container } = render(<EuiLoadingChart mono />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(<EuiLoadingChart size={size} />);
+        const { container } = render(<EuiLoadingChart size={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/loading/loading_elastic.test.tsx
+++ b/src/components/loading/loading_elastic.test.tsx
@@ -7,24 +7,24 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiLoadingElastic, SIZES } from './loading_elastic';
 
 describe('EuiLoadingElastic', () => {
   test('is rendered', () => {
-    const component = render(<EuiLoadingElastic {...requiredProps} />);
+    const { container } = render(<EuiLoadingElastic {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(<EuiLoadingElastic size={size} />);
+        const { container } = render(<EuiLoadingElastic size={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/loading/loading_logo.test.tsx
+++ b/src/components/loading/loading_logo.test.tsx
@@ -7,32 +7,32 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiLoadingLogo, SIZES } from './loading_logo';
 
 describe('EuiLoadingLogo', () => {
   test('is rendered', () => {
-    const component = render(<EuiLoadingLogo {...requiredProps} />);
+    const { container } = render(<EuiLoadingLogo {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('logo is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiLoadingLogo logo="logoElastic" {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(<EuiLoadingLogo size={size} />);
+        const { container } = render(<EuiLoadingLogo size={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/loading/loading_spinner.test.tsx
+++ b/src/components/loading/loading_spinner.test.tsx
@@ -7,30 +7,30 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiLoadingSpinner, SIZES } from './loading_spinner';
 
 describe('EuiLoadingSpinner', () => {
   test('is rendered', () => {
-    const component = render(<EuiLoadingSpinner {...requiredProps} />);
+    const { container } = render(<EuiLoadingSpinner {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {
-        const component = render(<EuiLoadingSpinner size={size} />);
+        const { container } = render(<EuiLoadingSpinner size={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   test('custom colors', () => {
-    const component = render(
+    const { container } = render(
       <>
         <EuiLoadingSpinner color={{ border: 'white' }} />
         <EuiLoadingSpinner color={{ highlight: 'black' }} />
@@ -41,6 +41,6 @@ describe('EuiLoadingSpinner', () => {
       </>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
+++ b/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
@@ -426,7 +426,6 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
   </div>
   <div
     class="euiMarkdownEditor__toggleContainer"
-    style="height:calc(100% - 0px)"
   >
     <div
       class="euiMarkdownEditorDropZone"
@@ -438,7 +437,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
         id="editorId"
         placeholder="placeholder"
         rows="6"
-        style="height:calc(250px);max-height:500px"
+        style="max-height: 500px;"
       />
       <div
         class="euiMarkdownEditorFooter"
@@ -466,7 +465,7 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
       <input
         autocomplete="off"
         multiple=""
-        style="display:none"
+        style="display: none;"
         tabindex="-1"
         type="file"
       />
@@ -672,7 +671,6 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
   </div>
   <div
     class="euiMarkdownEditor__toggleContainer"
-    style="height:calc(100% - 0px)"
   >
     <div
       class="euiMarkdownEditorDropZone"
@@ -683,7 +681,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
         data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
-        style="height:calc(250px);max-height:500px"
+        style="max-height: 500px;"
       />
       <div
         class="euiMarkdownEditorFooter"
@@ -711,7 +709,7 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
       <input
         autocomplete="off"
         multiple=""
-        style="display:none"
+        style="display: none;"
         tabindex="-1"
         type="file"
       />
@@ -917,7 +915,6 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
   </div>
   <div
     class="euiMarkdownEditor__toggleContainer"
-    style="height:calc(100% - 0px)"
   >
     <div
       class="euiMarkdownEditorDropZone"
@@ -928,7 +925,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
         data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
-        style="height:100%;max-height:"
+        style="height: 100%;"
       />
       <div
         class="euiMarkdownEditorFooter"
@@ -956,7 +953,7 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
       <input
         autocomplete="off"
         multiple=""
-        style="display:none"
+        style="display: none;"
         tabindex="-1"
         type="file"
       />
@@ -1162,7 +1159,6 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
   </div>
   <div
     class="euiMarkdownEditor__toggleContainer"
-    style="height:calc(100% - 0px)"
   >
     <div
       class="euiMarkdownEditorDropZone"
@@ -1173,7 +1169,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
         data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
-        style="height:calc(400px);max-height:500px"
+        style="max-height: 500px;"
       />
       <div
         class="euiMarkdownEditorFooter"
@@ -1201,7 +1197,7 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
       <input
         autocomplete="off"
         multiple=""
-        style="display:none"
+        style="display: none;"
         tabindex="-1"
         type="file"
       />
@@ -1407,7 +1403,6 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
   </div>
   <div
     class="euiMarkdownEditor__toggleContainer"
-    style="height:calc(100% - 0px)"
   >
     <div
       class="euiMarkdownEditorDropZone"
@@ -1418,7 +1413,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
         data-test-subj="euiMarkdownEditorTextArea"
         id="editorId"
         rows="6"
-        style="height:calc(250px);max-height:600px"
+        style="max-height: 600px;"
       />
       <div
         class="euiMarkdownEditorFooter"
@@ -1446,7 +1441,7 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
       <input
         autocomplete="off"
         multiple=""
-        style="display:none"
+        style="display: none;"
         tabindex="-1"
         type="file"
       />
@@ -1662,7 +1657,6 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
   </div>
   <div
     class="euiMarkdownEditor__toggleContainer"
-    style="height:calc(100% - 0px)"
   >
     <div
       class="euiMarkdownEditorDropZone"
@@ -1674,7 +1668,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
         id="editorId"
         readonly=""
         rows="6"
-        style="height:calc(250px);max-height:500px"
+        style="max-height: 500px;"
       />
       <div
         class="euiMarkdownEditorFooter"
@@ -1703,7 +1697,7 @@ exports[`EuiMarkdownEditor props readOnly is set to true 1`] = `
       <input
         autocomplete="off"
         multiple=""
-        style="display:none"
+        style="display: none;"
         tabindex="-1"
         type="file"
       />

--- a/src/components/markdown_editor/markdown_editor.test.tsx
+++ b/src/components/markdown_editor/markdown_editor.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount, ReactWrapper } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
+import { mount, ReactWrapper } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiMarkdownEditor } from './markdown_editor';
 import * as MarkdownTooltip from './plugins/markdown_tooltip';
@@ -28,7 +29,7 @@ describe('EuiMarkdownEditor', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiMarkdownEditor
         editorId="editorId"
         placeholder="placeholder"
@@ -38,13 +39,13 @@ describe('EuiMarkdownEditor', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('height', () => {
       test('is rendered with a custom size', () => {
-        const component = render(
+        const { container } = render(
           <EuiMarkdownEditor
             editorId="editorId"
             height={400}
@@ -54,11 +55,11 @@ describe('EuiMarkdownEditor', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered in full mode', () => {
-        const component = render(
+        const { container } = render(
           <EuiMarkdownEditor
             editorId="editorId"
             height="full"
@@ -68,13 +69,13 @@ describe('EuiMarkdownEditor', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('maxHeight', () => {
       test('is rendered with a custom size', () => {
-        const component = render(
+        const { container } = render(
           <EuiMarkdownEditor
             editorId="editorId"
             maxHeight={600}
@@ -84,13 +85,13 @@ describe('EuiMarkdownEditor', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('autoExpandPreview', () => {
       test('is rendered with false', () => {
-        const component = render(
+        const { container } = render(
           <EuiMarkdownEditor
             editorId="editorId"
             autoExpandPreview={false}
@@ -100,13 +101,13 @@ describe('EuiMarkdownEditor', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('readOnly', () => {
       test('is set to true', () => {
-        const component = render(
+        const { container } = render(
           <EuiMarkdownEditor
             editorId="editorId"
             autoExpandPreview={false}
@@ -117,7 +118,7 @@ describe('EuiMarkdownEditor', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`EuiNotificationEvent is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -78,6 +79,7 @@ exports[`EuiNotificationEvent props badgeColor is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-warning"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -190,6 +192,7 @@ exports[`EuiNotificationEvent props headingLevel is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -256,6 +259,7 @@ exports[`EuiNotificationEvent props iconAriaLabel is rendered 1`] = `
         </span>
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -321,6 +325,7 @@ exports[`EuiNotificationEvent props iconType is rendered 1`] = `
         />
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -399,6 +404,7 @@ exports[`EuiNotificationEvent props isRead  is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -459,6 +465,7 @@ exports[`EuiNotificationEvent props multiple messages are rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -573,6 +580,7 @@ exports[`EuiNotificationEvent props primaryAction is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -652,6 +660,7 @@ exports[`EuiNotificationEvent props primaryActionProps is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"
@@ -735,6 +744,7 @@ exports[`EuiNotificationEvent props severity  is rendered 1`] = `
       >
         <span
           class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+          title="Alert: severity"
         >
           <span
             class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`EuiNotificationEventMeta is rendered 1`] = `
   >
     <span
       class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+      title="Alert"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"
@@ -44,6 +45,7 @@ exports[`EuiNotificationEventMeta props badgeColor  is rendered 1`] = `
   >
     <span
       class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-success"
+      title="Alert"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"
@@ -136,6 +138,7 @@ exports[`EuiNotificationEventMeta props logoCloud  is rendered 1`] = `
     />
     <span
       class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+      title="Alert"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"
@@ -171,6 +174,7 @@ exports[`EuiNotificationEventMeta props severity is rendered 1`] = `
   >
     <span
       class="euiBadge euiNotificationEventMeta__badge emotion-euiBadge-hollow"
+      title="Alert: severity"
     >
       <span
         class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/notification/notification_event.test.tsx
+++ b/src/components/notification/notification_event.test.tsx
@@ -7,7 +7,8 @@
  */
 
 import React from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import {
   findTestSubject,
@@ -38,67 +39,67 @@ describe('EuiNotificationEvent', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiNotificationEvent {...props} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('multiple messages are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent
           {...props}
           messages={['message 1', 'message 2', 'message 3']}
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isRead  is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent {...props} isRead={true} onRead={() => {}} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('severity  is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent {...props} severity="severity" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('badgeColor is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent {...props} badgeColor="warning" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('iconType is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent {...props} iconType="logoCloud" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('headingLevel is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent {...props} headingLevel="h4" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('iconAriaLabel is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent
           {...props}
           iconType="logoCloud"
@@ -106,11 +107,11 @@ describe('EuiNotificationEvent', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('primaryAction is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent
           {...props}
           primaryAction="primaryAction label"
@@ -118,11 +119,11 @@ describe('EuiNotificationEvent', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('primaryActionProps is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEvent
           {...props}
           primaryAction="primaryAction"
@@ -131,7 +132,7 @@ describe('EuiNotificationEvent', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('contextMenuItems are rendered', () => {

--- a/src/components/notification/notification_event_meta.test.tsx
+++ b/src/components/notification/notification_event_meta.test.tsx
@@ -7,14 +7,15 @@
  */
 
 import React from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 import { EuiNotificationEventMeta } from './notification_event_meta';
 import { EuiContextMenuPanel, EuiContextMenuItem } from '../context_menu';
 import { findTestSubject, takeMountedSnapshot } from '../../test';
+import { render } from '../../test/rtl';
 
 describe('EuiNotificationEventMeta', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiNotificationEventMeta
         id="id"
         type="Alert"
@@ -23,12 +24,12 @@ describe('EuiNotificationEventMeta', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('severity is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEventMeta
           id="id"
           type="Alert"
@@ -38,11 +39,11 @@ describe('EuiNotificationEventMeta', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('badgeColor  is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEventMeta
           id="id"
           type="Alert"
@@ -52,11 +53,11 @@ describe('EuiNotificationEventMeta', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('logoCloud  is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiNotificationEventMeta
           id="id"
           type="Alert"
@@ -66,7 +67,7 @@ describe('EuiNotificationEventMeta', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('contextMenuItems are rendered', () => {

--- a/src/components/notification/notification_event_read_button.test.tsx
+++ b/src/components/notification/notification_event_read_button.test.tsx
@@ -7,13 +7,14 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { EuiNotificationEventReadButton } from './notification_event_read_button';
 
 describe('EuiNotificationEventReadButton', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiNotificationEventReadButton
         id="id"
         eventName="eventName"
@@ -22,11 +23,11 @@ describe('EuiNotificationEventReadButton', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders isRead to false', () => {
-    const component = render(
+    const { container } = render(
       <EuiNotificationEventReadButton
         id="id"
         eventName="eventName"
@@ -35,7 +36,7 @@ describe('EuiNotificationEventReadButton', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('onClick fires for buttons', () => {

--- a/src/components/panel/panel.test.tsx
+++ b/src/components/panel/panel.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPanel, SIZES, COLORS, BORDER_RADII } from './panel';
 
@@ -17,47 +17,47 @@ describe('EuiPanel', () => {
   shouldRenderCustomStyles(<EuiPanel />);
 
   test('is rendered', () => {
-    const component = render(<EuiPanel {...requiredProps} />);
+    const { container } = render(<EuiPanel {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('hasShadow', () => {
       test('can be false', () => {
-        const component = render(<EuiPanel hasShadow={false} />);
+        const { container } = render(<EuiPanel hasShadow={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('grow', () => {
       test('can be false', () => {
-        const component = render(<EuiPanel grow={false} />);
+        const { container } = render(<EuiPanel grow={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('hasBorder', () => {
       test('can be false', () => {
-        const component = render(<EuiPanel hasBorder={false} />);
+        const { container } = render(<EuiPanel hasBorder={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
       test('can be true', () => {
-        const component = render(<EuiPanel hasBorder={true} />);
+        const { container } = render(<EuiPanel hasBorder={true} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('paddingSize', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(<EuiPanel paddingSize={size} />);
+          const { container } = render(<EuiPanel paddingSize={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -65,9 +65,9 @@ describe('EuiPanel', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiPanel color={color} />);
+          const { container } = render(<EuiPanel color={color} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -75,19 +75,21 @@ describe('EuiPanel', () => {
     describe('borderRadius', () => {
       BORDER_RADII.forEach((borderRadius) => {
         test(`${borderRadius} is rendered`, () => {
-          const component = render(<EuiPanel borderRadius={borderRadius} />);
+          const { container } = render(
+            <EuiPanel borderRadius={borderRadius} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('onClick', () => {
-      const component = render(
+      const { container } = render(
         <EuiPanel {...requiredProps} onClick={jest.fn()} />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/panel/split_panel/split_panel.test.tsx
+++ b/src/components/panel/split_panel/split_panel.test.tsx
@@ -7,44 +7,44 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiSplitPanel } from './split_panel';
 
 describe('EuiSplitPanel', () => {
   test('is rendered', () => {
-    const component = render(<EuiSplitPanel.Outer {...requiredProps} />);
+    const { container } = render(<EuiSplitPanel.Outer {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('inner children', () => {
     test('are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiSplitPanel.Outer>
           <EuiSplitPanel.Inner />
         </EuiSplitPanel.Outer>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('accepts panel props', () => {
-    const component = render(
+    const { container } = render(
       <EuiSplitPanel.Outer color="primary">
         <EuiSplitPanel.Inner color="success" {...requiredProps} />
       </EuiSplitPanel.Outer>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders as row', () => {
-    const component = render(<EuiSplitPanel.Outer direction="row" />);
+    const { container } = render(<EuiSplitPanel.Outer direction="row" />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('responsive', () => {
@@ -53,15 +53,15 @@ describe('EuiSplitPanel', () => {
     afterAll(() => 1024); // reset to jsdom's default
 
     test('is rendered at small screens', () => {
-      const component = render(<EuiSplitPanel.Outer />);
+      const { container } = render(<EuiSplitPanel.Outer />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can be false', () => {
-      const component = render(<EuiSplitPanel.Outer responsive={false} />);
+      const { container } = render(<EuiSplitPanel.Outer responsive={false} />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
@@ -71,9 +71,11 @@ describe('EuiSplitPanel', () => {
     afterAll(() => 1024); // reset to jsdom's default
 
     test('can be changed to different breakpoints', () => {
-      const component = render(<EuiSplitPanel.Outer responsive={['m', 'l']} />);
+      const { container } = render(
+        <EuiSplitPanel.Outer responsive={['m', 'l']} />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React, { ReactNode } from 'react';
-import { render, mount } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
+import { mount } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 import { EuiFocusTrap } from '../';
 
 import {
@@ -44,7 +45,7 @@ describe('EuiPopover', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPopover
         id={getId()}
         button={<button />}
@@ -53,23 +54,23 @@ describe('EuiPopover', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('children is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiPopover id={getId()} button={<button />} closePopover={() => {}}>
         Children
       </EuiPopover>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('display block', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPopover
             id={getId()}
             display="block"
@@ -78,13 +79,13 @@ describe('EuiPopover', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('anchorClassName', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPopover
             id={getId()}
             anchorClassName="test"
@@ -93,7 +94,7 @@ describe('EuiPopover', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
@@ -134,7 +135,7 @@ describe('EuiPopover', () => {
 
     describe('anchorPosition', () => {
       test('defaults to centerDown', () => {
-        const component = render(
+        const { container } = render(
           <EuiPopover
             id={getId()}
             button={<button />}
@@ -142,11 +143,11 @@ describe('EuiPopover', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('leftCenter is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPopover
             id={getId()}
             button={<button />}
@@ -155,11 +156,11 @@ describe('EuiPopover', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('downRight is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiPopover
             id={getId()}
             button={<button />}
@@ -168,13 +169,13 @@ describe('EuiPopover', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isOpen', () => {
       test('defaults to false', () => {
-        const component = render(
+        const { container } = render(
           <EuiPopover
             id={getId()}
             button={<button />}
@@ -182,7 +183,7 @@ describe('EuiPopover', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders true', () => {

--- a/src/components/popover/popover_arrow/_popover_arrow.test.tsx
+++ b/src/components/popover/popover_arrow/_popover_arrow.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPopoverArrow, POSITIONS } from './_popover_arrow';
 
@@ -19,11 +19,11 @@ describe('EuiPopoverArrow', () => {
   describe('position', () => {
     POSITIONS.forEach((position) => {
       test(`${position} is rendered`, () => {
-        const component = render(
+        const { container } = render(
           <EuiPopoverArrow position={position} {...requiredProps} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/popover/popover_footer.test.tsx
+++ b/src/components/popover/popover_footer.test.tsx
@@ -7,18 +7,18 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPopoverFooter } from './popover_footer';
 import { PADDING_SIZES } from '../../global_styling';
 
 describe('EuiPopoverFooter', () => {
   test('is rendered', () => {
-    const component = render(<EuiPopoverFooter {...requiredProps} />);
+    const { container } = render(<EuiPopoverFooter {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiPopoverFooter />);
@@ -27,9 +27,9 @@ describe('EuiPopoverFooter', () => {
     describe('paddingSize', () => {
       PADDING_SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(<EuiPopoverFooter paddingSize={size} />);
+          const { container } = render(<EuiPopoverFooter paddingSize={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/popover/popover_panel/_popover_panel.test.tsx
+++ b/src/components/popover/popover_panel/_popover_panel.test.tsx
@@ -7,47 +7,47 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiPopoverPanel } from './_popover_panel';
 import { POSITIONS } from '../popover_arrow/_popover_arrow';
 
 describe('EuiPopoverPanel', () => {
   test('is rendered', () => {
-    const component = render(<EuiPopoverPanel {...requiredProps} />);
+    const { container } = render(<EuiPopoverPanel {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiPopoverPanel />);
 
   describe('props', () => {
     test('isOpen is rendered', () => {
-      const component = render(<EuiPopoverPanel isOpen />);
+      const { container } = render(<EuiPopoverPanel isOpen />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isAttached is rendered', () => {
-      const component = render(<EuiPopoverPanel isOpen />);
+      const { container } = render(<EuiPopoverPanel isOpen />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('hasDragDrop is rendered', () => {
-      const component = render(<EuiPopoverPanel hasDragDrop />);
+      const { container } = render(<EuiPopoverPanel hasDragDrop />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('position', () => {
       POSITIONS.forEach((position) => {
         test(`${position} is rendered`, () => {
-          const component = render(<EuiPopoverPanel position={position} />);
+          const { container } = render(<EuiPopoverPanel position={position} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/popover/popover_title.test.tsx
+++ b/src/components/popover/popover_title.test.tsx
@@ -7,18 +7,18 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
-import { shouldRenderCustomStyles } from '../../test/internal';
 import { PADDING_SIZES } from '../../global_styling';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiPopoverTitle } from './popover_title';
 
 describe('EuiPopoverTitle', () => {
   test('is rendered', () => {
-    const component = render(<EuiPopoverTitle {...requiredProps} />);
+    const { container } = render(<EuiPopoverTitle {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiPopoverTitle />);
@@ -27,9 +27,9 @@ describe('EuiPopoverTitle', () => {
     describe('paddingSize', () => {
       PADDING_SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(<EuiPopoverTitle paddingSize={size} />);
+          const { container } = render(<EuiPopoverTitle paddingSize={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });


### PR DESCRIPTION
## Summary

This PR converts `EuiPopover`, `EuiPanel`, `EuiNotification`, `EuiMarkdownEditor`, `EuiLoading*`, `EuiListGroup`, `EuiKeyPadMenu` and `EuiHeader` unit tests using Enzyme's render() function to RTL render() counterpart to reduce our tech debt.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
