### PR TITLE
[EuiBreadcrumbs] Add `popoverContent` and `popoverProps`

### DIFF
--- a/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiBreadcrumbs, EuiCode, EuiText } from '../../../../src/components';
+import {
+  EuiBreadcrumbs,
+  EuiCode,
+  EuiText,
+  EuiCallOut,
+} from '../../../../src/components';
 import { BreadcrumbProps, BreadcrumbResponsiveMaxCount } from './props';
 
 import { breadcrumbsConfig } from './playground';
@@ -22,11 +27,13 @@ import TruncateSingle from './truncate_single';
 const truncateSingleSource = require('!!raw-loader!./truncate_single');
 
 import Max from './max';
-import { EuiCallOut } from '../../../../src/components/call_out';
 const maxSource = require('!!raw-loader!./max');
 
 import Color from './color';
 const colorSource = require('!!raw-loader!./color');
+
+import PopoverContent from './popover_content';
+const popoverContentSource = require('!!raw-loader!./popover_content');
 
 const props = {
   EuiBreadcrumbs,
@@ -243,6 +250,75 @@ export const BreadcrumbsExample = {
 />`,
       ],
       demo: <ResponsiveCustom />,
+    },
+    {
+      title: 'Popover content',
+      text: (
+        <>
+          <p>
+            If you want a breadcrumb that toggles a popover, e.g. for an account
+            switcher, you can use the <EuiCode>popoverContent</EuiCode> prop for
+            this purpose. <strong>EuiBreadcrumbs</strong> will automatically
+            handle rendering a popover indicator and popover accessibility best
+            practies for you. We recommend using components such as{' '}
+            <Link to="/navigation/context-menu">
+              <strong>EuiContextMenu</strong>
+            </Link>{' '}
+            or{' '}
+            <Link to="/display/list-group">
+              <strong>EuiListGroup</strong>
+            </Link>{' '}
+            for displaying popover options, or potentially{' '}
+            <Link to="/forms/selectable">
+              <strong>EuiSelectable</strong>
+            </Link>{' '}
+            if you have many items that require filtering.
+          </p>
+          <p>
+            You may also pass <EuiCode>popoverProps</EuiCode> with almost any
+            prop that{' '}
+            <Link to="/layout/popover">
+              <strong>EuiPopover</strong>
+            </Link>{' '}
+            accepts, such as customizing <EuiCode>panelPaddingSize</EuiCode> or{' '}
+            <EuiCode>anchorPosition</EuiCode>. However, props that affect
+            popover state such as <EuiCode>closePopover</EuiCode>,{' '}
+            <EuiCode>isOpen</EuiCode>, and <EuiCode>button</EuiCode> are not
+            accepted as they are controlled automatically by{' '}
+            <strong>EuiBreadcrumbs</strong>.
+          </p>
+          <EuiCallOut
+            color="warning"
+            iconType="accessibility"
+            title={
+              <>
+                Please note that creating a breadcrumb with a popover will
+                nullify any passed <EuiCode>href</EuiCode> or{' '}
+                <EuiCode>onClick</EuiCode> behavior, as the <em>only</em>{' '}
+                interaction the breadcrumb should have at that point is the
+                popover toggle.
+              </>
+            }
+          ></EuiCallOut>
+        </>
+      ),
+      props,
+      demo: <PopoverContent />,
+      snippet: `<EuiBreadcrumbs
+  breadcrumbs={[
+    {
+      text: 'My account',
+      popoverContent: <AccountSwitcher />,
+      popoverProps: { panelPaddingSize: 's' },
+    }
+  ]}
+/>`,
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: popoverContentSource,
+        },
+      ],
     },
     {
       title: 'Color for emphasis',

--- a/src-docs/src/views/breadcrumbs/popover_content.tsx
+++ b/src-docs/src/views/breadcrumbs/popover_content.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+
+import {
+  EuiBreadcrumbs,
+  EuiBreadcrumb,
+  EuiPopoverTitle,
+  EuiPopoverFooter,
+  EuiContextMenuPanel,
+  EuiSelectable,
+  EuiSelectableOption,
+  EuiAvatar,
+  EuiButton,
+  EuiContextMenuItem,
+} from '../../../../src';
+
+export default () => {
+  const [spaces, setSpaces] = useState<EuiSelectableOption[]>([
+    {
+      label: 'My space',
+      checked: 'on',
+      prepend: <EuiAvatar type="space" size="s" name="My space" />,
+    },
+    {
+      label: "Jim's space",
+      prepend: <EuiAvatar type="space" size="s" name="Jim" />,
+    },
+    {
+      label: "Pam's space",
+      prepend: <EuiAvatar type="space" size="s" name="Pam" />,
+    },
+    {
+      label: "Michael's space",
+      prepend: <EuiAvatar type="space" size="s" name="Michael" />,
+    },
+    {
+      label: "Dwight's space",
+      prepend: <EuiAvatar type="space" size="s" name="Dwight" />,
+    },
+  ]);
+
+  const breadcrumbs: EuiBreadcrumb[] = [
+    {
+      text: 'My deployment',
+      popoverContent: (
+        <>
+          <EuiPopoverTitle paddingSize="s">Select a deployment</EuiPopoverTitle>
+          <EuiContextMenuPanel
+            size="s"
+            items={[
+              <EuiContextMenuItem
+                key="A"
+                href="#"
+                onClick={(e) => e.preventDefault()}
+              >
+                Go to Deployment A
+              </EuiContextMenuItem>,
+              <EuiContextMenuItem
+                key="B"
+                href="#"
+                onClick={(e) => e.preventDefault()}
+              >
+                Go to Deployment B
+              </EuiContextMenuItem>,
+              <EuiContextMenuItem
+                key="C"
+                href="#"
+                onClick={(e) => e.preventDefault()}
+              >
+                Go to all deployments
+              </EuiContextMenuItem>,
+            ]}
+          />
+        </>
+      ),
+      popoverProps: { panelPaddingSize: 'none' },
+    },
+    {
+      text: 'My space',
+      popoverContent: (
+        <EuiSelectable
+          singleSelection
+          options={spaces}
+          onChange={(newOptions) => setSpaces(newOptions)}
+          searchable
+          searchProps={{ placeholder: 'Filter spaces', compressed: true }}
+          aria-label="Space switcher"
+          emptyMessage="No spaces available"
+          noMatchesMessage="No spaces found"
+        >
+          {(list, search) => (
+            <>
+              <EuiPopoverTitle paddingSize="s">Select a space</EuiPopoverTitle>
+              <EuiPopoverTitle paddingSize="s">{search}</EuiPopoverTitle>
+              {list}
+              <EuiPopoverFooter paddingSize="s">
+                <EuiButton fullWidth size="s" iconType="gear">
+                  Manage all spaces
+                </EuiButton>
+              </EuiPopoverFooter>
+            </>
+          )}
+        </EuiSelectable>
+      ),
+      popoverProps: { panelPaddingSize: 'none' },
+    },
+    {
+      text: 'Home',
+    },
+  ];
+
+  return <EuiBreadcrumbs breadcrumbs={breadcrumbs} />;
+};

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -13,14 +13,16 @@ exports[`EuiBreadcrumbContent renders breadcrumbs with \`popoverContent\` with p
         <button
           class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
           data-test-subj="popoverToggle"
-          title="Toggles a popover "
+          title="Toggles a popover  - Clicking this button will toggle a popover dialog."
           type="button"
         >
           Toggles a popover
            
           <span
             data-euiicon-type="arrowDown"
-          />
+          >
+             - Clicking this button will toggle a popover dialog.
+          </span>
         </button>
       </div>
     </div>

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiBreadcrumbContent renders breadcrumbs with \`popoverContent\` with popovers 1`] = `
+<body>
+  <div>
+    <div
+      class="euiPopover euiPopover-isOpen emotion-euiPopover"
+      data-test-subj="popover"
+    >
+      <div
+        class="euiPopover__anchor css-16vtueo-render"
+      >
+        <button
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          data-test-subj="popoverToggle"
+          title="Toggles a popover "
+          type="button"
+        >
+          Toggles a popover
+           
+          <span
+            data-euiicon-type="arrowDown"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-isOpen-bottom"
+        data-autofocus="true"
+        data-popover-open="true"
+        data-popover-panel="true"
+        role="dialog"
+        style="top: 16px; left: -22px; z-index: 2000;"
+        tabindex="0"
+      >
+        <div
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+          data-popover-arrow="bottom"
+          style="left: 10px; top: 0px;"
+        />
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
+        </p>
+        <div>
+          Hello popover world
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`EuiBreadcrumbContent renders interactive breadcrumbs with href or onClick 1`] = `
+<div>
+  <a
+    class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+    href="#"
+    rel="noreferrer"
+    title="Link"
+  >
+    Link
+  </a>
+  <button
+    class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+    title="Button"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`EuiBreadcrumbContent renders plain uninteractive breadcrumb text 1`] = `
+<div>
+  <span
+    class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-euiTextColor-subdued"
+    title="Text"
+  >
+    Text
+  </span>
+</div>
+`;

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -45,16 +45,21 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
           class="euiPopover__anchor css-16vtueo-render"
         >
           <button
