### PR TITLE
[INFRA] Adding logic to prevent Buildkite triggered jobs on merge to `main`.

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
@@ -4,4 +4,4 @@ steps:
   - agents:
       provider: "gcp"
     command: .buildkite/scripts/pipeline_deploy_docs.sh
-    if: build.branch != "main"
+    if: build.branch != "main" # We don't want to deploy docs on main, only on manual release

--- a/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
@@ -4,3 +4,4 @@ steps:
   - agents:
       provider: "gcp"
     command: .buildkite/scripts/pipeline_deploy_docs.sh
+    if: build.branch != "main"

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -4,6 +4,6 @@ steps:
   - agents:
       provider: "gcp"
     command: .buildkite/scripts/pipeline_test.sh
-    if: build.branch != "main"
+    if: build.branch != "main" # We're skipping testing commits in main for now to maintain parity with previous Jenkins setup
     artifact_paths:
       - "cypress/screenshots/**/*.png"

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -4,5 +4,6 @@ steps:
   - agents:
       provider: "gcp"
     command: .buildkite/scripts/pipeline_test.sh
+    if: build.branch != "main"
     artifact_paths:
       - "cypress/screenshots/**/*.png"


### PR DESCRIPTION
## Summary

We don't want to run our pull request jobs on merge to `main` as they've just run on the PR during the review cycle. This PR adds a negation `if` statement to the jobs' YML files.

## QA

Testing will be confimed in the Buildkite UI. I'll be checking the `main` branch for two jobs, to ensure there's not new runs before or after the PR is merged.

* eui-pull-request-test
* eui-pull-request-deploy-docs

**UPDATE Monday 31 July**
Started a fresh run of this job. Looked through the Buildkite UI `main` branch runner for both jobs. Neither job started on `main` branch, only the feature branch. This change appears to be working as I wanted.
