### PR TITLE
[INFRA] Add command to stop running Buildkite jobs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -94,6 +94,7 @@ spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_test.yml"
       default_branch: main
+      cancel_intermediate_builds: true
       # Job runs as a step in pull request combined job
       provider_settings:
         build_branches: false
@@ -134,6 +135,7 @@ spec:
       repository: elastic/eui
       pipeline_file: ".buildkite/pipelines/pipeline_pull_request_deploy_docs.yml"
       default_branch: main
+      cancel_intermediate_builds: true
       # Job runs as a step in pull request combined job
       provider_settings:
         build_branches: false
@@ -177,6 +179,7 @@ spec:
       default_branch: main
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
+      cancel_intermediate_builds: true
       provider_settings:
         build_branches: false
         build_tags: false


### PR DESCRIPTION
## Summary

This job adds a `cancel_intermediate_jobs: true` boolean to `catalog-info.yml` to stop old jobs on PR update. I added the command to the combined PR test and deploy docs, as well as individual jobs so we get good coverage. 

I discussed this with @markjhoy as he's working on a same PR for Enterprise Search: https://github.com/elastic/ent-search/pull/7653


## QA

I added the `cancel_intermediate_jobs` boolean to all three jobs. Catalog changes have to be in main to get picked up by the Terraform task.

I'll rapidly test this by updating the PR, **after the fix is merged into main** by changing things rapidly and changing them back to see if it cancels jobs correctly. Will make the PR history a little dirtier, but eh, squash and merge.