### PR TITLE
Add `EuiTextTruncate` component

### DIFF
--- a/src-docs/src/routes.js
+++ b/src-docs/src/routes.js
@@ -227,6 +227,8 @@ import { TabsExample } from './views/tabs/tabs_example';
 
 import { TextDiffExample } from './views/text_diff/text_diff_example';
 
+import { TextTruncateExample } from './views/text_truncate/text_truncate_example';
+
 import { TextExample } from './views/text/text_example';
 
 import { TimelineExample } from './views/timeline/timeline_example';
@@ -652,6 +654,7 @@ const navigation = [
       ResizeObserverExample,
       ScrollExample,
       TextDiffExample,
+      TextTruncateExample,
       WindowEventExample,
     ].map((example) => createExample(example)),
   },

--- a/src-docs/src/views/text_truncate/ellipsis.tsx
+++ b/src-docs/src/views/text_truncate/ellipsis.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { EuiPanel, EuiText, EuiTextTruncate } from '../../../../src';
+
+export default () => {
+  return (
+    <EuiText>
+      <EuiPanel css={{ inlineSize: '40ch', maxInlineSize: '100%' }}>
+        <EuiTextTruncate
+          text="Opinions differ as to how to render ellipses in printed material. According to The Chicago Manual of Style, it should consist of three periods, each separated from its neighbor by a non-breaking space. According to the AP Stylebook, the periods should be rendered with no space between them."
+          ellipsis=". . ."
+        />
+        <EuiTextTruncate
+          text="In some legal writing, an ellipsis is written as three asterisks, to make it obvious that text has been omitted or to signal that the omitted text extends beyond the end of the paragraph."
+          ellipsis=" ***"
+        />
+        <EuiTextTruncate
+          text="Brackets are often used to indicate that a quotation has been condensed for space, brevity or relevance."
+          truncation="middle"
+          ellipsis="[...]"
+        />
+      </EuiPanel>
+    </EuiText>
+  );
+};

--- a/src-docs/src/views/text_truncate/performance.tsx
+++ b/src-docs/src/views/text_truncate/performance.tsx
@@ -1,0 +1,117 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { css } from '@emotion/react';
+import { throttle } from 'lodash';
+import { faker } from '@faker-js/faker';
+import { FixedSizeList } from 'react-window';
+
+import {
+  EuiFlexGroup,
+  EuiPanel,
+  EuiText,
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiSwitch,
+  EuiSpacer,
+  EuiTextTruncate,
+} from '../../../../src';
+
+const text = Array.from({ length: 100 }, () => faker.lorem.lines(5));
+
+export default () => {
+  // Testing toggles
+  const [canvasRendering, setCanvasRendering] = useState(true);
+  const measurementRenderAPI = canvasRendering ? 'canvas' : 'dom';
+  const [virtualization, setVirtualization] = useState(false);
+  const [throttleMs, setThrottleMs] = useState(100);
+
+  // Width resize observer
+  const widthRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(200);
+
+  useEffect(() => {
+    if (!widthRef.current) return;
+
+    const onObserve = throttle((entries) => {
+      // Skipping a forEach as we're only observing one element
+      setWidth(entries[0].contentRect.width);
+    }, throttleMs);
+
+    const resizeObserver = new ResizeObserver(onObserve);
+    resizeObserver.observe(widthRef.current);
+
+    () => resizeObserver.disconnect();
+  }, [throttleMs]);
+
+  return (
+    <EuiText>
+      <EuiFlexGroup alignItems="center">
+        <EuiSwitch
+          label="Toggle canvas rendering"
+          checked={canvasRendering}
+          onChange={() => setCanvasRendering(!canvasRendering)}
+        />
+        <EuiSwitch
+          label="Toggle virtualization"
+          checked={virtualization}
+          onChange={() => setVirtualization(!virtualization)}
+        />
+        <EuiFormRow label="Resize throttle" display="columnCompressed">
+          <EuiFieldNumber
+            value={throttleMs}
+            onChange={(e) => setThrottleMs(Number(e.target.value))}
+            style={{ width: 100 }}
+            compressed
+          />
+        </EuiFormRow>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+
+      <EuiPanel
+        panelRef={widthRef}
+        css={css`
+          overflow: auto;
+          resize: horizontal; /* Not all browsers support resize logical properties yet */
+          resize: inline;
+          max-inline-size: 100%;
+          inline-size: 600px;
+          block-size: 300px;
+        `}
+      >
+        {virtualization ? (
+          <FixedSizeList
+            width={width}
+            height={268}
+            itemCount={100}
+            itemSize={24}
+          >
+            {({ index, style }) => (
+              <EuiTextTruncate
+                style={style}
+                key={index}
+                text={text[index]}
+                truncation="middle"
+                width={width}
+                measurementRenderAPI={measurementRenderAPI}
+              />
+            )}
+          </FixedSizeList>
+        ) : (
+          text.map((text, i) => (
+            <EuiTextTruncate
+              key={i}
+              text={text}
+              truncation="middle"
+              width={width}
+              measurementRenderAPI={measurementRenderAPI}
+            />
+          ))
+        )}
+      </EuiPanel>
+      <EuiSpacer />
+      <p>
+        Drag the panel resize handle to test performance. Use the controls above
+        to compare the performance of different approaches.
+      </p>
+    </EuiText>
+  );
+};

--- a/src-docs/src/views/text_truncate/render_prop.tsx
+++ b/src-docs/src/views/text_truncate/render_prop.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+import {
+  EuiText,
+  EuiFormRow,
+  EuiFieldText,
+  EuiSpacer,
+  EuiPanel,
+  EuiHighlight,
+  EuiMark,
+  EuiTextTruncate,
+} from '../../../../src';
+
+const text =
+  "But the dog wasn't lazy, it was just practicing mindfulness, so it had a greater sense of life-satisfaction than that fox with all its silly jumping.";
+
+export default () => {
+  const [highlight, setHighlight] = useState('');
+  const highlightStartPosition = text
+    .toLowerCase()
+    .indexOf(highlight.toLowerCase());
+  const highlightCenterPosition =
+    highlightStartPosition + Math.floor(highlight.length / 2);
+
+  return (
+    <EuiText>
+      <EuiFormRow label="Type to highlight text">
+        <EuiFieldText
+          value={highlight}
+          onChange={(e) => setHighlight(e.target.value)}
+          placeholder={
+            'For example, try typing "lazy", "mindful", "life", or "silly"'
+          }
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiPanel css={{ inlineSize: '40ch', maxInlineSize: '100%' }}>
+        <EuiTextTruncate
+          text={text}
+          truncation="startEnd"
+          truncationPosition={highlightCenterPosition}
+        >
+          {(truncatedText) => (
+            <>
+              {truncatedText.length > highlight.length ? (
+                <EuiHighlight search={highlight}>{truncatedText}</EuiHighlight>
+              ) : (
+                // Highlight everything if the search match is greater than the visible text
+                <EuiMark>{truncatedText}</EuiMark>
+              )}
+            </>
+          )}
+        </EuiTextTruncate>
+      </EuiPanel>
+    </EuiText>
+  );
+};

--- a/src-docs/src/views/text_truncate/text_truncate_example.js
+++ b/src-docs/src/views/text_truncate/text_truncate_example.js
@@ -38,22 +38,14 @@ export const TextTruncateExample = {
       text: (
         <>
           <p>
-            <strong>EuiTextTruncate</strong> attempts to provide customizable
-            and size-aware truncation logic (until the happy day that browsers
-            add more{' '}
-            <EuiLink
-              href="https://github.com/w3c/csswg-drafts/issues/3937"
-              target="_blank"
-            >
-              customizable truncation out-of-the-box via CSS
-            </EuiLink>
-            ).
+            <strong>EuiTextTruncate</strong> provides customizable and
+            size-aware single line text truncation.
           </p>
           <p>
             The four truncation styles supported are <EuiCode>start</EuiCode>,{' '}
             <EuiCode>end</EuiCode>, <EuiCode>startEnd</EuiCode>, and{' '}
-            <EuiCode>middle</EuiCode>. The below demo can also be dynamically
-            resized to see how different truncation styles respond.
+            <EuiCode>middle</EuiCode>. Resize the below demo to see how
+            different truncation styles respond to dynamic width changes.
           </p>
         </>
       ),
@@ -72,7 +64,14 @@ export const TextTruncateExample = {
               <strong>EuiTextTruncate</strong> attempts to mimic the behavior of{' '}
               <EuiCode>text-overflow: ellipsis</EuiCode> as closely as possible,
               although there may be edge cases and cross-browser issues, as this
-              is essentially a browser implementation we are trying to polyfill.
+              is essentially a{' '}
+              <EuiLink
+                href="https://github.com/w3c/csswg-drafts/issues/3937"
+                target="_blank"
+              >
+                browser implementation
+              </EuiLink>{' '}
+              we are trying to polyfill.
             </p>
             <ul>
               <li>
@@ -103,7 +102,7 @@ export const TextTruncateExample = {
       ],
       text: (
         <p>
-          By default, <strong>EuiTextTruncate</strong> uses with the unicode
+          By default, <strong>EuiTextTruncate</strong> uses the unicode
           character for horizontal ellipis. It can be customized via the{' '}
           <EuiCode>ellipsis</EuiCode> prop as necessary (e.g. for specific
           languages, extra punctuation, etc).
@@ -157,10 +156,9 @@ export const TextTruncateExample = {
             prop allows.
           </p>
           <p>
-            This behavior will intelligently detect when positions are close to
-            the start or end of the text, and omit leading or trailing ellipses
-            when necessary. If the passed position is greater than the total
-            text length, the truncation will simply default to `start` instead.
+            This behavior will intelligently detect when positions are near
+            enough to the start or end of the text to omit leading or trailing
+            ellipses when necessary.
           </p>
           <p>
             Increase or decrease the number control below to see the prop in
@@ -194,17 +192,15 @@ export const TextTruncateExample = {
             rendering.
           </p>
           <p>
-            The primary type of use case in mind for this functionality would be
-            using{' '}
+            The below example demonstrates a primary use case for the render
+            prop and the <EuiCode>truncationPosition</EuiCode> prop. If a user
+            is searching for a specific word in truncated text, you can use{' '}
             <Link to="/#/utilities/highlight-and-mark">
               <strong>EuiHighlight</strong> or <strong>EuiMark</strong>
             </Link>{' '}
-            to highlight certain portions of the text. This example also
-            demonstrates the primary use case for the{' '}
-            <EuiCode>truncationPosition</EuiCode> prop. If a user is searching
-            for a specific word in truncated text, you should pass the index of
-            that found word to ensure it is always visible, for the best user
-            experience.
+            to highlight the search term, and passing the index of the found
+            word to <EuiCode>truncationPosition</EuiCode> ensures the search
+            term is always visible to the user.
           </p>
           <EuiCallOut
             color="warning"

--- a/src-docs/src/views/text_truncate/text_truncate_example.js
+++ b/src-docs/src/views/text_truncate/text_truncate_example.js
@@ -1,0 +1,223 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { GuideSectionTypes } from '../../components';
+
+import {
+  EuiLink,
+  EuiCode,
+  EuiCallOut,
+  EuiTextTruncate,
+} from '../../../../src/components';
+
+import Truncation from './truncation';
+const truncationSource = require('!!raw-loader!./truncation');
+
+import Ellipsis from './ellipsis';
+const ellipsisSource = require('!!raw-loader!./ellipsis');
+
+import TruncationOffset from './truncation_offset';
+const truncationOffsetSource = require('!!raw-loader!./truncation_offset');
+
+import TruncationPosition from './truncation_position';
+const truncationPositionSource = require('!!raw-loader!./truncation_position');
+
+import RenderProp from './render_prop';
+const renderPropSource = require('!!raw-loader!./render_prop');
+
+export const TextTruncateExample = {
+  title: 'Text truncation',
+  sections: [
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: truncationSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            <strong>EuiTextTruncate</strong> attempts to provide customizable
+            and size-aware truncation logic (until the happy day that browsers
+            add more{' '}
+            <EuiLink
+              href="https://github.com/w3c/csswg-drafts/issues/3937"
+              target="_blank"
+            >
+              customizable truncation out-of-the-box via CSS
+            </EuiLink>
+            ).
+          </p>
+          <p>
+            The four truncation styles supported are <EuiCode>start</EuiCode>,{' '}
+            <EuiCode>end</EuiCode>, <EuiCode>startEnd</EuiCode>, and{' '}
+            <EuiCode>middle</EuiCode>. The below demo can also be dynamically
+            resized to see how different truncation styles respond.
+          </p>
+        </>
+      ),
+      demo: <Truncation />,
+      props: { EuiTextTruncate },
+      snippet: `<EuiTextTruncate text="Hello world" />`,
+    },
+    {
+      text: (
+        <>
+          <EuiCallOut
+            iconType="accessibility"
+            title="Accessibility and comparison to text-overflow"
+          >
+            <p>
+              <strong>EuiTextTruncate</strong> attempts to mimic the behavior of{' '}
+              <EuiCode>text-overflow: ellipsis</EuiCode> as closely as possible,
+              although there may be edge cases and cross-browser issues, as this
+              is essentially a browser implementation we are trying to polyfill.
+            </p>
+            <ul>
+              <li>
+                Screen readers should ignore the truncated text and only read
+                out the full text.
+              </li>
+              <li>
+                Sighted mouse users will be able to briefly hover over the
+                truncated text and read the full text in a native browser title
+                tooltip.
+              </li>
+              <li>
+                For mouse users, double clicking to select the truncated line
+                should allow copying the full untruncated text.
+              </li>
+            </ul>
+          </EuiCallOut>
+        </>
+      ),
+    },
+    {
+      title: 'Custom ellipsis',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: ellipsisSource,
+        },
+      ],
+      text: (
+        <p>
+          By default, <strong>EuiTextTruncate</strong> uses with the unicode
+          character for horizontal ellipis. It can be customized via the{' '}
+          <EuiCode>ellipsis</EuiCode> prop as necessary (e.g. for specific
+          languages, extra punctuation, etc).
+        </p>
+      ),
+      demo: <Ellipsis />,
+      props: { EuiTextTruncate },
+      snippet: `<EuiTextTruncate text="Hello world" ellipsis="[...]" />`,
+    },
+    {
+      title: 'Truncation offset',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: truncationOffsetSource,
+        },
+      ],
+      text: (
+        <p>
+          The <EuiCode>start</EuiCode> and <EuiCode>end</EuiCode> truncation
+          types support a <EuiCode>truncationOffset</EuiCode> property that
+          allows preserving a specified number of characters at either the start
+          or end of the text. Increase or decrease the number control below to
+          see the prop in action.
+        </p>
+      ),
+      demo: <TruncationOffset />,
+      props: { EuiTextTruncate },
+      snippet: `<EuiTextTruncate
+  text="Hello world"
+  truncation="start"
+  truncationOffset={5}
+/>`,
+    },
+    {
+      title: 'Truncation position',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: truncationPositionSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            The <EuiCode>startEnd</EuiCode> truncation type supports a{' '}
+            <EuiCode>truncationPosition</EuiCode> property. By default,{' '}
+            <EuiCode>startEnd</EuiCode> anchors the displayed text to the middle
+            of the string. However, you may prefer to display a specific
+            subsection of the full text closer to the start or end, which this
+            prop allows.
+          </p>
+          <p>
+            This behavior will intelligently detect when positions are close to
+            the start or end of the text, and omit leading or trailing ellipses
+            when necessary. If the passed position is greater than the total
+            text length, the truncation will simply default to `start` instead.
+          </p>
+          <p>
+            Increase or decrease the number control below to see the prop in
+            action.
+          </p>
+        </>
+      ),
+      demo: <TruncationPosition />,
+      props: { EuiTextTruncate },
+      snippet: `<EuiTextTruncate
+  text="Hello world"
+  truncation="startEnd"
+  truncationPosition={10}
+/>`,
+    },
+    {
+      title: 'Render prop',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: renderPropSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            By default, <strong>EuiTextTruncate</strong> will automatically
+            output the calculated truncated string. You can optionally override
+            this by passing a render prop function to{' '}
+            <EuiCode>children</EuiCode>, which allows for more flexible text
+            rendering.
+          </p>
+          <p>
+            The primary type of use case in mind for this functionality would be
+            using{' '}
+            <Link to="/#/utilities/highlight-and-mark">
+              <strong>EuiHighlight</strong> or <strong>EuiMark</strong>
+            </Link>{' '}
+            to highlight certain portions of the text. This example also
+            demonstrates the primary use case for the{' '}
+            <EuiCode>truncationPosition</EuiCode> prop. If a user is searching
+            for a specific word in truncated text, you should pass the index of
+            that found word to ensure it is always visible, for the best user
+            experience.
+          </p>
+          <EuiCallOut
+            color="warning"
+            iconType="warning"
+            title="Do not render excessive extra content alongside the text. The sizing logic will not account for it, and the truncation calculations will be off."
+          />
+        </>
+      ),
+      demo: <RenderProp />,
+      props: { EuiTextTruncate },
+      snippet: `<EuiTextTruncate text="Hello world">
+  {(text) => <EuiMark>{text}</EuiMark>}
+</EuiTextTruncate>`,
+    },
+  ],
+};

