### PR TITLE
[EuiDescriptionList] Reverting gutter size to `m`.

### DIFF
--- a/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`useDataGridKeyboardShortcuts returns a popover containing a list of key
           >
             <dl
               aria-labelledby="generated-id"
-              class="euiDescriptionList emotion-euiDescriptionList-column-center-s-s"
+              class="euiDescriptionList emotion-euiDescriptionList-column-center-m-m"
               data-type="column"
             >
               <dt

--- a/src/components/description_list/__snapshots__/description_list.test.tsx.snap
+++ b/src/components/description_list/__snapshots__/description_list.test.tsx.snap
@@ -6,7 +6,7 @@ exports[` 1`] = `
   data-type="row"
 >
   <dt
-    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
+    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-m"
   >
     Title 1
   </dt>
@@ -16,7 +16,7 @@ exports[` 1`] = `
     Description 1
   </dd>
   <dt
-    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
+    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-m"
   >
     <em>
       Title 2
@@ -30,7 +30,7 @@ exports[` 1`] = `
     </code>
   </dd>
   <dt
-    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
+    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-m"
   >
     Title 3
   </dt>
@@ -69,14 +69,14 @@ exports[`EuiDescriptionList props align left is rendered 1`] = `
 
 exports[`EuiDescriptionList props column gap m is rendered 1`] = `
 <dl
-  class="euiDescriptionList emotion-euiDescriptionList-column-left-s-m"
+  class="euiDescriptionList emotion-euiDescriptionList-column-left-m-m"
   data-type="column"
 />
 `;
 
 exports[`EuiDescriptionList props column gap s is rendered 1`] = `
 <dl
-  class="euiDescriptionList emotion-euiDescriptionList-column-left-s-s"
+  class="euiDescriptionList emotion-euiDescriptionList-column-left-m-s"
   data-type="column"
 />
 `;
@@ -90,14 +90,14 @@ exports[`EuiDescriptionList props compressed is rendered 1`] = `
 
 exports[`EuiDescriptionList props gutter m is rendered 1`] = `
 <dl
-  class="euiDescriptionList emotion-euiDescriptionList-column-left-m-s"
+  class="euiDescriptionList emotion-euiDescriptionList-column-left-m-m"
   data-type="column"
 />
 `;
 
 exports[`EuiDescriptionList props gutter s is rendered 1`] = `
 <dl
-  class="euiDescriptionList emotion-euiDescriptionList-column-left-s-s"
+  class="euiDescriptionList emotion-euiDescriptionList-column-left-s-m"
   data-type="column"
 />
 `;
@@ -108,7 +108,7 @@ exports[`EuiDescriptionList props listItems descriptionProps is rendered 1`] = `
   data-type="row"
 >
   <dt
-    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
+    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-m"
   >
     Title 1
   </dt>
@@ -120,7 +120,7 @@ exports[`EuiDescriptionList props listItems descriptionProps is rendered 1`] = `
     Description 1
   </dd>
   <dt
-    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
+    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-m"
   >
     <em>
       Title 2
@@ -136,7 +136,7 @@ exports[`EuiDescriptionList props listItems descriptionProps is rendered 1`] = `
     </code>
   </dd>
   <dt
-    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-s"
+    class="euiDescriptionList__title emotion-euiDescriptionList__title-row-normal-m"
   >
     Title 3
   </dt>
@@ -157,7 +157,7 @@ exports[`EuiDescriptionList props listItems titleProps is rendered 1`] = `
 >
   <dt
     aria-label="aria-label"
-    class="euiDescriptionList__title testClass1 testClass2 emotion-euiDescriptionList__title-row-normal-s-euiTestCss"
+    class="euiDescriptionList__title testClass1 testClass2 emotion-euiDescriptionList__title-row-normal-m-euiTestCss"
     data-test-subj="test subject string"
   >
     Title 1
@@ -169,7 +169,7 @@ exports[`EuiDescriptionList props listItems titleProps is rendered 1`] = `
   </dd>
   <dt
     aria-label="aria-label"
-    class="euiDescriptionList__title testClass1 testClass2 emotion-euiDescriptionList__title-row-normal-s-euiTestCss"
+    class="euiDescriptionList__title testClass1 testClass2 emotion-euiDescriptionList__title-row-normal-m-euiTestCss"
     data-test-subj="test subject string"
   >
     <em>
@@ -185,7 +185,7 @@ exports[`EuiDescriptionList props listItems titleProps is rendered 1`] = `
   </dd>
   <dt
     aria-label="aria-label"
-    class="euiDescriptionList__title testClass1 testClass2 emotion-euiDescriptionList__title-row-normal-s-euiTestCss"
+    class="euiDescriptionList__title testClass1 testClass2 emotion-euiDescriptionList__title-row-normal-m-euiTestCss"
     data-test-subj="test subject string"
   >
     Title 3
@@ -200,7 +200,7 @@ exports[`EuiDescriptionList props listItems titleProps is rendered 1`] = `
 
 exports[`EuiDescriptionList props type column is rendered 1`] = `
 <dl
-  class="euiDescriptionList emotion-euiDescriptionList-column-left-s-s"
+  class="euiDescriptionList emotion-euiDescriptionList-column-left-m-m"
   data-type="column"
 />
 `;
@@ -214,7 +214,7 @@ exports[`EuiDescriptionList props type inline is rendered 1`] = `
 
 exports[`EuiDescriptionList props type responsiveColumn renders a column when the current window is above the responsive breakpoints 1`] = `
 <dl
-  class="euiDescriptionList emotion-euiDescriptionList-column-left-s-s"
+  class="euiDescriptionList emotion-euiDescriptionList-column-left-m-m"
   data-type="responsiveColumn"
 />
 `;

--- a/src/components/description_list/description_list.tsx
+++ b/src/components/description_list/description_list.tsx
@@ -30,8 +30,8 @@ export const EuiDescriptionList: FunctionComponent<
   textStyle = 'normal',
   titleProps,
   type: _type = 'row',
-  rowGutterSize = 's',
-  columnGutterSize = 's',
+  rowGutterSize = 'm',
+  columnGutterSize = 'm',
   ...rest
 }) => {
   const showResponsiveColumns = useIsWithinBreakpoints(['xs', 's']);

--- a/upcoming_changelogs/7140.md
+++ b/upcoming_changelogs/7140.md
@@ -1,0 +1,1 @@
+- Reverted `EuiDescriptionList` default gutter size to `m`.


### PR DESCRIPTION
## Summary

Reverting the `EuiDescriptionLIst` default row and column spacing to `m` after a discussion with @kyrspl today. This change ensures we retain the previous visual spacing and the new prop names to allow row and column adjustments independently.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [x] Checked for **breaking changes** and labeled appropriately
- [x] Checked for **accessibility** including keyboard-only and screenreader modes
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

---
### EUI `v87.2.0` and proposed change in PR

<img width="1249" alt="Screen Shot 2023-08-29 at 9 37 43 AM" src="https://github.com/elastic/eui/assets/934879/9d1f6694-551e-410c-a19b-9a26a257f822">

---
### EUI `v88.0.0`
<img width="1275" alt="Screen Shot 2023-08-29 at 9 37 27 AM" src="https://github.com/elastic/eui/assets/934879/5fc44186-85ac-4e56-b8ad-7f163a84fcb8">
