### PR TITLE
[Storybook] Update the `yarn storybook` script to compile Sass prior to running Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yo-doc": "yo ./generator-eui/app/documentation.js",
     "yo-changelog": "yo ./generator-eui/changelog/index.js",
     "release": "node ./scripts/release.js",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "yarn compile-scss && storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "repository": {


### PR DESCRIPTION
## Summary

This PR updates the `yarn storybook` script by prepending `yarn compile-scss` before it builds and runs Storybook. This is required for components that have not been converted to Emotion to ensure the proper styles are compiled.

## QA
- `gh pr checkout 7098`
- run `yarn && yarn storybook`
   - There should be no errors when running these scripts
   - You should be able to see that the themes have successfully compiled in the terminal
   - Open `http://localhost:6006/?path=/story/euiemptyprompt--playground` to run Storybook and navigate to a component that is using Sass styling. When toggling `paddingSize`, you should notice the padding shrinks or grows.



