### PR TITLE
[EuiDatePickerRange] Add support for `compressed` display

### DIFF
--- a/src-docs/src/views/date_picker/range.tsx
+++ b/src-docs/src/views/date_picker/range.tsx
@@ -10,7 +10,7 @@ export default () => {
 
   return (
     /* DisplayToggles wrapper for Docs only */
-    <DisplayToggles canCompressed={false} canPrepend={true} canAppend={true}>
+    <DisplayToggles canPrepend={true} canAppend={true}>
       <EuiDatePickerRange
         startDateControl={
           <EuiDatePicker

--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -75,6 +75,79 @@ exports[`EuiDatePickerRange is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiDatePickerRange props compressed 1`] = `
+<span
+  class="euiDatePickerRange emotion-euiDatePickerRange"
+>
+  <div
+    class="euiFormControlLayout euiFormControlLayout--compressed euiFormControlLayoutDelimited"
+  >
+    <div
+      class="euiFormControlLayout__childrenWrapper"
+    >
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--static"
+      >
+        <span
+          class="euiFormControlLayoutCustomIcon"
+        >
+          <span
+            aria-hidden="true"
+            class="euiFormControlLayoutCustomIcon__icon"
+            data-euiicon-type="calendar"
+          />
+        </span>
+      </div>
+      <div
+        class="euiPopover emotion-euiPopover"
+      >
+        <div
+          class="euiPopover__anchor css-zih94u-render"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              aria-label="Press the down key to open a popover containing a calendar."
+              class="euiDatePicker euiFieldText euiDatePickerRange__start euiFormControlLayoutDelimited__input"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiText euiFormControlLayoutDelimited__delimiter emotion-euiText-s-euiTextColor-subdued"
+      >
+        <span
+          data-euiicon-type="sortRight"
+        >
+          to
+        </span>
+      </div>
+      <div
+        class="euiPopover emotion-euiPopover"
+      >
+        <div
+          class="euiPopover__anchor css-zih94u-render"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              aria-label="Press the down key to open a popover containing a calendar."
+              class="euiDatePicker euiFieldText euiDatePickerRange__end euiFormControlLayoutDelimited__input"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</span>
+`;
+
 exports[`EuiDatePickerRange props disabled 1`] = `
 <span
   class="euiDatePickerRange emotion-euiDatePickerRange"

--- a/src/components/date_picker/date_picker_range.test.tsx
+++ b/src/components/date_picker/date_picker_range.test.tsx
@@ -41,6 +41,18 @@ describe('EuiDatePickerRange', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    test('compressed', () => {
+      const { container } = render(
+        <EuiDatePickerRange
+          startDateControl={<EuiDatePicker />}
+          endDateControl={<EuiDatePicker />}
+          compressed
+        />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
     test('readOnly', () => {
       const { container } = render(
         <EuiDatePickerRange

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -35,7 +35,13 @@ import { EuiDatePickerProps } from './date_picker';
 export type EuiDatePickerRangeProps = CommonProps &
   Pick<
     EuiFormControlLayoutDelimitedProps,
-    'isLoading' | 'isInvalid' | 'readOnly' | 'fullWidth' | 'prepend' | 'append'
+    | 'isLoading'
+    | 'isInvalid'
+    | 'readOnly'
+    | 'fullWidth'
+    | 'compressed'
+    | 'prepend'
+    | 'append'
   > & {
     /**
      * Including any children will replace all innards with the provided children
@@ -100,6 +106,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   inline,
   shadow = true,
   fullWidth: _fullWidth,
+  compressed: _compressed,
   isCustom,
   readOnly,
   isLoading,
@@ -111,8 +118,9 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   prepend,
   ...rest
 }) => {
-  // `fullWidth` should not affect inline datepickers (matches non-range behavior)
+  // `fullWidth` and `compressed` should not affect inline datepickers (matches non-range behavior)
   const fullWidth = _fullWidth && !inline;
+  const compressed = _compressed && !inline;
 
   const classes = classNames('euiDatePickerRange', className);
 
@@ -206,6 +214,7 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
         startControl={startControl}
         endControl={endControl}
         fullWidth={fullWidth}
+        compressed={compressed}
         readOnly={readOnly}
         isDisabled={disabled}
         isInvalid={isInvalid}

--- a/upcoming_changelogs/7058.md
+++ b/upcoming_changelogs/7058.md
@@ -1,0 +1,5 @@
+- Updated `EuiDatePickerRange` to support `compressed` display
+
+**Bug fixes**
+
+- Fixed `EuiSuperDatePicker`'s `compressed` display


### PR DESCRIPTION
## Summary

This PR fixes `EuiSuperDatePicker`'s compressed display not working correctly, by adding `EuiDatePickerRange` support for `compressed` display.

This behavior was regressed in #6705 (when we updated `EuiSuperDatePicker` to dogfood `EuiDatePickerRange`).

> ⚠️  This fix will need to be backported to Kibana 8.10 post-FF.

### Before
<img width="550" alt="" src="https://github.com/elastic/eui/assets/549407/4c8b93c0-c32a-40f0-a684-5aef309101c0">

### After
<img width="550" alt="" src="https://github.com/elastic/eui/assets/549407/063c5668-0cc4-4094-8ff6-cda0d0b064da">

## QA

- Go to https://eui.elastic.co/pr_7058/#/templates/super-date-picker#sizing
- Toggle the `compressed` switch
- [x] Confirm the compressed date picker works/is not broken-looking
- Go to https://eui.elastic.co/pr_7058/#/forms/date-picker#date-picker-range
- Click `Display toggles` and then toggle the `compressed` switch
- [x] Confirm the compressed date range works

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] ~Added~ Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
    -  Neither the super date picker nor date picker files have a `compressed` example, although one should probably be added

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Checked for **breaking changes** and labeled appropriately~