### PR TITLE
[EuiCollapsibleNavBeta] Improve collapsed button icon screen reader UX

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`EuiCollapsibleNavItem renders a collapsed button icon when in a collaps
   data-test-subj="test subject string"
 >
   <button
+    aria-label="Item"
     class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
     data-test-subj="euiCollapsedNavButton"
     type="button"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`EuiCollapsedNavButton renders a tooltip around the icon button 1`] = `
       data-test-subj="test subject string"
     >
       <button
-        aria-describedby="generated-id"
         aria-label="Nav item"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`EuiCollapsedNavButton renders a tooltip around the icon button 1`] = `
       data-test-subj="test subject string"
     >
       <button
+        aria-describedby="generated-id"
         aria-label="Nav item"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`EuiCollapsedNavButton renders a tooltip around the icon button 1`] = `
     >
       <button
         aria-describedby="generated-id"
+        aria-label="Nav item"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"
@@ -54,6 +55,7 @@ exports[`EuiCollapsedNavButton renders isSelected 1`] = `
     class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
   >
     <a
+      aria-label="Nav item"
       class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton-isSelected"
       data-test-subj="euiCollapsedNavButton"
       href="#"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`EuiCollapsedNavItem renders a popover if items exist 1`] = `
       class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
     >
       <button
