### PR TITLE
[A11y] Fixed two failing Cypress accessibility tests

### DIFF
--- a/src/components/date_picker/super_date_picker/super_date_picker.a11y.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.a11y.tsx
@@ -53,7 +53,7 @@ const SuperDatePicker = () => {
 
 beforeEach(() => {
   cy.mount(<SuperDatePicker />);
-  cy.get('div.euiSuperDatePicker__flexWrapper').should('exist');
+  cy.get('div.euiSuperDatePicker').should('exist');
 });
 
 describe('EuiSuperDatePicker', () => {

--- a/src/components/filter_group/filter_group.a11y.tsx
+++ b/src/components/filter_group/filter_group.a11y.tsx
@@ -257,7 +257,7 @@ describe('EuiFilterGroup multiselect example', () => {
         .find('span.euiSelectableListItem__text')
         .should(
           'have.text',
-          'Dmitri Shostakovich - Checked option. To exclude this option, press Enter.'
+          'Dmitri Shostakovich. Checked option. To exclude this option, press Enter.'
         );
       cy.realPress('ArrowDown');
       cy.repeatRealPress('Enter');
@@ -265,7 +265,7 @@ describe('EuiFilterGroup multiselect example', () => {
         .find('span.euiSelectableListItem__text')
         .should(
           'have.text',
-          'Felix Mendelssohn-Bartholdy - Excluded option. To uncheck this option, press Enter.'
+          'Felix Mendelssohn-Bartholdy. Excluded option. To uncheck this option, press Enter.'
         );
       cy.checkAxe();
     });


### PR DESCRIPTION
## Summary
Two tests were failing because of changes to an `aria-label` and a containing CSS class. I updated these and re-ran the tests locally.

This PR closes #7024.

## QA

Ran tests locally several times in CI (headless) mode and using the Cypress UI. All tests passing again.

### General checklist

- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**

---
<img width="1032" alt="Screen Shot 2023-08-02 at 1 11 13 PM" src="https://github.com/elastic/eui/assets/934879/44d1942a-b99c-41a1-899d-75427c9b0b2d">
