### PR TITLE
test: convert remaining component unit tests using enzyme render to RTL

### DIFF
--- a/src/components/accessibility/screen_reader_live/__snapshots__/screen_reader_live.test.tsx.snap
+++ b/src/components/accessibility/screen_reader_live/__snapshots__/screen_reader_live.test.tsx.snap
@@ -6,12 +6,6 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`aria-live\` 1
 >
   <div
     aria-atomic="true"
-    aria-hidden="true"
-    aria-live="off"
-    role="status"
-  />
-  <div
-    aria-atomic="true"
     aria-live="assertive"
     role="status"
   >
@@ -19,6 +13,12 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`aria-live\` 1
       This paragraph is not visible to sighted users but will be read by screenreaders.
     </p>
   </div>
+  <div
+    aria-atomic="true"
+    aria-hidden="true"
+    aria-live="off"
+    role="status"
+  />
 </div>
 `;
 
@@ -29,12 +29,6 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`focusRegionOn
 >
   <div
     aria-atomic="true"
-    aria-hidden="true"
-    aria-live="off"
-    role="status"
-  />
-  <div
-    aria-atomic="true"
     aria-live="off"
     role="status"
   >
@@ -42,6 +36,12 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`focusRegionOn
       This paragraph is not visible to sighted users but will be read by screenreaders.
     </p>
   </div>
+  <div
+    aria-atomic="true"
+    aria-hidden="true"
+    aria-live="off"
+    role="status"
+  />
 </div>
 `;
 
@@ -51,12 +51,6 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`role\` 1`] = 
 >
   <div
     aria-atomic="true"
-    aria-hidden="true"
-    aria-live="off"
-    role="log"
-  />
-  <div
-    aria-atomic="true"
     aria-live="polite"
     role="log"
   >
@@ -64,6 +58,12 @@ exports[`EuiScreenReaderLive with a static configuration accepts \`role\` 1`] = 
       This paragraph is not visible to sighted users but will be read by screenreaders.
     </p>
   </div>
+  <div
+    aria-atomic="true"
+    aria-hidden="true"
+    aria-live="off"
+    role="log"
+  />
 </div>
 `;
 
@@ -73,13 +73,13 @@ exports[`EuiScreenReaderLive with a static configuration does not render screen 
 >
   <div
     aria-atomic="true"
-    aria-hidden="true"
-    aria-live="off"
+    aria-live="polite"
     role="status"
   />
   <div
     aria-atomic="true"
-    aria-live="polite"
+    aria-hidden="true"
+    aria-live="off"
     role="status"
   />
 </div>
