### PR TITLE
[EuiFilterSelectItem] Convert to Emotion + mark as deprecated

### DIFF
--- a/src-docs/src/views/filter_group/filter_group.js
+++ b/src-docs/src/views/filter_group/filter_group.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 
 import {
-  EuiPopover,
   EuiFilterGroup,
   EuiFilterButton,
+  EuiPopover,
+  EuiSelectableMessage,
   EuiIcon,
   EuiSpacer,
 } from '../../../../src/components';
@@ -85,13 +86,11 @@ export default () => {
         closePopover={closePopover}
         panelPaddingSize="none"
       >
-        <div className="euiFilterSelect__note">
-          <div className="euiFilterSelect__noteContent">
-            <EuiIcon type="minusInCircle" />
-            <EuiSpacer size="xs" />
-            <p>No filters found</p>
-          </div>
-        </div>
+        <EuiSelectableMessage>
+          <EuiIcon type="minusInCircle" />
+          <EuiSpacer size="xs" />
+          <p>No filters found</p>
+        </EuiSelectableMessage>
       </EuiPopover>
       <EuiFilterButton
         numFilters={12}

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -531,7 +531,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
       >
         <button
           aria-selected="false"
-          class="euiFilterSelectItem"
+          class="euiFilterSelectItem emotion-euiFilterSelectItem"
           id="generated-id__option-0"
           role="option"
           style="position: absolute; left: 0px; top: 0px; height: 29px; width: 100%;"
@@ -542,7 +542,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
             class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
           >
             <span
-              class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+              class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
             >
               <span
                 class="euiComboBoxOption__contentWrapper"
@@ -567,7 +567,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
         </button>
         <button
           aria-selected="false"
-          class="euiFilterSelectItem"
+          class="euiFilterSelectItem emotion-euiFilterSelectItem"
           id="generated-id__option-1"
           role="option"
           style="position: absolute; left: 0px; top: 29px; height: 29px; width: 100%;"
@@ -578,7 +578,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
             class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
           >
             <span
-              class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+              class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
             >
               <span
                 class="euiComboBoxOption__contentWrapper"
@@ -684,7 +684,7 @@ exports[`props options list is rendered 1`] = `
         >
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             data-test-subj="titanOption"
             id="generated-id__option-0"
             role="option"
@@ -696,7 +696,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -712,7 +712,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-1"
             role="option"
             style="position: absolute; left: 0px; top: 29px; height: 29px; width: 100%;"
@@ -723,7 +723,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -739,7 +739,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-2"
             role="option"
             style="position: absolute; left: 0px; top: 58px; height: 29px; width: 100%;"
@@ -750,7 +750,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -766,7 +766,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-3"
             role="option"
             style="position: absolute; left: 0px; top: 87px; height: 29px; width: 100%;"
@@ -777,7 +777,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -793,7 +793,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-4"
             role="option"
             style="position: absolute; left: 0px; top: 116px; height: 29px; width: 100%;"
@@ -804,7 +804,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -820,7 +820,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-5"
             role="option"
             style="position: absolute; left: 0px; top: 145px; height: 29px; width: 100%;"
@@ -831,7 +831,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -847,7 +847,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-6"
             role="option"
             style="position: absolute; left: 0px; top: 174px; height: 29px; width: 100%;"
@@ -858,7 +858,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -874,7 +874,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-7"
             role="option"
             style="position: absolute; left: 0px; top: 203px; height: 29px; width: 100%;"
@@ -885,7 +885,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"
@@ -901,7 +901,7 @@ exports[`props options list is rendered 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="euiFilterSelectItem"
+            class="euiFilterSelectItem emotion-euiFilterSelectItem"
             id="generated-id__option-8"
             role="option"
             style="position: absolute; left: 0px; top: 232px; height: 29px; width: 100%;"
@@ -912,7 +912,7 @@ exports[`props options list is rendered 1`] = `
               class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
             >
               <span
-                class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+                class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
               >
                 <span
                   class="euiComboBoxOption__contentWrapper"

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { ReactNode } from 'react';
+import { fireEvent } from '@testing-library/react';
 import { shallow, mount } from 'enzyme';
 import { render } from '../../test/rtl';
 import {
@@ -297,18 +298,22 @@ test('does not show multiple checkmarks with duplicate labels', () => {
       label: 'Tethys',
     },
   ];
-  const component = mount(
+  const { baseElement, getByTestSubject } = render(
     <EuiComboBox
       singleSelection={{ asPlainText: true }}
       options={options}
       selectedOptions={[options[1]]}
     />
   );
+  fireEvent.focus(getByTestSubject('comboBoxSearchInput'));
 
-  const searchInput = findTestSubject(component, 'comboBoxSearchInput');
-  searchInput.simulate('focus');
-
-  expect(component.find('EuiFilterSelectItem[checked="on"]').length).toBe(1);
+  const dropdownOptions = baseElement.querySelectorAll('.euiFilterSelectItem');
+  expect(
+    dropdownOptions[0]!.querySelector('[data-euiicon-type="check"]')
+  ).toBeFalsy();
+  expect(
+    dropdownOptions[1]!.querySelector('[data-euiicon-type="check"]')
+  ).toBeTruthy();
 });
 
 describe('behavior', () => {

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -44,7 +44,7 @@ import {
   EuiComboBoxOptionsListPosition,
   EuiComboBoxSingleSelectionShape,
 } from './types';
-import { EuiFilterSelectItem } from '../filter_group';
+import { EuiFilterSelectItemClass } from '../filter_group/filter_select_item';
 import AutosizeInput from 'react-input-autosize';
 import { CommonProps } from '../common';
 import { EuiFormControlLayoutProps } from '../form';
@@ -279,7 +279,7 @@ export class EuiComboBox<T> extends Component<
     this.toggleButtonRefInstance = ref;
   };
 
-  optionsRefInstances: Array<RefInstance<EuiFilterSelectItem>> = [];
+  optionsRefInstances: Array<RefInstance<EuiFilterSelectItemClass>> = [];
   optionRefCallback: EuiComboBoxOptionsListProps<T>['optionRef'] = (
     index,
     ref

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -27,6 +27,7 @@ import { EuiComboBoxTitle } from './combo_box_title';
 import { EuiI18n } from '../../i18n';
 import {
   EuiFilterSelectItem,
+  EuiFilterSelectItemClass,
   FilterChecked,
 } from '../../filter_group/filter_select_item';
 import { htmlIdGenerator } from '../../../services';
@@ -73,7 +74,10 @@ export type EuiComboBoxOptionsListProps<T> = CommonProps &
     onOptionClick?: OptionHandler<T>;
     onOptionEnterKey?: OptionHandler<T>;
     onScroll?: ListProps['onScroll'];
-    optionRef: (index: number, node: RefInstance<EuiFilterSelectItem>) => void;
+    optionRef: (
+      index: number,
+      node: RefInstance<EuiFilterSelectItemClass>
+    ) => void;
     /**
      * Array of EuiComboBoxOptionOption objects. See #EuiComboBoxOptionOption
      */

--- a/src/components/filter_group/__snapshots__/filter_select_item.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_select_item.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiFilterSelectItem is rendered 1`] = `
+exports[`EuiFilterSelectItem renders 1`] = `
 <button
   aria-label="aria-label"
