### PR TITLE
[EuiResizableButton] Export as generic component; Add `alignIndicator` prop

### DIFF
--- a/src-docs/src/views/resizable_container/_props.tsx
+++ b/src-docs/src/views/resizable_container/_props.tsx
@@ -1,0 +1,8 @@
+import React, { FunctionComponent } from 'react';
+
+import { EuiResizableButtonProps } from '../../../../src/components/resizable_container/resizable_button';
+
+// Otherwise the props table lists the forwarded `ref`, which we don't actually want to document
+export const EuiResizableButton: FunctionComponent<
+  EuiResizableButtonProps
+> = () => <></>;

--- a/src-docs/src/views/resizable_container/resizable_button.tsx
+++ b/src-docs/src/views/resizable_container/resizable_button.tsx
@@ -54,9 +54,11 @@ export default () => {
 
     switch (e.key) {
       case keys.ARROW_RIGHT:
+        e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
         setPanelWidth((panelWidth) => panelWidth + KEYBOARD_OFFSET);
         break;
       case keys.ARROW_LEFT:
+        e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
         setPanelWidth((panelWidth) =>
           Math.max(panelWidth - KEYBOARD_OFFSET, MIN_PANEL_WIDTH)
         );

--- a/src-docs/src/views/resizable_container/resizable_button.tsx
+++ b/src-docs/src/views/resizable_container/resizable_button.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useCallback, useRef } from 'react';
+import { EuiResizableButton, EuiPanel, keys } from '../../../../src';
+
+const MIN_PANEL_WIDTH = 20;
+
+const getMouseOrTouchX = (
+  e: TouchEvent | MouseEvent | React.MouseEvent | React.TouchEvent
+): number => {
+  // Some Typescript fooling is needed here
+  const x = (e as TouchEvent).targetTouches
+    ? (e as TouchEvent).targetTouches[0].pageX
+    : (e as MouseEvent).pageX;
+  return x;
+};
+
+export default () => {
+  const [panelWidth, setPanelWidth] = useState(200);
+  const initialPanelWidth = useRef(panelWidth);
+  const initialMouseX = useRef(0);
+
+  const onMouseMove = useCallback((e: MouseEvent | TouchEvent) => {
+    const mouseOffset = getMouseOrTouchX(e) - initialMouseX.current;
+    const changedPanelWidth = initialPanelWidth.current + mouseOffset;
+
+    setPanelWidth(Math.max(changedPanelWidth, MIN_PANEL_WIDTH));
+  }, []);
+
+  const onMouseUp = useCallback(() => {
+    initialMouseX.current = 0;
+
+    window.removeEventListener('mousemove', onMouseMove);
+    window.removeEventListener('mouseup', onMouseUp);
+    window.removeEventListener('touchmove', onMouseMove);
+    window.removeEventListener('touchend', onMouseUp);
+  }, [onMouseMove]);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      initialMouseX.current = getMouseOrTouchX(e);
+      initialPanelWidth.current = panelWidth;
+
+      // Window event listeners instead of React events are used
+      // in case the user's mouse leaves the component
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+      window.addEventListener('touchmove', onMouseMove);
+      window.addEventListener('touchend', onMouseUp);
+    },
+    [panelWidth, onMouseMove, onMouseUp]
+  );
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const KEYBOARD_OFFSET = 10;
+
+    switch (e.key) {
+      case keys.ARROW_RIGHT:
+        setPanelWidth((panelWidth) => panelWidth + KEYBOARD_OFFSET);
+        break;
+      case keys.ARROW_LEFT:
+        setPanelWidth((panelWidth) =>
+          Math.max(panelWidth - KEYBOARD_OFFSET, MIN_PANEL_WIDTH)
+        );
+    }
+  }, []);
+
+  return (
+    <EuiPanel
+      paddingSize="s"
+      style={{
+        display: 'flex',
+        justifyContent: 'flex-end',
+        blockSize: 200,
+        inlineSize: panelWidth,
+        maxInlineSize: '100%',
+      }}
+    >
+      <EuiResizableButton
+        isHorizontal
+        onMouseDown={onMouseDown}
+        onTouchStart={onMouseDown}
+        onKeyDown={onKeyDown}
+      />
+    </EuiPanel>
+  );
+};

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -13,7 +13,7 @@ import {
 } from '../../../../src/components';
 // eslint-disable-next-line
 import { EuiResizablePanel } from '../../../../src/components/resizable_container/resizable_panel';
