### PR TITLE
Add dismiss all toast button for EuiGlobalToastList component

### DIFF
--- a/src-docs/src/views/toast/toast_list.js
+++ b/src-docs/src/views/toast/toast_list.js
@@ -121,7 +121,6 @@ export default () => {
         toasts={toasts}
         dismissToast={removeToast}
         toastLifeTimeMs={6000}
-        showClearAllButton
       />
     </div>
   );

--- a/src-docs/src/views/toast/toast_list.js
+++ b/src-docs/src/views/toast/toast_list.js
@@ -30,7 +30,9 @@ export default () => {
   };
 
   const removeToast = (removedToast) => {
-    setToasts(toasts.filter((toast) => toast.id !== removedToast.id));
+    setToasts((toasts) =>
+      toasts.filter((toast) => toast.id !== removedToast.id)
+    );
   };
 
   removeAllToastsHandler = () => {
@@ -119,6 +121,7 @@ export default () => {
         toasts={toasts}
         dismissToast={removeToast}
         toastLifeTimeMs={6000}
+        allowClearAll
       />
     </div>
   );

--- a/src-docs/src/views/toast/toast_list.js
+++ b/src-docs/src/views/toast/toast_list.js
@@ -121,7 +121,7 @@ export default () => {
         toasts={toasts}
         dismissToast={removeToast}
         toastLifeTimeMs={6000}
-        allowClearAll
+        showClearAllButton
       />
     </div>
   );

--- a/src/components/toast/global_toast_list.styles.ts
+++ b/src/components/toast/global_toast_list.styles.ts
@@ -98,6 +98,7 @@ export const euiGlobalToastListItemStyles = ({ euiTheme }: UseEuiTheme) => {
   return {
     // Base
     euiGlobalToastListItem: css`
+      flex-shrink: 0;
       ${logicalCSS('margin-bottom', euiTheme.size.base)}
       animation: ${euiTheme.animation.normal} ${euiShowToast}
         ${euiTheme.animation.resistance};

--- a/src/components/toast/global_toast_list.styles.ts
+++ b/src/components/toast/global_toast_list.styles.ts
@@ -80,6 +80,10 @@ export const euiGlobalToastListStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
     `,
+    euiGlobalToastListDismissButton: css`
+      position: sticky;
+      ${logicalCSS('bottom', '0%')}
+    `,
   };
 };
 

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -7,10 +7,10 @@
  */
 
 import React from 'react';
-import { act } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { mount } from 'enzyme';
 import { requiredProps, findTestSubject } from '../../test';
-import { render } from '../../test/rtl';
+import { render, findByTestSubject, queryByTestSubject } from '../../test/rtl';
 
 import {
   EuiGlobalToastList,
@@ -193,16 +193,14 @@ describe('EuiGlobalToastList', () => {
         const dismissToastSpy = jest.fn();
         const dismissAllToastsSpy = jest.fn();
         const TOAST_LIFE_TIME_MS = 10;
-        const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
 
         const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT;
 
-        const component = mount(
+        const { container } = render(
           <EuiGlobalToastList
             toasts={Array.from(new Array(TOAST_COUNT)).map((_, idx) => ({
               id: String(idx),
               'data-test-subj': String(idx),
-              toastLifeTimeMs: TOAST_LIFE_TIME_MS_OVERRIDE,
             }))}
             toastLifeTimeMs={TOAST_LIFE_TIME_MS}
             dismissToast={dismissToastSpy}
@@ -211,28 +209,26 @@ describe('EuiGlobalToastList', () => {
           />
         );
 
-        const dismissAllToastsButton = findTestSubject(
-          component,
+        const dismissAllToastsButton = queryByTestSubject(
+          container,
           'euiClearAllToastsButton'
         );
 
-        expect(dismissAllToastsButton.exists()).toEqual(false);
+        expect(dismissAllToastsButton).not.toBeInTheDocument();
       });
 
-      test('is displayed when the number of toasts to be displayed equals the internal default threshold value', () => {
+      test('is displayed when the number of toasts to be displayed equals the internal default threshold value', async () => {
         const dismissToastSpy = jest.fn();
         const dismissAllToastsSpy = jest.fn();
         const TOAST_LIFE_TIME_MS = 10;
-        const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
 
         const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT;
 
-        const component = mount(
+        const { container } = render(
           <EuiGlobalToastList
             toasts={Array.from(new Array(TOAST_COUNT)).map((_, idx) => ({
               id: String(idx),
               'data-test-subj': String(idx),
-              toastLifeTimeMs: TOAST_LIFE_TIME_MS_OVERRIDE,
             }))}
             toastLifeTimeMs={TOAST_LIFE_TIME_MS}
             dismissToast={dismissToastSpy}
@@ -240,33 +236,29 @@ describe('EuiGlobalToastList', () => {
           />
         );
 
-        const dismissAllToastsButton = findTestSubject(
-          component,
+        const dismissAllToastsButton = await findByTestSubject(
+          container,
           'euiClearAllToastsButton'
         );
 
-        expect(dismissAllToastsButton.exists()).toEqual(true);
-
-        dismissAllToastsButton.simulate('click');
+        fireEvent.click(dismissAllToastsButton);
 
         expect(dismissToastSpy).toHaveBeenCalledTimes(TOAST_COUNT);
         expect(dismissAllToastsSpy).toHaveBeenCalled();
       });
 
-      test('is visible when the number of toasts to be displayed exceeds the threshold value set with the showClearAllButtonAt prop', () => {
+      test('is visible when the number of toasts to be displayed exceeds the threshold value set with the showClearAllButtonAt prop', async () => {
         const dismissToastSpy = jest.fn();
         const dismissAllToastsSpy = jest.fn();
         const TOAST_LIFE_TIME_MS = 10;
-        const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
 
         const TOAST_COUNT = 5;
 
-        const component = mount(
+        const { container } = render(
           <EuiGlobalToastList
             toasts={Array.from(new Array(TOAST_COUNT)).map((_, idx) => ({
               id: String(idx),
               'data-test-subj': String(idx),
-              toastLifeTimeMs: TOAST_LIFE_TIME_MS_OVERRIDE,
             }))}
             toastLifeTimeMs={TOAST_LIFE_TIME_MS}
             dismissToast={dismissToastSpy}
@@ -275,14 +267,12 @@ describe('EuiGlobalToastList', () => {
           />
         );
 
-        const dismissAllToastsButton = findTestSubject(
-          component,
+        const dismissAllToastsButton = await findByTestSubject(
+          container,
           'euiClearAllToastsButton'
         );
 
-        expect(dismissAllToastsButton.exists()).toEqual(true);
-
-        dismissAllToastsButton.simulate('click');
+        fireEvent.click(dismissAllToastsButton);
 
         expect(dismissToastSpy).toHaveBeenCalledTimes(TOAST_COUNT);
         expect(dismissAllToastsSpy).toHaveBeenCalled();

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -206,12 +206,9 @@ describe('EuiGlobalToastList', () => {
       });
 
       test('is not visible when the showClearAllButtonAt prop is set to 0', () => {
-        const dismissAllToastsSpy = jest.fn();
-
         const { queryByTestSubject } = render(
           <EuiGlobalToastList
             {...sharedProps}
-            onClearAllToasts={dismissAllToastsSpy}
             showClearAllButtonAt={0}
           />
         );
@@ -237,13 +234,9 @@ describe('EuiGlobalToastList', () => {
       });
 
       test('is displayed when the number of toasts to be displayed equals the internal default threshold value', () => {
-        const dismissAllToastsSpy = jest.fn();
-
         const { getByTestSubject } = render(
-          <EuiGlobalToastList
-            {...sharedProps}
-            onClearAllToasts={dismissAllToastsSpy}
-          />
+          <EuiGlobalToastList {...sharedProps} />
+        );
         );
 
         expect(getByTestSubject('euiClearAllToastsButton')).toBeInTheDocument();

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -207,10 +207,7 @@ describe('EuiGlobalToastList', () => {
 
       test('is not visible when the showClearAllButtonAt prop is set to 0', () => {
         const { queryByTestSubject } = render(
-          <EuiGlobalToastList
-            {...sharedProps}
-            showClearAllButtonAt={0}
-          />
+          <EuiGlobalToastList {...sharedProps} showClearAllButtonAt={0} />
         );
 
         expect(

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -16,6 +16,7 @@ import {
   EuiGlobalToastList,
   Toast,
   TOAST_FADE_OUT_MS,
+  CLEAR_ALL_TOASTS_THRESHOLD,
 } from './global_toast_list';
 
 jest.useFakeTimers();
@@ -184,6 +185,75 @@ describe('EuiGlobalToastList', () => {
           jest.advanceTimersByTime(nowItsTime - notYetTime);
         });
         expect(dismissToastSpy).toBeCalled();
+      });
+    });
+
+    describe('dismissAllToasts Button', () => {
+      test("is not visible when toasts don't exceed the clear all threshold with the showClearAllButton prop passed", () => {
+        const dismissToastSpy = jest.fn();
+        const dismissAllToastsSpy = jest.fn();
+        const TOAST_LIFE_TIME_MS = 10;
+        const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
+
+        const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD - 1;
+
+        const component = mount(
+          <EuiGlobalToastList
+            toasts={Array.from(new Array(TOAST_COUNT)).map((_, idx) => ({
+              id: String(idx),
+              'data-test-subj': String(idx),
+              toastLifeTimeMs: TOAST_LIFE_TIME_MS_OVERRIDE,
+            }))}
+            toastLifeTimeMs={TOAST_LIFE_TIME_MS}
+            dismissToast={dismissToastSpy}
+            onClearAllToasts={dismissAllToastsSpy}
+            showClearAllButton
+          />
+        );
+
+        const dismissAllToastsButton = findTestSubject(
+          component,
+          'euiClearAllToastsButton'
+        );
+
+        expect(dismissAllToastsButton.exists()).toEqual(false);
+      });
+
+      test('is visible when toasts exceed the clear all threshold with the showClearAllButton prop passed', () => {
+        const dismissToastSpy = jest.fn();
+        const dismissAllToastsSpy = jest.fn();
+        const TOAST_LIFE_TIME_MS = 10;
+        const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
+
+        const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD + 1;
+
+        const component = mount(
+          <EuiGlobalToastList
+            toasts={Array.from(new Array(TOAST_COUNT)).map((_, idx) => ({
+              id: String(idx),
+              'data-test-subj': String(idx),
+              toastLifeTimeMs: TOAST_LIFE_TIME_MS_OVERRIDE,
+            }))}
+            toastLifeTimeMs={TOAST_LIFE_TIME_MS}
+            dismissToast={dismissToastSpy}
+            onClearAllToasts={dismissAllToastsSpy}
+            showClearAllButton
+          />
+        );
+
+        const dismissAllToastsButton = findTestSubject(
+          component,
+          'euiClearAllToastsButton'
+        );
+
+        dismissAllToastsButton.simulate('click');
+
+        act(() => {
+          jest.advanceTimersByTime(1);
+        });
+
+        expect(dismissToastSpy).toHaveBeenCalledTimes(TOAST_COUNT);
+        expect(dismissAllToastsSpy).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -16,7 +16,7 @@ import {
   EuiGlobalToastList,
   Toast,
   TOAST_FADE_OUT_MS,
-  CLEAR_ALL_TOASTS_THRESHOLD,
+  CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT,
 } from './global_toast_list';
 
 jest.useFakeTimers();
@@ -189,13 +189,13 @@ describe('EuiGlobalToastList', () => {
     });
 
     describe('dismissAllToasts Button', () => {
-      test("is not visible when toasts don't exceed the clear all threshold with the showClearAllButton prop passed", () => {
+      test('is not visible when the showClearAllButtonAt prop is set to 0', () => {
         const dismissToastSpy = jest.fn();
         const dismissAllToastsSpy = jest.fn();
         const TOAST_LIFE_TIME_MS = 10;
         const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
 
-        const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD - 1;
+        const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT;
 
         const component = mount(
           <EuiGlobalToastList
@@ -207,7 +207,7 @@ describe('EuiGlobalToastList', () => {
             toastLifeTimeMs={TOAST_LIFE_TIME_MS}
             dismissToast={dismissToastSpy}
             onClearAllToasts={dismissAllToastsSpy}
-            showClearAllButton
+            showClearAllButtonAt={0}
           />
         );
 
@@ -219,13 +219,13 @@ describe('EuiGlobalToastList', () => {
         expect(dismissAllToastsButton.exists()).toEqual(false);
       });
 
-      test('is visible when toasts exceed the clear all threshold with the showClearAllButton prop passed', () => {
+      test('is displayed when the number of toasts to be displayed equals the internal default threshold value', () => {
         const dismissToastSpy = jest.fn();
         const dismissAllToastsSpy = jest.fn();
         const TOAST_LIFE_TIME_MS = 10;
         const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
 
-        const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD + 1;
+        const TOAST_COUNT = CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT;
 
         const component = mount(
           <EuiGlobalToastList
@@ -237,7 +237,6 @@ describe('EuiGlobalToastList', () => {
             toastLifeTimeMs={TOAST_LIFE_TIME_MS}
             dismissToast={dismissToastSpy}
             onClearAllToasts={dismissAllToastsSpy}
-            showClearAllButton
           />
         );
 
@@ -246,11 +245,44 @@ describe('EuiGlobalToastList', () => {
           'euiClearAllToastsButton'
         );
 
+        expect(dismissAllToastsButton.exists()).toEqual(true);
+
         dismissAllToastsButton.simulate('click');
 
-        act(() => {
-          jest.advanceTimersByTime(1);
-        });
+        expect(dismissToastSpy).toHaveBeenCalledTimes(TOAST_COUNT);
+        expect(dismissAllToastsSpy).toHaveBeenCalled();
+      });
+
+      test('is visible when the number of toasts to be displayed exceeds the threshold value set with the showClearAllButtonAt prop', () => {
+        const dismissToastSpy = jest.fn();
+        const dismissAllToastsSpy = jest.fn();
+        const TOAST_LIFE_TIME_MS = 10;
+        const TOAST_LIFE_TIME_MS_OVERRIDE = 100;
+
+        const TOAST_COUNT = 5;
+
+        const component = mount(
+          <EuiGlobalToastList
+            toasts={Array.from(new Array(TOAST_COUNT)).map((_, idx) => ({
+              id: String(idx),
+              'data-test-subj': String(idx),
+              toastLifeTimeMs: TOAST_LIFE_TIME_MS_OVERRIDE,
+            }))}
+            toastLifeTimeMs={TOAST_LIFE_TIME_MS}
+            dismissToast={dismissToastSpy}
+            onClearAllToasts={dismissAllToastsSpy}
+            showClearAllButtonAt={TOAST_COUNT - 1}
+          />
+        );
+
+        const dismissAllToastsButton = findTestSubject(
+          component,
+          'euiClearAllToastsButton'
+        );
+
+        expect(dismissAllToastsButton.exists()).toEqual(true);
+
+        dismissAllToastsButton.simulate('click');
 
         expect(dismissToastSpy).toHaveBeenCalledTimes(TOAST_COUNT);
         expect(dismissAllToastsSpy).toHaveBeenCalled();

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -237,7 +237,6 @@ describe('EuiGlobalToastList', () => {
         const { getByTestSubject } = render(
           <EuiGlobalToastList {...sharedProps} />
         );
-        );
 
         expect(getByTestSubject('euiClearAllToastsButton')).toBeInTheDocument();
       });

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -36,6 +36,8 @@ export const SIDES = keysOf(sideToClassNameMap);
 
 export const TOAST_FADE_OUT_MS = 250;
 
+export const CLEAR_ALL_TOASTS_THRESHOLD = 3;
+
 export interface Toast extends EuiToastProps {
   id: string;
   text?: ReactChild;
@@ -301,7 +303,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
     );
   });
 
-  if (showClearAllButton && toasts.length > 3) {
+  if (showClearAllButton && toasts.length > CLEAR_ALL_TOASTS_THRESHOLD) {
     const dismissAllToastImmediately = () => {
       toasts.forEach((toast) => dismissToastProp(toast));
       onClearAllToasts?.();
@@ -320,16 +322,14 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
           clearAllToastsButtonAriaLabel,
           clearAllToastsButtonDisplayText,
         ]: string[]) => (
-          <EuiGlobalToastListItem
-            data-test-subj="euiClearAllToastsButton"
-            isDismissed={false}
-          >
+          <EuiGlobalToastListItem isDismissed={false}>
             <EuiButton
               fill
               color="text"
               onClick={dismissAllToastImmediately}
               css={[styles.euiGlobalToastListDismissButton]}
               aria-label={clearAllToastsButtonAriaLabel}
+              data-test-subj="euiClearAllToastsButton"
             >
               {clearAllToastsButtonDisplayText}
             </EuiButton>

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -316,7 +316,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
           'euiGlobalToastList.clearAllToastsButtonAriaLabel',
           'euiGlobalToastList.clearAllToastsButtonDisplayText',
         ]}
-        defaults={['clear all toast notifications', 'Clear all']}
+        defaults={['Clear all toast notifications', 'Clear all']}
       >
         {([
           clearAllToastsButtonAriaLabel,

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -297,7 +297,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
     );
   });
 
-  if (showClearAllButton && toasts.length > 1) {
+  if (showClearAllButton && toasts.length > 3) {
     const dismissAllToastImmediately = () => {
       toasts.forEach((toast) => dismissToastProp(toast));
       onClearAllToasts?.();
@@ -321,7 +321,10 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
             isDismissed={false}
           >
             <EuiButton
+              fill
+              color="text"
               onClick={dismissAllToastImmediately}
+              css={[styles.euiGlobalToastListDismissButton]}
               aria-label={clearAllToastsButtonAriaLabel}
             >
               {clearAllToastsButtonDisplayText}

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -61,7 +61,6 @@ export interface EuiGlobalToastListProps extends CommonProps {
   showClearAllButtonAt?: number;
   /**
    * Optional callback that fires when a user clicks the "Clear all" button.
-   * Ignored if `showClearAll` is not `true`.
    */
   onClearAllToasts?: () => void;
 }
@@ -306,7 +305,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
   });
 
   if (showClearAllButtonAt && toasts.length >= showClearAllButtonAt) {
-    const dismissAllToastImmediately = () => {
+    const dismissAllToasts = () => {
       toasts.forEach((toast) => dismissToastProp(toast));
       onClearAllToasts?.();
     };
@@ -328,7 +327,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
             <EuiButton
               fill
               color="text"
-              onClick={dismissAllToastImmediately}
+              onClick={dismissAllToasts}
               css={[styles.euiGlobalToastListDismissButton]}
               aria-label={clearAllToastsButtonAriaLabel}
               data-test-subj="euiClearAllToastsButton"

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -157,7 +157,11 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
   };
 
   const onScroll = () => {
-    if (listElement.current) {
+    // Given that this method also gets invoked by the synthetic scroll that happens when a new toast gets added,
+    // we want to evaluate if the scroll bottom has been reached only when the user is interacting with the toast,
+    // this way we always retain the scroll position the user has set despite adding in new toasts.
+    // User interaction is determined through the handler registered for mouseEnter and mouseLeave events.
+    if (listElement.current && isUserInteracting.current) {
       isScrolledToBottom.current =
         listElement.current.scrollHeight - listElement.current.scrollTop ===
         listElement.current.clientHeight;

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -36,7 +36,7 @@ export const SIDES = keysOf(sideToClassNameMap);
 
 export const TOAST_FADE_OUT_MS = 250;
 
-export const CLEAR_ALL_TOASTS_THRESHOLD = 3;
+export const CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT = 3;
 
 export interface Toast extends EuiToastProps {
   id: string;
@@ -53,10 +53,12 @@ export interface EuiGlobalToastListProps extends CommonProps {
    */
   side?: ToastSide;
   /**
-   * Displays a "Clear all" button at the bottom of the toast list
+   * At this threshold, a "Clear all" button will display at the bottom of the toast list
    * that allows users to dismiss all toasts in a single click.
+   *
+   * Defaults to `3`. Set to `0` to disable the button entirely.
    */
-  showClearAllButton?: boolean;
+  showClearAllButtonAt?: number;
   /**
    * Optional callback that fires when a user clicks the "Clear all" button.
    * Ignored if `showClearAll` is not `true`.
@@ -69,9 +71,9 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
   toasts = [],
   dismissToast: dismissToastProp,
   toastLifeTimeMs,
-  showClearAllButton,
   onClearAllToasts,
   side = 'right',
+  showClearAllButtonAt = CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT,
   ...rest
 }) => {
   const [toastIdToDismissedMap, setToastIdToDismissedMap] = useState<{
@@ -303,7 +305,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
     );
   });
 
-  if (showClearAllButton && toasts.length > CLEAR_ALL_TOASTS_THRESHOLD) {
+  if (showClearAllButtonAt && toasts.length >= showClearAllButtonAt) {
     const dismissAllToastImmediately = () => {
       toasts.forEach((toast) => dismissToastProp(toast));
       onClearAllToasts?.();

--- a/upcoming_changelogs/7111.md
+++ b/upcoming_changelogs/7111.md
@@ -1,1 +1,1 @@
-- Extends `EuiGlobalToastList` to display a dismiss all toasts button
+- Added new `showClearAllButton` and `onClearAllToasts` props to `EuiGlobalToastList`. The new prop will allow users to dismiss all toasts in one action.

--- a/upcoming_changelogs/7111.md
+++ b/upcoming_changelogs/7111.md
@@ -1,1 +1,2 @@
-- Added new `showClearAllButton` and `onClearAllToasts` props to `EuiGlobalToastList`. The new prop will allow users to dismiss all toasts in one action.
+- `EuiGlobalToastList` now shows a "Clear all" button by default once above a certain number of toasts (defaults to 3). This threshold is configurable with the `showClearAllButtonAt` prop
+- Added an optional `onClearAllToasts` callback to `EuiGlobalToastList`

--- a/upcoming_changelogs/7111.md
+++ b/upcoming_changelogs/7111.md
@@ -1,0 +1,1 @@
+- Extends `EuiGlobalToastList` to display a dismiss all toasts button


### PR DESCRIPTION
## Summary

Takes a shot at resolving the "Clear All Button" requirement of https://github.com/elastic/eui/issues/6945, referenced by https://github.com/elastic/kibana/issues/162646

#### Approach

- Leverages the pre-existing `EuiGlobalToastListItem` component to keep the clear all button fixed at the bottom of all toasts, having the clear all button on the top pushes the button out of the screen once the list of visible toast exceeds the current screen size. 
- Introduces a new prop `showClearAllButtonAt` with a default of 3, that denotes when the threshold for displaying the dismiss all toasts button, passing a value of `0` would opt one out of displaying the dismiss all toasts button. An accompanying prop `onClearAllToasts` is introduced to register a method that will be invoked if provided when the clear all button is trigged.
- Consideration for A11y; the button in this iteration has an aria-label set, so a long descriptive message can be provided for screen readers, whilst keeping the visual text short.


#### Usage

```jsx
 <EuiGlobalToastList
    toasts={toasts}
    dismissToast={removeToast}
    toastLifeTimeMs={6000}
   // new props
   onClearAllToasts={() => {/* do something after all toasts are cleared */}}
   showClearAllButtonAt={/* custom threshold for displaying dismiss button */}
  />
```


#### Caveat;
This approach requires that the dismissToast function passed to the `EuiGlobalToastListItem`, if it performs state updates adopts the updater function style to ensure the state updates are accurately computed ([see here for an explanation](https://react.dev/learn/queueing-a-series-of-state-updates#updating-the-same-state-multiple-times-before-the-next-render)), especially because we iterate over the existing toasts and remove them.

#### Visuals

![close button visuals](https://github.com/elastic/eui/assets/7893459/138aa9b4-8791-4325-9e44-b624a2112fa1)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [x] Added **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md)**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
