### PR TITLE
[Color Palette] Deprecate `euiPaletteComplimentary`; Add `euiPaletteComplementary`

### DIFF
--- a/src-docs/src/views/color_palette/color_palette_quantitative.js
+++ b/src-docs/src/views/color_palette/color_palette_quantitative.js
@@ -11,7 +11,7 @@ import {
 import { ColorPaletteFlexItem, ColorPaletteCopyCode } from './shared';
 
 import {
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteForStatus,
   euiPaletteForTemperature,
   euiPaletteCool,
@@ -23,7 +23,7 @@ import {
 const paletteData = {
   euiPaletteForStatus,
   euiPaletteForTemperature,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteNegative,
   euiPalettePositive,
   euiPaletteCool,

--- a/src-docs/src/views/color_picker/color_palette_display.js
+++ b/src-docs/src/views/color_picker/color_palette_display.js
@@ -3,7 +3,7 @@ import {
   euiPaletteColorBlind,
   euiPaletteForStatus,
   euiPaletteForTemperature,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteNegative,
   euiPalettePositive,
   euiPaletteCool,
@@ -49,7 +49,7 @@ const paletteWithStops = [
 const paletteData = {
   euiPaletteForStatus,
   euiPaletteForTemperature,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteNegative,
   euiPalettePositive,
   euiPaletteCool,

--- a/src-docs/src/views/elastic_charts/theming.js
+++ b/src-docs/src/views/elastic_charts/theming.js
@@ -23,7 +23,7 @@ import {
 
 import {
   euiPaletteColorBlind,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteForStatus,
   euiPaletteForTemperature,
   euiPaletteCool,
@@ -38,7 +38,7 @@ const paletteData = {
   euiPaletteColorBlind,
   euiPaletteForStatus,
   euiPaletteForTemperature,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteNegative,
   euiPalettePositive,
   euiPaletteCool,

--- a/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_with_plugins.js
@@ -37,7 +37,7 @@ import {
 
 import {
   useEuiTheme,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteCool,
   euiPaletteForStatus,
   euiPaletteForTemperature,
@@ -51,7 +51,7 @@ import { getDefaultEuiMarkdownUiPlugins } from '../../../../src/components/markd
 const paletteData = {
   euiPaletteForStatus,
   euiPaletteForTemperature,
-  euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteNegative,
   euiPalettePositive,
   euiPaletteCool,

--- a/src/services/color/eui_palettes.ts
+++ b/src/services/color/eui_palettes.ts
@@ -184,10 +184,7 @@ export const euiPaletteForTemperature = function (steps: number): EuiPalette {
   return euiPalette([...cools, ...warms], steps, true);
 };
 
-/**
- * @deprecated Use euiPaletteComplementary instead
- */
-export const euiPaletteComplimentary = function (steps: number): EuiPalette {
+export const euiPaletteComplementary = function (steps: number): EuiPalette {
   if (steps === 1) {
     return [euiPaletteColorBlind()[1]];
   }

--- a/src/services/color/eui_palettes.ts
+++ b/src/services/color/eui_palettes.ts
@@ -196,7 +196,11 @@ export const euiPaletteComplementary = function (steps: number): EuiPalette {
   );
 };
 
-export const euiPaletteComplementary = function (steps: number): EuiPalette {
+/**
+ * The old typo'd name for this palette remains exported until the end of its deprecation period
+ * @deprecated Use euiPaletteComplementary instead
+ */
+export const euiPaletteComplimentary = euiPaletteComplementary;
   if (steps === 1) {
     return [euiPaletteColorBlind()[1]];
   }

--- a/src/services/color/eui_palettes.ts
+++ b/src/services/color/eui_palettes.ts
@@ -184,7 +184,22 @@ export const euiPaletteForTemperature = function (steps: number): EuiPalette {
   return euiPalette([...cools, ...warms], steps, true);
 };
 
+/**
+ * @deprecated Use euiPaletteComplementary instead
+ */
 export const euiPaletteComplimentary = function (steps: number): EuiPalette {
+  if (steps === 1) {
+    return [euiPaletteColorBlind()[1]];
+  }
+
+  return euiPalette(
+    [euiPaletteColorBlind()[1], euiPaletteColorBlind()[7]],
+    steps,
+    true
+  );
+};
+
+export const euiPaletteComplementary = function (steps: number): EuiPalette {
   if (steps === 1) {
     return [euiPaletteColorBlind()[1]];
   }

--- a/src/services/color/eui_palettes.ts
+++ b/src/services/color/eui_palettes.ts
@@ -201,16 +201,6 @@ export const euiPaletteComplementary = function (steps: number): EuiPalette {
  * @deprecated Use euiPaletteComplementary instead
  */
 export const euiPaletteComplimentary = euiPaletteComplementary;
-  if (steps === 1) {
-    return [euiPaletteColorBlind()[1]];
-  }
-
-  return euiPalette(
-    [euiPaletteColorBlind()[1], euiPaletteColorBlind()[7]],
-    steps,
-    true
-  );
-};
 
 export const euiPaletteNegative = function (steps: number): EuiPalette {
   if (steps === 1) {

--- a/src/services/color/index.ts
+++ b/src/services/color/index.ts
@@ -31,6 +31,7 @@ export {
   euiPaletteForStatus,
   euiPaletteForTemperature,
   euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteNegative,
   euiPalettePositive,
   euiPaletteCool,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -37,6 +37,7 @@ export {
   euiPaletteColorBlind,
   euiPaletteColorBlindBehindText,
   euiPaletteComplimentary,
+  euiPaletteComplementary,
   euiPaletteCool,
   euiPaletteForDarkBackground,
   euiPaletteForLightBackground,

--- a/upcoming_changelogs/6992.md
+++ b/upcoming_changelogs/6992.md
@@ -1,0 +1,4 @@
+**Deprecations**
+
+- Deprecated `euiPaletteComplimentary`; Use `euiPaletteComplementary` instead.
+


### PR DESCRIPTION
closes #6901 

## Summary
It looks like we made a whoopsie a while ago and misspelled `complementary` when naming our color palettes. This PR:
- [x] Adds the `@deprecated` flag to `euiPaletteComplimentary` while continuing to export it
- [x] Creates `euiPaletteComplementary` and updates references in the docs

I've added `euiPaletteComplimentary` to the Deprecations schedule. Kibana is [only showing two usages](https://github.com/search?q=repo%3Aelastic%2Fkibana%20euiPaletteComplimentary&type=code) at this moment, so this shouldn't be difficult to update during an upgrade.

## QA

References to the old color palette name have been updated in the docs. Each example should have no visual changes between staging and prod. The new name should also be displayed (`euiPaletteComplementary`). 
- [x] **Color Palettes:** View the [available EUI color palettes in staging](https://eui.elastic.co/pr_6992/#/utilities/color-palettes#recommended-quantitative-palettes) and ensure you only see the correct version in the dropdown list.
- [x] **Color Picker:** View the [Color Palette Display example in staging](https://eui.elastic.co/pr_6992/#/forms/color-selection#color-palette-display) and customize the color palette (bottom right on the example). 
- [x] **Elastic Charts:** View the Elastic Charts - [Theming Via EUI example in staging](https://eui.elastic.co/pr_6992/#/elastic-charts/creating-charts#theming-via-eui) and change the color palette for the demo.
- [x] **Markdown Editor Plugins**: View the [Markdown Plugins example in staging](https://eui.elastic.co/pr_6992/#/editors-syntax/markdown-plugins), scroll to the bottom and find `euiPaletteComplementary` in use.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
