### PR TITLE
[EuiInputPopover] Add `panelMinWidth` prop

### DIFF
--- a/src-docs/src/views/popover/input_popover.tsx
+++ b/src-docs/src/views/popover/input_popover.tsx
@@ -43,6 +43,7 @@ export default () => {
           />
         }
         panelMinWidth={200}
+        anchorPosition="downRight"
       >
         The popover will adjust in size as the input does.
         <br />

--- a/src-docs/src/views/popover/input_popover.tsx
+++ b/src-docs/src/views/popover/input_popover.tsx
@@ -2,14 +2,19 @@ import React, { useState } from 'react';
 
 import {
   EuiInputPopover,
+  EuiInputPopoverProps,
   EuiFieldText,
   EuiTextArea,
+  EuiButtonGroup,
+  EuiFormRow,
   EuiSpacer,
 } from '../../../../src';
 
 export default () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [isResizablePopoverOpen, setIsResizablePopoverOpen] = useState(false);
+  const [anchorPosition, setAnchorPosition] =
+    useState<EuiInputPopoverProps['anchorPosition']>('downLeft');
 
   return (
     <>
@@ -19,7 +24,7 @@ export default () => {
         input={
           <EuiFieldText
             onFocus={() => setIsPopoverOpen(true)}
-            placeholder="Click me to toggle an input popover"
+            placeholder="Focus me to toggle an input popover"
             aria-label="Popover attached to input element"
           />
         }
@@ -35,19 +40,40 @@ export default () => {
         closePopover={() => setIsResizablePopoverOpen(false)}
         input={
           <EuiTextArea
-            onFocus={() => setIsResizablePopoverOpen(true)}
-            placeholder="Click me and drag the resize handle"
-            aria-label="Popover attached to a resizable textarea element"
-            rows={1}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setIsResizablePopoverOpen(true);
+              }
+            }}
+            placeholder="Focus me, press the down arrow key, then drag the resize handle"
+            aria-label="Press the down arrow key to toggle the popover attached to this textarea element."
+            rows={2}
             resize="horizontal"
           />
         }
-        panelMinWidth={200}
-        anchorPosition="downRight"
+        panelMinWidth={300}
+        anchorPosition={anchorPosition}
       >
-        The popover will adjust in size as the input does.
-        <br />
-        It has a minimum width of 200px.
+        This popover has a minimum width of 300px, and will adjust in size as
+        the textarea does.
+        <EuiSpacer size="s" />
+        <EuiFormRow label="Anchor position" display="columnCompressed">
+          <EuiButtonGroup
+            buttonSize="compressed"
+            legend="Anchor position"
+            name="anchorPosition"
+            idSelected={anchorPosition!}
+            onChange={(id) =>
+              setAnchorPosition(id as EuiInputPopoverProps['anchorPosition'])
+            }
+            options={[
+              { id: 'downLeft', label: 'Left' },
+              { id: 'downCenter', label: 'Center' },
+              { id: 'downRight', label: 'Right' },
+            ]}
+          />
+        </EuiFormRow>
       </EuiInputPopover>
     </>
   );

--- a/src-docs/src/views/popover/input_popover.tsx
+++ b/src-docs/src/views/popover/input_popover.tsx
@@ -42,8 +42,11 @@ export default () => {
             resize="horizontal"
           />
         }
+        panelMinWidth={200}
       >
         The popover will adjust in size as the input does.
+        <br />
+        It has a minimum width of 200px.
       </EuiInputPopover>
     </>
   );

--- a/src-docs/src/views/popover/input_popover.tsx
+++ b/src-docs/src/views/popover/input_popover.tsx
@@ -1,43 +1,28 @@
 import React, { useState } from 'react';
 
