### PR TITLE
[Cypress] Ignore even more `ResizeObserver loop` shenanigans

### DIFF
--- a/cypress/support/component.tsx
+++ b/cypress/support/component.tsx
@@ -26,7 +26,7 @@ import './setup/realMount';
 // @see https://github.com/quasarframework/quasar/issues/2233#issuecomment-492975745
 // @see also https://github.com/cypress-io/cypress/issues/20341
 Cypress.on('uncaught:exception', (err) => {
-  if (err.message.includes('> ResizeObserver loop limit exceeded')) {
+  if (err.message.includes('> ResizeObserver loop')) {
     return false;
   }
 });


### PR DESCRIPTION
## Summary

Bafflingly enough, this doesn't appear to occur on Jenkins CI but does occur/fail when running `yarn test-cypress` on some local machines.

There are now apparently two ResizeObserver-related error messages that can crop up in Cypress:

- (old) `> ResizeObserver loop limit exceeded`
- (new) `> ResizeObserver loop completed with undelivered notifications.`

Honestly we should just ignore all resize observer shenanigans as they don't appear to affect actual production behavior.

## QA

- [x] CI passes
- [ ] `yarn test-cypress` passes locally

### General checklist

N/A, internal/dev only