--- a/src-docs/src/views/text_truncate/text_truncate_example.js
+++ b/src-docs/src/views/text_truncate/text_truncate_example.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { css } from '@emotion/react';
 
 import { GuideSectionTypes } from '../../components';
 
@@ -24,6 +25,9 @@ const truncationPositionSource = require('!!raw-loader!./truncation_position');
 
 import RenderProp from './render_prop';
 const renderPropSource = require('!!raw-loader!./render_prop');
+
+import Performance from './performance';
+const performanceSource = require('!!raw-loader!./performance');
 
 export const TextTruncateExample = {
   title: 'Text truncation',
@@ -214,6 +218,80 @@ export const TextTruncateExample = {
       snippet: `<EuiTextTruncate text="Hello world">
   {(text) => <EuiMark>{text}</EuiMark>}
 </EuiTextTruncate>`,
+    },
+    {
+      title: 'Performance',
+      text: (
+        <>
+          <p>
+            <strong>EuiTextTruncate</strong> uses an extra DOM element under the
+            hood to manipulate text and calculate whether the text width fits
+            within the available width. Additionally, by default, the component
+            will include its own resize observer in order to react to width
+            changes.
+          </p>
+          <p>
+            These functionalities can cause performance issues if the component
+            is rendered many times per page, and we would strongly recommend
+            using caution when doing so. Several escape hatches are available
+            for performance improvements:
+          </p>
+          <ol
+            css={({ euiTheme }) =>
+              css`
+                li:not(:last-child) {
+                  margin-block-end: ${euiTheme.size.m};
+                }
+              `
+            }
+          >
+            <li>
+              Pass a <EuiCode>width</EuiCode> prop to skip initializing a resize
+              observer for each component instance. For text within a container
+              of the same width, we would strongly recommend applying a single
+              resize observer to the parent container and passing down that
+              width to all child <strong>EuiTextTruncate</strong>s.
+            </li>
+            <li>
+              Use the <EuiCode>measurementRenderAPI="canvas"</EuiCode> prop to
+              utilize the Canvas API for text measurement. While this can be
+              significantly more performant at higher iterations, please do note
+              that there are minute pixel to subpixel differences in this
+              rendering method.
+            </li>
+            <li>
+              Strongly consider using{' '}
+              <EuiLink
+                href="https://github.com/bvaughn/react-window"
+                target="_blank"
+              >
+                virtualization
+              </EuiLink>{' '}
+              to reduce the number of rendered elements visible at any given
+              time, or{' '}
+              <EuiLink href="https://lodash.com/docs/#throttle" target="_blank">
+                throttling
+              </EuiLink>{' '}
+              any resize observers or width-based logic.
+            </li>
+            <li>
+              If necessary, consider pulling out the underlying{' '}
+              <EuiCode>TruncationUtilsForDOM</EuiCode> and{' '}
+              <EuiCode>TruncationUtilsForCanvas</EuiCode> truncation utils and
+              re-using the same canvas context or DOM node, as opposed to
+              repeatedly creating new ones.
+            </li>
+          </ol>
+        </>
+      ),
+      demo: <Performance />,
+      source: [{ type: GuideSectionTypes.TSX, code: performanceSource }],
+      props: { EuiTextTruncate },
+      snippet: `<EuiTextTruncate
+  text="Hello world"
+  width={width}
+  measurementRenderAPI="canvas"
+/>`,
     },
   ],
 };

--- a/src-docs/src/views/text_truncate/truncation.tsx
+++ b/src-docs/src/views/text_truncate/truncation.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { css } from '@emotion/react';
+
+import { EuiPanel, EuiText, EuiTextTruncate } from '../../../../src';
+
+export default () => {
+  return (
+    <EuiText>
+      <EuiPanel
+        css={css`
+          overflow: auto;
+          resize: horizontal; /* Not all browsers support resize logical properties yet */
+          resize: inline;
+          inline-size: 35ch;
+          max-inline-size: 100%;
+        `}
+      >
+        <EuiTextTruncate
+          text="The quick brown fox jumps over the lazy dog."
+          truncation="start"
+        />
+        <EuiTextTruncate
+          text="But the dog wasn’t lazy, it was just practicing mindfulness, so it had a greater sense of life-satisfaction than that fox with all its silly jumping."
+          truncation="end"
+        />
+        <EuiTextTruncate
+          text="And from the fox’s perspective, life was full of hoops to jump through, low-hanging fruit to jump for, and dead car batteries to jump-start."
+          truncation="startEnd"
+        />
+        <EuiTextTruncate
+          text="So it thought the dog was making a poor life choice by focusing so much on mindfulness. What if its car broke down?"
+          truncation="middle"
+        />
+      </EuiPanel>
+    </EuiText>
+  );
+};

