### PR TITLE
[Emotion][Theming] Add new consumer-configurable `font.defaultUnits` token

### DIFF
--- a/src-docs/src/views/theme/typography/_typography_js.tsx
+++ b/src-docs/src/views/theme/typography/_typography_js.tsx
@@ -107,17 +107,17 @@ export const FontJS = () => {
       />
 
       <ThemeExample
-        title={<code>euiTheme.font.fontSizeUnit</code>}
-        description={getDescription(baseProps.fontSizeUnit)}
+        title={<code>euiTheme.font.defaultUnits</code>}
+        description={getDescription(baseProps.defaultUnits)}
         example={
-          <EuiThemeProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+          <EuiThemeProvider modify={{ font: { defaultUnits: 'px' } }}>
             <EuiText>
               My font size and line height is set using <EuiCode>px</EuiCode>{' '}
               and not <EuiCode>rem</EuiCode>
             </EuiText>
           </EuiThemeProvider>
         }
-        snippet={`<EuiProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+        snippet={`<EuiProvider modify={{ font: { defaultUnits: 'px' } }}>
   <EuiText>
     <p>Hello world</p>
   </EuiText>

--- a/src-docs/src/views/theme/typography/_typography_js.tsx
+++ b/src-docs/src/views/theme/typography/_typography_js.tsx
@@ -17,8 +17,8 @@ import {
   useEuiFontSize,
   EuiThemeFontWeights,
   EuiThemeFontScales,
-  EuiThemeFontSizeMeasurements,
-  _EuiThemeFontSizeMeasurement,
+  EuiThemeFontUnits,
+  _EuiThemeFontUnit,
 } from '../../../../../src/global_styling';
 
 import { EuiThemeFontBase, EuiThemeFontWeight, ThemeRowType } from '../_props';
@@ -250,27 +250,25 @@ export const FontScaleValuesJS = () => {
   const euiThemeContext = useEuiTheme();
   const scaleKeys = EuiThemeFontScales;
 
-  const measurementButtons = EuiThemeFontSizeMeasurements.map((m) => {
+  const unitButtons = EuiThemeFontUnits.map((m) => {
     return {
       id: m,
       label: m,
     };
   });
 
-  const [measurementSelected, setMeasurementSelected] = useState(
-    measurementButtons[0].id
-  );
+  const [unitSelected, setUnitSelected] = useState(unitButtons[0].id);
 
   return (
     <>
       <EuiPanel color="accent">
         <EuiDescribedFormGroup
           fullWidth
-          title={<h3>Value measurements</h3>}
+          title={<h3>Font units</h3>}
           description={
             <p>
-              The font sizing function also supports the three main measurements
-              for font-size, <EuiCode>rem | px | em</EuiCode>, with{' '}
+              The font sizing function also supports three main units for font
+              size and line height: <EuiCode>rem | px | em</EuiCode>, with{' '}
               <EuiCode>rem</EuiCode> being default for all EUI components.
             </p>
           }
@@ -278,12 +276,10 @@ export const FontScaleValuesJS = () => {
           <EuiSpacer />
           <EuiButtonGroup
             buttonSize="m"
-            legend="Value measurement to show in table"
-            options={measurementButtons}
-            idSelected={measurementSelected}
-            onChange={(id) =>
-              setMeasurementSelected(id as _EuiThemeFontSizeMeasurement)
-            }
+            legend="Value unit to show in table"
+            options={unitButtons}
+            idSelected={unitSelected}
+            onChange={(id) => setUnitSelected(id as _EuiThemeFontUnit)}
             color="accent"
             isFullWidth
           />
@@ -293,23 +289,17 @@ export const FontScaleValuesJS = () => {
       <EuiBasicTable<FontScaleDetails>
         tableLayout="auto"
         items={scaleKeys.map((scale, index) => {
+          const { fontSize, lineHeight } = euiFontSize(euiThemeContext, scale, {
+            unit: unitSelected,
+          });
+
           return {
             id: scale,
             value: `useEuiFontSize('${scale}'${
-              measurementSelected !== 'rem'
-                ? `,\n  { measurement: '${measurementSelected}' }\n`
-                : ''
+              unitSelected !== 'rem' ? `, { unit: '${unitSelected}' }` : ''
             })`,
-            size: `${
-              euiFontSize(euiThemeContext, scale, {
-                measurement: measurementSelected,
-              }).fontSize
-            }`,
-            lineHeight: `${
-              euiFontSize(euiThemeContext, scale, {
-                measurement: measurementSelected,
-              }).lineHeight
-            }`,
+            size: String(fontSize),
+            lineHeight: String(lineHeight),
             index,
           };
         })}
@@ -323,7 +313,7 @@ export const FontScaleValuesJS = () => {
               <div
                 css={css`
                   ${euiFontSize(euiThemeContext, item.id, {
-                    measurement: measurementSelected,
+                    unit: unitSelected,
                   })}
                 `}
               >

--- a/src-docs/src/views/theme/typography/_typography_js.tsx
+++ b/src-docs/src/views/theme/typography/_typography_js.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import { css } from '@emotion/react';
-import { useEuiTheme } from '../../../../../src/services';
+import { useEuiTheme, EuiThemeProvider } from '../../../../../src/services';
 import {
   EuiBasicTable,
   EuiButtonGroup,
@@ -9,6 +9,7 @@ import {
   EuiDescribedFormGroup,
   EuiPanel,
   EuiSpacer,
+  EuiText,
 } from '../../../../../src/components';
 
 import {
@@ -103,6 +104,26 @@ export const FontJS = () => {
         }
         snippet={'font-feature-settings: ${euiTheme.font.featureSettings};'}
         snippetLanguage="emotion"
+      />
+
+      <ThemeExample
+        title={<code>euiTheme.font.fontSizeUnit</code>}
+        description={getDescription(baseProps.fontSizeUnit)}
+        example={
+          <EuiThemeProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+            <EuiText>
+              My font size and line height is set using <EuiCode>px</EuiCode>{' '}
+              and not <EuiCode>rem</EuiCode>
+            </EuiText>
+          </EuiThemeProvider>
+        }
+        snippet={`<EuiProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+  <EuiText>
+    <p>Hello world</p>
+  </EuiText>
+</EuiProvider>
+`}
+        snippetLanguage="jsx"
       />
     </>
   );

--- a/src/components/markdown_editor/markdown_format.styles.ts
+++ b/src/components/markdown_editor/markdown_format.styles.ts
@@ -24,8 +24,8 @@ const euiScaleMarkdownFormatText = (
   options: _FontScaleOptions
 ) => {
   const { fontSize, lineHeight } = euiFontSize(euiTheme, 'm', options);
-  const { measurement } = options;
-  const lineHeightSize = measurement === 'em' ? `${lineHeight}em` : lineHeight;
+  const { unit } = options;
+  const lineHeightSize = unit === 'em' ? `${lineHeight}em` : lineHeight;
 
   // Custom scales
   const tablePaddingVertical = mathWithUnits(fontSize, (x) => x / 4);
@@ -82,7 +82,7 @@ export const euiMarkdownFormatStyles = (euiTheme: UseEuiTheme) => ({
   `,
   relative: css`
     ${euiScaleMarkdownFormatText(euiTheme, {
-      measurement: 'em',
+      unit: 'em',
     })}
   `,
 });

--- a/src/components/markdown_editor/markdown_format.styles.ts
+++ b/src/components/markdown_editor/markdown_format.styles.ts
@@ -67,19 +67,16 @@ export const euiMarkdownFormatStyles = (euiTheme: UseEuiTheme) => ({
   // Text sizes
   m: css`
     ${euiScaleMarkdownFormatText(euiTheme, {
-      measurement: 'rem',
       customScale: 'm',
     })}
   `,
   s: css`
     ${euiScaleMarkdownFormatText(euiTheme, {
-      measurement: 'rem',
       customScale: 's',
     })}
   `,
   xs: css`
     ${euiScaleMarkdownFormatText(euiTheme, {
-      measurement: 'rem',
       customScale: 'xs',
     })}
   `,

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -46,8 +46,8 @@ const euiScaleText = (
 ) => {
   const { fontSize, lineHeight } = euiFontSize(euiThemeContext, 'm', options);
   const { euiTheme } = euiThemeContext;
-  const { measurement, customScale: _customScale } = options;
-  const lineHeightSize = measurement === 'em' ? `${lineHeight}em` : lineHeight;
+  const { unit, customScale: _customScale } = options;
+  const lineHeightSize = unit === 'em' ? `${lineHeight}em` : lineHeight;
 
   const headings = {
     h1: euiTitle(euiThemeContext, 'l', options),
@@ -360,7 +360,7 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     relative: css`
       ${euiScaleText(euiThemeContext, {
-        measurement: 'em',
+        unit: 'em',
       })}
     `,
   };

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -345,19 +345,16 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
     // Sizes
     m: css`
       ${euiScaleText(euiThemeContext, {
-        measurement: 'rem',
         customScale: 'm',
       })}
     `,
     s: css`
       ${euiScaleText(euiThemeContext, {
-        measurement: 'rem',
         customScale: 's',
       })}
     `,
     xs: css`
       ${euiScaleText(euiThemeContext, {
-        measurement: 'rem',
         customScale: 'xs',
       })}
     `,

--- a/src/global_styling/functions/__snapshots__/typography.test.tsx.snap
+++ b/src/global_styling/functions/__snapshots__/typography.test.tsx.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`euiFontSizeFromScale measurement em 1`] = `"1em"`;
-
-exports[`euiFontSizeFromScale measurement px 1`] = `"16px"`;
-
-exports[`euiFontSizeFromScale measurement rem 1`] = `"1.1429rem"`;
-
 exports[`euiFontSizeFromScale scale l 1`] = `"1.5714rem"`;
 
 exports[`euiFontSizeFromScale scale m 1`] = `"1.1429rem"`;
@@ -22,11 +16,11 @@ exports[`euiFontSizeFromScale scale xxs 1`] = `"0.7857rem"`;
 
 exports[`euiFontSizeFromScale scale xxxs 1`] = `"0.6429rem"`;
 
-exports[`euiLineHeightFromBaseline measurement em 1`] = `"1.5000"`;
+exports[`euiFontSizeFromScale unit em 1`] = `"1em"`;
 
-exports[`euiLineHeightFromBaseline measurement px 1`] = `"24px"`;
+exports[`euiFontSizeFromScale unit px 1`] = `"16px"`;
 
-exports[`euiLineHeightFromBaseline measurement rem 1`] = `"1.7143rem"`;
+exports[`euiFontSizeFromScale unit rem 1`] = `"1.1429rem"`;
 
 exports[`euiLineHeightFromBaseline scale l 1`] = `"1.7143rem"`;
 
@@ -43,3 +37,9 @@ exports[`euiLineHeightFromBaseline scale xxl 1`] = `"2.8571rem"`;
 exports[`euiLineHeightFromBaseline scale xxs 1`] = `"1.1429rem"`;
 
 exports[`euiLineHeightFromBaseline scale xxxs 1`] = `"0.8571rem"`;
+
+exports[`euiLineHeightFromBaseline unit em 1`] = `"1.5000"`;
+
+exports[`euiLineHeightFromBaseline unit px 1`] = `"24px"`;
+
+exports[`euiLineHeightFromBaseline unit rem 1`] = `"1.7143rem"`;

--- a/src/global_styling/functions/__snapshots__/typography.test.tsx.snap
+++ b/src/global_styling/functions/__snapshots__/typography.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`euiFontSizeFromScale measurement em 1`] = `"1em"`;
+
+exports[`euiFontSizeFromScale measurement px 1`] = `"16px"`;
+
+exports[`euiFontSizeFromScale measurement rem 1`] = `"1.1429rem"`;
+
+exports[`euiFontSizeFromScale scale l 1`] = `"1.5714rem"`;
+
+exports[`euiFontSizeFromScale scale m 1`] = `"1.1429rem"`;
+
+exports[`euiFontSizeFromScale scale s 1`] = `"1.0000rem"`;
+
+exports[`euiFontSizeFromScale scale xl 1`] = `"1.9286rem"`;
+
+exports[`euiFontSizeFromScale scale xs 1`] = `"0.8571rem"`;
+
+exports[`euiFontSizeFromScale scale xxl 1`] = `"2.4286rem"`;
+
+exports[`euiFontSizeFromScale scale xxs 1`] = `"0.7857rem"`;
+
+exports[`euiFontSizeFromScale scale xxxs 1`] = `"0.6429rem"`;
+
+exports[`euiLineHeightFromBaseline measurement em 1`] = `"1.5000"`;
+
+exports[`euiLineHeightFromBaseline measurement px 1`] = `"24px"`;
+
+exports[`euiLineHeightFromBaseline measurement rem 1`] = `"1.7143rem"`;
+
+exports[`euiLineHeightFromBaseline scale l 1`] = `"1.7143rem"`;
+
+exports[`euiLineHeightFromBaseline scale m 1`] = `"1.7143rem"`;
+
+exports[`euiLineHeightFromBaseline scale s 1`] = `"1.4286rem"`;
+
+exports[`euiLineHeightFromBaseline scale xl 1`] = `"2.2857rem"`;
+
+exports[`euiLineHeightFromBaseline scale xs 1`] = `"1.1429rem"`;
+
+exports[`euiLineHeightFromBaseline scale xxl 1`] = `"2.8571rem"`;
+
+exports[`euiLineHeightFromBaseline scale xxs 1`] = `"1.1429rem"`;
+
+exports[`euiLineHeightFromBaseline scale xxxs 1`] = `"0.8571rem"`;

--- a/src/global_styling/functions/typography.test.tsx
+++ b/src/global_styling/functions/typography.test.tsx
@@ -49,9 +49,9 @@ describe('euiFontSizeFromScale', () => {
       });
     });
 
-    it('falls back to the `fontSizeUnit` theme token if measurement is not passed', () => {
+    it('falls back to the `defaultUnits` theme token if measurement is not passed', () => {
       const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-        <EuiProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+        <EuiProvider modify={{ font: { defaultUnits: 'px' } }}>
           {children}
         </EuiProvider>
       );
@@ -98,9 +98,9 @@ describe('euiLineHeightFromBaseline', () => {
       });
     });
 
-    it('falls back to the `fontSizeUnit` theme token if measurement is not passed', () => {
+    it('falls back to the `defaultUnits` theme token if measurement is not passed', () => {
       const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
-        <EuiProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+        <EuiProvider modify={{ font: { defaultUnits: 'px' } }}>
           {children}
         </EuiProvider>
       );

--- a/src/global_styling/functions/typography.test.tsx
+++ b/src/global_styling/functions/typography.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
+
+import { EuiProvider } from '../../components';
+import { useEuiTheme } from '../../services';
+import {
+  EuiThemeFontScales,
+  EuiThemeFontSizeMeasurements,
+} from '../variables/typography';
+
+import { euiFontSizeFromScale, euiLineHeightFromBaseline } from './typography';
+
+// Default euiTheme to use for most tests
+const { euiTheme } = renderHook(useEuiTheme).result.current;
+
+describe('euiFontSizeFromScale', () => {
+  describe('scale', () => {
+    EuiThemeFontScales.forEach((scale) => {
+      test(scale, () => {
+        expect(euiFontSizeFromScale(scale, euiTheme)).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('custom scale', () => {
+    it('allows passing a custom modifier to the existing scale', () => {
+      expect(
+        euiFontSizeFromScale('xxxs', euiTheme, { customScale: 's' })
+      ).toEqual('0.5625rem');
+    });
+  });
+
+  describe('measurement', () => {
+    EuiThemeFontSizeMeasurements.forEach((unit) => {
+      test(unit, () => {
+        const output = euiFontSizeFromScale('m', euiTheme, {
+          measurement: unit,
+        });
+        expect(output.endsWith(unit)).toBe(true);
+        expect(output).toMatchSnapshot();
+      });
+    });
+
+    it('falls back to the `fontSizeUnit` theme token if measurement is not passed', () => {
+      const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+        <EuiProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+          {children}
+        </EuiProvider>
+      );
+      const { euiTheme: modifiedEuiTheme } = renderHook(useEuiTheme, {
+        wrapper,
+      }).result.current;
+
+      expect(euiFontSizeFromScale('m', modifiedEuiTheme)).toEqual('16px');
+    });
+  });
+});
+
+describe('euiLineHeightFromBaseline', () => {
+  describe('scale', () => {
+    EuiThemeFontScales.forEach((scale) => {
+      test(scale, () => {
+        expect(euiLineHeightFromBaseline(scale, euiTheme)).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('custom scale', () => {
+    it('allows passing a custom modifier to the existing scale', () => {
+      expect(
+        euiLineHeightFromBaseline('xxxs', euiTheme, { customScale: 's' })
+      ).toEqual('0.8571rem');
+    });
+  });
+
+  describe('measurement', () => {
+    EuiThemeFontSizeMeasurements.forEach((unit) => {
+      test(unit, () => {
+        const output = euiLineHeightFromBaseline('m', euiTheme, {
+          measurement: unit,
+        });
+
+        if (unit !== 'em') {
+          expect(output.endsWith(unit)).toBe(true);
+        } else {
+          expect(Number(output)).not.toBeNaN();
+        }
+
+        expect(output).toMatchSnapshot();
+      });
+    });
+
+    it('falls back to the `fontSizeUnit` theme token if measurement is not passed', () => {
+      const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
+        <EuiProvider modify={{ font: { fontSizeUnit: 'px' } }}>
+          {children}
+        </EuiProvider>
+      );
+      const { euiTheme: modifiedEuiTheme } = renderHook(useEuiTheme, {
+        wrapper,
+      }).result.current;
+
+      expect(euiLineHeightFromBaseline('m', modifiedEuiTheme)).toEqual('24px');
+    });
+  });
+});

--- a/src/global_styling/functions/typography.test.tsx
+++ b/src/global_styling/functions/typography.test.tsx
@@ -11,10 +11,7 @@ import { renderHook } from '@testing-library/react';
 
 import { EuiProvider } from '../../components';
 import { useEuiTheme } from '../../services';
-import {
-  EuiThemeFontScales,
-  EuiThemeFontSizeMeasurements,
-} from '../variables/typography';
+import { EuiThemeFontScales, EuiThemeFontUnits } from '../variables/typography';
 
 import { euiFontSizeFromScale, euiLineHeightFromBaseline } from './typography';
 
@@ -38,18 +35,16 @@ describe('euiFontSizeFromScale', () => {
     });
   });
 
-  describe('measurement', () => {
-    EuiThemeFontSizeMeasurements.forEach((unit) => {
+  describe('unit', () => {
+    EuiThemeFontUnits.forEach((unit) => {
       test(unit, () => {
-        const output = euiFontSizeFromScale('m', euiTheme, {
-          measurement: unit,
-        });
+        const output = euiFontSizeFromScale('m', euiTheme, { unit });
         expect(output.endsWith(unit)).toBe(true);
         expect(output).toMatchSnapshot();
       });
     });
 
-    it('falls back to the `defaultUnits` theme token if measurement is not passed', () => {
+    it('falls back to the `defaultUnits` theme token if a unit is not passed', () => {
       const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
         <EuiProvider modify={{ font: { defaultUnits: 'px' } }}>
           {children}
@@ -81,12 +76,10 @@ describe('euiLineHeightFromBaseline', () => {
     });
   });
 
-  describe('measurement', () => {
-    EuiThemeFontSizeMeasurements.forEach((unit) => {
+  describe('unit', () => {
+    EuiThemeFontUnits.forEach((unit) => {
       test(unit, () => {
-        const output = euiLineHeightFromBaseline('m', euiTheme, {
-          measurement: unit,
-        });
+        const output = euiLineHeightFromBaseline('m', euiTheme, { unit });
 
         if (unit !== 'em') {
           expect(output.endsWith(unit)).toBe(true);
@@ -98,7 +91,7 @@ describe('euiLineHeightFromBaseline', () => {
       });
     });
 
-    it('falls back to the `defaultUnits` theme token if measurement is not passed', () => {
+    it('falls back to the `defaultUnits` theme token if a unit is not passed', () => {
       const wrapper: FunctionComponent<PropsWithChildren> = ({ children }) => (
         <EuiProvider modify={{ font: { defaultUnits: 'px' } }}>
           {children}

--- a/src/global_styling/functions/typography.ts
+++ b/src/global_styling/functions/typography.ts
@@ -38,7 +38,7 @@ export interface _FontScaleOptions {
 export function euiFontSizeFromScale(
   scale: _EuiThemeFontScale,
   { base, font }: UseEuiTheme['euiTheme'],
-  { measurement = 'rem', customScale }: _FontScaleOptions = {}
+  { measurement = font.fontSizeUnit, customScale }: _FontScaleOptions = {}
 ) {
   if (measurement === 'em') {
     return `${font.scale[scale]}em`;
@@ -68,7 +68,7 @@ export function euiFontSizeFromScale(
 export function euiLineHeightFromBaseline(
   scale: _EuiThemeFontScale,
   { base, font }: UseEuiTheme['euiTheme'],
-  { measurement = 'rem', customScale }: _FontScaleOptions = {}
+  { measurement = font.fontSizeUnit, customScale }: _FontScaleOptions = {}
 ) {
   const { baseline, lineHeightMultiplier } = font;
   let numerator = base * font.scale[scale];

--- a/src/global_styling/functions/typography.ts
+++ b/src/global_styling/functions/typography.ts
@@ -38,7 +38,7 @@ export interface _FontScaleOptions {
 export function euiFontSizeFromScale(
   scale: _EuiThemeFontScale,
   { base, font }: UseEuiTheme['euiTheme'],
-  { measurement = font.fontSizeUnit, customScale }: _FontScaleOptions = {}
+  { measurement = font.defaultUnits, customScale }: _FontScaleOptions = {}
 ) {
   if (measurement === 'em') {
     return `${font.scale[scale]}em`;
@@ -68,7 +68,7 @@ export function euiFontSizeFromScale(
 export function euiLineHeightFromBaseline(
   scale: _EuiThemeFontScale,
   { base, font }: UseEuiTheme['euiTheme'],
-  { measurement = font.fontSizeUnit, customScale }: _FontScaleOptions = {}
+  { measurement = font.defaultUnits, customScale }: _FontScaleOptions = {}
 ) {
   const { baseline, lineHeightMultiplier } = font;
   let numerator = base * font.scale[scale];

--- a/src/global_styling/functions/typography.ts
+++ b/src/global_styling/functions/typography.ts
@@ -8,7 +8,7 @@
 
 import {
   _EuiThemeFontScale,
-  _EuiThemeFontSizeMeasurement,
+  _EuiThemeFontUnit,
   _EuiThemeFontWeights,
 } from '../variables/typography';
 import { UseEuiTheme } from '../../services/theme/hooks';
@@ -16,9 +16,9 @@ import { logicalCSS } from './logicals';
 
 export interface _FontScaleOptions {
   /**
-   * The returned string measurement
+   * The font-size or line-height unit to return
    */
-  measurement?: _EuiThemeFontSizeMeasurement;
+  unit?: _EuiThemeFontUnit;
   /**
    * An additional custom scale multiplier to use against the current scale
    * This parameter can be used (e.g. by EuiText sizes) to get sizes of text smaller than the default
@@ -38,9 +38,9 @@ export interface _FontScaleOptions {
 export function euiFontSizeFromScale(
   scale: _EuiThemeFontScale,
   { base, font }: UseEuiTheme['euiTheme'],
-  { measurement = font.defaultUnits, customScale }: _FontScaleOptions = {}
+  { unit = font.defaultUnits, customScale }: _FontScaleOptions = {}
 ) {
-  if (measurement === 'em') {
+  if (unit === 'em') {
     return `${font.scale[scale]}em`;
   }
 
@@ -48,7 +48,7 @@ export function euiFontSizeFromScale(
   if (customScale) numerator *= font.scale[customScale];
   const denominator = base * font.scale[font.body.scale];
 
-  return measurement === 'px'
+  return unit === 'px'
     ? `${numerator}px`
     : `${(numerator / denominator).toFixed(4)}rem`;
 }
@@ -68,7 +68,7 @@ export function euiFontSizeFromScale(
 export function euiLineHeightFromBaseline(
   scale: _EuiThemeFontScale,
   { base, font }: UseEuiTheme['euiTheme'],
-  { measurement = font.defaultUnits, customScale }: _FontScaleOptions = {}
+  { unit = font.defaultUnits, customScale }: _FontScaleOptions = {}
 ) {
   const { baseline, lineHeightMultiplier } = font;
   let numerator = base * font.scale[scale];
@@ -78,7 +78,7 @@ export function euiLineHeightFromBaseline(
   const _lineHeightMultiplier =
     numerator <= base ? lineHeightMultiplier : lineHeightMultiplier * 0.833;
 
-  if (measurement === 'em') {
+  if (unit === 'em') {
     // Even though the line-height via `em` cannot be determined against the pixel baseline grid;
     // we will assume that typically larger scale font-sizes should have a shorter line-height;
     return _lineHeightMultiplier.toFixed(4).toString();
@@ -87,7 +87,7 @@ export function euiLineHeightFromBaseline(
   const pixelValue =
     Math.floor(Math.round(numerator * _lineHeightMultiplier) / baseline) *
     baseline;
-  return measurement === 'px'
+  return unit === 'px'
     ? `${pixelValue}px`
     : `${(pixelValue / denominator).toFixed(4)}rem`;
 }

--- a/src/global_styling/mixins/_typography.test.ts
+++ b/src/global_styling/mixins/_typography.test.ts
@@ -8,10 +8,7 @@
 
 import { testCustomHook } from '../../test/internal';
 
-import {
-  EuiThemeFontScales,
-  EuiThemeFontSizeMeasurements,
-} from '../variables/typography';
+import { EuiThemeFontScales, EuiThemeFontUnits } from '../variables/typography';
 import {
   useEuiFontSize,
   euiTextBreakWord,
@@ -21,12 +18,12 @@ import {
 
 describe('euiFontSize', () => {
   describe('returns an object of font-size and line-height for each scale', () => {
-    EuiThemeFontSizeMeasurements.forEach((measurement) => {
-      describe(measurement, () => {
+    EuiThemeFontUnits.forEach((unit) => {
+      describe(unit, () => {
         EuiThemeFontScales.forEach((size) => {
           test(size, () => {
             expect(
-              testCustomHook(() => useEuiFontSize(size, { measurement })).return
+              testCustomHook(() => useEuiFontSize(size, { unit })).return
             ).toMatchSnapshot();
           });
         });

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -60,7 +60,7 @@ export type _EuiThemeFontBase = {
   featureSettings?: string;
   /**
    * Sets the default units used for font size & line height set by UI components
-   * like EuiText or EuiTitle.
+   * like EuiText or EuiTitle. Defaults to `rem`.
    *
    * NOTE: This may overridden by some internal usages, e.g.
    * EuiText's `relative` size which must use `em`.

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -12,10 +12,9 @@ import { CSSProperties } from 'react';
  * Font units of measure
  */
 
-export const EuiThemeFontSizeMeasurements = ['rem', 'px', 'em'] as const;
+export const EuiThemeFontUnits = ['rem', 'px', 'em'] as const;
 
-export type _EuiThemeFontSizeMeasurement =
-  (typeof EuiThemeFontSizeMeasurements)[number];
+export type _EuiThemeFontUnit = (typeof EuiThemeFontUnits)[number];
 
 /*
  * Font scale
@@ -68,7 +67,7 @@ export type _EuiThemeFontBase = {
    *
    * @default 'rem'
    */
-  defaultUnits: _EuiThemeFontSizeMeasurement;
+  defaultUnits: _EuiThemeFontUnit;
   /**
    * A computed number that is 1/4 of `base`
    */

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -60,14 +60,15 @@ export type _EuiThemeFontBase = {
    */
   featureSettings?: string;
   /**
-   * Sets the default font size unit used by UI components like EuiText or EuiTitle.
+   * Sets the default units used for font size & line height set by UI components
+   * like EuiText or EuiTitle.
    *
    * NOTE: This may overridden by some internal usages, e.g.
    * EuiText's `relative` size which must use `em`.
    *
    * @default 'rem'
    */
-  fontSizeUnit: _EuiThemeFontSizeMeasurement;
+  defaultUnits: _EuiThemeFontSizeMeasurement;
   /**
    * A computed number that is 1/4 of `base`
    */

--- a/src/global_styling/variables/typography.ts
+++ b/src/global_styling/variables/typography.ts
@@ -60,6 +60,15 @@ export type _EuiThemeFontBase = {
    */
   featureSettings?: string;
   /**
+   * Sets the default font size unit used by UI components like EuiText or EuiTitle.
+   *
+   * NOTE: This may overridden by some internal usages, e.g.
+   * EuiText's `relative` size which must use `em`.
+   *
+   * @default 'rem'
+   */
+  fontSizeUnit: _EuiThemeFontSizeMeasurement;
+  /**
    * A computed number that is 1/4 of `base`
    */
   baseline: number;

--- a/src/themes/amsterdam/global_styling/variables/_typography.ts
+++ b/src/themes/amsterdam/global_styling/variables/_typography.ts
@@ -34,7 +34,7 @@ export const fontBase: _EuiThemeFontBase = {
 
   // Careful using ligatures. Code editors like ACE will often error because of width calculations
   featureSettings: "'calt' 1, 'kern' 1, 'liga' 1",
-  fontSizeUnit: 'rem',
+  defaultUnits: 'rem',
 
   baseline: computed(([base]) => base / 4, ['base']),
   lineHeightMultiplier: 1.5,

--- a/src/themes/amsterdam/global_styling/variables/_typography.ts
+++ b/src/themes/amsterdam/global_styling/variables/_typography.ts
@@ -34,6 +34,7 @@ export const fontBase: _EuiThemeFontBase = {
 
   // Careful using ligatures. Code editors like ACE will often error because of width calculations
   featureSettings: "'calt' 1, 'kern' 1, 'liga' 1",
+  fontSizeUnit: 'rem',
 
   baseline: computed(([base]) => base / 4, ['base']),
   lineHeightMultiplier: 1.5,

--- a/upcoming_changelogs/7133.md
+++ b/upcoming_changelogs/7133.md
@@ -1,1 +1,5 @@
 - Added `font.defaultUnits` theme token. EUI component font sizes default to `rem` units - this token allows consumers to configure this to `px` or `em`
+
+**CSS-in-JS conversions**
+
+- Renamed `useEuiFontSize()`'s `measurement` option to `unit` for clarity

--- a/upcoming_changelogs/7133.md
+++ b/upcoming_changelogs/7133.md
@@ -1,0 +1,1 @@
+- Added `font.fontSizeUnit` theme token. EUI component font sizes default to `rem` units - this token allows consumers to configure this to `px` or `em`

--- a/upcoming_changelogs/7133.md
+++ b/upcoming_changelogs/7133.md
@@ -1,1 +1,1 @@
-- Added `font.fontSizeUnit` theme token. EUI component font sizes default to `rem` units - this token allows consumers to configure this to `px` or `em`
+- Added `font.defaultUnits` theme token. EUI component font sizes default to `rem` units - this token allows consumers to configure this to `px` or `em`


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7124

Currently, all Emotion component font sizes use `rem` sizing and this isn't something that we allow configuration for (e.g. to `px` or `em`) values. Adding a new `font.defaultUnits` token to our EUI theme will enable consumers to easily and quickly customize our component font size CSS output in one place.

> ⚠️ Note that there are a few components that do need to set a custom measurement override that does not use this new token - primarily `<EuiText size="relative">` is the (current) one instance of this in EUI where `em` is enforced.

### Screencap of example usage:

<img width="500" alt="" src="https://github.com/elastic/eui/assets/549407/79393e2d-8e42-44f5-b7c2-4986eba6d731">

## QA

- Go to http://localhost:8030/#/theming/typography/values
- [x] Inspect the EuiText wrapper around the example text and confirm both its `font-size` and `line-height` CSS properties are using `px` and not `rem`

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