-import { EuiResizableButton } from '../../../../src/components/resizable_container/resizable_button';
+import { EuiResizableButton } from './_props';
 
 // prettier-ignore
 // eslint-disable-next-line
@@ -29,6 +29,7 @@ import ResizablePanelCollapsible from './resizable_panel_collapsible';
 import ResizablePanelCollapsibleResponsive from './resizable_panel_collapsible_responsive';
 import ResizablePanelCollapsibleOpts from './resizable_panel_collapsible_options';
 import ResizablePanelCollapsibleExt from './resizable_panel_collapsible_external';
+import ResizableButton from './resizable_button';
 
 const ResizableContainerSource = require('!!raw-loader!./resizable_container_basic');
 const ResizableContainerVerticalSource = require('!!raw-loader!./resizable_container_vertical');
@@ -39,6 +40,7 @@ const ResizablePanelCollapsibleSource = require('!!raw-loader!./resizable_panel_
 const ResizablePanelCollapsibleResponsiveSource = require('!!raw-loader!./resizable_panel_collapsible_responsive');
 const ResizablePanelCollapsibleOptsSource = require('!!raw-loader!./resizable_panel_collapsible_options');
 const ResizablePanelCollapsibleExtSource = require('!!raw-loader!./resizable_panel_collapsible_external');
+const ResizableButtonSource = require('!!raw-loader!./resizable_button');
 
 const basicSnippet = `<EuiResizableContainer>
   {(EuiResizablePanel, EuiResizableButton) => (
@@ -501,6 +503,34 @@ export const ResizableContainerExample = {
       ),
       demo: <ResizablePanelCollapsibleExt />,
       snippet: collapsibleExtSnippet,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: ResizableButtonSource,
+        },
+      ],
+      title: 'Custom resizable button',
+      text: (
+        <>
+          <p>
+            If you want to break out of <strong>EuiResizableContainer</strong>{' '}
+            usage completely, you may import the standalone{' '}
+            <strong>EuiResizableButton</strong> component. You will need to
+            attach your own mouse, touch, and keyboard events and logic to the
+            button - see the example below.
+          </p>
+        </>
+      ),
+      demo: <ResizableButton />,
+      props: { EuiResizableButton },
+      snippet: `<EuiResizableButton
+  isHorizontal
+  onMouseDown={onMouseDown}
+  onTouchStart={onTouchStart}
+  onKeyDown={onKeyDown}
+/>`,
     },
   ],
 };

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
@@ -64,7 +64,7 @@ export default () => {
               <EuiListGroup flush>{itemElements}</EuiListGroup>
             </EuiResizablePanel>
 
-            <EuiResizableButton alignHandle="start" />
+            <EuiResizableButton alignIndicator="start" />
 
             <EuiResizablePanel
               mode="main"
@@ -81,7 +81,7 @@ export default () => {
               </EuiPanel>
             </EuiResizablePanel>
 
-            <EuiResizableButton alignHandle="end" />
+            <EuiResizableButton alignIndicator="end" />
 
             <EuiResizablePanel
               mode={[

--- a/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
+++ b/src-docs/src/views/resizable_container/resizable_panel_collapsible_options.tsx
@@ -64,7 +64,7 @@ export default () => {
               <EuiListGroup flush>{itemElements}</EuiListGroup>
             </EuiResizablePanel>
 
-            <EuiResizableButton />
+            <EuiResizableButton alignHandle="start" />
 
             <EuiResizablePanel
               mode="main"
@@ -81,7 +81,7 @@ export default () => {
               </EuiPanel>
             </EuiResizablePanel>
 
-            <EuiResizableButton />
+            <EuiResizableButton alignHandle="end" />
 
             <EuiResizablePanel
               mode={[

--- a/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiResizableButton renders 1`] = `
 <div>
   <button
     aria-label="aria-label"
-    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-vertical-euiTestCss"
+    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-vertical-center-euiTestCss"
     data-test-subj="test subject string"
     type="button"
   />

--- a/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`EuiResizableButton renders 1`] = `
     aria-label="aria-label"
     class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-vertical-euiTestCss"
     data-test-subj="test subject string"
