### PR TITLE
fix: docs layout jumping

### DIFF
--- a/src/components/page/page_sidebar/page_sidebar.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.tsx
@@ -10,7 +10,7 @@ import React, {
   CSSProperties,
   FunctionComponent,
   HTMLAttributes,
-  useEffect,
+  useLayoutEffect,
   useState,
 } from 'react';
 import { CommonProps } from '../../common';
@@ -80,7 +80,7 @@ export const EuiPageSidebar: FunctionComponent<EuiPageSidebarProps> = ({
     ...logicalStyle('min-width', isResponding ? '100%' : minWidth),
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     let updatedStyles = {
       ...style,
       ...logicalStyle('min-width', isResponding ? '100%' : minWidth),

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -80,6 +80,8 @@ export type EuiPageTemplateProps = _EuiPageOuterProps &
   };
 
 function calculateOffset(base: number): number {
+  if (typeof document === 'undefined') return 0; // SSR catch
+
   const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders ?? 0);
   return base * 3 * euiHeaderFixedCounter;
 }

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -79,6 +79,11 @@ export type EuiPageTemplateProps = _EuiPageOuterProps &
     component?: ComponentTypes;
   };
 
+function calculateOffset(base: number): number {
+  const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders ?? 0);
+  return base * 3 * euiHeaderFixedCounter;
+}
+
 /**
  * Consumed via `EuiPageTemplate`,
  * it controls and propogates most of the shared props per direct child
@@ -104,7 +109,9 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
 }) => {
   const { euiTheme } = useEuiTheme();
 
-  const [offset, setOffset] = useState(_offset);
+  const [offset, setOffset] = useState(
+    () => _offset ?? calculateOffset(euiTheme.base)
+  );
   const templateContext = useContext(TemplateContext);
 
   // Used as a target to insert the bottom bar component
@@ -115,10 +122,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
 
   useEffect(() => {
     if (_offset === undefined) {
-      const euiHeaderFixedCounter = Number(
-        document.body.dataset.fixedHeaders ?? 0
-      );
-      setOffset(euiTheme.base * 3 * euiHeaderFixedCounter);
+      setOffset(calculateOffset(euiTheme.base));
     }
   }, [_offset, euiTheme.base]);
 

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -79,12 +79,12 @@ export type EuiPageTemplateProps = _EuiPageOuterProps &
     component?: ComponentTypes;
   };
 
-function calculateOffset(base: number): number {
+const calculateOffset = (base: number): number => {
   if (typeof document === 'undefined') return 0; // SSR catch
 
   const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders ?? 0);
   return base * 3 * euiHeaderFixedCounter;
-}
+};
 
 /**
  * Consumed via `EuiPageTemplate`,


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7016

This PR fixes side navigation scroll and page content top offset updating after the page is already rendered.

Due to the implementation details of checking if there are `EuiHeader` components with fixed position rendered based on data attributes, there's still a single top offset update when the docs page is first loaded. However, the content doesn't jump whenever users navigate through pages anymore. I need to think of a clean fix for that, possibly moving away from using data attributes to store information like that. I'll fix it in a separate PR.

## QA

- [x] Click through a few side navigation items. Confirm the scroll behavior is the same as in [EUI v85](https://eui.elastic.co/v85.0.0)
- [x] Make sure there are no content section offset jumps when changing routes (padding-top being set to `0` and back to `48px`)

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
