### PR TITLE
[EuiBasicTable][EuiInMemoryTable][EuiDataGrid] Update to use `EuiTablePagination` component defaults

### DIFF
--- a/src-docs/src/views/datagrid/_snippets.tsx
+++ b/src-docs/src/views/datagrid/_snippets.tsx
@@ -69,8 +69,8 @@ renderCustomDataGridBody={({ visibleColumns, visibleRowData, Cell }) => (
 )}`,
   pagination: `pagination={{
   pageIndex: 1,
-  pageSize: 100,
-  pageSizeOptions: [50, 100, 200],
+  pageSize: 100, // If not specified, defaults to EuiTablePagination.itemsPerPage
+  pageSizeOptions: [50, 100, 200], // If not specified, defaults to EuiTablePagination.itemsPerPageOptions
   onChangePage: () => {},
   onChangeItemsPerPage: () => {},
 }}`,

--- a/src-docs/src/views/datagrid/advanced/custom_renderer.tsx
+++ b/src-docs/src/views/datagrid/advanced/custom_renderer.tsx
@@ -168,7 +168,7 @@ export default () => {
   );
 
   // Pagination
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) => {
       setPagination((pagination) => ({ ...pagination, pageIndex }));
@@ -294,7 +294,6 @@ export default () => {
         inMemory={{ level: 'sorting' }}
         pagination={{
           ...pagination,
-          pageSizeOptions: [10, 25, 50],
           onChangePage: onChangePage,
           onChangeItemsPerPage: onChangePageSize,
         }}

--- a/src-docs/src/views/datagrid/advanced/datagrid_memory_example.js
+++ b/src-docs/src/views/datagrid/advanced/datagrid_memory_example.js
@@ -23,7 +23,6 @@ const inMemorySortingDataGridSource = require('!!raw-loader!./in_memory_sorting'
 
 import {
   EuiDataGridColumn,
-  EuiDataGridPaginationProps,
   EuiDataGridSorting,
   EuiDataGridInMemory,
   EuiDataGridStyle,
@@ -32,6 +31,7 @@ import {
   EuiDataGridCellValueElementProps,
   EuiDataGridSchemaDetector,
 } from '!!prop-loader!../../../../../src/components/datagrid/data_grid_types';
+import { EuiDataGridPaginationProps } from '../basics/_props';
 
 export const DataGridMemoryExample = {
   sections: [

--- a/src-docs/src/views/datagrid/advanced/in_memory.js
+++ b/src-docs/src/views/datagrid/advanced/in_memory.js
@@ -130,7 +130,6 @@ export default () => {
       sorting={{ columns: sortingColumns, onSort }}
       pagination={{
         ...pagination,
-        pageSizeOptions: [10, 50, 100],
         onChangeItemsPerPage: onChangeItemsPerPage,
         onChangePage: onChangePage,
       }}

--- a/src-docs/src/views/datagrid/advanced/in_memory_enhancements.js
+++ b/src-docs/src/views/datagrid/advanced/in_memory_enhancements.js
@@ -131,7 +131,6 @@ export default () => {
         sorting={{ columns: sortingColumns, onSort }}
         pagination={{
           ...pagination,
-          pageSizeOptions: [10, 50, 100],
           onChangeItemsPerPage: onChangeItemsPerPage,
           onChangePage: onChangePage,
         }}

--- a/src-docs/src/views/datagrid/advanced/in_memory_pagination.js
+++ b/src-docs/src/views/datagrid/advanced/in_memory_pagination.js
@@ -52,7 +52,7 @@ for (let i = 1; i < 100; i++) {
 
 export default () => {
   // Pagination
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
       setPagination((pagination) => ({
@@ -115,7 +115,6 @@ export default () => {
       sorting={{ columns: sortingColumns, onSort }}
       pagination={{
         ...pagination,
-        pageSizeOptions: [10, 50, 0],
         onChangeItemsPerPage: onChangeItemsPerPage,
         onChangePage: onChangePage,
       }}

--- a/src-docs/src/views/datagrid/advanced/in_memory_sorting.js
+++ b/src-docs/src/views/datagrid/advanced/in_memory_sorting.js
@@ -52,7 +52,7 @@ for (let i = 1; i < 100; i++) {
 
 export default () => {
   // Pagination
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
       setPagination((pagination) => ({
@@ -101,7 +101,6 @@ export default () => {
       sorting={{ columns: sortingColumns, onSort }}
       pagination={{
         ...pagination,
-        pageSizeOptions: [10, 50, 100],
         onChangeItemsPerPage: onChangeItemsPerPage,
         onChangePage: onChangePage,
       }}

--- a/src-docs/src/views/datagrid/advanced/ref.tsx
+++ b/src-docs/src/views/datagrid/advanced/ref.tsx
@@ -111,7 +111,7 @@ export default () => {
   );
 
   // Pagination
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
     (pageIndex) => {
       setPagination((pagination) => ({ ...pagination, pageIndex }));
@@ -224,7 +224,6 @@ export default () => {
         }
         pagination={{
           ...pagination,
-          pageSizeOptions: [25, 50],
           onChangePage: onChangePage,
           onChangeItemsPerPage: onChangePageSize,
         }}

--- a/src-docs/src/views/datagrid/basics/_props.tsx
+++ b/src-docs/src/views/datagrid/basics/_props.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
-import { EuiDataGrid } from '../../../../../src/components';
+import React, { FunctionComponent } from 'react';
+import {
+  EuiDataGrid,
+  EuiDataGridPaginationProps as _EuiDataGridPaginationProps,
+} from '../../../../../src/components';
 
 import { DataGridPropsTable } from '../_props_table';
 import { gridSnippets } from '../_snippets';
@@ -41,3 +44,8 @@ export const DataGridTopProps = () => {
     />
   );
 };
+
+// Loading `EuiDataGridPaginationProps` via !prop-loader doesn't correctly inherit @defaults
+export const EuiDataGridPaginationProps: FunctionComponent<
+  _EuiDataGridPaginationProps
+> = () => <div />;

--- a/src-docs/src/views/datagrid/basics/container.js
+++ b/src-docs/src/views/datagrid/basics/container.js
@@ -34,7 +34,7 @@ for (let i = 1; i < 20; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
 
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
@@ -74,7 +74,6 @@ export default () => {
         renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
         pagination={{
           ...pagination,
-          pageSizeOptions: [5, 10, 25],
           onChangeItemsPerPage: setPageSize,
           onChangePage: setPageIndex,
         }}

--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -372,7 +372,7 @@ const trailingControlColumns = [
 
 export default () => {
   // Pagination
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
       setPagination((pagination) => ({
@@ -419,7 +419,6 @@ export default () => {
         sorting={{ columns: sortingColumns, onSort }}
         pagination={{
           ...pagination,
-          pageSizeOptions: [10, 50, 100],
           onChangeItemsPerPage: onChangeItemsPerPage,
           onChangePage: onChangePage,
         }}

--- a/src-docs/src/views/datagrid/basics/datagrid_example.js
+++ b/src-docs/src/views/datagrid/basics/datagrid_example.js
@@ -12,7 +12,7 @@ import {
 } from '../../../../../src/components';
 
 import DataGrid from './datagrid';
-import { DataGridTopProps } from './_props';
+import { DataGridTopProps, EuiDataGridPaginationProps } from './_props';
 const dataGridSource = require('!!raw-loader!./datagrid');
 
 import DataGridContainer from './container';
@@ -28,7 +28,6 @@ const dataGridVirtualizationConstrainedSource = require('!!raw-loader!./virtuali
 import {
   EuiDataGridColumn,
   EuiDataGridColumnCellAction,
-  EuiDataGridPaginationProps,
   EuiDataGridSorting,
   EuiDataGridInMemory,
   EuiDataGridStyle,

--- a/src-docs/src/views/datagrid/basics/flex.js
+++ b/src-docs/src/views/datagrid/basics/flex.js
@@ -40,7 +40,7 @@ for (let i = 1; i < 20; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
 
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
@@ -89,7 +89,6 @@ export default () => {
             }
             pagination={{
               ...pagination,
-              pageSizeOptions: [5, 10, 25],
               onChangeItemsPerPage: setPageSize,
               onChangePage: setPageIndex,
             }}

--- a/src-docs/src/views/datagrid/cells_popovers/column_cell_actions.js
+++ b/src-docs/src/views/datagrid/cells_popovers/column_cell_actions.js
@@ -120,7 +120,7 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
 
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
@@ -153,7 +153,6 @@ export default () => {
       renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
       pagination={{
         ...pagination,
-        pageSizeOptions: [5, 10, 25],
         onChangeItemsPerPage: setPageSize,
         onChangePage: setPageIndex,
       }}

--- a/src-docs/src/views/datagrid/schema_columns/column_actions.js
+++ b/src-docs/src/views/datagrid/schema_columns/column_actions.js
@@ -69,7 +69,7 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 5 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
 
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
@@ -102,7 +102,6 @@ export default () => {
       renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
       pagination={{
         ...pagination,
-        pageSizeOptions: [5, 10, 25],
         onChangeItemsPerPage: setPageSize,
         onChangePage: setPageIndex,
       }}

--- a/src-docs/src/views/datagrid/schema_columns/column_widths.js
+++ b/src-docs/src/views/datagrid/schema_columns/column_widths.js
@@ -46,7 +46,7 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 5 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
 
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
@@ -79,7 +79,6 @@ export default () => {
       renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
       pagination={{
         ...pagination,
-        pageSizeOptions: [5, 10, 25],
         onChangeItemsPerPage: setPageSize,
         onChangePage: setPageIndex,
       }}

--- a/src-docs/src/views/datagrid/schema_columns/control_columns.js
+++ b/src-docs/src/views/datagrid/schema_columns/control_columns.js
@@ -309,10 +309,7 @@ const trailingControlColumns = [
 ];
 
 export default function DataGrid() {
-  const [pagination, setPagination] = useState({
-    pageIndex: 0,
-    pageSize: 15,
-  });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const setPageIndex = useCallback(
     (pageIndex) =>
       setPagination((pagination) => ({ ...pagination, pageIndex })),
@@ -369,7 +366,6 @@ export default function DataGrid() {
           renderCellValue={renderCellValue}
           pagination={{
             ...pagination,
-            pageSizeOptions: [5, 15, 25],
             onChangeItemsPerPage: setPageSize,
             onChangePage: setPageIndex,
           }}

--- a/src-docs/src/views/datagrid/schema_columns/footer_row.js
+++ b/src-docs/src/views/datagrid/schema_columns/footer_row.js
@@ -130,7 +130,7 @@ const RenderFooterCellValue = ({ columnId, setCellProps }) => {
 
 export default () => {
   // Pagination
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const onChangeItemsPerPage = useCallback(
     (pageSize) =>
       setPagination((pagination) => ({
@@ -177,7 +177,6 @@ export default () => {
           }
           pagination={{
             ...pagination,
-            pageSizeOptions: [10, 15, 20],
             onChangeItemsPerPage: onChangeItemsPerPage,
             onChangePage: onChangePage,
           }}

--- a/src-docs/src/views/datagrid/styling/styling_grid.js
+++ b/src-docs/src/views/datagrid/styling/styling_grid.js
@@ -59,10 +59,7 @@ const DataGridStyle = ({
   header = 'underline',
   footer = 'overline',
 }) => {
-  const [pagination, setPagination] = useState({
-    pageIndex: 0,
-    pageSize: 5,
-  });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
@@ -111,7 +108,6 @@ const DataGridStyle = ({
       renderFooterCellValue={renderFooterCellValue}
       pagination={{
         ...pagination,
-        pageSizeOptions: [5, 10, 25],
         onChangeItemsPerPage: setPageSize,
         onChangePage: setPageIndex,
       }}

--- a/src-docs/src/views/datagrid/toolbar/_grid.js
+++ b/src-docs/src/views/datagrid/toolbar/_grid.js
@@ -55,10 +55,7 @@ const DataGridStyle = ({
   allowHideColumns,
   allowOrderingColumns,
 }) => {
-  const [pagination, setPagination] = useState({
-    pageIndex: 0,
-    pageSize: 5,
-  });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
@@ -139,7 +136,6 @@ const DataGridStyle = ({
       renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
       pagination={{
         ...pagination,
-        pageSizeOptions: [5, 10, 25],
         onChangeItemsPerPage: setPageSize,
         onChangePage: setPageIndex,
       }}

--- a/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
+++ b/src-docs/src/views/datagrid/toolbar/additional_controls.tsx
@@ -50,7 +50,7 @@ for (let i = 1; i < 20; i++) {
 }
 
 export default () => {
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
   const flyoutTitleId = useGeneratedHtmlId({
     prefix: 'dataGridAdditionalControlsFlyout',
@@ -129,7 +129,6 @@ export default () => {
         renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
         pagination={{
           ...pagination,
-          pageSizeOptions: [5, 10, 25],
           onChangeItemsPerPage: setPageSize,
           onChangePage: setPageIndex,
         }}

--- a/src-docs/src/views/tables/basic/basic_section.js
+++ b/src-docs/src/views/tables/basic/basic_section.js
@@ -7,7 +7,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
@@ -9,7 +9,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
@@ -9,7 +9,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_callback_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_callback_section.js
@@ -8,7 +8,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_external_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_external_section.js
@@ -8,7 +8,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_section.js
@@ -9,7 +9,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -9,7 +9,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/in_memory/in_memory_selection_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection_section.js
@@ -8,7 +8,7 @@ import {
   Criteria,
   CriteriaWithPagination,
 } from '!!prop-loader!../../../../../src/components/basic_table/basic_table';
-import { Pagination } from '!!prop-loader!../../../../../src/components/basic_table/pagination_bar';
+import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
   EuiTableComputedColumnType,

--- a/src-docs/src/views/tables/paginated/_props.tsx
+++ b/src-docs/src/views/tables/paginated/_props.tsx
@@ -1,0 +1,6 @@
+import React, { FunctionComponent } from 'react';
+
+import { Pagination as _Pagination } from '../../../../../src/components/basic_table/pagination_bar';
+
+// Loading `Pagination` directly via !prop-loader doesn't correctly inherit @defaults
+export const Pagination: FunctionComponent<_Pagination> = () => <div />;

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -1,6 +1,211 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiInMemoryTable behavior pagination 1`] = `
+<nav
+  aria-label="Pagination for table: "
+  class="euiPagination emotion-euiPagination"
+>
+  <span
+    aria-atomic="true"
+    aria-relevant="additions text"
+    class="emotion-euiScreenReaderOnly"
+    role="status"
+  >
+    Page 2 of 2
+  </span>
+  <a
+    aria-controls="__table_generated-id"
+    aria-label="Previous page"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
+    data-test-subj="pagination-button-previous"
+    href="#__table_generated-id"
+    rel="noreferrer"
+    title="Previous page"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="arrowLeft"
+    />
+  </a>
+  <ul
+    aria-label="Pagination for table: "
+    class="euiPagination__list emotion-euiPagination__list"
+  >
+    <li
+      class="euiPagination__item"
+    >
+      <a
+        aria-controls="__table_generated-id"
+        aria-label="Page 1 of 2"
+        class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text-euiPaginationButton"
+        data-test-subj="pagination-button-0"
+        href="#__table_generated-id"
+        rel="noreferrer"
+      >
+        <span
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+        >
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            1
+          </span>
+        </span>
+      </a>
+    </li>
+    <li
+      class="euiPagination__item"
+    >
+      <button
+        aria-controls="__table_generated-id"
+        aria-current="true"
+        aria-label="Page 2 of 2"
+        class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
+        data-test-subj="pagination-button-1"
+        disabled=""
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+        >
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            2
+          </span>
+        </span>
+      </button>
+    </li>
+  </ul>
+  <button
+    aria-label="Next page"
+    class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
+    data-test-subj="pagination-button-next"
+    disabled=""
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="arrowRight"
+    />
+  </button>
+</nav>
+`;
+
+exports[`EuiInMemoryTable empty array 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiBasicTable testClass1 testClass2 emotion-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <div>
+    <div
+      class="euiTableHeaderMobile"
+    >
+      <div
+        class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-baseline-row"
+      >
+        <div
+          class="euiFlexItem emotion-euiFlexItem-growZero"
+        />
+        <div
+          class="euiFlexItem emotion-euiFlexItem-growZero"
+        />
+      </div>
+    </div>
+    <table
+      class="euiTable css-0 euiTable--responsive"
+      id="__table_generated-id"
+      tabindex="-1"
+    >
+      <caption
+        class="euiTableCaption emotion-euiScreenReaderOnly"
+      />
+      <thead>
+        <tr>
+          <th
+            class="euiTableHeaderCell"
+            data-test-subj="tableHeaderCell_name_0"
+            role="columnheader"
+            scope="col"
+          >
+            <span
+              class="euiTableCellContent"
+            >
+              <span
+                class="euiTableCellContent__text"
+                title="Name; description"
+              >
+                Name
+              </span>
+              <span
+                class="emotion-euiScreenReaderOnly"
+              >
+                description
+              </span>
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="css-0"
+      >
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell euiTableRowCell--middle"
+            colspan="1"
+          >
+            <div
+              class="euiTableCellContent euiTableCellContent--alignCenter"
+            >
+              <span
+                class="euiTableCellContent__text"
+              >
+                No items found
+              </span>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`EuiInMemoryTable with executeQueryOptions 1`] = `
+<EuiBasicTable
+  aria-label="aria-label"
+  className="testClass1 testClass2 emotion-euiTestCss"
+  columns={
+    Array [
+      Object {
+        "description": "description",
+        "field": "name",
+        "name": "Name",
+      },
+    ]
+  }
+  data-test-subj="test subject string"
+  items={Array []}
+  noItemsMessage={
+    <EuiI18n
+      default="No items found"
+      token="euiBasicTable.noItemsMessage"
+    />
+  }
+  onChange={[Function]}
+  responsive={true}
+  tableLayout="fixed"
+/>
+`;
+
+exports[`EuiInMemoryTable with items 1`] = `
 <div
   aria-label="aria-label"
   class="euiBasicTable testClass1 testClass2 emotion-euiTestCss"
@@ -75,7 +280,7 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
               <span
                 class="euiTableCellContent__text"
               >
-                name3
+                name1
               </span>
             </div>
           </td>
@@ -97,7 +302,29 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
               <span
                 class="euiTableCellContent__text"
               >
-                name4
+                name2
+              </span>
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="euiTableRow"
+        >
+          <td
+            class="euiTableRowCell euiTableRowCell--middle"
+          >
+            <div
+              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            >
+              Name
+            </div>
+            <div
+              class="euiTableCellContent"
+            >
+              <span
+                class="euiTableCellContent__text"
+              >
+                name3
               </span>
             </div>
           </td>
@@ -105,1251 +332,5 @@ exports[`EuiInMemoryTable behavior pagination 1`] = `
       </tbody>
     </table>
   </div>
-  <div>
-    <div
-      class="euiSpacer euiSpacer--m emotion-euiSpacer-m"
-    />
-    <div
-      class="euiFlexGroup eui-xScroll emotion-euiFlexGroup-wrap-s-spaceBetween-center-row"
-    >
-      <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
-      >
-        <div
-          class="euiPopover emotion-euiPopover"
-        >
-          <div
-            class="euiPopover__anchor css-16vtueo-render"
-          >
-            <button
-              class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-text"
-              data-test-subj="tablePaginationPopoverButton"
-              type="button"
-            >
-              <span
-                class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-              >
-                <span
-                  class="eui-textTruncate euiButtonEmpty__text"
-                >
-                  Rows per page: 2
-                </span>
-                <span
-                  color="inherit"
-                  data-euiicon-type="arrowDown"
-                />
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem emotion-euiFlexItem-growZero"
-      >
-        <nav
-          aria-label="Pagination for table: "
-          class="euiPagination emotion-euiPagination"
-        >
-          <span
-            aria-atomic="true"
-            aria-relevant="additions text"
-            class="emotion-euiScreenReaderOnly"
-            role="status"
-          >
-            Page 2 of 2
-          </span>
-          <a
-            aria-controls="__table_generated-id"
-            aria-label="Previous page"
-            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-text-euiPaginationButton"
-            data-test-subj="pagination-button-previous"
-            href="#__table_generated-id"
-            rel="noreferrer"
-            title="Previous page"
-          >
-            <span
-              aria-hidden="true"
-              class="euiButtonIcon__icon"
-              color="inherit"
-              data-euiicon-type="arrowLeft"
-            />
-          </a>
-          <ul
-            aria-label="Pagination for table: "
-            class="euiPagination__list emotion-euiPagination__list"
-          >
-            <li
-              class="euiPagination__item"
-            >
-              <a
-                aria-controls="__table_generated-id"
-                aria-label="Page 1 of 2"
-                class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text-euiPaginationButton"
-                data-test-subj="pagination-button-0"
-                href="#__table_generated-id"
-                rel="noreferrer"
-              >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                >
-                  <span
-                    class="eui-textTruncate euiButtonEmpty__text"
-                  >
-                    1
-                  </span>
-                </span>
-              </a>
-            </li>
-            <li
-              class="euiPagination__item"
-            >
-              <button
-                aria-controls="__table_generated-id"
-                aria-current="true"
-                aria-label="Page 2 of 2"
-                class="euiButtonEmpty euiPaginationButton emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled-euiPaginationButton-isActive"
-                data-test-subj="pagination-button-1"
-                disabled=""
-                type="button"
-              >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                >
-                  <span
-                    class="eui-textTruncate euiButtonEmpty__text"
-                  >
-                    2
-                  </span>
-                </span>
-              </button>
-            </li>
-          </ul>
-          <button
-            aria-label="Next page"
-            class="euiButtonIcon euiPaginationArrowButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiPaginationButton"
-            data-test-subj="pagination-button-next"
-            disabled=""
-            type="button"
-          >
-            <span
-              aria-hidden="true"
-              class="euiButtonIcon__icon"
-              color="inherit"
-              data-euiicon-type="arrowRight"
-            />
-          </button>
-        </nav>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`EuiInMemoryTable empty array 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={Array []}
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with executeQueryOptions 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={Array []}
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with initial selection 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 emotion-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  itemId="id"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  responsive={true}
-  selection={
-    Object {
-      "initialSelected": Array [
-        Object {
-          "id": "1",
-          "name": "name1",
-        },
-      ],
-      "onSelectionChange": [Function],
-    }
-  }
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with initial sorting 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 emotion-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-        "sortable": true,
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  responsive={true}
-  sorting={
-    Object {
-      "allowNeutralSort": true,
-      "sort": Object {
-        "direction": "desc",
-        "field": "Name",
-      },
-    }
-  }
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with items 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with items and expanded item 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  itemId="id"
-  itemIdToExpandedRowMap={
-    Object {
-      "1": <div>
-        expanded row content
-      </div>,
-    }
-  }
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with items and message - expecting to show the items 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage="show me!"
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with message 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={Array []}
-  noItemsMessage="where my items at?"
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with message and loading 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={Array []}
-  loading={true}
-  noItemsMessage="Loading items...."
-  onChange={[Function]}
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 2,
-      "pageSizeOptions": Array [
-        2,
-        4,
-        6,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination and "show all" page size 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 0,
-      "pageSizeOptions": Array [
-        1,
-        2,
-        3,
-        0,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination and default page size and index 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 1,
-      "pageSize": 2,
-      "pageSizeOptions": Array [
-        1,
-        2,
-        3,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination and selection 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 emotion-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  itemId="id"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 10,
-      "pageSizeOptions": Array [
-        10,
-        25,
-        50,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  selection={
-    Object {
-      "onSelectionChange": [Function],
-    }
-  }
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination, default page size and error 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  error="ouch!"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 4,
-      "pageSizeOptions": Array [
-        2,
-        4,
-        6,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 1,
-    }
-  }
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination, hiding the per page options 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 css-hzx95w-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 10,
-      "pageSizeOptions": Array [
-        10,
-        25,
-        50,
-      ],
-      "showPerPageOptions": false,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination, selection and sorting 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 emotion-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-        "sortable": true,
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  itemId="id"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 10,
-      "pageSizeOptions": Array [
-        10,
-        25,
-        50,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  selection={
-    Object {
-      "onSelectionChange": [Function],
-    }
-  }
-  sorting={
-    Object {
-      "allowNeutralSort": true,
-      "sort": undefined,
-    }
-  }
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination, selection, sorting  and simple search 1`] = `
-<div>
-  <EuiSearchBar
-    onChange={[Function]}
-  />
-  <EuiSpacer
-    size="l"
-  />
-  <EuiBasicTable
-    aria-label="aria-label"
-    className="testClass1 testClass2 emotion-euiTestCss"
-    columns={
-      Array [
-        Object {
-          "description": "description",
-          "field": "name",
-          "name": "Name",
-          "sortable": true,
-        },
-        Object {
-          "actions": Array [
-            Object {
-              "description": "edit",
-              "name": "Edit",
-              "onClick": [Function],
-            },
-          ],
-          "name": "Actions",
-        },
-      ]
-    }
-    data-test-subj="test subject string"
-    itemId="id"
-    items={
-      Array [
-        Object {
-          "id": "1",
-          "name": "name1",
-        },
-        Object {
-          "id": "2",
-          "name": "name2",
-        },
-        Object {
-          "id": "3",
-          "name": "name3",
-        },
-      ]
-    }
-    noItemsMessage={
-      <EuiI18n
-        default="No items found"
-        token="euiBasicTable.noItemsMessage"
-      />
-    }
-    onChange={[Function]}
-    pagination={
-      Object {
-        "pageIndex": 0,
-        "pageSize": 10,
-        "pageSizeOptions": Array [
-          10,
-          25,
-          50,
-        ],
-        "showPerPageOptions": undefined,
-        "totalItemCount": 3,
-      }
-    }
-    responsive={true}
-    selection={
-      Object {
-        "onSelectionChange": [Function],
-      }
-    }
-    sorting={
-      Object {
-        "allowNeutralSort": true,
-        "sort": undefined,
-      }
-    }
-    tableLayout="fixed"
-  />
-</div>
-`;
-
-exports[`EuiInMemoryTable with pagination, selection, sorting and a single record action 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 emotion-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-        "sortable": true,
-      },
-      Object {
-        "actions": Array [
-          Object {
-            "description": "edit",
-            "name": "Edit",
-            "onClick": [Function],
-          },
-        ],
-        "name": "Actions",
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  itemId="id"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-      Object {
-        "id": "3",
-        "name": "name3",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 10,
-      "pageSizeOptions": Array [
-        10,
-        25,
-        50,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  selection={
-    Object {
-      "onSelectionChange": [Function],
-    }
-  }
-  sorting={
-    Object {
-      "allowNeutralSort": true,
-      "sort": undefined,
-    }
-  }
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination, selection, sorting and column renderer 1`] = `
-<EuiBasicTable
-  aria-label="aria-label"
-  className="testClass1 testClass2 emotion-euiTestCss"
-  columns={
-    Array [
-      Object {
-        "description": "description",
-        "field": "name",
-        "name": "Name",
-        "render": [Function],
-        "sortable": true,
-      },
-    ]
-  }
-  data-test-subj="test subject string"
-  itemId="id"
-  items={
-    Array [
-      Object {
-        "id": "1",
-        "name": "name1",
-      },
-      Object {
-        "id": "2",
-        "name": "name2",
-      },
-    ]
-  }
-  noItemsMessage={
-    <EuiI18n
-      default="No items found"
-      token="euiBasicTable.noItemsMessage"
-    />
-  }
-  onChange={[Function]}
-  pagination={
-    Object {
-      "pageIndex": 0,
-      "pageSize": 2,
-      "pageSizeOptions": Array [
-        2,
-        4,
-        6,
-      ],
-      "showPerPageOptions": undefined,
-      "totalItemCount": 3,
-    }
-  }
-  responsive={true}
-  selection={
-    Object {
-      "onSelectionChange": [Function],
-    }
-  }
-  sorting={
-    Object {
-      "allowNeutralSort": true,
-      "sort": undefined,
-    }
-  }
-  tableLayout="fixed"
-/>
-`;
-
-exports[`EuiInMemoryTable with pagination, selection, sorting and configured search 1`] = `
-<div>
-  <EuiSearchBar
-    box={
-      Object {
-        "incremental": true,
-      }
-    }
-    defaultQuery="name:name1"
-    filters={
-      Array [
-        Object {
-          "field": "name",
-          "name": "Name1",
-          "negatedName": "Not Name1",
-          "type": "field_value_toggle",
-          "value": "name1",
-        },
-      ]
-    }
-    onChange={[Function]}
-  />
-  <EuiSpacer
-    size="l"
-  />
-  <EuiBasicTable
-    aria-label="aria-label"
-    className="testClass1 testClass2 emotion-euiTestCss"
-    columns={
-      Array [
-        Object {
-          "description": "description",
-          "field": "name",
-          "name": "Name",
-          "sortable": true,
-        },
-        Object {
-          "actions": Array [
-            Object {
-              "description": "edit",
-              "name": "Edit",
-              "onClick": [Function],
-            },
-          ],
-          "name": "Actions",
-        },
-      ]
-    }
-    data-test-subj="test subject string"
-    itemId="id"
-    items={
-      Array [
-        Object {
-          "id": "1",
-          "name": "name1",
-        },
-      ]
-    }
-    noItemsMessage={
-      <EuiI18n
-        default="No items found"
-        token="euiBasicTable.noItemsMessage"
-      />
-    }
-    onChange={[Function]}
-    pagination={
-      Object {
-        "pageIndex": 0,
-        "pageSize": 10,
-        "pageSizeOptions": Array [
-          10,
-          25,
-          50,
-        ],
-        "showPerPageOptions": undefined,
-        "totalItemCount": 1,
-      }
-    }
-    responsive={true}
-    selection={
-      Object {
-        "onSelectionChange": [Function],
-      }
-    }
-    sorting={
-      Object {
-        "allowNeutralSort": true,
-        "sort": undefined,
-      }
-    }
-    tableLayout="fixed"
-  />
-</div>
-`;
-
-exports[`EuiInMemoryTable with search and component between search and table 1`] = `
-<div>
-  <EuiSearchBar
-    onChange={[Function]}
-  />
-  <EuiSpacer
-    size="l"
-  />
-  <div>
-    Children Between
-  </div>
-  <EuiBasicTable
-    aria-label="aria-label"
-    className="testClass1 testClass2 emotion-euiTestCss"
-    columns={
-      Array [
-        Object {
-          "description": "description",
-          "field": "name",
-          "name": "Name",
-          "sortable": true,
-        },
-        Object {
-          "actions": Array [
-            Object {
-              "description": "edit",
-              "name": "Edit",
-              "onClick": [Function],
-            },
-          ],
-          "name": "Actions",
-        },
-      ]
-    }
-    data-test-subj="test subject string"
-    itemId="id"
-    items={
-      Array [
-        Object {
-          "id": "1",
-          "name": "name1",
-        },
-        Object {
-          "id": "2",
-          "name": "name2",
-        },
-        Object {
-          "id": "3",
-          "name": "name3",
-        },
-      ]
-    }
-    noItemsMessage={
-      <EuiI18n
-        default="No items found"
-        token="euiBasicTable.noItemsMessage"
-      />
-    }
-    onChange={[Function]}
-    responsive={true}
-    tableLayout="fixed"
-  />
 </div>
 `;

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -36,8 +36,7 @@ interface ComplexItem {
   };
 }
 
-// Shallow snapshots were converted to `dive()` to match output before Emotion wrappers were added
-// TODO: Convert to RTL render, or even better, use specific assertions instead of snapshots
+// TODO: Convert remaining shallow/mount tests to RTL
 
 describe('EuiInMemoryTable', () => {
   test('empty array', () => {
@@ -52,9 +51,9 @@ describe('EuiInMemoryTable', () => {
         },
       ],
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { container } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('with message', () => {
@@ -70,9 +69,9 @@ describe('EuiInMemoryTable', () => {
       ],
       message: 'where my items at?',
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('where my items at?')).toBeTruthy();
   });
 
   test('with message and loading', () => {
@@ -89,9 +88,9 @@ describe('EuiInMemoryTable', () => {
       message: 'Loading items....',
       loading: true,
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { container } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(container.querySelector('.euiBasicTable-loading')).toBeTruthy();
   });
 
   test('with executeQueryOptions', () => {
@@ -130,9 +129,9 @@ describe('EuiInMemoryTable', () => {
         },
       ],
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { container } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   test('with items and expanded item', () => {
@@ -155,9 +154,9 @@ describe('EuiInMemoryTable', () => {
         '1': <div>expanded row content</div>,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('expanded row content')).toBeTruthy();
   });
 
   test('with items and message - expecting to show the items', () => {
@@ -177,9 +176,9 @@ describe('EuiInMemoryTable', () => {
         },
       ],
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { queryByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(queryByText('show me!')).toBeFalsy();
   });
 
   test('with pagination', () => {
@@ -201,9 +200,9 @@ describe('EuiInMemoryTable', () => {
         pageSizeOptions: [2, 4, 6],
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { container } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(container.querySelector('.euiPagination')).toBeTruthy();
   });
 
   test('with pagination and default page size and index', () => {
@@ -227,9 +226,12 @@ describe('EuiInMemoryTable', () => {
         pageSizeOptions: [1, 2, 3],
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText, getByTestSubject } = render(
+      <EuiInMemoryTable {...props} />
+    );
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Rows per page: 2')).toBeTruthy();
+    expect(getByTestSubject('pagination-button-1')).toBeDisabled(); // disabled = current page
   });
 
   test('with pagination and "show all" page size', () => {
@@ -252,9 +254,9 @@ describe('EuiInMemoryTable', () => {
         pageSizeOptions: [1, 2, 3, 0],
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Showing all rows')).toBeTruthy();
   });
 
   test('with pagination, default page size and error', () => {
@@ -274,9 +276,12 @@ describe('EuiInMemoryTable', () => {
         pageSizeOptions: [2, 4, 6],
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText, queryByTestSubject } = render(
+      <EuiInMemoryTable {...props} />
+    );
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('ouch!')).toBeTruthy();
+    expect(queryByTestSubject('tablePaginationPopoverButton')).toBe(null);
   });
 
   test('with pagination, hiding the per page options', () => {
@@ -298,9 +303,9 @@ describe('EuiInMemoryTable', () => {
         showPerPageOptions: false,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { queryByTestSubject } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(queryByTestSubject('tablePaginationPopoverButton')).toBe(null);
   });
 
   describe('sorting', () => {
@@ -570,10 +575,13 @@ describe('EuiInMemoryTable', () => {
         },
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
-
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    const { container } = render(<EuiInMemoryTable {...props} />);
     expect(itemsProp).toEqual(items);
+
+    const cells = container.querySelectorAll('td');
+    expect(cells[0]).toHaveTextContent('name3');
+    expect(cells[1]).toHaveTextContent('name2');
+    expect(cells[2]).toHaveTextContent('name1');
   });
 
   test('with initial selection', () => {
@@ -597,9 +605,16 @@ describe('EuiInMemoryTable', () => {
         initialSelected: [{ id: '1', name: 'name1' }],
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { container } = render(<EuiInMemoryTable {...props} />);
+    const selections = container.querySelectorAll(
+      '[data-test-subj^="checkboxSelect"]'
+    );
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(selections.length).toEqual(4);
+    expect(selections[0]).not.toBeChecked(); // Select all row
+    expect(selections[1]).toBeChecked();
+    expect(selections[2]).not.toBeChecked();
+    expect(selections[3]).not.toBeChecked();
   });
 
   test('with pagination and selection', () => {
@@ -623,9 +638,10 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Page 1 of 1')).toBeTruthy();
+    expect(getByText('Select all rows')).toBeTruthy();
   });
 
   test('with pagination, selection and sorting', () => {
@@ -651,9 +667,11 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Page 1 of 1')).toBeTruthy();
+    expect(getByText('Select all rows')).toBeTruthy();
+    expect(getByText('Sorting')).toBeTruthy();
   });
 
   test('with pagination, selection, sorting and column renderer', () => {
@@ -682,9 +700,12 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Page 1 of 2')).toBeTruthy();
+    expect(getByText('Select all rows')).toBeTruthy();
+    expect(getByText('Sorting')).toBeTruthy();
+    expect(getByText('NAME1')).toBeTruthy();
   });
 
   test('with pagination, selection, sorting and a single record action', () => {
@@ -720,9 +741,12 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Page 1 of 1')).toBeTruthy();
+    expect(getByText('Select all rows')).toBeTruthy();
+    expect(getByText('Sorting')).toBeTruthy();
+    expect(getByText('Actions')).toBeTruthy();
   });
 
   test('with pagination, selection, sorting  and simple search', () => {
@@ -759,9 +783,15 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByText, getByPlaceholderText } = render(
+      <EuiInMemoryTable {...props} />
+    );
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByText('Page 1 of 1')).toBeTruthy();
+    expect(getByText('Select all rows')).toBeTruthy();
+    expect(getByText('Sorting')).toBeTruthy();
+    expect(getByText('Actions')).toBeTruthy();
+    expect(getByPlaceholderText('Search...')).toBeTruthy();
   });
 
   test('with search and component between search and table', () => {
@@ -794,9 +824,12 @@ describe('EuiInMemoryTable', () => {
       search: true,
       childrenBetween: <div>Children Between</div>,
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { getByPlaceholderText, getByText } = render(
+      <EuiInMemoryTable {...props} />
+    );
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(getByPlaceholderText('Search...')).toBeTruthy();
+    expect(getByText('Children Between')).toBeTruthy();
   });
 
   test('with pagination, selection, sorting and configured search', () => {
@@ -848,9 +881,22 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const component = shallow(<EuiInMemoryTable {...props} />);
+    const { container, queryByText } = render(<EuiInMemoryTable {...props} />);
 
-    expect(component.find(EuiInMemoryTable).dive()).toMatchSnapshot();
+    expect(queryByText('Page 1 of 1')).toBeTruthy();
+    expect(queryByText('Select all rows')).toBeTruthy();
+    expect(queryByText('Sorting')).toBeTruthy();
+
+    expect(container.querySelector('input[type="search"]')).toHaveValue(
+      'name:name1'
+    );
+    const filterButton = container.querySelector('.euiFilterButton');
+    expect(filterButton).toHaveTextContent('Name1');
+    expect(filterButton?.getAttribute('aria-pressed')).toEqual('true');
+
+    expect(queryByText('name1')).toBeTruthy();
+    expect(queryByText('name2')).toBeFalsy();
+    expect(queryByText('name3')).toBeFalsy();
   });
 
   describe('search interaction & functionality', () => {
@@ -1062,17 +1108,17 @@ describe('EuiInMemoryTable', () => {
           pageSizeOptions: [2, 4, 6],
         },
       };
-      const component = mount(<EuiInMemoryTable {...props} />);
+      const { getByTestSubject, rerender, container } = render(
+        <EuiInMemoryTable {...props} />
+      );
 
-      component
-        .find('a[data-test-subj="pagination-button-1"]')
-        .simulate('click');
+      fireEvent.click(getByTestSubject('pagination-button-1'));
 
       // forces EuiInMemoryTable's getDerivedStateFromProps to re-execute
       // this is specifically testing regression against https://github.com/elastic/eui/issues/1007
-      component.setProps({});
+      rerender(<EuiInMemoryTable {...props} />);
 
-      expect(component.render()).toMatchSnapshot();
+      expect(container.querySelector('.euiPagination')).toMatchSnapshot();
     });
 
     // Other pagination tests already check default pagination sizes
@@ -1125,11 +1171,9 @@ describe('EuiInMemoryTable', () => {
           pageSizeOptions: [2, 4, 6],
         },
       };
-      const component = mount(<EuiInMemoryTable {...props} />);
+      const { getByTestSubject } = render(<EuiInMemoryTable {...props} />);
 
-      component
-        .find('a[data-test-subj="pagination-button-1"]')
-        .simulate('click');
+      fireEvent.click(getByTestSubject('pagination-button-1'));
     });
 
     test('onTableChange callback', () => {
@@ -1156,13 +1200,13 @@ describe('EuiInMemoryTable', () => {
         onTableChange: jest.fn(),
       };
 
-      const component = mount(<EuiInMemoryTable {...props} />);
+      const { getByTestSubject, container } = render(
+        <EuiInMemoryTable {...props} />
+      );
       expect(props.onTableChange).toHaveBeenCalledTimes(0);
 
       // Pagination change
-      component
-        .find('a[data-test-subj="pagination-button-1"]')
-        .simulate('click');
+      fireEvent.click(getByTestSubject('pagination-button-1'));
       expect(props.onTableChange).toHaveBeenCalledTimes(1);
       expect(props.onTableChange).toHaveBeenLastCalledWith({
         sort: {},
@@ -1173,11 +1217,11 @@ describe('EuiInMemoryTable', () => {
       });
 
       // Sorting change
-      component
-        .find(
+      fireEvent.click(
+        container.querySelector(
           '[data-test-subj*="tableHeaderCell_name_0"] [data-test-subj="tableHeaderSortButton"]'
-        )
-        .simulate('click');
+        )!
+      );
       expect(props.onTableChange).toHaveBeenCalledTimes(2);
       expect(props.onTableChange).toHaveBeenLastCalledWith({
         sort: {
@@ -1191,9 +1235,7 @@ describe('EuiInMemoryTable', () => {
       });
 
       // Sorted pagination change
-      component
-        .find('a[data-test-subj="pagination-button-1"]')
-        .simulate('click');
+      fireEvent.click(getByTestSubject('pagination-button-1'));
       expect(props.onTableChange).toHaveBeenCalledTimes(3);
       expect(props.onTableChange).toHaveBeenLastCalledWith({
         sort: {
@@ -1230,7 +1272,7 @@ describe('EuiInMemoryTable', () => {
         },
       ];
       const onTableChange = jest.fn();
-      const component = mount(
+      const { getByTestSubject, container, rerender } = render(
         <EuiInMemoryTable
           items={items}
           columns={columns}
@@ -1240,17 +1282,12 @@ describe('EuiInMemoryTable', () => {
       );
 
       // ensure table is on 2nd page (pageIndex=1)
-      expect(
-        component.find('button[data-test-subj="pagination-button-1"][disabled]')
-          .length
-      ).toBe(1);
-      expect(component.find('td').at(0).text()).toBe('Index2');
-      expect(component.find('td').at(1).text()).toBe('Index3');
+      expect(getByTestSubject('pagination-button-1')).toBeDisabled();
+      expect(container.querySelectorAll('td')[0]).toHaveTextContent('Index2');
+      expect(container.querySelectorAll('td')[1]).toHaveTextContent('Index3');
 
       // click the first pagination button
-      component
-        .find('a[data-test-subj="pagination-button-0"]')
-        .simulate('click');
+      fireEvent.click(getByTestSubject('pagination-button-0'));
       expect(onTableChange).toHaveBeenCalledTimes(1);
       expect(onTableChange).toHaveBeenCalledWith({
         sort: {},
@@ -1261,24 +1298,24 @@ describe('EuiInMemoryTable', () => {
       });
 
       // ensure table is still on the 2nd page (pageIndex=1)
-      expect(
-        component.find('button[data-test-subj="pagination-button-1"][disabled]')
-          .length
-      ).toBe(1);
-      expect(component.find('td').at(0).text()).toBe('Index2');
-      expect(component.find('td').at(1).text()).toBe('Index3');
+      expect(getByTestSubject('pagination-button-1')).toBeDisabled();
+      expect(container.querySelectorAll('td')[0]).toHaveTextContent('Index2');
+      expect(container.querySelectorAll('td')[1]).toHaveTextContent('Index3');
 
       // re-render with an updated `pageIndex` value
-      pagination.pageIndex = 2;
-      component.setProps({ pagination });
+      rerender(
+        <EuiInMemoryTable
+          items={items}
+          columns={columns}
+          pagination={{ ...pagination, pageIndex: 2 }}
+          onTableChange={onTableChange}
+        />
+      );
 
       // ensure table is on 3rd page (pageIndex=2)
-      expect(
-        component.find('button[data-test-subj="pagination-button-2"][disabled]')
-          .length
-      ).toBe(1);
-      expect(component.find('td').at(0).text()).toBe('Index4');
-      expect(component.find('td').at(1).text()).toBe('Index5');
+      expect(getByTestSubject('pagination-button-2')).toBeDisabled();
+      expect(container.querySelectorAll('td')[0]).toHaveTextContent('Index4');
+      expect(container.querySelectorAll('td')[1]).toHaveTextContent('Index5');
     });
 
     it('respects pageSize', () => {

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -8,7 +8,11 @@
 
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { fireEvent } from '@testing-library/react';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
+
+import { EuiProvider } from '../provider';
 
 import { EuiInMemoryTable, EuiInMemoryTableProps } from './in_memory_table';
 import { keys, SortDirection } from '../../services';
@@ -1069,6 +1073,36 @@ describe('EuiInMemoryTable', () => {
       component.setProps({});
 
       expect(component.render()).toMatchSnapshot();
+    });
+
+    // Other pagination tests already check default pagination sizes
+    // and individual pagination setting, so we'll just check here that
+    // `componentDefaults` is respected
+    test('pagination inherited from EuiProvider componentDefaults', () => {
+      const props = {
+        items: [{ title: 'foo' }, { title: 'bar' }, { title: 'baz' }],
+        columns: [{ field: 'title', name: 'Title' }],
+      };
+      const { getByText, getByTestSubject } = render(
+        <EuiProvider
+          componentDefaults={{
+            EuiTablePagination: {
+              itemsPerPage: 50,
+              itemsPerPageOptions: [25, 50, 100],
+            },
+          }}
+        >
+          <EuiInMemoryTable {...props} pagination={true} />
+        </EuiProvider>,
+        { wrapper: undefined }
+      );
+
+      expect(getByText('Rows per page: 50')).toBeTruthy();
+
+      fireEvent.click(getByTestSubject('tablePaginationPopoverButton'));
+      expect(getByTestSubject('tablePagination-25-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-50-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-100-rows')).toBeTruthy();
     });
 
     test('pagination with actions column and sorting set to true', async () => {

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -76,7 +76,13 @@ type InMemoryTableProps<T> = Omit<
    * Configures #Search.
    */
   search?: Search;
+  /**
+   * Configures #Pagination
+   */
   pagination?: undefined;
+  /**
+   * Configures #EuiTableSortingType
+   */
   sorting?: Sorting;
   /**
    * Set `allowNeutralSort` to false to force column sorting. Defaults to true.

--- a/src/components/basic_table/pagination_bar.test.tsx
+++ b/src/components/basic_table/pagination_bar.test.tsx
@@ -11,6 +11,8 @@ import { fireEvent } from '@testing-library/react';
 import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 
+import { EuiProvider } from '../provider';
+
 import { PaginationBar } from './pagination_bar';
 
 describe('PaginationBar', () => {
@@ -46,5 +48,66 @@ describe('PaginationBar', () => {
 
     fireEvent.click(getByLabelText('Page 2 of 2'));
     expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  describe('EuiTablePagination component defaults', () => {
+    it('falls back to EuiTablePagination defaults', () => {
+      const { getByText, getByTestSubject } = render(
+        <PaginationBar
+          {...props}
+          pagination={{ pageIndex: 1, totalItemCount: 100 }}
+        />
+      );
+
+      expect(getByText('Rows per page: 50')).toBeTruthy();
+      fireEvent.click(getByTestSubject('tablePaginationPopoverButton'));
+      expect(getByTestSubject('tablePagination-10-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-20-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-50-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-100-rows')).toBeTruthy();
+    });
+
+    it('correctly uses configured EuiTablePagination defaults', () => {
+      const { getByText, getByTestSubject } = render(
+        <EuiProvider
+          componentDefaults={{
+            EuiTablePagination: {
+              itemsPerPage: 5,
+              itemsPerPageOptions: [5, 15],
+            },
+          }}
+        >
+          <PaginationBar
+            {...props}
+            pagination={{ pageIndex: 1, totalItemCount: 100 }}
+          />
+        </EuiProvider>,
+        { wrapper: undefined }
+      );
+
+      expect(getByText('Rows per page: 5')).toBeTruthy();
+      fireEvent.click(getByTestSubject('tablePaginationPopoverButton'));
+      expect(getByTestSubject('tablePagination-5-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-15-rows')).toBeTruthy();
+    });
+
+    it('correctly overrides all defaults', () => {
+      const { getByText, getByTestSubject } = render(
+        <PaginationBar
+          {...props}
+          pagination={{
+            pageIndex: 3,
+            totalItemCount: 20,
+            pageSize: 4,
+            pageSizeOptions: [2, 4],
+          }}
+        />
+      );
+
+      expect(getByText('Rows per page: 4')).toBeTruthy();
+      fireEvent.click(getByTestSubject('tablePaginationPopoverButton'));
+      expect(getByTestSubject('tablePagination-2-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-4-rows')).toBeTruthy();
+    });
   });
 });

--- a/src/components/basic_table/pagination_bar.test.tsx
+++ b/src/components/basic_table/pagination_bar.test.tsx
@@ -59,12 +59,11 @@ describe('PaginationBar', () => {
         />
       );
 
-      expect(getByText('Rows per page: 50')).toBeTruthy();
+      expect(getByText('Rows per page: 10')).toBeTruthy();
       fireEvent.click(getByTestSubject('tablePaginationPopoverButton'));
       expect(getByTestSubject('tablePagination-10-rows')).toBeTruthy();
-      expect(getByTestSubject('tablePagination-20-rows')).toBeTruthy();
+      expect(getByTestSubject('tablePagination-25-rows')).toBeTruthy();
       expect(getByTestSubject('tablePagination-50-rows')).toBeTruthy();
-      expect(getByTestSubject('tablePagination-100-rows')).toBeTruthy();
     });
 
     it('correctly uses configured EuiTablePagination defaults', () => {

--- a/src/components/basic_table/pagination_bar.tsx
+++ b/src/components/basic_table/pagination_bar.tsx
@@ -7,8 +7,12 @@
  */
 
 import React, { useEffect } from 'react';
+
 import { EuiSpacer } from '../spacer';
-import { EuiTablePagination } from '../table';
+import {
+  EuiTablePagination,
+  useEuiTablePaginationDefaults,
+} from '../table/table_pagination';
 import {
   ItemsPerPageChangeHandler,
   PageChangeHandler,
@@ -22,8 +26,10 @@ export interface Pagination {
   /**
    * The maximum number of items that can be shown in a single page.
    * Pass `0` to display the selected "Show all" option and hide the pagination.
+   *
+   * @default 50
    */
-  pageSize: number;
+  pageSize?: number;
   /**
    * The total number of items the page is "sliced" of
    */
@@ -31,10 +37,14 @@ export interface Pagination {
   /**
    * Configures the page size dropdown options.
    * Pass `0` as one of the options to create a "Show all" option.
+   *
+   * @default [10, 20, 50, 100]
    */
   pageSizeOptions?: number[];
   /**
-   * Hides the page size dropdown
+   * Set to false to hide the page size dropdown
+   *
+   * @default true
    */
   showPerPageOptions?: boolean;
 }
@@ -61,26 +71,30 @@ export const PaginationBar = ({
   'aria-controls': ariaControls,
   'aria-label': ariaLabel,
 }: PaginationBarProps) => {
-  const pageSizeOptions = pagination.pageSizeOptions
-    ? pagination.pageSizeOptions
-    : defaults.pageSizeOptions;
-  const pageCount = pagination.pageSize
-    ? Math.ceil(pagination.totalItemCount / pagination.pageSize)
-    : 1;
+  const defaults = useEuiTablePaginationDefaults();
+  const {
+    pageIndex,
+    totalItemCount,
+    pageSize = defaults.itemsPerPage,
+    pageSizeOptions = defaults.itemsPerPageOptions,
+    showPerPageOptions = defaults.showPerPageOptions,
+  } = pagination;
+
+  const pageCount = pageSize ? Math.ceil(totalItemCount / pageSize) : 1;
 
   useEffect(() => {
-    if (pageCount < pagination.pageIndex + 1) {
+    if (pageCount < pageIndex + 1) {
       onPageChange?.(pageCount - 1);
     }
-  }, [pageCount, onPageChange, pagination]);
+  }, [pageCount, onPageChange, pageIndex]);
 
   return (
     <div>
       <EuiSpacer size="m" />
       <EuiTablePagination
-        activePage={pagination.pageIndex}
-        showPerPageOptions={pagination.showPerPageOptions}
-        itemsPerPage={pagination.pageSize}
+        activePage={pageIndex}
+        showPerPageOptions={showPerPageOptions}
+        itemsPerPage={pageSize}
         itemsPerPageOptions={pageSizeOptions}
         pageCount={pageCount}
         onChangeItemsPerPage={onPageSizeChange}

--- a/src/components/basic_table/pagination_bar.tsx
+++ b/src/components/basic_table/pagination_bar.tsx
@@ -27,7 +27,7 @@ export interface Pagination {
    * The maximum number of items that can be shown in a single page.
    * Pass `0` to display the selected "Show all" option and hide the pagination.
    *
-   * @default 50
+   * @default 10
    */
   pageSize?: number;
   /**
@@ -38,7 +38,7 @@ export interface Pagination {
    * Configures the page size dropdown options.
    * Pass `0` as one of the options to create a "Show all" option.
    *
-   * @default [10, 20, 50, 100]
+   * @default [10, 25, 50]
    */
   pageSizeOptions?: number[];
   /**
@@ -59,10 +59,6 @@ export interface PaginationBarProps {
   'aria-controls'?: string;
   'aria-label'?: string;
 }
-
-export const defaults = {
-  pageSizeOptions: [10, 25, 50],
-};
 
 export const PaginationBar = ({
   pagination,

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -60,6 +60,7 @@ describe('EuiDataGridCell', () => {
         pagination={{
           pageIndex: 3,
           pageSize: 20,
+          pageSizeOptions: [20],
           onChangePage: () => {},
           onChangeItemsPerPage: () => {},
         }}

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -13,6 +13,7 @@ import {
   GridOnItemsRenderedProps,
 } from 'react-window';
 import { useGeneratedHtmlId } from '../../services';
+import { useEuiTablePaginationDefaults } from '../table/table_pagination';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiI18n, useEuiI18n } from '../i18n';
 import { useMutationObserver } from '../observer/mutation_observer';
@@ -118,7 +119,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
       className,
       gridStyle,
       toolbarVisibility = true,
-      pagination,
+      pagination: _pagination,
       sorting,
       inMemory,
       onColumnResize,
@@ -134,6 +135,17 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
     /**
      * Merge consumer settings with defaults
      */
+    const paginationDefaults = useEuiTablePaginationDefaults();
+    const pagination = useMemo(() => {
+      return _pagination
+        ? {
+            pageSize: paginationDefaults.itemsPerPage,
+            pageSizeOptions: paginationDefaults.itemsPerPageOptions,
+            ..._pagination,
+          }
+        : _pagination;
+    }, [_pagination, paginationDefaults]);
+
     const gridStyleWithDefaults = useMemo(
       () => ({ ...startingStyles, ...gridStyle }),
       [gridStyle]

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -300,7 +300,7 @@ export type CommonGridProps = CommonProps &
      */
     inMemory?: EuiDataGridInMemory;
     /**
-     * A #EuiDataGridPagination object. Omit to disable pagination completely.
+     * A #EuiDataGridPaginationProps object. Omit to disable pagination completely.
      */
     pagination?: EuiDataGridPaginationProps;
     /**
@@ -918,12 +918,16 @@ export interface EuiDataGridPaginationProps {
   /**
    * How many rows should initially be shown per page.
    * Pass `0` to display the selected "Show all" option and hide the pagination.
+   *
+   * @default 10
    */
-  pageSize: number;
+  pageSize?: number;
   /**
    * An array of page sizes the user can select from.
    * Pass `0` as one of the options to create a "Show all" option.
-   * Leave this prop undefined or use an empty array to hide "Rows per page" select button.
+   * Pass an empty array to hide "Rows per page" select button.
+   *
+   * @default [10, 25, 50]
    */
   pageSizeOptions?: number[];
   /**

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -429,7 +429,7 @@ export interface EuiDataGridBodyProps {
   renderFooterCellValue?: EuiDataGridCellProps['renderCellValue'];
   renderCustomGridBody?: EuiDataGridProps['renderCustomGridBody'];
   interactiveCellId: EuiDataGridCellProps['interactiveCellId'];
-  pagination?: EuiDataGridPaginationProps;
+  pagination?: Required<EuiDataGridPaginationProps>;
   headerIsInteractive: boolean;
   handleHeaderMutation: MutationCallback;
   setVisibleColumns: EuiDataGridHeaderRowProps['setVisibleColumns'];
@@ -594,7 +594,7 @@ export interface EuiDataGridCellProps {
   rowHeightsOptions?: EuiDataGridRowHeightsOptions;
   rowHeightUtils?: RowHeightUtilsType;
   rowManager?: EuiDataGridRowManager;
-  pagination?: EuiDataGridPaginationProps;
+  pagination?: Required<EuiDataGridPaginationProps>;
 }
 
 export interface EuiDataGridCellState {

--- a/src/components/datagrid/utils/data_grid_pagination.test.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.test.tsx
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import { shallow, mount } from 'enzyme';
 import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 
@@ -29,134 +28,61 @@ describe('EuiDataGridPaginationRenderer', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('renders', () => {
-    const component = shallow(<EuiDataGridPaginationRenderer {...props} />);
-    expect(component).toMatchInlineSnapshot(`
-      <div
-        className="euiDataGrid__pagination"
-      >
-        <EuiTablePagination
-          activePage={0}
-          aria-controls="data-grid-id"
-          aria-label="Pagination for preceding grid"
-          itemsPerPage={25}
-          itemsPerPageOptions={
-            Array [
-              25,
-            ]
-          }
-          onChangeItemsPerPage={[MockFunction]}
-          onChangePage={[Function]}
-          pageCount={4}
-          showPerPageOptions={true}
-        />
-      </div>
-    `);
+    const { container, getByText } = render(
+      <EuiDataGridPaginationRenderer {...props} />
+    );
+    expect(container.firstChild).toHaveClass('euiDataGrid__pagination');
+    fireEvent.click(getByText('Rows per page: 25'));
+    expect(getByText('25 rows')).toBeTruthy();
+    expect(getByText('Page 1 of 4')).toBeTruthy();
   });
 
   it('renders a detailed aria-label', () => {
-    const component = shallow(
+    const { getAllByLabelText } = render(
       <EuiDataGridPaginationRenderer {...props} aria-label="Test Grid" />
     );
-    expect(component).toMatchInlineSnapshot(`
-      <div
-        className="euiDataGrid__pagination"
-      >
-        <EuiTablePagination
-          activePage={0}
-          aria-controls="data-grid-id"
-          aria-label="Pagination for preceding grid: Test Grid"
-          itemsPerPage={25}
-          itemsPerPageOptions={
-            Array [
-              25,
-            ]
-          }
-          onChangeItemsPerPage={[MockFunction]}
-          onChangePage={[Function]}
-          pageCount={4}
-          showPerPageOptions={true}
-        />
-      </div>
-    `);
+    expect(
+      getAllByLabelText('Pagination for preceding grid: Test Grid')
+    ).toBeTruthy();
   });
 
   it('hides the page size selection if pageSizeOptions is empty', () => {
-    const component = shallow(
+    const { queryByTestSubject, queryByText } = render(
       <EuiDataGridPaginationRenderer {...props} pageSizeOptions={[]} />
     );
-    expect(component).toMatchInlineSnapshot(`
-      <div
-        className="euiDataGrid__pagination"
-      >
-        <EuiTablePagination
-          activePage={0}
-          aria-controls="data-grid-id"
-          aria-label="Pagination for preceding grid"
-          itemsPerPage={25}
-          itemsPerPageOptions={Array []}
-          onChangeItemsPerPage={[MockFunction]}
-          onChangePage={[Function]}
-          pageCount={4}
-          showPerPageOptions={false}
-        />
-      </div>
-    `);
+    expect(queryByTestSubject('tablePaginationPopoverButton')).toBeFalsy();
+    expect(queryByText('Rows per page:')).toBeFalsy();
   });
 
   it('handles the "show all" page size option', () => {
-    const component = shallow(
+    const { getByText } = render(
       <EuiDataGridPaginationRenderer
         {...props}
         pageSize={0}
         pageSizeOptions={[10, 25, 0]}
       />
     );
-    expect(component).toMatchInlineSnapshot(`
-      <div
-        className="euiDataGrid__pagination"
-      >
-        <EuiTablePagination
-          activePage={0}
-          aria-controls="data-grid-id"
-          aria-label="Pagination for preceding grid"
-          itemsPerPage={0}
-          itemsPerPageOptions={
-            Array [
-              10,
-              25,
-              0,
-            ]
-          }
-          onChangeItemsPerPage={[MockFunction]}
-          onChangePage={[Function]}
-          pageCount={1}
-          showPerPageOptions={true}
-        />
-      </div>
-    `);
+    expect(getByText('Showing all rows')).toBeTruthy();
   });
 
   it('does not render if there are fewer rows than the smallest page size option', () => {
-    const component = shallow(
+    const { container } = render(
       <EuiDataGridPaginationRenderer
         {...props}
         rowCount={1}
         pageSizeOptions={[10, 25]}
       />
     );
-    expect(component.isEmptyRender()).toBe(true);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('focuses the first data cell on page change', () => {
-    const component = mount(
+    const { getByTestSubject } = render(
       <DataGridFocusContext.Provider value={mockFocusContext}>
         <EuiDataGridPaginationRenderer {...props} />
       </DataGridFocusContext.Provider>
     );
-    const onChangePage: Function = component
-      .find('EuiTablePagination')
-      .prop('onChangePage');
-    onChangePage(3);
+    fireEvent.click(getByTestSubject('pagination-button-2'));
     expect(mockFocusContext.setFocusedCell).toHaveBeenCalledWith([0, 0]);
   });
 

--- a/src/components/datagrid/utils/data_grid_pagination.test.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.test.tsx
@@ -8,6 +8,8 @@
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { fireEvent } from '@testing-library/react';
+import { render } from '../../../test/rtl';
 
 import { DataGridFocusContext } from './focus';
 import { mockFocusContext } from './__mocks__/focus_context';
@@ -156,5 +158,21 @@ describe('EuiDataGridPaginationRenderer', () => {
       .prop('onChangePage');
     onChangePage(3);
     expect(mockFocusContext.setFocusedCell).toHaveBeenCalledWith([0, 0]);
+  });
+
+  describe('EuiProvider component defaults', () => {
+    it('falls back to EuiTablePagination defaults if pageSize and pageSizeOptions are undefined', () => {
+      const { getByText } = render(
+        <EuiDataGridPaginationRenderer
+          {...props}
+          pageSize={undefined}
+          pageSizeOptions={undefined}
+        />
+      );
+      fireEvent.click(getByText('Rows per page: 10'));
+      expect(getByText('10 rows')).toBeTruthy();
+      expect(getByText('25 rows')).toBeTruthy();
+      expect(getByText('50 rows')).toBeTruthy();
+    });
   });
 });

--- a/src/components/datagrid/utils/data_grid_pagination.tsx
+++ b/src/components/datagrid/utils/data_grid_pagination.tsx
@@ -7,8 +7,12 @@
  */
 
 import React, { useCallback, useContext } from 'react';
+
 import { useEuiI18n } from '../../i18n'; // Note: this file must be named data_grid_pagination to match i18n tokens
-import { EuiTablePagination } from '../../table/table_pagination';
+import {
+  EuiTablePagination,
+  useEuiTablePaginationDefaults,
+} from '../../table/table_pagination';
 import {
   EuiDataGridPaginationProps,
   EuiDataGridPaginationRendererProps,
@@ -17,14 +21,18 @@ import { DataGridFocusContext } from './focus';
 
 export const EuiDataGridPaginationRenderer = ({
   pageIndex,
-  pageSize,
-  pageSizeOptions,
+  pageSize: _pageSize,
+  pageSizeOptions: _pageSizeOptions,
   onChangePage: _onChangePage,
   onChangeItemsPerPage,
   rowCount,
   controls,
   'aria-label': ariaLabel,
 }: EuiDataGridPaginationRendererProps) => {
+  const defaults = useEuiTablePaginationDefaults();
+  const pageSize = _pageSize ?? defaults.itemsPerPage;
+  const pageSizeOptions = _pageSizeOptions ?? defaults.itemsPerPageOptions;
+
   const detailedPaginationLabel = useEuiI18n(
     'euiDataGridPagination.detailedPaginationLabel',
     'Pagination for preceding grid: {label}',
@@ -46,8 +54,7 @@ export const EuiDataGridPaginationRenderer = ({
   );
 
   const pageCount = pageSize ? Math.ceil(rowCount / pageSize) : 1;
-  const minSizeOption =
-    pageSizeOptions && [...pageSizeOptions].sort((a, b) => a - b)[0];
+  const minSizeOption = [...pageSizeOptions].sort((a, b) => a - b)[0];
 
   if (rowCount < (minSizeOption || pageSize)) {
     /**
@@ -58,8 +65,8 @@ export const EuiDataGridPaginationRenderer = ({
     return null;
   }
 
-  // hide select rows per page if pageSizeOptions is undefined or an empty array
-  const hidePerPageOptions = !pageSizeOptions || pageSizeOptions.length === 0;
+  // Hide select rows per page if pageSizeOptions is an empty array
+  const hidePerPageOptions = pageSizeOptions.length === 0;
 
   return (
     <div className="euiDataGrid__pagination">

--- a/src/components/datagrid/utils/focus.test.tsx
+++ b/src/components/datagrid/utils/focus.test.tsx
@@ -387,6 +387,7 @@ describe('createKeyDownHandler', () => {
       const pagination = {
         pageIndex: 0,
         pageSize: 5,
+        pageSizeOptions: [5],
         onChangePage: jest.fn(),
         onChangeItemsPerPage: () => {},
       };
@@ -433,6 +434,7 @@ describe('createKeyDownHandler', () => {
       const pagination = {
         pageIndex: 1,
         pageSize: 5,
+        pageSizeOptions: [5],
         onChangePage: jest.fn(),
         onChangeItemsPerPage: () => {},
       };

--- a/src/components/datagrid/utils/focus.ts
+++ b/src/components/datagrid/utils/focus.ts
@@ -181,7 +181,7 @@ export const createKeyDownHandler = ({
   visibleRowCount: number;
   visibleRowStartIndex: number;
   rowCount: EuiDataGridProps['rowCount'];
-  pagination: EuiDataGridProps['pagination'];
+  pagination: Required<EuiDataGridProps['pagination']>;
   hasFooter: boolean;
   headerIsInteractive: boolean;
   focusContext: DataGridFocusContextShape;

--- a/src/components/datagrid/utils/ref.test.ts
+++ b/src/components/datagrid/utils/ref.test.ts
@@ -72,8 +72,9 @@ describe('useSortPageCheck', () => {
 
   describe('if the grid is paginated', () => {
     const pagination = {
-      pageSize: 20,
       pageIndex: 0,
+      pageSize: 20,
+      pageSizeOptions: [20],
       onChangePage: jest.fn(),
       onChangeItemsPerPage: jest.fn(),
     };

--- a/src/components/datagrid/utils/ref.ts
+++ b/src/components/datagrid/utils/ref.ts
@@ -23,7 +23,7 @@ interface Dependencies {
   focusContext: DataGridFocusContextShape;
   cellPopoverContext: DataGridCellPopoverContextShape;
   sortingContext: DataGridSortingContextShape;
-  pagination: EuiDataGridProps['pagination'];
+  pagination: Required<EuiDataGridProps['pagination']>;
   rowCount: number;
   visibleColCount: number;
 }
@@ -144,7 +144,7 @@ export const useCellLocationCheck = (rowCount: number, colCount: number) => {
  * paginating to that row.
  */
 export const useSortPageCheck = (
-  pagination: EuiDataGridProps['pagination'],
+  pagination: Required<EuiDataGridProps['pagination']>,
   sortedRowMap: DataGridSortingContextShape['sortedRowMap']
 ) => {
   const findVisibleRowIndex = useCallback(

--- a/src/components/datagrid/utils/row_count.ts
+++ b/src/components/datagrid/utils/row_count.ts
@@ -12,7 +12,7 @@ export const computeVisibleRows = ({
   pagination,
   rowCount,
 }: {
-  pagination: EuiDataGridProps['pagination'];
+  pagination: Required<EuiDataGridProps['pagination']>;
   rowCount: EuiDataGridProps['rowCount'];
 }): EuiDataGridVisibleRows => {
   const startRow =

--- a/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`EuiTablePagination renders 1`] = `
                 >
                   Rows per page
                   : 
-                  50
+                  10
                 </span>
                 <span
                   color="inherit"
@@ -245,7 +245,7 @@ exports[`EuiTablePagination renders 1`] = `
                   <span
                     class="euiContextMenu__icon"
                     color="inherit"
-                    data-euiicon-type="empty"
+                    data-euiicon-type="check"
                   />
                   <span
                     class="euiContextMenuItem__text"
@@ -256,7 +256,7 @@ exports[`EuiTablePagination renders 1`] = `
               </button>
               <button
                 class="euiContextMenuItem"
-                data-test-subj="tablePagination-20-rows"
+                data-test-subj="tablePagination-25-rows"
                 type="button"
               >
                 <span
@@ -270,7 +270,7 @@ exports[`EuiTablePagination renders 1`] = `
                   <span
                     class="euiContextMenuItem__text"
                   >
-                    20 rows
+                    25 rows
                   </span>
                 </span>
               </button>
@@ -285,32 +285,12 @@ exports[`EuiTablePagination renders 1`] = `
                   <span
                     class="euiContextMenu__icon"
                     color="inherit"
-                    data-euiicon-type="check"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    50 rows
-                  </span>
-                </span>
-              </button>
-              <button
-                class="euiContextMenuItem"
-                data-test-subj="tablePagination-100-rows"
-                type="button"
-              >
-                <span
-                  class="euiContextMenu__itemLayout"
-                >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
                     data-euiicon-type="empty"
                   />
                   <span
                     class="euiContextMenuItem__text"
                   >
-                    100 rows
+                    50 rows
                   </span>
                 </span>
               </button>

--- a/src/components/table/table_pagination/index.ts
+++ b/src/components/table/table_pagination/index.ts
@@ -8,3 +8,9 @@
 
 export type { EuiTablePaginationProps } from './table_pagination';
 export { EuiTablePagination } from './table_pagination';
+
+// Not public top-level exports
+export {
+  useEuiTablePaginationDefaults,
+  euiTablePaginationDefaults,
+} from './table_pagination_defaults';

--- a/src/components/table/table_pagination/table_pagination.tsx
+++ b/src/components/table/table_pagination/table_pagination.tsx
@@ -21,6 +21,7 @@ import { EuiPopover } from '../../popover';
 import { EuiI18n } from '../../i18n';
 
 import { usePropsWithComponentDefaults } from '../../provider/component_defaults';
+import { euiTablePaginationDefaults } from './table_pagination_defaults';
 
 export type PageChangeHandler = EuiPaginationProps['onPageClick'];
 export type ItemsPerPageChangeHandler = (pageSize: number) => void;
@@ -64,9 +65,9 @@ export const EuiTablePagination: FunctionComponent<EuiTablePaginationProps> = (
 ) => {
   const {
     activePage,
-    itemsPerPage = 50,
-    itemsPerPageOptions = [10, 20, 50, 100],
-    showPerPageOptions = true,
+    itemsPerPage = euiTablePaginationDefaults.itemsPerPage,
+    itemsPerPageOptions = euiTablePaginationDefaults.itemsPerPageOptions,
+    showPerPageOptions = euiTablePaginationDefaults.showPerPageOptions,
     onChangeItemsPerPage,
     onChangePage,
     pageCount,

--- a/src/components/table/table_pagination/table_pagination.tsx
+++ b/src/components/table/table_pagination/table_pagination.tsx
@@ -38,14 +38,14 @@ export interface EuiTablePaginationProps
    * Current selection for "Rows per page".
    * Pass `0` to display the selected "Show all" option and hide the pagination.
    *
-   * @default 50
+   * @default 10
    */
   itemsPerPage?: number;
   /**
    * Custom array of options for "Rows per page".
    * Pass `0` as one of the options to create a "Show all" option.
    *
-   * @default [10, 20, 50, 100]
+   * @default [10, 25, 50]
    */
   itemsPerPageOptions?: number[];
   /**

--- a/src/components/table/table_pagination/table_pagination_defaults.ts
+++ b/src/components/table/table_pagination/table_pagination_defaults.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useMemo } from 'react';
+import { useComponentDefaults } from '../../provider/component_defaults';
+
+import { EuiTablePaginationProps } from './table_pagination';
+
+/**
+ * Table pagination prop defaults live in a separate file because
+ * they'll be reused by basic tables and datagrids as fallbacks
+ */
+
+export const euiTablePaginationDefaults: Required<
+  Pick<
+    EuiTablePaginationProps,
+    'itemsPerPage' | 'itemsPerPageOptions' | 'showPerPageOptions'
+  >
+> = {
+  itemsPerPage: 50,
+  itemsPerPageOptions: [10, 20, 50, 100],
+  showPerPageOptions: true,
+};
+
+export const useEuiTablePaginationDefaults = () => {
+  const consumerDefaults = useComponentDefaults().EuiTablePagination;
+
+  return useMemo(
+    () => ({
+      ...euiTablePaginationDefaults,
+      ...consumerDefaults,
+    }),
+    [consumerDefaults]
+  );
+};

--- a/src/components/table/table_pagination/table_pagination_defaults.ts
+++ b/src/components/table/table_pagination/table_pagination_defaults.ts
@@ -22,8 +22,8 @@ export const euiTablePaginationDefaults: Required<
     'itemsPerPage' | 'itemsPerPageOptions' | 'showPerPageOptions'
   >
 > = {
-  itemsPerPage: 50,
-  itemsPerPageOptions: [10, 20, 50, 100],
+  itemsPerPage: 10,
+  itemsPerPageOptions: [10, 25, 50],
   showPerPageOptions: true,
 };
 

--- a/upcoming_changelogs/6993.md
+++ b/upcoming_changelogs/6993.md
@@ -1,0 +1,7 @@
+- `EuiBasicTable`, `EuiInMemoryTable`, and `EuiDataGrid` now allow `pagination.pageSize` to be undefined. If undefined, `pageSize` defaults to `EuiTablePagination`'s `itemsPerPage` component default.
+- `EuiBasicTable`, `EuiInMemoryTable`, and `EuiDataGrid`'s `pagination.pageSizeOptions` will now fall back to `EuiTablePagination`'s `itemsPerPageOptions` component default.
+
+**Breaking changes**
+
+- `EuiTablePagination`'s default `itemsPerPage` is now `10` (was previously `50`). This can be configured through `EuiProvider.componentDefaults`.
+- `EuiTablePagination`'s default `itemsPerPageOptions` is now `[10, 25, 50]` (was previously `[10, 20, 50, 100]`). This can be configured through `EuiProvider.componentDefaults`.


### PR DESCRIPTION
## Summary

This PR is part 2 of 2 of the work required to allow all EUI tables and grids to have their pagination page size configurable by consumer defaults (see https://github.com/elastic/kibana/issues/56406 for more context).

> ⚠️  Note that there is still actual work that needs to be done within Kibana itself to take advantage of the new component defaults functionality:
> 1. The top-level `<EuiProvider>` in each Kibana app needs to be configured with user-preferred `itemsPerPage` and/or `itemsPerPageOptions`
> 2. Every single instance of `EuiBasicTable`, `EuiInMemoryTable`, and `EuiDataGrid` needs to be configured to not initially pass a defined `pagination.pageSize`/`pagination.pageSizeOptions`. See https://github.com/elastic/eui/commit/ab3016d4423a2ef24415634aff7f723a1ce42274 for an example of this change

This PR is also the last PR in the `provider/component-defaults` feature branch - once this PR merges in, the final feature PR itself will be opened up against main 🚢

As always, I strongly recommend [following along by commit](https://github.com/elastic/eui/pull/6993/commits) because there's a lot of RTL test tech debt as well as docs changes/tweaks in here.

## QA

- `gh pr checkout 6993`
- `yarn && yarn start`
- Go to http://localhost:8030/#/tabular-content/data-grid and http://localhost:8030/#/tabular-content/in-memory-tables
- Confirm the first tables/grids default to a page size of 10, and when clicked, show `10, 25, 50` page sizes
- Open `src-docs/src/views/app_context.js`
- On the `<EuiProvider` component, add `componentDefaults={{ EuiTablePagination: { itemsPerPage: 20, itemsPerPageOptions: [10, 20, 0] }}}`
- Save and refresh the above pages
- [x] Confirm the first tables/grids on the page now default to a page size of 20 and show `10, 20, show all rows` options

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~