### PR TITLE
[EuiFlyout] Resolve disparity between push flyouts and overlay flyouts

### DIFF
--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -344,7 +344,7 @@ export const FlyoutExample = {
               >
                 dialog role
               </EuiLink>
-              , and do not contain any of the default screen reader guidance
+              , and do not include any of the default screen reader guidance
               that overlay flyouts contain out-of-the-box.
             </p>
             <p>

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { GuideSectionTypes } from '../../components';
@@ -10,6 +10,7 @@ import {
   EuiFlyoutHeader,
   EuiFlyoutFooter,
   EuiCallOut,
+  EuiLink,
 } from '../../../../src/components';
 
 import Flyout from './flyout';
@@ -315,7 +316,7 @@ export const FlyoutExample = {
         },
       ],
       text: (
-        <Fragment>
+        <>
           <p>
             Another way to allow for continued interactions of the page content
             while a flyout is visible, is to change the <EuiCode>type</EuiCode>{' '}
@@ -329,7 +330,29 @@ export const FlyoutExample = {
             window widths. You can adjust this minimum breakpoint with{' '}
             <EuiCode>pushMinBreakpoint</EuiCode>.
           </p>
-        </Fragment>
+          <EuiCallOut
+            iconType="accessibility"
+            title="Push flyouts require manual accessibility management"
+            color="warning"
+          >
+            <p>
+              Push flyouts do not use a focus trap, do not close on Escape
+              keypress, do not inherit a{' '}
+              <EuiLink
+                href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role"
+                target="_blank"
+              >
+                dialog role
+              </EuiLink>
+              , and do not contain any of the default screen reader guidance
+              that overlay flyouts contain out-of-the-box.
+            </p>
+            <p>
+              Please be cautious when using push flyouts, and make sure you are
+              managing your own focus and screen reader UX.
+            </p>
+          </EuiCallOut>
+        </>
       ),
       snippet: flyoutPushedSnippet,
       demo: <FlyoutPush />,
@@ -344,7 +367,7 @@ export const FlyoutExample = {
         },
       ],
       text: (
-        <Fragment>
+        <>
           <p>
             By default, flyouts will continue to grow with the width of the
             window. To stop this growth at an ideal width, set{' '}
@@ -355,7 +378,7 @@ export const FlyoutExample = {
             color="warning"
             title="Note that there are some caveats to providing a maxWidth that is smaller than the minWidth."
           />
-        </Fragment>
+        </>
       ),
       snippet: flyoutMaxWidthSnippet,
       demo: <FlyoutMaxWidth />,

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -274,7 +274,6 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
   >
     <nav
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNav-push"
-      data-autofocus="true"
       id="id"
       style="inline-size: 320px;"
     />
@@ -355,7 +354,6 @@ exports[`EuiCollapsibleNav props showButtonIfDocked 1`] = `
   >
     <nav
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNav-push"
-      data-autofocus="true"
       id="id"
       style="inline-size: 320px;"
     />

--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -276,9 +276,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNav-push"
       data-autofocus="true"
       id="id"
-      role="dialog"
       style="inline-size: 320px;"
-      tabindex="0"
     />
   </div>
   <div
@@ -359,9 +357,7 @@ exports[`EuiCollapsibleNav props showButtonIfDocked 1`] = `
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNav-push"
       data-autofocus="true"
       id="id"
-      role="dialog"
       style="inline-size: 320px;"
-      tabindex="0"
     />
   </div>
   <div

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <nav
+        aria-label="Site menu"
         class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left-isPush-isPushCollapsed"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
@@ -177,7 +178,7 @@ exports[`EuiCollapsibleNavBeta responsive behavior makes the overlay flyout full
     >
       <nav
         aria-describedby="generated-id"
-        aria-label="Site navigation"
+        aria-label="Site menu"
         class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-overlay-left-euiCollapsibleNavBeta-left-isOverlayFullWidth"
         data-autofocus="true"
         id="generated-id_euiCollapsibleNav"

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -177,6 +177,7 @@ exports[`EuiCollapsibleNavBeta responsive behavior makes the overlay flyout full
     >
       <nav
         aria-describedby="generated-id"
+        aria-label="Site navigation"
         class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-overlay-left-euiCollapsibleNavBeta-left-isOverlayFullWidth"
         data-autofocus="true"
         id="generated-id_euiCollapsibleNav"

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
       <nav
         aria-label="aria-label"
         class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left-isPush-euiTestCss"
-        data-autofocus="true"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
         style="inline-size: 248px;"
@@ -90,7 +89,6 @@ exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
     >
       <nav
         class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left-isPush-isPushCollapsed"
-        data-autofocus="true"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
         style="inline-size: 48px;"

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -40,9 +40,7 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
         data-autofocus="true"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
-        role="dialog"
         style="inline-size: 248px;"
-        tabindex="0"
       >
         Nav content
       </nav>
@@ -95,9 +93,7 @@ exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
         data-autofocus="true"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
-        role="dialog"
         style="inline-size: 48px;"
-        tabindex="0"
       >
         Nav content
       </nav>

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -60,6 +60,16 @@ export type EuiCollapsibleNavBetaProps = CommonProps &
      * take up the full width of the page.
      */
     width?: number;
+    /**
+     * Overlay flyouts are considered dialogs, and dialogs must have a label.
+     * By default, a label of `Site menu` will be applied.
+     *
+     * If your usage of this component is not actually for site-wide navigation,
+     * please set your own `aria-label` or `aria-labelledby`.
+     *
+     * @default 'Site menu'
+     */
+    'aria-label'?: string;
   };
 
 export const EuiCollapsibleNavBeta: FunctionComponent<
@@ -157,9 +167,9 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
     conditionalId: id,
     suffix: 'euiCollapsibleNav',
   });