+        aria-label="Item"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"
@@ -35,6 +36,7 @@ exports[`EuiCollapsedNavItem renders an icon button/link if items are missing or
   data-test-subj="test subject string"
 >
   <a
+    aria-label="Item"
     class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
     data-test-subj="euiCollapsedNavButton"
     href="#"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`EuiCollapsedNavPopover renders the title and sub-items within the popov
           class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
         >
           <button
+            aria-label="Item"
             class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
             data-test-subj="euiCollapsedNavButton"
             type="button"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -78,6 +78,7 @@ export const EuiCollapsedNavButton: FunctionComponent<
         color="text"
         href={href}
         onClick={onClick}
+        aria-label={title}
         {...(linkProps as EuiButtonIconPropsForAnchor)} // Exclusive union shenanigans
         className={buttonClassName}
         css={buttonCssStyles}

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -67,7 +67,6 @@ export const EuiCollapsedNavButton: FunctionComponent<
   return (
     <EuiToolTip
       content={title}
-      setAriaDescribedBy={false} // `title` content already set in `aria-label` below
       css={tooltipCssStyles}
       position={side}
       display="block"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -67,6 +67,7 @@ export const EuiCollapsedNavButton: FunctionComponent<
   return (
     <EuiToolTip
       content={title}
+      setAriaDescribedBy={false} // `title` content already set in `aria-label` below
       css={tooltipCssStyles}
       position={side}
       display="block"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -60,7 +60,7 @@ export type _SharedEuiCollapsibleNavItemProps = HTMLAttributes<HTMLElement> &
 
 export type EuiCollapsibleNavItemProps = {
   /**
-   * Required Text to render as the nav item title
+   * Required text to render as the nav item title
    */
   title: string;
   /**

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -6,12 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, {
-  FunctionComponent,
-  ReactNode,
-  HTMLAttributes,
-  useContext,
-} from 'react';
+import React, { FunctionComponent, HTMLAttributes, useContext } from 'react';
 import classNames from 'classnames';
 
 import { useEuiTheme } from '../../../services';
@@ -65,11 +60,11 @@ export type _SharedEuiCollapsibleNavItemProps = HTMLAttributes<HTMLElement> &
 
 export type EuiCollapsibleNavItemProps = {
   /**
-   * ReactNode to render as this component's title
+   * Required Text to render as the nav item title
    */
-  title: ReactNode;
+  title: string;
   /**
-   * Allows customizing title's element.
+   * Allows customizing the title element.
    * Consider using a heading element for better accessibility.
    * Defaults to an unsemantic `span` or `div`, depending on context.
    */

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -107,6 +107,8 @@ describe('EuiToolTip', () => {
     ).not.toBeNull();
 
     jest.useRealTimers();
+
+    component.unmount(); // Enzyme's portals stay in the DOM otherwise
   });
 
   test('display prop renders block', () => {
@@ -148,6 +150,40 @@ describe('EuiToolTip', () => {
     // Should remove the scroll event listener on unmount
     unmount();
     expect(removeEventSpy).toHaveBeenCalledWith('scroll', repositionFn, true);
+  });
+
+  describe('aria-describedby', () => {
+    it('by default, sets an `aria-describedby` on the anchor when the tooltip is visible', async () => {
+      const { getByTestSubject } = render(
+        <EuiToolTip content="Tooltip content" id="toolTipId">
+          <button data-test-subj="anchor" />
+        </EuiToolTip>
+      );
+      fireEvent.mouseOver(getByTestSubject('anchor'));
+      await waitForEuiToolTipVisible();
+
+      expect(
+        getByTestSubject('anchor').getAttribute('aria-describedby')
+      ).toEqual('toolTipId');
+    });
+
+    it('allows disabling the default `aria-describedby` via `setAriaDescribedBy`', async () => {
+      const { getByTestSubject } = render(
+        <EuiToolTip
+          content="Tooltip content"
+          id="toolTipId"
+          setAriaDescribedBy={false}
+        >
+          <button data-test-subj="anchor" />
+        </EuiToolTip>
+      );
+      fireEvent.mouseOver(getByTestSubject('anchor'));
+      await waitForEuiToolTipVisible();
+
+      expect(
+        getByTestSubject('anchor').getAttribute('aria-describedby')
+      ).toBeFalsy();
+    });
   });
 
   describe('ref methods', () => {

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -180,24 +180,6 @@ describe('EuiToolTip', () => {
         getByTestSubject('anchor').getAttribute('aria-describedby')
       ).toEqual('toolTipId customId');
     });
-
-    it('allows disabling the default `aria-describedby` via `setAriaDescribedBy`', async () => {
-      const { getByTestSubject } = render(
-        <EuiToolTip
-          content="Tooltip content"
-          id="toolTipId"
-          setAriaDescribedBy={false}
-        >
-          <button data-test-subj="anchor" />
-        </EuiToolTip>
-      );
-      fireEvent.mouseOver(getByTestSubject('anchor'));
-      await waitForEuiToolTipVisible();
-
-      expect(
-        getByTestSubject('anchor').getAttribute('aria-describedby')
-      ).toBeFalsy();
-    });
   });
 
   describe('ref methods', () => {

--- a/src/components/tool_tip/tool_tip.test.tsx
+++ b/src/components/tool_tip/tool_tip.test.tsx
@@ -167,6 +167,20 @@ describe('EuiToolTip', () => {
       ).toEqual('toolTipId');
     });
 
+    it('merges with custom consumer `aria-describedby`s', async () => {
+      const { getByTestSubject } = render(
+        <EuiToolTip content="Tooltip content" id="toolTipId">
+          <button data-test-subj="anchor" aria-describedby="customId" />
+        </EuiToolTip>
+      );
+      fireEvent.mouseOver(getByTestSubject('anchor'));
+      await waitForEuiToolTipVisible();
+
+      expect(
+        getByTestSubject('anchor').getAttribute('aria-describedby')
+      ).toEqual('toolTipId customId');
+    });
+
     it('allows disabling the default `aria-describedby` via `setAriaDescribedBy`', async () => {
       const { getByTestSubject } = render(
         <EuiToolTip

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -348,7 +348,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           onFocus={this.onFocus}
           onMouseOver={this.showToolTip}
           onMouseOut={this.onMouseOut}
-          id={this.state.id}
+          id={id}
           className={anchorClasses}
           display={display!}
           isVisible={visible}

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -15,7 +15,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, keysOf } from '../common';
+import { CommonProps } from '../common';
 import { findPopoverPosition, htmlIdGenerator } from '../../services';
 import { enqueueStateChange } from '../../services/react';
 import { EuiResizeObserver } from '../observer/resize_observer';
@@ -26,14 +26,8 @@ import { EuiToolTipAnchor } from './tool_tip_anchor';
 import { EuiToolTipArrow } from './tool_tip_arrow';
 import { toolTipManager } from './tool_tip_manager';
 
-const positionsToClassNameMap: { [key in ToolTipPositions]: string } = {
-  top: 'euiToolTip--top',
-  right: 'euiToolTip--right',
-  bottom: 'euiToolTip--bottom',
-  left: 'euiToolTip--left',
-};
-
-export const POSITIONS = keysOf(positionsToClassNameMap);
+export const POSITIONS = ['top', 'right', 'bottom', 'left'] as const;
+const DISPLAYS = ['inlineBlock', 'block'] as const;
 
 export type ToolTipDelay = 'regular' | 'long';
 
@@ -49,11 +43,6 @@ interface ToolTipStyles {
   opacity?: number;
   visibility?: 'hidden';
 }
-
-const displayToClassNameMap = {
-  inlineBlock: undefined,
-  block: 'euiToolTipAnchor--displayBlock',
-};
 
 const DEFAULT_TOOLTIP_STYLES: ToolTipStyles = {
   // position the tooltip content near the top-left
@@ -92,7 +81,7 @@ export interface EuiToolTipProps extends CommonProps {
   /**
    * Common display alternatives for the anchor wrapper
    */
-  display?: keyof typeof displayToClassNameMap;
+  display?: (typeof DISPLAYS)[number];
   /**
    * Delay before showing tooltip. Good for repeatable items.
    */

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -116,6 +116,15 @@ export interface EuiToolTipProps extends CommonProps {
    * When nesting an `EuiTooltip` in a scrollable container, `repositionOnScroll` should be `true`
    */
   repositionOnScroll?: boolean;
+  /**
+   * By default, EuiToolTips will attach an `aria-describedby` to its children
+   * that points to the tooltip content.
+   *
+   * If you don't want this screen reader behavior, e.g., because you're setting
+   * your own aria attributes and the tooltip content is duplicative, you can
+   * disable this behavior by setting this prop to `false`.
+   */
+  setAriaDescribedBy?: boolean;
 
   /**
    * If supplied, called when mouse movement causes the tool tip to be
@@ -152,6 +161,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
     position: 'top',
     delay: 'regular',
     display: 'inlineBlock',
+    setAriaDescribedBy: true,
   };
 
   clearAnimationTimeout = () => {
@@ -319,6 +329,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
       delay,
       display,
       repositionOnScroll,
+      setAriaDescribedBy,
       ...rest
     } = this.props;
 
@@ -341,6 +352,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           className={anchorClasses}
           display={display!}
           isVisible={visible}
+          setAriaDescribedBy={setAriaDescribedBy!}
         >
           {children}
         </EuiToolTipAnchor>

--- a/src/components/tool_tip/tool_tip.tsx
+++ b/src/components/tool_tip/tool_tip.tsx
@@ -106,16 +106,6 @@ export interface EuiToolTipProps extends CommonProps {
    */
   repositionOnScroll?: boolean;
   /**
-   * By default, EuiToolTips will attach an `aria-describedby` to its children
-   * that points to the tooltip content.
-   *
-   * If you don't want this screen reader behavior, e.g., because you're setting
-   * your own aria attributes and the tooltip content is duplicative, you can
-   * disable this behavior by setting this prop to `false`.
-   */
-  setAriaDescribedBy?: boolean;
-
-  /**
    * If supplied, called when mouse movement causes the tool tip to be
    * hidden.
    */
@@ -150,7 +140,6 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
     position: 'top',
     delay: 'regular',
     display: 'inlineBlock',
-    setAriaDescribedBy: true,
   };
 
   clearAnimationTimeout = () => {
@@ -318,7 +307,6 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
       delay,
       display,
       repositionOnScroll,
-      setAriaDescribedBy,
       ...rest
     } = this.props;
 
@@ -341,7 +329,6 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           className={anchorClasses}
           display={display!}
           isVisible={visible}
-          setAriaDescribedBy={setAriaDescribedBy!}
         >
           {children}
         </EuiToolTipAnchor>

--- a/src/components/tool_tip/tool_tip_anchor.tsx
+++ b/src/components/tool_tip/tool_tip_anchor.tsx
@@ -16,9 +16,7 @@ export type EuiToolTipAnchorProps = Omit<
   HTMLAttributes<HTMLSpanElement>,
   'onBlur' | 'onFocus' | 'children'
 > &
-  Required<
-    Pick<EuiToolTipProps, 'display' | 'setAriaDescribedBy' | 'children'>
-  > & {
+  Required<Pick<EuiToolTipProps, 'display' | 'children'>> & {
     onBlur: () => void;
     onFocus: () => void;
     isVisible: boolean;
@@ -39,7 +37,6 @@ export const EuiToolTipAnchor = forwardRef<
       children,
       display,
       isVisible,
-      setAriaDescribedBy,
       ...rest
     },
     ref
@@ -76,10 +73,9 @@ export const EuiToolTipAnchor = forwardRef<
             onBlur();
             children.props.onBlur && children.props.onBlur(e);
           },
-          'aria-describedby':
-            isVisible && setAriaDescribedBy
-              ? classNames(id, children.props['aria-describedby'])
-              : children.props['aria-describedby'],
+          'aria-describedby': isVisible
+            ? classNames(id, children.props['aria-describedby'])
+            : children.props['aria-describedby'],
         })}
       </span>
     );

--- a/src/components/tool_tip/tool_tip_anchor.tsx
+++ b/src/components/tool_tip/tool_tip_anchor.tsx
@@ -78,7 +78,7 @@ export const EuiToolTipAnchor = forwardRef<
           },
           'aria-describedby':
             isVisible && setAriaDescribedBy
-              ? id
+              ? classNames(id, children.props['aria-describedby'])
               : children.props['aria-describedby'],
         })}
       </span>

--- a/src/components/tool_tip/tool_tip_anchor.tsx
+++ b/src/components/tool_tip/tool_tip_anchor.tsx
@@ -6,27 +6,23 @@
  * Side Public License, v 1.
  */
 
-import React, {
-  cloneElement,
-  HTMLAttributes,
-  ReactElement,
-  forwardRef,
-} from 'react';
+import React, { cloneElement, HTMLAttributes, forwardRef } from 'react';
 import classNames from 'classnames';
 
+import type { EuiToolTipProps } from './tool_tip';
 import { euiToolTipAnchorStyles } from './tool_tip.styles';
 
-export interface EuiToolTipAnchorProps
-  extends Omit<
-    HTMLAttributes<HTMLSpanElement>,
-    'onBlur' | 'onFocus' | 'children'
-  > {
-  onBlur: () => void;
-  onFocus: () => void;
-  children: ReactElement;
-  isVisible: boolean;
-  display: 'block' | 'inlineBlock';
-}
+export type EuiToolTipAnchorProps = Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'onBlur' | 'onFocus' | 'children'
+> &
+  Required<
+    Pick<EuiToolTipProps, 'display' | 'setAriaDescribedBy' | 'children'>
+  > & {
+    onBlur: () => void;
+    onFocus: () => void;
+    isVisible: boolean;
+  };
 
 export const EuiToolTipAnchor = forwardRef<
   HTMLSpanElement,
@@ -43,6 +39,7 @@ export const EuiToolTipAnchor = forwardRef<
       children,
       display,
       isVisible,
+      setAriaDescribedBy,
       ...rest
     },
     ref
