### PR TITLE
[EuiFilterGroup] Fix responsive styles

### DIFF
--- a/src/components/filter_group/filter_group.styles.ts
+++ b/src/components/filter_group/filter_group.styles.ts
@@ -10,11 +10,7 @@ import { CSSProperties } from 'react';
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import {
-  logicalCSS,
-  mathWithUnits,
-  euiMaxBreakpoint,
-} from '../../global_styling';
+import { logicalCSS, mathWithUnits, euiBreakpoint } from '../../global_styling';
 import { euiFormVariables } from '../form/form.styles';
 import { euiFilterButtonDisplay } from './filter_button.styles';
 
@@ -51,10 +47,10 @@ export const euiFilterGroupStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
 
-      ${euiMaxBreakpoint(euiThemeContext, 's')} {
+      ${euiBreakpoint(euiThemeContext, ['xs', 's'])} {
         flex-wrap: wrap;
       }
-      ${euiMaxBreakpoint(euiThemeContext, 'xs')} {
+      ${euiBreakpoint(euiThemeContext, ['xs'])} {
         /* Force all tiny screens to take up the entire width */
         display: flex;
 

--- a/upcoming_changelogs/6983.md
+++ b/upcoming_changelogs/6983.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFilterGroup`'s responsive styles


### PR DESCRIPTION
## Summary

🤦 I messed up the syntax for this during https://github.com/elastic/eui/pull/6982, and now `EuiFilterGroup` is full width at all breakpoints when it should only be full-width at the xs->s breakpoint.

### Above `m` breakpoint (width):

**Broken on prod:**
<img width="1154" alt="" src="https://github.com/elastic/eui/assets/549407/a7320d19-947f-450c-9276-44bf92c5cba6">

**After fix:**
<img width="150" alt="" src="https://github.com/elastic/eui/assets/549407/cc2f16aa-5404-43e4-997c-e0807a4aea9a">


### Below `m` breakpoint (flex wrapping):

**Broken on prod:**
<img width="592" alt="" src="https://github.com/elastic/eui/assets/549407/a2b3df02-9c7b-4845-bacf-9d2abe060740">

**After fix:**
<img width="598" alt="" src="https://github.com/elastic/eui/assets/549407/bcbd13a6-0b8a-4521-826f-18f7d2f34961">

## QA

### General checklist

- [x] Checked in **mobile**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