-  const dialogAriaLabel = useEuiI18n(
+  const defaultAriaLabel = useEuiI18n(
     'euiCollapsibleNavBeta.ariaLabel',
-    'Site navigation'
+    'Site menu'
   );
 
   const buttonRef = useRef<HTMLDivElement | null>(null);
@@ -188,7 +198,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   // Wait for any fixed headers to be queried before rendering (prevents position jumping)
   const flyout = fixedHeadersCount !== false && (
     <EuiFlyout
-      aria-label={isOverlay ? dialogAriaLabel : undefined} // Overlay flyouts are dialogs and need a label. Push flyouts are not dialogs.
+      aria-label={defaultAriaLabel}
       {...rest} // EuiCollapsibleNav is significantly less permissive than EuiFlyout
       id={flyoutID}
       css={cssStyles}

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -23,6 +23,7 @@ import { mathWithUnits, logicalStyle } from '../../global_styling';
 
 import { CommonProps } from '../common';
 import { EuiFlyout, EuiFlyoutProps } from '../flyout';
+import { useEuiI18n } from '../i18n';
 import { euiHeaderVariables } from '../header/header.styles';
 
 import { EuiCollapsibleNavContext } from './context';
@@ -156,6 +157,10 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
     conditionalId: id,
     suffix: 'euiCollapsibleNav',
   });
