### PR TITLE
[WIP] [EuiInlineEdit] Allow `EuiInlineEdit` to be used as a controlled component

### DIFF
--- a/src-docs/src/views/inline_edit/inline_edit_title.tsx
+++ b/src-docs/src/views/inline_edit/inline_edit_title.tsx
@@ -42,6 +42,8 @@ export default () => {
     setToggleTitleButtonSize(optionId);
   };
 
+  const [inlineEditValue, setInlineEditValue] = useState('hello world');
+
   return (
     <>
       <EuiButtonGroup
@@ -58,6 +60,21 @@ export default () => {
         size={toggleTitleButtonSize}
         inputAriaLabel="Edit title inline"
         defaultValue="Hello World (but as a title)!"
+      />
+
+      <EuiSpacer />
+
+      <EuiInlineEditTitle
+        heading="h3"
+        size={toggleTitleButtonSize}
+        inputAriaLabel="Edit title inline"
+        value={inlineEditValue}
+        onChange={(e) => {
+          setInlineEditValue(e.target.value);
+        }}
+        onCancel={(previousValue) => {
+          setInlineEditValue(previousValue);
+        }}
       />
     </>
   );

--- a/src/components/inline_edit/inline_edit_form.tsx
+++ b/src/components/inline_edit/inline_edit_form.tsx
@@ -18,7 +18,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps } from '../common';
+import { CommonProps, ExclusiveUnion } from '../common';
 import {
   EuiFormRow,
   EuiFormRowProps,
@@ -42,7 +42,6 @@ export type EuiInlineEditCommonProps = Omit<
   'children'
 > &
   CommonProps & {
-    defaultValue: string;
     placeholder?: string;
     /**
      * Callback that fires when a user clicks the save button.
@@ -90,7 +89,22 @@ export type EuiInlineEditCommonProps = Omit<
      * Locks inline edit in read mode and displays the text value
      */
     isReadOnly?: boolean;
-  };
+  } & ExclusiveUnion<
+    {
+      /**
+       * Initial inline edit text value
+       */
+      defaultValue: string;
+    },
+    {
+      /**
+       * To use inline edit as a controlled component, continuously pass the value via this prop
+       */
+      value: string;
+      // TODO: Update to an HTML Change Event
+      onChange: (event: any) => void;
+    }
+  >;
 
 // Internal-only props, passed by the consumer-facing components
 export type EuiInlineEditFormProps = EuiInlineEditCommonProps & {


### PR DESCRIPTION
🛑 WIP - DO NOT MERGE

#7084 

## Summary
Allows `EuiInlineEdit` to be used as a controlled component with the addition of three new props
More to come (this is a WIP)

### Feature Checklist
1. Create three new props
    1. value - controlled value for consumers 
    2. onChange - onChange callback that returns the HTML event
    3. onCancel - onCancel callback that returns the previous value 
2. Create exclusive union between defaultValue and {value, onChange}
3. Create useMemo to return valueToUse
    1. Should return which value should be used in edit mode and read mode elements.
        1. If ( value ) - use it | Else Fall back to readModeValue / editModeValue based on isEditing
    2. Replace instances of readModeValue & editModeValue with valueToUse
4. Pass onChange from props to edit mode form element (ln. 238)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
