### PR TITLE
[Emotion] Convert `EuiResizableButton`

### DIFF
--- a/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiResizableButton renders 1`] = `
+<div>
+  <button
+    aria-label="aria-label"
+    class="euiResizableButton euiResizableButton--vertical testClass1 testClass2 emotion-euiResizableButton-euiTestCss"
+    data-test-subj="test subject string"
+    id="resizable-button_generated-id"
+    type="button"
+  />
+</div>
+`;

--- a/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiResizableButton renders 1`] = `
 <div>
   <button
     aria-label="aria-label"
-    class="euiResizableButton euiResizableButton--vertical testClass1 testClass2 emotion-euiResizableButton-euiTestCss"
+    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-vertical-euiTestCss"
     data-test-subj="test subject string"
     id="resizable-button_generated-id"
     type="button"

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -60,7 +60,7 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiResizableContainer can be vertical 1`] = `
   </div>
   <button
     aria-label="Press up or down to adjust panels size"
-    class="euiResizableButton euiResizableButton--vertical emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-vertical"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -140,7 +140,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -159,7 +159,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -199,7 +199,7 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -251,7 +251,7 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -291,7 +291,7 @@ exports[`EuiResizableContainer is rendered 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -344,7 +344,7 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
+    class="euiResizableButton emotion-euiResizableButton-horizontal"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -60,7 +60,7 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiResizableContainer can be vertical 1`] = `
   </div>
   <button
     aria-label="Press up or down to adjust panels size"
-    class="euiResizableButton euiResizableButton--vertical"
+    class="euiResizableButton euiResizableButton--vertical emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -140,7 +140,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -159,7 +159,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -199,7 +199,7 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -251,7 +251,7 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -291,7 +291,7 @@ exports[`EuiResizableContainer is rendered 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -344,7 +344,7 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton euiResizableButton--horizontal"
+    class="euiResizableButton euiResizableButton--horizontal emotion-euiResizableButton"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"

--- a/src/components/resizable_container/_index.scss
+++ b/src/components/resizable_container/_index.scss
@@ -1,3 +1,1 @@
-@import 'variables';
-@import 'resizable_button';
 @import 'resizable_collapse_button';

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -1,22 +1,6 @@
 // Mimics the "grab" icon with CSS psuedo-elements.
 // The "grab" icon transforms into a 2px straight line on :hover and :focus.
 .euiResizableButton {
-  &::before,
-  &::after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    background-color: $euiColorDarkestShade;
-    transition:
-      width $euiResizableButtonTransitionSpeed ease,
-      height $euiResizableButtonTransitionSpeed ease,
-      transform $euiResizableButtonTransitionSpeed ease,
-      background-color $euiResizableButtonTransitionSpeed ease
-    ;
-  }
-
   &.euiResizableButton--horizontal {
     cursor: col-resize;
     width: $euiResizableButtonSize;
@@ -56,32 +40,6 @@
 
     &::after {
       transform: translate(-50%, 1px);
-    }
-  }
-
-  // Lighten the "grab" icon on :hover
-  &:hover {
-    &::before,
-    &::after {
-      background-color: $euiColorMediumShade;
-      transition-delay: $euiResizableButtonTransitionSpeed; // Delay transition on hover so animation is not accidentally triggered on mouse over
-    }
-  }
-
-  // Add a transparent background to the container and emphasis the "grab" icon with primary color on :focus
-  &:focus {
-    background-color: transparentize($euiColorPrimary, .9);
-
-    &::before,
-    &::after {
-      background-color: $euiColorPrimary;
-      // Overrides default transition so that "grab" icon background-color doesn't animate
-      transition:
-        width $euiResizableButtonTransitionSpeed ease,
-        height $euiResizableButtonTransitionSpeed ease,
-        transform $euiResizableButtonTransitionSpeed ease
-      ;
-      transition-delay: $euiResizableButtonTransitionSpeed / 2;
     }
   }
 

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -60,7 +60,7 @@
   }
 
   // Lighten the "grab" icon on :hover