-  class="euiFilterSelectItem testClass1 testClass2 emotion-euiTestCss"
+  class="euiFilterSelectItem testClass1 testClass2 emotion-euiFilterSelectItem-euiTestCss"
   data-test-subj="test subject string"
   role="option"
   type="button"

--- a/src/components/filter_group/__snapshots__/filter_select_item.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_select_item.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`EuiFilterSelectItem renders 1`] = `
       />
     </div>
     <span
-      class="euiFlexItem euiFilterSelectItem__content emotion-euiFlexItem-grow-1"
+      class="euiFlexItem euiFilterSelectItem__content eui-textTruncate emotion-euiFlexItem-grow-1"
     />
   </span>
 </button>

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,14 +1,3 @@
-.euiFilterSelectItem {
-  @include euiInteractiveStates;
-  outline-offset: -$euiFocusRingSize;
-
-  &:focus,
-  &-isFocused {
-    @include euiFocusBackground;
-    color: $euiColorPrimary;
-  }
-}
-
 .euiFilterSelectItem__content {
   @include euiTextTruncate;
 }

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -4,16 +4,3 @@
   overflow-y: auto;
   max-height: $euiSize * 30;
 }
-
-.euiFilterSelect__note {
-  height: $euiSize * 4;
-  text-align: center;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-}
-
-.euiFilterSelect__noteContent {
-  color: $euiColorDarkShade;
-  font-size: $euiFontSizeS;
-}

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,6 +1,0 @@
-.euiFilterSelect__items {
-  @include euiScrollBar;
-
-  overflow-y: auto;
-  max-height: $euiSize * 30;
-}

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,5 +1,4 @@
 .euiFilterSelectItem {
-  @include euiFontSizeS;
   @include euiInteractiveStates;
 
   padding: $euiSizeXS $euiSizeM;

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,7 +1,3 @@
-.euiFilterSelectItem__content {
-  @include euiTextTruncate;
-}
-
 .euiFilterSelect__items {
   @include euiScrollBar;
 

--- a/src/components/filter_group/_filter_select_item.scss
+++ b/src/components/filter_group/_filter_select_item.scss
@@ -1,13 +1,5 @@
 .euiFilterSelectItem {
   @include euiInteractiveStates;
-
-  padding: $euiSizeXS $euiSizeM;
-  display: block; // Necessary to make sure it doesn't force the whole popover to be too wide
-  width: 100%;
-  text-align: left;
-  color: $euiTextColor;
-  border-bottom: $euiBorderThin;
-  border-color: darken($euiColorLightestShade, 2%);
   outline-offset: -$euiFocusRingSize;
 
   &:focus,

--- a/src/components/filter_group/_index.scss
+++ b/src/components/filter_group/_index.scss
@@ -1,1 +1,0 @@
-@import 'filter_select_item';

--- a/src/components/filter_group/filter_select_item.styles.ts
+++ b/src/components/filter_group/filter_select_item.styles.ts
@@ -8,7 +8,7 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, transparentize } from '../../services';
 import {
   logicalCSS,
   logicalShorthandCSS,
@@ -24,6 +24,10 @@ export const euiFilterSelectItemStyles = (euiThemeContext: UseEuiTheme) => {
     background-color: ${euiTheme.focus.backgroundColor};
     outline-offset: -${euiTheme.focus.width};
     text-decoration: underline;
+
+    &:disabled {
+      background-color: ${transparentize(euiTheme.colors.disabled, 0.1)};
+    }
   `;
 
   return {

--- a/src/components/filter_group/filter_select_item.styles.ts
+++ b/src/components/filter_group/filter_select_item.styles.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+import { euiFontSize } from '../../global_styling';
+
+export const euiFilterSelectItemStyles = (euiThemeContext: UseEuiTheme) => {
+  return {
+    euiFilterSelectItem: css`
+      ${euiFontSize(euiThemeContext, 's')}
+    `,
+  };
+};

--- a/src/components/filter_group/filter_select_item.styles.ts
+++ b/src/components/filter_group/filter_select_item.styles.ts
@@ -9,12 +9,32 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import { euiFontSize } from '../../global_styling';
+import {
+  logicalCSS,
+  logicalShorthandCSS,
+  logicalTextAlignCSS,
+  euiFontSize,
+} from '../../global_styling';
 
 export const euiFilterSelectItemStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
   return {
     euiFilterSelectItem: css`
+      display: block; /* Necessary to make sure it doesn't force the whole popover to be too wide */
+      ${logicalCSS('width', '100%')}
+      ${logicalShorthandCSS(
+        'padding',
+        `${euiTheme.size.xs} ${euiTheme.size.m}`
+      )}
+
       ${euiFontSize(euiThemeContext, 's')}
+      ${logicalTextAlignCSS('left')}
+
+      color: ${euiTheme.colors.text};
+      ${logicalCSS(
+        'border-bottom',
+        `${euiTheme.border.width.thin} solid ${euiTheme.colors.lightestShade}`
+      )}
     `,
   };
 };

