### PR TITLE
[EuiSteps] Add outer halo to `current` step

### DIFF
--- a/src-docs/src/views/steps/status.tsx
+++ b/src-docs/src/views/steps/status.tsx
@@ -70,6 +70,21 @@ export default () => {
     );
   }
 
+  let currentButton;
+  if (status !== 'current') {
+    currentButton = (
+      <EuiButton color="accent" onClick={() => setStatus('current')}>
+        Current
+      </EuiButton>
+    );
+  } else {
+    currentButton = (
+      <EuiButton color="accent" onClick={() => setStatus('incomplete')}>
+        Reset
+      </EuiButton>
+    );
+  }
+
   const firstSetOfSteps = [
     {
       title: 'Normal step',
@@ -91,6 +106,7 @@ export default () => {
             <EuiFlexItem grow={false}> {warningButton} </EuiFlexItem>
             <EuiFlexItem grow={false}> {dangerButton} </EuiFlexItem>
             <EuiFlexItem grow={false}> {disabledButton} </EuiFlexItem>
+            <EuiFlexItem grow={false}> {currentButton} </EuiFlexItem>
           </EuiFlexGroup>
         </>
       ),

--- a/src-docs/src/views/steps/status.tsx
+++ b/src-docs/src/views/steps/status.tsx
@@ -70,21 +70,6 @@ export default () => {
     );
   }
 
-  let currentButton;
-  if (status !== 'current') {
-    currentButton = (
-      <EuiButton color="accent" onClick={() => setStatus('current')}>
-        Current
-      </EuiButton>
-    );
-  } else {
-    currentButton = (
-      <EuiButton color="accent" onClick={() => setStatus('incomplete')}>
-        Reset
-      </EuiButton>
-    );
-  }
-
   const firstSetOfSteps = [
     {
       title: 'Normal step',
@@ -106,7 +91,6 @@ export default () => {
             <EuiFlexItem grow={false}> {warningButton} </EuiFlexItem>
             <EuiFlexItem grow={false}> {dangerButton} </EuiFlexItem>
             <EuiFlexItem grow={false}> {disabledButton} </EuiFlexItem>
-            <EuiFlexItem grow={false}> {currentButton} </EuiFlexItem>
           </EuiFlexGroup>
         </>
       ),

--- a/src/components/steps/step_number.styles.ts
+++ b/src/components/steps/step_number.styles.ts
@@ -106,7 +106,16 @@ export const euiStepNumberStyles = (euiThemeContext: UseEuiTheme) => {
           ${euiTheme.animation.bounce};
       }
     `,
-    current: css``,
+    current: css`
+      border: 2px solid ${euiTheme.colors.body};
+      box-shadow: 0 0 0 2px ${euiTheme.colors.primary};
+
+      .euiStepNumber__number {
+        /* Transform the step number so it appears in the center of the step circle */
+        display: inline-block;
+        transform: translateY(-2px);
+      }
+    `,
   };
 };
 

--- a/upcoming_changelogs/7048.md
+++ b/upcoming_changelogs/7048.md
@@ -1,0 +1,1 @@
+- Updated `EuiSteps` and `EuiStepsHorizontal` to highlight and provide a more clear visual indication of the current step


### PR DESCRIPTION
Included in #6932 

## Summary

This PR adds a `2px` outer halo to steps within `EuiSteps` and `EuiStepsHorizontal` that have the `current` status. This will create a better user experience by providing users with a more clear indication of the step they are currently on. 

<img width="350" alt="image" src="https://github.com/elastic/eui/assets/40739624/db7977fd-c856-463c-87c5-8b64731d91b9">
<img width="350" alt="image" src="https://github.com/elastic/eui/assets/40739624/d73bf900-b3de-4822-8097-c235842276cf">

## QA

Remove or strikethrough items that do not apply to your PR.

- [ ] **Steps - Vertical:** View the [Steps Status example](https://eui.elastic.co/pr_7048/#/navigation/steps#steps-status) and click the _temporary_ "Current" button. You should find that the step becomes blue and has a halo. When switching to other statuses, the halo should not be present.
- [ ] **Steps - Horizontal:** View the [Horizontal Steps examples](https://eui.elastic.co/pr_7048/#/navigation/steps#steps-status) and find that step 2 has a halo. When switching between medium and small sizes, the number should remain in the middle of the step button.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
