### PR TITLE
[EuiCollapsibleNavBeta] Build out component state and responsive behavior

### DIFF
--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -7,6 +7,26 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
 >
   <div>
     <div
+      class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+    >
+      <button
+        aria-controls="generated-id_euiCollapsibleNav"
+        aria-expanded="true"
+        aria-label="Toggle navigation closed"
+        aria-pressed="true"
+        class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+        data-test-subj="euiCollapsibleNavButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="menuLeft"
+        />
+      </button>
+    </div>
+    <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
       tabindex="-1"

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -55,3 +55,156 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
   </div>
 </body>
 `;
+
+exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
+<body
+  class="euiBody--hasFlyout"
+  style="padding-left: 0px;"
+>
+  <div>
+    <div
+      class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+    >
+      <button
+        aria-controls="generated-id_euiCollapsibleNav"
+        aria-expanded="false"
+        aria-label="Toggle navigation open"
+        aria-pressed="false"
+        class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+        data-test-subj="euiCollapsibleNavButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="menuRight"
+        />
+      </button>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-lock-disabled="disabled"
+    >
+      <nav
+        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left"
+        data-autofocus="true"
+        data-test-subj="nav"
+        id="generated-id_euiCollapsibleNav"
+        role="dialog"
+        style="inline-size: 48px;"
+        tabindex="0"
+      >
+        Nav content
+      </nav>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+  </div>
+</body>
+`;
+
+exports[`EuiCollapsibleNavBeta responsive behavior collapses from a push flyout to an overlay flyout once the screen is smaller than 3x the flyout width 1`] = `
+<body
+  class=""
+  style="padding-left: 0px;"
+>
+  <div>
+    <div
+      class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+    >
+      <button
+        aria-controls="generated-id_euiCollapsibleNav"
+        aria-expanded="false"
+        aria-label="Toggle navigation open"
+        aria-pressed="false"
+        class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+        data-test-subj="euiCollapsibleNavButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="menu"
+        />
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`EuiCollapsibleNavBeta responsive behavior makes the overlay flyout full width once the screen is smaller than 1.5x the flyout width 1`] = `
+<body
+  class="euiBody--hasFlyout"
+  style="padding-left: 0px;"
+>
+  <div>
+    <div
+      class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+    >
+      <button
+        aria-controls="generated-id_euiCollapsibleNav"
+        aria-expanded="true"
+        aria-label="Toggle navigation closed"
+        aria-pressed="true"
+        class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+        data-test-subj="euiCollapsibleNavButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="cross"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="euiOverlayMask emotion-euiOverlayMask-belowHeader"
+    data-euiportal="true"
+    data-relative-to-header="below"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <nav
+        aria-describedby="generated-id"
+        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-overlay-left-euiCollapsibleNavBeta-left-isSmallestScreen"
+        data-autofocus="true"
+        id="generated-id_euiCollapsibleNav"
+        role="dialog"
+        style="inline-size: 100%;"
+        tabindex="0"
+      >
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.
+           
+        </p>
+        Nav content
+      </nav>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNavBeta renders 1`] = `
+<body
+  class="euiBody--hasFlyout"
+  style="padding-left: 0px;"
+>
+  <div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+    <div
+      data-focus-lock-disabled="disabled"
+    >
+      <nav
+        aria-label="aria-label"
+        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left-euiTestCss"
+        data-autofocus="true"
+        data-test-subj="nav"
+        id="generated-id_euiCollapsibleNav"
+        role="dialog"
+        style="inline-size: 248px;"
+        tabindex="0"
+      >
+        Nav content
+      </nav>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="-1"
+    />
+  </div>
+</body>
+`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -9,6 +9,8 @@
 import React, { FunctionComponent, PropsWithChildren } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { EuiHeader, EuiHeaderSection } from '../header';
+import { EuiPageTemplate } from '../page_template';
 import { EuiFlyoutBody, EuiFlyoutFooter } from '../flyout';
 
 import { EuiCollapsibleNavItem } from './collapsible_nav_item';
@@ -39,7 +41,18 @@ type Story = StoryObj<EuiCollapsibleNavBetaProps>;
 const OpenCollapsibleNav: FunctionComponent<
   PropsWithChildren & Partial<EuiCollapsibleNavBetaProps>
 > = (props) => {
-  return <EuiCollapsibleNavBeta {...props} />;
+  return (
+    <>
+      <EuiHeader position="fixed">
+        <EuiHeaderSection side={props?.side}>
+          <EuiCollapsibleNavBeta {...props} />
+        </EuiHeaderSection>
+      </EuiHeader>
+      <EuiPageTemplate>
+        <EuiPageTemplate.Section>Hello world</EuiPageTemplate.Section>
+      </EuiPageTemplate>
+    </>
+  );
 };
 
 export const KibanaExample: Story = {
@@ -378,5 +391,22 @@ export const SecurityExample: Story = {
         />
       </EuiFlyoutFooter>
     </OpenCollapsibleNav>
+  ),
+};
+
+export const MultipleFixedHeaders: Story = {
+  render: ({ ...args }) => (
+    <>
+      <EuiHeader position="fixed">First header</EuiHeader>
+      <EuiHeader position="fixed">
+        <EuiHeaderSection>
+          <EuiCollapsibleNavBeta {...args}>
+            This story tests that EuiCollapsibleNav's fixed header detection &
+            offsetting works as expected
+          </EuiCollapsibleNavBeta>
+          Second header
+        </EuiHeaderSection>
+      </EuiHeader>
+    </>
   ),
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -12,29 +12,39 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { EuiFlyoutBody, EuiFlyoutFooter } from '../flyout';
 
 import { EuiCollapsibleNavItem } from './collapsible_nav_item';
-import { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
+import {
+  EuiCollapsibleNavBeta,
+  EuiCollapsibleNavBetaProps,
+} from './collapsible_nav_beta';
 
-// TODO: EuiCollapsibleNavBetaProps
-const meta: Meta<{}> = {
+const meta: Meta<EuiCollapsibleNavBetaProps> = {
   title: 'EuiCollapsibleNavBeta',
+  component: EuiCollapsibleNavBeta,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    side: {
+      control: 'radio',
+      options: ['left', 'right'],
+    },
+  },
+  args: {
+    side: 'left',
+  },
 };
 export default meta;
-type Story = StoryObj<{}>;
+type Story = StoryObj<EuiCollapsibleNavBetaProps>;
 
-// TODO: Make this a stateful component in upcoming EuiCollapsibleNavBeta work
-const OpenCollapsibleNav: FunctionComponent<PropsWithChildren> = ({
-  children,
-}) => {
-  return (
-    <EuiCollapsibleNavBeta isOpen={true} onClose={() => {}}>
-      {children}
-    </EuiCollapsibleNavBeta>
-  );
+const OpenCollapsibleNav: FunctionComponent<
+  PropsWithChildren & Partial<EuiCollapsibleNavBetaProps>
+> = (props) => {
+  return <EuiCollapsibleNavBeta {...props} />;
 };
 
 export const KibanaExample: Story = {
-  render: () => (
-    <OpenCollapsibleNav>
+  render: ({ ...args }) => (
+    <OpenCollapsibleNav {...args}>
       <EuiFlyoutBody>
         <EuiCollapsibleNavItem title="Home" icon="home" isSelected href="#" />
         <EuiCollapsibleNavItem
@@ -260,8 +270,8 @@ export const KibanaExample: Story = {
 
 // Security has a very custom nav
 export const SecurityExample: Story = {
-  render: () => (
-    <OpenCollapsibleNav>
+  render: ({ ...args }) => (
+    <OpenCollapsibleNav {...args}>
       <EuiFlyoutBody>
         <EuiCollapsibleNavItem
           title="Recent"

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta<EuiCollapsibleNavBetaProps> = {
   },
   args: {
     side: 'left',
+    initialIsCollapsed: false,
   },
 };
 export default meta;

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
@@ -15,8 +15,6 @@ export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
 
   return {
     euiCollapsibleNavBeta: css`