--- a/src-docs/src/views/text_truncate/truncation_offset.tsx
+++ b/src-docs/src/views/text_truncate/truncation_offset.tsx
@@ -18,6 +18,7 @@ export default () => {
           compressed
           value={truncationOffset}
           onChange={(e) => setTruncationOffset(Number(e.target.value))}
+          max={30}
         />
       </EuiFormRow>
       <EuiSpacer />

--- a/src-docs/src/views/text_truncate/truncation_offset.tsx
+++ b/src-docs/src/views/text_truncate/truncation_offset.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+import {
+  EuiPanel,
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiSpacer,
+  EuiText,
+  EuiTextTruncate,
+} from '../../../../src';
+
+export default () => {
+  const [truncationOffset, setTruncationOffset] = useState(3);
+  return (
+    <EuiText>
+      <EuiFormRow label="Truncation offset">
+        <EuiFieldNumber
+          compressed
+          value={truncationOffset}
+          onChange={(e) => setTruncationOffset(Number(e.target.value))}
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiPanel css={{ inlineSize: '40ch', maxInlineSize: '100%' }}>
+        <EuiTextTruncate
+          text="But the dog wasn’t lazy, it was just practicing mindfulness, so it had a greater sense of life-satisfaction than that fox with all its silly jumping."
+          truncation="start"
+          truncationOffset={truncationOffset}
+        />
+        <EuiTextTruncate
+          text="And from the fox’s perspective, life was full of hoops to jump through, low-hanging fruit to jump for, and dead car batteries to jump-start."
+          truncation="end"
+          truncationOffset={truncationOffset}
+        />
+      </EuiPanel>
+    </EuiText>
+  );
+};

--- a/src-docs/src/views/text_truncate/truncation_position.tsx
+++ b/src-docs/src/views/text_truncate/truncation_position.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+import {
+  EuiPanel,
+  EuiFormRow,
+  EuiFieldNumber,
+  EuiSpacer,
+  EuiText,
+  EuiTextTruncate,
+} from '../../../../src';
+
+export default () => {
+  const [truncationPosition, setTruncationPosition] = useState(45);
+  return (
+    <EuiText>
+      <EuiFormRow label="Truncation position">
+        <EuiFieldNumber
+          compressed
+          value={truncationPosition}
+          onChange={(e) => setTruncationPosition(Number(e.target.value))}
+        />
+      </EuiFormRow>
+      <EuiSpacer />
+      <EuiPanel css={{ inlineSize: '40ch', maxInlineSize: '100%' }}>
+        <EuiTextTruncate
+          text="But the dog wasn’t lazy, it was just practicing mindfulness, so it had a greater sense of life-satisfaction than that fox with all its silly jumping."
+          truncation="startEnd"
+          truncationPosition={truncationPosition}
+        />
+      </EuiPanel>
+    </EuiText>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -168,6 +168,8 @@ export * from './text';
 
 export * from './text_diff';
 
+export * from './text_truncate';
+
 export * from './timeline';
 
 export * from './title';

--- a/src/components/text_truncate/__snapshots__/text_truncate.test.tsx.snap
+++ b/src/components/text_truncate/__snapshots__/text_truncate.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiTextTruncate renders 1`] = `
+<div
+  aria-label="aria-label"
+  class="testClass1 testClass2 emotion-euiTextTruncate-euiTestCss"
+  data-test-subj="test subject string"
+  title="Hello world"
+>
+  Hello world
+</div>
+`;

--- a/src/components/text_truncate/__snapshots__/text_truncate.test.tsx.snap
+++ b/src/components/text_truncate/__snapshots__/text_truncate.test.tsx.snap
@@ -5,8 +5,11 @@ exports[`EuiTextTruncate renders 1`] = `
   aria-label="aria-label"
   class="testClass1 testClass2 emotion-euiTextTruncate-euiTestCss"
   data-test-subj="test subject string"
-  title="Hello world"
 >
-  Hello world
+  <span
+    data-test-subj="fullText"
+  >
+    Hello world
+  </span>
 </div>
 `;

--- a/src/components/text_truncate/index.ts
+++ b/src/components/text_truncate/index.ts
@@ -12,4 +12,4 @@ export type {
 } from './text_truncate';
 export { EuiTextTruncate } from './text_truncate';
 
-export { TruncationUtils } from './utils';
+export { TruncationUtilsForDOM, TruncationUtilsForCanvas } from './utils';

--- a/src/components/text_truncate/index.ts
+++ b/src/components/text_truncate/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type { EuiTextTruncateProps } from './text_truncate';
+export { EuiTextTruncate } from './text_truncate';

--- a/src/components/text_truncate/index.ts
+++ b/src/components/text_truncate/index.ts
@@ -12,4 +12,4 @@ export type {
 } from './text_truncate';
 export { EuiTextTruncate } from './text_truncate';
 
-export { TruncationUtilsForDOM, TruncationUtilsForCanvas } from './utils';
+export { TruncationUtilsWithDOM, TruncationUtilsWithCanvas } from './utils';

--- a/src/components/text_truncate/index.ts
+++ b/src/components/text_truncate/index.ts
@@ -11,3 +11,5 @@ export type {
   EuiTextTruncationTypes,
 } from './text_truncate';
 export { EuiTextTruncate } from './text_truncate';
+
+export { TruncationUtils } from './utils';

--- a/src/components/text_truncate/index.ts
+++ b/src/components/text_truncate/index.ts
@@ -6,5 +6,8 @@
  * Side Public License, v 1.
  */
 
-export type { EuiTextTruncateProps } from './text_truncate';
+export type {
+  EuiTextTruncateProps,
+  EuiTextTruncationTypes,
+} from './text_truncate';
 export { EuiTextTruncate } from './text_truncate';

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -1,0 +1,285 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../cypress/support" />
+
+import React from 'react';
+
+import { EuiTextTruncate } from './text_truncate';
+
+describe('EuiTextTruncate', () => {
+  const props = {
+    id: 'text',
+    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    width: 200,
+  };
+
+  it('returns the text in full if no truncation is needed', () => {
+    cy.mount(<EuiTextTruncate {...props} text="Hello world" />);
+    cy.get('#text').should('have.text', 'Hello world');
+  });
+
+  describe('truncation', () => {
+    const expectedMiddleOutput = 'Lorem ipsum d…adipiscing elit';
+    const expectedStartOutput = '…t, consectetur adipiscing elit';
+    const expectedEndOutput = 'Lorem ipsum dolor sit amet, …';
+    const expectedStartEndOutput = '…lor sit amet, consectetur a…';
+
+    describe('middle', () => {
+      it('truncations and inserts ellispes in the middle of the text', () => {
+        cy.mount(<EuiTextTruncate {...props} truncation="middle" />);
+        cy.get('#text').should('have.text', expectedMiddleOutput);
+      });
+
+      it('ignores `truncationOffset` and `truncationPosition`', () => {
+        cy.mount(
+          <EuiTextTruncate
+            {...props}
+            truncation="middle"
+            truncationOffset={5}
+            truncationPosition={20}
+          />
+        );
+        cy.get('#text').should('have.text', expectedMiddleOutput);
+      });
+    });
+
+    describe('start', () => {
+      it('truncates and inserts ellispis at the start of the text', () => {
+        cy.mount(<EuiTextTruncate {...props} truncation="start" />);
+        cy.get('#text').should('have.text', expectedStartOutput);
+      });
+
+      describe('truncationOffset', () => {
+        it('preserves starting characters with `truncationOffset`', () => {
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="start"
+              truncationOffset={5}
+            />
+          );
+          cy.get('#text').should('have.text', 'Lorem…ectetur adipiscing elit');
+        });
+
+        it('falls back to middle truncation if truncationOffset is too large', () => {
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="start"
+              truncationOffset={100}
+            />
+          );
+          cy.get('#text').should('have.text', expectedMiddleOutput);
+        });
+      });
+    });
+
+    describe('end', () => {
+      it('truncates and inserts ellispis at the end of the text', () => {
+        cy.mount(<EuiTextTruncate {...props} truncation="end" />);
+        cy.get('#text').should('have.text', expectedEndOutput);
+      });
+
+      describe('truncationOffset', () => {
+        it('preserves starting characters with `truncationOffset`', () => {
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="end"
+              truncationOffset={10}
+            />
+          );
+          cy.get('#text').should('have.text', 'Lorem ipsum dolor …scing elit');
+        });
+
+        it('falls back to middle truncation if truncationOffset is too large', () => {
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="end"
+              truncationOffset={30}
+            />
+          );
+          cy.get('#text').should('have.text', expectedMiddleOutput);
+        });
+      });
+    });
+
+    describe('startEnd', () => {
+      it('truncates and inserts ellipses at both the start and end of the text', () => {
+        cy.mount(<EuiTextTruncate {...props} truncation="startEnd" />);
+        cy.get('#text').should('have.text', expectedStartEndOutput);
+      });
+
+      it('ignores `truncationOffset`', () => {
+        cy.mount(
+          <EuiTextTruncate
+            {...props}
+            truncation="startEnd"
+            truncationOffset={10}
+          />
+        );
+        cy.get('#text').should('have.text', expectedStartEndOutput);
+      });
+
+      describe('truncationPosition', () => {
+        it('allows customizing the anchor at which the truncation is positioned from', () => {
+          cy.mount(
+            <>
+              <EuiTextTruncate
+                {...props}
+                id="text1"
+                truncation="startEnd"
+                truncationPosition={15}
+              />
+              <EuiTextTruncate
+                {...props}
+                id="text2"
+                truncation="startEnd"
+                truncationPosition={35}
+              />
+            </>
+          );
+          cy.get('#text1').should('have.text', '…rem ipsum dolor sit amet, …');
+          cy.get('#text2').should('have.text', '…amet, consectetur adipisci…');
+        });
+
+        it('does not display the leading ellipsis if the anchor is close enough to the start', () => {
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="startEnd"
+              truncationPosition={5}
+            />
+          );
+          cy.get('#text').should('have.text', expectedEndOutput);
+        });
+
+        it('does not display the leading ellipsis if the anchor position is <= 0', () => {
+          cy.mount(
+            <>
+              <EuiTextTruncate
+                {...props}
+                id="text1"
+                truncation="startEnd"
+                truncationPosition={0}
+              />
+              <EuiTextTruncate
+                {...props}
+                id="text2"
+                truncation="startEnd"
+                truncationPosition={-100}
+              />
+            </>
+          );
+          cy.get('#text1').should('have.text', expectedEndOutput);
+          cy.get('#text2').should('have.text', expectedEndOutput);
+        });
+
+        it('does not display the trailing ellipsis if the anchor is close enough to the end', () => {
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="startEnd"
+              truncationPosition={42}
+            />
+          );
+          cy.get('#text').should('have.text', expectedStartOutput);
+        });
+
+        it('does not display the trailing ellipsis if the anchor position is >= the text length', () => {
+          cy.mount(
+            <>
+              <EuiTextTruncate
+                {...props}
+                id="text1"
+                truncation="startEnd"
+                truncationPosition={props.text.length}
+              />
+              <EuiTextTruncate
+                {...props}
+                id="text2"
+                truncation="startEnd"
+                truncationPosition={100}
+              />
+            </>
+          );
+          cy.get('#text1').should('have.text', expectedStartOutput);
+          cy.get('#text2').should('have.text', expectedStartOutput);
+        });
+      });
+    });
+  });
+
+  describe('ellipsis', () => {
+    it('allows customizing the symbols used to represent an ellipsis', () => {
+      cy.mount(
+        <>
+          <EuiTextTruncate
+            {...props}
+            id="text1"
+            truncation="middle"
+            ellipsis="[...]"
+          />
+          <EuiTextTruncate
+            {...props}
+            id="text2"
+            truncation="startEnd"
+            ellipsis="--"
+          />
+        </>
+      );
+      cy.get('#text1').should('have.text', 'Lorem ipsum [...]dipiscing elit');
+      cy.get('#text2').should('have.text', '--lor sit amet, consectetur a--');
+    });
+
+    it("does not render if the container isn't wide enough for the ellipsis", () => {
+      cy.window().then((win) => {
+        cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
+      });
+      cy.mount(
+        <>
+          <EuiTextTruncate
+            {...props}
+            id="text1"
+            truncation="startEnd"
+            width={30}
+          />
+          <EuiTextTruncate
+            {...props}
+            id="text2"
+            ellipsis="A ridiculously long ellipsis, longer than the container"
+          />
+        </>
+      );
+      cy.get('#text1').should('have.text', '');
+      cy.get('#text2').should('have.text', '');
+
+      cy.get('@spyConsoleError')
+        .should(
+          'be.calledWith',
+          'The truncation ellipsis is larger than the available width. No text can be rendered.'
+        )
+        .should('be.calledTwice');
+    });
+  });
+
+  describe('children', () => {
+    it('allows customizing the rendered text via a render prop', () => {
+      cy.mount(
+        <EuiTextTruncate {...props}>
+          {(text) => <span data-test-subj="test">{text}</span>}
+        </EuiTextTruncate>
+      );
+      cy.get('[data-test-subj="test"]').should('exist');
+    });
+  });
+});

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -108,7 +108,7 @@ describe('EuiTextTruncate', () => {
           );
         });
 
-        it('falls back to middle truncation if truncationOffset is too large for the text', () => {
+        it('ignores truncationOffset if larger than the text length', () => {
           mount(
             <EuiTextTruncate
               {...props}
@@ -116,7 +116,7 @@ describe('EuiTextTruncate', () => {
               truncationOffset={100}
             />
           );
-          getTruncatedText().should('have.text', expectedMiddleOutput);
+          getTruncatedText().should('have.text', expectedStartOutput);
         });
 
         it('logs an error if the truncationOffset is too large for the container', () => {
@@ -133,7 +133,7 @@ describe('EuiTextTruncate', () => {
           );
           cy.get('@spyConsoleError').should(
             'be.calledWith',
-            'The passed truncationOffset of 5 is too large for available width.'
+            'The passed truncationOffset is too large for the available width. Truncating the offset instead.'
           );
         });
       });
@@ -160,15 +160,15 @@ describe('EuiTextTruncate', () => {
           );
         });
 
-        it('falls back to middle truncation if truncationOffset is too large for the text', () => {
+        it('ignores truncationOffset if larger than the text length', () => {
           mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
-              truncationOffset={30}
+              truncationOffset={100}
             />
           );
-          getTruncatedText().should('have.text', expectedMiddleOutput);
+          getTruncatedText().should('have.text', expectedEndOutput);
         });
 
         it('logs an error if the truncationOffset is too large for the container', () => {
@@ -185,7 +185,7 @@ describe('EuiTextTruncate', () => {
           );
           cy.get('@spyConsoleError').should(
             'be.calledWith',
-            'The passed truncationOffset of 10 is too large for available width.'
+            'The passed truncationOffset is too large for the available width. Truncating the offset instead.'
           );
         });
       });

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -364,4 +364,15 @@ describe('EuiTextTruncate', () => {
       cy.get('[data-test-subj="test"]').should('exist');
     });
   });
+
+  describe('resize observer behavior', () => {
+    it('renders a resize observer if `width` is not passed', () => {
+      cy.viewport(200, 50);
+      cy.mount(<EuiTextTruncate {...props} width={undefined} />);
+      getTruncatedText().should('have.text', 'Lorem ipsum dolor sit amet, …');
+
+      cy.viewport(100, 50);
+      getTruncatedText().should('have.text', 'Lorem ipsum …');
+    });
+  });
 });

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -10,7 +10,7 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../cypress/support" />
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { EuiTextTruncate } from './text_truncate';
 
@@ -21,11 +21,32 @@ describe('EuiTextTruncate', () => {
     width: 200,
   };
 
+  // CI doesn't have access to the Inter font, so we need to manually include it
+  // for font calculations to work correctly
+  const createFontStylesheet = () => {
+    const linkElem = document.createElement('link');
+    linkElem.setAttribute('rel', 'stylesheet');
+    linkElem.setAttribute(
+      'href',
+      'https://fonts.googleapis.com/css2?family=Inter:wght@300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap'
+    );
+    linkElem.id = 'font-loaded';
+    document.head.appendChild(linkElem);
+    cy.wait(1000); // Wait a tick to give the time to load/swap in
+  };
+
+  const mount = (children: ReactNode) => {
+    if (!document.getElementById('font-loaded')) {
+      createFontStylesheet();
+    }
+    cy.mount(children);
+  };
+
   const getTruncatedText = (selector = '#text') =>
     cy.get(`${selector} [data-test-subj="truncatedText"]`);
 
   it('does not render truncated text if no truncation is needed', () => {
-    cy.mount(<EuiTextTruncate {...props} text="Hello world" />);
+    mount(<EuiTextTruncate {...props} text="Hello world" />);
     cy.get('#text').should('not.have.attr', 'title');
     cy.get('#text [data-test-subj="fullText"]').should(
       'have.text',
@@ -35,7 +56,7 @@ describe('EuiTextTruncate', () => {
   });
 
   it('renders truncated text and a title when truncation is needed', () => {
-    cy.mount(<EuiTextTruncate {...props} />);
+    mount(<EuiTextTruncate {...props} />);
     cy.get('#text').should('have.attr', 'title', props.text);
     cy.get('#text [data-test-subj="fullText"]').should('have.text', props.text);
     getTruncatedText().should('exist');
@@ -49,12 +70,12 @@ describe('EuiTextTruncate', () => {
 
     describe('middle', () => {
       it('truncations and inserts ellispes in the middle of the text', () => {
-        cy.mount(<EuiTextTruncate {...props} truncation="middle" />);
+        mount(<EuiTextTruncate {...props} truncation="middle" />);
         getTruncatedText().should('have.text', expectedMiddleOutput);
       });
 
       it('ignores `truncationOffset` and `truncationPosition`', () => {
-        cy.mount(
+        mount(
           <EuiTextTruncate
             {...props}
             truncation="middle"
@@ -68,13 +89,13 @@ describe('EuiTextTruncate', () => {
 
     describe('start', () => {
       it('truncates and inserts ellispis at the start of the text', () => {
-        cy.mount(<EuiTextTruncate {...props} truncation="start" />);
+        mount(<EuiTextTruncate {...props} truncation="start" />);
         getTruncatedText().should('have.text', expectedStartOutput);
       });
 
       describe('truncationOffset', () => {
         it('preserves starting characters with `truncationOffset`', () => {
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="start"
@@ -88,7 +109,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('falls back to middle truncation if truncationOffset is too large for the text', () => {
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="start"
@@ -102,7 +123,7 @@ describe('EuiTextTruncate', () => {
           cy.window().then((win) => {
             cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
           });
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="start"
@@ -120,13 +141,13 @@ describe('EuiTextTruncate', () => {
 
     describe('end', () => {
       it('truncates and inserts ellispis at the end of the text', () => {
-        cy.mount(<EuiTextTruncate {...props} truncation="end" />);
+        mount(<EuiTextTruncate {...props} truncation="end" />);
         getTruncatedText().should('have.text', expectedEndOutput);
       });
 
       describe('truncationOffset', () => {
         it('preserves ending characters with `truncationOffset`', () => {
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
@@ -140,7 +161,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('falls back to middle truncation if truncationOffset is too large for the text', () => {
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
@@ -154,7 +175,7 @@ describe('EuiTextTruncate', () => {
           cy.window().then((win) => {
             cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
           });
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
@@ -172,12 +193,12 @@ describe('EuiTextTruncate', () => {
 
     describe('startEnd', () => {
       it('truncates and inserts ellipses at both the start and end of the text', () => {
-        cy.mount(<EuiTextTruncate {...props} truncation="startEnd" />);
+        mount(<EuiTextTruncate {...props} truncation="startEnd" />);
         getTruncatedText().should('have.text', expectedStartEndOutput);
       });
 
       it('ignores `truncationOffset`', () => {
-        cy.mount(
+        mount(
           <EuiTextTruncate
             {...props}
             truncation="startEnd"
@@ -189,7 +210,7 @@ describe('EuiTextTruncate', () => {
 
       describe('truncationPosition', () => {
         it('allows customizing the anchor at which the truncation is positioned from', () => {
-          cy.mount(
+          mount(
             <>
               <EuiTextTruncate
                 {...props}
@@ -216,7 +237,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the leading ellipsis if the anchor is close enough to the start', () => {
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="startEnd"
@@ -227,7 +248,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the leading ellipsis if the anchor position is <= 0', () => {
-          cy.mount(
+          mount(
             <>
               <EuiTextTruncate
                 {...props}
@@ -248,7 +269,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the trailing ellipsis if the anchor is close enough to the end', () => {
-          cy.mount(
+          mount(
             <EuiTextTruncate
               {...props}
               truncation="startEnd"
@@ -259,7 +280,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the trailing ellipsis if the anchor position is >= the text length', () => {
-          cy.mount(
+          mount(
             <>
               <EuiTextTruncate
                 {...props}
@@ -284,7 +305,7 @@ describe('EuiTextTruncate', () => {
 
   describe('ellipsis', () => {
     it('allows customizing the symbols used to represent an ellipsis', () => {
-      cy.mount(
+      mount(
         <>
           <EuiTextTruncate
             {...props}
@@ -314,7 +335,7 @@ describe('EuiTextTruncate', () => {
       cy.window().then((win) => {
         cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
       });
-      cy.mount(
+      mount(
         <>
           <EuiTextTruncate
             {...props}
@@ -343,7 +364,7 @@ describe('EuiTextTruncate', () => {
 
   describe('children', () => {
     it('allows customizing the rendered text via a render prop', () => {
-      cy.mount(
+      mount(
         <EuiTextTruncate {...props}>
           {(text) => <span data-test-subj="test">{text}</span>}
         </EuiTextTruncate>

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -31,7 +31,7 @@ describe('EuiTextTruncate', () => {
       'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap'
     );
     document.head.appendChild(linkElem);
-    cy.wait(1000); // Wait a tick to give the font time to load/swap in
+    cy.wait(1000); // Wait a second to give the font time to load/swap in
   });
 
   const getTruncatedText = (selector = '#text') =>
@@ -61,7 +61,7 @@ describe('EuiTextTruncate', () => {
     const expectedStartEndOutput = '…lor sit amet, consectetur a…';
 
     describe('middle', () => {
-      it('truncations and inserts ellispes in the middle of the text', () => {
+      it('truncates and inserts ellispes in the middle of the text', () => {
         cy.mount(<EuiTextTruncate {...props} truncation="middle" />);
         getTruncatedText().should('have.text', expectedMiddleOutput);
       });
@@ -110,24 +110,6 @@ describe('EuiTextTruncate', () => {
           );
           getTruncatedText().should('have.text', expectedStartOutput);
         });
-
-        it('logs an error if the truncationOffset is too large for the container', () => {
-          cy.window().then((win) => {
-            cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
-          });
-          cy.mount(
-            <EuiTextTruncate
-              {...props}
-              truncation="start"
-              truncationOffset={5}
-              width={15}
-            />
-          );
-          cy.get('@spyConsoleError').should(
-            'be.calledWith',
-            'The passed truncationOffset is too large for the available width. Truncating the offset instead.'
-          );
-        });
       });
     });
 
@@ -161,24 +143,6 @@ describe('EuiTextTruncate', () => {
             />
           );
           getTruncatedText().should('have.text', expectedEndOutput);
-        });
-
-        it('logs an error if the truncationOffset is too large for the container', () => {
-          cy.window().then((win) => {
-            cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
-          });
-          cy.mount(
-            <EuiTextTruncate
-              {...props}
-              truncation="end"
-              truncationOffset={10}
-              width={20}
-            />
-          );
-          cy.get('@spyConsoleError').should(
-            'be.calledWith',
-            'The passed truncationOffset is too large for the available width. Truncating the offset instead.'
-          );
         });
       });
     });

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -10,7 +10,7 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../cypress/support" />
 
-import React, { ReactNode } from 'react';
+import React from 'react';
 
 import { EuiTextTruncate } from './text_truncate';
 
@@ -23,30 +23,22 @@ describe('EuiTextTruncate', () => {
 
   // CI doesn't have access to the Inter font, so we need to manually include it
   // for font calculations to work correctly
-  const createFontStylesheet = () => {
+  before(() => {
     const linkElem = document.createElement('link');
     linkElem.setAttribute('rel', 'stylesheet');
     linkElem.setAttribute(
       'href',
-      'https://fonts.googleapis.com/css2?family=Inter:wght@300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap'
+      'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap'
     );
-    linkElem.id = 'font-loaded';
     document.head.appendChild(linkElem);
-    cy.wait(1000); // Wait a tick to give the time to load/swap in
-  };
-
-  const mount = (children: ReactNode) => {
-    if (!document.getElementById('font-loaded')) {
-      createFontStylesheet();
-    }
-    cy.mount(children);
-  };
+    cy.wait(1000); // Wait a tick to give the font time to load/swap in
+  });
 
   const getTruncatedText = (selector = '#text') =>
     cy.get(`${selector} [data-test-subj="truncatedText"]`);
 
   it('does not render truncated text if no truncation is needed', () => {
-    mount(<EuiTextTruncate {...props} text="Hello world" />);
+    cy.mount(<EuiTextTruncate {...props} text="Hello world" />);
     cy.get('#text').should('not.have.attr', 'title');
     cy.get('#text [data-test-subj="fullText"]').should(
       'have.text',
@@ -56,7 +48,7 @@ describe('EuiTextTruncate', () => {
   });
 
   it('renders truncated text and a title when truncation is needed', () => {
-    mount(<EuiTextTruncate {...props} />);
+    cy.mount(<EuiTextTruncate {...props} />);
     cy.get('#text').should('have.attr', 'title', props.text);
     cy.get('#text [data-test-subj="fullText"]').should('have.text', props.text);
     getTruncatedText().should('exist');
@@ -70,12 +62,12 @@ describe('EuiTextTruncate', () => {
 
     describe('middle', () => {
       it('truncations and inserts ellispes in the middle of the text', () => {
-        mount(<EuiTextTruncate {...props} truncation="middle" />);
+        cy.mount(<EuiTextTruncate {...props} truncation="middle" />);
         getTruncatedText().should('have.text', expectedMiddleOutput);
       });
 
       it('ignores `truncationOffset` and `truncationPosition`', () => {
-        mount(
+        cy.mount(
           <EuiTextTruncate
             {...props}
             truncation="middle"
@@ -89,13 +81,13 @@ describe('EuiTextTruncate', () => {
 
     describe('start', () => {
       it('truncates and inserts ellispis at the start of the text', () => {
-        mount(<EuiTextTruncate {...props} truncation="start" />);
+        cy.mount(<EuiTextTruncate {...props} truncation="start" />);
         getTruncatedText().should('have.text', expectedStartOutput);
       });
 
       describe('truncationOffset', () => {
         it('preserves starting characters with `truncationOffset`', () => {
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="start"
@@ -109,7 +101,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('ignores truncationOffset if larger than the text length', () => {
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="start"
@@ -123,7 +115,7 @@ describe('EuiTextTruncate', () => {
           cy.window().then((win) => {
             cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
           });
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="start"
@@ -141,13 +133,13 @@ describe('EuiTextTruncate', () => {
 
     describe('end', () => {
       it('truncates and inserts ellispis at the end of the text', () => {
-        mount(<EuiTextTruncate {...props} truncation="end" />);
+        cy.mount(<EuiTextTruncate {...props} truncation="end" />);
         getTruncatedText().should('have.text', expectedEndOutput);
       });
 
       describe('truncationOffset', () => {
         it('preserves ending characters with `truncationOffset`', () => {
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
@@ -161,7 +153,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('ignores truncationOffset if larger than the text length', () => {
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
@@ -175,7 +167,7 @@ describe('EuiTextTruncate', () => {
           cy.window().then((win) => {
             cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
           });
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="end"
@@ -193,12 +185,12 @@ describe('EuiTextTruncate', () => {
 
     describe('startEnd', () => {
       it('truncates and inserts ellipses at both the start and end of the text', () => {
-        mount(<EuiTextTruncate {...props} truncation="startEnd" />);
+        cy.mount(<EuiTextTruncate {...props} truncation="startEnd" />);
         getTruncatedText().should('have.text', expectedStartEndOutput);
       });
 
       it('ignores `truncationOffset`', () => {
-        mount(
+        cy.mount(
           <EuiTextTruncate
             {...props}
             truncation="startEnd"
@@ -210,7 +202,7 @@ describe('EuiTextTruncate', () => {
 
       describe('truncationPosition', () => {
         it('allows customizing the anchor at which the truncation is positioned from', () => {
-          mount(
+          cy.mount(
             <>
               <EuiTextTruncate
                 {...props}
@@ -237,7 +229,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the leading ellipsis if the anchor is close enough to the start', () => {
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="startEnd"
@@ -248,7 +240,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the leading ellipsis if the anchor position is <= 0', () => {
-          mount(
+          cy.mount(
             <>
               <EuiTextTruncate
                 {...props}
@@ -269,7 +261,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the trailing ellipsis if the anchor is close enough to the end', () => {
-          mount(
+          cy.mount(
             <EuiTextTruncate
               {...props}
               truncation="startEnd"
@@ -280,7 +272,7 @@ describe('EuiTextTruncate', () => {
         });
 
         it('does not display the trailing ellipsis if the anchor position is >= the text length', () => {
-          mount(
+          cy.mount(
             <>
               <EuiTextTruncate
                 {...props}
@@ -305,7 +297,7 @@ describe('EuiTextTruncate', () => {
 
   describe('ellipsis', () => {
     it('allows customizing the symbols used to represent an ellipsis', () => {
-      mount(
+      cy.mount(
         <>
           <EuiTextTruncate
             {...props}
@@ -335,7 +327,7 @@ describe('EuiTextTruncate', () => {
       cy.window().then((win) => {
         cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
       });
-      mount(
+      cy.mount(
         <>
           <EuiTextTruncate
             {...props}
@@ -364,7 +356,7 @@ describe('EuiTextTruncate', () => {
 
   describe('children', () => {
     it('allows customizing the rendered text via a render prop', () => {
-      mount(
+      cy.mount(
         <EuiTextTruncate {...props}>
           {(text) => <span data-test-subj="test">{text}</span>}
         </EuiTextTruncate>

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -21,9 +21,24 @@ describe('EuiTextTruncate', () => {
     width: 200,
   };
 
-  it('returns the text in full if no truncation is needed', () => {
+  const getTruncatedText = (selector = '#text') =>
+    cy.get(`${selector} [data-test-subj="truncatedText"]`);
+
+  it('does not render truncated text if no truncation is needed', () => {
     cy.mount(<EuiTextTruncate {...props} text="Hello world" />);
-    cy.get('#text').should('have.text', 'Hello world');
+    cy.get('#text').should('not.have.attr', 'title');
+    cy.get('#text [data-test-subj="fullText"]').should(
+      'have.text',
+      'Hello world'
+    );
+    getTruncatedText().should('not.exist');
+  });
+
+  it('renders truncated text and a title when truncation is needed', () => {
+    cy.mount(<EuiTextTruncate {...props} />);
+    cy.get('#text').should('have.attr', 'title', props.text);
+    cy.get('#text [data-test-subj="fullText"]').should('have.text', props.text);
+    getTruncatedText().should('exist');
   });
 
   describe('truncation', () => {
@@ -35,7 +50,7 @@ describe('EuiTextTruncate', () => {
     describe('middle', () => {
       it('truncations and inserts ellispes in the middle of the text', () => {
         cy.mount(<EuiTextTruncate {...props} truncation="middle" />);
-        cy.get('#text').should('have.text', expectedMiddleOutput);
+        getTruncatedText().should('have.text', expectedMiddleOutput);
       });
 
       it('ignores `truncationOffset` and `truncationPosition`', () => {
@@ -47,14 +62,14 @@ describe('EuiTextTruncate', () => {
             truncationPosition={20}
           />
         );
-        cy.get('#text').should('have.text', expectedMiddleOutput);
+        getTruncatedText().should('have.text', expectedMiddleOutput);
       });
     });
 
     describe('start', () => {
       it('truncates and inserts ellispis at the start of the text', () => {
         cy.mount(<EuiTextTruncate {...props} truncation="start" />);
-        cy.get('#text').should('have.text', expectedStartOutput);
+        getTruncatedText().should('have.text', expectedStartOutput);
       });
 
       describe('truncationOffset', () => {
@@ -66,7 +81,10 @@ describe('EuiTextTruncate', () => {
               truncationOffset={5}
             />
           );
-          cy.get('#text').should('have.text', 'Lorem…ectetur adipiscing elit');
+          getTruncatedText().should(
+            'have.text',
+            'Lorem…ectetur adipiscing elit'
+          );
         });
 
         it('falls back to middle truncation if truncationOffset is too large for the text', () => {
@@ -77,7 +95,7 @@ describe('EuiTextTruncate', () => {
               truncationOffset={100}
             />
           );
-          cy.get('#text').should('have.text', expectedMiddleOutput);
+          getTruncatedText().should('have.text', expectedMiddleOutput);
         });
 
         it('logs an error if the truncationOffset is too large for the container', () => {
@@ -103,7 +121,7 @@ describe('EuiTextTruncate', () => {
     describe('end', () => {
       it('truncates and inserts ellispis at the end of the text', () => {
         cy.mount(<EuiTextTruncate {...props} truncation="end" />);
-        cy.get('#text').should('have.text', expectedEndOutput);
+        getTruncatedText().should('have.text', expectedEndOutput);
       });
 
       describe('truncationOffset', () => {
@@ -115,7 +133,10 @@ describe('EuiTextTruncate', () => {
               truncationOffset={10}
             />
           );
-          cy.get('#text').should('have.text', 'Lorem ipsum dolor …scing elit');
+          getTruncatedText().should(
+            'have.text',
+            'Lorem ipsum dolor …scing elit'
+          );
         });
 
         it('falls back to middle truncation if truncationOffset is too large for the text', () => {
@@ -126,7 +147,7 @@ describe('EuiTextTruncate', () => {
               truncationOffset={30}
             />
           );
-          cy.get('#text').should('have.text', expectedMiddleOutput);
+          getTruncatedText().should('have.text', expectedMiddleOutput);
         });
 
         it('logs an error if the truncationOffset is too large for the container', () => {
@@ -152,7 +173,7 @@ describe('EuiTextTruncate', () => {
     describe('startEnd', () => {
       it('truncates and inserts ellipses at both the start and end of the text', () => {
         cy.mount(<EuiTextTruncate {...props} truncation="startEnd" />);
-        cy.get('#text').should('have.text', expectedStartEndOutput);
+        getTruncatedText().should('have.text', expectedStartEndOutput);
       });
 
       it('ignores `truncationOffset`', () => {
@@ -163,7 +184,7 @@ describe('EuiTextTruncate', () => {
             truncationOffset={10}
           />
         );
-        cy.get('#text').should('have.text', expectedStartEndOutput);
+        getTruncatedText().should('have.text', expectedStartEndOutput);
       });
 
       describe('truncationPosition', () => {
@@ -184,8 +205,14 @@ describe('EuiTextTruncate', () => {
               />
             </>
           );
-          cy.get('#text1').should('have.text', '…rem ipsum dolor sit amet, …');
-          cy.get('#text2').should('have.text', '…amet, consectetur adipisci…');
+          getTruncatedText('#text1').should(
+            'have.text',
+            '…rem ipsum dolor sit amet, …'
+          );
+          getTruncatedText('#text2').should(
+            'have.text',
+            '…amet, consectetur adipisci…'
+          );
         });
 
         it('does not display the leading ellipsis if the anchor is close enough to the start', () => {
@@ -196,7 +223,7 @@ describe('EuiTextTruncate', () => {
               truncationPosition={5}
             />
           );
-          cy.get('#text').should('have.text', expectedEndOutput);
+          getTruncatedText().should('have.text', expectedEndOutput);
         });
 
         it('does not display the leading ellipsis if the anchor position is <= 0', () => {
@@ -216,8 +243,8 @@ describe('EuiTextTruncate', () => {
               />
             </>
           );
-          cy.get('#text1').should('have.text', expectedEndOutput);
-          cy.get('#text2').should('have.text', expectedEndOutput);
+          getTruncatedText('#text1').should('have.text', expectedEndOutput);
+          getTruncatedText('#text2').should('have.text', expectedEndOutput);
         });
 
         it('does not display the trailing ellipsis if the anchor is close enough to the end', () => {
@@ -228,7 +255,7 @@ describe('EuiTextTruncate', () => {
               truncationPosition={42}
             />
           );
-          cy.get('#text').should('have.text', expectedStartOutput);
+          getTruncatedText().should('have.text', expectedStartOutput);
         });
 
         it('does not display the trailing ellipsis if the anchor position is >= the text length', () => {
@@ -248,8 +275,8 @@ describe('EuiTextTruncate', () => {
               />
             </>
           );
-          cy.get('#text1').should('have.text', expectedStartOutput);
-          cy.get('#text2').should('have.text', expectedStartOutput);
+          getTruncatedText('#text1').should('have.text', expectedStartOutput);
+          getTruncatedText('#text2').should('have.text', expectedStartOutput);
         });
       });
     });
@@ -273,8 +300,14 @@ describe('EuiTextTruncate', () => {
           />
         </>
       );
-      cy.get('#text1').should('have.text', 'Lorem ipsum [...]dipiscing elit');
-      cy.get('#text2').should('have.text', '--lor sit amet, consectetur a--');
+      getTruncatedText('#text1').should(
+        'have.text',
+        'Lorem ipsum [...]dipiscing elit'
+      );
+      getTruncatedText('#text2').should(
+        'have.text',
+        '--lor sit amet, consectetur a--'
+      );
     });
 
     it("does not render if the container isn't wide enough for the ellipsis", () => {
@@ -296,8 +329,8 @@ describe('EuiTextTruncate', () => {
           />
         </>
       );
-      cy.get('#text1').should('have.text', '');
-      cy.get('#text2').should('have.text', '');
+      getTruncatedText('#text1').should('have.text', '');
+      getTruncatedText('#text2').should('have.text', '');
 
       cy.get('@spyConsoleError')
         .should(

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -69,7 +69,7 @@ describe('EuiTextTruncate', () => {
           cy.get('#text').should('have.text', 'Lorem…ectetur adipiscing elit');
         });
 
-        it('falls back to middle truncation if truncationOffset is too large', () => {
+        it('falls back to middle truncation if truncationOffset is too large for the text', () => {
           cy.mount(
             <EuiTextTruncate
               {...props}
@@ -78,6 +78,24 @@ describe('EuiTextTruncate', () => {
             />
           );
           cy.get('#text').should('have.text', expectedMiddleOutput);
+        });
+
+        it('logs an error if the truncationOffset is too large for the container', () => {
+          cy.window().then((win) => {
+            cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
+          });
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="start"
+              truncationOffset={5}
+              width={15}
+            />
+          );
+          cy.get('@spyConsoleError').should(
+            'be.calledWith',
+            'The passed truncationOffset of 5 is too large for available width.'
+          );
         });
       });
     });
@@ -89,7 +107,7 @@ describe('EuiTextTruncate', () => {
       });
 
       describe('truncationOffset', () => {
-        it('preserves starting characters with `truncationOffset`', () => {
+        it('preserves ending characters with `truncationOffset`', () => {
           cy.mount(
             <EuiTextTruncate
               {...props}
@@ -100,7 +118,7 @@ describe('EuiTextTruncate', () => {
           cy.get('#text').should('have.text', 'Lorem ipsum dolor …scing elit');
         });
 
-        it('falls back to middle truncation if truncationOffset is too large', () => {
+        it('falls back to middle truncation if truncationOffset is too large for the text', () => {
           cy.mount(
             <EuiTextTruncate
               {...props}
@@ -109,6 +127,24 @@ describe('EuiTextTruncate', () => {
             />
           );
           cy.get('#text').should('have.text', expectedMiddleOutput);
+        });
+
+        it('logs an error if the truncationOffset is too large for the container', () => {
+          cy.window().then((win) => {
+            cy.wrap(cy.spy(win.console, 'error')).as('spyConsoleError');
+          });
+          cy.mount(
+            <EuiTextTruncate
+              {...props}
+              truncation="end"
+              truncationOffset={10}
+              width={20}
+            />
+          );
+          cy.get('@spyConsoleError').should(
+            'be.calledWith',
+            'The passed truncationOffset of 10 is too large for available width.'
+          );
         });
       });
     });

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiTextTruncate, EuiTextTruncateProps } from './text_truncate';
+
+const meta: Meta<EuiTextTruncateProps> = {
+  title: 'EuiTextTruncate',
+  component: EuiTextTruncate,
+};
+
+export default meta;
+type Story = StoryObj<EuiTextTruncateProps>;
+
+export const Playground: Story = {
+  render: (props) => (
+    <div css={{ inlineSize: props.width || 200 }}>
+      <EuiTextTruncate {...props}>{(text) => <>{text}</>}</EuiTextTruncate>
+    </div>
+  ),
+  args: {
+    text: 'Lorem ipsum dolor sit amet, test test test test test test',
+    truncation: 'middle',
+    truncationOffset: 0,
+    separator: '...',
+  },
+};

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -40,8 +40,6 @@ export const Playground: Story = {
   ),
   args: {
     ...componentDefaults,
-    truncationOffset: 0,
-    truncationPosition: 0,
     width: 200,
   },
 };

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -23,7 +23,7 @@ type Story = StoryObj<EuiTextTruncateProps>;
 
 const componentDefaults = {
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-  truncation: 'middle',
+  truncation: 'end',
 } as const;
 
 export const Playground: Story = {

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -19,16 +19,45 @@ const meta: Meta<EuiTextTruncateProps> = {
 export default meta;
 type Story = StoryObj<EuiTextTruncateProps>;
 
+const componentDefaults = {
+  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+  truncation: 'middle',
+} as const;
+
 export const Playground: Story = {
   render: (props) => (
-    <div css={{ inlineSize: props.width || 200 }}>
+    <div css={{ inlineSize: props.width }}>
       <EuiTextTruncate {...props}>{(text) => <>{text}</>}</EuiTextTruncate>
     </div>
   ),
   args: {
-    text: 'Lorem ipsum dolor sit amet, test test test test test test',
-    truncation: 'middle',
+    ...componentDefaults,
     truncationOffset: 0,
     ellipsis: '...',
+    width: 200,
+  },
+};
+
+export const ResizeObserver: Story = {
+  render: (props) => (
+    <>
+      <i>
+        Drag the corner of the text to resize, and look in the console log to
+        see the reported width
+      </i>
+      <br />
+      <br />
+      {/* // Width here is just for testing resize behavior and isn't meant to be RTL compliant */}
+      <div css={{ width: 200, overflow: 'auto', resize: 'horizontal' }}>
+        <EuiTextTruncate {...props}>{(text) => text}</EuiTextTruncate>
+      </div>
+    </>
+  ),
+  args: {
+    ...componentDefaults,
+    onResize: console.log,
+  },
+  argTypes: {
+    width: { control: false },
   },
 };

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -29,7 +29,7 @@ const componentDefaults = {
 export const Playground: Story = {
   render: (props) => (
     <div css={{ inlineSize: props.width }}>
-      <EuiTextTruncate {...props}>{(text) => text}</EuiTextTruncate>
+      <EuiTextTruncate {...props} />
     </div>
   ),
   args: {
@@ -51,7 +51,7 @@ export const ResizeObserver: Story = {
       <br />
       {/* // Width here is just for testing resize behavior and isn't meant to be RTL compliant */}
       <div css={{ width: 200, overflow: 'auto', resize: 'horizontal' }}>
-        <EuiTextTruncate {...props}>{(text) => text}</EuiTextTruncate>
+        <EuiTextTruncate {...props} />
       </div>
     </>
   ),

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -6,8 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiHighlight, EuiMark } from '../../components';
 
 import { EuiTextTruncate, EuiTextTruncateProps } from './text_truncate';
 
@@ -27,7 +29,7 @@ const componentDefaults = {
 export const Playground: Story = {
   render: (props) => (
     <div css={{ inlineSize: props.width }}>
-      <EuiTextTruncate {...props}>{(text) => <>{text}</>}</EuiTextTruncate>
+      <EuiTextTruncate {...props}>{(text) => text}</EuiTextTruncate>
     </div>
   ),
   args: {
@@ -59,5 +61,63 @@ export const ResizeObserver: Story = {
   },
   argTypes: {
     width: { control: false },
+  },
+};
+
+export const StartEndAnchorForSearch: Story = {
+  render: (props) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [highlight, setHighlight] = useState('');
+    const highlightStartPosition = props.text
+      .toLowerCase()
+      .indexOf(highlight.toLowerCase());
+    const highlightCenterPosition =
+      highlightStartPosition + Math.floor(highlight.length / 2);
+
+    return (
+      <>
+        <i>Type into the below textarea to highlight, e.g. "consec"</i>
+        <br />
+        <input
+          type="textarea"
+          value={highlight}
+          onChange={(e) => setHighlight(e.target.value)}
+        />
+        <br />
+        <br />
+        <div css={{ inlineSize: props.width }}>
+          <EuiTextTruncate
+            {...props}
+            truncation="startEnd"
+            startEndAnchor={highlightCenterPosition}
+          >
+            {(text) => (
+              <>
+                {text.length > highlight.length ? (
+                  <EuiHighlight search={highlight}>{text}</EuiHighlight>
+                ) : (
+                  <EuiMark>{text}</EuiMark>
+                )}
+              </>
+            )}
+          </EuiTextTruncate>
+        </div>
+      </>
+    );
+  },
+  args: {
+    ...componentDefaults,
+    width: 200,
+    truncation: 'startEnd',
+    startEndAnchor: 30,
+  },
+  argTypes: {
+    // Disable uncontrollable props
+    truncation: { table: { disable: true } },
+    startEndAnchor: { table: { disable: true } },
+    // Disable props that aren't useful for this this demo
+    truncationOffset: { table: { disable: true } },
+    children: { table: { disable: true } },
+    onResize: { table: { disable: true } },
   },
 };

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { css } from '@emotion/react';
 
 import { EuiHighlight, EuiMark } from '../../components';
 
@@ -54,8 +55,14 @@ export const ResizeObserver: Story = {
       </i>
       <br />
       <br />
-      {/* // Width here is just for testing resize behavior and isn't meant to be RTL compliant */}
-      <div css={{ width: 200, overflow: 'auto', resize: 'horizontal' }}>
+      <div
+        css={css`
+          overflow: auto;
+          resize: horizontal;
+          resize: inline; /* not yet supported by all browsers, hence the fallback */
+          inline-size: 200px;
+        `}
+      >
         <EuiTextTruncate {...props} />
       </div>
     </>

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -16,6 +16,10 @@ import { EuiTextTruncate, EuiTextTruncateProps } from './text_truncate';
 const meta: Meta<EuiTextTruncateProps> = {
   title: 'EuiTextTruncate',
   component: EuiTextTruncate,
+  argTypes: {
+    truncationOffset: { if: { arg: 'truncation', neq: 'startEnd' } }, // Should also not show on `middle`, but Storybook doesn't currently support multiple if conditions :(
+    truncationPosition: { if: { arg: 'truncation', eq: 'startEnd' } },
+  },
 };
 
 export default meta;
@@ -24,6 +28,7 @@ type Story = StoryObj<EuiTextTruncateProps>;
 const componentDefaults = {
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
   truncation: 'end',
+  ellipsis: '…',
 } as const;
 
 export const Playground: Story = {
@@ -35,7 +40,7 @@ export const Playground: Story = {
   args: {
     ...componentDefaults,
     truncationOffset: 0,
-    ellipsis: '...',
+    truncationPosition: 0,
     width: 200,
   },
 };
@@ -89,7 +94,7 @@ export const StartEndAnchorForSearch: Story = {
           <EuiTextTruncate
             {...props}
             truncation="startEnd"
-            startEndAnchor={highlightCenterPosition}
+            truncationPosition={highlightCenterPosition}
           >
             {(text) => (
               <>
@@ -109,12 +114,12 @@ export const StartEndAnchorForSearch: Story = {
     ...componentDefaults,
     width: 200,
     truncation: 'startEnd',
-    startEndAnchor: 30,
+    truncationPosition: 30,
   },
   argTypes: {
     // Disable uncontrollable props
     truncation: { table: { disable: true } },
-    startEndAnchor: { table: { disable: true } },
+    truncationPosition: { table: { disable: true } },
     // Disable props that aren't useful for this this demo
     truncationOffset: { table: { disable: true } },
     children: { table: { disable: true } },

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -29,6 +29,6 @@ export const Playground: Story = {
     text: 'Lorem ipsum dolor sit amet, test test test test test test',
     truncation: 'middle',
     truncationOffset: 0,
-    separator: '...',
+    ellipsis: '...',
   },
 };

--- a/src/components/text_truncate/text_truncate.styles.ts
+++ b/src/components/text_truncate/text_truncate.styles.ts
@@ -10,7 +10,26 @@ import { css } from '@emotion/react';
 
 export const euiTextTruncateStyles = {
   euiTextTruncate: css`
+    position: relative;
     overflow: hidden;
     white-space: nowrap;
+  `,
+  truncatedText: css`
+    user-select: none;
+    pointer-events: none;
+  `,
+  fullText: css`
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    color: rgba(0, 0, 0, 0);
+
+    /* Safari-only CSS hack
+       Adding text-overflow: ellipsis makes VoiceOver's screen reader outline obey the container width,
+       but Chrome+FF don't need it, and it interferes with their text selection highlights
+     */
+    @supports (-webkit-hyphens: none) {
+      text-overflow: ellipsis;
+    }
   `,
 };

--- a/src/components/text_truncate/text_truncate.styles.ts
+++ b/src/components/text_truncate/text_truncate.styles.ts
@@ -14,10 +14,23 @@ export const euiTextTruncateStyles = {
     overflow: hidden;
     white-space: nowrap;
   `,
+  /**
+   * The below CSS is a hack to get double clicking and selecting the *full* text
+   * instead of the truncated text (useful for copying/pasting, and mimics how
+   * `text-overflow: ellipsis` works).
+   *
+   * Real talk: I'm lowkey amazed it works and it wouldn't surprise me if we ran into
+   * cross-browser issues with this at some point. Hopefully CSS natively implements
+   * custom text truncation some day (https://github.com/w3c/csswg-drafts/issues/3937)
+   * and there'll be no need for the entire component at that point 🙏
+   */
+  // Makes the truncated text unselectable/un-clickable
   truncatedText: css`
     user-select: none;
     pointer-events: none;
   `,
+  // Positions the full text on top of the truncated text (so that clicking targets it)
+  // and gives it a color opacity of 0 so that it's not actually visible
   fullText: css`
     position: absolute;
     inset: 0;

--- a/src/components/text_truncate/text_truncate.styles.ts
+++ b/src/components/text_truncate/text_truncate.styles.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+export const euiTextTruncateStyles = {
+  euiTextTruncate: css`
+    overflow: hidden;
+    white-space: nowrap;
+  `,
+};

--- a/src/components/text_truncate/text_truncate.test.tsx
+++ b/src/components/text_truncate/text_truncate.test.tsx
@@ -11,9 +11,25 @@ import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test';
 
+// Util mocks
+const mockEarlyReturn = { checkIfTruncationIsNeeded: () => false };
+const mockCleanup = jest.fn();
+jest.mock('./utils', () => {
+  return {
+    TruncationUtilsWithDOM: jest.fn(() => ({
+      ...mockEarlyReturn,
+      cleanup: mockCleanup,
+    })),
+    TruncationUtilsWithCanvas: jest.fn(() => mockEarlyReturn),
+  };
+});
+import { TruncationUtilsWithCanvas } from './utils';
+
 import { EuiTextTruncate } from './text_truncate';
 
 describe('EuiTextTruncate', () => {
+  beforeEach(() => jest.clearAllMocks());
+
   const props = {
     text: 'Hello world',
     width: 50,
@@ -29,20 +45,40 @@ describe('EuiTextTruncate', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('does not render a resize observer if a width is passed', () => {
-    const onResize = jest.fn();
-    render(<EuiTextTruncate {...props} width={100} onResize={onResize} />);
-    expect(onResize).not.toHaveBeenCalled();
+  describe('resize observer', () => {
+    it('does not render a resize observer if a width is passed', () => {
+      const onResize = jest.fn();
+      render(<EuiTextTruncate {...props} width={100} onResize={onResize} />);
+      expect(onResize).not.toHaveBeenCalled();
+    });
+
+    it('renders a resize observer when no width is passed', () => {
+      const onResize = jest.fn();
+      render(
+        <EuiTextTruncate {...props} width={undefined} onResize={onResize} />
+      );
+      expect(onResize).toHaveBeenCalledWith(0);
+    });
   });
 
-  it('renders a resize observer when no width is passed', () => {
-    const onResize = jest.fn();
-    render(
-      <EuiTextTruncate {...props} width={undefined} onResize={onResize} />
-    );
-    expect(onResize).toHaveBeenCalledWith(0);
+  describe('render API', () => {
+    it('calls the DOM cleanup method after each render', () => {
+      render(<EuiTextTruncate {...props} measurementRenderAPI="dom" />);
+      expect(mockCleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows switching to canvas rendering via `measurementRenderAPI`', () => {
+      render(
+        <EuiTextTruncate
+          width={100}
+          text="Canvas test"
+          measurementRenderAPI="canvas"
+        />
+      );
+      expect(TruncationUtilsWithCanvas).toHaveBeenCalledTimes(1);
+      expect(mockCleanup).not.toHaveBeenCalled();
+    });
   });
 
-  // We can't unit test the actual truncation logic in JSDOM, because
-  // JSDOM doesn't have `offsetWidth`. See the Cypress spec tests instead
+  // We can't unit test the actual truncation logic in JSDOM - see Cypress spec tests instead
 });

--- a/src/components/text_truncate/text_truncate.test.tsx
+++ b/src/components/text_truncate/text_truncate.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render } from '../../test/rtl';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test';
+
+import { EuiTextTruncate } from './text_truncate';
+
+describe('EuiTextTruncate', () => {
+  const props = {
+    text: 'Hello world',
+    width: 50,
+  } as const;
+
+  shouldRenderCustomStyles(<EuiTextTruncate {...props} />);
+
+  it('renders', () => {
+    const { container } = render(
+      <EuiTextTruncate {...props} {...requiredProps} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('does not render a resize observer if a width is passed', () => {
+    const onResize = jest.fn();
+    render(<EuiTextTruncate {...props} width={100} onResize={onResize} />);
+    expect(onResize).not.toHaveBeenCalled();
+  });
+
+  it('renders a resize observer when no width is passed', () => {
+    const onResize = jest.fn();
+    render(
+      <EuiTextTruncate {...props} width={undefined} onResize={onResize} />
+    );
+    expect(onResize).toHaveBeenCalledWith(0);
+  });
+
+  // We can't unit test the actual truncation logic in JSDOM, because
+  // JSDOM doesn't have `offsetWidth`. See the Cypress spec tests instead
+});

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, {
+  HTMLAttributes,
   FunctionComponent,
   ReactNode,
   Ref,
@@ -16,17 +17,22 @@ import React, {
 
 import { useCombinedRefs } from '../../services';
 import { EuiResizeObserver } from '../observer/resize_observer';
+import type { CommonProps } from '../common';
 
 import { euiTextTruncateStyles } from './text_truncate.styles';
 
-export type EuiTextTruncateProps = {
-  children: (truncatedString: string) => ReactNode;
-  text: string;
-  truncation: 'end' | 'start' | 'startEnd' | 'middle'; // TODO: [start: x, end: y?]; - needs to support combobox search highlight
-  truncationOffset?: number; // only applies to end and start
-  separator?: string;
-  width?: number; // Will allow turning off the automatic resize observer for performance, e.g. in EuiComboBox
-};
+export type EuiTextTruncateProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'children'
+> &
+  CommonProps & {
+    children: (truncatedString: string) => ReactNode;
+    text: string;
+    truncation: 'end' | 'start' | 'startEnd' | 'middle'; // TODO: [start: x, end: y?]; - needs to support combobox search highlight
+    truncationOffset?: number; // only applies to end and start
+    separator?: string;
+    width?: number; // Will allow turning off the automatic resize observer for performance, e.g. in EuiComboBox
+  };
 
 export const EuiTextTruncate: FunctionComponent<EuiTextTruncateProps> = ({
   width,
@@ -59,6 +65,7 @@ const EuiTextTruncateToWidth: FunctionComponent<
   separator = '…',
   width,
   containerRef,
+  ...rest
 }) => {
   // Note: This needs to be a state and not a ref to trigger a rerender on mount
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
@@ -174,6 +181,7 @@ const EuiTextTruncateToWidth: FunctionComponent<
       ref={refs}
       title={text}
       aria-label={text}
+      {...rest}
     >
       {truncatedText && children(truncatedText)}
     </div>

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -31,12 +31,6 @@ export type EuiTextTruncateProps = Omit<
 > &
   CommonProps & {
     /**
-     * EuiTextTruncate passes back the truncated text as a render prop
-     * (instead of rendering the truncated string directly). This API allows
-     * you to use the text more flexibly, e.g. adding custom markup/highlighting
-     */
-    children: (truncatedString: string) => ReactNode;
-    /**
      * The full text string to truncate
      */
     text: string;
@@ -86,6 +80,13 @@ export type EuiTextTruncateProps = Omit<
      * registers a size change. This callback will **not** fire if `width` is passed.
      */
     onResize?: (width: number) => void;
+    /**
+     * By default, EuiTextTruncate will render the truncated string directly.
+     * You can optionally pass a render prop function to the component, which
+     * allows for more flexible text rendering, e.g. adding custom markup
+     * or highlighting
+     */
+    children?: (truncatedString: string) => ReactNode;
   };
 
 export const EuiTextTruncate: FunctionComponent<EuiTextTruncateProps> = ({
@@ -294,7 +295,7 @@ const EuiTextTruncateWithWidth: FunctionComponent<
       aria-label={text}
       {...rest}
     >
-      {truncatedText && children(truncatedText)}
+      {children ? children(truncatedText) : truncatedText}
     </div>
   );
 };

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -133,7 +133,7 @@ const EuiTextTruncateWithWidth: FunctionComponent<
       if (offsetIsTooLarge) {
         truncation = 'middle';
       } else {
-        truncationOffset = _truncationOffset; // The only time we respect truncationOffset
+        truncationOffset = _truncationOffset > 0 ? _truncationOffset : 0; // Negative offsets cause infinite loops
       }
     } else if (_truncation === 'startEnd' && truncationPosition != null) {
       if (truncationPosition <= 0) {
@@ -180,6 +180,17 @@ const EuiTextTruncateWithWidth: FunctionComponent<
         const endPosition = text.length - truncationOffset;
         const endOffset = span.textContent.substring(endPosition);
         const endRemaining = span.textContent.substring(0, endPosition);
+
+        // Make sure that the offset alone isn't larger than the actual available width
+        span.textContent = `${ellipsis}${endOffset}`;
+        if (span.offsetWidth > width) {
+          // There isn't a super great way to handle this visually.
+          // The best we can do is simply render the broken truncation
+          console.error(
+            `The passed truncationOffset of ${truncationOffset} is too large for available width.`
+          );
+          break;
+        }
         span.textContent = `${endRemaining}${ellipsis}${endOffset}`;
 
         while (span.offsetWidth > width) {
@@ -192,6 +203,17 @@ const EuiTextTruncateWithWidth: FunctionComponent<
       case 'start':
         const startOffset = span.textContent.substring(0, truncationOffset);
         const startRemaining = span.textContent.substring(truncationOffset);
+
+        // Make sure that the offset alone isn't larger than the actual available width
+        span.textContent = `${startOffset}${ellipsis}`;
+        if (span.offsetWidth > width) {
+          // There isn't a super great way to handle this visually.
+          // The best we can do is simply render the broken truncation
+          console.error(
+            `The passed truncationOffset of ${truncationOffset} is too large for available width.`
+          );
+          break;
+        }
         span.textContent = `${startOffset}${ellipsis}${startRemaining}`;
 
         while (span.offsetWidth > width) {

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -23,7 +23,7 @@ import {
 } from '../observer/resize_observer';
 import type { CommonProps } from '../common';
 
-import { TruncationUtilsForDOM } from './utils';
+import { TruncationUtilsWithDOM } from './utils';
 import { euiTextTruncateStyles } from './text_truncate.styles';
 
 const TRUNCATION_TYPES = ['end', 'start', 'startEnd', 'middle'] as const;
@@ -147,7 +147,7 @@ const EuiTextTruncateWithWidth: FunctionComponent<
     let truncatedText = '';
     if (!containerEl || !width) return truncatedText;
 
-    const utils = new TruncationUtilsForDOM({
+    const utils = new TruncationUtilsWithDOM({
       fullText: text,
       ellipsis,
       container: containerEl,

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -309,15 +309,31 @@ const EuiTextTruncateWithWidth: FunctionComponent<
     containerEl,
   ]);
 
+  const isTruncating = truncatedText !== text;
+
   return (
     <div
       css={euiTextTruncateStyles.euiTextTruncate}
       ref={refs}
-      title={text}
-      aria-label={text}
+      title={isTruncating ? text : undefined}
       {...rest}
     >
-      {children ? children(truncatedText) : truncatedText}
+      {isTruncating ? (
+        <>
+          <span
+            css={euiTextTruncateStyles.truncatedText}
+            aria-hidden
+            data-test-subj="truncatedText"
+          >
+            {children ? children(truncatedText) : truncatedText}
+          </span>
+          <span css={euiTextTruncateStyles.fullText} data-test-subj="fullText">
+            {text}
+          </span>
+        </>
+      ) : (
+        <span data-test-subj="fullText">{text}</span>
+      )}
     </div>
   );
 };

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -23,7 +23,7 @@ import {
 } from '../observer/resize_observer';
 import type { CommonProps } from '../common';
 
-import { TruncationUtils } from './utils';
+import { TruncationUtilsForDOM } from './utils';
 import { euiTextTruncateStyles } from './text_truncate.styles';
 
 const TRUNCATION_TYPES = ['end', 'start', 'startEnd', 'middle'] as const;
@@ -147,7 +147,7 @@ const EuiTextTruncateWithWidth: FunctionComponent<
     let truncatedText = '';
     if (!containerEl || !width) return truncatedText;
 
-    const utils = new TruncationUtils({
+    const utils = new TruncationUtilsForDOM({
       fullText: text,
       ellipsis,
       container: containerEl,

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  ReactNode,
+  Ref,
+  useState,
+  useMemo,
+} from 'react';
+
+import { useCombinedRefs } from '../../services';
+import { EuiResizeObserver } from '../observer/resize_observer';
+
+import { euiTextTruncateStyles } from './text_truncate.styles';
+
+export type EuiTextTruncateProps = {
+  children: (truncatedString: string) => ReactNode;
+  text: string;
+  truncation: 'end' | 'start' | 'startEnd' | 'middle'; // TODO: [start: x, end: y?]; - needs to support combobox search highlight
+  truncationOffset?: number; // only applies to end and start
+  separator?: string;
+  width?: number; // Will allow turning off the automatic resize observer for performance, e.g. in EuiComboBox
+};
+
+export const EuiTextTruncate: FunctionComponent<EuiTextTruncateProps> = ({
+  width,
+  ...props
+}) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  return width ? (
+    <EuiTextTruncateToWidth width={width} {...props} />
+  ) : (
+    <EuiResizeObserver onResize={({ width }) => setContainerWidth(width)}>
+      {(containerResizeRef) => (
+        <EuiTextTruncateToWidth
+          width={containerWidth}
+          containerRef={containerResizeRef}
+          {...props}
+        />
+      )}
+    </EuiResizeObserver>
+  );
+};
+
+const EuiTextTruncateToWidth: FunctionComponent<
+  EuiTextTruncateProps & { width: number; containerRef?: Ref<HTMLDivElement> }
+> = ({
+  children,
+  text,
+  truncation: _truncation = 'end',
+  truncationOffset: _truncationOffset = 0,
+  separator = '…',
+  width,
+  containerRef,
+}) => {
+  // Note: This needs to be a state and not a ref to trigger a rerender on mount
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
+  const refs = useCombinedRefs([setContainerEl, containerRef]);
+
+  const truncationUsesOffset = _truncation === 'end' || _truncation === 'start';
+  const truncationOffsetIsTooLarge =
+    truncationUsesOffset && _truncationOffset >= Math.floor(text.length / 2);
+
+  const truncation = useMemo(() => {
+    if (truncationOffsetIsTooLarge) {
+      return 'middle' as const;
+    } else {
+      return _truncation;
+    }
+  }, [_truncation, truncationOffsetIsTooLarge]);
+
+  const truncationOffset = useMemo(() => {
+    if (truncationUsesOffset && !truncationOffsetIsTooLarge) {
+      return _truncationOffset;
+    } else {
+      return 0;
+    }
+  }, [_truncationOffset, truncationOffsetIsTooLarge, truncationUsesOffset]);
+
+  const truncatedText = useMemo(() => {
+    if (!containerEl || !width) return '';
+
+    // Create a temporary DOM element for manipulating text and determining text width
+    const span = document.createElement('span');
+    containerEl.appendChild(span);
+
+    // Quick check to make sure consumers didn't pass in an insane separator
+    span.textContent = separator;
+    if (span.offsetWidth >= width * 0.9) {
+      throw new Error(
+        'The separator passed is larger than the available width and cannot be used.'
+      );
+    }
+
+    span.textContent = text;
+
+    // Check if we need to truncate at all
+    if (width > span.offsetWidth) {
+      containerEl.removeChild(span);
+      return text;
+    }
+
+    const substringOffset = truncationOffset + separator.length + 1;
+
+    switch (truncation) {
+      case 'end':
+        const endPosition = text.length - truncationOffset;
+        const endOffset = span.textContent.substring(endPosition);
+        const endRemaining = span.textContent.substring(0, endPosition);
+        span.textContent = `${endRemaining}${separator}${endOffset}`;
+
+        while (span.offsetWidth > width) {
+          const offset = span.textContent.length - substringOffset;
+          const trimmedText = span.textContent.substring(0, offset);
+          span.textContent = `${trimmedText}${separator}${endOffset}`;
+        }
+        break;
+
+      case 'start':
+        const startOffset = span.textContent.substring(0, truncationOffset);
+        const startRemaining = span.textContent.substring(truncationOffset);
+        span.textContent = `${startOffset}${separator}${startRemaining}`;
+
+        while (span.offsetWidth > width) {
+          const trimmedText = span.textContent.substring(substringOffset);
+          span.textContent = `${startOffset}${separator}${trimmedText}`;
+        }
+        break;
+
+      case 'startEnd':
+        while (span.offsetWidth > width) {
+          const trimmedMiddle = span.textContent.substring(
+            substringOffset,
+            span.textContent.length - substringOffset
+          );
+          span.textContent = `${separator}${trimmedMiddle}${separator}`;
+        }
+        break;
+
+      case 'middle':
+        const middlePosition = Math.floor(text.length / 2);
+        let firstHalf = text.substring(0, middlePosition);
+        let secondHalf = text.substring(middlePosition);
+        let trimfirstHalf = true;
+
+        while (span.offsetWidth > width) {
+          if (trimfirstHalf) {
+            firstHalf = firstHalf.substring(0, firstHalf.length - 1);
+          } else {
+            secondHalf = secondHalf.substring(1);
+          }
+          span.textContent = `${firstHalf}${separator}${secondHalf}`;
+          trimfirstHalf = !trimfirstHalf;
+        }
+        break;
+    }
+
+    const truncatedText = span.textContent;
+    containerEl.removeChild(span);
+
+    return truncatedText;
+  }, [width, text, truncation, truncationOffset, separator, containerEl]);
+
+  return (
+    <div
+      css={euiTextTruncateStyles.euiTextTruncate}
+      ref={refs}
+      title={text}
+      aria-label={text}
+    >
+      {truncatedText && children(truncatedText)}
+    </div>
+  );
+};

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -25,6 +25,9 @@ import type { CommonProps } from '../common';
 
 import { euiTextTruncateStyles } from './text_truncate.styles';
 
+const TRUNCATION_TYPES = ['end', 'start', 'startEnd', 'middle'] as const;
+export type EuiTextTruncationTypes = (typeof TRUNCATION_TYPES)[number];
+
 export type EuiTextTruncateProps = Omit<
   HTMLAttributes<HTMLDivElement>,
   'children' | 'onResize'
@@ -37,7 +40,7 @@ export type EuiTextTruncateProps = Omit<
     /**
      * The truncation type desired. Determines where the ellipses are placed.
      */
-    truncation: 'end' | 'start' | 'startEnd' | 'middle';
+    truncation?: EuiTextTruncationTypes;
     /**
      * This prop **only** applies to the `start` and `end` truncation types.
      * It allows preserving a certain number of characters of either the

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -47,8 +47,8 @@ export type EuiTextTruncateProps = Omit<
      * It allows preserving a certain number of characters of either the
      * starting or ending text.
      *
-     * If the passed offset is greater than half of the total text length,
-     * the truncation will simply default to `middle` instead.
+     * If the passed offset is greater than the total text length,
+     * the offset will be ignored.
      */
     truncationOffset?: number;
     /**
@@ -130,11 +130,8 @@ const EuiTextTruncateWithWidth: FunctionComponent<
     let truncationOffset = 0;
 
     if (_truncation === 'end' || _truncation === 'start') {
-      const offsetIsTooLarge = _truncationOffset >= Math.floor(text.length / 2);
-      if (offsetIsTooLarge) {
-        truncation = 'middle';
-      } else {
-        truncationOffset = _truncationOffset > 0 ? _truncationOffset : 0; // Negative offsets cause infinite loops
+      if (0 < _truncationOffset && _truncationOffset < text.length) {
+        truncationOffset = _truncationOffset;
       }
     } else if (_truncation === 'startEnd' && truncationPosition != null) {
       if (truncationPosition <= 0) {

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -83,8 +83,7 @@ describe('TruncationUtilsWithDOM', () => {
       <TestSetup
         getUtils={() => {
           document.body.appendChild(container);
-          const utils = new TruncationUtilsWithDOM(props);
-          return utils;
+          return new TruncationUtilsWithDOM(props);
         }}
       />
     );
@@ -93,12 +92,32 @@ describe('TruncationUtilsWithDOM', () => {
 });
 
 describe('TruncationUtilsWithCanvas', () => {
-  const props = { ...sharedProps, font };
+  describe('container', () => {
+    const container = document.createElement('div');
+    container.style.font = font;
+    const props = { ...sharedProps, container };
 
-  it('truncates text as expected', () => {
-    cy.mount(
-      <TestSetup getUtils={() => new TruncationUtilsWithCanvas(props)} />
-    );
-    assertExpectedOutput();
+    it('truncates text as expected', () => {
+      cy.mount(
+        <TestSetup
+          getUtils={() => {
+            document.body.appendChild(container);
+            return new TruncationUtilsWithCanvas(props);
+          }}
+        />
+      );
+      assertExpectedOutput();
+    });
+  });
+
+  describe('font', () => {
+    const props = { ...sharedProps, font };
+
+    it('truncates text as expected', () => {
+      cy.mount(
+        <TestSetup getUtils={() => new TruncationUtilsWithCanvas(props)} />
+      );
+      assertExpectedOutput();
+    });
   });
 });

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -40,8 +40,8 @@ const TestSetup: FunctionComponent<{
     const utils = getUtils();
     setRendered(
       <div style={{ font }}>
-        <div id="start">{utils.truncateStart(0)}</div>
-        <div id="end">{utils.truncateEnd(0)}</div>
+        <div id="start">{utils.truncateStart()}</div>
+        <div id="end">{utils.truncateEnd()}</div>
         <div id="middle">{utils.truncateMiddle()}</div>
         <div id="startEnd">{utils.truncateStartEndAtMiddle()}</div>
         <div id="startEndAt">{utils.truncateStartEndAtPosition(15)}</div>

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -19,12 +19,6 @@ import React, {
 
 import { TruncationUtilsWithDOM, TruncationUtilsWithCanvas } from './utils';
 
-const sharedProps = {
-  fullText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-  availableWidth: 200,
-  ellipsis: '...',
-};
-
 // CI doesn't have access to the Inter font, so we need to manually include it
 // for font calculations to work correctly
 const font = '14px Inter';
@@ -36,63 +30,57 @@ before(() => {
     'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap'
   );
   document.head.appendChild(linkElem);
-  cy.wait(1000); // Wait a tick to give the font time to load/swap in
+  cy.wait(1000); // Wait a second to give the font time to load/swap in
 });
 
-// Test utility for outputting the returned strings from each truncation utility
-// in React. Given the same shared props and fonts, both render methods should
-// arrive at the same truncated strings
-const TestSetup: FunctionComponent<{
-  getUtils: () => TruncationUtilsWithDOM | TruncationUtilsWithCanvas;
-}> = ({ getUtils }) => {
-  const [rendered, setRendered] = useState<ReactNode>(null);
+describe('Truncation utils', () => {
+  const sharedProps = {
+    fullText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    availableWidth: 200,
+    ellipsis: '...',
+  };
 
-  useEffect(() => {
-    const utils = getUtils();
-    setRendered(
-      <div style={{ font }}>
-        <div id="start">{utils.truncateStart()}</div>
-        <div id="end">{utils.truncateEnd()}</div>
-        <div id="middle">{utils.truncateMiddle()}</div>
-        <div id="startEnd">{utils.truncateStartEndAtMiddle()}</div>
-        <div id="startEndAt">{utils.truncateStartEndAtPosition(15)}</div>
-      </div>
+  // Test utility for outputting the returned strings from each truncation utility
+  // in React. Given the same shared props and fonts, both render methods should
+  // arrive at the same truncated strings
+  const TestSetup: FunctionComponent<{
+    getUtils: () => TruncationUtilsWithDOM | TruncationUtilsWithCanvas;
+  }> = ({ getUtils }) => {
+    const [rendered, setRendered] = useState<ReactNode>(null);
+
+    useEffect(() => {
+      const utils = getUtils();
+      setRendered(
+        <div style={{ font }}>
+          <div id="start">{utils.truncateStart()}</div>
+          <div id="end">{utils.truncateEnd()}</div>
+          <div id="middle">{utils.truncateMiddle()}</div>
+          <div id="startEnd">{utils.truncateStartEndAtMiddle()}</div>
+          <div id="startEndAt">{utils.truncateStartEndAtPosition(15)}</div>
+        </div>
+      );
+      // @ts-ignore - the `?.` handles canvas which doesn't require a cleanup
+      utils.cleanup?.();
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return <>{rendered}</>;
+  };
+
+  const assertExpectedOutput = () => {
+    cy.get('#start').should('have.text', '...t, consectetur adipiscing elit');
+    cy.get('#end').should('have.text', 'Lorem ipsum dolor sit amet, ...');
+    cy.get('#middle').should('have.text', 'Lorem ipsum d...adipiscing elit');
+    cy.get('#startEnd').should(
+      'have.text',
+      '...lor sit amet, consectetur a...'
     );
-    // @ts-ignore - the `?.` handles canvas which doesn't require a cleanup
-    utils.cleanup?.();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return <>{rendered}</>;
-};
-
-const assertExpectedOutput = () => {
-  cy.get('#start').should('have.text', '...t, consectetur adipiscing elit');
-  cy.get('#end').should('have.text', 'Lorem ipsum dolor sit amet, ...');
-  cy.get('#middle').should('have.text', 'Lorem ipsum d...adipiscing elit');
-  cy.get('#startEnd').should('have.text', '...lor sit amet, consectetur a...');
-  cy.get('#startEndAt').should('have.text', '...rem ipsum dolor sit amet, ...');
-};
-
-describe('TruncationUtilsWithDOM', () => {
-  const container = document.createElement('div');
-  container.style.font = font;
-  const props = { ...sharedProps, container };
-
-  it('truncates text as expected', () => {
-    cy.mount(
-      <TestSetup
-        getUtils={() => {
-          document.body.appendChild(container);
-          return new TruncationUtilsWithDOM(props);
-        }}
-      />
+    cy.get('#startEndAt').should(
+      'have.text',
+      '...rem ipsum dolor sit amet, ...'
     );
-    assertExpectedOutput();
-  });
-});
+  };
 
-describe('TruncationUtilsWithCanvas', () => {
-  describe('container', () => {
+  describe('TruncationUtilsWithDOM', () => {
     const container = document.createElement('div');
     container.style.font = font;
     const props = { ...sharedProps, container };
@@ -102,7 +90,7 @@ describe('TruncationUtilsWithCanvas', () => {
         <TestSetup
           getUtils={() => {
             document.body.appendChild(container);
-            return new TruncationUtilsWithCanvas(props);
+            return new TruncationUtilsWithDOM(props);
           }}
         />
       );
@@ -110,14 +98,34 @@ describe('TruncationUtilsWithCanvas', () => {
     });
   });
 
-  describe('font', () => {
-    const props = { ...sharedProps, font };
+  describe('TruncationUtilsWithCanvas', () => {
+    describe('container', () => {
+      const container = document.createElement('div');
+      container.style.font = font;
+      const props = { ...sharedProps, container };
 
-    it('truncates text as expected', () => {
-      cy.mount(
-        <TestSetup getUtils={() => new TruncationUtilsWithCanvas(props)} />
-      );
-      assertExpectedOutput();
+      it('truncates text as expected', () => {
+        cy.mount(
+          <TestSetup
+            getUtils={() => {
+              document.body.appendChild(container);
+              return new TruncationUtilsWithCanvas(props);
+            }}
+          />
+        );
+        assertExpectedOutput();
+      });
+    });
+
+    describe('font', () => {
+      const props = { ...sharedProps, font };
+
+      it('truncates text as expected', () => {
+        cy.mount(
+          <TestSetup getUtils={() => new TruncationUtilsWithCanvas(props)} />
+        );
+        assertExpectedOutput();
+      });
     });
   });
 });

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -24,13 +24,24 @@ const sharedProps = {
   availableWidth: 200,
   ellipsis: '...',
 };
-const font = '14px Verdana'; // We need to use a OS-safe font that CI machines are likely to have
 
-/**
- * Test utility for outputting the returned strings from each truncation utility
- * in React. Given the same shared props and fonts, both render methods should
- * arrive at the same truncated strings
- */
+// CI doesn't have access to the Inter font, so we need to manually include it
+// for font calculations to work correctly
+const font = '14px Inter';
+before(() => {
+  const linkElem = document.createElement('link');
+  linkElem.setAttribute('rel', 'stylesheet');
+  linkElem.setAttribute(
+    'href',
+    'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap'
+  );
+  document.head.appendChild(linkElem);
+  cy.wait(1000); // Wait a tick to give the font time to load/swap in
+});
+
+// Test utility for outputting the returned strings from each truncation utility
+// in React. Given the same shared props and fonts, both render methods should
+// arrive at the same truncated strings
 const TestSetup: FunctionComponent<{
   getUtils: () => TruncationUtilsWithDOM | TruncationUtilsWithCanvas;
 }> = ({ getUtils }) => {
@@ -55,11 +66,11 @@ const TestSetup: FunctionComponent<{
 };
 
 const assertExpectedOutput = () => {
-  cy.get('#start').should('have.text', '...consectetur adipiscing elit');
-  cy.get('#end').should('have.text', 'Lorem ipsum dolor sit am...');
-  cy.get('#middle').should('have.text', 'Lorem ipsum ...dipiscing elit');
-  cy.get('#startEnd').should('have.text', '...r sit amet, consectetur...');
-  cy.get('#startEndAt').should('have.text', '...m ipsum dolor sit amet...');
+  cy.get('#start').should('have.text', '...t, consectetur adipiscing elit');
+  cy.get('#end').should('have.text', 'Lorem ipsum dolor sit amet, ...');
+  cy.get('#middle').should('have.text', 'Lorem ipsum d...adipiscing elit');
+  cy.get('#startEnd').should('have.text', '...lor sit amet, consectetur a...');
+  cy.get('#startEndAt').should('have.text', '...rem ipsum dolor sit amet, ...');
 };
 
 describe('TruncationUtilsWithDOM', () => {

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../cypress/support" />
+
+import React, {
+  ReactNode,
+  FunctionComponent,
+  useState,
+  useEffect,
+} from 'react';
+
+import { TruncationUtilsForDOM, TruncationUtilsForCanvas } from './utils';
+
+const sharedProps = {
+  fullText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+  availableWidth: 200,
+  ellipsis: '...',
+};
+const font = '14px Verdana'; // We need to use a OS-safe font that CI machines are likely to have
+
+/**
+ * Test utility for outputting the returned strings from each truncation utility
+ * in React. Given the same shared props and fonts, both render methods should
+ * arrive at the same truncated strings
+ */
+const TestSetup: FunctionComponent<{
+  getUtils: () => TruncationUtilsForDOM | TruncationUtilsForCanvas;
+}> = ({ getUtils }) => {
+  const [rendered, setRendered] = useState<ReactNode>(null);
+
+  useEffect(() => {
+    const utils = getUtils();
+    setRendered(
+      <div style={{ font }}>
+        <div id="start">{utils.truncateStart(0)}</div>
+        <div id="end">{utils.truncateEnd(0)}</div>
+        <div id="middle">{utils.truncateMiddle()}</div>
+        <div id="startEnd">{utils.truncateStartEndAtMiddle()}</div>
+        <div id="startEndAt">{utils.truncateStartEndAtPosition(15)}</div>
+      </div>
+    );
+    // @ts-ignore - the `?.` handles canvas which doesn't require a cleanup
+    utils.cleanup?.();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return <>{rendered}</>;
+};
+
+const assertExpectedOutput = () => {
+  cy.get('#start').should('have.text', '...consectetur adipiscing elit');
+  cy.get('#end').should('have.text', 'Lorem ipsum dolor sit am...');
+  cy.get('#middle').should('have.text', 'Lorem ipsum ...dipiscing elit');
+  cy.get('#startEnd').should('have.text', '...r sit amet, consectetur...');
+  cy.get('#startEndAt').should('have.text', '...m ipsum dolor sit amet...');
+};
+
+describe('TruncationUtilsForDOM', () => {
+  const container = document.createElement('div');
+  container.style.font = font;
+  const props = { ...sharedProps, container };
+
+  it('truncates text as expected', () => {
+    cy.mount(
+      <TestSetup
+        getUtils={() => {
+          document.body.appendChild(container);
+          const utils = new TruncationUtilsForDOM(props);
+          return utils;
+        }}
+      />
+    );
+    assertExpectedOutput();
+  });
+});
+
+describe('TruncationUtilsForCanvas', () => {
+  const props = { ...sharedProps, font };
+
+  it('truncates text as expected', () => {
+    cy.mount(
+      <TestSetup getUtils={() => new TruncationUtilsForCanvas(props)} />
+    );
+    assertExpectedOutput();
+  });
+});

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -17,7 +17,7 @@ import React, {
   useEffect,
 } from 'react';
 
-import { TruncationUtilsForDOM, TruncationUtilsForCanvas } from './utils';
+import { TruncationUtilsWithDOM, TruncationUtilsWithCanvas } from './utils';
 
 const sharedProps = {
   fullText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
@@ -32,7 +32,7 @@ const font = '14px Verdana'; // We need to use a OS-safe font that CI machines a
  * arrive at the same truncated strings
  */
 const TestSetup: FunctionComponent<{
-  getUtils: () => TruncationUtilsForDOM | TruncationUtilsForCanvas;
+  getUtils: () => TruncationUtilsWithDOM | TruncationUtilsWithCanvas;
 }> = ({ getUtils }) => {
   const [rendered, setRendered] = useState<ReactNode>(null);
 
@@ -62,7 +62,7 @@ const assertExpectedOutput = () => {
   cy.get('#startEndAt').should('have.text', '...m ipsum dolor sit amet...');
 };
 
-describe('TruncationUtilsForDOM', () => {
+describe('TruncationUtilsWithDOM', () => {
   const container = document.createElement('div');
   container.style.font = font;
   const props = { ...sharedProps, container };
@@ -72,7 +72,7 @@ describe('TruncationUtilsForDOM', () => {
       <TestSetup
         getUtils={() => {
           document.body.appendChild(container);
-          const utils = new TruncationUtilsForDOM(props);
+          const utils = new TruncationUtilsWithDOM(props);
           return utils;
         }}
       />
@@ -81,12 +81,12 @@ describe('TruncationUtilsForDOM', () => {
   });
 });
 
-describe('TruncationUtilsForCanvas', () => {
+describe('TruncationUtilsWithCanvas', () => {
   const props = { ...sharedProps, font };
 
   it('truncates text as expected', () => {
     cy.mount(
-      <TestSetup getUtils={() => new TruncationUtilsForCanvas(props)} />
+      <TestSetup getUtils={() => new TruncationUtilsWithCanvas(props)} />
     );
     assertExpectedOutput();
   });

--- a/src/components/text_truncate/utils.test.ts
+++ b/src/components/text_truncate/utils.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { TruncationUtilsForDOM, TruncationUtilsForCanvas } from './utils';
+import { TruncationUtilsWithDOM, TruncationUtilsWithCanvas } from './utils';
 
 const sharedParams = {
   fullText: 'Lorem ipsum dolor sit amet',
@@ -14,7 +14,7 @@ const sharedParams = {
   availableWidth: 200,
 };
 
-describe('TruncationUtilsForDOM', () => {
+describe('TruncationUtilsWithDOM', () => {
   const params = {
     ...sharedParams,
     container: document.createElement('div'),
@@ -34,7 +34,7 @@ describe('TruncationUtilsForDOM', () => {
   afterAll(() => consoleErrorSpy.mockRestore());
 
   describe('DOM utils', () => {
-    const utils = new TruncationUtilsForDOM(params);
+    const utils = new TruncationUtilsWithDOM(params);
 
     describe('textWidth', () => {
       it('returns the offsetWidth of the internal span element', () => {
@@ -60,7 +60,7 @@ describe('TruncationUtilsForDOM', () => {
   });
 
   describe('early return checks', () => {
-    const utils = new TruncationUtilsForDOM(params);
+    const utils = new TruncationUtilsWithDOM(params);
     afterAll(() => utils.cleanup());
 
     describe('checkIfTruncationIsNeeded', () => {
@@ -112,10 +112,10 @@ describe('TruncationUtilsForDOM', () => {
     let mockTextWidth: jest.SpyInstance;
     beforeAll(() => {
       mockTextWidth = jest
-        .spyOn(TruncationUtilsForDOM.prototype, 'textWidth', 'get')
+        .spyOn(TruncationUtilsWithDOM.prototype, 'textWidth', 'get')
         .mockImplementation(() => mockSpanWidth--);
     });
-    const utils = new TruncationUtilsForDOM(params);
+    const utils = new TruncationUtilsWithDOM(params);
 
     afterAll(() => {
       utils.cleanup();
@@ -205,7 +205,7 @@ describe('TruncationUtilsForDOM', () => {
   });
 });
 
-describe('TruncationUtilsForCanvas', () => {
+describe('TruncationUtilsWithCanvas', () => {
   // Jest absolutely does not have canvas so I honestly have no idea why I'm even doing this
   // Except that like a Pavlovian dog conditioned for treats, so I am conditioned
   // for that sweet sweet green 100% code coverage
@@ -214,7 +214,7 @@ describe('TruncationUtilsForCanvas', () => {
   });
 
   it('allows customizing the font', () => {
-    const utils = new TruncationUtilsForCanvas({
+    const utils = new TruncationUtilsWithCanvas({
       ...sharedParams,
       font: 'Inter',
     });
@@ -222,7 +222,7 @@ describe('TruncationUtilsForCanvas', () => {
   });
 
   describe('canvas utils', () => {
-    const utils = new TruncationUtilsForCanvas(sharedParams);
+    const utils = new TruncationUtilsWithCanvas(sharedParams);
 
     describe('textWidth', () => {
       it('returns the measured text width from the canvas', () => {

--- a/src/components/text_truncate/utils.test.ts
+++ b/src/components/text_truncate/utils.test.ts
@@ -81,6 +81,19 @@ describe('TruncationUtils', () => {
         expect(utils.checkSufficientEllipsisWidth('start')).toBeUndefined();
       });
     });
+
+    describe('checkTruncationOffsetWidth', () => {
+      it('returns false and errors if the container is not wide enough for the offset text', () => {
+        setSpanWidth(201);
+        expect(utils.checkTruncationOffsetWidth('hello')).toEqual(false);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'The passed truncationOffset is too large for the available width. Truncating the offset instead.'
+        );
+
+        setSpanWidth(200);
+        expect(utils.checkTruncationOffsetWidth('world')).toBeUndefined();
+      });
+    });
   });
 
   describe('truncation types', () => {
@@ -115,6 +128,12 @@ describe('TruncationUtils', () => {
           mockTextWidth.mockImplementationOnce(() => 30); // Mocks the `checkTruncationOffsetWidth` check
           expect(utils.truncateStart(3)).toEqual('Lor...sum dolor sit amet');
         });
+
+        it('truncates the offset if the truncationOffset is too large', () => {
+          mockTextWidth.mockImplementationOnce(() => 201);
+          expect(utils.truncateStart(20)).toEqual('... ipsum dolor si');
+          expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        });
       });
     });
 
@@ -127,6 +146,12 @@ describe('TruncationUtils', () => {
         it('preserves the specified number of characters at the end of the text', () => {
           mockTextWidth.mockImplementationOnce(() => 30); // Mocks the `checkTruncationOffsetWidth` check
           expect(utils.truncateEnd(3)).toEqual('Lorem ipsum dolor ...met');
+        });
+
+        it('truncates the offset if the truncationOffset is too large', () => {
+          mockTextWidth.mockImplementationOnce(() => 201);
+          expect(utils.truncateEnd(18)).toEqual('sum dolor sit...');
+          expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
         });
       });
     });

--- a/src/components/text_truncate/utils.test.ts
+++ b/src/components/text_truncate/utils.test.ts
@@ -213,16 +213,29 @@ describe('TruncationUtilsWithCanvas', () => {
     value: () => ({ measureText: () => ({ width: 200 }), font: '' }),
   });
 
-  it('allows customizing the font', () => {
-    const utils = new TruncationUtilsWithCanvas({
-      ...sharedParams,
-      font: 'Inter',
+  describe('font calculations', () => {
+    it('computes the set font if passed a container element', () => {
+      const container = document.createElement('div');
+      container.style.font = '14px Inter';
+
+      const utils = new TruncationUtilsWithCanvas({
+        ...sharedParams,
+        container,
+      });
+      expect(utils.context.font).toEqual('14px Inter');
     });
-    expect(utils.context.font).toEqual('Inter');
+
+    it('accepts a static font string', () => {
+      const utils = new TruncationUtilsWithCanvas({
+        ...sharedParams,
+        font: '14px Inter',
+      });
+      expect(utils.context.font).toEqual('14px Inter');
+    });
   });
 
   describe('canvas utils', () => {
-    const utils = new TruncationUtilsWithCanvas(sharedParams);
+    const utils = new TruncationUtilsWithCanvas({ ...sharedParams, font: '' });
 
     describe('textWidth', () => {
       it('returns the measured text width from the canvas', () => {

--- a/src/components/text_truncate/utils.test.ts
+++ b/src/components/text_truncate/utils.test.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { TruncationUtils } from './utils';
+
+describe('TruncationUtils', () => {
+  const params = {
+    fullText: 'Lorem ipsum dolor sit amet',
+    ellipsis: '...',
+    availableWidth: 200,
+    container: document.createElement('div'),
+  };
+
+  // JSDOM doesn't have box model widths, so we need to mock it
+  const setSpanWidth = (width: number) => {
+    Object.defineProperty(HTMLSpanElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: width,
+    });
+  };
+
+  // A few utilities log errors - silence them and capture the messages
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  beforeEach(() => consoleErrorSpy.mockClear());
+  afterAll(() => consoleErrorSpy.mockRestore());
+
+  describe('span utils', () => {
+    const utils = new TruncationUtils(params);
+
+    describe('textWidth', () => {
+      it('returns the offsetWidth of the internal span element', () => {
+        setSpanWidth(500);
+        expect(utils.textWidth).toEqual(500);
+      });
+    });
+
+    describe('setTextToCheck', () => {
+      it('sets the text content of the internal span element', () => {
+        utils.setTextToCheck('hello world');
+        expect(utils.span.textContent).toEqual('hello world');
+      });
+    });
+
+    describe('cleanup', () => {
+      it('removes the internal span element from the DOM', () => {
+        expect(params.container.contains(utils.span)).toBeTruthy();
+        utils.cleanup();
+        expect(params.container.contains(utils.span)).toBeFalsy();
+      });
+    });
+  });
+
+  describe('early return checks', () => {
+    const utils = new TruncationUtils(params);
+    afterAll(() => utils.cleanup());
+
+    describe('checkIfTruncationIsNeeded', () => {
+      it('returns false if truncation is not needed', () => {
+        setSpanWidth(100);
+        expect(utils.checkIfTruncationIsNeeded()).toEqual(false);
+
+        setSpanWidth(400);
+        expect(utils.checkIfTruncationIsNeeded()).toBeUndefined();
+      });
+    });
+
+    describe('checkSufficientEllipsisWidth', () => {
+      it('returns false and errors if the container is not wide enough for the ellipsis', () => {
+        setSpanWidth(201);
+        expect(utils.checkSufficientEllipsisWidth('startEnd')).toEqual(false);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'The truncation ellipsis is larger than the available width. No text can be rendered.'
+        );
+
+        setSpanWidth(10);
+        expect(utils.checkSufficientEllipsisWidth('start')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('truncation types', () => {
+    // Again, JSDOM doesn't have the concept of widths, so this is a bit
+    // of a mockery, but it at least gives us some confidence in our substring logic
+    let mockSpanWidth: number;
+    beforeEach(() => {
+      mockSpanWidth = params.availableWidth + 5; // 5 while loop iterations
+    });
+
+    // Simulate the width going down with each removed character
+    let mockTextWidth: jest.SpyInstance;
+    beforeAll(() => {
+      mockTextWidth = jest
+        .spyOn(TruncationUtils.prototype, 'textWidth', 'get')
+        .mockImplementation(() => mockSpanWidth--);
+    });
+    const utils = new TruncationUtils(params);
+
+    afterAll(() => {
+      utils.cleanup();
+      mockTextWidth.mockRestore();
+    });
+
+    describe('start', () => {
+      it('inserts ellipsis at the start of the text', () => {
+        expect(utils.truncateStart(0)).toEqual('... ipsum dolor sit amet');
+      });
+
+      describe('truncationOffset', () => {
+        it('preserves the specified number of characters at the start of the text', () => {
+          mockTextWidth.mockImplementationOnce(() => 30); // Mocks the `checkTruncationOffsetWidth` check
+          expect(utils.truncateStart(3)).toEqual('Lor...sum dolor sit amet');
+        });
+      });
+    });
+
+    describe('end', () => {
+      it('inserts ellipsis at the end of the text', () => {
+        expect(utils.truncateEnd(0)).toEqual('Lorem ipsum dolor sit...');
+      });
+
+      describe('truncationOffset', () => {
+        it('preserves the specified number of characters at the end of the text', () => {
+          mockTextWidth.mockImplementationOnce(() => 30); // Mocks the `checkTruncationOffsetWidth` check
+          expect(utils.truncateEnd(3)).toEqual('Lorem ipsum dolor ...met');
+        });
+      });
+    });
+
+    describe('startEnd', () => {
+      describe('with no truncationPosition', () => {
+        it('inserts ellipsis at the start and end of the text', () => {
+          expect(utils.truncateStartEndAtMiddle()).toEqual(
+            '... ipsum dolor sit...'
+          );
+        });
+      });
+
+      describe('with truncationPosition', () => {
+        // Because this approach builds up text instead of removing, we need to re-mock widths
+        beforeEach(() => {
+          mockSpanWidth = params.availableWidth - 8;
+          mockTextWidth.mockImplementation(() => mockSpanWidth++);
+        });
+        afterAll(() => {
+          mockTextWidth.mockImplementation(() => mockSpanWidth--); // restore mock
+        });
+
+        it('allows moving the anchor point of the displayed text', () => {
+          expect(utils.truncateStartEndAtPosition(10)).toEqual(
+            '...rem ipsum dolor ...'
+          );
+        });
+
+        it('does not display the leading ellipsis if the index is close to the start', () => {
+          expect(utils.truncateStartEndAtPosition(2)).toEqual('Lorem ipsu...');
+        });
+
+        it('does not display the trailing ellipsis if the index is close to the end', () => {
+          expect(utils.truncateStartEndAtPosition(20)).toEqual(
+            '...dolor sit amet'
+          );
+        });
+      });
+    });
+
+    describe('middle', () => {
+      it('inserts ellipsis in the middle of the text', () => {
+        expect(utils.truncateMiddle()).toEqual('Lorem ipsu...or sit amet');
+      });
+    });
+  });
+});

--- a/src/components/text_truncate/utils.test.ts
+++ b/src/components/text_truncate/utils.test.ts
@@ -124,7 +124,7 @@ describe('TruncationUtilsForDOM', () => {
 
     describe('start', () => {
       it('inserts ellipsis at the start of the text', () => {
-        expect(utils.truncateStart(0)).toEqual('... ipsum dolor sit amet');
+        expect(utils.truncateStart()).toEqual('... ipsum dolor sit amet');
       });
 
       describe('truncationOffset', () => {
@@ -143,7 +143,7 @@ describe('TruncationUtilsForDOM', () => {
 
     describe('end', () => {
       it('inserts ellipsis at the end of the text', () => {
-        expect(utils.truncateEnd(0)).toEqual('Lorem ipsum dolor sit...');
+        expect(utils.truncateEnd()).toEqual('Lorem ipsum dolor sit...');
       });
 
       describe('truncationOffset', () => {

--- a/src/components/text_truncate/utils.ts
+++ b/src/components/text_truncate/utils.ts
@@ -270,6 +270,8 @@ export class TruncationUtilsWithDOM extends _TruncationUtils {
     this.container = container;
 
     this.span = document.createElement('span');
+    this.span.style.position = 'absolute'; // Prevent page reflow/repaint for performance
+    this.span.style.whiteSpace = 'nowrap'; // EuiTextTruncate already sets this on the parent, but we'll set it here as well for consumers who use this util standalone
     this.container.appendChild(this.span);
   }
 

--- a/src/components/text_truncate/utils.ts
+++ b/src/components/text_truncate/utils.ts
@@ -106,7 +106,7 @@ class _TruncationUtils {
    * Truncation types logic. This is where the magic happens
    */
 
-  truncateStart = (truncationOffset: number) => {
+  truncateStart = (truncationOffset?: number) => {
     let truncatedText = this.fullText;
     let leadingText = '';
     const combinedText = () => `${leadingText}${truncatedText}`;

--- a/src/components/text_truncate/utils.ts
+++ b/src/components/text_truncate/utils.ts
@@ -74,6 +74,17 @@ export class TruncationUtils {
     }
   };
 
+  checkTruncationOffsetWidth = (text: string) => {
+    this.setTextToCheck(text);
+
+    if (this.textWidth > this.availableWidth) {
+      console.error(
+        `The passed truncationOffset is too large for the available width. Truncating the offset instead.`
+      );
+      return false;
+    }
+  };
+
   /**
    * Truncation enums
    */
@@ -87,7 +98,12 @@ export class TruncationUtils {
       [leadingText, truncatedText] = splitText(this.fullText).at(
         truncationOffset
       );
-      // TODO: offset width check
+
+      const widthCheck = `${leadingText}${this.ellipsis}`;
+      if (this.checkTruncationOffsetWidth(widthCheck) === false) {
+        truncatedText = leadingText;
+        leadingText = '';
+      }
     }
 
     leadingText += this.ellipsis;
@@ -109,7 +125,12 @@ export class TruncationUtils {
     if (truncationOffset) {
       const index = this.fullText.length - truncationOffset;
       [truncatedText, trailingText] = splitText(this.fullText).at(index);
-      // TODO: offset width check
+
+      const widthCheck = `${this.ellipsis}${trailingText}`;
+      if (this.checkTruncationOffsetWidth(widthCheck) === false) {
+        truncatedText = trailingText;
+        trailingText = '';
+      }
     }
 
     trailingText = this.ellipsis + trailingText;

--- a/src/components/text_truncate/utils.ts
+++ b/src/components/text_truncate/utils.ts
@@ -35,10 +35,10 @@ type CanvasParams = SharedParams &
  * which works by building up from an empty string / by adding characters
  * instead of removing them.
  */
-class _TruncationUtils {
-  fullText: SharedParams['fullText'];
-  ellipsis: SharedParams['ellipsis'];
-  availableWidth: SharedParams['availableWidth'];
+abstract class _TruncationUtils {
+  protected fullText: SharedParams['fullText'];
+  protected ellipsis: SharedParams['ellipsis'];
+  protected availableWidth: SharedParams['availableWidth'];
 
   constructor({ fullText, ellipsis, availableWidth }: SharedParams) {
     this.fullText = fullText;
@@ -49,24 +49,10 @@ class _TruncationUtils {
   /**
    * Internal measurement utils which will be overridden depending on the
    * rendering approach used (e.g. DOM vs Canvas).
-   *
-   * The thrown errors are there to ensure the base instance utils do not
-   * get called standalone in the future, if more extended classes are added
-   * someday (e.g. new shadow DOM tech, or Flash makes a surprise comeback).
-   *
-   * The istanbul code coverage ignores are there because this base class
-   * is not exported and in theory the code should never be reachable.
    */
 
-  /* istanbul ignore next */
-  get textWidth(): number {
-    throw new Error('This function must be superseded by a DOM or Canvas util');
-  }
-
-  /* istanbul ignore next */
-  setTextToCheck = (_: string): void => {
-    throw new Error('This function must be superseded by a DOM or Canvas util');
-  };
+  abstract textWidth: number;
+  abstract setTextToCheck: (text: string) => void;
 
   /**
    * Early return checks

--- a/src/components/text_truncate/utils.ts
+++ b/src/components/text_truncate/utils.ts
@@ -261,7 +261,7 @@ class _TruncationUtils {
  * NOTE: The consumer is responsible for calling the `cleanup()` method manually
  * to remove the temporary DOM node once their usage of this utility is complete.
  */
-export class TruncationUtilsForDOM extends _TruncationUtils {
+export class TruncationUtilsWithDOM extends _TruncationUtils {
   container: DOMParams['container'];
   span: HTMLSpanElement;
 
@@ -292,7 +292,7 @@ export class TruncationUtilsForDOM extends _TruncationUtils {
  * and requires no cleanup method. It will typically require passing font
  * information to accurately measure text width.
  */
-export class TruncationUtilsForCanvas extends _TruncationUtils {
+export class TruncationUtilsWithCanvas extends _TruncationUtils {
   context: CanvasRenderingContext2D;
   currentText = '';
 

--- a/src/components/text_truncate/utils.ts
+++ b/src/components/text_truncate/utils.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+type Params = {
+  fullText: string;
+  ellipsis: string;
+  availableWidth: number;
+  container: HTMLElement;
+};
+
+export class TruncationUtils {
+  fullText: Params['fullText'];
+  ellipsis: Params['ellipsis'];
+  availableWidth: Params['availableWidth'];
+  container: Params['container'];
+  span: HTMLSpanElement;
+
+  constructor({ fullText, ellipsis, availableWidth, container }: Params) {
+    this.fullText = fullText;
+    this.ellipsis = ellipsis;
+    this.availableWidth = availableWidth;
+    this.container = container;
+
+    // Create a temporary DOM element for manipulating text and determining text width
+    this.span = document.createElement('span');
+    this.container.appendChild(this.span);
+  }
+
+  /**
+   * Span utils
+   */
+
+  get textWidth() {
+    return this.span.offsetWidth;
+  }
+
+  setTextToCheck = (text: string) => {
+    this.span.textContent = text;
+  };
+
+  cleanup = () => {
+    this.container.removeChild(this.span);
+  };
+
+  /**
+   * Early return checks
+   */
+
+  checkIfTruncationIsNeeded = () => {
+    this.setTextToCheck(this.fullText);
+
+    if (this.availableWidth > this.textWidth) {
+      return false;
+    }
+  };
+
+  checkSufficientEllipsisWidth = (truncation: string) => {
+    const textToCheck =
+      truncation === 'startEnd'
+        ? `${this.ellipsis} ${this.ellipsis}` // startEnd needs a little more space
+        : this.ellipsis;
+    this.setTextToCheck(textToCheck);
+
+    if (this.textWidth >= this.availableWidth * 0.9) {
+      console.error(
+        'The truncation ellipsis is larger than the available width. No text can be rendered.'
+      );
+      return false;
+    }
+  };
+
+  /**
+   * Truncation enums
+   */
+
+  truncateStart = (truncationOffset: number) => {
+    let truncatedText = this.fullText;
+    let leadingText = '';
+    const combinedText = () => `${leadingText}${truncatedText}`;
+
+    if (truncationOffset) {
+      [leadingText, truncatedText] = splitText(this.fullText).at(
+        truncationOffset
+      );
+      // TODO: offset width check
+    }
+
+    leadingText += this.ellipsis;
+    this.setTextToCheck(combinedText());
+
+    while (this.textWidth > this.availableWidth) {
+      truncatedText = removeFirstCharacter(truncatedText);
+      this.setTextToCheck(combinedText());
+    }
+
+    return combinedText();
+  };
+
+  truncateEnd = (truncationOffset?: number) => {
+    let truncatedText = this.fullText;
+    let trailingText = '';
+    const combinedText = () => `${truncatedText}${trailingText}`;
+
+    if (truncationOffset) {
+      const index = this.fullText.length - truncationOffset;
+      [truncatedText, trailingText] = splitText(this.fullText).at(index);
+      // TODO: offset width check
+    }
+
+    trailingText = this.ellipsis + trailingText;
+    this.setTextToCheck(combinedText());
+
+    while (this.textWidth > this.availableWidth) {
+      truncatedText = removeLastCharacter(truncatedText);
+      this.setTextToCheck(combinedText());
+    }
+
+    return combinedText();
+  };
+
+  truncateStartEndAtPosition = (truncationPosition: number) => {
+    // If using a non-centered startEnd anchor position, we need to *build*
+    // the string from scratch instead of *removing* from the full text string,
+    // to make sure we don't go past the beginning or end of the text
+    let truncatedText = '';
+    this.setTextToCheck(truncatedText);
+
+    // Ellipses are conditional - if the anchor is towards the beginning or end,
+    // it's possible they shouldn't render
+    let startingEllipsis = this.ellipsis;
+    let endingEllipsis = this.ellipsis;
+
+    // Split the text into two at the anchor position
+    let [firstPart, secondPart] = splitText(this.fullText).at(
+      truncationPosition
+    );
+
+    const combinedText = () =>
+      `${startingEllipsis}${truncatedText}${endingEllipsis}`;
+
+    while (this.textWidth <= this.availableWidth) {
+      if (firstPart.length > 0) {
+        truncatedText = `${getLastCharacter(firstPart)}${truncatedText}`;
+        firstPart = removeLastCharacter(firstPart);
+      } else {
+        startingEllipsis = '';
+      }
+
+      if (secondPart.length > 0) {
+        truncatedText = `${truncatedText}${getFirstCharacter(secondPart)}`;
+        secondPart = removeFirstCharacter(secondPart);
+      } else {
+        endingEllipsis = '';
+      }
+
+      this.setTextToCheck(combinedText());
+    }
+
+    // Because this logic builds text outwards vs. removes inwards, the final text
+    // width ends up a little larger than the container, and we need to remove
+    // the last added character(s)
+    if (!startingEllipsis) {
+      truncatedText = removeLastCharacter(truncatedText);
+    } else if (!endingEllipsis) {
+      truncatedText = removeFirstCharacter(truncatedText);
+    } else {
+      truncatedText = removeFirstAndLastCharacters(truncatedText);
+    }
+
+    return combinedText();
+  };
+
+  truncateStartEndAtMiddle = () => {
+    let truncatedText = this.fullText;
+    this.setTextToCheck(truncatedText);
+
+    const combinedText = () =>
+      `${this.ellipsis}${truncatedText}${this.ellipsis}`;
+
+    while (this.textWidth > this.availableWidth) {
+      truncatedText = removeFirstAndLastCharacters(truncatedText);
+      this.setTextToCheck(combinedText());
+    }
+
+    return combinedText();
+  };
+
+  truncateMiddle = () => {
+    const middlePosition = Math.floor(this.fullText.length / 2);
+    let [firstHalf, secondHalf] = splitText(this.fullText).at(middlePosition);
+    let trimfirstHalf;
+
+    const combinedText = () => `${firstHalf}${this.ellipsis}${secondHalf}`;
+    this.setTextToCheck(combinedText());
+
+    while (this.textWidth > this.availableWidth) {
+      trimfirstHalf = !trimfirstHalf;
+      if (trimfirstHalf) {
+        firstHalf = removeLastCharacter(firstHalf);
+      } else {
+        secondHalf = removeFirstCharacter(secondHalf);
+      }
+      this.setTextToCheck(combinedText());
+    }
+
+    return combinedText();
+  };
+}
+
+/**
+ * DRY character utils
+ */
+const removeLastCharacter = (text: string) =>
+  text.substring(0, text.length - 1);
+
+const getLastCharacter = (text: string) => text.substring(text.length - 1);
+
+const removeFirstCharacter = (text: string) => text.substring(1);
+
+const getFirstCharacter = (text: string) => text.substring(0, 1);
+
+const removeFirstAndLastCharacters = (text: string) =>
+  text.substring(1, text.length - 1);
+
+const splitText = (text: string) => ({
+  at: (index: number) => [text.substring(0, index), text.substring(index)],
+});

--- a/upcoming_changelogs/7116.md
+++ b/upcoming_changelogs/7116.md
@@ -1,0 +1,1 @@
+- Added a new `EuiTextTruncate` component, which provides custom truncation options beyond native CSS


### PR DESCRIPTION
## Summary

This standalone component was created from @dej611's proposal for customizable truncation for `EuiComboBox`. Once this PR merges, we'll update #7028 to dogfood the new component.

⚠️ Unlike most PRs, I **don't** recommend following along by commit, as I went through a ton of back and forth and refactoring with Marco 😅 (see https://github.com/elastic/eui/pull/7028#discussion_r1301242633). I preserved the commit history just in case anyone was interested in seeing it, but since it's a brand new component, it's way easier to just look at the final diff. I promise most 50-60% of it is just tests and documentations 🤞 

### Screencaps

![screencap](https://github.com/elastic/eui/assets/549407/4fb245e9-192b-4f09-9a2b-c6a6f44c3ae7)

![screencap](https://github.com/elastic/eui/assets/549407/c0cdf9cd-154d-4279-a21c-a41a83d32115)

Note that highlighting truncated text will see a significant UX improvement with this utility compared to previously (highlighted text that was out of view would not be visible to users).

## QA

- Go to https://eui.elastic.co/pr_7116/#/utilities/text-truncation
- Review all new descriptions and demos, leave feedback on any that don't make sense

### General checklist

- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~ - skipping playground due to imminent move to Storybook
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

~- [ ] Checked in both **light and dark** modes~ - N/A, doesn't apply to this component
~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~ 
~- [ ] Checked for **breaking changes** and labeled appropriately~
~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ - I don't think this needs a Figma counterpart since it's purely a utility