-    id="resizable-button_generated-id"
     type="button"
   />
 </div>

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -59,7 +59,7 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -99,7 +99,7 @@ exports[`EuiResizableContainer can be vertical 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press up or down to adjust panels size"
+    aria-label="Press the up or down arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-vertical-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -139,7 +139,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -158,7 +158,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -198,7 +198,7 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -250,7 +250,7 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -290,7 +290,7 @@ exports[`EuiResizableContainer is rendered 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
@@ -343,7 +343,7 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
     </div>
   </div>
   <button
-    aria-label="Press left or right to adjust panels size"
+    aria-label="Press the left or right arrow keys to adjust panels size"
     class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -60,7 +60,7 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiResizableContainer can be vertical 1`] = `
   </div>
   <button
     aria-label="Press up or down to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-vertical"
+    class="euiResizableButton emotion-euiResizableButton-vertical-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -140,7 +140,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -159,7 +159,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -199,7 +199,7 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -251,7 +251,7 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -291,7 +291,7 @@ exports[`EuiResizableContainer is rendered 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -344,7 +344,7 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
   </div>
   <button
     aria-label="Press left or right to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal"
+    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"

--- a/src/components/resizable_container/index.ts
+++ b/src/components/resizable_container/index.ts
@@ -8,3 +8,6 @@
 
 export type { EuiResizableContainerProps } from './resizable_container';
 export { EuiResizableContainer } from './resizable_container';
+
+export type { EuiResizableButtonProps } from './resizable_button';
+export { EuiResizableButton } from './resizable_button';

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiPanel } from '../panel';
+
+import {
+  EuiResizableButton,
+  EuiResizableButtonProps,
+} from './resizable_button';
+
+const meta: Meta<EuiResizableButtonProps> = {
+  title: 'EuiResizableButton',
+  component: EuiResizableButton,
+};
+
+export default meta;
+type Story = StoryObj<EuiResizableButtonProps>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <EuiPanel style={{ blockSize: 200, inlineSize: 200 }}>
+      <EuiResizableButton {...args} />
+    </EuiPanel>
+  ),
+  args: {
+    isHorizontal: true,
+    disabled: false,
+  },
+};

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -32,6 +32,7 @@ export const Playground: Story = {
   ),
   args: {
     isHorizontal: true,
+    alignHandle: 'center',
     disabled: false,
   },
 };

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -32,7 +32,7 @@ export const Playground: Story = {
   ),
   args: {
     isHorizontal: true,
-    alignHandle: 'center',
+    alignIndicator: 'center',
     disabled: false,
   },
 };

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -24,11 +24,11 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     // Mimics the "grab" icon with CSS psuedo-elements.
     // 1. The "grab" icon transforms into a thicker straight line on :hover and :focus
+    // 2. Start/end aligned handles should have a slight margin offset that disappears on hover/focus
     euiResizableButton: css`
       z-index: 1;
       flex-shrink: 0;
       display: flex;
-      align-items: center;
       justify-content: center;
       gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
 
@@ -58,7 +58,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
 
         ${euiCanAnimate} {
           transition: width ${transition}, height ${transition},
-            background-color ${transition};
+            margin ${transition}, background-color ${transition};
         }
       }
 
@@ -102,6 +102,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       &::after {
         ${logicalCSS('width', grabHandleHeight)}
         ${logicalCSS('height', grabHandleWidth)}
+        margin-block: ${euiTheme.size.base}; /* 2 */
       }
 
       /* 1 */
@@ -110,6 +111,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::before,
         &::after {
           ${logicalCSS('height', '100%')}
+          margin-block: 0; /* 2 */
         }
       }
     `,
@@ -124,6 +126,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       &::after {
         ${logicalCSS('height', grabHandleHeight)}
         ${logicalCSS('width', grabHandleWidth)}
+        margin-inline: ${euiTheme.size.base}; /* 2 */
       }
 
       /* 1 */
@@ -132,8 +135,20 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::before,
         &::after {
           ${logicalCSS('width', '100%')}
+          margin-inline: 0; /* 2 */
         }
       }
     `,
+    alignHandle: {
+      center: css`
+        align-items: center;
+      `,
+      start: css`
+        align-items: flex-start;
+      `,
+      end: css`
+        align-items: flex-end;
+      `,
+    },
   };
 };

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -143,7 +143,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
     `,
