### PR TITLE
[EuiCollapsibleNavBeta] Add `onCollapseToggle` callback

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -449,3 +449,31 @@ export const FlyoutInFixedHeaders: Story = {
     );
   },
 };
+
+export const CollapsedStateInLocalStorage: Story = {
+  render: () => {
+    const key = 'EuiCollapsibleNav__isCollapsed';
+    const initialIsCollapsed = window.localStorage.getItem(key) === 'true';
+    const onCollapseToggle = (isCollapsed: boolean) =>
+      window.localStorage.setItem(key, String(isCollapsed));
+
+    return (
+      <>
+        <EuiHeader position="fixed">
+          <EuiHeaderSection>
+            <EuiCollapsibleNavBeta
+              initialIsCollapsed={initialIsCollapsed}
+              onCollapseToggle={onCollapseToggle}
+            />
+          </EuiHeaderSection>
+        </EuiHeader>
+        <EuiPageTemplate>
+          <EuiPageTemplate.Section>
+            Toggle the collapsed state and refresh the page. The collapsed state
+            should have been saved/remembered
+          </EuiPageTemplate.Section>
+        </EuiPageTemplate>
+      </>
+    );
+  },
+};

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -50,6 +50,22 @@ describe('EuiCollapsibleNavBeta', () => {
     expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '48px' });
   });
 
+  it('calls `onCollapseToggle` with the new collapsed state', () => {
+    const onCollapseToggle = jest.fn();
+    const { getByTestSubject } = render(
+      <EuiCollapsibleNavBeta
+        initialIsCollapsed={true}
+        onCollapseToggle={onCollapseToggle}
+      >
+        Nav content
+      </EuiCollapsibleNavBeta>
+    );
+    fireEvent.click(getByTestSubject('euiCollapsibleNavButton'));
+    expect(onCollapseToggle).toHaveBeenLastCalledWith(false);
+    fireEvent.click(getByTestSubject('euiCollapsibleNavButton'));
+    expect(onCollapseToggle).toHaveBeenLastCalledWith(true);
+  });
+
   it('automatically accounts for fixed EuiHeaders in its positioning', () => {
     const { getByTestSubject } = render(
       <EuiHeader position="fixed">

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -46,6 +46,11 @@ export type EuiCollapsibleNavBetaProps = CommonProps &
      */
     initialIsCollapsed?: boolean;
     /**
+     * Optional callback that fires when the user toggles the nav between
+     * collapsed and uncollapsed states
+     */
+    onCollapseToggle?: (isCollapsed: boolean) => void;
+    /**
      * Defaults to 248px wide. The navigation width determines behavior at
      * various responsive breakpoints.
      *
@@ -80,6 +85,7 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   className,
   style,
   initialIsCollapsed = false,
+  onCollapseToggle,
   width: _width = 248,
   side = 'left',
   focusTrapProps: _focusTrapProps,
@@ -93,8 +99,12 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
    */
   const [isCollapsed, setIsCollapsed] = useState(initialIsCollapsed);
   const toggleCollapsed = useCallback(
-    () => setIsCollapsed((isCollapsed) => !isCollapsed),
-    []
+    () =>
+      setIsCollapsed((isCollapsed) => {
+        onCollapseToggle?.(!isCollapsed);
+        return !isCollapsed;
+      }),
+    [onCollapseToggle]
   );
   const onClose = useCallback(() => setIsCollapsed(true), []);
 


### PR DESCRIPTION
## Summary

Consumers will need this callback to store current collapsed state (e.g. in local storage, for feeding back to `initialIsCollapsed`).

## QA

- `gh pr checkout 7134 && yarn storybook`
- Go to http://localhost:6006/?path=/story/euicollapsiblenavbeta--collapsed-state-in-local-storage
- [x] Confirm collapsed state is remembered on page refresh

### General checklist

- [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~ - N/A, beta component