-  &:hover:not(:disabled) {
+  &:hover {
     &::before,
     &::after {
       background-color: $euiColorMediumShade;
@@ -69,7 +69,7 @@
   }
 
   // Add a transparent background to the container and emphasis the "grab" icon with primary color on :focus
-  &:focus:not(:disabled) {
+  &:focus {
     background-color: transparentize($euiColorPrimary, .9);
 
     &::before,
@@ -86,8 +86,8 @@
   }
 
   // Morph the "grab" icon into a fluid 2px straight line on :hover and :focus
-  &:hover:not(:disabled),
-  &:focus:not(:disabled) {
+  &:hover,
+  &:focus {
     &.euiResizableButton--horizontal {
       &::before,
       &::after {
@@ -117,9 +117,5 @@
         transform: translate(-50%, 0);
       }
     }
-  }
-
-  &:disabled {
-    display: none !important; // stylelint-disable-line declaration-no-important
   }
 }

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -1,10 +1,6 @@
 // Mimics the "grab" icon with CSS psuedo-elements.
 // The "grab" icon transforms into a 2px straight line on :hover and :focus.
 .euiResizableButton {
-  position: relative;
-  flex-shrink: 0;
-  z-index: 1;
-
   &::before,
   &::after {
     content: '';

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -1,79 +1,7 @@
-// Mimics the "grab" icon with CSS psuedo-elements.
-// The "grab" icon transforms into a 2px straight line on :hover and :focus.
 .euiResizableButton {
   &.euiResizableButton--horizontal {
-    cursor: col-resize;
-    width: $euiResizableButtonSize;
-    margin-left: -($euiResizableButtonSize / 2);
-    margin-right: -($euiResizableButtonSize / 2);
-
-    &::before,
-    &::after {
-      width: 1px;
-      height: $euiSizeM;
-    }
-
-    &::before {
-      transform: translate(-2px, -50%);
-    }
-
-    &::after {
-      transform: translate(1px, -50%);
-    }
   }
 
   &.euiResizableButton--vertical {
-    cursor: row-resize;
-    height: $euiResizableButtonSize;
-    margin-top: -($euiResizableButtonSize / 2);
-    margin-bottom: -($euiResizableButtonSize / 2);
-
-    &::before,
-    &::after {
-      width: $euiSizeM;
-      height: 1px;
-    }
-
-    &::before {
-      transform: translate(-50%, -2px);
-    }
-
-    &::after {
-      transform: translate(-50%, 1px);
-    }
-  }
-
-  // Morph the "grab" icon into a fluid 2px straight line on :hover and :focus
-  &:hover,
-  &:focus {
-    &.euiResizableButton--horizontal {
-      &::before,
-      &::after {
-        height: 100%;
-      }
-
-      &::before {
-        transform: translate(-1px, -50%);
-      }
-
-      &::after {
-        transform: translate(0, -50%);
-      }
-    }
-
-    &.euiResizableButton--vertical {
-      &::before,
-      &::after {
-        width: 100%;
-      }
-
-      &::before {
-        transform: translate(-50%, -1px);
-      }
-
-      &::after {
-        transform: translate(-50%, 0);
-      }
-    }
   }
 }

--- a/src/components/resizable_container/_resizable_button.scss
+++ b/src/components/resizable_container/_resizable_button.scss
@@ -1,7 +1,0 @@
-.euiResizableButton {
-  &.euiResizableButton--horizontal {
-  }
-
-  &.euiResizableButton--vertical {
-  }
-}

--- a/src/components/resizable_container/_variables.scss
+++ b/src/components/resizable_container/_variables.scss
@@ -1,1 +1,0 @@
-$euiResizableButtonSize: $euiSize !default;

--- a/src/components/resizable_container/_variables.scss
+++ b/src/components/resizable_container/_variables.scss
@@ -1,2 +1,1 @@
-$euiResizableButtonTransitionSpeed: $euiAnimSpeedFast !default;
 $euiResizableButtonSize: $euiSize !default;

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -17,7 +17,6 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const buttonSize = euiTheme.size.base;
   const grabHandleWidth = euiTheme.size.m;
   const grabHandleHeight = euiTheme.border.width.thin;
-  const grabHandleFocusHeight = mathWithUnits(grabHandleHeight, (x) => x * 2); // This is the thick border width by default, but we should re-use the thin width in case consumers customize both tokens
 
   const transitionSpeed = euiTheme.animation.fast;
   const transition = `${transitionSpeed} ease`;
@@ -26,22 +25,36 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
     // Mimics the "grab" icon with CSS psuedo-elements.
     // 1. The "grab" icon transforms into a thicker straight line on :hover and :focus
     euiResizableButton: css`
-      position: relative;
-      flex-shrink: 0;
       z-index: 1;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
+
+      /* 1 */
+      &:hover,
+      &:focus {
+        gap: 0;
+        justify-content: center;
+      }
+
+      ${euiCanAnimate} {
+        transition: gap ${transition}, justify-content ${transition};
+      }
 
       &::before,
       &::after {
         content: '';
         display: block;
-        position: absolute;
-        ${logicalCSS('top', '50%')}
-        ${logicalCSS('left', '50%')}
         background-color: ${euiTheme.colors.darkestShade};
+
+        /* CSS hack to smooth out/anti-alias the 1px wide handles at various zoom levels */
+        transform: translateZ(0);
 
         ${euiCanAnimate} {
           transition: width ${transition}, height ${transition},
-            transform ${transition}, background-color ${transition};
+            background-color ${transition};
         }
       }
 
@@ -69,8 +82,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
 
           /* Overrides default transition so that "grab" icon background-color doesn't animate */
           ${euiCanAnimate} {
-            transition: width ${transition}, height ${transition},
-              transform ${transition};
+            transition: width ${transition}, height ${transition};
             transition-delay: ${mathWithUnits(transitionSpeed, (x) => x / 2)};
           }
         }
@@ -87,14 +99,6 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('height', grabHandleWidth)}
       }
 
-      &::before {
-        transform: translate(-${grabHandleFocusHeight}, -50%);
-      }
-
-      &::after {
-        transform: translate(${grabHandleHeight}, -50%);
-      }
-
       /* 1 */
       &:hover,
       &:focus {
@@ -102,17 +106,10 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::after {
           ${logicalCSS('height', '100%')}
         }
-
-        &::before {
-          transform: translate(-${grabHandleHeight}, -50%);
-        }
-
-        &::after {
-          transform: translate(0, -50%);
-        }
       }
     `,
     vertical: css`
+      flex-direction: column;
       cursor: row-resize;
       ${logicalCSS('height', buttonSize)}
       margin-block: ${mathWithUnits(buttonSize, (x) => x / -2)};
@@ -123,28 +120,12 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('width', grabHandleWidth)}
       }
 
-      &::before {
-        transform: translate(-50%, -${grabHandleFocusHeight});
-      }
-
-      &::after {
-        transform: translate(-50%, ${grabHandleHeight});
-      }
-
       /* 1 */
       &:hover,
       &:focus {
         &::before,
         &::after {
           ${logicalCSS('width', '100%')}
-        }
-
-        &::before {
-          transform: translate(-50%, -${grabHandleHeight});
-        }
-
-        &::after {
-          transform: translate(-50%, 0);
         }
       }
     `,

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -8,16 +8,58 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, transparentize } from '../../services';
+import { logicalCSS, mathWithUnits } from '../../global_styling';
 
 export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
+
+  const transitionSpeed = euiTheme.animation.fast;
+  const transition = `${transitionSpeed} ease`;
 
   return {
     euiResizableButton: css`
       position: relative;
       flex-shrink: 0;
       z-index: 1;
+
+      &::before,
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        ${logicalCSS('top', '50%')}
+        ${logicalCSS('left', '50%')}
+        background-color: ${euiTheme.colors.darkestShade};
+        transition: width ${transition}, height ${transition},
+          transform ${transition}, background-color ${transition};
+      }
+
+      /* Lighten the "grab" icon on :hover */
+      &:hover {
+        &::before,
+        &::after {
+          background-color: ${euiTheme.colors.mediumShade};
+          /* Delay transition on hover so animation is not accidentally triggered on mouse over */
+          transition-delay: ${transitionSpeed};
+        }
+      }
+
+      /* Add a transparent background to the container and
+         emphasize the "grab" icon with primary color on :focus */
+      &:focus {
+        background-color: ${transparentize(euiTheme.colors.primary, 0.1)};
+
+        &::before,
+        &::after {
+          background-color: ${euiTheme.colors.primary};
+
+          /* Overrides default transition so that "grab" icon background-color doesn't animate */
+          transition: width ${transition}, height ${transition},
+            transform ${transition};
+          transition-delay: ${mathWithUnits(transitionSpeed, (x) => x / 2)};
+        }
+      }
     `,
   };
 };

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -14,10 +14,17 @@ import { logicalCSS, mathWithUnits } from '../../global_styling';
 export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
+  const buttonSize = euiTheme.size.base;
+  const grabHandleWidth = euiTheme.size.m;
+  const grabHandleHeight = euiTheme.border.width.thin;
+  const grabHandleFocusHeight = mathWithUnits(grabHandleHeight, (x) => x * 2); // This is the thick border width by default, but we should re-use the thin width in case consumers customize both tokens
+
   const transitionSpeed = euiTheme.animation.fast;
   const transition = `${transitionSpeed} ease`;
 
   return {
+    // Mimics the "grab" icon with CSS psuedo-elements.
+    // 1. The "grab" icon transforms into a thicker straight line on :hover and :focus
     euiResizableButton: css`
       position: relative;
       flex-shrink: 0;
@@ -58,6 +65,78 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
           transition: width ${transition}, height ${transition},
             transform ${transition};
           transition-delay: ${mathWithUnits(transitionSpeed, (x) => x / 2)};
+        }
+      }
+    `,
+    horizontal: css`
+      cursor: col-resize;
+      ${logicalCSS('width', buttonSize)}
+      margin-inline: ${mathWithUnits(buttonSize, (x) => x / -2)};
+
+      &::before,
+      &::after {
+        ${logicalCSS('width', grabHandleHeight)}
+        ${logicalCSS('height', grabHandleWidth)}
+      }
+
+      &::before {
+        transform: translate(-${grabHandleFocusHeight}, -50%);
+      }
+
+      &::after {
+        transform: translate(${grabHandleHeight}, -50%);
+      }
+
+      /* 1 */
+      &:hover,
+      &:focus {
+        &::before,
+        &::after {
+          ${logicalCSS('height', '100%')}
+        }
+
+        &::before {
+          transform: translate(-${grabHandleHeight}, -50%);
+        }
+
+        &::after {
+          transform: translate(0, -50%);
+        }
+      }
+    `,
+    vertical: css`
+      cursor: row-resize;
+      ${logicalCSS('height', buttonSize)}
+      margin-block: ${mathWithUnits(buttonSize, (x) => x / -2)};
+
+      &::before,
+      &::after {
+        ${logicalCSS('height', grabHandleHeight)}
+        ${logicalCSS('width', grabHandleWidth)}
+      }
+
+      &::before {
+        transform: translate(-50%, -${grabHandleFocusHeight});
+      }
+
+      &::after {
+        transform: translate(-50%, ${grabHandleHeight});
+      }
+
+      /* 1 */
+      &:hover,
+      &:focus {
+        &::before,
+        &::after {
+          ${logicalCSS('width', '100%')}
+        }
+
+        &::before {
+          transform: translate(-50%, -${grabHandleHeight});
+        }
+
+        &::after {
+          transform: translate(-50%, 0);
         }
       }
     `,

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -9,7 +9,7 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme, transparentize } from '../../services';
-import { logicalCSS, mathWithUnits } from '../../global_styling';
+import { logicalCSS, mathWithUnits, euiCanAnimate } from '../../global_styling';
 
 export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
@@ -38,8 +38,11 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('top', '50%')}
         ${logicalCSS('left', '50%')}
         background-color: ${euiTheme.colors.darkestShade};
-        transition: width ${transition}, height ${transition},
-          transform ${transition}, background-color ${transition};
+
+        ${euiCanAnimate} {
+          transition: width ${transition}, height ${transition},
+            transform ${transition}, background-color ${transition};
+        }
       }
 
       /* Lighten the "grab" icon on :hover */
@@ -47,8 +50,11 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::before,
         &::after {
           background-color: ${euiTheme.colors.mediumShade};
+
           /* Delay transition on hover so animation is not accidentally triggered on mouse over */
-          transition-delay: ${transitionSpeed};
+          ${euiCanAnimate} {
+            transition-delay: ${transitionSpeed};
+          }
         }
       }
 
