### PR TITLE
[Docs] Add callout to selection components with a link to selection components FAQ

### DIFF
--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -3,13 +3,14 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
-import { EuiCallOut } from '../../../../src';
 
 import {
   EuiLink,
   EuiCode,
   EuiComboBox,
   EuiText,
+  EuiCallOut,
+  EuiSpacer,
 } from '../../../../src/components';
 
 import { EuiComboBoxOptionOption } from '!!prop-loader!../../../../src/components/combo_box/types';
@@ -269,6 +270,19 @@ export const ComboBoxExample = {
           <EuiCode>aria-labelledby</EuiCode> prop.
         </EuiCallOut>
       </EuiText>
+      <EuiSpacer />
+      <EuiCallOut
+        iconType="questionInCircle"
+        title="Learn more about EUI selection components"
+      >
+        <p>
+          Can't decide which selection component to use? Checkout{' '}
+          <EuiLink href="https://github.com/elastic/eui/discussions/7049">
+            the ultimate guide to EUI's selection components{' '}
+          </EuiLink>
+          for in depth explanations and comparisons.
+        </p>
+      </EuiCallOut>
     </>
   ),
   sections: [

--- a/src-docs/src/views/form_controls/form_controls_example.js
+++ b/src-docs/src/views/form_controls/form_controls_example.js
@@ -333,6 +333,18 @@ export const FormControlsExample = {
             , which has search and multi-select capabilities, but also has
             restrictions on how items are rendered.
           </p>
+          <EuiCallOut
+            iconType="questionInCircle"
+            title="Learn more about EUI selection components"
+          >
+            <p>
+              Can't decide which selection component to use? Checkout{' '}
+              <EuiLink href="https://github.com/elastic/eui/discussions/7049">
+                the ultimate guide to EUI's selection components{' '}
+              </EuiLink>
+              for in depth explanations and comparisons.
+            </p>
+          </EuiCallOut>
         </>
       ),
       snippet: selectSnippet,

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -9,6 +9,8 @@ import {
   EuiSelectableMessage,
   EuiText,
   EuiCallOut,
+  EuiLink,
+  EuiSpacer,
 } from '../../../../src';
 
 import {
@@ -50,28 +52,43 @@ const props = {
 export const SelectableExample = {
   title: 'Selectable',
   intro: (
-    <EuiText>
-      <p>
-        <strong>EuiSelectable</strong> aims to make the pattern of a selectable
-        list (with or without search) consistent across implementations. It is
-        the same concept used in{' '}
-        <Link to="/forms/combo-box">
-          <strong>EuiComboBox</strong>
-        </Link>{' '}
-        and{' '}
-        <Link to="/forms/filter-group">
-          <strong>EuiFilterGroup</strong>
-        </Link>
-        .{' '}
-        <strong>
-          This is not intended for{' '}
-          <Link to="/display/list-group">primary navigation</Link>
-        </strong>{' '}
-        but can be used to simplify the construction of popover navigational
-        menus; i.e. the spaces menu in the{' '}
-        <Link to="/layout/header">header</Link>.
-      </p>
-    </EuiText>
+    <>
+      <EuiText>
+        <p>
+          <strong>EuiSelectable</strong> aims to make the pattern of a
+          selectable list (with or without search) consistent across
+          implementations. It is the same concept used in{' '}
+          <Link to="/forms/combo-box">
+            <strong>EuiComboBox</strong>
+          </Link>{' '}
+          and{' '}
+          <Link to="/forms/filter-group">
+            <strong>EuiFilterGroup</strong>
+          </Link>
+          .{' '}
+          <strong>
+            This is not intended for{' '}
+            <Link to="/display/list-group">primary navigation</Link>
+          </strong>{' '}
+          but can be used to simplify the construction of popover navigational
+          menus; i.e. the spaces menu in the{' '}
+          <Link to="/layout/header">header</Link>.
+        </p>
+      </EuiText>
+      <EuiSpacer />
+      <EuiCallOut
+        iconType="questionInCircle"
+        title="Learn more about EUI selection components"
+      >
+        <p>
+          Can't decide which selection component to use? Checkout{' '}
+          <EuiLink href="https://github.com/elastic/eui/discussions/7049">
+            the ultimate guide to EUI's selection components{' '}
+          </EuiLink>
+          for in depth explanations and comparisons.
+        </p>
+      </EuiCallOut>
+    </>
   ),
   sections: [
     {

--- a/src-docs/src/views/super_select/super_select_example.js
+++ b/src-docs/src/views/super_select/super_select_example.js
@@ -2,7 +2,12 @@ import React from 'react';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiSuperSelect } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiSuperSelect,
+  EuiLink,
+  EuiCallOut,
+} from '../../../../src/components';
 
 import SuperSelectBasic from './super_select_basic';
 const superSelectBasicSource = require('!!raw-loader!./super_select_basic');
@@ -87,6 +92,19 @@ export const SuperSelectExample = {
             &hellip; and the component will create a select styled button that
             triggers a popover of selectable items.
           </p>
+
+          <EuiCallOut
+            iconType="questionInCircle"
+            title="Learn more about EUI selection components"
+          >
+            <p>
+              Can't decide which selection component to use? Checkout{' '}
+              <EuiLink href="https://github.com/elastic/eui/discussions/7049">
+                the ultimate guide to EUI's selection components{' '}
+              </EuiLink>
+              for in depth explanations and comparisons.
+            </p>
+          </EuiCallOut>
         </>
       ),
       props: { EuiSuperSelect },


### PR DESCRIPTION
Closes #6880

## Summary
Added an `EuiCallout` to the four selection components compared in [The Ultimate Guide to EUI Selection Components](https://github.com/elastic/eui/discussions/7049) FAQ.

## QA


### General checklist
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**