@@ -91,12 +91,6 @@ exports[`EuiScreenReaderLive with a static configuration renders screen reader c
 >
   <div
     aria-atomic="true"
-    aria-hidden="true"
-    aria-live="off"
-    role="status"
-  />
-  <div
-    aria-atomic="true"
     aria-live="polite"
     role="status"
   >
@@ -104,6 +98,12 @@ exports[`EuiScreenReaderLive with a static configuration renders screen reader c
       This paragraph is not visible to sighted users but will be read by screenreaders.
     </p>
   </div>
+  <div
+    aria-atomic="true"
+    aria-hidden="true"
+    aria-live="off"
+    role="status"
+  />
 </div>
 `;
 
@@ -148,19 +148,20 @@ exports[`EuiScreenReaderLive with dynamic properties initially renders screen re
   >
     <div
       aria-atomic="true"
-      aria-hidden="true"
-      aria-live="off"
-      role="status"
-    />
-    <div
-      aria-atomic="true"
       aria-live="polite"
       role="status"
     >
       <p>
-        Number of active options: 0
+        Number of active options: 
+        0
       </p>
     </div>
+    <div
+      aria-atomic="true"
+      aria-hidden="true"
+      aria-live="off"
+      role="status"
+    />
   </div>
 </div>
 `;

--- a/src/components/accessibility/screen_reader_live/screen_reader_live.test.tsx
+++ b/src/components/accessibility/screen_reader_live/screen_reader_live.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React, { useState } from 'react';
-import { mount, render } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { findTestSubject } from '../../../test';
+import { render } from '../../../test/rtl';
 
 import { EuiScreenReaderLive } from './screen_reader_live';
 
@@ -23,47 +24,47 @@ const content = (
 describe('EuiScreenReaderLive', () => {
   describe('with a static configuration', () => {
     it('renders screen reader content when active', () => {
-      const component = render(
+      const { container } = render(
         <EuiScreenReaderLive isActive={true}>{content}</EuiScreenReaderLive>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('does not render screen reader content when inactive', () => {
-      const component = render(
+      const { container } = render(
         <EuiScreenReaderLive isActive={false}>{content}</EuiScreenReaderLive>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('accepts `role`', () => {
-      const component = render(
+      const { container } = render(
         <EuiScreenReaderLive role="log">{content}</EuiScreenReaderLive>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('accepts `aria-live`', () => {
-      const component = render(
+      const { container } = render(
         <EuiScreenReaderLive aria-live="assertive">
           {content}
         </EuiScreenReaderLive>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('accepts `focusRegionOnTextChange`', () => {
-      const component = render(
+      const { container } = render(
         <EuiScreenReaderLive focusRegionOnTextChange>
           {content}
         </EuiScreenReaderLive>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
@@ -87,9 +88,9 @@ describe('EuiScreenReaderLive', () => {
     };
 
     it('initially renders screen reader content in the first live region', () => {
-      const component = render(<Component />);
+      const { container } = render(<Component />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     it('alternates rendering screen reader content into the second live region when changed/toggled', () => {

--- a/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
+++ b/src/components/accessibility/screen_reader_only/screen_reader_only.test.tsx
@@ -7,14 +7,14 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render } from '../../../test/rtl';
 
 import { EuiScreenReaderOnly } from './screen_reader_only';
 
 describe('EuiScreenReaderOnly', () => {
   describe('adds an accessibility class to a child element', () => {
     test('when used with no props', () => {
-      const $paragraph = render(
+      const { container } = render(
         <EuiScreenReaderOnly>
           <p>
             This paragraph is not visibile to sighted users but will be read by
@@ -23,10 +23,10 @@ describe('EuiScreenReaderOnly', () => {
         </EuiScreenReaderOnly>
       );
 
-      expect($paragraph).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
     test('and combines other classNames (foo, bar) given as props on the child', () => {
-      const $paragraph = render(
+      const { container } = render(
         <EuiScreenReaderOnly>
           <p className="foo bar">
             This paragraph is not visibile to sighted users but will be read by
@@ -35,17 +35,17 @@ describe('EuiScreenReaderOnly', () => {
         </EuiScreenReaderOnly>
       );
 
-      expect($paragraph).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('will show on focus', () => {
-    const component = render(
+    const { container } = render(
       <EuiScreenReaderOnly showOnFocus>
         <a href="#">Link</a>
       </EuiScreenReaderOnly>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
+import { mount } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiAccordion } from './accordion';
 
@@ -22,140 +23,142 @@ describe('EuiAccordion', () => {
   });
 
   test('is rendered', () => {
-    const component = render(<EuiAccordion id={getId()} {...requiredProps} />);
+    const { container } = render(
+      <EuiAccordion id={getId()} {...requiredProps} />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('element', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} element="fieldset" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('buttonContentClassName', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion
             id={getId()}
             buttonContentClassName="button content class name"
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('buttonContent', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion
             id={getId()}
             buttonContent={<div>Button content</div>}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('buttonProps', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} buttonProps={requiredProps} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('buttonElement', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} buttonElement="div" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('extraAction', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion
             id={getId()}
             extraAction={<button>Extra action</button>}
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('initialIsOpen', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} initialIsOpen={true}>
             <p>You can see me.</p>
           </EuiAccordion>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('arrowDisplay', () => {
       it('right is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} arrowDisplay="right" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('none is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} arrowDisplay="none" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('arrowProps', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} arrowProps={requiredProps} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('forceState', () => {
       it('closed is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} forceState="closed">
             <p>You can not see me</p>
           </EuiAccordion>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('open is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} forceState="open">
             <p>You can see me</p>
           </EuiAccordion>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('accepts and calls an optional callback on click', () => {
@@ -176,28 +179,28 @@ describe('EuiAccordion', () => {
 
     describe('isLoading', () => {
       it('is rendered', () => {
-        const component = render(<EuiAccordion id={getId()} isLoading />);
+        const { container } = render(<EuiAccordion id={getId()} isLoading />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isLoadingMessage', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAccordion id={getId()} isLoadingMessage="Please wait" isLoading />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
 
   describe('isDisabled', () => {
     it('is rendered', () => {
-      const component = render(<EuiAccordion id={getId()} isDisabled />);
+      const { container } = render(<EuiAccordion id={getId()} isDisabled />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 

--- a/src/components/avatar/__snapshots__/avatar.test.tsx.snap
+++ b/src/components/avatar/__snapshots__/avatar.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiAvatar allows a name composed entirely of whitespace 1`] = `
   class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2 emotion-euiAvatar-user-m-uppercase-euiTestCss"
   data-test-subj="test subject string"
   role="img"
-  style="background-color:#ee789d;color:#000000"
+  style="background-color: rgb(238, 120, 157); color: rgb(0, 0, 0);"
   title="  "
 >
   <span
@@ -23,7 +23,7 @@ exports[`EuiAvatar is rendered 1`] = `
   class="euiAvatar euiAvatar--m euiAvatar--user testClass1 testClass2 emotion-euiAvatar-user-m-uppercase-euiTestCss"
   data-test-subj="test subject string"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -39,7 +39,7 @@ exports[`EuiAvatar props casing capitalize is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-capitalize"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -55,7 +55,7 @@ exports[`EuiAvatar props casing lowercase is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-lowercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -71,7 +71,7 @@ exports[`EuiAvatar props casing none is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-none"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -87,7 +87,7 @@ exports[`EuiAvatar props casing uppercase is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -133,7 +133,7 @@ exports[`EuiAvatar props color as string is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#000;color:#FFFFFF"
+  style="background-color: rgb(0, 0, 0); color: rgb(255, 255, 255);"
   title="name"
 >
   <span
@@ -164,7 +164,7 @@ exports[`EuiAvatar props iconType and iconColor as null is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -179,7 +179,7 @@ exports[`EuiAvatar props iconType and iconColor is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -195,7 +195,7 @@ exports[`EuiAvatar props iconType and iconSize is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -211,7 +211,7 @@ exports[`EuiAvatar props iconType is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -227,7 +227,7 @@ exports[`EuiAvatar props imageUrl is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000;background-image:url(image url)"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 />
 `;
@@ -237,7 +237,7 @@ exports[`EuiAvatar props initials is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -253,7 +253,7 @@ exports[`EuiAvatar props initialsLength is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -268,7 +268,7 @@ exports[`EuiAvatar props isDisabled is rendered 1`] = `
 <div
   class="euiAvatar euiAvatar--m euiAvatar--user euiAvatar-isDisabled emotion-euiAvatar-user-m-uppercase-isDisabled"
   role="presentation"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -284,7 +284,7 @@ exports[`EuiAvatar props size l is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--l euiAvatar--user emotion-euiAvatar-user-l-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -300,7 +300,7 @@ exports[`EuiAvatar props size m is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--user emotion-euiAvatar-user-m-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -316,7 +316,7 @@ exports[`EuiAvatar props size s is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--s euiAvatar--user emotion-euiAvatar-user-s-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -332,7 +332,7 @@ exports[`EuiAvatar props size xl is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--xl euiAvatar--user emotion-euiAvatar-user-xl-uppercase"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -348,7 +348,7 @@ exports[`EuiAvatar props type is rendered 1`] = `
   aria-label="name"
   class="euiAvatar euiAvatar--m euiAvatar--space emotion-euiAvatar-space-m-none"
   role="img"
-  style="background-color:#e4a6c7;color:#000000"
+  style="background-color: rgb(228, 166, 199); color: rgb(0, 0, 0);"
   title="name"
 >
   <span
@@ -358,5 +358,3 @@ exports[`EuiAvatar props type is rendered 1`] = `
   </span>
 </div>
 `;
-
-exports[`EuiAvatar should throw error if color is not a hex 1`] = `"EuiAvatar needs to pass a valid color. This can either be a three or six character hex value"`;

--- a/src/components/avatar/avatar.test.tsx
+++ b/src/components/avatar/avatar.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiAvatar, SIZES, CASING } from './avatar';
 
@@ -17,66 +17,66 @@ describe('EuiAvatar', () => {
   shouldRenderCustomStyles(<EuiAvatar name="name" />);
 
   test('is rendered', () => {
-    const component = render(<EuiAvatar name="name" {...requiredProps} />);
+    const { container } = render(<EuiAvatar name="name" {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('allows a name composed entirely of whitespace', () => {
-    const component = render(<EuiAvatar name="  " {...requiredProps} />);
+    const { container } = render(<EuiAvatar name="  " {...requiredProps} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('imageUrl', () => {
       it('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAvatar name="name" imageUrl="image url" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('iconType', () => {
       it('is rendered', () => {
-        const component = render(<EuiAvatar name="name" iconType="bolt" />);
+        const { container } = render(<EuiAvatar name="name" iconType="bolt" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('and iconSize is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAvatar name="name" iconType="bolt" iconSize="xl" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('and iconColor is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAvatar name="name" iconType="bolt" iconColor="primary" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('and iconColor as null is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiAvatar name="name" iconType="bolt" iconColor={null} />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('size', () => {
       SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {
-          const component = render(<EuiAvatar name="name" size={size} />);
+          const { container } = render(<EuiAvatar name="name" size={size} />);
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -84,68 +84,74 @@ describe('EuiAvatar', () => {
     describe('casing', () => {
       CASING.forEach((casing) => {
         it(`${casing} is rendered`, () => {
-          const component = render(<EuiAvatar name="name" casing={casing} />);
+          const { container } = render(
+            <EuiAvatar name="name" casing={casing} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     describe('initials', () => {
       it('is rendered', () => {
-        const component = render(<EuiAvatar name="name" initials="lo" />);
+        const { container } = render(<EuiAvatar name="name" initials="lo" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('initialsLength', () => {
       it('is rendered', () => {
-        const component = render(<EuiAvatar name="name" initialsLength={2} />);
+        const { container } = render(
+          <EuiAvatar name="name" initialsLength={2} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('type', () => {
       it('is rendered', () => {
-        const component = render(<EuiAvatar name="name" type="space" />);
+        const { container } = render(<EuiAvatar name="name" type="space" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('color', () => {
       it('as string is rendered', () => {
-        const component = render(<EuiAvatar name="name" color="#000" />);
+        const { container } = render(<EuiAvatar name="name" color="#000" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('as null is rendered', () => {
-        const component = render(<EuiAvatar name="name" color={null} />);
+        const { container } = render(<EuiAvatar name="name" color={null} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('as plain is rendered', () => {
-        const component = render(<EuiAvatar name="name" color="plain" />);
+        const { container } = render(<EuiAvatar name="name" color="plain" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('as subdued is rendered', () => {
-        const component = render(<EuiAvatar name="name" color="subdued" />);
+        const { container } = render(<EuiAvatar name="name" color="subdued" />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('isDisabled', () => {
       it('is rendered', () => {
-        const component = render(<EuiAvatar name="name" isDisabled={true} />);
+        const { container } = render(
+          <EuiAvatar name="name" isDisabled={true} />
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });
@@ -154,6 +160,8 @@ describe('EuiAvatar', () => {
     const component = () =>
       render(<EuiAvatar name="name" color="rgba(0,0,0,0)" />);
 
-    expect(component).toThrowErrorMatchingSnapshot();
+    expect(component).toThrowError(
+      'EuiAvatar needs to pass a valid color. This can either be a three or six character hex value'
+    );
   });
 });

--- a/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EuiBadge is disabled 1`] = `
   aria-label="aria-label"
   class="euiBadge testClass1 testClass2 emotion-euiBadge-default-disabled-euiTestCss"
   data-test-subj="test subject string"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -23,6 +24,7 @@ exports[`EuiBadge is rendered 1`] = `
   aria-label="aria-label"
   class="euiBadge testClass1 testClass2 emotion-euiBadge-default-euiTestCss"
   data-test-subj="test subject string"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -49,6 +51,7 @@ exports[`EuiBadge is rendered with href and rel provided 1`] = `
       data-test-subj="test subject string"
       href="/#/"
       rel="noopener noreferrer"
+      title="Content"
     >
       Content
     </a>
@@ -63,6 +66,7 @@ exports[`EuiBadge is rendered with href provided 1`] = `
   data-test-subj="test subject string"
   href="/#/"
   rel="noreferrer"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -89,6 +93,7 @@ exports[`EuiBadge is rendered with iconOnClick and href provided 1`] = `
       data-test-subj="test subject string"
       href="/#/"
       rel="noreferrer"
+      title="Content"
     >
       Content
     </a>
@@ -107,6 +112,7 @@ exports[`EuiBadge is rendered with iconOnClick and onClick provided 1`] = `
       aria-label="aria-label"
       class="euiBadge__childButton emotion-euiBadge__childButton"
       data-test-subj="test subject string"
+      title="Content"
     >
       Content
     </button>
@@ -119,6 +125,7 @@ exports[`EuiBadge is rendered with iconOnClick provided 1`] = `
   aria-label="aria-label"
   class="euiBadge testClass1 testClass2 emotion-euiBadge-default-euiTestCss"
   data-test-subj="test subject string"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -137,6 +144,7 @@ exports[`EuiBadge is rendered with onClick provided 1`] = `
   aria-label="aria-label"
   class="euiBadge testClass1 testClass2 emotion-euiBadge-default-clickable-euiTestCss"
   data-test-subj="test subject string"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -153,6 +161,7 @@ exports[`EuiBadge is rendered with onClick provided 1`] = `
 exports[`EuiBadge props color accent is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-accent"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -169,7 +178,8 @@ exports[`EuiBadge props color accent is rendered 1`] = `
 exports[`EuiBadge props color accepts hex 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:#333;color:#FFF"
+  style="background-color: rgb(51, 51, 51); color: rgb(255, 255, 255);"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -186,7 +196,8 @@ exports[`EuiBadge props color accepts hex 1`] = `
 exports[`EuiBadge props color accepts rgba 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
-  style="background-color:rgba(255,255,255,1);color:#000"
+  style="background-color: rgb(255, 255, 255); color: rgb(0, 0, 0);"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -203,6 +214,7 @@ exports[`EuiBadge props color accepts rgba 1`] = `
 exports[`EuiBadge props color danger is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-danger"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -219,6 +231,7 @@ exports[`EuiBadge props color danger is rendered 1`] = `
 exports[`EuiBadge props color default is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-default"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -235,6 +248,7 @@ exports[`EuiBadge props color default is rendered 1`] = `
 exports[`EuiBadge props color hollow is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-hollow"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -251,6 +265,7 @@ exports[`EuiBadge props color hollow is rendered 1`] = `
 exports[`EuiBadge props color primary is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-primary"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -267,6 +282,7 @@ exports[`EuiBadge props color primary is rendered 1`] = `
 exports[`EuiBadge props color success is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-success"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -283,6 +299,7 @@ exports[`EuiBadge props color success is rendered 1`] = `
 exports[`EuiBadge props color warning is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-warning"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -299,6 +316,7 @@ exports[`EuiBadge props color warning is rendered 1`] = `
 exports[`EuiBadge props iconSide left is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-default"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -320,6 +338,7 @@ exports[`EuiBadge props iconSide left is rendered 1`] = `
 exports[`EuiBadge props iconSide right is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-default"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -341,6 +360,7 @@ exports[`EuiBadge props iconSide right is rendered 1`] = `
 exports[`EuiBadge props iconType is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-default"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -362,7 +382,8 @@ exports[`EuiBadge props iconType is rendered 1`] = `
 exports[`EuiBadge props style is rendered 1`] = `
 <span
   class="euiBadge emotion-euiBadge-default"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -379,7 +400,8 @@ exports[`EuiBadge props style is rendered 1`] = `
 exports[`EuiBadge props style is rendered with accent 1`] = `
 <span
   class="euiBadge emotion-euiBadge-accent"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -396,7 +418,8 @@ exports[`EuiBadge props style is rendered with accent 1`] = `
 exports[`EuiBadge props style is rendered with danger 1`] = `
 <span
   class="euiBadge emotion-euiBadge-danger"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -413,7 +436,8 @@ exports[`EuiBadge props style is rendered with danger 1`] = `
 exports[`EuiBadge props style is rendered with default 1`] = `
 <span
   class="euiBadge emotion-euiBadge-default"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -430,7 +454,8 @@ exports[`EuiBadge props style is rendered with default 1`] = `
 exports[`EuiBadge props style is rendered with hollow 1`] = `
 <span
   class="euiBadge emotion-euiBadge-hollow"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -447,7 +472,8 @@ exports[`EuiBadge props style is rendered with hollow 1`] = `
 exports[`EuiBadge props style is rendered with hollow 2`] = `
 <span
   class="euiBadge emotion-euiBadge-hollow"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -464,7 +490,8 @@ exports[`EuiBadge props style is rendered with hollow 2`] = `
 exports[`EuiBadge props style is rendered with primary 1`] = `
 <span
   class="euiBadge emotion-euiBadge-primary"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -481,7 +508,8 @@ exports[`EuiBadge props style is rendered with primary 1`] = `
 exports[`EuiBadge props style is rendered with success 1`] = `
 <span
   class="euiBadge emotion-euiBadge-success"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"
@@ -498,7 +526,8 @@ exports[`EuiBadge props style is rendered with success 1`] = `
 exports[`EuiBadge props style is rendered with warning 1`] = `
 <span
   class="euiBadge emotion-euiBadge-warning"
-  style="border:4px solid tomato"
+  style="border: 4px solid tomato;"
+  title="Content"
 >
   <span
     class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
 
 import { EuiBadge, COLORS, ICON_SIDES } from './badge';
 
@@ -24,23 +24,25 @@ describe('EuiBadge', () => {
   );
 
   test('is rendered', () => {
-    const component = render(<EuiBadge {...requiredProps}>Content</EuiBadge>);
+    const { container } = render(
+      <EuiBadge {...requiredProps}>Content</EuiBadge>
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is disabled', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge isDisabled {...requiredProps}>
         Content
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with onClick provided', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge
         {...requiredProps}
         onClick={jest.fn()}
@@ -50,21 +52,21 @@ describe('EuiBadge', () => {
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with href provided', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge {...requiredProps} href="/#/">
         Content
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with iconOnClick provided', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge
         {...requiredProps}
         iconOnClick={jest.fn()}
@@ -74,11 +76,11 @@ describe('EuiBadge', () => {
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with iconOnClick and onClick provided', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge
         {...requiredProps}
         iconOnClick={jest.fn()}
@@ -90,11 +92,11 @@ describe('EuiBadge', () => {
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with iconOnClick and href provided', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge
         {...requiredProps}
         iconOnClick={jest.fn()}
@@ -105,11 +107,11 @@ describe('EuiBadge', () => {
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with href and rel provided', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadge
         {...requiredProps}
         iconOnClick={jest.fn()}
@@ -121,52 +123,56 @@ describe('EuiBadge', () => {
       </EuiBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('iconType', () => {
       it('is rendered', () => {
-        const component = render(<EuiBadge iconType="user">Content</EuiBadge>);
+        const { container } = render(
+          <EuiBadge iconType="user">Content</EuiBadge>
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('color', () => {
       COLORS.forEach((color) => {
         it(`${color} is rendered`, () => {
-          const component = render(<EuiBadge color={color}>Content</EuiBadge>);
+          const { container } = render(
+            <EuiBadge color={color}>Content</EuiBadge>
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
       it('accepts rgba', () => {
-        const component = render(
+        const { container } = render(
           <EuiBadge color="rgba(255,255,255,1)">Content</EuiBadge>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       it('accepts hex', () => {
-        const component = render(<EuiBadge color="#333">Content</EuiBadge>);
+        const { container } = render(<EuiBadge color="#333">Content</EuiBadge>);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('iconSide', () => {
       ICON_SIDES.forEach((iconSide) => {
         it(`${iconSide} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiBadge iconType="user" iconSide={iconSide}>
               Content
             </EuiBadge>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -175,31 +181,33 @@ describe('EuiBadge', () => {
       const style = { border: '4px solid tomato' };
 
       it('is rendered', () => {
-        const component = render(<EuiBadge style={style}>Content</EuiBadge>);
+        const { container } = render(
+          <EuiBadge style={style}>Content</EuiBadge>
+        );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       COLORS.forEach((color) => {
         it(`is rendered with ${color}`, () => {
-          const component = render(
+          const { container } = render(
             <EuiBadge style={style} color={color}>
               Content
             </EuiBadge>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
 
       it('is rendered with hollow', () => {
-        const component = render(
+        const { container } = render(
           <EuiBadge style={style} color="hollow">
             Content
           </EuiBadge>
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/badge/badge_group/__snapshots__/badge_group.test.tsx.snap
+++ b/src/components/badge/badge_group/__snapshots__/badge_group.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`EuiBadgeGroup is rendered 1`] = `
 >
   <span
     class="euiBadge emotion-euiBadge-default"
+    title="Content"
   >
     <span
       class="euiBadge__content emotion-euiBadge__content"

--- a/src/components/badge/badge_group/badge_group.test.tsx
+++ b/src/components/badge/badge_group/badge_group.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiBadge } from '../badge';
 import { EuiBadgeGroup, GUTTER_SIZES } from './badge_group';
@@ -18,21 +18,21 @@ describe('EuiBadgeGroup', () => {
   shouldRenderCustomStyles(<EuiBadgeGroup />);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiBadgeGroup {...requiredProps}>
         <EuiBadge>Content</EuiBadge>
       </EuiBadgeGroup>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('gutterSize', () => {
     GUTTER_SIZES.forEach((size) => {
       it(`${size} is rendered`, () => {
-        const component = render(<EuiBadgeGroup gutterSize={size} />);
+        const { container } = render(<EuiBadgeGroup gutterSize={size} />);
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/badge/beta_badge/beta_badge.test.tsx
+++ b/src/components/badge/beta_badge/beta_badge.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiBetaBadge, COLORS, SIZES, ALIGNMENTS } from './beta_badge';
 
@@ -20,18 +20,22 @@ describe('EuiBetaBadge', () => {
   );
 
   test('is rendered', () => {
-    const component = render(<EuiBetaBadge label="Beta" {...requiredProps} />);
+    const { container } = render(
+      <EuiBetaBadge label="Beta" {...requiredProps} />
+    );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(<EuiBetaBadge label="Beta" color={color} />);
+          const { container } = render(
+            <EuiBetaBadge label="Beta" color={color} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -39,27 +43,31 @@ describe('EuiBetaBadge', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(<EuiBetaBadge label="Beta" size={size} />);
+          const { container } = render(
+            <EuiBetaBadge label="Beta" size={size} />
+          );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     test('iconType', () => {
-      const component = render(<EuiBetaBadge label="Beta" iconType="beta" />);
+      const { container } = render(
+        <EuiBetaBadge label="Beta" iconType="beta" />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('single letter', () => {
-      const component = render(<EuiBetaBadge label="B" />);
+      const { container } = render(<EuiBetaBadge label="B" />);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('tooltip and anchorProps are rendered', () => {
-      const component = render(
+      const { container } = render(
         <EuiBetaBadge
           label="Beta"
           tooltipContent="Tooltip"
@@ -70,17 +78,17 @@ describe('EuiBetaBadge', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('alignement', () => {
       ALIGNMENTS.forEach((alignment) => {
         test(`${alignment} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiBetaBadge label="Beta" alignment={alignment} />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/badge/notification_badge/badge_notification.test.tsx
+++ b/src/components/badge/notification_badge/badge_notification.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiNotificationBadge, COLORS, SIZES } from './badge_notification';
 
@@ -17,22 +17,22 @@ describe('EuiNotificationBadge', () => {
   shouldRenderCustomStyles(<EuiNotificationBadge>1</EuiNotificationBadge>);
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiNotificationBadge {...requiredProps}>5</EuiNotificationBadge>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('props', () => {
     describe('color', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiNotificationBadge color={color}>5</EuiNotificationBadge>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -40,11 +40,11 @@ describe('EuiNotificationBadge', () => {
     describe('size', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiNotificationBadge size={size}>5</EuiNotificationBadge>
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
+        title="Animals"
       >
         Animals
       </a>
@@ -28,6 +29,7 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Metazoans"
       >
         Metazoans
       </span>
@@ -62,6 +64,7 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
     >
       <button
         class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page-isTruncated"
+        title="Reptiles"
         type="button"
       >
         Reptiles
@@ -87,6 +90,7 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -113,6 +117,7 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
+        title="Animals"
       >
         Animals
       </a>
@@ -123,6 +128,7 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Metazoans"
       >
         Metazoans
       </span>
@@ -170,6 +176,7 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Edit"
       >
         Edit
       </span>
@@ -183,6 +190,7 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
         class="euiLink euiBreadcrumb__content emotion-euiLink-text-euiBreadcrumb__content-page-isTruncatedLast"
         href="#"
         rel="noreferrer"
+        title="test"
       >
         test
       </a>
@@ -208,6 +216,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
+        title="Animals"
       >
         Animals
       </a>
@@ -218,6 +227,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Metazoans"
       >
         Metazoans
       </span>
@@ -228,6 +238,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Chordates"
       >
         Chordates
       </span>
@@ -238,6 +249,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Nebulosa subspecies is also a real mouthful, especially for creatures without mouths"
       >
         Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
       </span>
@@ -248,6 +260,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Tetrapods"
       >
         Tetrapods
       </span>
@@ -258,6 +271,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
     >
       <button
         class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page-isTruncated"
+        title="Reptiles"
         type="button"
       >
         Reptiles
@@ -283,6 +297,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -330,6 +345,7 @@ exports[`EuiBreadcrumbs props max renders 1 item 1`] = `
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -355,6 +371,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
+        title="Animals"
       >
         Animals
       </a>
@@ -365,6 +382,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Metazoans"
       >
         Metazoans
       </span>
@@ -375,6 +393,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Chordates"
       >
         Chordates
       </span>
@@ -385,6 +404,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Nebulosa subspecies is also a real mouthful, especially for creatures without mouths"
       >
         Nebulosa subspecies is also a real mouthful, especially for creatures without mouths
       </span>
@@ -395,6 +415,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Tetrapods"
       >
         Tetrapods
       </span>
@@ -405,6 +426,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
     >
       <button
         class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page-isTruncated"
+        title="Reptiles"
         type="button"
       >
         Reptiles
@@ -430,6 +452,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -455,6 +478,7 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
+        title="Animals"
       >
         Animals
       </a>
@@ -465,6 +489,7 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Metazoans"
       >
         Metazoans
       </span>
@@ -499,6 +524,7 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
     >
       <button
         class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page-isTruncated"
+        title="Reptiles"
         type="button"
       >
         Reptiles
@@ -524,6 +550,7 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -549,6 +576,7 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
+        title="Animals"
       >
         Animals
       </a>
@@ -559,6 +587,7 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued"
+        title="Metazoans"
       >
         Metazoans
       </span>
@@ -593,6 +622,7 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
     >
       <button
         class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page-isTruncated"
+        title="Reptiles"
         type="button"
       >
         Reptiles
@@ -618,6 +648,7 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -665,6 +696,7 @@ exports[`EuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default"
+        title="Edit"
       >
         Edit
       </span>
@@ -687,6 +719,7 @@ exports[`EuiBreadcrumbs truncation setting truncate on breadcrumbs parents casca
     >
       <span
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-euiTextColor-subdued"
+        title="A"
       >
         A
       </span>
@@ -698,6 +731,7 @@ exports[`EuiBreadcrumbs truncation setting truncate on breadcrumbs parents casca
       <span
         aria-current="page"
         class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-euiTextColor-default"
+        title="B"
       >
         B
       </span>

--- a/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps, replaceEmotionPrefix } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiBreadcrumbs, EuiBreadcrumb } from './';
 
@@ -62,40 +62,38 @@ describe('EuiBreadcrumbs', () => {
   );
 
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiBreadcrumbs {...requiredProps} breadcrumbs={breadcrumbs} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered with final item as link', () => {
     const customBreadcrumbs = [...breadcrumbs, { text: 'test', href: '#' }];
-    const component = render(
+    const { container } = render(
       <EuiBreadcrumbs {...requiredProps} breadcrumbs={customBreadcrumbs} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('truncation', () => {
     test('setting truncate on breadcrumbs parents cascades down to all children', () => {
-      const component = render(
+      const { container } = render(
         <EuiBreadcrumbs
           breadcrumbs={[{ text: 'A' }, { text: 'B' }]}
           truncate={false}
         />
       );
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
-    const getBreadcrumbClass = (component: Cheerio, dataTestSubj: string) =>
-      replaceEmotionPrefix(
-        component.find(`[data-test-subj=${dataTestSubj}]`).attr('class')
-      );
+    const getBreadcrumbClass = (element: HTMLElement) =>
+      replaceEmotionPrefix(element.className);
 
     test('child breadcrumbs can override truncate set on parent breadcrumbs', () => {
-      const component = render(
+      const { getByTestSubject } = render(
         <>
           <EuiBreadcrumbs
             breadcrumbs={[
@@ -113,10 +111,10 @@ describe('EuiBreadcrumbs', () => {
           />
         </>
       );
-      expect(getBreadcrumbClass(component, 'A')).toEqual(
+      expect(getBreadcrumbClass(getByTestSubject('A'))).toEqual(
         'emotion-euiBreadcrumb__content-page-euiTextColor-subdued'
       );
-      expect(getBreadcrumbClass(component, 'C')).toEqual(
+      expect(getBreadcrumbClass(getByTestSubject('C'))).toEqual(
         'emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-subdued'
       );
     });
@@ -124,7 +122,7 @@ describe('EuiBreadcrumbs', () => {
     describe('last breadcrumb', () => {
       describe('if the parent truncate is true and the last breadcrumb does not have its own truncate property', () => {
         it('sets a isTruncatedLast style that allows the last breadcrumb to occupy the remaining width of the breadcrumbs line', () => {
-          const component = render(
+          const { getByTestSubject } = render(
             <EuiBreadcrumbs
               breadcrumbs={[
                 { text: 'A' },
@@ -133,7 +131,7 @@ describe('EuiBreadcrumbs', () => {
               truncate
             />
           );
-          expect(getBreadcrumbClass(component, 'last')).toEqual(
+          expect(getBreadcrumbClass(getByTestSubject('last'))).toEqual(
             'emotion-euiBreadcrumb__content-page-isTruncatedLast-euiTextColor-default'
           );
         });
@@ -141,7 +139,7 @@ describe('EuiBreadcrumbs', () => {
 
       describe('if the last breadcrumb has its own truncate property', () => {
         it('uses the normal isTruncated if truncate is true', () => {
-          const component = render(
+          const { getByTestSubject } = render(
             <EuiBreadcrumbs
               breadcrumbs={[
                 { text: 'A' },
@@ -150,13 +148,13 @@ describe('EuiBreadcrumbs', () => {
               truncate
             />
           );
-          expect(getBreadcrumbClass(component, 'last')).toEqual(
+          expect(getBreadcrumbClass(getByTestSubject('last'))).toEqual(
             'emotion-euiBreadcrumb__content-page-isTruncated-euiTextColor-default'
           );
         });
 
         it('does not set any truncation classes if truncate is false', () => {
-          const component = render(
+          const { getByTestSubject } = render(
             <EuiBreadcrumbs
               breadcrumbs={[
                 { text: 'A' },
@@ -165,7 +163,7 @@ describe('EuiBreadcrumbs', () => {
               truncate
             />
           );
-          expect(getBreadcrumbClass(component, 'last')).toEqual(
+          expect(getBreadcrumbClass(getByTestSubject('last'))).toEqual(
             'emotion-euiBreadcrumb__content-page-euiTextColor-default'
           );
         });
@@ -176,50 +174,50 @@ describe('EuiBreadcrumbs', () => {
   describe('props', () => {
     describe('responsive', () => {
       test('is rendered', () => {
-        const component = render(
+        const { container } = render(
           <EuiBreadcrumbs breadcrumbs={breadcrumbs} responsive />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered as false', () => {
-        const component = render(
+        const { container } = render(
           <EuiBreadcrumbs breadcrumbs={breadcrumbs} responsive={false} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('is rendered with custom breakpoints', () => {
-        const component = render(
+        const { container } = render(
           <EuiBreadcrumbs
             breadcrumbs={breadcrumbs}
             responsive={{ xs: 1, s: 1, m: 1, l: 1, xl: 1 }}
           />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     describe('max', () => {
       test('renders 1 item', () => {
-        const component = render(
+        const { container } = render(
           <EuiBreadcrumbs breadcrumbs={breadcrumbs} max={1} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test('renders all items with null', () => {
-        const component = render(
+        const { container } = render(
           <EuiBreadcrumbs breadcrumbs={breadcrumbs} max={null} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
 
       test("doesn't break when max exceeds the number of breadcrumbs", () => {
-        const component = render(
+        const { container } = render(
           <EuiBreadcrumbs breadcrumbs={breadcrumbs} max={20} />
         );
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
   });

--- a/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/src/components/card/__snapshots__/card.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`EuiCard props a null icon 1`] = `
 exports[`EuiCard props accepts div props like style 1`] = `
 <div
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
-  style="min-width:0"
+  style="min-width: 0;"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
+import { render } from '../../test/rtl';
 
 import { EuiCard, ALIGNMENTS } from './card';
 
@@ -18,7 +19,7 @@ import { COLORS, SIZES } from '../panel/panel';
 
 describe('EuiCard', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCard
         title="Card title"
         description="Card description"
@@ -26,7 +27,7 @@ describe('EuiCard', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(
@@ -36,7 +37,7 @@ describe('EuiCard', () => {
 
   describe('props', () => {
     test('icon', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -44,11 +45,11 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('an avatar icon', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -56,11 +57,11 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('a null icon', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -68,19 +69,19 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('hasBorder', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard title="Card title" description="Card description" hasBorder />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('horizontal', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -88,11 +89,11 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('image', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -107,16 +108,16 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('href', () => {
       it('supports href as a link', () => {
-        const component = render(
+        const { container } = render(
           <EuiCard title="Hoi" description="There" href="#" />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
@@ -154,7 +155,7 @@ describe('EuiCard', () => {
     });
 
     test('titleElement', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -162,11 +163,11 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('titleElement with nodes', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title={
             <EuiI18n token="euiCard.title" default="Card title" /> // eslint-disable-line
@@ -176,11 +177,11 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('titleSize', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -188,12 +189,12 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('accepts div props', () => {
       test('like style', () => {
-        const component = render(
+        const { container } = render(
           <EuiCard
             title="Card title"
             description="Card description"
@@ -201,12 +202,12 @@ describe('EuiCard', () => {
           />
         );
 
-        expect(component).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
       });
     });
 
     test('footer', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -214,29 +215,29 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('children', () => {
-      const component = render(<EuiCard title="Card title">Child</EuiCard>);
+      const { container } = render(<EuiCard title="Card title">Child</EuiCard>);
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('children with description', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard title="Card title" description="Card description">
           Child
         </EuiCard>
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('textAlign', () => {
       ALIGNMENTS.forEach((textAlign) => {
         test(textAlign, () => {
-          const component = render(
+          const { container } = render(
             <EuiCard
               title="Card title"
               description="Card description"
@@ -244,23 +245,23 @@ describe('EuiCard', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     test('isDisabled', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard title="Card title" description="Card description" isDisabled />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     describe('paddingSize', () => {
       SIZES.forEach((size) => {
         test(`${size} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiCard
               title="Card title"
               description="Card description"
@@ -268,7 +269,7 @@ describe('EuiCard', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
@@ -276,7 +277,7 @@ describe('EuiCard', () => {
     describe('display', () => {
       COLORS.forEach((color) => {
         test(`${color} is rendered`, () => {
-          const component = render(
+          const { container } = render(
             <EuiCard
               title="Card title"
               description="Card description"
@@ -284,13 +285,13 @@ describe('EuiCard', () => {
             />
           );
 
-          expect(component).toMatchSnapshot();
+          expect(container.firstChild).toMatchSnapshot();
         });
       });
     });
 
     test('selectable', () => {
-      const component = render(
+      const { container } = render(
         <EuiCard
           title="Card title"
           description="Card description"
@@ -300,12 +301,12 @@ describe('EuiCard', () => {
         />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 
   test('horizontal selectable', () => {
-    const component = render(
+    const { container } = render(
       <EuiCard
         title="Card title"
         description="Card description"
@@ -316,11 +317,11 @@ describe('EuiCard', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('betaBadgeProps renders href', () => {
-    const component = render(
+    const { container } = render(
       <EuiCard
         title="Card title"
         description="Card description"
@@ -331,6 +332,6 @@ describe('EuiCard', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/card/card_select/card_select.test.tsx
+++ b/src/components/card/card_select/card_select.test.tsx
@@ -7,50 +7,54 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { render } from '../../../test/rtl';
 
 import { EuiCardSelect } from './card_select';
 
 describe('EuiCardSelect', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCardSelect onClick={() => {}} {...requiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(<EuiCardSelect />);
 
   describe('props', () => {
     test('isSelected', () => {
-      const component = render(<EuiCardSelect onClick={() => {}} isSelected />);
+      const { container } = render(
+        <EuiCardSelect onClick={() => {}} isSelected />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('isDisabled', () => {
-      const component = render(<EuiCardSelect onClick={() => {}} isDisabled />);
+      const { container } = render(
+        <EuiCardSelect onClick={() => {}} isDisabled />
+      );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can override color', () => {
-      const component = render(
+      const { container } = render(
         <EuiCardSelect onClick={() => {}} color="danger" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
 
     test('can override text', () => {
-      const component = render(
+      const { container } = render(
         <EuiCardSelect onClick={() => {}} children="Custom text" />
       );
 
-      expect(component).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/components/card/checkable_card/__snapshots__/checkable_card.test.tsx.snap
+++ b/src/components/card/checkable_card/__snapshots__/checkable_card.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`EuiCheckableCard is rendered 1`] = `
         class="euiRadio__input"
         id="id"
         type="radio"
+        value=""
       />
       <div
         class="euiRadio__circle"
@@ -84,6 +85,7 @@ exports[`EuiCheckableCard renders children 1`] = `
         class="euiRadio__input"
         id="id"
         type="radio"
+        value=""
       />
       <div
         class="euiRadio__circle"
@@ -125,6 +127,7 @@ exports[`EuiCheckableCard renders disabled 1`] = `
         disabled=""
         id="id"
         type="radio"
+        value=""
       />
       <div
         class="euiRadio__circle"
@@ -158,6 +161,7 @@ exports[`EuiCheckableCard renders panel props 1`] = `
         class="euiRadio__input"
         id="id"
         type="radio"
+        value=""
       />
       <div
         class="euiRadio__circle"

--- a/src/components/card/checkable_card/checkable_card.test.tsx
+++ b/src/components/card/checkable_card/checkable_card.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { render } from 'enzyme';
-import { requiredProps } from '../../../test/required_props';
 import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
 
 import { EuiCheckableCard } from './checkable_card';
 
@@ -21,11 +21,11 @@ const checkablePanelRequiredProps = {
 
 describe('EuiCheckableCard', () => {
   test('is rendered', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckableCard {...requiredProps} {...checkablePanelRequiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   shouldRenderCustomStyles(
@@ -42,7 +42,7 @@ describe('EuiCheckableCard', () => {
   );
 
   test('renders panel props', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckableCard
         hasBorder={false}
         hasShadow={true}
@@ -50,29 +50,29 @@ describe('EuiCheckableCard', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders disabled', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckableCard disabled={true} {...checkablePanelRequiredProps} />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders children', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckableCard {...checkablePanelRequiredProps}>
         Child
       </EuiCheckableCard>
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders a checkbox when specified', () => {
-    const component = render(
+    const { container } = render(
       <EuiCheckableCard
         {...requiredProps}
         {...checkablePanelRequiredProps}
@@ -80,6 +80,6 @@ describe('EuiCheckableCard', () => {
       />
     );
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/services/emotion/clone_element.test.tsx
+++ b/src/services/emotion/clone_element.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { css } from '@emotion/react';
-import { render } from 'enzyme';
+import { render } from '../../test/rtl';
 
 import { cloneElementWithCss } from './clone_element';
 
@@ -18,24 +18,24 @@ describe('cloneElementWithCss', () => {
   };
 
   it('correctly renders css on elements that do not already have a `css` property', () => {
-    const component = render(
+    const { container } = render(
       <CloningParent css={{ color: 'red' }}>
         <div>hello world</div>
       </CloningParent>
     );
 
-    expect(component).toMatchInlineSnapshot(`
+    expect(container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="css-1h3ogp1-component"
+        class="css-hwfcu5"
       >
         hello world
       </div>
     `);
-    expect(component).toHaveStyleRule('color', 'red');
+    expect(container.firstChild).toHaveStyleRule('color', 'red');
   });
 
   it('combines css properties on cloned elements that already have a `css` property', () => {
-    const component = render(
+    const { container } = render(
       <CloningParent css={{ color: 'red' }}>
         <div
           css={[
@@ -49,15 +49,15 @@ describe('cloneElementWithCss', () => {
       </CloningParent>
     );
 
-    expect(component).toMatchInlineSnapshot(`
+    expect(container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="css-88aly5-component-component-component"
+        class="css-1x864jj-CloningParent"
       >
         hello world
       </div>
     `);
-    expect(component).toHaveStyleRule('color', 'red');
-    expect(component).toHaveStyleRule('background-color', 'blue');
+    expect(container.firstChild).toHaveStyleRule('color', 'red');
+    expect(container.firstChild).toHaveStyleRule('background-color', 'blue');
   });
 
   it('handles components', () => {
@@ -67,38 +67,38 @@ describe('cloneElementWithCss', () => {
       </div>
     );
 
-    const component = render(
+    const { container } = render(
       <CloningParent css={{ color: 'red' }}>
         <TestComponent css={{ border: '1px solid black' }} />
       </CloningParent>
     );
 
-    expect(component).toMatchInlineSnapshot(`
+    expect(container.firstChild).toMatchInlineSnapshot(`
       <div
-        class="css-1fcrfq4-TestComponent-component-component"
+        class="css-pie7sa-TestComponent-CloningParent"
       >
         hello world
       </div>
     `);
-    expect(component).toHaveStyleRule('color', 'red');
-    expect(component).toHaveStyleRule('background-color', 'blue');
-    expect(component).toHaveStyleRule('border', '1px solid black');
+    expect(container.firstChild).toHaveStyleRule('color', 'red');
+    expect(container.firstChild).toHaveStyleRule('background-color', 'blue');
+    expect(container.firstChild).toHaveStyleRule('border', '1px solid black');
   });
 
   it('does nothing if no css property is set', () => {
-    const component = render(
+    const { container } = render(
       <CloningParent className="test">
         <div>hello world</div>
       </CloningParent>
     );
 
-    expect(component).toMatchInlineSnapshot(`
+    expect(container.firstChild).toMatchInlineSnapshot(`
       <div
         class="test"
       >
         hello world
       </div>
     `);
-    expect(component).not.toHaveStyleRule('color', 'red');
+    expect(container.firstChild).not.toHaveStyleRule('color', 'red');
   });
 });


### PR DESCRIPTION
## Summary

This PR converts `EuiCard`, `EuiBreadcrumbs`, `EuiBadge`, `EuiAvatar`, `EuiAccordion`, `EuiScreenReaderLive`, `EuiScreenReaderOnly` and `cloneElementWithCss` unit tests using Enzyme's render() function to RTL render() counterpart to reduce our tech debt.

## QA

* Make sure all unit tests are passing
* Verify the updated snapshots don't contain any unexpected changes

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
