### PR TITLE
feat: update useGeneratedHtmlId to use React.useId when available

### DIFF
--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -160,7 +160,8 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const getBottomBarProps = () => ({
     restrictWidth,
     paddingSize,
-    parent: `#${pageInnerId}`,
+    // pageInnerId may contain colons that are parsed as pseudo-elements if not escaped
+    parent: `#${CSS.escape(pageInnerId)}`,
   });
 
   const innerPanelled = () => panelled ?? Boolean(sidebar.length > 0);

--- a/src/services/accessibility/html_id_generator.ts
+++ b/src/services/accessibility/html_id_generator.ts
@@ -44,7 +44,7 @@ export type UseGeneratedHtmlIdOptions = {
    */
   conditionalId?: string;
 };
-export const useDeprecatedGeneratedHtmlId = ({
+const useDeprecatedGeneratedHtmlId = ({
   prefix,
   suffix,
   conditionalId,

--- a/src/services/accessibility/html_id_generator.ts
+++ b/src/services/accessibility/html_id_generator.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
+import React, { useMemo } from 'react';
 import { v1 as uuidv1 } from 'uuid';
-import { useMemo } from 'react';
 
 /**
  * This function returns a function to generate ids.
@@ -44,7 +44,7 @@ export type UseGeneratedHtmlIdOptions = {
    */
   conditionalId?: string;
 };
-export const useGeneratedHtmlId = ({
+export const useDeprecatedGeneratedHtmlId = ({
   prefix,
   suffix,
   conditionalId,
@@ -53,3 +53,20 @@ export const useGeneratedHtmlId = ({
     return conditionalId || htmlIdGenerator(prefix)(suffix);
   }, [conditionalId, prefix, suffix]);
 };
+
+const useNewGeneratedHtmlId = ({
+  prefix = '',
+  suffix = '',
+  conditionalId,
+}: UseGeneratedHtmlIdOptions = {}) => {
+  // Using the default export and dot notation here is intentional
+  // to prevent React <18 import errors.
+  const id = React.useId();
+
+  return useMemo<string>(() => {
+    return conditionalId || `${prefix}${id}${suffix}`;
+  }, [id, conditionalId, prefix, suffix]);
+};
+
+export const useGeneratedHtmlId =
+  'useId' in React ? useNewGeneratedHtmlId : useDeprecatedGeneratedHtmlId;

--- a/src/services/accessibility/html_id_generator.ts
+++ b/src/services/accessibility/html_id_generator.ts
@@ -44,6 +44,8 @@ export type UseGeneratedHtmlIdOptions = {
    */
   conditionalId?: string;
 };
+
+// We can remove this deprecated hook once EUI no longer needs to support React 16-17
 const useDeprecatedGeneratedHtmlId = ({
   prefix,
   suffix,

--- a/upcoming_changelogs/7095.md
+++ b/upcoming_changelogs/7095.md
@@ -1,0 +1,1 @@
+- Updated `useNewGeneratedHtmlId` to use `React.useId` as the source of unique identifiers when available

--- a/upcoming_changelogs/7095.md
+++ b/upcoming_changelogs/7095.md
@@ -1,1 +1,1 @@
-- Updated `useNewGeneratedHtmlId` to use `React.useId` as the source of unique identifiers when available
+- Updated `useGeneratedHtmlId` hook to use `React.useId` as the source of unique identifiers when available


### PR DESCRIPTION
## Summary

This PR resolves #7078 by updating `useGeneratedHtmlId` utility function to use [`React.useId`](https://react.dev/reference/react/useId) when it's available (which means when running React 18).

It's the first step in making `useGeneratedHtmlId` and its usages SSR-compatible. We must do #7094 to make `useGeneratedHtmlId` SSR-safe across all supported React versions.

## QA

* Make sure all tests are passing
* Verify that `<EuiSwitch>` and `<EuiDataGrid>` generated DOM `id` attributes reference the same objects as before. The id values will be different (instead of UUIDs there's gonna be strings like `:r1:` generated by `React.useId`)

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
