### PR TITLE
[EuiAccordion] Improve keyboard accessibility of tabbable children

### DIFF
--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -218,6 +218,59 @@ exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`]
 </div>
 `;
 
+exports[`EuiAccordion behavior restores tabbable children on accordion open 1`] = `
+<div
+  class="euiAccordion__children emotion-euiAccordion__children"
+>
+  <button>
+    tabbable item one
+  </button>
+  <input
+    placeholder="tabbable item two"
+    type="text"
+  />
+  <a
+    href="#"
+  >
+    tabbable item three
+  </a>
+  <div
+    tabindex="0"
+  >
+    tabbable item four
+  </div>
+</div>
+`;
+
+exports[`EuiAccordion behavior sets tabbable children to \`tabIndex={-1}\` when accordions are closed 1`] = `
+<div
+  class="euiAccordion__children emotion-euiAccordion__children"
+>
+  <button
+    tabindex="-1"
+  >
+    tabbable item one
+  </button>
+  <input
+    placeholder="tabbable item two"
+    tabindex="-1"
+    type="text"
+  />
+  <a
+    href="#"
+    tabindex="-1"
+  >
+    tabbable item three
+  </a>
+  <div
+    data-original-tabindex="0"
+    tabindex="-1"
+  >
+    tabbable item four
+  </div>
+</div>
+`;
+
 exports[`EuiAccordion is rendered 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 import { mount } from 'enzyme';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
@@ -280,6 +281,40 @@ describe('EuiAccordion', () => {
       component.find('button').at(0).simulate('click');
 
       expect(childWrapper).toBe(document.activeElement);
+    });
+
+    it('sets tabbable children to `tabIndex={-1}` when accordions are closed', () => {
+      const { container } = render(
+        <EuiAccordion id={getId()}>
+          <button>tabbable item one</button>
+          <input type="text" placeholder="tabbable item two" />
+          <a href="#">tabbable item three</a>
+          <div tabIndex={0}>tabbable item four</div>
+        </EuiAccordion>
+      );
+      const children = container.querySelector('.euiAccordion__children')!;
+
+      expect(children.querySelectorAll('[tabindex="-1"]')).toHaveLength(4);
+      expect(children).toMatchSnapshot();
+    });
+
+    it('restores tabbable children on accordion open', () => {
+      const { container, getByTestSubject } = render(
+        <EuiAccordion
+          id={getId()}
+          buttonProps={{ 'data-test-subj': 'trigger' }}
+        >
+          <button>tabbable item one</button>
+          <input type="text" placeholder="tabbable item two" />
+          <a href="#">tabbable item three</a>
+          <div tabIndex={0}>tabbable item four</div>
+        </EuiAccordion>
+      );
+      fireEvent.click(getByTestSubject('trigger'));
+      const children = container.querySelector('.euiAccordion__children')!;
+
+      expect(children.querySelectorAll('[tabindex="-1"]')).toHaveLength(0);
+      expect(children).toMatchSnapshot();
     });
   });
 });

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -159,8 +159,7 @@ export class EuiAccordionClass extends Component<
   onToggle = () => {
     const { forceState } = this.props;
     if (forceState) {
-      this.props.onToggle &&
-        this.props.onToggle(forceState === 'open' ? false : true);
+      this.props.onToggle?.(forceState === 'open' ? false : true);
     } else {
       this.setState(
         (prevState) => ({
@@ -170,7 +169,7 @@ export class EuiAccordionClass extends Component<
           if (this.state.isOpen && this.childWrapper) {
             this.childWrapper.focus();
           }
-          this.props.onToggle && this.props.onToggle(this.state.isOpen);
+          this.props.onToggle?.(this.state.isOpen);
         }
       );
     }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -132,14 +132,16 @@ export class EuiAccordionClass extends Component<
       : this.props.initialIsOpen!,
   };
 
+  get isOpen() {
+    return this.props.forceState
+      ? this.props.forceState === 'open'
+      : this.state.isOpen;
+  }
+
   setChildContentHeight = () => {
-    const { forceState } = this.props;
     requestAnimationFrame(() => {
       const height =
-        this.childContent &&
-        (forceState ? forceState === 'open' : this.state.isOpen)
-          ? this.childContent.clientHeight
-          : 0;
+        this.childContent && this.isOpen ? this.childContent.clientHeight : 0;
       this.childWrapper &&
         this.childWrapper.setAttribute(
           'style',
@@ -213,8 +215,6 @@ export class EuiAccordionClass extends Component<
       ...rest
     } = this.props;
 
-    const isOpen = forceState ? forceState === 'open' : this.state.isOpen;
-
     // Force button element to be a legend if the element is a fieldset
     const ButtonElement = Element === 'fieldset' ? 'legend' : _ButtonElement;
     const buttonElementIsFocusable = ButtonElement === 'button';
@@ -228,7 +228,7 @@ export class EuiAccordionClass extends Component<
     const classes = classNames(
       'euiAccordion',
       {
-        'euiAccordion-isOpen': isOpen,
+        'euiAccordion-isOpen': this.isOpen,
       },
       className
     );
@@ -251,7 +251,7 @@ export class EuiAccordionClass extends Component<
     const iconButtonClasses = classNames(
       'euiAccordion__iconButton',
       {
-        'euiAccordion__iconButton-isOpen': isOpen,
+        'euiAccordion__iconButton-isOpen': this.isOpen,
         'euiAccordion__iconButton--right': _arrowDisplay === 'right',
       },
       arrowProps?.className
@@ -275,13 +275,13 @@ export class EuiAccordionClass extends Component<
     const childWrapperStyles = euiAccordionChildWrapperStyles(theme);
     const cssChildWrapperStyles = [
       childWrapperStyles.euiAccordion__childWrapper,
-      isOpen && childWrapperStyles.isOpen,
+      this.isOpen && childWrapperStyles.isOpen,
     ];
 
     const iconButtonStyles = euiAccordionIconButtonStyles(theme);
     const cssIconButtonStyles = [
       iconButtonStyles.euiAccordion__iconButton,
-      isOpen && iconButtonStyles.isOpen,
+      this.isOpen && iconButtonStyles.isOpen,
       _arrowDisplay === 'right' && iconButtonStyles.arrowRight,
       arrowProps?.css,
     ];
@@ -311,7 +311,7 @@ export class EuiAccordionClass extends Component<
           iconType="arrowRight"
           onClick={this.onToggle}
           aria-controls={id}
-          aria-expanded={isOpen}
+          aria-expanded={this.isOpen}
           aria-labelledby={buttonId}
           tabIndex={buttonElementIsFocusable ? -1 : 0}
           isDisabled={isDisabled}
@@ -363,7 +363,7 @@ export class EuiAccordionClass extends Component<
         css={cssButtonStyles}
         aria-controls={id}
         // `aria-expanded` is only a valid attribute on interactive controls - axe-core throws a violation otherwise
-        aria-expanded={ButtonElement === 'button' ? isOpen : undefined}
+        aria-expanded={ButtonElement === 'button' ? this.isOpen : undefined}
         onClick={isDisabled ? undefined : this.onToggle}
         type={ButtonElement === 'button' ? 'button' : undefined}
         disabled={ButtonElement === 'button' ? isDisabled : undefined}

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -47,7 +47,9 @@ export const Playground: Story = {
 
 export const EdgeCaseTesting: Story = {
   render: ({ ...args }) => (
-    <EuiCollapsibleNavBeta>
+    // Since we're not using EuiFlyoutBody/Footer, the flex display isn't needed
+    // and causes item vertical margins to not collapse
+    <EuiCollapsibleNavBeta className="eui-displayBlock">
       <EuiCollapsibleNavItem {...args} href="#" title="Link with no icon" />
       <EuiCollapsibleNavItem
         {...args}

--- a/upcoming_changelogs/7064.md
+++ b/upcoming_changelogs/7064.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiAccordion` to remove tabbable children from sequential keyboard navigation when the accordion is closed


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6980, part of https://github.com/elastic/eui/issues/7041

`EuiAccordion`s children cannot be hidden due to accordions needing to detect their height. This means that interactive/tabbable children still remain the keyboard tab order when accordions are closed when they should not be. Example production behavior: https://codesandbox.io/s/withered-moon-hc3ft6?file=/demo.js (notice several tabs are required to reach the 2nd visible button).

The solution to this is that on close, `EuiAccordion` needs to evaluate its tabbable children and manually set them to `tabIndex={-1}` to remove them from tab order. On open, their original tabindex behavior should be restored.

There's some misc syntax cleanup in this PR, so as always, follow along by commit!

### Extra note

An example of similar behavior/logic in EUI also exists in [EuiDataGridCell](https://github.com/elastic/eui/blob/d3e8e0b8688d312b86b750a7059262baa7958ade/src/components/datagrid/body/data_grid_cell.tsx#L443-L454).

## QA

- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavitem--edge-case-testing
- [x] Close the `Accordion with nested accordions` item and confirm that pressing tab jumps you immediately to the next top-level accordion item
- [x] Re-open the accordion and confirm its children are tabbable
- Repeat the above with as many other accordions/nested accordions as you want to see if you can catch any unexpected tab behavior

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~** - I skipped Cypress test for now as the Jest tests felt adequate to me, but feel free to shout if you think E2E tests would feel better
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
