### PR TITLE
Reorders icon grid to go left to right instead of vertically.

### DIFF
--- a/src-docs/src/views/icon/apps.js
+++ b/src-docs/src/views/icon/apps.js
@@ -69,7 +69,7 @@ export default () => (
       {'<EuiIcon type="addDataApp" size="xl" />'}
     </EuiCodeBlock>
     <EuiSpacer />
-    <EuiFlexGrid direction="column" columns={3}>
+    <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
           <EuiCopy

--- a/src-docs/src/views/icon/icons.js
+++ b/src-docs/src/views/icon/icons.js
@@ -292,7 +292,7 @@ export default () => (
       {'<EuiIcon type="warning" />'}
     </EuiCodeBlock>
     <EuiSpacer />
-    <EuiFlexGrid direction="column" columns={3}>
+    <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
           <EuiCopy

--- a/src-docs/src/views/icon/logos.js
+++ b/src-docs/src/views/icon/logos.js
@@ -71,7 +71,7 @@ export default () => {
             : `<EuiIcon type="logoElasticsearch" size="xl" color="${iconColor}" />`}
         </EuiCodeBlock>
         <EuiSpacer />
-        <EuiFlexGrid direction="column" columns={3}>
+        <EuiFlexGrid direction="row" columns={3}>
           {iconTypes.map((iconType) => (
             <EuiFlexItem key={iconType}>
               <EuiCopy

--- a/src-docs/src/views/icon/ml.js
+++ b/src-docs/src/views/icon/ml.js
@@ -27,7 +27,7 @@ export default () => (
       {'<EuiIcon type="dataVisualizer" size="xl" />'}
     </EuiCodeBlock>
     <EuiSpacer />
-    <EuiFlexGrid direction="column" columns={3}>
+    <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
           <EuiCopy

--- a/src-docs/src/views/icon/tokens.tsx
+++ b/src-docs/src/views/icon/tokens.tsx
@@ -74,7 +74,7 @@ export default () => (
       {'<EuiToken iconType="tokenAnnotation" />'}
     </EuiCodeBlock>
     <EuiSpacer />
-    <EuiFlexGrid direction="column" columns={3}>
+    <EuiFlexGrid direction="row" columns={3}>
       {tokens.map((token) => (
         <EuiFlexItem key={token}>
           <EuiCopy


### PR DESCRIPTION
## Summary

Reorders the icons grid view to go left to right (rows) rather than vertically down (columns).  It can be difficult to find icons currently.

https://github.com/elastic/eui/assets/3756330/15c411b6-0611-4b82-bf6b-f47dd2ad3088

![Screenshot--2023-08-29--Icons - Elastic UI Framework](https://github.com/elastic/eui/assets/3756330/148e49ba-4e75-444c-a8ff-3fd8e62e0de5)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
- [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- [ ] ~Checked for **breaking changes** and labeled appropriately~
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [ ] ~A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately~