+  const dialogAriaLabel = useEuiI18n(
+    'euiCollapsibleNavBeta.ariaLabel',
+    'Site navigation'
+  );
 
   const buttonRef = useRef<HTMLDivElement | null>(null);
   const focusTrapProps: EuiFlyoutProps['focusTrapProps'] = useMemo(
@@ -183,6 +188,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   // Wait for any fixed headers to be queried before rendering (prevents position jumping)
   const flyout = fixedHeadersCount !== false && (
     <EuiFlyout
+      aria-label={isOverlay ? dialogAriaLabel : undefined} // Overlay flyouts are dialogs and need a label. Push flyouts are not dialogs.
       {...rest} // EuiCollapsibleNav is significantly less permissive than EuiFlyout
       id={flyoutID}
       css={cssStyles}

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -1059,7 +1059,6 @@ Array [
   >
     <div
       class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-right"
-      data-autofocus="true"
     >
       <button
         aria-label="Close this dialog"

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -1060,8 +1060,6 @@ Array [
     <div
       class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-right"
       data-autofocus="true"
-      role="dialog"
-      tabindex="0"
     >
       <button
         aria-label="Close this dialog"

--- a/src/components/flyout/flyout.test.tsx
+++ b/src/components/flyout/flyout.test.tsx
@@ -71,6 +71,25 @@ describe('EuiFlyout', () => {
     ).toBeFalsy();
   });
 
+  it('allows setting custom aria-describedby attributes', () => {
+    const { getByTestSubject } = render(
+      <>
+        <EuiFlyout
+          onClose={() => {}}
+          aria-describedby="custom-test-id"
+          data-test-subj="flyout"
+        />
+        <div id="custom-test-id" hidden>
+          This flyout does X, Y, and Z
+        </div>
+      </>
+    );
+    expect(getByTestSubject('flyout')).toHaveAttribute(
+      'aria-describedby',
+      'generated-id custom-test-id'
+    );
+  });
+
   describe('props', () => {
     test('hideCloseButton', () => {
       const component = mount(<EuiFlyout onClose={() => {}} hideCloseButton />);

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -417,7 +417,7 @@ export const EuiFlyout = forwardRef(
           role={!isPushed ? 'dialog' : rest.role}
           tabIndex={!isPushed ? 0 : rest.tabIndex}
           aria-describedby={!isPushed ? descriptionId : undefined}
-          data-autofocus
+          data-autofocus={!isPushed || undefined}
         >
           {!isPushed && screenReaderDescription}
           {closeButton}

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -183,6 +183,7 @@ export const EuiFlyout = forwardRef(
       pushMinBreakpoint = 'l',
       focusTrapProps: _focusTrapProps = {},
       includeFixedHeadersInFocusTrap = true,
+      'aria-describedby': _ariaDescribedBy,
       ...rest
     }: EuiFlyoutProps<T>,
     ref:
@@ -349,6 +350,7 @@ export const EuiFlyout = forwardRef(
      */
     const hasOverlayMask = ownFocus && !isPushed;
     const descriptionId = useGeneratedHtmlId();
+    const ariaDescribedBy = classnames(descriptionId, _ariaDescribedBy);
 
     const screenReaderDescription = (
       <EuiScreenReaderOnly>
@@ -416,7 +418,7 @@ export const EuiFlyout = forwardRef(
           {...(rest as ComponentPropsWithRef<T>)}
           role={!isPushed ? 'dialog' : rest.role}
           tabIndex={!isPushed ? 0 : rest.tabIndex}
-          aria-describedby={!isPushed ? descriptionId : undefined}
+          aria-describedby={!isPushed ? ariaDescribedBy : _ariaDescribedBy}
           data-autofocus={!isPushed || undefined}
         >
           {!isPushed && screenReaderDescription}

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -409,15 +409,15 @@ export const EuiFlyout = forwardRef(
         {...focusTrapProps}
       >
         <Element
-          css={cssStyles}
-          {...(rest as ComponentPropsWithRef<T>)}
-          role="dialog"
           className={classes}
-          tabIndex={0}
-          data-autofocus
-          aria-describedby={!isPushed ? descriptionId : undefined}
+          css={cssStyles}
           style={newStyle}
           ref={setRef}
+          {...(rest as ComponentPropsWithRef<T>)}
+          role="dialog"
+          tabIndex={0}
+          aria-describedby={!isPushed ? descriptionId : undefined}
+          data-autofocus
         >
           {!isPushed && screenReaderDescription}
           {closeButton}

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -414,8 +414,8 @@ export const EuiFlyout = forwardRef(
           style={newStyle}
           ref={setRef}
           {...(rest as ComponentPropsWithRef<T>)}
-          role="dialog"
-          tabIndex={0}
+          role={!isPushed ? 'dialog' : rest.role}
+          tabIndex={!isPushed ? 0 : rest.tabIndex}
           aria-describedby={!isPushed ? descriptionId : undefined}
           data-autofocus
         >

--- a/upcoming_changelogs/7065.md
+++ b/upcoming_changelogs/7065.md
@@ -1,0 +1,7 @@
+**Bug fixes**
+
+- Fixed `EuiFlyout`s to accept custom `aria-describedby` IDs
+
+**Accessibility**
+
+- Removed the default `dialog` role and `tabIndex` from push `EuiFlyout`s. Push flyouts, compared to overlay flyouts, require manual accessibility management.


### PR DESCRIPTION
## Summary

This is my last PR for https://github.com/elastic/eui/issues/7041.

This relates to the discussion brought up in https://github.com/elastic/eui/issues/6576, but **does not resolve it** per the issue. It instead takes a completely different direction of specifically marking push flyouts **not** as dialogs, and removing all dialog-related props (primarily `role` and `tabIndex`).

<img width="1179" alt="" src="https://github.com/elastic/eui/assets/549407/2142db27-19e1-4891-8664-8716f24f29f5">

I've opted to go with this approach because of the direction that the new beta collapsible nav has gone in, which will eventually be present on every page of Kibana.

## QA

- `gh pr checkout 7065`
- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--kibana-example (ensure the nav is on a wide enough screen that it's pushing the page as opposed to being an overlay)
- Click the toggle button
- [x] Confirm that only one tab press is needed to get to first item/link in the nav
- [x] Confirm that screen readers announce/inherit the `navigation` context/information
- Regression testing
    - Make your screen small enough so that the nav becomes an overlay
    - Click the toggle button
    - [x] Confirm the flyout has a label and the normal screen reader dialog text reads out

### General checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
    - Note: I'd prefer not to mark this as a breaking change personally, as I doubt it will affect any consumers and will have minimal effect on end-users (if anything, it will remove an extra tab stop and unnecessary role announcement for SR users).