### PR TITLE
[EuiThemeProvider] Add context & state required for theme CSS variables architecture

### DIFF
--- a/src/services/theme/__snapshots__/provider.test.tsx.snap
+++ b/src/services/theme/__snapshots__/provider.test.tsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiThemeProvider CSS variables allows child components to set non-global theme CSS variables 1`] = `
+<span
+  class="euiThemeProvider emotion-euiCSSVariables-euiColorMode--colorClassName"
+/>
+`;
+
 exports[`EuiThemeProvider nested EuiThemeProviders allows avoiding the extra span wrapper with \`wrapperProps.cloneElement\` 1`] = `
 <div>
   Top-level provider

--- a/src/services/theme/context.ts
+++ b/src/services/theme/context.ts
@@ -34,4 +34,6 @@ export const EuiNestedThemeContext = createContext<EuiThemeNested>({
   hasDifferentColorFromGlobalTheme: false,
   bodyColor: '',
   colorClassName: '',
+  setGlobalCSSVariables: () => {},
+  setNearestThemeCSSVariables: () => {},
 });

--- a/src/services/theme/hooks.test.tsx
+++ b/src/services/theme/hooks.test.tsx
@@ -7,8 +7,10 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { renderHook } from '../../test/rtl';
+
+import { EuiProvider } from '../../components';
 
 import { setEuiDevProviderWarning } from './warning';
 import {
@@ -16,6 +18,7 @@ import {
   UseEuiTheme,
   withEuiTheme,
   RenderWithEuiTheme,
+  useEuiThemeCSSVariables,
 } from './hooks';
 
 describe('useEuiTheme', () => {
@@ -80,5 +83,23 @@ describe('RenderWithEuiTheme', () => {
     expect(container.firstChild!.textContent).toEqual(
       'euiTheme,colorMode,modifications'
     );
+  });
+});
+
+describe('useEuiThemeCSSVariables', () => {
+  it('returns CSS variable related state setters/getters', () => {
+    const { result } = renderHook(useEuiThemeCSSVariables, {
+      wrapper: EuiProvider,
+    });
+    expect(result.current.globalCSSVariables).toBeUndefined();
+    expect(result.current.themeCSSVariables).toBeUndefined();
+
+    act(() => {
+      result.current.setNearestThemeCSSVariables({ '--hello': 'world' });
+    });
+
+    // In this case, the nearest theme is the global one, so it should set both
+    expect(result.current.globalCSSVariables).toEqual({ '--hello': 'world' });
+    expect(result.current.themeCSSVariables).toEqual({ '--hello': 'world' });
   });
 });

--- a/src/services/theme/hooks.tsx
+++ b/src/services/theme/hooks.tsx
@@ -13,6 +13,7 @@ import {
   EuiModificationsContext,
   EuiColorModeContext,
   defaultComputedTheme,
+  EuiNestedThemeContext,
 } from './context';
 import { emitEuiProviderWarning } from './warning';
 import {
@@ -94,4 +95,24 @@ export const RenderWithEuiTheme = <T extends {} = {}>({
 }) => {
   const theme = useEuiTheme<T>();
   return children(theme);
+};
+
+/**
+ * Minor syntactical sugar hook for theme CSS variables.
+ * Primarily meant for internal EUI usage.
+ */
+export const useEuiThemeCSSVariables = () => {
+  const {
+    setGlobalCSSVariables,
+    globalCSSVariables,
+    setNearestThemeCSSVariables,
+    themeCSSVariables,
+  } = useContext(EuiNestedThemeContext);
+
+  return {
+    setGlobalCSSVariables,
+    globalCSSVariables,
+    setNearestThemeCSSVariables,
+    themeCSSVariables,
+  };
 };

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -14,7 +14,12 @@ export {
   EuiColorModeContext,
 } from './context';
 export type { UseEuiTheme, WithEuiThemeProps } from './hooks';
-export { useEuiTheme, withEuiTheme, RenderWithEuiTheme } from './hooks';
+export {
+  useEuiTheme,
+  withEuiTheme,
+  RenderWithEuiTheme,
+  useEuiThemeCSSVariables,
+} from './hooks';
 export type { EuiThemeProviderProps } from './provider';
 export { EuiThemeProvider } from './provider';
 export { getEuiDevProviderWarning, setEuiDevProviderWarning } from './warning';

--- a/src/services/theme/provider.stories.tsx
+++ b/src/services/theme/provider.stories.tsx
@@ -6,10 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, useContext, useEffect } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { EuiNestedThemeContext } from './context';
+import { useEuiThemeCSSVariables } from './hooks';
 import { EuiThemeProvider, EuiThemeProviderProps } from './provider';
 
 const meta: Meta<EuiThemeProviderProps<{}>> = {
@@ -79,9 +79,8 @@ const MockComponent: FunctionComponent<{
   color: string;
   children: any;
 }> = ({ global, color, children }) => {
-  const { setGlobalCSSVariables, setNearestThemeCSSVariables } = useContext(
-    EuiNestedThemeContext
-  );
+  const { setGlobalCSSVariables, setNearestThemeCSSVariables } =
+    useEuiThemeCSSVariables();
 
   useEffect(() => {
     if (global) {

--- a/src/services/theme/provider.stories.tsx
+++ b/src/services/theme/provider.stories.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, useContext, useEffect } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiNestedThemeContext } from './context';
+import { EuiThemeProvider, EuiThemeProviderProps } from './provider';
+
+const meta: Meta<EuiThemeProviderProps<{}>> = {
+  title: 'EuiThemeProvider',
+  component: EuiThemeProvider,
+};
+
+export default meta;
+type Story = StoryObj<EuiThemeProviderProps<{}>>;
+
+export const WrapperCloneElement: Story = {
+  render: () => (
+    <>
+      <EuiThemeProvider wrapperProps={{ cloneElement: true }}>
+        <main className="clonedExample">
+          This example should only have 1 main wrapper rendered.
+        </main>
+      </EuiThemeProvider>
+    </>
+  ),
+};
+
+export const CSSVariablesNearest: Story = {
+  render: () => (
+    <>
+      <MockComponent color="red">
+        This component sets the nearest theme provider (the global theme) with a
+        red CSS variable color. Inspect the `:root` styles to see the variable
+        set.
+      </MockComponent>
+      <EuiThemeProvider>
+        <MockComponent color="blue">
+          This component sets the nearest local theme provider with a blue CSS
+          variable color. Inspect the parent theme wrapper to see the variable
+          set.
+        </MockComponent>
+      </EuiThemeProvider>
+    </>
+  ),
+};
+
+export const CSSVariablesGlobal: Story = {
+  render: () => (
+    <>
+      <MockComponent color="red">
+        This component sets the nearest theme provider (the global theme) with a
+        red CSS variable color. However, it should be overridden by the next
+        component.
+      </MockComponent>
+      <EuiThemeProvider>
+        <MockComponent color="blue" global={true}>
+          This component sets the global theme with a blue CSS variable color.
+          It should override the previous component. Inspect the `:root` styles
+          to see this behavior
+        </MockComponent>
+      </EuiThemeProvider>
+    </>
+  ),
+};
+
+/**
+ * Component for QA/testing purposes that mocks an EUI component
+ * that sets global or theme-level CSS variables
+ */
+const MockComponent: FunctionComponent<{
+  global?: boolean;
+  color: string;
+  children: any;
+}> = ({ global, color, children }) => {
+  const { setGlobalCSSVariables, setNearestThemeCSSVariables } = useContext(
+    EuiNestedThemeContext
+  );
+
+  useEffect(() => {
+    if (global) {
+      setGlobalCSSVariables({ '--testColor': color });
+    } else {
+      setNearestThemeCSSVariables({ '--testColor': color });
+    }
+  }, [global, color, setGlobalCSSVariables, setNearestThemeCSSVariables]);
+
+  return (
+    <p style={{ color: 'var(--testColor)', marginBlockEnd: '1em' }}>
+      {children}
+    </p>
+  );
+};

--- a/src/services/theme/types.ts
+++ b/src/services/theme/types.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import type { CSSObject } from '@emotion/react';
+
 import { RecursivePartial, ValueOf } from '../../components/common';
 import { _EuiThemeAnimation } from '../../global_styling/variables/animations';
 import { _EuiThemeBreakpoints } from '../../global_styling/variables/breakpoint';
@@ -99,4 +101,8 @@ export type EuiThemeNested = {
   hasDifferentColorFromGlobalTheme: boolean;
   bodyColor: string;
   colorClassName: string;
+  setGlobalCSSVariables: Function;
+  globalCSSVariables?: CSSObject;
+  setNearestThemeCSSVariables: Function;
+  themeCSSVariables?: CSSObject;
 };


### PR DESCRIPTION
## Summary

> ⚠️ NOTE: This PR is merging into a feature branch, as it doesn't make much sense on its own without another component utilizing its behavior.

This PR adds the architecture for CSS variables to be set by EUI components. This is part of the work needed for #7025, in particular:

> Some components have style-related **variables** that may need to be reused by consumers, or even by other components within EUI. Examples of these are [`euiFormVariables`](https://github.com/elastic/eui/blob/d39c0e988409f90f62af57174590044664b2bfce/src/components/form/form.styles.ts#L19) and [`euiHeaderVariables`](https://github.com/elastic/eui/blob/3e950bf7605c6fea31f75cd7f2aedfe233d5607e/src/components/header/header.styles.ts#L20).
> Instead of moving these style variables outside our `.styles.ts` files and continuing to export them publicly, @tkajtoch has suggested switching them to CSS variables instead. This will involve:
>    [...] Declaring these component style vars once at the top level in our [global styles](https://github.com/elastic/eui/blob/3ab325b45049d65899d6c2f0f6cb86dadcd6f1d0/src/global_styling/reset/global_styles.tsx#L122) (ensuring consumers have access to the default vars everywhere in the app)

### Screencaps

**Global theme variables:**
<img width="300" alt="global root variables" src="https://github.com/elastic/eui/assets/549407/e38c8f90-8203-44db-948b-a5070f29baea">

**Local theme variables:**
<img width="250" alt="theme variables" src="https://github.com/elastic/eui/assets/549407/cd2c6f6a-0669-43ae-a690-50241e268fb7">

## QA

- `gh pr checkout 7132`
- `yarn storybook`
- Go to http://localhost:6006/?path=/story/euithemeprovider--css-variables-nearest and inspect the story's CSS
- [x] Confirm the red text is setting its color from a CSS var, and that CSS var definition is set in `:root`
- [x] Confirm the blue text is setting its color from a CSS var, and that CSS var definition is set on the parent `.euiThemeProvider` wrapper
- Go to http://localhost:6006/?path=/story/euithemeprovider--css-variables-global
- [x] Confirm both text lines are setting using css var definition from `:root`

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox** - [caniuse CSS variables](https://caniuse.com/css-variables)
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ No documentation, this architecture is meant for EUI internal components, not for consumers
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~ No changelog, see above reasoning