### PR TITLE
test: convert further component unit tests using enzyme render to RTL

### DIFF
--- a/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/src/components/button/__snapshots__/button.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`EuiButton props color danger is rendered 1`] = `
 
 exports[`EuiButton props color ghost is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-text"
+  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-text-euiColorMode-dark-colorClassName"
   type="button"
 >
   <span
@@ -299,7 +299,7 @@ exports[`EuiButton props isLoading is rendered 1`] = `
       aria-label="Loading"
       class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
       role="progressbar"
-      style="border-color:#07C currentcolor currentcolor currentcolor"
+      style="border-color: #07c currentcolor currentcolor currentcolor;"
     />
   </span>
 </button>

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
+import { mount } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiButton, COLORS, SIZES } from './button';
 
@@ -24,92 +25,94 @@ describe('EuiButton', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiButton {...requiredProps}>Content</EuiButton>);
+    const { container } = render(
+      <EuiButton {...requiredProps}>Content</EuiButton>
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('fill', () => {
       it('is rendered', () => {
-        const component = render(<EuiButton fill />);
+        const { container } = render(<EuiButton fill />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isDisabled', () => {
       it('is rendered', () => {
-        const component = render(<EuiButton isDisabled />);
+        const { container } = render(<EuiButton isDisabled />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('renders a button even when href is defined', () => {
-        const component = render(<EuiButton href="#" isDisabled />);
+        const { container } = render(<EuiButton href="#" isDisabled />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('renders if passed as disabled', () => {
-        const component = render(<EuiButton disabled />);
+        const { container } = render(<EuiButton disabled />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isLoading', () => {
       it('is rendered', () => {
-        const component = render(<EuiButton isLoading />);
+        const { container } = render(<EuiButton isLoading />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isSelected', () => {
       it('is rendered as true', () => {
-        const component = render(<EuiButton isSelected />);
+        const { container } = render(<EuiButton isSelected />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('is rendered as false', () => {
-        const component = render(<EuiButton isSelected={false} />);
+        const { container } = render(<EuiButton isSelected={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('fullWidth', () => {
       it('is rendered', () => {
-        const component = render(<EuiButton fullWidth />);
+        const { container } = render(<EuiButton fullWidth />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('minWidth', () => {
       it('is rendered', () => {
-        const component = render(<EuiButton minWidth={0} />);
+        const { container } = render(<EuiButton minWidth={0} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('iconType', () => {
       it('is rendered', () => {
-        const component = render(<EuiButton iconType="user" />);
+        const { container } = render(<EuiButton iconType="user" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiButton color={color} />);
+          const { container } = render(<EuiButton color={color} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -117,9 +120,9 @@ describe('EuiButton', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(<EuiButton size={size} />);
+          const { container } = render(<EuiButton size={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -127,13 +130,13 @@ describe('EuiButton', () => {
     describe('iconSide', () => {
       ICON_SIDES.forEach((iconSide) => {
         test(`${iconSide} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiButton iconType="user" iconSide={iconSide}>
               Content
             </EuiButton>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -141,22 +144,22 @@ describe('EuiButton', () => {
     describe('iconSize', () => {
       ICON_SIZES.forEach((iconSize) => {
         test(`${iconSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiButton iconType="user" iconSize={iconSize}>
               Content
             </EuiButton>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('href', () => {
       it('secures the rel attribute when the target is _blank', () => {
-        const component = render(<EuiButton href="#" target="_blank" />);
+        const { container } = render(<EuiButton href="#" target="_blank" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
@@ -177,19 +180,19 @@ describe('EuiButton', () => {
     });
 
     test('contentProps is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiButton contentProps={requiredProps}>Content</EuiButton>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('textProps is rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiButton textProps={requiredProps}>Content</EuiButton>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -13,7 +13,27 @@ exports[`EuiCodeBlock dynamic content updates DOM when input changes 1`] = `
         class="euiCodeBlock__code emotion-euiCodeBlock__code"
         data-code-language="javascript"
       >
-        const value = 'State 1'
+        <span
+          class="euiCodeBlock__line emotion-euiCodeBlock__line"
+        >
+          <span
+            class="token keyword"
+          >
+            const
+          </span>
+           value 
+          <span
+            class="token operator"
+          >
+            =
+          </span>
+           
+          <span
+            class="token string"
+          >
+            'State 1'
+          </span>
+        </span>
       </code>
     </pre>
   </div>
@@ -33,7 +53,27 @@ exports[`EuiCodeBlock dynamic content updates DOM when input changes 2`] = `
         class="euiCodeBlock__code emotion-euiCodeBlock__code"
         data-code-language="javascript"
       >
-        const value = 'State 2'
+        <span
+          class="euiCodeBlock__line emotion-euiCodeBlock__line"
+        >
+          <span
+            class="token keyword"
+          >
+            const
+          </span>
+           value 
+          <span
+            class="token operator"
+          >
+            =
+          </span>
+           
+          <span
+            class="token string"
+          >
+            'State 2'
+          </span>
+        </span>
       </code>
     </pre>
   </div>
@@ -115,7 +155,7 @@ exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:8px"
+          style="inline-size: 8px;"
         >
           <span
             aria-hidden="true"
@@ -153,7 +193,7 @@ exports[`EuiCodeBlock line numbers renders annotated line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:8px"
+          style="inline-size: 8px;"
         >
           <span
             aria-hidden="true"
@@ -191,7 +231,7 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:8px"
+          style="inline-size: 8px;"
         >
           <span
             aria-hidden="true"
@@ -211,7 +251,7 @@ exports[`EuiCodeBlock line numbers renders highlighted line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:8px"
+          style="inline-size: 8px;"
         >
           <span
             aria-hidden="true"
@@ -249,7 +289,7 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:8px"
+          style="inline-size: 8px;"
         >
           <span
             aria-hidden="true"
@@ -269,7 +309,7 @@ exports[`EuiCodeBlock line numbers renders line numbers 1`] = `
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:8px"
+          style="inline-size: 8px;"
         >
           <span
             aria-hidden="true"
@@ -307,7 +347,7 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:16px"
+          style="inline-size: 16px;"
         >
           <span
             aria-hidden="true"
@@ -327,7 +367,7 @@ exports[`EuiCodeBlock line numbers renders line numbers with a start value 1`] =
       >
         <span
           class="euiCodeBlock__lineNumberWrapper emotion-euiCodeBlock__lineNumberWrapper"
-          style="inline-size:16px"
+          style="inline-size: 16px;"
         >
           <span
             aria-hidden="true"
@@ -432,10 +472,10 @@ exports[`EuiCodeBlock props fontSize s is rendered 1`] = `
 
 exports[`EuiCodeBlock props isCopyable is rendered 1`] = `
 <div
-  class="euiCodeBlock emotion-euiCodeBlock-s"
+  class="euiCodeBlock emotion-euiCodeBlock-s-hasControls"
 >
   <pre
-    class="euiCodeBlock__pre emotion-euiCodeBlock__pre-preWrap-padding"
+    class="euiCodeBlock__pre emotion-euiCodeBlock__pre-preWrap-padding-controlsOffset"
     tabindex="-1"
   >
     <code
@@ -455,6 +495,31 @@ exports[`EuiCodeBlock props isCopyable is rendered 1`] = `
       </span>
     </code>
   </pre>
+  <div
+    class="euiCodeBlock__controls emotion-euiCodeBlock__controls-l"
+  >
+    <div
+      class="euiCodeBlock__copyButton"
+    >
+      <span
+        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+      >
+        <button
+          aria-label="Copy"
+          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+          data-test-subj="euiCodeBlockCopy"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="copyClipboard"
+          />
+        </button>
+      </span>
+    </div>
+  </div>
 </div>
 `;
 
@@ -489,11 +554,11 @@ exports[`EuiCodeBlock props language is rendered 1`] = `
 exports[`EuiCodeBlock props overflowHeight is rendered 1`] = `
 <div
   class="euiCodeBlock emotion-euiCodeBlock-s-hasControls"
-  style="max-block-size:200px"
+  style="max-block-size: 200px;"
 >
   <pre
     class="euiCodeBlock__pre emotion-euiCodeBlock__pre-preWrap-padding-controlsOffset"
-    style="max-block-size:200px"
+    style="max-block-size: 200px;"
     tabindex="-1"
   >
     <code
@@ -735,14 +800,14 @@ exports[`EuiCodeBlock renders a code block 1`] = `
 exports[`EuiCodeBlock virtualization renders a virtualized code block 1`] = `
 <div
   class="euiCodeBlock testClass1 testClass2 emotion-euiCodeBlock-s-hasControls-euiTestCss"
-  style="block-size:50%"
+  style="block-size: 50%;"
 >
   <div
     data-eui="EuiAutoSizer"
   >
     <pre
       class="euiCodeBlock__pre emotion-euiCodeBlock__pre-pre-padding-controlsOffset"
-      style="position:relative;block-size:600px;inline-size:600px;overflow:auto;-webkit-overflow-scrolling:touch;will-change:transform;direction:ltr"
+      style="position: relative; block-size: 600px; inline-size: 600px; overflow: auto; will-change: transform; direction: ltr;"
       tabindex="0"
     >
       <code
@@ -750,18 +815,18 @@ exports[`EuiCodeBlock virtualization renders a virtualized code block 1`] = `
         class="euiCodeBlock__code emotion-euiCodeBlock__code-isVirtualized"
         data-code-language="text"
         data-test-subj="test subject string"
-        style="block-size:36px;inline-size:100%"
+        style="block-size: 36px; inline-size: 100%;"
       >
         <span
           class="euiCodeBlock__line emotion-euiCodeBlock__line"
-          style="position:absolute;inset-inline-start:0;inset-block-start:0;block-size:18px;inline-size:100%"
+          style="position: absolute; inset-inline-start: 0; inset-block-start: 0; block-size: 18px; inline-size: 100%;"
         >
           var some = 'code';
 
         </span>
         <span
           class="euiCodeBlock__line emotion-euiCodeBlock__line"
-          style="position:absolute;inset-inline-start:0;inset-block-start:18px;block-size:18px;inline-size:100%"
+          style="position: absolute; inset-inline-start: 0; inset-block-start: 18px; block-size: 18px; inline-size: 100%;"
         >
           console.log(some);
         </span>

--- a/src/components/code/code.test.tsx
+++ b/src/components/code/code.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiCode } from './code';
 
@@ -20,28 +20,28 @@ describe('EuiCode', () => {
   shouldRenderCustomStyles(<EuiCode>{code}</EuiCode>);
 
   it('renders a code snippet', () => {
-    const component = render(<EuiCode {...requiredProps}>{code}</EuiCode>);
+    const { container } = render(<EuiCode {...requiredProps}>{code}</EuiCode>);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders transparent backgrounds', () => {
-    const component = render(
+    const { container } = render(
       <EuiCode {...requiredProps} transparentBackground>
         {code}
       </EuiCode>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders languages', () => {
-    const component = render(
+    const { container } = render(
       <EuiCode {...requiredProps} language="js">
         {code}
       </EuiCode>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/code/code_block.test.tsx
+++ b/src/components/code/code_block.test.tsx
@@ -6,11 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React, { useState, useEffect } from 'react';
-import ReactDOM from 'react-dom';
-import { mount, render, shallow } from 'enzyme';
-import { act } from 'react-dom/test-utils';
+import React from 'react';
+import { mount, shallow } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiCodeBlock, FONT_SIZES, PADDING_SIZES } from './code_block';
 
@@ -19,62 +18,62 @@ console.log(some);`;
 
 describe('EuiCodeBlock', () => {
   it('renders a code block', () => {
-    const component = render(
+    const { container } = render(
       <EuiCodeBlock {...requiredProps}>{code}</EuiCodeBlock>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('transparentBackground', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCodeBlock transparentBackground>{code}</EuiCodeBlock>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isCopyable', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCodeBlock isCopyable>{code}</EuiCodeBlock>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('overflowHeight', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCodeBlock overflowHeight={200}>{code}</EuiCodeBlock>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('language', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiCodeBlock language="html">{code}</EuiCodeBlock>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('fontSize', () => {
       FONT_SIZES.forEach((fontSize) => {
         test(`${fontSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiCodeBlock fontSize={fontSize}>{code}</EuiCodeBlock>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -82,69 +81,44 @@ describe('EuiCodeBlock', () => {
     describe('paddingSize', () => {
       PADDING_SIZES.forEach((paddingSize) => {
         test(`${paddingSize} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiCodeBlock paddingSize={paddingSize}>{code}</EuiCodeBlock>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('whiteSpace', () => {
       it('renders a pre block tag with a css class modifier', () => {
-        const component = render(
+        const { container } = render(
           <EuiCodeBlock whiteSpace="pre" {...requiredProps}>
             {code}
           </EuiCodeBlock>
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('dynamic content', () => {
-    it('updates DOM when input changes', (done) => {
-      expect.assertions(2);
+    it('updates DOM when input changes', () => {
+      const { container, rerender } = render(
+        <EuiCodeBlock language="javascript">
+          const value = &apos;State 1&apos;
+        </EuiCodeBlock>
+      );
 
-      function takeSnapshot() {
-        const snapshot = render(
-          <div dangerouslySetInnerHTML={{ __html: appDiv.innerHTML }} />
-        );
-        expect(snapshot).toMatchSnapshot();
-      }
+      expect(container).toMatchSnapshot();
 
-      // enzyme does not recreate enough of the React<->DOM interaction to reproduce this bug
-      const appDiv = document.createElement('div');
+      rerender(
+        <EuiCodeBlock language="javascript">
+          const value = &apos;State 2&apos;
+        </EuiCodeBlock>
+      );
 
-      function App() {
-        const [value, setValue] = useState('State 1');
-
-        useEffect(() => {
-          // Wait a tick for EuiCodeBlock internal state to update on render
-          setTimeout(() => {
-            takeSnapshot();
-            act(() => {
-              setValue('State 2');
-            });
-          });
-        }, []);
-
-        useEffect(() => {
-          if (value === 'State 2') {
-            takeSnapshot();
-            done();
-          }
-        }, [value]);
-
-        return (
-          <EuiCodeBlock language="javascript">
-            const value = &apos;{value}&apos;
-          </EuiCodeBlock>
-        );
-      }
-
-      ReactDOM.render(<App />, appDiv);
+      expect(container).toMatchSnapshot();
     });
   });
 
@@ -188,7 +162,7 @@ describe('EuiCodeBlock', () => {
 
   describe('virtualization', () => {
     it('renders a virtualized code block', () => {
-      const component = render(
+      const { container } = render(
         <EuiCodeBlock
           isVirtualized={true}
           overflowHeight="50%"
@@ -197,7 +171,7 @@ describe('EuiCodeBlock', () => {
           {code}
         </EuiCodeBlock>
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('type checks', () => {
@@ -225,34 +199,34 @@ describe('EuiCodeBlock', () => {
 
   describe('line numbers', () => {
     it('renders line numbers', () => {
-      const component = render(
+      const { container } = render(
         <EuiCodeBlock lineNumbers {...requiredProps}>
           {code}
         </EuiCodeBlock>
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('renders line numbers with a start value', () => {
-      const component = render(
+      const { container } = render(
         <EuiCodeBlock lineNumbers={{ start: 10 }} {...requiredProps}>
           {code}
         </EuiCodeBlock>
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('renders highlighted line numbers', () => {
-      const component = render(
+      const { container } = render(
         <EuiCodeBlock lineNumbers={{ highlight: '1' }} {...requiredProps}>
           {code}
         </EuiCodeBlock>
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('renders annotated line numbers', () => {
-      const component = render(
+      const { container } = render(
         <EuiCodeBlock
           lineNumbers={{ annotations: { 1: 'hello world' } }}
           {...requiredProps}
@@ -260,7 +234,7 @@ describe('EuiCodeBlock', () => {
           {code}
         </EuiCodeBlock>
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`EuiContextMenu can pass-through horizontal rule props 1`] = `
 <div
   class="euiContextMenu"
+  style="height: 0px;"
 >
   <div
     class="euiContextMenuPanel euiContextMenu__panel"
@@ -37,6 +38,7 @@ exports[`EuiContextMenu is rendered 1`] = `
 exports[`EuiContextMenu panel item can be a separator line 1`] = `
 <div
   class="euiContextMenu"
+  style="height: 0px;"
 >
   <div
     class="euiContextMenuPanel euiContextMenu__panel"
@@ -91,6 +93,7 @@ exports[`EuiContextMenu panel item can be a separator line 1`] = `
 exports[`EuiContextMenu panel item can contain JSX 1`] = `
 <div
   class="euiContextMenu"
+  style="height: 0px;"
 >
   <div
     class="euiContextMenuPanel euiContextMenu__panel"
@@ -117,7 +120,7 @@ exports[`EuiContextMenu panel item can contain JSX 1`] = `
             class="euiContextMenuItem__text"
           >
             <span
-              style="color:tomato"
+              style="color: tomato;"
             >
               foo
             </span>
@@ -286,6 +289,7 @@ exports[`EuiContextMenu props panels and initialPanelId allows you to click the 
 exports[`EuiContextMenu props panels and initialPanelId renders the referenced panel 1`] = `
 <div
   class="euiContextMenu"
+  style="height: 0px;"
 >
   <div
     class="euiContextMenuPanel euiContextMenu__panel"
@@ -322,6 +326,7 @@ exports[`EuiContextMenu props panels and initialPanelId renders the referenced p
 exports[`EuiContextMenu props size m is rendered 1`] = `
 <div
   class="euiContextMenu"
+  style="height: 0px;"
 >
   <div
     class="euiContextMenuPanel euiContextMenu__panel"
@@ -358,6 +363,7 @@ exports[`EuiContextMenu props size m is rendered 1`] = `
 exports[`EuiContextMenu props size s is rendered 1`] = `
 <div
   class="euiContextMenu euiContextMenu--small"
+  style="height: 0px;"
 >
   <div
     class="euiContextMenuPanel euiContextMenu__panel"

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps, takeMountedSnapshot } from '../../test';
+import { render } from '../../test/rtl';
 
 import { EuiContextMenu, SIZES } from './context_menu';
 import { setTimeout } from 'timers';
@@ -70,21 +71,21 @@ export const tick = (ms = 0) =>
 
 describe('EuiContextMenu', () => {
   test('is rendered', () => {
-    const component = render(<EuiContextMenu {...requiredProps} />);
+    const { container } = render(<EuiContextMenu {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('panel item can contain JSX', () => {
-    const component = render(
+    const { container } = render(
       <EuiContextMenu panels={panels} initialPanelId={3} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('panel item can be a separator line', () => {
-    const component = render(
+    const { container } = render(
       <EuiContextMenu
         panels={[
           {
@@ -101,11 +102,11 @@ describe('EuiContextMenu', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('can pass-through horizontal rule props', () => {
-    const component = render(
+    const { container } = render(
       <EuiContextMenu
         panels={[
           {
@@ -125,17 +126,17 @@ describe('EuiContextMenu', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('panels and initialPanelId', () => {
       it('renders the referenced panel', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenu panels={panels} initialPanelId={2} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('allows you to click the title button to go back to the previous panel', async () => {
@@ -170,11 +171,11 @@ describe('EuiContextMenu', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiContextMenu panels={panels} initialPanelId={2} size={size} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/context_menu/context_menu_item.test.tsx
+++ b/src/components/context_menu/context_menu_item.test.tsx
@@ -7,56 +7,57 @@
  */
 
 import React from 'react';
-import { render, shallow, mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiContextMenuItem, SIZES } from './context_menu_item';
 
 describe('EuiContextMenuItem', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiContextMenuItem {...requiredProps}>Hello</EuiContextMenuItem>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('icon', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenuItem icon={<span className="euiIcon fa-user" />} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('disabled', () => {
       test('is rendered', () => {
-        const component = render(<EuiContextMenuItem disabled />);
+        const { container } = render(<EuiContextMenuItem disabled />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {
-          const component = render(<EuiContextMenuItem size={size} />);
+          const { container } = render(<EuiContextMenuItem size={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('onClick', () => {
       test('renders a button', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenuItem {...requiredProps} onClick={() => {}} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test("isn't called upon instantiation", () => {
@@ -94,39 +95,39 @@ describe('EuiContextMenuItem', () => {
 
     describe('href', () => {
       test('renders a link', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenuItem {...requiredProps} href="url" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('rel', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenuItem {...requiredProps} href="url" rel="help" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('target', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenuItem {...requiredProps} href="url" target="_blank" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('hasPanel', () => {
       test('is rendered', () => {
-        const component = render(<EuiContextMenuItem hasPanel />);
+        const { container } = render(<EuiContextMenuItem hasPanel />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/context_menu/context_menu_panel.test.tsx
+++ b/src/components/context_menu/context_menu_panel.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 
 import { EuiContextMenuPanel, SIZES } from './context_menu_panel';
 
@@ -30,41 +31,41 @@ const items = [
 
 describe('EuiContextMenuPanel', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiContextMenuPanel {...requiredProps}>Hello</EuiContextMenuPanel>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('title', () => {
       test('is rendered', () => {
-        const component = render(<EuiContextMenuPanel title="Title" />);
+        const { container } = render(<EuiContextMenuPanel title="Title" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiContextMenuPanel title="Title" size={size} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('onClose', () => {
       test('renders a button as a title', () => {
-        const component = render(
+        const { container } = render(
           <EuiContextMenuPanel title="Title" onClose={() => {}} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test("isn't called upon instantiation", () => {
@@ -103,27 +104,27 @@ describe('EuiContextMenuPanel', () => {
         describe('with transitionType', () => {
           describe('in', () => {
             test('is rendered', () => {
-              const component = render(
+              const { container } = render(
                 <EuiContextMenuPanel
                   transitionDirection="next"
                   transitionType="in"
                 />
               );
 
-              expect(component).toMatchSnapshot();
+              expect(container.firstChild).toMatchSnapshot();
             });
           });
 
           describe('out', () => {
             test('is rendered', () => {
-              const component = render(
+              const { container } = render(
                 <EuiContextMenuPanel
                   transitionDirection="next"
                   transitionType="out"
                 />
               );
 
-              expect(component).toMatchSnapshot();
+              expect(container.firstChild).toMatchSnapshot();
             });
           });
         });
@@ -133,27 +134,27 @@ describe('EuiContextMenuPanel', () => {
         describe('with transitionType', () => {
           describe('in', () => {
             test('is rendered', () => {
-              const component = render(
+              const { container } = render(
                 <EuiContextMenuPanel
                   transitionDirection="previous"
                   transitionType="in"
                 />
               );
 
-              expect(component).toMatchSnapshot();
+              expect(container.firstChild).toMatchSnapshot();
             });
           });
 
           describe('out', () => {
             test('is rendered', () => {
-              const component = render(
+              const { container } = render(
                 <EuiContextMenuPanel
                   transitionDirection="previous"
                   transitionType="out"
                 />
               );
 
-              expect(component).toMatchSnapshot();
+              expect(container.firstChild).toMatchSnapshot();
             });
           });
         });

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -271,7 +271,7 @@ exports[`EuiDatePickerRange props inline renders 1`] = `
                 <div
                   aria-label="Button. Open the month selector. January is currently selected."
                   class="react-datepicker__month-read-view"
-                  style="visibility:visible"
+                  style="visibility: visible;"
                   tabindex="0"
                 >
                   <span
@@ -290,7 +290,7 @@ exports[`EuiDatePickerRange props inline renders 1`] = `
                 <div
                   aria-label="Button. Open the year selector. 2000 is currently selected."
                   class="react-datepicker__year-read-view"
-                  style="visibility:visible"
+                  style="visibility: visible;"
                   tabindex="0"
                 >
                   <span
@@ -721,7 +721,7 @@ exports[`EuiDatePickerRange props inline renders 1`] = `
                 <div
                   aria-label="Button. Open the month selector. January is currently selected."
                   class="react-datepicker__month-read-view"
-                  style="visibility:visible"
+                  style="visibility: visible;"
                   tabindex="0"
                 >
                   <span
@@ -740,7 +740,7 @@ exports[`EuiDatePickerRange props inline renders 1`] = `
                 <div
                   aria-label="Button. Open the year selector. 2000 is currently selected."
                   class="react-datepicker__year-read-view"
-                  style="visibility:visible"
+                  style="visibility: visible;"
                   tabindex="0"
                 >
                   <span
@@ -1162,6 +1162,7 @@ exports[`EuiDatePickerRange props isInvalid 1`] = `
             class="react-datepicker__input-container"
           >
             <input
+              aria-invalid="true"
               aria-label="Press the down key to open a popover containing a calendar."
               class="euiDatePicker euiFieldText euiDatePickerRange__start euiFormControlLayoutDelimited__input"
               type="text"
@@ -1189,6 +1190,7 @@ exports[`EuiDatePickerRange props isInvalid 1`] = `
             class="react-datepicker__input-container"
           >
             <input
+              aria-invalid="true"
               aria-label="Press the down key to open a popover containing a calendar."
               class="euiDatePicker euiFieldText euiDatePickerRange__end euiFormControlLayoutDelimited__input"
               type="text"

--- a/src/components/date_picker/auto_refresh/auto_refresh.test.tsx
+++ b/src/components/date_picker/auto_refresh/auto_refresh.test.tsx
@@ -7,30 +7,30 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiAutoRefresh, EuiAutoRefreshButton } from './auto_refresh';
 
 describe('EuiAutoRefresh', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiAutoRefresh onRefreshChange={() => {}} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('isPaused is false', () => {
-    const component = render(
+    const { container } = render(
       <EuiAutoRefresh isPaused={false} onRefreshChange={() => {}} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('refreshInterval is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiAutoRefresh
         isPaused={false}
         refreshInterval={2000}
@@ -38,29 +38,29 @@ describe('EuiAutoRefresh', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });
 
 describe('EuiAutoRefreshButton', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiAutoRefreshButton onRefreshChange={() => {}} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('isPaused is false', () => {
-    const component = render(
+    const { container } = render(
       <EuiAutoRefreshButton isPaused={false} onRefreshChange={() => {}} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('refreshInterval is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiAutoRefreshButton
         isPaused={false}
         refreshInterval={2000}
@@ -68,6 +68,6 @@ describe('EuiAutoRefreshButton', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/date_picker/date_picker_range.test.tsx
+++ b/src/components/date_picker/date_picker_range.test.tsx
@@ -7,8 +7,9 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 import moment from 'moment';
 
 import { EuiDatePickerRange } from './date_picker_range';
@@ -16,7 +17,7 @@ import { EuiDatePicker } from './date_picker';
 
 describe('EuiDatePickerRange', () => {
   it('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiDatePickerRange
         startDateControl={<EuiDatePicker />}
         endDateControl={<EuiDatePicker />}
@@ -24,12 +25,12 @@ describe('EuiDatePickerRange', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     test('fullWidth', () => {
-      const component = render(
+      const { container } = render(
         <EuiDatePickerRange
           startDateControl={<EuiDatePicker />}
           endDateControl={<EuiDatePicker />}
@@ -37,11 +38,11 @@ describe('EuiDatePickerRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('readOnly', () => {
-      const component = render(
+      const { container } = render(
         <EuiDatePickerRange
           startDateControl={<EuiDatePicker />}
           endDateControl={<EuiDatePicker />}
@@ -49,11 +50,11 @@ describe('EuiDatePickerRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('disabled', () => {
-      const component = render(
+      const { container } = render(
         <EuiDatePickerRange
           startDateControl={<EuiDatePicker />}
           endDateControl={<EuiDatePicker />}
@@ -61,11 +62,11 @@ describe('EuiDatePickerRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isInvalid', () => {
-      const component = render(
+      const { container } = render(
         <EuiDatePickerRange
           startDateControl={<EuiDatePicker />}
           endDateControl={<EuiDatePicker />}
@@ -73,11 +74,11 @@ describe('EuiDatePickerRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isLoading', () => {
-      const component = render(
+      const { container } = render(
         <EuiDatePickerRange
           startDateControl={<EuiDatePicker />}
           endDateControl={<EuiDatePicker />}
@@ -85,7 +86,7 @@ describe('EuiDatePickerRange', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('inline', () => {
@@ -93,7 +94,7 @@ describe('EuiDatePickerRange', () => {
         const selectedStartDate = moment('2000-01-01T00:00:00-0800');
         const selectedEndDate = moment(selectedStartDate).add(1, 'd');
 
-        const component = render(
+        const { container } = render(
           <EuiDatePickerRange
             startDateControl={<EuiDatePicker selected={selectedStartDate} />}
             endDateControl={<EuiDatePicker selected={selectedEndDate} />}
@@ -106,11 +107,11 @@ describe('EuiDatePickerRange', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('allows turning off the default shadow', () => {
-        const component = render(
+        const { container } = render(
           <EuiDatePickerRange
             startDateControl={<EuiDatePicker />}
             endDateControl={<EuiDatePicker />}
@@ -119,7 +120,9 @@ describe('EuiDatePickerRange', () => {
           />
         );
 
-        expect(component.attr('class')).not.toContain('shadow');
+        expect((container.firstChild as HTMLElement).className).not.toContain(
+          'shadow'
+        );
       });
 
       // TODO: Use storybook to test inline invalid, loading, disabled, & readOnly
@@ -128,7 +131,7 @@ describe('EuiDatePickerRange', () => {
   });
 
   it('uses individual EuiDatePicker props', () => {
-    const component = render(
+    const { container } = render(
       <EuiDatePickerRange
         startDateControl={<EuiDatePicker className="hello" />}
         endDateControl={<EuiDatePicker className="world" />}
@@ -136,7 +139,7 @@ describe('EuiDatePickerRange', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('calls blur and focus handlers for date pickers while also triggering range control handlers', () => {

--- a/src/components/description_list/description_list.test.tsx
+++ b/src/components/description_list/description_list.test.tsx
@@ -7,8 +7,8 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiDescriptionList } from './description_list';
@@ -23,11 +23,11 @@ describe('EuiDescriptionList', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiDescriptionList {...requiredProps}>Content</EuiDescriptionList>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   const listItems = [
@@ -46,55 +46,55 @@ describe('EuiDescriptionList', () => {
   ];
   describe('props', () => {
     describe('listItems', () => {
-      const component = render(
+      const { container } = render(
         <EuiDescriptionList listItems={listItems}>
           listItems will render instead of this content
         </EuiDescriptionList>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
 
       describe('titleProps', () => {
         test('is rendered', () => {
-          const component = render(
+          const { container } = render(
             <EuiDescriptionList
               listItems={listItems}
               titleProps={requiredProps}
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
       describe('descriptionProps', () => {
         test('is rendered', () => {
-          const component = render(
+          const { container } = render(
             <EuiDescriptionList
               listItems={listItems}
               descriptionProps={requiredProps}
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('compressed', () => {
       test('is rendered', () => {
-        const component = render(<EuiDescriptionList compressed />);
+        const { container } = render(<EuiDescriptionList compressed />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('type', () => {
       TYPES.forEach((type) => {
         test(`${type} is rendered`, () => {
-          const component = render(<EuiDescriptionList type={type} />);
+          const { container } = render(<EuiDescriptionList type={type} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -102,9 +102,11 @@ describe('EuiDescriptionList', () => {
     describe('align', () => {
       ALIGNMENTS.forEach((alignment) => {
         test(`${alignment} is rendered`, () => {
-          const component = render(<EuiDescriptionList align={alignment} />);
+          const { container } = render(
+            <EuiDescriptionList align={alignment} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -112,9 +114,11 @@ describe('EuiDescriptionList', () => {
     describe('gutter', () => {
       GUTTER_SIZES.forEach((gutter) => {
         test(`${gutter} is rendered`, () => {
-          const component = render(<EuiDescriptionList gutterSize={gutter} />);
+          const { container } = render(
+            <EuiDescriptionList gutterSize={gutter} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/description_list/description_list_description.test.tsx
+++ b/src/components/description_list/description_list_description.test.tsx
@@ -7,12 +7,12 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiDescriptionListDescription } from './description_list_description';
 import { TYPES } from './description_list_types';
-import { shouldRenderCustomStyles } from '../../test/internal';
 import {
   EuiDescriptionListContext,
   contextDefaults,
@@ -22,20 +22,20 @@ describe('EuiDescriptionListDescription', () => {
   shouldRenderCustomStyles(<EuiDescriptionListDescription />);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiDescriptionListDescription {...requiredProps}>
         Content
       </EuiDescriptionListDescription>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('EuiDescriptionListDescription prop variations', () => {
     describe('type', () => {
       TYPES.forEach((type) => {
         test(`${type} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiDescriptionListContext.Provider
               value={{ ...contextDefaults, type }}
             >
@@ -43,14 +43,14 @@ describe('EuiDescriptionListDescription', () => {
             </EuiDescriptionListContext.Provider>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('align', () => {
       test('center alignment is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiDescriptionListContext.Provider
             value={{ ...contextDefaults, align: 'center' }}
           >
@@ -58,13 +58,13 @@ describe('EuiDescriptionListDescription', () => {
           </EuiDescriptionListContext.Provider>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('text styles', () => {
       test('reversed text is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiDescriptionListContext.Provider
             value={{ ...contextDefaults, textStyle: 'reverse' }}
           >
@@ -72,13 +72,13 @@ describe('EuiDescriptionListDescription', () => {
           </EuiDescriptionListContext.Provider>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('compressed', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiDescriptionListContext.Provider
             value={{ ...contextDefaults, compressed: true }}
           >
@@ -86,7 +86,7 @@ describe('EuiDescriptionListDescription', () => {
           </EuiDescriptionListContext.Provider>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/description_list/description_list_title.test.tsx
+++ b/src/components/description_list/description_list_title.test.tsx
@@ -7,11 +7,11 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiDescriptionListTitle } from './description_list_title';
-import { shouldRenderCustomStyles } from '../../test/internal';
 import { TYPES } from './description_list_types';
 import {
   EuiDescriptionListContext,
@@ -22,20 +22,20 @@ describe('EuiDescriptionListTitle', () => {
   shouldRenderCustomStyles(<EuiDescriptionListTitle />);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiDescriptionListTitle {...requiredProps}>
         Content
       </EuiDescriptionListTitle>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('EuiDescriptionListTitle prop variations', () => {
     describe('type', () => {
       TYPES.forEach((type) => {
         test(`${type} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiDescriptionListContext.Provider
               value={{ ...contextDefaults, type }}
             >
@@ -43,14 +43,14 @@ describe('EuiDescriptionListTitle', () => {
             </EuiDescriptionListContext.Provider>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('align', () => {
       test('center alignment is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiDescriptionListContext.Provider
             value={{ ...contextDefaults, align: 'center' }}
           >
@@ -58,13 +58,13 @@ describe('EuiDescriptionListTitle', () => {
           </EuiDescriptionListContext.Provider>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('text styles', () => {
       test('reversed text is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiDescriptionListContext.Provider
             value={{ ...contextDefaults, textStyle: 'reverse' }}
           >
@@ -72,13 +72,13 @@ describe('EuiDescriptionListTitle', () => {
           </EuiDescriptionListContext.Provider>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('compressed', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiDescriptionListContext.Provider
             value={{ ...contextDefaults, compressed: true }}
           >
@@ -86,7 +86,7 @@ describe('EuiDescriptionListTitle', () => {
           </EuiDescriptionListContext.Provider>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/empty_prompt/__snapshots__/empty_prompt.test.tsx.snap
+++ b/src/components/empty_prompt/__snapshots__/empty_prompt.test.tsx.snap
@@ -470,7 +470,7 @@ exports[`EuiEmptyPrompt props paddingSize s is rendered 1`] = `
 exports[`EuiEmptyPrompt props styles are rendered 1`] = `
 <div
   class="euiPanel euiPanel--transparent euiEmptyPrompt euiEmptyPrompt--vertical euiEmptyPrompt--paddingLarge emotion-euiPanel-m-transparent"
-  style="background:yellow;min-width:200px;max-width:600px"
+  style="background: yellow; min-width: 200px; max-width: 600px;"
 >
   <div
     class="euiEmptyPrompt__main"

--- a/src/components/empty_prompt/empty_prompt.test.tsx
+++ b/src/components/empty_prompt/empty_prompt.test.tsx
@@ -7,14 +7,14 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../test';
+import { render } from '../../test/rtl';
 import { EuiEmptyPrompt, PADDING_SIZES } from './empty_prompt';
 import { COLORS } from '../panel/panel';
 
 describe('EuiEmptyPrompt', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiEmptyPrompt
         iconType="arrowUp"
         title={<h2>Title</h2>}
@@ -24,81 +24,83 @@ describe('EuiEmptyPrompt', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('iconType', () => {
       test('renders alone', () => {
-        const component = render(<EuiEmptyPrompt iconType="arrowUp" />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiEmptyPrompt iconType="arrowUp" />);
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders with iconColor', () => {
-        const component = render(
+        const { container } = render(
           <EuiEmptyPrompt iconType="arrowUp" iconColor="danger" />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('icon', () => {
       test('renders alone', () => {
-        const component = render(
+        const { container } = render(
           <EuiEmptyPrompt icon={<span>Custom icon</span>} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('title', () => {
       test('renders alone', () => {
-        const component = render(<EuiEmptyPrompt title={<div>title</div>} />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(
+          <EuiEmptyPrompt title={<div>title</div>} />
+        );
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('body', () => {
       test('renders alone', () => {
-        const component = render(<EuiEmptyPrompt body="body" />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiEmptyPrompt body="body" />);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('actions', () => {
       test('renders alone', () => {
-        const component = render(<EuiEmptyPrompt actions="actions" />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiEmptyPrompt actions="actions" />);
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders an array', () => {
-        const component = render(
+        const { container } = render(
           <EuiEmptyPrompt actions={['action1', 'action2']} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('footer', () => {
       test('renders alone', () => {
-        const component = render(<EuiEmptyPrompt footer="footer" />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiEmptyPrompt footer="footer" />);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('layout', () => {
       test('renders alone', () => {
-        const component = render(<EuiEmptyPrompt layout="horizontal" />);
-        expect(component).toMatchSnapshot();
+        const { container } = render(<EuiEmptyPrompt layout="horizontal" />);
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('paddingSize', () => {
       PADDING_SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {
-          const component = render(<EuiEmptyPrompt paddingSize={size} />);
+          const { container } = render(<EuiEmptyPrompt paddingSize={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -106,16 +108,16 @@ describe('EuiEmptyPrompt', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiEmptyPrompt color={color} />);
+          const { container } = render(<EuiEmptyPrompt color={color} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('styles', () => {
       test('are rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiEmptyPrompt
             style={{
               background: 'yellow',
@@ -125,7 +127,7 @@ describe('EuiEmptyPrompt', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/expression/__snapshots__/expression.test.tsx.snap
+++ b/src/components/expression/__snapshots__/expression.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`EuiExpression props descriptionWidth changes the description&apos;s wid
 >
   <span
     class="euiExpression__description emotion-euiExpression__description-danger-isUppercase-columns"
-    style="flex-basis:50px"
+    style="flex-basis: 50px;"
   >
     the answer is
   </span>
@@ -150,7 +150,7 @@ exports[`EuiExpression props display can be columns 1`] = `
 >
   <span
     class="euiExpression__description emotion-euiExpression__description-success-isUppercase-columns"
-    style="flex-basis:20%"
+    style="flex-basis: 20%;"
   >
     the answer is
   </span>

--- a/src/components/expression/expression.test.tsx
+++ b/src/components/expression/expression.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
+import { mount } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiExpression, COLORS } from './expression';
 
@@ -20,7 +21,7 @@ describe('EuiExpression', () => {
   );
 
   test('renders', () => {
-    const component = (
+    const { container } = render(
       <EuiExpression
         description="the answer is"
         value="42"
@@ -30,11 +31,11 @@ describe('EuiExpression', () => {
       />
     );
 
-    expect(render(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('render with only description', () => {
-    const component = (
+    const { container } = render(
       <EuiExpression
         description="the answer is"
         isActive={false}
@@ -42,14 +43,14 @@ describe('EuiExpression', () => {
         {...requiredProps}
       />
     );
-    expect(render(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiExpression
               description="the answer is"
               value="42"
@@ -58,14 +59,14 @@ describe('EuiExpression', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('uppercase', () => {
       test('true renders uppercase', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             value="42"
@@ -73,11 +74,11 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('false renders inherited case', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             value="42"
@@ -85,13 +86,13 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('display', () => {
       test('can be columns', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             value="42"
@@ -99,23 +100,23 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isInvalid', () => {
       test('renders error state', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression description="the answer is" value="42" isInvalid />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('descriptionWidth', () => {
       test('changes the description&apos;s width when using columns', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             descriptionWidth={50}
@@ -125,13 +126,13 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('textWrap', () => {
       test('can truncate text', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             value="42"
@@ -139,13 +140,13 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isActive', () => {
       test('true renders active', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             value="42"
@@ -153,11 +154,11 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('false renders inactive', () => {
-        const component = (
+        const { container } = render(
           <EuiExpression
             description="the answer is"
             value="42"
@@ -165,7 +166,7 @@ describe('EuiExpression', () => {
           />
         );
 
-        expect(render(component)).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 

--- a/src/components/flex/flex_grid.test.tsx
+++ b/src/components/flex/flex_grid.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import {
   EuiFlexGrid,
@@ -22,22 +22,22 @@ describe('EuiFlexGrid', () => {
   shouldRenderCustomStyles(<EuiFlexGrid />);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFlexGrid columns={3} {...requiredProps}>
         <h2>My Child</h2>
       </EuiFlexGrid>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('gutterSize', () => {
       GUTTER_SIZES.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGrid gutterSize={value} />);
+          const { container } = render(<EuiFlexGrid gutterSize={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -45,9 +45,9 @@ describe('EuiFlexGrid', () => {
     describe('columns', () => {
       ([1, 2, 3, 4] as const).forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGrid columns={value} />);
+          const { container } = render(<EuiFlexGrid columns={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -55,9 +55,9 @@ describe('EuiFlexGrid', () => {
     describe('direction', () => {
       DIRECTIONS.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGrid direction={value} />);
+          const { container } = render(<EuiFlexGrid direction={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -65,18 +65,18 @@ describe('EuiFlexGrid', () => {
     describe('alignItems', () => {
       ALIGN_ITEMS.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGrid alignItems={value} />);
+          const { container } = render(<EuiFlexGrid alignItems={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('responsive', () => {
       test('is rendered', () => {
-        const component = render(<EuiFlexGrid responsive={false} />);
+        const { container } = render(<EuiFlexGrid responsive={false} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/flex/flex_group.test.tsx
+++ b/src/components/flex/flex_group.test.tsx
@@ -7,13 +7,13 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import {
   requiredProps,
   startThrowingReactWarnings,
   stopThrowingReactWarnings,
 } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import {
   EuiFlexGroup,
@@ -30,22 +30,22 @@ describe('EuiFlexGroup', () => {
   shouldRenderCustomStyles(<EuiFlexGroup />);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiFlexGroup {...requiredProps}>
         <h2>My Child</h2>
       </EuiFlexGroup>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('responsive', () => {
       [true, false].forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGroup responsive={value} />);
+          const { container } = render(<EuiFlexGroup responsive={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -53,9 +53,9 @@ describe('EuiFlexGroup', () => {
     describe('gutterSize', () => {
       GUTTER_SIZES.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGroup gutterSize={value} />);
+          const { container } = render(<EuiFlexGroup gutterSize={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -63,9 +63,9 @@ describe('EuiFlexGroup', () => {
     describe('alignItems', () => {
       ALIGN_ITEMS.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGroup alignItems={value} />);
+          const { container } = render(<EuiFlexGroup alignItems={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -73,9 +73,9 @@ describe('EuiFlexGroup', () => {
     describe('justifyContent', () => {
       JUSTIFY_CONTENTS.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGroup justifyContent={value} />);
+          const { container } = render(<EuiFlexGroup justifyContent={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -83,9 +83,9 @@ describe('EuiFlexGroup', () => {
     describe('direction', () => {
       DIRECTIONS.forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGroup direction={value} />);
+          const { container } = render(<EuiFlexGroup direction={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -93,11 +93,11 @@ describe('EuiFlexGroup', () => {
     describe('component', () => {
       ['div', 'span'].forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiFlexGroup component={value as 'div' | 'span'} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
@@ -116,9 +116,9 @@ describe('EuiFlexGroup', () => {
     describe('wrap', () => {
       [true, false].forEach((value) => {
         test(`${value} is rendered`, () => {
-          const component = render(<EuiFlexGroup wrap={value} />);
+          const { container } = render(<EuiFlexGroup wrap={value} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/flex/flex_item.test.tsx
+++ b/src/components/flex/flex_item.test.tsx
@@ -7,13 +7,13 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import {
   requiredProps,
   startThrowingReactWarnings,
   stopThrowingReactWarnings,
 } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiFlexItem, VALID_GROW_VALUES } from './flex_item';
 
@@ -24,23 +24,23 @@ describe('EuiFlexItem', () => {
   shouldRenderCustomStyles(<EuiFlexItem />);
 
   test('is rendered', () => {
-    const component = render(<EuiFlexItem {...requiredProps} />);
+    const { container } = render(<EuiFlexItem {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('component', () => {
-    const component = render(<EuiFlexItem component="span" />);
+    const { container } = render(<EuiFlexItem component="span" />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('grow', () => {
     VALID_GROW_VALUES.forEach((value) => {
       test(`${value} is rendered`, () => {
-        const component = render(<EuiFlexItem grow={value} />);
+        const { container } = render(<EuiFlexItem grow={value} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR converts `EuiFlex`, `EuiExpression`, `EuiEmptyPrompt`, `EuiDescriptionList`, `EuiDatePicker`, `EuiContextMenu`, `EuiCode`, `EuiButton` and `EuiAspectRation` unit tests using Enzyme's render() function to RTL render() counterpart to reduce our tech debt.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