-      ${logicalCSS('border-top', euiTheme.border.thin)}
-
       .euiFlyoutFooter {
         background-color: ${euiTheme.colors.emptyShade};
         ${logicalCSS('border-top', euiTheme.border.thin)}

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
@@ -26,5 +26,11 @@ export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
     right: css`
       ${logicalCSS('border-left', euiTheme.border.thin)}
     `,
+    isSmallestScreen: css`
+      /* Override EuiFlyout's max-width */
+      &.euiFlyout {
+        ${logicalCSS('max-width', '100% !important')}
+      }
+    `,
   };
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
@@ -16,12 +16,17 @@ export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     euiCollapsibleNavBeta: css`
       ${logicalCSS('border-top', euiTheme.border.thin)}
-      ${logicalCSS('border-right', euiTheme.border.thin)}
 
       .euiFlyoutFooter {
         background-color: ${euiTheme.colors.emptyShade};
         ${logicalCSS('border-top', euiTheme.border.thin)}
       }
+    `,
+    left: css`
+      ${logicalCSS('border-right', euiTheme.border.thin)}
+    `,
+    right: css`
+      ${logicalCSS('border-left', euiTheme.border.thin)}
     `,
   };
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../test/rtl';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test';
+
+import { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
+
+describe('EuiCollapsibleNavBeta', () => {
+  shouldRenderCustomStyles(<EuiCollapsibleNavBeta />);
+
+  it('renders', () => {
+    const { baseElement, getByTestSubject } = render(
+      <EuiCollapsibleNavBeta {...requiredProps} data-test-subj="nav">
+        Nav content
+      </EuiCollapsibleNavBeta>
+    );
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '248px' });
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  // TODO: Visual snapshot for left vs right `side` prop, once we add visual snapshot testing
+});

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test';
@@ -29,23 +30,24 @@ describe('EuiCollapsibleNavBeta', () => {
   });
 
   it('renders initialIsCollapsed', () => {
-    const { queryByTestSubject } = render(
+    const { baseElement, getByTestSubject } = render(
       <EuiCollapsibleNavBeta data-test-subj="nav" initialIsCollapsed={true}>
         Nav content
       </EuiCollapsibleNavBeta>
     );
-    expect(queryByTestSubject('nav')).not.toBeInTheDocument();
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '48px' });
+    expect(baseElement).toMatchSnapshot();
   });
 
   it('toggles collapsed state', () => {
-    const { getByTestSubject, queryByTestSubject } = render(
+    const { getByTestSubject } = render(
       <EuiCollapsibleNavBeta data-test-subj="nav">
         Nav content
       </EuiCollapsibleNavBeta>
     );
-    expect(queryByTestSubject('nav')).toBeInTheDocument();
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '248px' });
     fireEvent.click(getByTestSubject('euiCollapsibleNavButton'));
-    expect(queryByTestSubject('nav')).not.toBeInTheDocument();
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '48px' });
   });
 
   it('automatically accounts for fixed EuiHeaders in its positioning', () => {
@@ -59,6 +61,60 @@ describe('EuiCollapsibleNavBeta', () => {
     expect(getByTestSubject('nav')).toHaveStyle({
       'inset-block-start': '48px',
       'block-size': 'calc(100% - 48px)',
+    });
+  });
+
+  describe('responsive behavior', () => {
+    const mockWindowResize = (width: number) => {
+      window.innerWidth = width;
+      window.dispatchEvent(new Event('resize'));
+    };
+
+    it('collapses from a push flyout to an overlay flyout once the screen is smaller than 3x the flyout width', () => {
+      mockWindowResize(600);
+      const { baseElement } = render(
+        <EuiCollapsibleNavBeta>Nav content</EuiCollapsibleNavBeta>
+      );
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('makes the overlay flyout full width once the screen is smaller than 1.5x the flyout width', () => {
+      mockWindowResize(320);
+      const { baseElement, getByTestSubject } = render(
+        <EuiCollapsibleNavBeta>Nav content</EuiCollapsibleNavBeta>
+      );
+      fireEvent.click(getByTestSubject('euiCollapsibleNavButton'));
+      expect(baseElement).toMatchSnapshot();
+
+      // onClose testing
+      expect(
+        baseElement.querySelector('[data-euiicon-type="cross"')
+      ).toBeInTheDocument();
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(
+        baseElement.querySelector('[data-euiicon-type="menu"')
+      ).toBeInTheDocument();
+    });
+
+    it('adjusts breakpoints for custom widths', () => {
+      mockWindowResize(1600);
+      const desktop = render(
+        <EuiCollapsibleNavBeta width={500} data-test-subj="pushFlyout">
+          Nav content
+        </EuiCollapsibleNavBeta>
+      );
+      expect(desktop.getByTestSubject('pushFlyout')).toBeInTheDocument();
+      desktop.unmount();
+
+      mockWindowResize(1200);
+      const mobile = render(
+        <EuiCollapsibleNavBeta width={500} data-test-subj="overlayFlyout">
+          Nav content
+        </EuiCollapsibleNavBeta>
+      );
+      expect(
+        mobile.queryByTestSubject('overlayFlyout')
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -11,6 +11,8 @@ import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test';
 
+import { EuiHeader } from '../header';
+
 import { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
 
 describe('EuiCollapsibleNavBeta', () => {
@@ -24,6 +26,20 @@ describe('EuiCollapsibleNavBeta', () => {
     );
     expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '248px' });
     expect(baseElement).toMatchSnapshot();
+  });
+
+  it('automatically accounts for fixed EuiHeaders in its positioning', () => {
+    const { getByTestSubject } = render(
+      <EuiHeader position="fixed">
+        <EuiCollapsibleNavBeta data-test-subj="nav">
+          Nav content
+        </EuiCollapsibleNavBeta>
+      </EuiHeader>
+    );
+    expect(getByTestSubject('nav')).toHaveStyle({
+      'inset-block-start': '48px',
+      'block-size': 'calc(100% - 48px)',
+    });
   });
 
   // TODO: Visual snapshot for left vs right `side` prop, once we add visual snapshot testing

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -28,6 +28,15 @@ describe('EuiCollapsibleNavBeta', () => {
     expect(baseElement).toMatchSnapshot();
   });
 
+  it('renders initialIsCollapsed', () => {
+    const { queryByTestSubject } = render(
+      <EuiCollapsibleNavBeta data-test-subj="nav" initialIsCollapsed={true}>
+        Nav content
+      </EuiCollapsibleNavBeta>
+    );
+    expect(queryByTestSubject('nav')).not.toBeInTheDocument();
+  });
+
   it('automatically accounts for fixed EuiHeaders in its positioning', () => {
     const { getByTestSubject } = render(
       <EuiHeader position="fixed">

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -37,6 +37,17 @@ describe('EuiCollapsibleNavBeta', () => {
     expect(queryByTestSubject('nav')).not.toBeInTheDocument();
   });
 
+  it('toggles collapsed state', () => {
+    const { getByTestSubject, queryByTestSubject } = render(
+      <EuiCollapsibleNavBeta data-test-subj="nav">
+        Nav content
+      </EuiCollapsibleNavBeta>
+    );
+    expect(queryByTestSubject('nav')).toBeInTheDocument();
+    fireEvent.click(getByTestSubject('euiCollapsibleNavButton'));
+    expect(queryByTestSubject('nav')).not.toBeInTheDocument();
+  });
+
   it('automatically accounts for fixed EuiHeaders in its positioning', () => {
     const { getByTestSubject } = render(
       <EuiHeader position="fixed">

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -10,6 +10,7 @@ import React, {
   FunctionComponent,
   HTMLAttributes,
   ReactNode,
+  useRef,
   useMemo,
   useState,
   useEffect,
@@ -24,6 +25,7 @@ import { CommonProps } from '../common';
 import { EuiFlyout, EuiFlyoutProps } from '../flyout';
 import { euiHeaderVariables } from '../header/header.styles';
 
+import { EuiCollapsibleNavButton } from './collapsible_nav_button';
 import { euiCollapsibleNavBetaStyles } from './collapsible_nav_beta.styles';
 
 export type EuiCollapsibleNavBetaProps = CommonProps &
@@ -52,7 +54,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   style,
   initialIsCollapsed = false,
   side = 'left',
-  focusTrapProps,
+  focusTrapProps: _focusTrapProps,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -102,6 +104,15 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
     suffix: 'euiCollapsibleNav',
   });
 
+  const buttonRef = useRef<HTMLDivElement | null>(null);
+  const focusTrapProps: EuiFlyoutProps['focusTrapProps'] = useMemo(
+    () => ({
+      ..._focusTrapProps,
+      shards: [buttonRef, ...(_focusTrapProps?.shards || [])],
+    }),
+    [_focusTrapProps]
+  );
+
   const classes = classNames(
     'euiCollapsibleNav',
     'euiCollapsibleNavBeta',
@@ -133,8 +144,15 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   );
 
   return (
+    // TODO: Context for sharing state to all children
     <>
-      {/* TODO: collapsible button */}
+      <EuiCollapsibleNavButton
+        ref={buttonRef}
+        onClick={toggleCollapsed}
+        isCollapsed={isCollapsed}
+        side={side}
+        aria-controls={flyoutID}
+      />
       {!isCollapsed && flyout}
     </>
   );

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -6,29 +6,77 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  ReactNode,
+} from 'react';
+import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiTheme, useGeneratedHtmlId } from '../../services';
 
-import {
-  EuiCollapsibleNav,
-  EuiCollapsibleNavProps,
-} from '../collapsible_nav/collapsible_nav';
+import { CommonProps } from '../common';
+import { EuiFlyout, EuiFlyoutProps } from '../flyout';
 
 import { euiCollapsibleNavBetaStyles } from './collapsible_nav_beta.styles';
 
-/**
- * TODO: Actual component in a follow-up PR
- */
-export const EuiCollapsibleNavBeta = (props: EuiCollapsibleNavProps) => {
+export type EuiCollapsibleNavBetaProps = CommonProps &
+  HTMLAttributes<HTMLElement> &
+  Pick<
+    EuiFlyoutProps, // Extend only specific flyout props - EuiCollapsibleNav is much less customizable than EuiFlyout
+    'side' | 'focusTrapProps' | 'includeFixedHeadersInFocusTrap'
+  > & {
+    /**
+     * ReactNode(s) to render as navigation flyout content, typically `EuiCollapsibleNavItem`s.
+     * You may also want to use `EuiFlyoutBody` and `EuiFlyoutFooter` for organization.
+     */
+    children?: ReactNode;
+  };
+
+export const EuiCollapsibleNavBeta: FunctionComponent<
+  EuiCollapsibleNavBetaProps
+> = ({
+  id,
+  children,
+  className,
+  style,
+  side = 'left',
+  focusTrapProps,
+  ...rest
+}) => {
+  const flyoutID = useGeneratedHtmlId({
+    conditionalId: id,
+    suffix: 'euiCollapsibleNav',
+  });
+
   const euiTheme = useEuiTheme();
+  const classes = classNames(
+    'euiCollapsibleNav',
+    'euiCollapsibleNavBeta',
+    className
+  );
   const styles = euiCollapsibleNavBetaStyles(euiTheme);
+  const cssStyles = [styles.euiCollapsibleNavBeta, styles[side]];
 
   return (
-    <EuiCollapsibleNav
-      css={styles.euiCollapsibleNavBeta}
-      size={248}
-      {...props}
-    />
+    <EuiFlyout
+      {...rest} // EuiCollapsibleNav is significantly less permissive than EuiFlyout
+      id={flyoutID}
+      css={cssStyles}
+      className={classes}
+      style={style}
+      size={248} // TODO: Responsive behavior
+      side={side}
+      focusTrapProps={focusTrapProps}
+      as="nav"
+      type="push" // TODO: Responsive behavior
+      paddingSize="none"
+      pushMinBreakpoint="s"
+      onClose={() => {}} // TODO: Collapsed state
+      hideCloseButton={true}
+    >
+      {/* TODO: collapsible button */}
+      {children}
+    </EuiFlyout>
   );
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -13,6 +13,7 @@ import React, {
   useMemo,
   useState,
   useEffect,
+  useCallback,
 } from 'react';
 import classNames from 'classnames';
 
@@ -36,6 +37,10 @@ export type EuiCollapsibleNavBetaProps = CommonProps &
      * You may also want to use `EuiFlyoutBody` and `EuiFlyoutFooter` for organization.
      */
     children?: ReactNode;
+    /**
+     * Whether the navigation flyout should default to initially collapsed or expanded
+     */
+    initialIsCollapsed?: boolean;
   };
 
 export const EuiCollapsibleNavBeta: FunctionComponent<
@@ -45,12 +50,23 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   children,
   className,
   style,
+  initialIsCollapsed = false,
   side = 'left',
   focusTrapProps,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
   const headerHeight = euiHeaderVariables(euiTheme).height;
+
+  /**
+   * Collapsed state
+   */
+  const [isCollapsed, setIsCollapsed] = useState(initialIsCollapsed);
+  const toggleCollapsed = useCallback(
+    () => setIsCollapsed((isCollapsed) => !isCollapsed),
+    []
+  );
+  const onClose = useCallback(() => setIsCollapsed(true), []);
 
   /**
    * Header affordance
@@ -109,7 +125,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
       type="push" // TODO: Responsive behavior
       paddingSize="none"
       pushMinBreakpoint="s"
-      onClose={() => {}} // TODO: Collapsed state
+      onClose={onClose}
       hideCloseButton={true}
     >
       {children}
@@ -119,7 +135,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   return (
     <>
       {/* TODO: collapsible button */}
-      {flyout}
+      {!isCollapsed && flyout}
     </>
   );
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -18,7 +18,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme, useGeneratedHtmlId } from '../../services';
+import { useEuiTheme, useGeneratedHtmlId, throttle } from '../../services';
 import { mathWithUnits, logicalStyle } from '../../global_styling';
 
 import { CommonProps } from '../common';
@@ -43,6 +43,21 @@ export type EuiCollapsibleNavBetaProps = CommonProps &
      * Whether the navigation flyout should default to initially collapsed or expanded
      */
     initialIsCollapsed?: boolean;
+    /**
+     * Defaults to 248px wide. The navigation width determines behavior at
+     * various responsive breakpoints.
+     *
+     * At larger screen sizes (at least 3x the width of the nav), the nav will
+     * be able to be toggled between a docked full width nav and a collapsed
+     * side bar that only shows the icon of each item.
+     *
+     * At under 3 times the width of the nav, the behavior will lose the collapsed
+     * side bar behavior, and switch from a docked flyout to an overlay flyout only.
+     *
+     * If the page is under 1.5 times the width of the nav, the overlay will
+     * take up the full width of the page.
+     */
+    width?: number;
   };
 
 export const EuiCollapsibleNavBeta: FunctionComponent<
@@ -53,6 +68,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   className,
   style,
   initialIsCollapsed = false,
+  width: _width = 248,
   side = 'left',
   focusTrapProps: _focusTrapProps,
   ...rest
@@ -69,6 +85,42 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
     []
   );
   const onClose = useCallback(() => setIsCollapsed(true), []);
+
+  /**
+   * Mobile behavior
+   */
+  const [isSmallScreen, setIsSmallScreen] = useState(false);
+  const [isSmallestScreen, setIsSmallestScreen] = useState(false);
+
+  // Add a window resize listener that determines breakpoint behavior
+  useEffect(() => {
+    const getBreakpoints = () => {
+      setIsSmallScreen(window.innerWidth < _width * 3);
+      setIsSmallestScreen(window.innerWidth < _width * 1.5);
+    };
+    getBreakpoints();
+
+    const onWindowResize = throttle(getBreakpoints, 50);
+    window.addEventListener('resize', onWindowResize);
+    return () => window.removeEventListener('resize', onWindowResize);
+  }, [_width]);
+
+  // If the screen was previously uncollapsed and shrinks down to
+  // a smaller mobile view, default that view to a collapsed state
+  useEffect(() => {
+    if (isSmallScreen) setIsCollapsed(true);
+  }, [isSmallScreen]);
+
+  // On small screens, the flyout becomes an overlay rather than a push
+  const flyoutType = isSmallScreen ? 'overlay' : 'push';
+  const isMobileCollapsed = isSmallScreen && isCollapsed;
+
+  const width = useMemo(() => {
+    if (isSmallestScreen) return '100%';
+    if (isSmallScreen) return _width;
+    if (isCollapsed) return headerHeight;
+    return _width;
+  }, [_width, isSmallScreen, isSmallestScreen, isCollapsed, headerHeight]);
 
   /**
    * Header affordance
@@ -119,7 +171,11 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
     className
   );
   const styles = euiCollapsibleNavBetaStyles(euiTheme);
-  const cssStyles = [styles.euiCollapsibleNavBeta, styles[side]];
+  const cssStyles = [
+    styles.euiCollapsibleNavBeta,
+    styles[side],
+    isSmallestScreen && styles.isSmallestScreen,
+  ];
 
   // Wait for any fixed headers to be queried before rendering (prevents position jumping)
   const flyout = fixedHeadersCount !== false && (
@@ -129,13 +185,13 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
       css={cssStyles}
       className={classes}
       style={stylesWithHeaderOffset}
-      size={248} // TODO: Responsive behavior
+      size={width}
       side={side}
       focusTrapProps={focusTrapProps}
       as="nav"
-      type="push" // TODO: Responsive behavior
+      type={flyoutType}
       paddingSize="none"
-      pushMinBreakpoint="s"
+      pushMinBreakpoint="xs"
       onClose={onClose}
       hideCloseButton={true}
     >
@@ -150,10 +206,11 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
         ref={buttonRef}
         onClick={toggleCollapsed}
         isCollapsed={isCollapsed}
+        isSmallScreen={isSmallScreen}
         side={side}
         aria-controls={flyoutID}
       />
-      {!isCollapsed && flyout}
+      {!isMobileCollapsed && flyout}
     </>
   );
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/__snapshots__/collapsible_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/__snapshots__/collapsible_nav_button.test.tsx.snap
@@ -87,3 +87,47 @@ exports[`EuiCollapsibleNavButton desktop right side renders a menu right icon wh
   </button>
 </div>
 `;
+
+exports[`EuiCollapsibleNavButton mobile renders a hamburger icon when collapsed 1`] = `
+<div
+  class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-right"
+>
+  <button
+    aria-expanded="false"
+    aria-label="Toggle navigation open"
+    aria-pressed="false"
+    class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+    data-test-subj="euiCollapsibleNavButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="menu"
+    />
+  </button>
+</div>
+`;
+
+exports[`EuiCollapsibleNavButton mobile renders an X icon when expanded 1`] = `
+<div
+  class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+>
+  <button
+    aria-expanded="true"
+    aria-label="Toggle navigation closed"
+    aria-pressed="true"
+    class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+    data-test-subj="euiCollapsibleNavButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="cross"
+    />
+  </button>
+</div>
+`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/__snapshots__/collapsible_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/__snapshots__/collapsible_nav_button.test.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiCollapsibleNavButton desktop left side renders a menu left icon when expanded 1`] = `
+<div
+  class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+>
+  <button
+    aria-expanded="true"
+    aria-label="Toggle navigation closed"
+    aria-pressed="true"
+    class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+    data-test-subj="euiCollapsibleNavButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="menuLeft"
+    />
+  </button>
+</div>
+`;
+
+exports[`EuiCollapsibleNavButton desktop left side renders a menu right icon when collapsed 1`] = `
+<div
+  class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-left"
+>
+  <button
+    aria-expanded="false"
+    aria-label="Toggle navigation open"
+    aria-pressed="false"
+    class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+    data-test-subj="euiCollapsibleNavButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="menuRight"
+    />
+  </button>
+</div>
+`;
+
+exports[`EuiCollapsibleNavButton desktop right side renders a menu left icon when collapsed 1`] = `
+<div
+  class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-right"
+>
+  <button
+    aria-expanded="false"
+    aria-label="Toggle navigation open"
+    aria-pressed="false"
+    class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+    data-test-subj="euiCollapsibleNavButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="menuLeft"
+    />
+  </button>
+</div>
+`;
+
+exports[`EuiCollapsibleNavButton desktop right side renders a menu right icon when expanded 1`] = `
+<div
+  class="euiCollapsibleNavButtonWrapper emotion-euiCollapsibleNavButtonWrapper-right"
+>
+  <button
+    aria-expanded="true"
+    aria-label="Toggle navigation closed"
+    aria-pressed="true"
+    class="euiButtonIcon euiCollapsibleNavButton emotion-euiButtonIcon-s-empty-text"
+    data-test-subj="euiCollapsibleNavButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="menuRight"
+    />
+  </button>
+</div>
+`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.styles.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../../services';
+import { logicalCSS, logicalSizeCSS } from '../../../global_styling';
+
+import { euiHeaderVariables } from '../../header/header.styles';
+
+export const euiCollapsibleNavButtonWrapperStyles = (
+  euiThemeContext: UseEuiTheme
+) => {
+  const { euiTheme } = euiThemeContext;
+  const { height, padding } = euiHeaderVariables(euiThemeContext);
+
+  return {
+    euiCollapsibleNavButtonWrapper: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      ${logicalSizeCSS(height)}
+    `,
+    left: css`
+      ${logicalCSS('border-right', euiTheme.border.thin)}
+      ${logicalCSS('margin-left', `-${padding}`)}
+      ${logicalCSS('margin-right', padding)}
+    `,
+    right: css`
+      ${logicalCSS('border-left', euiTheme.border.thin)}
+      ${logicalCSS('margin-right', `-${padding}`)}
+      ${logicalCSS('margin-left', padding)}
+    `,
+  };
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../../test/rtl';
+
+import { EuiCollapsibleNavButton } from './collapsible_nav_button';
+
+describe('EuiCollapsibleNavButton', () => {
+  describe('desktop', () => {
+    describe('left side', () => {
+      it('renders a menu left icon when expanded', () => {
+        const { container } = render(
+          <EuiCollapsibleNavButton side="left" isCollapsed={false} />
+        );
+
+        expect(container.firstChild).toMatchSnapshot();
+        expect(
+          container.querySelector('[data-euiicon-type="menuLeft"]')
+        ).toBeInTheDocument();
+      });
+
+      it('renders a menu right icon when collapsed', () => {
+        const { container } = render(
+          <EuiCollapsibleNavButton side="left" isCollapsed={true} />
+        );
+
+        expect(container.firstChild).toMatchSnapshot();
+        expect(
+          container.querySelector('[data-euiicon-type="menuRight"]')
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('right side', () => {
+      it('renders a menu right icon when expanded', () => {
+        const { container } = render(
+          <EuiCollapsibleNavButton side="right" isCollapsed={false} />
+        );
+
+        expect(container.firstChild).toMatchSnapshot();
+        expect(
+          container.querySelector('[data-euiicon-type="menuRight"]')
+        ).toBeInTheDocument();
+      });
+
+      it('renders a menu left icon when collapsed', () => {
+        const { container } = render(
+          <EuiCollapsibleNavButton side="right" isCollapsed={true} />
+        );
+
+        expect(container.firstChild).toMatchSnapshot();
+        expect(
+          container.querySelector('[data-euiicon-type="menuLeft"]')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.test.tsx
@@ -16,7 +16,11 @@ describe('EuiCollapsibleNavButton', () => {
     describe('left side', () => {
       it('renders a menu left icon when expanded', () => {
         const { container } = render(
-          <EuiCollapsibleNavButton side="left" isCollapsed={false} />
+          <EuiCollapsibleNavButton
+            side="left"
+            isSmallScreen={false}
+            isCollapsed={false}
+          />
         );
 
         expect(container.firstChild).toMatchSnapshot();
@@ -27,7 +31,11 @@ describe('EuiCollapsibleNavButton', () => {
 
       it('renders a menu right icon when collapsed', () => {
         const { container } = render(
-          <EuiCollapsibleNavButton side="left" isCollapsed={true} />
+          <EuiCollapsibleNavButton
+            side="left"
+            isSmallScreen={false}
+            isCollapsed={true}
+          />
         );
 
         expect(container.firstChild).toMatchSnapshot();
@@ -40,7 +48,11 @@ describe('EuiCollapsibleNavButton', () => {
     describe('right side', () => {
       it('renders a menu right icon when expanded', () => {
         const { container } = render(
-          <EuiCollapsibleNavButton side="right" isCollapsed={false} />
+          <EuiCollapsibleNavButton
+            side="right"
+            isSmallScreen={false}
+            isCollapsed={false}
+          />
         );
 
         expect(container.firstChild).toMatchSnapshot();
@@ -51,7 +63,11 @@ describe('EuiCollapsibleNavButton', () => {
 
       it('renders a menu left icon when collapsed', () => {
         const { container } = render(
-          <EuiCollapsibleNavButton side="right" isCollapsed={true} />
+          <EuiCollapsibleNavButton
+            side="right"
+            isSmallScreen={false}
+            isCollapsed={true}
+          />
         );
 
         expect(container.firstChild).toMatchSnapshot();
@@ -59,6 +75,38 @@ describe('EuiCollapsibleNavButton', () => {
           container.querySelector('[data-euiicon-type="menuLeft"]')
         ).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('mobile', () => {
+    it('renders an X icon when expanded', () => {
+      const { container } = render(
+        <EuiCollapsibleNavButton
+          side="left"
+          isSmallScreen={true}
+          isCollapsed={false}
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+      expect(
+        container.querySelector('[data-euiicon-type="cross"]')
+      ).toBeInTheDocument();
+    });
+
+    it('renders a hamburger icon when collapsed', () => {
+      const { container } = render(
+        <EuiCollapsibleNavButton
+          side="right"
+          isSmallScreen={true}
+          isCollapsed={true}
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+      expect(
+        container.querySelector('[data-euiicon-type="menu"]')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.tsx
@@ -19,23 +19,27 @@ import { euiCollapsibleNavButtonWrapperStyles } from './collapsible_nav_button.s
 export type EuiCollapsibleNavButtonProps = CommonProps &
   Partial<EuiButtonIconPropsForButton> & {
     isCollapsed: boolean;
+    isSmallScreen: boolean;
     side: EuiCollapsibleNavBetaProps['side'];
   };
 
 export const EuiCollapsibleNavButton = forwardRef<
   HTMLDivElement,
   EuiCollapsibleNavButtonProps
->(({ isCollapsed, side, ...rest }, ref) => {
+>(({ isCollapsed, isSmallScreen, side, ...rest }, ref) => {
   const euiTheme = useEuiTheme();
   const styles = euiCollapsibleNavButtonWrapperStyles(euiTheme);
   const cssStyles = [styles.euiCollapsibleNavButtonWrapper, styles[side!]];
 
-  // TODO: Mobile menu/cross behavior
   let iconType: string;
-  if (side === 'left') {
-    iconType = isCollapsed ? 'menuRight' : 'menuLeft';
+  if (isSmallScreen) {
+    iconType = isCollapsed ? 'menu' : 'cross';
   } else {
-    iconType = isCollapsed ? 'menuLeft' : 'menuRight';
+    if (side === 'left') {
+      iconType = isCollapsed ? 'menuRight' : 'menuLeft';
+    } else {
+      iconType = isCollapsed ? 'menuLeft' : 'menuRight';
+    }
   }
 
   const toggleOpenLabel = useEuiI18n(

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { forwardRef } from 'react';
+
+import { useEuiTheme } from '../../../services';
+import { CommonProps } from '../../common';
+import { EuiButtonIcon, EuiButtonIconPropsForButton } from '../../button';
+import { useEuiI18n } from '../../i18n';
+
+import { EuiCollapsibleNavBetaProps } from '../';
+import { euiCollapsibleNavButtonWrapperStyles } from './collapsible_nav_button.styles';
+
+export type EuiCollapsibleNavButtonProps = CommonProps &
+  Partial<EuiButtonIconPropsForButton> & {
+    isCollapsed: boolean;
+    side: EuiCollapsibleNavBetaProps['side'];
+  };
+
+export const EuiCollapsibleNavButton = forwardRef<
+  HTMLDivElement,
+  EuiCollapsibleNavButtonProps
+>(({ isCollapsed, side, ...rest }, ref) => {
+  const euiTheme = useEuiTheme();
+  const styles = euiCollapsibleNavButtonWrapperStyles(euiTheme);
+  const cssStyles = [styles.euiCollapsibleNavButtonWrapper, styles[side!]];
+
+  // TODO: Mobile menu/cross behavior
+  let iconType: string;
+  if (side === 'left') {
+    iconType = isCollapsed ? 'menuRight' : 'menuLeft';
+  } else {
+    iconType = isCollapsed ? 'menuLeft' : 'menuRight';
+  }
+
+  const toggleOpenLabel = useEuiI18n(
+    'euiCollapsibleNavButton.ariaLabelOpen',
+    'Toggle navigation open'
+  );
+  const toggleCloselLabel = useEuiI18n(
+    'euiCollapsibleNavButton.ariaLabelClose',
+    'Toggle navigation closed'
+  );
+  const ariaLabel = isCollapsed ? toggleOpenLabel : toggleCloselLabel;
+
+  return (
+    <div className="euiCollapsibleNavButtonWrapper" css={cssStyles} ref={ref}>
+      <EuiButtonIcon
+        data-test-subj="euiCollapsibleNavButton"
+        className="euiCollapsibleNavButton"
+        size="s"
+        color="text"
+        iconType={iconType}
+        aria-label={ariaLabel}
+        aria-pressed={!isCollapsed}
+        aria-expanded={!isCollapsed}
+        {...rest}
+      />
+    </div>
+  );
+});
+
+EuiCollapsibleNavButton.displayName = 'EuiCollapsibleNavButton';

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/collapsible_nav_button.tsx
@@ -12,15 +12,15 @@ import { useEuiTheme } from '../../../services';
 import { CommonProps } from '../../common';
 import { EuiButtonIcon, EuiButtonIconPropsForButton } from '../../button';
 import { useEuiI18n } from '../../i18n';
+import { _EuiFlyoutSide } from '../../flyout/flyout';
 
-import { EuiCollapsibleNavBetaProps } from '../';
 import { euiCollapsibleNavButtonWrapperStyles } from './collapsible_nav_button.styles';
 
 export type EuiCollapsibleNavButtonProps = CommonProps &
   Partial<EuiButtonIconPropsForButton> & {
     isCollapsed: boolean;
     isSmallScreen: boolean;
-    side: EuiCollapsibleNavBetaProps['side'];
+    side: _EuiFlyoutSide;
   };
 
 export const EuiCollapsibleNavButton = forwardRef<
@@ -29,7 +29,7 @@ export const EuiCollapsibleNavButton = forwardRef<
 >(({ isCollapsed, isSmallScreen, side, ...rest }, ref) => {
   const euiTheme = useEuiTheme();
   const styles = euiCollapsibleNavButtonWrapperStyles(euiTheme);
-  const cssStyles = [styles.euiCollapsibleNavButtonWrapper, styles[side!]];
+  const cssStyles = [styles.euiCollapsibleNavButtonWrapper, styles[side]];
 
   let iconType: string;
   if (isSmallScreen) {

--- a/src/components/collapsible_nav_beta/collapsible_nav_button/index.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_button/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { EuiCollapsibleNavButton } from './collapsible_nav_button';

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -47,7 +47,7 @@ export const Playground: Story = {
 
 export const EdgeCaseTesting: Story = {
   render: ({ ...args }) => (
-    <EuiCollapsibleNavBeta isOpen={true} onClose={() => {}}>
+    <EuiCollapsibleNavBeta>
       <div className="eui-yScroll">
         <EuiCollapsibleNavItem {...args} href="#" title="Link with no icon" />
         <EuiCollapsibleNavItem

--- a/src/components/collapsible_nav_beta/index.ts
+++ b/src/components/collapsible_nav_beta/index.ts
@@ -11,6 +11,7 @@
  * development usage. It is not yet fully documented or supported.
  */
 
+export type { EuiCollapsibleNavBetaProps } from './collapsible_nav_beta';
 export { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
 
 export type {

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -46,7 +46,7 @@ export const TYPES = ['push', 'overlay'] as const;
 type _EuiFlyoutType = (typeof TYPES)[number];
 
 export const SIDES = ['left', 'right'] as const;
-type _EuiFlyoutSide = (typeof SIDES)[number];
+export type _EuiFlyoutSide = (typeof SIDES)[number];
 
 export const SIZES = ['s', 'm', 'l'] as const;
 export type EuiFlyoutSize = (typeof SIZES)[number];

--- a/src/components/header/header.styles.ts
+++ b/src/components/header/header.styles.ts
@@ -23,12 +23,13 @@ export const euiHeaderVariables = (euiThemeContext: UseEuiTheme) => {
   return {
     height: euiTheme.size.xxxl,
     childHeight: euiTheme.size.xxl,
+    padding: euiTheme.size.s,
   };
 };
 
 export const euiHeaderStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme, colorMode } = euiThemeContext;
-  const { height } = euiHeaderVariables(euiThemeContext);
+  const { height, padding } = euiHeaderVariables(euiThemeContext);
 
   // Curated border color to fade into the shadow without looking too much like a border
   // It adds separation between the header and flyout
@@ -42,7 +43,7 @@ export const euiHeaderStyles = (euiThemeContext: UseEuiTheme) => {
       display: flex;
       justify-content: space-between;
       ${logicalCSS('height', height)}
-      ${logicalCSS('padding-horizontal', euiTheme.size.s)}
+      ${logicalCSS('padding-horizontal', padding)}
       ${euiShadowSmall(euiThemeContext)}
     `,
     // Position


### PR DESCRIPTION
## Summary

- ⚠️ This PR is part **1 of 2** of completing EuiCollapsibleNavBeta's responsive/docked behavior.
  - The part that is missing is the part where `EuiCollapsibleNavItem` needs to conditionally render a icon that toggles a popover, but only for larger desktop screens when in the "collapsed" state.
  - I opted to split out this work into separate PRs, as this one was already getting pretty long in the tooth in terms of LOC/review time.
- Parent issue: https://github.com/elastic/eui/issues/6759
- Previous PRs: https://github.com/elastic/eui/pull/6904

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7027/commits).

### Screenshots

#### Desktop - expanded
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/6cd6b097-3d34-4adf-9817-f46e35289414">

#### Desktop - collapsed
As noted above, this is **expected to be broken** and will be implemented in the next PR. However, the flyout width should be correct.

<img width="200" alt="" src="https://github.com/elastic/eui/assets/549407/7f1b0406-f1aa-4485-bcad-a093b3ec27e0">

<img width="100" alt="" src="https://github.com/elastic/eui/assets/549407/21b7847f-06ea-4238-b485-3c9c57cf9d9f">

#### Mobile - expanded
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/d0d80ddc-9a45-4334-be9a-6496c50d8eee">

Smallest screens should have the flyout overlay to 100% width
<img width="300" alt="" src="https://github.com/elastic/eui/assets/549407/68ea2ebe-ff7c-4c55-9e74-4330013c8fd1">

#### Mobile - collapsed
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/2868d3fd-e53a-4497-ae91-29b7af5a2ba0">

## QA

- `gh pr checkout 7027`
- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--kibana-example
- View the demo on desktop
    - [x] Confirm that clicking the collapse button sets the flyout width correctly (should be same as the width of the toggle button)
    - [x] Confirm the toggle button toggles between left/right menu icons
    - [x] Confirm that changing the `side` prop in the Storybook controls panel correctly toggles the flyout position and the icon directions
- View the demo on large mobile
    - [x] Confirm the flyout is now an overlay 
    - [x] Confirm the icons now toggle between a menu and a cross
- View the demo on small mobile
    - [x] Confirm the flyout is now full-width over the entire screen
- In the Storybook controls panel, set the `width` prop to a custom width, e.g. `400`
- [x] Resize your window appropriately to confirm that the nav's breakpoints are dynamic based on the width passed - it's considered "desktop" at 3x the width of the nav, and "smallest" at under 1.5x the width of the nav
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--multiple-fixed-headers
- [ ] Confirm the header has correctly accounted and positioned for both fixed headers

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
  - NOTE: This isn't quite yet ready due to the component being merged in in-progress states. I plan on making a final a11y/screenreader pass at the end / after the final PR

Below items are all N/A due to the component's beta status
~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~