### PR TITLE
[BUG] Update `catalog-info.yml` to avoid double job starts in Buildkite

### DIFF
--- a/.github/workflows/_fragment.yml
+++ b/.github/workflows/_fragment.yml
@@ -1,5 +1,0 @@
-uses: thollander/actions-comment-pull-request@v2
-with:
-  message: |
-    Since this is a community submitted pull request, a Buildkite build has not been kicked off automatically. Would an Elastic organization member please verify the contents of this patch and then kick off a build manually?
-  pr_number: ${{ env.PULL_REQUEST_NUMBER }}

--- a/.github/workflows/_fragment.yml
+++ b/.github/workflows/_fragment.yml
@@ -1,0 +1,5 @@
+uses: thollander/actions-comment-pull-request@v2
+with:
+  message: |
+    Since this is a community submitted pull request, a Buildkite build has not been kicked off automatically. Would an Elastic organization member please verify the contents of this patch and then kick off a build manually?
+  pr_number: ${{ env.PULL_REQUEST_NUMBER }}

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -184,6 +184,10 @@ spec:
         build_branches: false
         build_tags: false
         build_pull_requests: true
+        filter_enabled: true
+        # Start Buildkite jobs using the API only
+        filter_condition: |
+          (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       teams:
         eui-team:
          access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## Summary
This PR fixes the issue where Buildkite runs the combined test and deploy docs job twice. The root cause was determined to be the job kicking off with an API and webhook call. 

This PR is modeled after a Fleet Server PR the Buildkite CI team sent me to [avoid duplicate builds](https://github.com/elastic/fleet-server/pull/2573/files?w=1).

This PR closes #7069.

## QA

QA will be done manually after the PR is merged into `main`. I will open a feature branch on the EUI repo (not my fork) to ensure it doesn't run duplicate jobs, and a community PR to ensure it also runs correctly.