### PR TITLE
[INFRA] Updating Jenkins and BK permissions for PR jobs.

### DIFF
--- a/.ci/jobs/elastic+eui+pull-request.yml
+++ b/.ci/jobs/elastic+eui+pull-request.yml
@@ -6,18 +6,7 @@
     project-type: multijob
     concurrent: true
     node: master
-    triggers:
-      - github-pull-request:
-          org-list:
-            - elastic
-          white-list:
-            - renovate
-            - renovatebot
-          allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '(.*(?:jenkins\W+)?test\W+(?:this|it)(?:\W+please)?.*)|^retest$'
-          github-hooks: true
-          status-context: eui-ci
-          cancel-builds-on-update: true
+    triggers: [] # Pull request job can now only be triggered from Jenkins UI
     builders:
       - multijob:
           name: run child jobs

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -104,7 +104,7 @@ spec:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ
         everyone:
-          access_level: READ_ONLY
+          access_level: BUILD_AND_READ
 
 ############################ Pull request deploy docs #############################
 # Deploy docs to cloud on PR
@@ -145,7 +145,7 @@ spec:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ
         everyone:
-          access_level: READ_ONLY
+          access_level: BUILD_AND_READ
 
 
 ############################ Pull request combined job #############################
@@ -188,7 +188,7 @@ spec:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ
         everyone:
-          access_level: READ_ONLY
+          access_level: BUILD_AND_READ
 
 
 ############################ Release deploy docs #############################


### PR DESCRIPTION
## Summary

This PR removes the automatic trigger for Jenkins' combined pull request test and deploy PR docs job. The job will still be able to be triggered from the Jenkins UI for now, but will be phased out in favor of the automatic Buildkite run.

This PR also updates the `catalog-info.yml` file to enable `build` permissions for Elasticians.

## QA

QA will be done manually:

- [x] Buildkite combined PR job should run automatically
- [ ] Jenkins combined PR job should not run automatically (after merged into main)
- [ ] Elasticians outside EUI should be able to start / restart jobs in Buildkite UI
- [ ] Community members should still be able to submit PRs from forked repos
- [ ] Confirm if the message about community contributions appears (Jenkins only)