-            aria-label="See collapsed breadcrumbs"
             class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
             title="See collapsed breadcrumbs"
             type="button"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
              
             <span
               data-euiicon-type="arrowDown"
-            />
+            >
+               - Clicking this button will toggle a popover dialog.
+            </span>
           </button>
         </div>
       </div>
@@ -145,16 +150,21 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
           class="euiPopover__anchor css-16vtueo-render"
         >
           <button
-            aria-label="See collapsed breadcrumbs"
             class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
             title="See collapsed breadcrumbs"
             type="button"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
              
             <span
               data-euiicon-type="arrowDown"
-            />
+            >
+               - Clicking this button will toggle a popover dialog.
+            </span>
           </button>
         </div>
       </div>
@@ -327,16 +337,21 @@ exports[`EuiBreadcrumbs props max renders 1 item 1`] = `
           class="euiPopover__anchor css-16vtueo-render"
         >
           <button
-            aria-label="See collapsed breadcrumbs"
             class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
             title="See collapsed breadcrumbs"
             type="button"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
              
             <span
               data-euiicon-type="arrowDown"
-            />
+            >
+               - Clicking this button will toggle a popover dialog.
+            </span>
           </button>
         </div>
       </div>
@@ -508,16 +523,21 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
           class="euiPopover__anchor css-16vtueo-render"
         >
           <button
-            aria-label="See collapsed breadcrumbs"
             class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
             title="See collapsed breadcrumbs"
             type="button"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
              
             <span
               data-euiicon-type="arrowDown"
-            />
+            >
+               - Clicking this button will toggle a popover dialog.
+            </span>
           </button>
         </div>
       </div>
@@ -607,16 +627,21 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
           class="euiPopover__anchor css-16vtueo-render"
         >
           <button
-            aria-label="See collapsed breadcrumbs"
             class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
             title="See collapsed breadcrumbs"
             type="button"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
              
             <span
               data-euiicon-type="arrowDown"
-            />
+            >
+               - Clicking this button will toggle a popover dialog.
+            </span>
           </button>
         </div>
       </div>
@@ -681,16 +706,21 @@ exports[`EuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
           class="euiPopover__anchor css-16vtueo-render"
         >
           <button
