### PR TITLE
[Buildkite] Avoid deploying backport and prerelease tags

### DIFF
--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -99,9 +99,9 @@ publish_to_bucket()
 if [[ "$1" != "nodocker" ]]; then
   ./scripts/deploy/build_docs
 
-  # we look this up to inject into the next docker run so it can decide whether
-  # we need to overwrite the root /index.html file with a new one.
-  CURRENT_RELEASE=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+  # Get the latest tag on main, which will determine whether we deploy to the root `eui.elastic.co` bucket
+  # NOTE: specifying the main branch means we don't override prod with backport or prerelease tags.
+  CURRENT_RELEASE=$(git describe --tags "$(git rev-list --branches=main --tags --max-count=1)")
   echo "Current release: $CURRENT_RELEASE"
 
   # Run this script from inside the docker container, using google/cloud-sdk image


### PR DESCRIPTION
## Summary

Based on [EUI's release wiki docs](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/releasing-versions.md#backport-process), backports and prerelease tags should, _theoretically_, only exist on branches that aren't main. Tweaking our git command to only grab the latest tag from the main branch should prevent us from accidentally deploying tags we don't want to `eui.elastic.co`.

Caveat: this isn't completely bulletproof and we probably still want some sort of way to trigger a manual deploy to `eui.elastic.co` in the event someone accidentally tags something they shouldn't, but that's pretty unlikely for EUI's current workflow, so this gets us most of the way there for now.

## QA

N/A, CI only