--- a/src/components/filter_group/filter_select_item.styles.ts
+++ b/src/components/filter_group/filter_select_item.styles.ts
@@ -18,6 +18,14 @@ import {
 
 export const euiFilterSelectItemStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
+
+  const focusStyles = `
+    color: ${euiTheme.colors.primary};
+    background-color: ${euiTheme.focus.backgroundColor};
+    outline-offset: -${euiTheme.focus.width};
+    text-decoration: underline;
+  `;
+
   return {
     euiFilterSelectItem: css`
       display: block; /* Necessary to make sure it doesn't force the whole popover to be too wide */
@@ -35,6 +43,24 @@ export const euiFilterSelectItemStyles = (euiThemeContext: UseEuiTheme) => {
         'border-bottom',
         `${euiTheme.border.width.thin} solid ${euiTheme.colors.lightestShade}`
       )}
+
+      &:hover {
+        cursor: pointer;
+        text-decoration: underline;
+      }
+
+      &:focus {
+        ${focusStyles}
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        text-decoration: none;
+        color: ${euiTheme.colors.disabledText};
+      }
+    `,
+    isFocused: css`
+      ${focusStyles}
     `,
   };
 };

--- a/src/components/filter_group/filter_select_item.test.tsx
+++ b/src/components/filter_group/filter_select_item.test.tsx
@@ -9,11 +9,14 @@
 import React from 'react';
 import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
