### PR TITLE
build: upgrade mdast-util-to-hast to 10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "chroma-js": "^2.1.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.21",
-    "mdast-util-to-hast": "^10.0.0",
+    "mdast-util-to-hast": "^10.2.0",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.0",
     "react-dropzone": "^11.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14692,6 +14692,20 @@ mdast-util-to-hast@^10.0.0:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+mdast-util-to-hast@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz#61875526a017d8857b71abc9333942700b2d3604"
+  integrity sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    mdast-util-definitions "^4.0.0"
+    mdurl "^1.0.0"
+    unist-builder "^2.0.0"
+    unist-util-generated "^1.0.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^2.0.0"
+
 mdast-util-to-string@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"


### PR DESCRIPTION
## Summary

This PR resolves Snyk dependency upgrade recommendation from #6811 by upgrading `mdast-util-to-hast` to version 10.2.0.

## [Changelog](https://github.com/syntax-tree/mdast-util-to-hast/releases) diff

- https://github.com/syntax-tree/mdast-util-to-hast/commit/c3397021866c90bfbefb3dc3c5668dded1613f13 Add mdast code.meta to hast as code.data.meta
- https://github.com/syntax-tree/mdast-util-to-hast/commit/703a652d75f57c3ab292c0df9685dcd56338cfe8 Fix exception on node.data set to undefined
- https://github.com/syntax-tree/mdast-util-to-hast/commit/a4979905ac423b2581d4d2aa0b8fb410f18fa573 Add passThrough option to keep custom nodes
- https://github.com/syntax-tree/mdast-util-to-hast/commit/197247c95c98cf864733f110b7995dbf9c11cfa9 Fix support for hName on non-element

## QA

- [ ] Custom markdown plugins (checkbox, tooltip) work and update content as expected

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
