### PR TITLE
[INFRA] Configuring Buildkite `branch` plus commit hash to run jobs accurately.

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
@@ -4,10 +4,12 @@ steps:
   - trigger: "eui-pull-request-test"
     label: ":hammer: EUI pull request test"
     build:
+      branch: "${BUILDKITE_BRANCH}"
       commit: "${BUILDKITE_COMMIT}"
   - trigger: "eui-pull-request-deploy-docs"
     label: ":newspaper: EUI pull request deploy docs"
     build:
+      branch: "${BUILDKITE_BRANCH}"
       commit: "${BUILDKITE_COMMIT}"
       env:
         GIT_BRANCH: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
## Summary

Buildkite needs more information to ensure we are polling the correct branch and correct commit hash to run PR jobs.

I went back to the trigger step docs in Buildkite and came up with the **build > branch** variable:

```
# https://buildkite.com/docs/pipelines/trigger-step

branch

The branch for the build.
Default: The triggered pipeline's default branch.
Example: "production"
```

I added this branch env variable to the commit hash we're already asking for. In a previous experiment I added the branch without the commit hash and buildkite failed the job because it didn't have the ref to the forked repo. It takes both variables to accurately check out the branch and commit to be run against, I'm now learning.

## QA

QA will be done manually using Buildkite logs to review env variables and build output.

**Findings**
* This PR has the correct branch as an env variable `BUILDKITE_BRANCH="1Copenut:infra/buildkite-branch-and-hash"`
* The correct env variable is carried through to the parent job, and both child jobs
* Other jobs without this fix are all being run against `main`. And that was an issue.
* Tomasz had one job that did run the correct branch. I hypothesize this was because he ran it against a feature branch.

**Continued testing options**
* I will merge this branch into `main` and create a draft feature branch on EUI, then run PRs against it to verify the fix is carrying correctly.