+import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiFilterSelectItem } from './filter_select_item';
 
 describe('EuiFilterSelectItem', () => {
-  test('is rendered', () => {
+  shouldRenderCustomStyles(<EuiFilterSelectItem />);
+
+  it('renders', () => {
     const { container } = render(<EuiFilterSelectItem {...requiredProps} />);
 
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/filter_group/filter_select_item.tsx
+++ b/src/components/filter_group/filter_select_item.tsx
@@ -41,6 +41,12 @@ const resolveIconAndColor = (checked?: FilterChecked) => {
       };
 };
 
+/**
+ * TODO: This component should removed in favor of EuiSelectable usage
+ * once EuiComboBox has been converted to dogfood EuiSelectable.
+ *
+ * @deprecated - Use EuiSelectable instead
+ */
 export class EuiFilterSelectItemClass extends Component<
   WithEuiThemeProps & EuiFilterSelectItemProps
 > {
@@ -125,6 +131,9 @@ export class EuiFilterSelectItemClass extends Component<
   }
 }
 
+/**
+ * @deprecated - Use EuiSelectable instead
+ */
 export const EuiFilterSelectItem = withEuiTheme<EuiFilterSelectItemProps>(
   EuiFilterSelectItemClass
 );

--- a/src/components/filter_group/filter_select_item.tsx
+++ b/src/components/filter_group/filter_select_item.tsx
@@ -114,7 +114,7 @@ export class EuiFilterSelectItemClass extends Component<
         >
           {iconNode}
           <EuiFlexItem
-            className="euiFilterSelectItem__content"
+            className="euiFilterSelectItem__content eui-textTruncate"
             component="span"
           >
             {children}

--- a/src/components/filter_group/filter_select_item.tsx
+++ b/src/components/filter_group/filter_select_item.tsx
@@ -9,11 +9,13 @@
 import React, { ButtonHTMLAttributes, Component } from 'react';
 import classNames from 'classnames';
 
+import { withEuiTheme, WithEuiThemeProps } from '../../services';
 import { CommonProps } from '../common';
 
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
-
 import { EuiIcon } from '../icon';
+
+import { euiFilterSelectItemStyles } from './filter_select_item.styles';
 
 export type FilterChecked = 'on' | 'off';
 export interface EuiFilterSelectItemProps
@@ -39,7 +41,9 @@ const resolveIconAndColor = (checked?: FilterChecked) => {
       };
 };
 
-export class EuiFilterSelectItem extends Component<EuiFilterSelectItemProps> {
+export class EuiFilterSelectItemClass extends Component<
+  WithEuiThemeProps & EuiFilterSelectItemProps
+> {
   static defaultProps = {
     showIcons: true,
   };
@@ -62,6 +66,7 @@ export class EuiFilterSelectItem extends Component<EuiFilterSelectItemProps> {
 
   render() {
     const {
+      theme,
       children,
       className,
       disabled,
@@ -70,6 +75,10 @@ export class EuiFilterSelectItem extends Component<EuiFilterSelectItemProps> {
       showIcons,
       ...rest
     } = this.props;
+
+    const styles = euiFilterSelectItemStyles(theme);
+    const cssStyles = [styles.euiFilterSelectItem];
+
     const classes = classNames(
       'euiFilterSelectItem',
       {
@@ -95,6 +104,7 @@ export class EuiFilterSelectItem extends Component<EuiFilterSelectItemProps> {
         type="button"
         aria-selected={isFocused}
         className={classes}
+        css={cssStyles}
         disabled={disabled}
         aria-disabled={disabled}
         {...rest}
@@ -117,3 +127,7 @@ export class EuiFilterSelectItem extends Component<EuiFilterSelectItemProps> {
     );
   }
 }
+
+export const EuiFilterSelectItem = withEuiTheme<EuiFilterSelectItemProps>(
+  EuiFilterSelectItemClass
+);

--- a/src/components/filter_group/filter_select_item.tsx
+++ b/src/components/filter_group/filter_select_item.tsx
@@ -77,15 +77,12 @@ export class EuiFilterSelectItemClass extends Component<
     } = this.props;
 
     const styles = euiFilterSelectItemStyles(theme);
-    const cssStyles = [styles.euiFilterSelectItem];
+    const cssStyles = [
+      styles.euiFilterSelectItem,
+      isFocused && styles.isFocused,
+    ];
 
-    const classes = classNames(
-      'euiFilterSelectItem',
-      {
-        'euiFilterSelectItem-isFocused': isFocused,
-      },
-      className
-    );
+    const classes = classNames('euiFilterSelectItem', className);
 
     let iconNode;
     if (showIcons) {

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -9,7 +9,6 @@
 @import 'datagrid/index';
 @import 'drag_and_drop/index';
 @import 'empty_prompt/index';
-@import 'filter_group/index';
 @import 'form/index';
 @import 'header/index';
 @import 'key_pad_menu/index';

--- a/upcoming_changelogs/6982.md
+++ b/upcoming_changelogs/6982.md
@@ -1,0 +1,9 @@
+**Deprecations**
+
+- Deprecated `EuiFilterSelectItem`; Use `EuiSelectable` instead
+
+**CSS-in-JS conversions**
+
+- Converted `EuiFilterSelectItem` to Emotion
+- Removed `.euiFilterSelect__items` CSS; Use `EuiSelectable` instead
+- Removed `.euiFilterSelect__note` and `.euiFilterSelect__noteContent` CSS; Use `EuiSelectableMessage` instead


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6398

This PR:

1. Converts `EuiFilterSelectItem` to Emotion
    - This involves removing several CSS classNames that not being used directly within the EUI component, but instead as separate CSS hooks: `.euiFilterSelect__items`, `.euiFilterSelect__note`, and `.euiFilterSelect__noteContent`

2.  Improves the keyboard "focus" state of disabled items - now uses a clearly disabled background color instead of the previous primary background color

3. Marks `EuiFilterSelectItem` for deprecation - once `EuiComboBox` switches to dogfooding `EuiSelectable`, we should move away from it entirely and request that Kibana usages do so as well

## QA

Note that I opted not to create stories for this component since we'll eventually be removing it. The easiest way to QA it is to view its usage in EuiComboBox, and ensure combo boxes look the same as production: https://eui.elastic.co/pr_6982/#/forms/combo-box

### General checklist

- [x] Checked in both **light and dark** modes
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] ~Added or~ updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only ~and screenreader~ modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] Checked for **breaking changes** and labeled appropriately~

### Emotion checklist

**Kibana usage**

~- [ ] Search Kibana's codebase for `{euiComponent}-` (case sensitive) to check for usage of modifier classes~
~- [ ] If usage exists, consider converting to a `data` attribute so that consumers still have something to hook into~
- [x] Pre-emptively check how your conversion will impact the next Kibana upgrade. This entails searching/grepping through Kibana (excluding `**/target, **/*.snap, **/*.storyshot` for less noise) for `eui{Component}` (case sensitive) to find:
- ~[ ] Any test/query selectors that will need to be updated~ - None
- ~[ ] Any Sass or CSS that will need to be updated, particularly if a component Sass var was deleted~
- [x] Any direct className usages that will need to be refactored (e.g. someone calling the `euiBadge` class on a div instead of simply using the `EuiBadge` component)
   - ⚠️ YES, there are multiple usages of this documented in the changelog that I will open a separate PR for.

---

**General**

- [x] Output CSS matches the previous CSS (works as expected in all browsers)
- [x] Rendered `className(s)` read as expected in snapshots and browsers
~- [ ] Checked component playground~ No playground/docs for this component

---

**Unit tests**

- [x] [`shouldRenderCustomStyles()`](https://github.com/elastic/eui/blob/6054e9b8310bdb106371c0c9ff8bc48e3e0e594b/src/test/internal/render_custom_styles.tsx) test was added and passes with parent component and any nested `childProps` (e.g. `tooltipProps`)
- [x] Converted tests to RTL

---

**Sass/Emotion conversion process**

- [x] Removed component from `src/components/index.scss`
~- [ ] Deleted any `src/amsterdam/overrides/{component}.scss` files (styles within should have been converted to the baseline Emotion styles)~
~- [ ] Converted all global Sass vars/mixins to JS (e.g. `$euiSize` to `euiTheme.size.base`)~
~- [ ] Removed or converted component-specific Sass vars/mixins to exported JS versions~
~- [ ] Listed var/mixin removals in changelog~
~- [ ] Ran `yarn compile-scss` to update var/mixin [JSON files](https://github.com/elastic/eui/tree/main/src-docs/src/views/theme/_json)~
~- [ ] Simplified `calc()` to `mathWithUnits` if possible (if mixing different unit types, this may not be possible)~
~- [ ] Added an `@warn` deprecation message within the `global_styling/mixins/{component}.scss` file~

---

**CSS tech debt**

- [x] Converted side specific padding, margin, and position to `-inline` and `-block` [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) (check inline styles as well as CSS)
~- [ ] Wrapped all animations or transitions in `euiCanAnimate`~
~- [ ] Used `gap` property to add margin between items if using flex~

---

**DOM Cleanup**

- [x] Did **NOT** remove any block/element classNames (e.g. `euiComponent`, `euiComponent__child`)
~- [ ] **SEARCH KIBANA FIRST**: Deleted any modifier classNames or maps if not being used in Kibana.~

---

**Extras/nice-to-have**

- [x] Reduced specificity where possible (usually by reducing nesting and class name chaining)
~- [ ] Documentation pass:~
~- [ ] Check for issues in the backlog that could be a quick fix for that component~
~- [ ] Optional component/code cleanup: consider splitting up the component into multiple children if it's overly verbose or difficult to reason about~
