### PR TITLE
[EuiFlyoutBody] Add `scrollableTabIndex` prop

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -61,7 +61,7 @@ const OpenCollapsibleNav: FunctionComponent<
 export const KibanaExample: Story = {
   render: ({ ...args }) => (
     <OpenCollapsibleNav {...args}>
-      <EuiFlyoutBody>
+      <EuiFlyoutBody scrollableTabIndex={-1}>
         <EuiCollapsibleNavItem title="Home" icon="home" isSelected href="#" />
         <EuiCollapsibleNavItem
           title="Recent"
@@ -288,7 +288,7 @@ export const KibanaExample: Story = {
 export const SecurityExample: Story = {
   render: ({ ...args }) => (
     <OpenCollapsibleNav {...args}>
-      <EuiFlyoutBody>
+      <EuiFlyoutBody scrollableTabIndex={-1}>
         <EuiCollapsibleNavItem
           title="Recent"
           icon="clock"

--- a/src/components/flyout/flyout_body.test.tsx
+++ b/src/components/flyout/flyout_body.test.tsx
@@ -19,7 +19,7 @@ describe('EuiFlyoutBody', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('is rendered', () => {
+  test('scrollableTabIndex', () => {
     const { container } = render(<EuiFlyoutBody scrollableTabIndex={-1} />);
 
     expect(container.querySelector('.euiFlyoutBody__overflow')).toHaveAttribute(

--- a/src/components/flyout/flyout_body.test.tsx
+++ b/src/components/flyout/flyout_body.test.tsx
@@ -18,4 +18,13 @@ describe('EuiFlyoutBody', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('is rendered', () => {
+    const { container } = render(<EuiFlyoutBody scrollableTabIndex={-1} />);
+
+    expect(container.querySelector('.euiFlyoutBody__overflow')).toHaveAttribute(
+      'tabIndex',
+      '-1'
+    );
+  });
 });

--- a/src/components/flyout/flyout_body.tsx
+++ b/src/components/flyout/flyout_body.tsx
@@ -19,6 +19,16 @@ export type EuiFlyoutBodyProps = FunctionComponent<
        * Use to display a banner at the top of the body. It is suggested to use `EuiCallOut` for it.
        */
       banner?: ReactNode;
+      /**
+       * [Scrollable regions (or their children) should be focusable](https://dequeuniversity.com/rules/axe/4.0/scrollable-region-focusable)
+       * to allow keyboard users to scroll the region via arrow keys.
+       *
+       * By default, EuiFlyoutBody's scroll overflow wrapper sets a `tabIndex` of `0`.
+       * If you know your flyout body content already contains focusable children
+       * that satisfy keyboard accessibility requirements, you can use this prop
+       * to override this default.
+       */
+      scrollableTabIndex?: number;
     }
 >;
 
@@ -26,6 +36,7 @@ export const EuiFlyoutBody: EuiFlyoutBodyProps = ({
   children,
   className,
   banner,
+  scrollableTabIndex = 0,
   ...rest
 }) => {
   const classes = classNames('euiFlyoutBody', className);
@@ -44,7 +55,7 @@ export const EuiFlyoutBody: EuiFlyoutBodyProps = ({
   return (
     <div className={classes} css={cssStyles} {...rest}>
       <div
-        tabIndex={0}
+        tabIndex={scrollableTabIndex}
         className="euiFlyoutBody__overflow"
         css={overflowCssStyles}
       >

--- a/upcoming_changelogs/7061.md
+++ b/upcoming_changelogs/7061.md
@@ -1,0 +1,1 @@
+- Updated `EuiFlyoutBody` with a new `scrollableTabIndex` prop


### PR DESCRIPTION
## Summary

This PR is part of #7041 (several a11y improvements/enhancements for the new `EuiCollapsibleNavBeta` work).

This PR _only_ addresses the extra tab stop caused by `EuiFlyoutBody` - it does not address any issues inherent to push flyouts (https://github.com/elastic/eui/issues/6576). I'll be looking into that as a separate PR.

## QA

- `gh pr checkout 7061`
- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--kibana-example
- Click the collapse nav button and press tab - there should only be 1 tab stop (instead of 2) between the toggle button and the flyout content
- Run axe devtools, there should be 0 issues caught

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - Opting for just props documentation, I don't think this needs its own docs example
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