-            aria-label="See collapsed breadcrumbs"
             class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
             title="See collapsed breadcrumbs"
             type="button"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
              
             <span
               data-euiicon-type="arrowDown"
-            />
+            >
+               - Clicking this button will toggle a popover dialog.
+            </span>
           </button>
         </div>
       </div>

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -50,7 +50,8 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
             title="See collapsed breadcrumbs"
             type="button"
           >
-            … 
+            …
+             
             <span
               data-euiicon-type="arrowDown"
             />
@@ -149,7 +150,8 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
             title="See collapsed breadcrumbs"
             type="button"
           >
-            … 
+            …
+             
             <span
               data-euiicon-type="arrowDown"
             />
@@ -330,7 +332,8 @@ exports[`EuiBreadcrumbs props max renders 1 item 1`] = `
             title="See collapsed breadcrumbs"
             type="button"
           >
-            … 
+            …
+             
             <span
               data-euiicon-type="arrowDown"
             />
@@ -510,7 +513,8 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
             title="See collapsed breadcrumbs"
             type="button"
           >
-            … 
+            …
+             
             <span
               data-euiicon-type="arrowDown"
             />
@@ -608,7 +612,8 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
             title="See collapsed breadcrumbs"
             type="button"
           >
-            … 
+            …
+             
             <span
               data-euiicon-type="arrowDown"
             />
@@ -681,7 +686,8 @@ exports[`EuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
             title="See collapsed breadcrumbs"
             type="button"
           >