-    alignHandle: {
+    alignIndicator: {
       center: css`
         align-items: center;
       `,

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -74,9 +74,10 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
 
-      /* Add a transparent background to the container and
-         emphasize the "grab" icon with primary color on :focus */
-      &:focus {
+      /* Add a transparent background to the container and emphasize the "grab" icon
+         with primary color on :focus (NOTE - :active is needed for Safari) */
+      &:focus,
+      &:active {
         background-color: ${transparentize(euiTheme.colors.primary, 0.1)};
 
         &::before,
@@ -106,7 +107,8 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
 
       /* 1 */
       &:hover,
-      &:focus {
+      &:focus,
+      &:active {
         &::before,
         &::after {
           ${logicalCSS('height', '100%')}
@@ -131,7 +133,8 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
 
       /* 1 */
       &:hover,
-      &:focus {
+      &:focus,
+      &:active {
         &::before,
         &::after {
           ${logicalCSS('width', '100%')}

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -25,6 +25,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
     // Mimics the "grab" icon with CSS psuedo-elements.
     // 1. The "grab" icon transforms into a thicker straight line on :hover and :focus
     // 2. Start/end aligned handles should have a slight margin offset that disappears on hover/focus
+    // 3. CSS hack to smooth out/anti-alias the 1px wide handles at various zoom levels
     euiResizableButton: css`
       z-index: 1;
       flex-shrink: 0;
@@ -52,9 +53,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         content: '';
         display: block;
         background-color: ${euiTheme.colors.darkestShade};
-
-        /* CSS hack to smooth out/anti-alias the 1px wide handles at various zoom levels */
-        transform: translateZ(0);
+        transform: translateZ(0); /* 3 */
 
         ${euiCanAnimate} {
           transition: width ${transition}, height ${transition},
@@ -112,6 +111,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::after {
           ${logicalCSS('height', '100%')}
           margin-block: 0; /* 2 */
+          transform: none; /* 3 */
         }
       }
     `,
@@ -136,6 +136,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::after {
           ${logicalCSS('width', '100%')}
           margin-inline: 0; /* 2 */
+          transform: none; /* 3 */
         }
       }
     `,

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -94,6 +94,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     horizontal: css`
       cursor: col-resize;
+      ${logicalCSS('height', '100%')}
       ${logicalCSS('width', buttonSize)}
       margin-inline: ${mathWithUnits(buttonSize, (x) => x / -2)};
 
@@ -115,6 +116,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
     vertical: css`
       flex-direction: column;
       cursor: row-resize;
+      ${logicalCSS('width', '100%')}
       ${logicalCSS('height', buttonSize)}
       margin-block: ${mathWithUnits(buttonSize, (x) => x / -2)};
 

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -40,7 +40,7 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
      * Specify the alignment of the resize handle indicator. Defaults to `center`,
      * but consider using `start` for extremely tall content that scrolls off-screen
      */
-    alignHandle?: 'center' | 'start' | 'end';
+    alignIndicator?: 'center' | 'start' | 'end';
     /**
      * When disabled, the button will be completely hidden
      */
@@ -53,7 +53,7 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 export const EuiResizableButton = forwardRef<
   HTMLButtonElement,
   EuiResizableButtonProps
->(({ isHorizontal, alignHandle = 'center', className, ...rest }, ref) => {
+>(({ isHorizontal, alignIndicator = 'center', className, ...rest }, ref) => {
   const classes = classNames('euiResizableButton', className);
 
   const euiTheme = useEuiTheme();
@@ -61,7 +61,7 @@ export const EuiResizableButton = forwardRef<
   const cssStyles = [
     styles.euiResizableButton,
     isHorizontal ? styles.horizontal : styles.vertical,
-    styles.alignHandle[alignHandle],
+    styles.alignIndicator[alignIndicator],
   ];
 
   return (

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -37,6 +37,11 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
      */
     isHorizontal?: boolean;
     /**
+     * Specify the alignment of the resize handle indicator. Defaults to `center`,
+     * but consider using `start` for extremely tall content that scrolls off-screen
+     */
+    alignHandle?: 'center' | 'start' | 'end';
+    /**
      * When disabled, the button will be completely hidden
      */
     disabled?: boolean;
@@ -48,7 +53,7 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 export const EuiResizableButton = forwardRef<
   HTMLButtonElement,
   EuiResizableButtonProps
->(({ isHorizontal, className, ...rest }, ref) => {
+>(({ isHorizontal, alignHandle = 'center', className, ...rest }, ref) => {
   const classes = classNames('euiResizableButton', className);
 
   const euiTheme = useEuiTheme();
@@ -56,6 +61,7 @@ export const EuiResizableButton = forwardRef<
   const cssStyles = [
     styles.euiResizableButton,
     isHorizontal ? styles.horizontal : styles.vertical,
+    styles.alignHandle[alignHandle],
   ];
 
   return (

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -47,25 +47,8 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
   isHorizontal,
   className,
-  // id,
-  // registration,
-  // disabled,
-  // onFocus,
-  // onBlur,
   ...rest
 }) => {
-  // const resizerId = useGeneratedHtmlId({
-  //   prefix: 'resizable-button',
-  //   conditionalId: id,
-  // });
-  // const {
-  //   registry: { resizers } = { resizers: {} } as EuiResizableContainerRegistry,
-  // } = useEuiResizableContainerContext();
-  // const isDisabled = useMemo(
-  //   () => disabled || resizers[resizerId]?.isDisabled,
-  //   [resizers, resizerId, disabled]
-  // );
-
   const classes = classNames('euiResizableButton', className);
   const euiTheme = useEuiTheme();
   const styles = euiResizableButtonStyles(euiTheme);
@@ -73,28 +56,6 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     styles.euiResizableButton,
     isHorizontal ? styles.horizontal : styles.vertical,
   ];
-
-  // const previousRef = useRef<HTMLElement>();
-  // const onRef = useCallback(
-  //   (ref: HTMLElement | null) => {
-  //     if (!registration) return;
-  //     if (ref) {
-  //       previousRef.current = ref;
-  //       registration.register({
-  //         id: resizerId,
-  //         ref,
-  //         isFocused: false,
-  //         isDisabled: disabled || false,
-  //       });
-  //     } else {
-  //       if (previousRef.current != null) {
-  //         registration.deregister(resizerId);
-  //         previousRef.current = undefined;
-  //       }
-  //     }
-  //   },
-  //   [registration, resizerId, disabled]
-  // );
 
   return (
     <EuiI18n
@@ -109,8 +70,6 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     >
       {([horizontalResizerAriaLabel, verticalResizerAriaLabel]: string[]) => (
         <button
-          // id={resizerId}
-          // ref={onRef}
           aria-label={
             isHorizontal ? horizontalResizerAriaLabel : verticalResizerAriaLabel
           }
@@ -118,10 +77,6 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
           css={cssStyles}
           data-test-subj="euiResizableButton"
           type="button"
-          // onClick={(e) => e.currentTarget.focus()}
-          // onFocus={() => onFocus?.(resizerId)}
-          // onBlur={onBlur}
-          // disabled={isDisabled}
           {...rest}
         />
       )}
@@ -150,12 +105,49 @@ export type EuiResizableButtonControls = Omit<
 
 export const EuiResizableButtonControlled: FunctionComponent<
   Partial<EuiResizableButtonControls>
-> = ({ ...rest }) => {
-  // TODO: Move resizer & registration logic to this component
+> = ({ registration, id, disabled, onFocus, ...rest }) => {
+  const resizerId = useGeneratedHtmlId({
+    prefix: 'resizable-button',
+    conditionalId: id,
+  });
+  const {
+    registry: { resizers } = { resizers: {} } as EuiResizableContainerRegistry,
+  } = useEuiResizableContainerContext();
+
+  const isDisabled = useMemo(
+    () => disabled || resizers[resizerId]?.isDisabled,
+    [resizers, resizerId, disabled]
+  );
+
+  const previousRef = useRef<HTMLElement>();
+  const onRef = useCallback(
+    (ref: HTMLElement | null) => {
+      if (!registration) return;
+      if (ref) {
+        previousRef.current = ref;
+        registration.register({
+          id: resizerId,
+          ref,
+          isFocused: false,
+          isDisabled: disabled || false,
+        });
+      } else {
+        if (previousRef.current != null) {
+          registration.deregister(resizerId);
+          previousRef.current = undefined;
+        }
+      }
+    },
+    [registration, resizerId, disabled]
+  );
 
   return (
     <EuiResizableButton
-      // TODO - move commented out props here
+      id={resizerId}
+      // ref={onRef} TODO - forwardRef
+      disabled={isDisabled}
+      onClick={(e) => e.currentTarget.focus()}
+      onFocus={() => onFocus?.(resizerId)}
       {...rest}
     />
   );

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -71,8 +71,8 @@ export const EuiResizableButton = forwardRef<
         'euiResizableButton.verticalResizerAriaLabel',
       ]}
       defaults={[
-        'Press left or right to adjust panels size',
-        'Press up or down to adjust panels size',
+        'Press the left or right arrow keys to adjust panels size',
+        'Press the up or down arrow keys to adjust panels size',
       ]}
     >
       {([horizontalResizerAriaLabel, verticalResizerAriaLabel]: string[]) => (

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -32,23 +32,24 @@ import { euiResizableButtonStyles } from './resizable_button.styles';
 export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
   CommonProps & {
     /**
-     * Defaults to displaying a resize handle button for vertical (y-axis) resizing.
-     * Set to `true` to display a handle for horizontal (x-axis) resizing.
+     * Defaults to displaying a resizer for vertical (y-axis) resizing.
+     * Set to `true` to display a resizer for horizontal (x-axis) resizing.
      */
     isHorizontal?: boolean;
     /**
-     * Specify the alignment of the resize handle indicator. Defaults to `center`,
+     * Specify the alignment of the initial resize indicator. Defaults to `center`,
      * but consider using `start` for extremely tall content that scrolls off-screen
      */
     alignIndicator?: 'center' | 'start' | 'end';
     /**
-     * When disabled, the button will be completely hidden
+     * When disabled, the resizer button will be completely hidden
      */
     disabled?: boolean;
   };
 
 /**
- * A generic resizable button/drag handle, usable outside of the EuiResizableContainer context
+ * A generic button for indicating/facilitating resizable content,
+ * usable outside of the EuiResizableContainer context
  */
 export const EuiResizableButton = forwardRef<
   HTMLButtonElement,
@@ -94,7 +95,7 @@ export const EuiResizableButton = forwardRef<
 EuiResizableButton.displayName = 'EuiResizableButton';
 
 /**
- * Button specific to controlled EuiResizableContainer usage
+ * Resizer button specific to controlled EuiResizableContainer usage
  */
 export type EuiResizableButtonControls = Omit<
   EuiResizableButtonProps,

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -28,49 +28,43 @@ import {
 } from './types';
 import { euiResizableButtonStyles } from './resizable_button.styles';
 
-interface EuiResizableButtonControls {
-  onKeyDown: (eve: EuiResizableButtonKeyEvent) => void;
-  onKeyUp: (eve: EuiResizableButtonKeyEvent) => void;
-  onMouseDown: (eve: EuiResizableButtonMouseEvent) => void;
-  onTouchStart: (eve: EuiResizableButtonMouseEvent) => void;
-  onFocus: (id: string) => void;
-  onBlur: () => void;
-  registration: {
-    register: (resizer: EuiResizableButtonController) => void;
-    deregister: (resizerId: EuiResizableButtonController['id']) => void;
+export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  CommonProps & {
+    /**
+     * Defaults to displaying a resize handle button for vertical (y-axis) resizing.
+     * Set to `true` to display a handle for horizontal (x-axis) resizing.
+     */
+    isHorizontal?: boolean;
+    /**
+     * When disabled, the button will be completely hidden
+     */
+    disabled?: boolean;
   };
-  isHorizontal: boolean;
-}
 
-export interface EuiResizableButtonProps
-  extends Omit<
-      ButtonHTMLAttributes<HTMLButtonElement>,
-      keyof EuiResizableButtonControls
-    >,
-    CommonProps,
-    Partial<EuiResizableButtonControls> {}
-
+/**
+ * A generic resizable button/drag handle, usable outside of the EuiResizableContainer context
+ */
 export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
   isHorizontal,
   className,
-  id,
-  registration,
-  disabled,
-  onFocus,
-  onBlur,
+  // id,
+  // registration,
+  // disabled,
+  // onFocus,
+  // onBlur,
   ...rest
 }) => {
-  const resizerId = useGeneratedHtmlId({
-    prefix: 'resizable-button',
-    conditionalId: id,
-  });
-  const {
-    registry: { resizers } = { resizers: {} } as EuiResizableContainerRegistry,
-  } = useEuiResizableContainerContext();
-  const isDisabled = useMemo(
-    () => disabled || resizers[resizerId]?.isDisabled,
-    [resizers, resizerId, disabled]
-  );
+  // const resizerId = useGeneratedHtmlId({
+  //   prefix: 'resizable-button',
+  //   conditionalId: id,
+  // });
+  // const {
+  //   registry: { resizers } = { resizers: {} } as EuiResizableContainerRegistry,
+  // } = useEuiResizableContainerContext();
+  // const isDisabled = useMemo(
+  //   () => disabled || resizers[resizerId]?.isDisabled,
+  //   [resizers, resizerId, disabled]
+  // );
 
   const classes = classNames('euiResizableButton', className);
   const euiTheme = useEuiTheme();
@@ -80,27 +74,27 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     isHorizontal ? styles.horizontal : styles.vertical,
   ];
 
-  const previousRef = useRef<HTMLElement>();
-  const onRef = useCallback(
-    (ref: HTMLElement | null) => {
-      if (!registration) return;
-      if (ref) {
-        previousRef.current = ref;
-        registration.register({
-          id: resizerId,
-          ref,
-          isFocused: false,
-          isDisabled: disabled || false,
-        });
-      } else {
-        if (previousRef.current != null) {
-          registration.deregister(resizerId);
-          previousRef.current = undefined;
-        }
-      }
-    },
-    [registration, resizerId, disabled]
-  );
+  // const previousRef = useRef<HTMLElement>();
+  // const onRef = useCallback(
+  //   (ref: HTMLElement | null) => {
+  //     if (!registration) return;
+  //     if (ref) {
+  //       previousRef.current = ref;
+  //       registration.register({
+  //         id: resizerId,
+  //         ref,
+  //         isFocused: false,
+  //         isDisabled: disabled || false,
+  //       });
+  //     } else {
+  //       if (previousRef.current != null) {
+  //         registration.deregister(resizerId);
+  //         previousRef.current = undefined;
+  //       }
+  //     }
+  //   },
+  //   [registration, resizerId, disabled]
+  // );
 
   return (
     <EuiI18n
@@ -115,8 +109,8 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     >
       {([horizontalResizerAriaLabel, verticalResizerAriaLabel]: string[]) => (
         <button
-          id={resizerId}
-          ref={onRef}
+          // id={resizerId}
+          // ref={onRef}
           aria-label={
             isHorizontal ? horizontalResizerAriaLabel : verticalResizerAriaLabel
           }
@@ -124,10 +118,10 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
           css={cssStyles}
           data-test-subj="euiResizableButton"
           type="button"
-          onClick={(e) => e.currentTarget.focus()}
-          onFocus={() => onFocus?.(resizerId)}
-          onBlur={onBlur}
-          disabled={isDisabled}
+          // onClick={(e) => e.currentTarget.focus()}
+          // onFocus={() => onFocus?.(resizerId)}
+          // onBlur={onBlur}
+          // disabled={isDisabled}
           {...rest}
         />
       )}
@@ -135,10 +129,38 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
   );
 };
 
-export function euiResizableButtonWithControls(
-  controls: EuiResizableButtonControls
-) {
-  return (props: CommonProps) => (
-    <EuiResizableButton {...controls} {...props} />
+/**
+ * Button specific to controlled EuiResizableContainer usage
+ */
+export type EuiResizableButtonControls = Omit<
+  EuiResizableButtonProps,
+  'onFocus'
+> & {
+  registration: {
+    register: (resizer: EuiResizableButtonController) => void;
+    deregister: (resizerId: EuiResizableButtonController['id']) => void;
+  };
+  onKeyDown: (e: EuiResizableButtonKeyEvent) => void;
+  onKeyUp: (e: EuiResizableButtonKeyEvent) => void;
+  onMouseDown: (e: EuiResizableButtonMouseEvent) => void;
+  onTouchStart: (e: EuiResizableButtonMouseEvent) => void;
+  onBlur: () => void;
+  onFocus: (id: string) => void;
+};
+
+export const EuiResizableButtonControlled: FunctionComponent<
+  Partial<EuiResizableButtonControls>
+> = ({ ...rest }) => {
+  // TODO: Move resizer & registration logic to this component
+
+  return (
+    <EuiResizableButton
+      // TODO - move commented out props here
+      {...rest}
+    />
   );
-}
+};
+
+export const euiResizableButtonWithControls =
+  (controls: EuiResizableButtonControls) => (props: CommonProps) =>
+    <EuiResizableButtonControlled {...controls} {...props} />;

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -12,6 +12,7 @@ import React, {
   useCallback,
   useMemo,
   useRef,
+  forwardRef,
 } from 'react';
 import classNames from 'classnames';
 
@@ -44,12 +45,12 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 /**
  * A generic resizable button/drag handle, usable outside of the EuiResizableContainer context
  */
-export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
-  isHorizontal,
-  className,
-  ...rest
-}) => {
+export const EuiResizableButton = forwardRef<
+  HTMLButtonElement,
+  EuiResizableButtonProps
+>(({ isHorizontal, className, ...rest }, ref) => {
   const classes = classNames('euiResizableButton', className);
+
   const euiTheme = useEuiTheme();
   const styles = euiResizableButtonStyles(euiTheme);
   const cssStyles = [
@@ -70,6 +71,7 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
     >
       {([horizontalResizerAriaLabel, verticalResizerAriaLabel]: string[]) => (
         <button
+          ref={ref}
           aria-label={
             isHorizontal ? horizontalResizerAriaLabel : verticalResizerAriaLabel
           }
@@ -82,7 +84,8 @@ export const EuiResizableButton: FunctionComponent<EuiResizableButtonProps> = ({
       )}
     </EuiI18n>
   );
-};
+});
+EuiResizableButton.displayName = 'EuiResizableButton';
 
 /**
  * Button specific to controlled EuiResizableContainer usage
@@ -144,7 +147,7 @@ export const EuiResizableButtonControlled: FunctionComponent<
   return (
     <EuiResizableButton
       id={resizerId}
-      // ref={onRef} TODO - forwardRef
+      ref={onRef}
       disabled={isDisabled}
       onClick={(e) => e.currentTarget.focus()}
       onFocus={() => onFocus?.(resizerId)}

--- a/upcoming_changelogs/7087.md
+++ b/upcoming_changelogs/7087.md
@@ -1,0 +1,2 @@
+- `EuiResizableButton` is now available as a generic top-level export
+- Added new `alignHandle` prop to `EuiResizableButton`. Defaults to `center`, and can now additionally be configured to `start` and `end`

--- a/upcoming_changelogs/7087.md
+++ b/upcoming_changelogs/7087.md
@@ -1,2 +1,2 @@
 - `EuiResizableButton` is now available as a generic top-level export
-- Added new `alignHandle` prop to `EuiResizableButton`. Defaults to `center`, and can now additionally be configured to `start` and `end`
+- Added new `alignIndicator` prop to `EuiResizableButton`. Defaults to `center`, and can now additionally be configured to `start` and `end`


### PR DESCRIPTION
## Summary

- closes #6100
    Exports a generic `EuiResizableButton` with no context or references to the registry/resizers from `EuiResizableContainer`, and sets up a new internal `EuiResizableButtonControlled` component for the container parent to use
    ![screencap](https://github.com/elastic/eui/assets/549407/3babbdef-702b-44ec-8fd4-045131122b9f)
- closes #5787
    Creates a new `alignIndicator` prop that determines the position/alignment of the resize indicator
    ![screencap](https://github.com/elastic/eui/assets/549407/d564879e-1d6c-4cbf-bf4e-7080e4238a2e)

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7087/commits).

## QA

### Docs
- Go to https://eui.elastic.co/pr_7087/#/layout/resizable-container#custom-resizable-button
- [x] Play around with the component with mouse, touch, and keyboard, and confirm it works as expected

### Storybook
- `gh pr checkout 7087`
- `yarn compile-scss && yarn storybook`
    - Note that the `yarn compile-scss` step is important/required ever since we changed Storybook to import our distributed CSS, the old Sass will linger/override Emotion otherwise
- Go to http://localhost:6006/?path=/story/euiresizablebutton--playground
- [x] Play with the `isHorizontal` and `alignIndicator` props and confirm they work as expected

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] ~Added or~ updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
