### PR TITLE
[Docs] Remove `isNew` flag from `EuiSkeleton` components

### DIFF
--- a/src-docs/src/views/skeleton/skeleton_example.js
+++ b/src-docs/src/views/skeleton/skeleton_example.js
@@ -83,7 +83,6 @@ const skeletonLivePropsSnippet = `<EuiSkeletonText
 
 export const SkeletonExample = {
   title: 'Skeleton',
-  isNew: true,
   intro: (
     <>
       <EuiText>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7021

Our `EuiSkeleton` components have been publicly available for ~6 months now, and should no longer be considered "new".

## QA

- [x] Go to https://eui.elastic.co/pr_7050/ and confirm the `Skeleton` component in the side nav does not have a "NEW" badge
- [x] Go to https://eui.elastic.co/pr_7050/#/display/skeleton and confirm the page header does not have a "NEW" badge

### General checklist

N/A, docs only