@@ -79,7 +76,10 @@ export const EuiToolTipAnchor = forwardRef<
             onBlur();
             children.props.onBlur && children.props.onBlur(e);
           },
-          ...(isVisible && { 'aria-describedby': id }),
+          'aria-describedby':
+            isVisible && setAriaDescribedBy
+              ? id
+              : children.props['aria-describedby'],
         })}
       </span>
     );

--- a/upcoming_changelogs/7055.md
+++ b/upcoming_changelogs/7055.md
@@ -1,5 +1,3 @@
-- Updated `EuiToolTip` with a new `setAriaDescribedBy` prop. This defaults to true (reflecting prior behavior), and can now be configured to `false` if your tooltip contains duplicative content or (e.g. when setting your own `aria-label` or `aria-describedby` attributes).
-
 **Bug fixes**
 
 - Fixed `EuiToolTip` overriding instead of merging its `aria-describedby` tooltip ID with any existing `aria-describedby`s

--- a/upcoming_changelogs/7055.md
+++ b/upcoming_changelogs/7055.md
@@ -1,0 +1,5 @@
+- Updated `EuiToolTip` with a new `setAriaDescribedBy` prop. This defaults to true (reflecting prior behavior), and can now be configured to `false` if your tooltip contains duplicative content or (e.g. when setting your own `aria-label` or `aria-describedby` attributes).
+
+**Bug fixes**
+
+- Fixed `EuiToolTip` overriding instead of merging its `aria-describedby` tooltip ID with any existing `aria-describedby`s


