### PR TITLE
[EuiCollapsibleNavBeta] Add storybook QA test for ensuring flyouts sit above the nav

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, PropsWithChildren } from 'react';
+import React, { FunctionComponent, PropsWithChildren, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { EuiHeader, EuiHeaderSection } from '../header';
+import { EuiHeader, EuiHeaderSection, EuiHeaderSectionItem } from '../header';
 import { EuiPageTemplate } from '../page_template';
-import { EuiFlyoutBody, EuiFlyoutFooter } from '../flyout';
+import { EuiFlyout, EuiFlyoutBody, EuiFlyoutFooter } from '../flyout';
+import { EuiButton } from '../button';
 
 import { EuiCollapsibleNavItem } from './collapsible_nav_item';
 import {
@@ -411,4 +412,40 @@ export const MultipleFixedHeaders: Story = {
       </EuiHeader>
     </>
   ),
+};
+
+const MockConsumerFlyout: FunctionComponent = () => {
+  const [flyoutIsOpen, setFlyoutOpen] = useState(false);
+  return (
+    <>
+      <EuiButton size="s" onClick={() => setFlyoutOpen(!flyoutIsOpen)}>
+        Toggle a flyout
+      </EuiButton>
+      {flyoutIsOpen && (
+        <EuiFlyout onClose={() => setFlyoutOpen(false)}>
+          <EuiFlyoutBody>
+            Some other mock consumer flyout that <strong>should</strong> overlap
+            EuiCollapsibleNav
+          </EuiFlyoutBody>
+        </EuiFlyout>
+      )}
+    </>
+  );
+};
+
+export const FlyoutInFixedHeaders: Story = {
+  render: ({ ...args }) => {
+    return (
+      <EuiHeader position="fixed">
+        <EuiHeaderSection>
+          <EuiCollapsibleNavBeta {...args}>Nav content</EuiCollapsibleNavBeta>
+        </EuiHeaderSection>
+        <EuiHeaderSection>
+          <EuiHeaderSectionItem>
+            <MockConsumerFlyout />
+          </EuiHeaderSectionItem>
+        </EuiHeaderSection>
+      </EuiHeader>
+    );
+  },
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -34,6 +34,7 @@ const meta: Meta<EuiCollapsibleNavBetaProps> = {
   args: {
     side: 'left',
     initialIsCollapsed: false,
+    width: 248,
   },
 };
 export default meta;


### PR DESCRIPTION
## Summary

Per Marcialis's comment in https://github.com/elastic/kibana/issues/161889#issuecomment-1644172690, the new collapsible nav should sit below any flyout/modal/general overlay masks. This Storybook adds a quick way to visually QA that Kibana behavior and confirm it's working as expected.

## QA

- `gh pr checkout 7051`
- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--flyout-in-fixed-headers
- [x] Confirm that the flyout (toggled from top right) sits above the collapsible nav in all states, including in mobile / overlay mode

<img width="800" alt="" src="https://github.com/elastic/eui/assets/549407/9a70b33f-53f3-44fc-a4aa-fd36cac32348">


### General checklist

N/A, internal dev-only