-            … 
+            …
+             
             <span
               data-euiicon-type="arrowDown"
             />

--- a/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -51,4 +51,49 @@ describe('EuiBreadcrumbContent', () => {
     expect(getByTestSubject('popover')).toBeInTheDocument();
     expect(baseElement).toMatchSnapshot();
   });
+
+  describe('highlightLastBreadcrumb', () => {
+    it('adds an aria-current attr', () => {
+      const { getByText } = render(
+        <EuiBreadcrumbContent type="page" text="Home" highlightLastBreadcrumb />
+      );
+      expect(getByText('Home')).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('colors both interactive and non-interactive breadcrumbs text-colored', () => {
+      const { getByTestSubject } = render(
+        <>
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="control" // Not the last breadcrumb / not highlighted
+          />
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="text"
+            highlightLastBreadcrumb
+          />
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="link"
+            href="#"
+            highlightLastBreadcrumb
+          />
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="popover"
+            popoverContent="popover"
+            highlightLastBreadcrumb
+          />
+        </>
+      );
+      expect(getByTestSubject('control')).toHaveStyleRule('color', '#646a77');
+      expect(getByTestSubject('text')).toHaveStyleRule('color', '#343741');
+      expect(getByTestSubject('link')).toHaveStyleRule('color', '#343741');
+      expect(getByTestSubject('popover')).toHaveStyleRule('color', '#343741');
+    });
+  });
 });