-import { EuiInputPopover, EuiFieldText, EuiSpacer } from '../../../../src';
+import {
+  EuiInputPopover,
+  EuiFieldText,
+  EuiTextArea,
+  EuiSpacer,
+} from '../../../../src';
 
 export default () => {
-  const [inputWidth, setInputWidth] = useState(200);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const [isPopoverOpenTwo, setIsPopoverOpenTwo] = useState(false);
-  const toggleIsPopoverOpen = (shouldBeOpen = !isPopoverOpen) => {
-    setIsPopoverOpen(shouldBeOpen);
-  };
-  const toggleIsPopoverOpenTwo = (shouldBeOpen = !isPopoverOpenTwo) => {
-    setIsPopoverOpenTwo(shouldBeOpen);
-  };
-
-  const input = (
-    <EuiFieldText
-      onFocus={() => toggleIsPopoverOpen()}
-      aria-label="Popover attached to input element"
-    />
-  );
-
-  const inputTwo = (
-    <EuiFieldText
-      onFocus={() => {
-        setInputWidth(300);
-        toggleIsPopoverOpenTwo();
-      }}
-      aria-label="Popover attached to an adjustable sized input element"
-    />
-  );
+  const [isResizablePopoverOpen, setIsResizablePopoverOpen] = useState(false);
 
   return (
-    <React.Fragment>
+    <>
       <EuiInputPopover
-        input={input}
         isOpen={isPopoverOpen}
-        closePopover={() => {
-          toggleIsPopoverOpen(false);
-        }}
+        closePopover={() => setIsPopoverOpen(false)}
+        input={
+          <EuiFieldText
+            onFocus={() => setIsPopoverOpen(true)}
+            placeholder="Click me to toggle an input popover"
+            aria-label="Popover attached to input element"
+          />
+        }
       >
         Popover content
       </EuiInputPopover>
@@ -45,16 +30,21 @@ export default () => {
       <EuiSpacer />
 
       <EuiInputPopover
-        input={inputTwo}
-        isOpen={isPopoverOpenTwo}
-        style={{ width: inputWidth }}
-        closePopover={() => {
-          toggleIsPopoverOpenTwo(false);
-          setInputWidth(200);
-        }}
+        display="inline-block"
+        isOpen={isResizablePopoverOpen}
+        closePopover={() => setIsResizablePopoverOpen(false)}
+        input={
+          <EuiTextArea
+            onFocus={() => setIsResizablePopoverOpen(true)}
+            placeholder="Click me and drag the resize handle"
+            aria-label="Popover attached to a resizable textarea element"
+            rows={1}
+            resize="horizontal"
+          />
+        }
       >
-        Popover will adjust in size as the input does
+        The popover will adjust in size as the input does.
       </EuiInputPopover>
-    </React.Fragment>
+    </>
   );
 };

--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -364,19 +364,20 @@ export const PopoverExample = {
           <p>
             <strong>EuiInputPopover</strong> is a specialized popover component
             intended to be used with form elements. Stylistically, the popover
-            panel is
-            {'"attached"'} to the input. Functionally, consumers have control
-            over what events open and close the popover, and it can allow for
-            natural tab order.
+            panel is {'"attached"'} to the input. As a result, the popover will
+            always try to set its width to match the width of the input,
+            although this can be configured via <EuiCode>panelMinWidth</EuiCode>
+            .
           </p>
           <p>
-            Although some assumptions are made about keyboard behavior,
-            consumers should provide specific key event handlers depending on
-            the use case. For instance, a <EuiCode>type=text</EuiCode> input
-            could use the down key to trigger popover opening, but this
-            interaction would not be appropriate for{' '}
-            <EuiCode>type=number</EuiCode> inputs as they natively bind to the
-            down key.
+            Functionally, consumers have control over what events open and close
+            the popover, and it can allow for natural tab order. Although some
+            assumptions are made about keyboard behavior, consumers should
+            provide specific key event handlers depending on the use case. For
+            instance, a <EuiCode>type=text</EuiCode> input could use the down
+            key to trigger popover opening, but this interaction would not be
+            appropriate for <EuiCode>type=number</EuiCode> inputs as they
+            natively bind to the down key.
           </p>
         </>
       ),

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 8px; left: -22px; will-change: transform, opacity; z-index: 2000;"
     >
       <div>
         <div
@@ -390,7 +390,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
       class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 8px; left: -22px; will-change: transform, opacity; z-index: 2000;"
     >
       <div>
         <div
@@ -536,7 +536,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
       class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 8px; left: -22px; will-change: transform, opacity; z-index: 2000;"
     >
       <div>
         <div
@@ -681,7 +681,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
       class="euiPanel euiPanel--plain euiPopover__panel goes-on-popover-panel emotion-euiPanel-grow-m-plain-euiPopover__panel-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 8px; left: 0px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 8px; left: -22px; will-change: transform, opacity; z-index: 2000;"
     >
       <div>
         <div

--- a/src/components/form/super_select/super_select.tsx
+++ b/src/components/form/super_select/super_select.tsx
@@ -18,7 +18,7 @@ import {
   EuiSuperSelectControlProps,
   EuiSuperSelectOption,
 } from './super_select_control';
-import { EuiInputPopover, EuiPopoverProps } from '../../popover';
+import { EuiInputPopover, EuiInputPopoverProps } from '../../popover';
 import {
   EuiContextMenuItem,
   EuiContextMenuItemLayoutAlignment,
@@ -80,7 +80,7 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
     isOpen?: boolean;
 
     /**
-     * Optional props to pass to the underlying [EuiPopover](/#/layout/popover).
+     * Optional props to pass to the underlying [EuiInputPopover](/#/layout/popover#popover-attached-to-input-element).
      * Allows fine-grained control of the popover dropdown menu, including
      * `repositionOnScroll` for EuiSuperSelects used within scrollable containers,
      * and customizing popover panel styling.
@@ -88,7 +88,7 @@ export type EuiSuperSelectProps<T extends string> = CommonProps &
      * Does not accept a nested `popoverProps.isOpen` property - use the top level
      * `isOpen` API instead.
      */
-    popoverProps?: Partial<CommonProps & Omit<EuiPopoverProps, 'isOpen'>>;
+    popoverProps?: Partial<CommonProps & Omit<EuiInputPopoverProps, 'isOpen'>>;
   };
 
 export class EuiSuperSelect<T extends string> extends Component<

--- a/src/components/popover/input_popover.spec.tsx
+++ b/src/components/popover/input_popover.spec.tsx
@@ -24,7 +24,10 @@ describe('EuiPopover', () => {
 
   it('renders a popover with equal width to the input', () => {
     cy.mount(<EuiInputPopover {...props}>Popover content</EuiInputPopover>);
-    cy.get('[data-popover-panel]').invoke('outerWidth').should('equal', 400);
+    cy.get('[data-popover-panel]')
+      .should('have.css', 'left', '0px')
+      .invoke('outerWidth')
+      .should('equal', 400);
   });
 
   it('respects `panelMinWidth`', () => {
@@ -34,5 +37,22 @@ describe('EuiPopover', () => {
       </EuiInputPopover>
     );
     cy.get('[data-popover-panel]').invoke('outerWidth').should('equal', 450);
+  });
+
+  it('respects `anchorPosition`', () => {
+    cy.mount(
+      <div className="eui-textRight">
+        <EuiInputPopover
+          {...props}
+          display="inline-block"
+          input={<EuiFieldText controlOnly={true} style={{ width: 150 }} />}
+          panelMinWidth={300}
+          anchorPosition="downRight"
+        >
+          Popover content
+        </EuiInputPopover>
+      </div>
+    );
+    cy.get('[data-popover-panel]').should('have.css', 'left', '200px');
   });
 });

--- a/src/components/popover/input_popover.spec.tsx
+++ b/src/components/popover/input_popover.spec.tsx
@@ -16,6 +16,11 @@ import { EuiFieldText, EuiTextArea } from '../../components';
 import { EuiInputPopover } from './input_popover';
 
 describe('EuiPopover', () => {
+  // The viewport width matters for position assertions, so ensure it's explicitly defined
+  beforeEach(() => {
+    cy.viewport(500, 300);
+  });
+
   const props = {
     input: <EuiFieldText />,
     closePopover: () => {},
@@ -62,13 +67,15 @@ describe('EuiPopover', () => {
         <EuiInputPopover
           {...props}
           display="inline-block"
-          input={<EuiTextArea rows={1} resize="horizontal" />}
+          input={
+            <EuiTextArea rows={1} resize="horizontal" style={{ width: 150 }} />
+          }
         >
           Popover content
         </EuiInputPopover>
       </div>
     );
-    cy.get('[data-popover-panel]').should('have.css', 'left', '155.5px');
+    cy.get('[data-popover-panel]').should('have.css', 'left', '175px');
     cy.wait(100); // Wait a tick, otherwise Cypress returns a false positive
 
     // Cypress doesn't seem to have a way to mimic manual dragging/resizing, so we'll do it programmatically

--- a/src/components/popover/input_popover.spec.tsx
+++ b/src/components/popover/input_popover.spec.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../cypress/support" />
+
+import React from 'react';
+
+import { EuiFieldText } from '../../components';
+import { EuiInputPopover } from './input_popover';
+
+describe('EuiPopover', () => {
+  const props = {
+    input: <EuiFieldText />,
+    closePopover: () => {},
+    isOpen: true,
+  };
+
+  it('renders a popover with equal width to the input', () => {
+    cy.mount(<EuiInputPopover {...props}>Popover content</EuiInputPopover>);
+    cy.get('[data-popover-panel]').invoke('outerWidth').should('equal', 400);
+  });
+
+  it('respects `panelMinWidth`', () => {
+    cy.mount(
+      <EuiInputPopover {...props} panelMinWidth={450}>
+        Popover content
+      </EuiInputPopover>
+    );
+    cy.get('[data-popover-panel]').invoke('outerWidth').should('equal', 450);
+  });
+});

--- a/src/components/popover/input_popover.spec.tsx
+++ b/src/components/popover/input_popover.spec.tsx
@@ -12,7 +12,7 @@
 
 import React from 'react';
 
-import { EuiFieldText } from '../../components';
+import { EuiFieldText, EuiTextArea } from '../../components';
 import { EuiInputPopover } from './input_popover';
 
 describe('EuiPopover', () => {
@@ -54,5 +54,25 @@ describe('EuiPopover', () => {
       </div>
     );
     cy.get('[data-popover-panel]').should('have.css', 'left', '200px');
+  });
+
+  it('correctly repositions the popover on input resize', () => {
+    cy.mount(
+      <div className="eui-textCenter">
+        <EuiInputPopover
+          {...props}
+          display="inline-block"
+          input={<EuiTextArea rows={1} resize="horizontal" />}
+        >
+          Popover content
+        </EuiInputPopover>
+      </div>
+    );
+    cy.get('[data-popover-panel]').should('have.css', 'left', '155.5px');
+    cy.wait(100); // Wait a tick, otherwise Cypress returns a false positive
+
+    // Cypress doesn't seem to have a way to mimic manual dragging/resizing, so we'll do it programmatically
+    cy.get('textarea').then(($el) => ($el[0].style.width = '500px'));
+    cy.get('[data-popover-panel]').should('have.css', 'left', '50px');
   });
 });

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -36,6 +36,12 @@ export interface _EuiInputPopoverProps
   input: EuiPopoverProps['button'];
   inputRef?: EuiPopoverProps['buttonRef'];
   onPanelResize?: (width?: number) => void;
+  /**
+   * By default, **EuiInputPopovers** inherit the same width as the passed input element.
+   * However, if the input width is too small, you can pass a minimum panel width
+   * (that should be based on the popover content).
+   */
+  panelMinWidth?: number;
 }
 
 export type EuiInputPopoverProps = CommonProps &
@@ -49,6 +55,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   focusTrapProps,
   input,
   fullWidth = false,
+  panelMinWidth = 0,
   onPanelResize,
   inputRef: _inputRef,
   panelRef: _panelRef,
@@ -66,13 +73,14 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
     (width?: number) => {
       if (panelEl && (!!inputElWidth || !!width)) {
         const newWidth = !!width ? width : inputElWidth;
-        panelEl.style.width = `${newWidth}px`;
-        if (onPanelResize) {
-          onPanelResize(newWidth);
-        }
+        const widthToSet =
+          newWidth && newWidth > panelMinWidth ? newWidth : panelMinWidth;
+
+        panelEl.style.width = `${widthToSet}px`;
+        onPanelResize?.(widthToSet);
       }
     },
-    [panelEl, inputElWidth, onPanelResize]
+    [panelEl, inputElWidth, onPanelResize, panelMinWidth]
   );
   const onResize = useCallback(() => {
     if (inputEl) {

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -30,7 +30,11 @@ import { css } from '@emotion/react';
 import { logicalCSS } from '../../global_styling';
 
 export interface _EuiInputPopoverProps
-  extends Omit<EuiPopoverProps, 'button' | 'buttonRef'> {
+  extends Omit<EuiPopoverProps, 'button' | 'buttonRef' | 'anchorPosition'> {
+  /**
+   * Alignment of the popover relative to the input
+   */
+  anchorPosition?: 'downLeft' | 'downRight' | 'downCenter';
   disableFocusTrap?: boolean;
   fullWidth?: boolean;
   input: EuiPopoverProps['button'];

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -12,6 +12,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useRef,
 } from 'react';
 import classnames from 'classnames';
 import { tabbable, FocusableElement } from 'tabbable';
@@ -69,6 +70,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   const [inputEl, setInputEl] = useState<HTMLElement | null>(null);
   const [inputElWidth, setInputElWidth] = useState<number>();
   const [panelEl, setPanelEl] = useState<HTMLElement | null>(null);
+  const popoverClassRef = useRef<EuiPopover | null>(null);
 
   const inputRef = useCombinedRefs([setInputEl, _inputRef]);
   const panelRef = useCombinedRefs([setPanelEl, _panelRef]);
@@ -91,6 +93,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
       const width = inputEl.getBoundingClientRect().width;
       setInputElWidth(width);
       setPanelWidth(width);
+      popoverClassRef.current?.positionPopoverFluid();
     }
   }, [inputEl, setPanelWidth]);
   useEffect(() => {
@@ -134,6 +137,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
       buttonRef={inputRef}
       panelRef={panelRef}
       className={classes}
+      ref={popoverClassRef}
       {...props}
     >
       <EuiFocusTrap

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -78,9 +78,8 @@ export interface EuiPopoverProps extends PropsWithChildren, CommonProps {
    */
   anchorPosition?: PopoverAnchorPosition;
   /**
-   * Style and position alteration for arrow-less, left-aligned
-   * attachment. Intended for use with inputs as anchors, e.g.
-   * EuiInputPopover
+   * Style and position alteration for arrow-less attachment.
+   * Intended for use with inputs as anchors, e.g. EuiInputPopover
    */
   attachToAnchor?: boolean;
   /**
@@ -501,7 +500,6 @@ export class EuiPopover extends Component<Props, State> {
       left,
       position: foundPosition,
       arrow,
-      anchorBoundingBox,
     } = findPopoverPosition({
       container: this.props.container,
       position,
@@ -533,10 +531,7 @@ export class EuiPopover extends Component<Props, State> {
     const popoverStyles = {
       ...this.props.panelStyle,
       top,
-      left:
-        this.props.attachToAnchor && anchorBoundingBox
-          ? anchorBoundingBox.left
-          : left,
+      left,
       zIndex,
     };
 

--- a/upcoming_changelogs/7071.md
+++ b/upcoming_changelogs/7071.md
@@ -1,0 +1,1 @@
+- Added a new `panelMinWidth` prop to `EuiInputPopover`


### PR DESCRIPTION
## Summary

See this conversation https://github.com/elastic/kibana/pull/162651#discussion_r1283757785 with @Heenawter and @andreadelrio about some of the new Discover work being done to standardize the visual behavior of input popovers.

Prior to this prop, `EuiInputPopover` widths were entirely tied to the width of the input element. Now, consumers can specify a minimum width, allowing wider content to display at desired widths if necessary, e.g.:

![screencap](https://github.com/elastic/eui/assets/549407/c22147ac-0e52-47f2-aad6-4d9f04ed4111)

This PR also fixes `EuiPopver` to allow `EuiInputPopover` to respect different side anchors and to update the popover position if the input resizes.

## QA

- https://eui.elastic.co/pr_7071_buildkite/#/layout/popover#popover-attached-to-input-element

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~
~- [ ] Checked in **mobile**~
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
~- [ ] Checked for **breaking changes** and labeled appropriately~