### PR TITLE
[Emotion] Add new `focus.transparency` and `focus.backgroundColor` theme tokens

### DIFF
--- a/src/global_styling/variables/states.ts
+++ b/src/global_styling/variables/states.ts
@@ -9,18 +9,6 @@
 import { ColorModeSwitch } from '../../services/theme/types';
 import { CSSProperties } from 'react';
 
-/**
- * NOTE: These were quick conversions of their Sass counterparts.
- *       The commented out keys have not been established as necessary yet.
- */
-
-export interface _EuiThemeFocusOutline {
-  /**
-   * A single CSS property: value
-   */
-  [key: string]: ColorModeSwitch;
-}
-
 export interface _EuiThemeFocus {
   /**
    * Default color of the focus ring, some components may override this property
@@ -42,8 +30,4 @@ export interface _EuiThemeFocus {
    * - Default value: `colors.primary` computed with `focus.transparency`
    */
   backgroundColor: ColorModeSwitch;
-  /**
-   * Using `outline` is new for Amsterdam but is set to `none` in legacy theme
-   */
-  // outline: _EuiThemeFocusOutline;
 }

--- a/src/global_styling/variables/states.ts
+++ b/src/global_styling/variables/states.ts
@@ -33,13 +33,15 @@ export interface _EuiThemeFocus {
    */
   width: CSSProperties['borderWidth'];
   /**
-   * Used to transparentize any color at certain values
+   * Used to transparentize the focus background color
+   * - Default value: { LIGHT: 0.1, DARK: 0.2 }
    */
-  // transparency: ColorModeSwitch<number>;
+  transparency: ColorModeSwitch<number>;
   /**
-   * Default color plus transparency
+   * Default focus background color. Not all components set a background color on focus
+   * - Default value: `colors.primary` computed with `focus.transparency`
    */
-  // backgroundColor: ColorModeSwitch;
+  backgroundColor: ColorModeSwitch;
   /**
    * Using `outline` is new for Amsterdam but is set to `none` in legacy theme
    */

--- a/src/themes/amsterdam/global_styling/variables/_states.ts
+++ b/src/themes/amsterdam/global_styling/variables/_states.ts
@@ -19,10 +19,10 @@ export const focus: _EuiThemeFocus = {
   color: 'currentColor',
   width: computed(sizeToPixel(0.125)),
 
-  // transparency: { LIGHT: 0.9, DARK: 0.7 },
-  // backgroundColor: computed(({ colors, focus }) =>
-  //   transparentize(colors.primary, focus!.transparency)
-  // ),
+  transparency: { LIGHT: 0.1, DARK: 0.2 },
+  backgroundColor: computed(({ colors, focus }) =>
+    transparentize(colors.primary, focus.transparency)
+  ),
 
   // Outline
   // outline: {

--- a/src/themes/amsterdam/global_styling/variables/_states.ts
+++ b/src/themes/amsterdam/global_styling/variables/_states.ts
@@ -6,26 +6,18 @@
  * Side Public License, v 1.
  */
 
-/**
- * NOTE: These were quick conversions of their Sass counterparts.
- *       The commented out keys have not been established as necessary yet.
- */
-
 import { computed } from '../../../../services/theme/utils';
+import { transparentize } from '../../../../services/color/manipulation';
 import { _EuiThemeFocus } from '../../../../global_styling/variables/states';
 import { sizeToPixel } from '../../../../global_styling/functions/size';
 
 export const focus: _EuiThemeFocus = {
+  // Focus ring
   color: 'currentColor',
   width: computed(sizeToPixel(0.125)),
-
+  // Focus background
   transparency: { LIGHT: 0.1, DARK: 0.2 },
   backgroundColor: computed(({ colors, focus }) =>
     transparentize(colors.primary, focus.transparency)
   ),
-
-  // Outline
-  // outline: {
-  //   outline: computed(({ focus }) => `${focus!.width} solid ${focus!.color}`),
-  // },
 };

--- a/upcoming_changelogs/6984.md
+++ b/upcoming_changelogs/6984.md
@@ -1,0 +1,3 @@
+**CSS-in-JS conversions**
+
+- Added `focus.transparency` and `focus.backgroundColor` theme tokens


### PR DESCRIPTION
## Summary

- Adds `focus.transparency` (mostly just needed for `focus.backgroundColor`) and `focus.backgroundColor`
  - ⚠️  Note: an `euiFocusBackground` Sass mixin exists ([link](https://github.com/elastic/eui/blob/329eb41a8c36ba76be780fc6a45d375cf7184033/src/themes/amsterdam/global_styling/mixins/_states.scss#L39-L41)). This mixin allows customizing the background color used (defaulting to `primary`). I **did not** convert this mixin to a CSS-in-JS util, and opted to go this route (theme tokens) instead. I did this for several reasons:
  - Kibana has multiple usages of basic `$euiFocusBackgroundColor` usages (which uses the default `primary` color) and has 0 usages of custom focus background colors. Based on this, consumers will want an easier-to-grab theme token vs. a util they have to specifically import
  - EUI itself only has 2 usages of custom focus background colors, and honestly, those usages don't need a specific mixin. They can simply grab the `transparentize` util (which does all the heavy lifting) and then the `focus.transparency` token at that point.

- Updated various comments in the focus states files, including removing a hypothetical `outline` token (our theme tokens already suffice for building this CSS, we have an `euiOutline()` which essentially already does this and more, and there are zero consumer usages of outline-related CSS)

## QA

- Go to https://eui.elastic.co/pr_6984/#/theming/customizing-themes, scroll to the bottom of the page
    <img width="800" alt="" src="https://github.com/elastic/eui/assets/549407/f127b514-2fe4-4d74-80dc-d0706b4a2845">
- [x] Confirm `focus.transparency` and `focus.backgroundColor` exist
- [x] Confirm they output different values when changing the page between light and dark mode

### General checklist

- [x] Checked in both **light and dark** modes
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - I don't see any docs listed for the focus ring tokens, so going to skip any specific docs (other than the above QA links) for this
- ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ - Caroline and Greg apparently did not write any tests to snapshot EUI theme output, so there's no tests to update here
- [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart - renamed `$euiFocusBackgroundColor` to just `Focus background color`
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