@@ -62,9 +68,11 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
           background-color: ${euiTheme.colors.primary};
 
           /* Overrides default transition so that "grab" icon background-color doesn't animate */
-          transition: width ${transition}, height ${transition},
-            transform ${transition};
-          transition-delay: ${mathWithUnits(transitionSpeed, (x) => x / 2)};
+          ${euiCanAnimate} {
+            transition: width ${transition}, height ${transition},
+              transform ${transition};
+            transition-delay: ${mathWithUnits(transitionSpeed, (x) => x / 2)};
+          }
         }
       }
     `,

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+
+export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiResizableButton: css`
+      position: relative;
+      flex-shrink: 0;
+      z-index: 1;
+    `,
+  };
+};

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -32,6 +32,10 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       justify-content: center;
       gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
 
+      &:disabled {
+        display: none;
+      }
+
       /* 1 */
       &:hover,
       &:focus {

--- a/src/components/resizable_container/resizable_button.test.tsx
+++ b/src/components/resizable_container/resizable_button.test.tsx
@@ -37,16 +37,17 @@ describe('EuiResizableButton', () => {
     expect(container).toMatchSnapshot();
   });
 
-  describe('disabled', () => {
-    it('renders as disabled if the disabled prop is passed', () => {
+  describe('disabled/hidden', () => {
+    it('renders as disabled and hidden if the disabled prop is passed', () => {
       const { container } = render(<EuiResizableButton disabled />, {
         wrapper,
       });
 
       expect(container.firstChild).toBeDisabled();
+      expect(container.firstChild).not.toBeVisible();
     });
 
-    it('renders as disabled if the resizerId is disabled in context', () => {
+    it('renders as disabled and hidden if the resizerId is disabled in context', () => {
       const { container } = render(
         <EuiResizableContainerContextProvider
           registry={
@@ -63,6 +64,7 @@ describe('EuiResizableButton', () => {
       );
 
       expect(container.firstChild).toBeDisabled();
+      expect(container.firstChild).not.toBeVisible();
     });
   });
 

--- a/src/components/resizable_container/resizable_button.test.tsx
+++ b/src/components/resizable_container/resizable_button.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { FunctionComponent, PropsWithChildren } from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -35,5 +35,55 @@ describe('EuiResizableButton', () => {
     });
 
     expect(container).toMatchSnapshot();
+  });
+
+  describe('disabled', () => {
+    it('renders as disabled if the disabled prop is passed', () => {
+      const { container } = render(<EuiResizableButton disabled />, {
+        wrapper,
+      });
+
+      expect(container.firstChild).toBeDisabled();
+    });
+
+    it('renders as disabled if the resizerId is disabled in context', () => {
+      const { container } = render(
+        <EuiResizableContainerContextProvider
+          registry={
+            {
+              panels: {},
+              resizers: {
+                'resizable-button_generated-id': { isDisabled: true },
+              },
+            } as unknown as EuiResizableContainerRegistry // Skipping correct obj types for the sake of the test
+          }
+        >
+          <EuiResizableButton />
+        </EuiResizableContainerContextProvider>
+      );
+
+      expect(container.firstChild).toBeDisabled();
+    });
+  });
+
+  describe('focus', () => {
+    it('focuses the button on click', () => {
+      const { container } = render(<EuiResizableButton />, {
+        wrapper,
+      });
+      fireEvent.click(container.firstChild!);
+
+      expect(container.firstChild).toBe(document.activeElement);
+    });
+
+    it('calls the onFocus prop', () => {
+      const onFocus = jest.fn();
+      const { container } = render(<EuiResizableButton onFocus={onFocus} />, {
+        wrapper,
+      });
+      fireEvent.focus(container.firstChild!);
+
+      expect(onFocus).toHaveBeenCalledWith('resizable-button_generated-id');
+    });
   });
 });

--- a/src/components/resizable_container/resizable_button.test.tsx
+++ b/src/components/resizable_container/resizable_button.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+import { render } from '@testing-library/react';
+import { requiredProps } from '../../test/required_props';
+import { shouldRenderCustomStyles } from '../../test/internal';
+
+import { EuiResizableContainerContextProvider } from './context';
+import { EuiResizableContainerRegistry } from './types';
+
+import { EuiResizableButton } from './resizable_button';
+
+describe('EuiResizableButton', () => {
+  // Context setup
+  const mockRegistry = { panels: {}, resizers: {} };
+  const wrapper: FunctionComponent<
+    PropsWithChildren & { registry?: EuiResizableContainerRegistry }
+  > = ({ children, registry = mockRegistry }) => (
+    <EuiResizableContainerContextProvider registry={registry}>
+      {children}
+    </EuiResizableContainerContextProvider>
+  );
+
+  shouldRenderCustomStyles(<EuiResizableButton />, { wrapper });
+
+  it('renders', () => {
+    const { container } = render(<EuiResizableButton {...requiredProps} />, {
+      wrapper,
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -128,7 +128,6 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
           onFocus={() => onFocus?.(resizerId)}
           onBlur={onBlur}
           disabled={isDisabled}
-          hidden={isDisabled}
           {...rest}
         />
       )}

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -133,6 +133,7 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
           onFocus={() => onFocus?.(resizerId)}
           onBlur={onBlur}
           disabled={isDisabled}
+          hidden={isDisabled}
           {...rest}
         />
       )}

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -18,13 +18,15 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../common';
 import { EuiI18n } from '../i18n';
-import { useGeneratedHtmlId } from '../../services';
+import { useEuiTheme, useGeneratedHtmlId } from '../../services';
+
 import { useEuiResizableContainerContext } from './context';
 import {
   EuiResizableButtonController,
   EuiResizableButtonMouseEvent,
   EuiResizableButtonKeyEvent,
 } from './types';
+import { euiResizableButtonStyles } from './resizable_button.styles';
 
 interface EuiResizableButtonControls {
   onKeyDown: (eve: EuiResizableButtonKeyEvent) => void;
@@ -68,6 +70,7 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     () => disabled || (resizers[resizerId] && resizers[resizerId].isDisabled),
     [resizers, resizerId, disabled]
   );
+
   const classes = classNames(
     'euiResizableButton',
     {
@@ -77,6 +80,9 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     },
     className
   );
+  const euiTheme = useEuiTheme();
+  const styles = euiResizableButtonStyles(euiTheme);
+  const cssStyles = [styles.euiResizableButton];
 
   const previousRef = useRef<HTMLElement>();
   const onRef = useCallback(
@@ -126,6 +132,7 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
             isHorizontal ? horizontalResizerAriaLabel : verticalResizerAriaLabel
           }
           className={classes}
+          css={cssStyles}
           data-test-subj="euiResizableButton"
           type="button"
           onClick={setFocus}

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -22,6 +22,7 @@ import { useEuiTheme, useGeneratedHtmlId } from '../../services';
 
 import { useEuiResizableContainerContext } from './context';
 import {
+  EuiResizableContainerRegistry,
   EuiResizableButtonController,
   EuiResizableButtonMouseEvent,
   EuiResizableButtonKeyEvent,
@@ -64,8 +65,9 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     prefix: 'resizable-button',
     conditionalId: id,
   });
-  const { registry: { resizers } = { resizers: {} } } =
-    useEuiResizableContainerContext();
+  const {
+    registry: { resizers } = { resizers: {} } as EuiResizableContainerRegistry,
+  } = useEuiResizableContainerContext();
   const isDisabled = useMemo(
     () => disabled || (resizers[resizerId] && resizers[resizerId].isDisabled),
     [resizers, resizerId, disabled]

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -72,18 +72,13 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     [resizers, resizerId, disabled]
   );
 
-  const classes = classNames(
-    'euiResizableButton',
-    {
-      'euiResizableButton--vertical': !isHorizontal,
-      'euiResizableButton--horizontal': isHorizontal,
-      'euiResizableButton--disabled': isDisabled,
-    },
-    className
-  );
+  const classes = classNames('euiResizableButton', className);
   const euiTheme = useEuiTheme();
   const styles = euiResizableButtonStyles(euiTheme);
-  const cssStyles = [styles.euiResizableButton];
+  const cssStyles = [
+    styles.euiResizableButton,
+    isHorizontal ? styles.horizontal : styles.vertical,
+  ];
 
   const previousRef = useRef<HTMLElement>();
   const onRef = useCallback(

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -9,7 +9,6 @@
 import React, {
   FunctionComponent,
   ButtonHTMLAttributes,
-  MouseEvent,
   useCallback,
   useMemo,
   useRef,
@@ -69,7 +68,7 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     registry: { resizers } = { resizers: {} } as EuiResizableContainerRegistry,
   } = useEuiResizableContainerContext();
   const isDisabled = useMemo(
-    () => disabled || (resizers[resizerId] && resizers[resizerId].isDisabled),
+    () => disabled || resizers[resizerId]?.isDisabled,
     [resizers, resizerId, disabled]
   );
 
@@ -108,13 +107,6 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     [registration, resizerId, disabled]
   );
 
-  const setFocus = (e: MouseEvent<HTMLButtonElement>) =>
-    e.currentTarget.focus();
-
-  const handleFocus = () => {
-    onFocus && onFocus(resizerId);
-  };
-
   return (
     <EuiI18n
       tokens={[
@@ -137,8 +129,8 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
           css={cssStyles}
           data-test-subj="euiResizableButton"
           type="button"
-          onClick={setFocus}
-          onFocus={handleFocus}
+          onClick={(e) => e.currentTarget.focus()}
+          onFocus={() => onFocus?.(resizerId)}
           onBlur={onBlur}
           disabled={isDisabled}
           {...rest}

--- a/upcoming_changelogs/7081.md
+++ b/upcoming_changelogs/7081.md
@@ -1,0 +1,3 @@
+**CSS-in-JS conversions**
+
+- Converted `EuiResizableButton` to Emotion; Removed `$euiResizableButtonTransitionSpeed` and `$euiResizableButtonSize`


### PR DESCRIPTION
## Summary

https://github.com/elastic/eui/issues/6408

- This PR converts `EuiResizableButton` to Emotion
  - This PR **does not** convert `EuiResizableCollapseButton`. That conversion + this one was getting fairly gnarly, so I opted to leave it separate to make review easier.
- This PR performs several incidental cleanup items on `EuiResizableButton`, including adding unit tests that were previously missing, and gets component code coverage up to 100%
- This PR performs a large CSS refactor (https://github.com/elastic/eui/pull/7081/commits/78e57b8164847170c9cc78e4a6b2d97a6f8afdee) that converts from absolute positioning & transform CSS to using flex CSS instead. This has the major benefit of: 
    1. fixing an existing Safari visual bug on production (go to https://eui.elastic.co/v87.0.0/#/layout/resizable-container on Safari and hover over any drag handle), and
    2. also makes the component fully work with logical properties, as `transform: translateX/Y` currently does not respect `direction` or `writing-mode` and flex does.

## QA

- [ ] Compare staging against production and confirm the **grab handle** (not the collapsible button) looks and behaves as before (**except on Safari**, which has broken CSS transitions on production)
- Go to http://localhost:8030/#/layout/resizable-container#collapsible-panels-with-external-control
- Inspect the first resizable button / drag handle in the DOM
- Click the "Toggle panel 1" button in the demo
- [ ] In the DOM, confirm the button is hidden with `display: none`
- [ ] Confirm that the now-hidden button cannot be interacted with in any way, e.g. via mouseover or keyboard tab or screen reader navigation

### General checklist

- [x] Checked in both **light and dark** modes
~- [ ] Checked in **mobile**~
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

<details><summary><h3>Emotion checklist</h3></summary>

**Kibana usage**

- [x] Search Kibana's codebase for `{euiComponent}-` (case sensitive) to check for usage of modifier classes
  - ~[ ] If usage exists, consider converting to a `data` attribute so that consumers still have something to hook into~
  - ⚠️ Only one modifier usage exists, and it's one I added earlier to override Sass behavior. It should be completely removable

---

**General**

- [x] Output CSS matches the previous CSS (works as expected in all browsers)
- [x] Rendered `className(s)` read as expected in snapshots and browsers
- ~[ ] Checked component playground~

---

**Unit tests**

- [x] [`shouldRenderCustomStyles()`](https://github.com/elastic/eui/blob/6054e9b8310bdb106371c0c9ff8bc48e3e0e594b/src/test/internal/render_custom_styles.tsx) test was added and passes with parent component and any nested `childProps` (e.g. `tooltipProps`)
- ~[ ] Removed any `mount()`ed snapshots in favor of `render()` or a more specific assertion~

---

**Sass/Emotion conversion process**

- [x] Converted all global Sass vars/mixins to JS (e.g. `$euiSize` to `euiTheme.size.base`)
- [x] Removed ~or converted~ component-specific Sass vars/mixins to exported JS versions
- [x] Listed var/mixin removals in changelog
- ~[ ] Ran `yarn compile-scss` to update var/mixin [JSON files](https://github.com/elastic/eui/tree/main/src-docs/src/views/theme/_json)~
- ~[ ] Added an `@warn` deprecation message within the `global_styling/mixins/{component}.scss` file~
- ~[ ] Simplified `calc()` to `mathWithUnits` if possible (if mixing different unit types, this may not be possible)~
- ~[ ] Removed component from `src/components/index.scss`~ - Not doable yet
- ~[ ] Deleted any `src/amsterdam/overrides/{component}.scss` files (styles within should have been converted to the baseline Emotion styles)~

---

**CSS tech debt**

- [x] Wrapped all animations or transitions in `euiCanAnimate`
- [x] Used `gap` property to add margin between items if using flex
- [x] Converted side specific padding, margin, and position to `-inline` and `-block` [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) (check inline styles as well as CSS)

---

**DOM Cleanup**

- [x] Did **NOT** remove any block/element classNames (e.g. `euiComponent`, `euiComponent__child`)
- [x] **SEARCH KIBANA FIRST**: Deleted any modifier classNames or maps if not being used in Kibana. 

---

**Kibana due diligence**

- [x] Pre-emptively check how your conversion will impact the next Kibana upgrade. This entails searching/grepping through Kibana (excluding `**/target, **/*.snap, **/*.storyshot` for less noise) for `eui{Component}` (case sensitive) to find:
- [x] Any test/query selectors that will need to be updated - **None**
- [x] Any Sass or CSS that will need to be updated, particularly if a component Sass var was deleted - **One instance**
- [x] Any direct className usages that will need to be refactored (e.g. someone calling the `euiBadge` class on a div instead of simply using the `EuiBadge` component) - **No usages**

---

**Extras/nice-to-have**

- ~[ ] Documentation pass:~
- [x] Reduced specificity where possible (usually by reducing nesting and class name chaining)
- ~[ ] Check for issues in the backlog that could be a quick fix for that component~ - Will be opening up a follow-up PR for this
- ~[ ] Optional component/code cleanup: consider splitting up the component into multiple children if it's overly verbose or difficult to reason about~
</details>