### PR DESCRIPTION
## Summary

- Part of https://github.com/elastic/eui/issues/7041.
- ⚠️ This PR does not resolve **all** a11y issues with EuiCollapsibleNavBeta, just _one_ of them (see linked issue for full list).

This PR:

1. Makes the typing of nav item `title`s stricter - they now **must** be strings and not ReactNodes (in order to support `aria-label`/`title` type attributes)

2. Sets an `aria-label` on all collapsed/docked button icon nav items (example below)
    <img width="221" alt="" src="https://github.com/elastic/eui/assets/549407/a5c424c4-6d30-4ee8-abed-e1a54910c174">
    which resolves the many warnings in tests as well as devtools:
   <img width="600" alt="" src="https://github.com/elastic/eui/assets/549407/2fd389aa-0a02-434b-8529-bdc6e92cc513">

3. ~However, adding an `aria-label` to button icons with a tooltip wrapped around them leads to duplicated content, because the `aria-label` and `aria-describedby` contain the same exact content. The solution is to modify `EuiToolTip` to allow configuring disabling the `aria-describedby` logic if necessary/if tooltip content is duplicative.~
    - We went back on this decision after more SR testing and per the below GitHub discussion. This PR contains several EuiToolTip cleanup items instead.

## QA

- **Do not check out this PR yet** - on main, run `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--kibana-example&args=initialIsCollapsed:true (NOTE: Storybook is being odd about not setting `initialIsCollapsed` properly, if you refresh the page and the button icons aren't present, simply click the collapse nav button in the top left corner)
- Turn on VoiceOver and tab to any of the button icons
- The tooltip content should be read out after a pause, because it lives in `aria-describedby`:
<img width="588" alt="" src="https://github.com/elastic/eui/assets/549407/1a5ff1b1-b08d-48d1-aeac-b3bcbe51af91">
<img width="585" alt="" src="https://github.com/elastic/eui/assets/549407/7d64245b-6872-40b7-95c6-ea080737c6af">


- Now `gh pr checkout TODO` (yarn storybook should update automatically)
- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--kibana-example&args=initialIsCollapsed:true again (or refresh the page and re-collapse the nav)
- [x] Tab to the button icons, and confirm they now read out the label of the button immediately, and do not contain duplicate `aria-describedby` text:
<img width="598" alt="aria-label" src="https://github.com/elastic/eui/assets/549407/67ec4440-0000-48b3-a3f8-4831fa4cf710">


### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
