### PR TITLE
[React 18] Fix flaky cypress tests

### DIFF
--- a/src/components/context_menu/context_menu_panel.spec.tsx
+++ b/src/components/context_menu/context_menu_panel.spec.tsx
@@ -332,10 +332,11 @@ describe('EuiContextMenuPanel', () => {
           },
         ];
 
-        const FLAKY_WAIT = 100; // For some reason CI is flaking on these two tests in way that is hard to repro locally
+        const FLAKY_WAIT = 200; // For some reason CI is flaking on these two tests in way that is hard to repro locally
 
         it('does not lose focus while using left/right arrow navigation between panels', () => {
           cy.mount(<EuiContextMenu panels={panels} initialPanelId={0} />);
+          cy.wait(FLAKY_WAIT);
           cy.realPress('{downarrow}');
           cy.focused().should('have.attr', 'data-test-subj', 'itemA');
           cy.realPress('{rightarrow}');

--- a/src/components/datagrid/utils/ref.spec.tsx
+++ b/src/components/datagrid/utils/ref.spec.tsx
@@ -185,6 +185,7 @@ describe('useImperativeGridRef', () => {
 
   describe('closeCellPopover', () => {
     it('allows the consumer to manually close any open popovers', () => {
+      cy.get('[data-gridcell-row-index="0"]').should('exist');
       ref.current!.setFocusedCell({ colIndex: 0, rowIndex: 0 });
       cy.realPress('Enter');
       cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
@@ -213,6 +214,7 @@ describe('useImperativeGridRef', () => {
 
   describe('scrollToItem', () => {
     it('scrolls to a specific cell position, rendering the cell', () => {
+      cy.get('[data-gridcell-row-index="0"]').should('exist');
       cy.get('[data-gridcell-row-index="15"]').should('not.exist');
       cy.then(() => {
         ref.current!.scrollToItem?.({ rowIndex: 15, columnIndex: 5 });

--- a/src/components/flyout/flyout.spec.tsx
+++ b/src/components/flyout/flyout.spec.tsx
@@ -53,6 +53,7 @@ describe('EuiFlyout', () => {
 
     it('traps focus and cycles tabbable items', () => {
       cy.mount(<Flyout />);
+      cy.wait(100); // wait for focus lib to focus the right element
       cy.repeatRealPress('Tab', 4);
       cy.focused().should('have.attr', 'data-test-subj', 'itemC');
       cy.repeatRealPress('Tab', 3);
@@ -129,11 +130,8 @@ describe('EuiFlyout', () => {
 
     it('closes the flyout when the overlay mask is clicked', () => {
       cy.mount(<Flyout />);
-      cy.get('.euiOverlayMask')
-        .realClick()
-        .then(() => {
-          expect(cy.get('[data-test-subj="flyoutSpec"]').should('not.exist'));
-        });
+      cy.get('.euiOverlayMask').should('be.visible').realClick();
+      cy.get('[data-test-subj="flyoutSpec"]').should('not.exist');
     });
 
     it('does not close the flyout when `outsideClickCloses=false` and the overlay mask is clicked', () => {
@@ -167,10 +165,9 @@ describe('EuiFlyout', () => {
     it('closes the flyout when the toast is clicked when `ownFocus=false`', () => {
       cy.mount(<FlyoutWithToasts ownFocus={false} outsideClickCloses={true} />);
       cy.get('[data-test-subj="toastCloseButton"]')
-        .realClick()
-        .then(() => {
-          expect(cy.get('[data-test-subj="flyoutSpec"]').should('not.exist'));
-        });
+        .should('be.visible')
+        .realClick();
+      cy.get('[data-test-subj="flyoutSpec"]').should('not.exist');
     });
   });
 

--- a/src/components/modal/confirm_modal.tsx
+++ b/src/components/modal/confirm_modal.tsx
@@ -11,7 +11,7 @@ import React, {
   ComponentProps,
   ReactNode,
   useEffect,
-  useState,
+  useRef,
 } from 'react';
 import classnames from 'classnames';
 
@@ -88,30 +88,25 @@ export const EuiConfirmModal: FunctionComponent<EuiConfirmModalProps> = ({
   isLoading,
   ...rest
 }) => {
-  const [cancelButton, setCancelButton] = useState<
-    HTMLButtonElement | HTMLAnchorElement | null
-  >(null);
-  const [confirmButton, setConfirmButton] = useState<HTMLButtonElement | null>(
-    null
-  );
+  const cancelButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     // We have to do this instead of using `autoFocus` because React's polyfill for auto-focusing
     // elements conflicts with the focus-trap logic we have on EuiModal.
     // Wait a beat for the focus-trap to complete, and then set focus to the right button. Check that
     // the buttons exist first, because it's possible the modal has been closed already.
-    requestAnimationFrame(() => {
-      if (defaultFocusedButton === CANCEL_BUTTON && cancelButton) {
-        cancelButton.focus();
-      } else if (defaultFocusedButton === CONFIRM_BUTTON && confirmButton) {
-        confirmButton.focus();
+    setTimeout(() => {
+      if (defaultFocusedButton === CANCEL_BUTTON && cancelButtonRef.current) {
+        cancelButtonRef.current.focus();
+      } else if (
+        defaultFocusedButton === CONFIRM_BUTTON &&
+        confirmButtonRef.current
+      ) {
+        confirmButtonRef.current.focus();
       }
     });
-  });
-
-  const confirmRef = (node: HTMLButtonElement | null) => setConfirmButton(node);
-  const cancelRef = (node: HTMLButtonElement | HTMLAnchorElement | null) =>
-    setCancelButton(node);
+  }, [defaultFocusedButton, cancelButtonRef, confirmButtonRef]);
 
   const classes = classnames('euiModal--confirmation', className);
 
@@ -156,7 +151,7 @@ export const EuiConfirmModal: FunctionComponent<EuiConfirmModalProps> = ({
         <EuiButtonEmpty
           data-test-subj="confirmModalCancelButton"
           onClick={onCancel}
-          buttonRef={cancelRef}
+          buttonRef={cancelButtonRef}
         >
           {cancelButtonText}
         </EuiButtonEmpty>
@@ -166,7 +161,7 @@ export const EuiConfirmModal: FunctionComponent<EuiConfirmModalProps> = ({
           onClick={onConfirm}
           isLoading={isLoading}
           fill
-          buttonRef={confirmRef}
+          buttonRef={confirmButtonRef}
           color={buttonColor}
           isDisabled={confirmButtonDisabled}
         >

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -14,6 +14,7 @@ import React, {
   ReactNode,
   Ref,
   RefCallback,
+  PropsWithChildren,
 } from 'react';
 import classNames from 'classnames';
 import { focusable } from 'tabbable';
@@ -67,7 +68,7 @@ export const popoverAnchorPosition = [
 export type PopoverAnchorPosition = (typeof popoverAnchorPosition)[number];
 type AnchorPosition = 'up' | 'right' | 'down' | 'left';
 
-export interface EuiPopoverProps extends CommonProps {
+export interface EuiPopoverProps extends PropsWithChildren, CommonProps {
   /**
    * Class name passed to the direct parent of the button
    */


### PR DESCRIPTION
## Summary

This PR fixes flaky cypress tests that didn't like asynchronous nature of React 18 and refactors `<EuiConfirmModal>` to always focus selected `defaultFocusedButton`.

## QA

1. Checkout this branch locally
2. Run `rm -rf node_modules && yarn` to ensure you have all packages installed
3. Run `yarn lint`
4. Run `yarn test-cypress` and `yarn test-cypress --react-version 17`
5. Confirm all of the commands above succeeded