### PR TITLE
[EuiSteps] Create High Contrast Color for Disabled Step Titles

### DIFF
--- a/src-docs/src/views/steps/status.tsx
+++ b/src-docs/src/views/steps/status.tsx
@@ -55,6 +55,21 @@ export default () => {
     );
   }
 
+  let disabledButton;
+  if (status !== 'disabled') {
+    disabledButton = (
+      <EuiButton color="accent" onClick={() => setStatus('disabled')}>
+        Disabled
+      </EuiButton>
+    );
+  } else {
+    disabledButton = (
+      <EuiButton color="accent" onClick={() => setStatus('incomplete')}>
+        Reset
+      </EuiButton>
+    );
+  }
+
   const firstSetOfSteps = [
     {
       title: 'Normal step',
@@ -75,6 +90,7 @@ export default () => {
             <EuiFlexItem grow={false}> {completeButton} </EuiFlexItem>
             <EuiFlexItem grow={false}> {warningButton} </EuiFlexItem>
             <EuiFlexItem grow={false}> {dangerButton} </EuiFlexItem>
+            <EuiFlexItem grow={false}> {disabledButton} </EuiFlexItem>
           </EuiFlexGroup>
         </>
       ),

--- a/src/components/steps/step.styles.ts
+++ b/src/components/steps/step.styles.ts
@@ -7,7 +7,7 @@
  */
 
 import { css } from '@emotion/react';
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, makeHighContrastColor } from '../../services';
 import { mathWithUnits, logicalCSS } from '../../global_styling';
 
 export const euiStepVariables = (euiTheme: UseEuiTheme['euiTheme']) => {
@@ -132,7 +132,9 @@ export const euiStepTitleStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     euiStep__title: css``,
     isDisabled: css`
-      color: ${euiTheme.colors.disabledText};
+      color: ${makeHighContrastColor(euiTheme.colors.disabledText)(
+        euiTheme.colors.body
+      )};
     `,
     // Sizes
     m: css``,

--- a/src/components/steps/step_horizontal.styles.ts
+++ b/src/components/steps/step_horizontal.styles.ts
@@ -7,7 +7,7 @@
  */
 
 import { css } from '@emotion/react';
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, makeHighContrastColor } from '../../services';
 import {
   euiBreakpoint,
   logicalShorthandCSS,
@@ -135,7 +135,9 @@ export const euiStepHorizontalTitleStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     disabled: css`
-      color: ${euiTheme.colors.disabledText};
+      color: ${makeHighContrastColor(euiTheme.colors.disabledText)(
+        euiTheme.colors.body
+      )};
     `,
   };
 };

--- a/src/components/steps/step_number.styles.ts
+++ b/src/components/steps/step_number.styles.ts
@@ -67,12 +67,11 @@ export const euiStepNumberStyles = (euiThemeContext: UseEuiTheme) => {
       border: ${euiTheme.border.thick};
     `,
     disabled: css`
-      background-color: ${
-        euiButtonFillColor(euiThemeContext, 'disabled').backgroundColor
-      };
+      background-color: ${euiButtonFillColor(euiThemeContext, 'disabled')
+        .backgroundColor};
       color: ${makeHighContrastColor(euiTheme.colors.disabledText)(
         euiButtonFillColor(euiThemeContext, 'disabled').backgroundColor
-      )};}
+      )};
     `,
     loading: css`
       background: transparent;

--- a/src/components/steps/step_number.styles.ts
+++ b/src/components/steps/step_number.styles.ts
@@ -14,7 +14,7 @@ import {
   euiCanAnimate,
   euiAnimScale,
 } from '../../global_styling';
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, makeHighContrastColor } from '../../services';
 import { euiStepVariables } from './step.styles';
 import { euiButtonFillColor } from '../../themes/amsterdam/global_styling/mixins';
 
@@ -67,9 +67,12 @@ export const euiStepNumberStyles = (euiThemeContext: UseEuiTheme) => {
       border: ${euiTheme.border.thick};
     `,
     disabled: css`
-      color: ${euiButtonFillColor(euiThemeContext, 'disabled').color};
-      background-color: ${euiButtonFillColor(euiThemeContext, 'disabled')
-        .backgroundColor};
+      background-color: ${
+        euiButtonFillColor(euiThemeContext, 'disabled').backgroundColor
+      };
+      color: ${makeHighContrastColor(euiTheme.colors.disabledText)(
+        euiButtonFillColor(euiThemeContext, 'disabled').backgroundColor
+      )};}
     `,
     loading: css`
       background: transparent;

--- a/upcoming_changelogs/7032.md
+++ b/upcoming_changelogs/7032.md
@@ -1,0 +1,1 @@
+- Improved the contrast ratio of disabled titles within `EuiSteps` and `EuiStepsHorizontal` to meet WCAG AA guidelines.


### PR DESCRIPTION
Included in #6932

## Summary
Updated the `disabled` title color for `EuiSteps` and `EuiStepsHorizontal` to meet the 4:5.1 contrast ratio.

**Vertical Steps**

Please note: There's no background color change!
<img width="600" alt="image" src="https://github.com/elastic/eui/assets/40739624/32a598be-db02-41f6-85de-8a71bb18a75a">

---

**Horizontal Steps**
<img width="600" alt="image" src="https://github.com/elastic/eui/assets/40739624/631edcdf-967d-41d1-a75b-2350d0c25a22">


## QA

1. Check the disabled state for `EuiSteps` and `EuiStepsHorizontal`. When using your browsers developer tools, you should find that the title and step number meet the and exceed the 4:5.1 contrast level
   - [ ] View the [Step Status](src/components/steps/step_number.styles.ts) example and toggle the "Disabled" button
   - [ ] View the [Horizontal Steps](src/components/steps/step_number.styles.ts) example and view Step 4 which is disabled

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