--- a/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { render, waitForEuiPopoverOpen } from '../../test/rtl';
+
+import { EuiBreadcrumbContent } from './breadcrumb';
+
+describe('EuiBreadcrumbContent', () => {
+  it('renders plain uninteractive breadcrumb text', () => {
+    const { container, getByText } = render(
+      <>
+        <EuiBreadcrumbContent type="page" text="Text" />
+      </>
+    );
+    expect(getByText('Text').nodeName).toEqual('SPAN');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders interactive breadcrumbs with href or onClick', () => {
+    const { container, getByText } = render(
+      <>
+        <EuiBreadcrumbContent type="page" text="Link" href="#" />
+        <EuiBreadcrumbContent type="page" text="Button" onClick={() => {}} />
+      </>
+    );
+    expect(getByText('Link').nodeName).toEqual('A');
+    expect(getByText('Button').nodeName).toEqual('BUTTON');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders breadcrumbs with `popoverContent` with popovers', async () => {
+    const { baseElement, getByTestSubject } = render(
+      <EuiBreadcrumbContent
+        type="page"
+        text="Toggles a popover"
+        data-test-subj="popoverToggle"
+        popoverContent="Hello popover world"
+        popoverProps={{ 'data-test-subj': 'popover' }}
+      />
+    );
+    fireEvent.click(getByTestSubject('popoverToggle'));
+    await waitForEuiPopoverOpen();
+
+    expect(getByTestSubject('popover')).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -219,8 +219,6 @@ export const EuiBreadcrumbCollapsed: FunctionComponent<_EuiBreadcrumbProps> = ({
   isFirstBreadcrumb,
   type,
 }) => {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-
   const euiTheme = useEuiTheme();
   const styles = euiBreadcrumbStyles(euiTheme);
   const cssStyles = [styles.isCollapsed];
@@ -230,31 +228,17 @@ export const EuiBreadcrumbCollapsed: FunctionComponent<_EuiBreadcrumbProps> = ({
     'See collapsed breadcrumbs'
   );
 
-  const ellipsisButton = (
-    <EuiBreadcrumbContent
-      aria-label={ariaLabel}
-      title={ariaLabel}
-      onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-      truncate={false}
-      text={
-        <>
-          &hellip; <EuiIcon type="arrowDown" size="s" />
-        </>
-      }
-      isFirstBreadcrumb={isFirstBreadcrumb}
-      type={type}
-    />
-  );
-
   return (
     <EuiBreadcrumb css={cssStyles} type={type}>
-      <EuiPopover
-        button={ellipsisButton}
-        isOpen={isPopoverOpen}
-        closePopover={() => setIsPopoverOpen(false)}
-      >
-        {children}
-      </EuiPopover>
+      <EuiBreadcrumbContent
+        popoverContent={children}
+        text="&hellip;"
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        truncate={false}
+        isFirstBreadcrumb={isFirstBreadcrumb}
+        type={type}
+      />
     </EuiBreadcrumb>
   );
 };

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -182,40 +182,42 @@ export const EuiBreadcrumbContent: FunctionComponent<
               {popoverContent}
             </EuiPopover>
           );
-        }
-
-        return !href && !onClick ? (
-          <EuiTextColor
-            color={highlightLastBreadcrumb ? 'default' : 'subdued'}
-            cloneElement
-          >
-            <span
+        } else if (href || onClick) {
+          return (
+            <EuiLink
               ref={ref}
               title={title}
               aria-current={ariaCurrent}
               className={classes}
               css={cssStyles}
+              color={color || (highlightLastBreadcrumb ? 'text' : 'subdued')}
+              onClick={onClick}
+              href={href}
+              rel={rel}
               {...rest}
             >
               {text}
-            </span>
-          </EuiTextColor>
-        ) : (
-          <EuiLink
-            ref={ref}
-            title={title}
-            aria-current={ariaCurrent}
-            className={classes}
-            css={cssStyles}
-            color={color || (highlightLastBreadcrumb ? 'text' : 'subdued')}
-            onClick={onClick}
-            href={href}
-            rel={rel}
-            {...rest}
-          >
-            {text}
-          </EuiLink>
-        );
+            </EuiLink>
+          );
+        } else {
+          return (
+            <EuiTextColor
+              color={highlightLastBreadcrumb ? 'default' : 'subdued'}
+              cloneElement
+            >
+              <span
+                ref={ref}
+                title={title}
+                aria-current={ariaCurrent}
+                className={classes}
+                css={cssStyles}
+                {...rest}
+              >
+                {text}
+              </span>
+            </EuiTextColor>
+          );
+        }
       }}
     </EuiInnerText>
   );

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -56,7 +56,7 @@ export type EuiBreadcrumbProps = Omit<
      */
     'aria-current'?: AriaAttributes['aria-current'];
     /**
-     * Creates a breadcrumb that toggles a
+     * Creates a breadcrumb that toggles a popover dialog
      *
      * If passed, both `href` and `onClick` will be ignored - the breadcrumb's
      * click behavior should only trigger a popover.

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -152,6 +152,10 @@ export const EuiBreadcrumbContent: FunctionComponent<
 
   const isPopoverBreadcrumb = !!popoverContent;
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const popoverAriaLabel = useEuiI18n(
+    'euiBreadcrumb.popoverAriaLabel',
+    'Clicking this button will toggle a popover dialog.'
+  );
 
   return (
     <EuiInnerText>
@@ -180,7 +184,12 @@ export const EuiBreadcrumbContent: FunctionComponent<
                   onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
                   {...rest}
                 >
-                  {text} <EuiIcon type="arrowDown" size="s" />
+                  {text}{' '}
+                  <EuiIcon
+                    type="arrowDown"
+                    size="s"
+                    aria-label={` - ${popoverAriaLabel}`}
+                  />
                 </EuiLink>
               }
             >
@@ -232,8 +241,7 @@ export const EuiBreadcrumbCollapsed: FunctionComponent<_EuiBreadcrumbProps> = ({
     <EuiBreadcrumb css={cssStyles} type={type}>
       <EuiBreadcrumbContent
         popoverContent={children}
-        text="&hellip;"
-        aria-label={ariaLabel}
+        text={<span aria-label={ariaLabel}>&hellip;</span>}
         title={ariaLabel}
         truncate={false}
         isFirstBreadcrumb={isFirstBreadcrumb}

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -145,7 +145,10 @@ export const EuiBreadcrumbContent: FunctionComponent<
     }
   }
 
-  const ariaCurrent = highlightLastBreadcrumb ? 'page' : undefined;
+  const isInteractiveBreadcrumb = href || onClick;
+  const linkColor = color || (highlightLastBreadcrumb ? 'text' : 'subdued');
+  const plainTextColor = highlightLastBreadcrumb ? 'default' : 'subdued'; // Does not inherit `color` prop
+  const ariaCurrent = highlightLastBreadcrumb ? ('page' as const) : undefined;
 
   const isPopoverBreadcrumb = !!popoverContent;
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -155,6 +158,14 @@ export const EuiBreadcrumbContent: FunctionComponent<
       {(ref, innerText) => {
         const title = innerText === '' ? undefined : innerText;
 
+        const sharedProps = {
+          ref,
+          title,
+          'aria-current': ariaCurrent,
+          className: classes,
+          css: cssStyles,
+        };
+
         if (isPopoverBreadcrumb) {
           return (
             <EuiPopover
@@ -163,14 +174,8 @@ export const EuiBreadcrumbContent: FunctionComponent<
               closePopover={() => setIsPopoverOpen(false)}
               button={
                 <EuiLink
-                  ref={ref}
-                  title={title}
-                  aria-current={ariaCurrent}
-                  className={classes}
-                  css={cssStyles}
-                  color={
-                    color || (highlightLastBreadcrumb ? 'text' : 'subdued')
-                  }
+                  {...sharedProps}
+                  color={linkColor}
                   // Avoid passing href and onClick - should only toggle the popover
                   onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
                   {...rest}
@@ -182,15 +187,11 @@ export const EuiBreadcrumbContent: FunctionComponent<
               {popoverContent}
             </EuiPopover>
           );
-        } else if (href || onClick) {
+        } else if (isInteractiveBreadcrumb) {
           return (
             <EuiLink
-              ref={ref}
-              title={title}
-              aria-current={ariaCurrent}
-              className={classes}
-              css={cssStyles}
-              color={color || (highlightLastBreadcrumb ? 'text' : 'subdued')}
+              {...sharedProps}
+              color={linkColor}
               onClick={onClick}
               href={href}
               rel={rel}
@@ -201,18 +202,8 @@ export const EuiBreadcrumbContent: FunctionComponent<
           );
         } else {
           return (
-            <EuiTextColor
-              color={highlightLastBreadcrumb ? 'default' : 'subdued'}
-              cloneElement
-            >
-              <span
-                ref={ref}
-                title={title}
-                aria-current={ariaCurrent}
-                className={classes}
-                css={cssStyles}
-                {...rest}
-              >
+            <EuiTextColor color={plainTextColor} cloneElement>
+              <span {...sharedProps} {...rest}>
                 {text}
               </span>
             </EuiTextColor>

--- a/upcoming_changelogs/7031.md
+++ b/upcoming_changelogs/7031.md
@@ -1,0 +1,1 @@
+- Updated `EuiBreadcrumbs` to support breadcrumbs that toggle popovers via `popoverContent` and `popoverProps`


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7015

Per the above issue, Kibana's new serverless design needs the ability to allow breadcrumbs to toggle popovers that can act as more complex navigation patterns:

<img width="431" alt="" src="https://github.com/elastic/eui/assets/549407/18bf9bd2-7db8-43e3-a896-be12f2fcd1b3">

This PR also updates the collapsed `...` breadcrumb to dogfood the new popover API and (hopefully) increases a11y UX for it as well. As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7031/commits) as there's a few incidental cleanups.

## QA

- Go to https://eui.elastic.co/pr_7031/#/navigation/breadcrumbs#popover-content
- [x] Confirm the demo renders breadcrumbs that trigger popovers, and the content within the popovers look correct
- Regression testing
    - [x] In the "Responsive" demo on the page, confirm the `...` collapsed breadcrumb's popover behavior is the same as on production

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
  - Mobile collapsed behavior isn't _super_ great because you end up in a popover-within-a-popover situation, but I'm not super sure there's any way around this, and at least it works?
    <img width="300" alt="" src="https://github.com/elastic/eui/assets/549407/eda10213-e775-44f4-ad39-80685bebab38">
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~