### PR TITLE
[INFRA] Adding a GitHub action to comment community PRs.

### DIFF
--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -1,0 +1,26 @@
+name: "Community contribution"
+on:
+  pull_request:
+    types: [ 'opened', 'reopened' ]
+
+jobs:
+  # Add a comment to manually start Buildkite for community contributions
+  community-pr-message:
+    env:
+      EUI_REPO: ${{ github.event.pull_request.base.repo.url }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.url }}
+      PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Print repo URLs"
+        run: |
+          echo "EUI: ${{ env.EUI_REPO }}"
+          echo "Head: ${{ env.HEAD_REPO }}"
+      - name: "Add community comment"
+        # Assume forked repo PR if these URLs are not the same
+        if: ${{ env.EUI_REPO != env.HEAD_REPO }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            Since this is a community submitted pull request, a Buildkite build has not been kicked off automatically. Would an Elastic organization member please verify the contents of this patch and then kick off a build manually?
+          pr_number: ${{ env.PULL_REQUEST_NUMBER }}


### PR DESCRIPTION
## Summary

This PR creates a new GitHub Action that will prompt Elastic org members to manually start the Buildkite job for community pull requests. It replaces the legacy Jenkins message and references Buildkite specifically.

New action uses this comment action from the GitHub marketplace: https://github.com/marketplace/actions/comment-pull-request

~~First run didn't account that I am making a forked repo request but also an Elastician. So I need to add logic for that.~~ First run failed because GitHub Actions submitted from forked repos are limited in scope. I'll make the necessary change locally, close this PR and resubmit on the EUI repo for accurate testing.

## QA

QA will be manual. Testing will consist of:

- [x] Test that the action is `echoing` the `EUI` and `Head` URLs to console correctly
- [ ] Test that the action correctly identifies non-Elastic user forked repos (NEW)
- [ ] Test that the action exits cleanly if this is not a community PR
- [ ] Test that the action exits cleanly if this IS a community PR
- [ ] Test that the action prints a comment to the correct PR page
- [ ] Test that an Elastic org member can start the Buildkite job manually using the trigger comment
