### PR TITLE
[docs] Document requirement for using drag & drop components in popovers

### DIFF
--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -123,7 +123,7 @@ export const DragAndDropExample = {
             functional separation (see later examples).
           </p>
           <p>
-            <strong>EuiDragDropContext</strong> handles all eventing but makes
+            <strong>EuiDragDropContext</strong> handles all events but makes
             no assumptions about the result of a drop event. As such, the
             following event handlers are available:
           </p>
@@ -158,6 +158,13 @@ export const DragAndDropExample = {
               <EuiCode>move</EuiCode>: move an item to a differnt droppable area
             </li>
           </ul>
+          <EuiCallOut
+            size="s"
+            iconType="asterisk"
+            title="Extra prop for EuiPopover usage"
+          >
+            <p>When using <strong>EuiDraggable</strong> within an <EuiCode>EuiPopover</EuiCode>, be sure to include the prop <EuiCode>hasDragDrop</EuiCode> so it displays correctly.</p>
+          </EuiCallOut>
         </React.Fragment>
       ),
       props: { EuiDragDropContext, EuiDraggable, EuiDroppable },

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -38,7 +38,7 @@ const dragAndDropComplexSource = require('!!raw-loader!./drag_and_drop_complex')
 export const DragAndDropExample = {
   title: 'Drag and drop',
   intro: (
-    <React.Fragment>
+    <>
       <EuiText>
         <p>
           An extension of{' '}
@@ -87,7 +87,7 @@ export const DragAndDropExample = {
           mind, keep your users&apos; working context in mind.
         </p>
       </EuiCallOut>
-    </React.Fragment>
+    </>
   ),
   sections: [
     {
@@ -99,7 +99,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             <strong>EuiDraggable</strong> makes very few assumptions about what
             content it contains. To give affordance to draggable elements and to
@@ -169,7 +169,7 @@ export const DragAndDropExample = {
               <EuiCode>hasDragDrop</EuiCode> so it displays correctly.
             </p>
           </EuiCallOut>
-        </React.Fragment>
+        </>
       ),
       props: { EuiDragDropContext, EuiDraggable, EuiDroppable },
       demo: <DragAndDropBare />,
@@ -183,7 +183,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             The simplest case, demonstrating a single{' '}
             <strong>EuiDroppable</strong> with <EuiCode>reorder</EuiCode>{' '}
@@ -197,7 +197,7 @@ export const DragAndDropExample = {
             data that can be used to alter appearance or behavior (e.g.,{' '}
             <EuiCode>isDragging</EuiCode>).
           </p>
-        </React.Fragment>
+        </>
       ),
       props: { EuiDragDropContext, EuiDraggable, EuiDroppable },
       demo: <DragAndDrop />,
@@ -211,7 +211,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             By default the entire element surface can initiate a drag. To
             specify an element within as the handle and create a containing
@@ -240,7 +240,7 @@ export const DragAndDropExample = {
               </>
             }
           />
-        </React.Fragment>
+        </>
       ),
       demo: <DragAndDropCustomHandle />,
     },
@@ -253,7 +253,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             <strong>EuiDraggable</strong> can contain interactive elements such
             as buttons and form fields. Interactive elements require{' '}
@@ -263,7 +263,7 @@ export const DragAndDropExample = {
             functionality and accessibility, while enabling click, keypress,
             etc., events on the interactive child elements.
           </p>
-        </React.Fragment>
+        </>
       ),
       demo: <DragAndDropDisableBlocking />,
     },
@@ -276,7 +276,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             By default, all <strong>EuiDroppable</strong> elements are of the
             same type and will accept <strong>EuiDraggable</strong> elements
@@ -286,7 +286,7 @@ export const DragAndDropExample = {
             The EUI <EuiCode>move</EuiCode> method is demonstrated in this
             example.
           </p>
-        </React.Fragment>
+        </>
       ),
       demo: <DragAndDropMoveLists />,
     },
@@ -299,7 +299,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             Setting the <EuiCode>type</EuiCode> prop on an{' '}
             <strong>EuiDroppable</strong> element will ensure that it will only
@@ -311,7 +311,7 @@ export const DragAndDropExample = {
             elements have a visual change that indicates they can accept the
             actively moving/focused <strong>EuiDraggable</strong> element.
           </p>
-        </React.Fragment>
+        </>
       ),
       demo: <DragAndDropTypes />,
     },
@@ -324,7 +324,7 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             For cases where collections of <strong>EuiDraggable</strong>{' '}
             elements are static or can be used in multiple places set{' '}
@@ -344,7 +344,7 @@ export const DragAndDropExample = {
             items. This API is likely to change, but currently provides the
             visual changes with drop-to-remove interactions.
           </p>
-        </React.Fragment>
+        </>
       ),
       demo: <DragAndDropClone />,
     },
@@ -357,14 +357,14 @@ export const DragAndDropExample = {
         },
       ],
       text: (
-        <React.Fragment>
+        <>
           <p>
             <strong>EuiDraggables</strong> in <strong>EuiDroppables</strong>,{' '}
             <strong>EuiDroppables</strong> in <strong>EuiDraggables</strong>,
             custom drag handles, horizontal movement, vertical movement,
             flexbox, panel inception, you name it.
           </p>
-        </React.Fragment>
+        </>
       ),
       demo: <DragAndDropComplex />,
     },

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -123,9 +123,9 @@ export const DragAndDropExample = {
             functional separation (see later examples).
           </p>
           <p>
-            <strong>EuiDragDropContext</strong> handles all events but makes
-            no assumptions about the result of a drop event. As such, the
-            following event handlers are available:
+            <strong>EuiDragDropContext</strong> handles all events but makes no
+            assumptions about the result of a drop event. As such, the following
+            event handlers are available:
           </p>
           <ul>
             <li>
@@ -163,7 +163,11 @@ export const DragAndDropExample = {
             iconType="asterisk"
             title="Extra prop for EuiPopover usage"
           >
-            <p>When using <strong>EuiDraggable</strong> within an <EuiCode>EuiPopover</EuiCode>, be sure to include the prop <EuiCode>hasDragDrop</EuiCode> so it displays correctly.</p>
+            <p>
+              When using <strong>EuiDraggable</strong> within an{' '}
+              <EuiCode>EuiPopover</EuiCode> , be sure to include the prop{' '}
+              <EuiCode>hasDragDrop</EuiCode> so it displays correctly.
+            </p>
           </EuiCallOut>
         </React.Fragment>
       ),

--- a/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
+++ b/src-docs/src/views/drag_and_drop/drag_and_drop_example.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
 import { GuideSectionTypes } from '../../components';
 import {
   EuiCallOut,
@@ -34,6 +36,9 @@ const dragAndDropCloneSource = require('!!raw-loader!./drag_and_drop_clone');
 
 import DragAndDropComplex from './drag_and_drop_complex';
 const dragAndDropComplexSource = require('!!raw-loader!./drag_and_drop_complex');
+
+import DragAndDropInPopover from './in_popover';
+const dragAndDropInPopoverSource = require('!!raw-loader!./in_popover');
 
 export const DragAndDropExample = {
   title: 'Drag and drop',
@@ -158,17 +163,6 @@ export const DragAndDropExample = {
               <EuiCode>move</EuiCode>: move an item to a differnt droppable area
             </li>
           </ul>
-          <EuiCallOut
-            size="s"
-            iconType="asterisk"
-            title="Extra prop for EuiPopover usage"
-          >
-            <p>
-              When using <strong>EuiDraggable</strong> within an{' '}
-              <EuiCode>EuiPopover</EuiCode> , be sure to include the prop{' '}
-              <EuiCode>hasDragDrop</EuiCode> so it displays correctly.
-            </p>
-          </EuiCallOut>
         </>
       ),
       props: { EuiDragDropContext, EuiDraggable, EuiDroppable },
@@ -349,7 +343,7 @@ export const DragAndDropExample = {
       demo: <DragAndDropClone />,
     },
     {
-      title: 'We have fun',
+      title: 'Kitchen sink',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -367,6 +361,42 @@ export const DragAndDropExample = {
         </>
       ),
       demo: <DragAndDropComplex />,
+    },
+    {
+      title: 'Using drag and drop in popovers',
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: dragAndDropInPopoverSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            <strong>EuiDraggables</strong> use fixed positioning to render and
+            animate the item being dragged. This positioning logic does not work
+            as expected when used inside of containers that have their own{' '}
+            <EuiLink
+              href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context"
+              target="_blank"
+            >
+              stacking context
+            </EuiLink>
+            .
+          </p>
+          <p>
+            This behavior particularly affects{' '}
+            <Link to="/layout/popover">
+              <strong>EuiPopover</strong>
+            </Link>
+            . If using drag and drop UX within a popover, you{' '}
+            <strong>must</strong> include the{' '}
+            <EuiCode>{'<EuiPopover hasDragDrop>'}</EuiCode> prop for items to
+            propertly render while being dragged.
+          </p>
+        </>
+      ),
+      demo: <DragAndDropInPopover />,
     },
   ],
 };

--- a/src-docs/src/views/drag_and_drop/in_popover.tsx
+++ b/src-docs/src/views/drag_and_drop/in_popover.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import {
+  EuiPopover,
+  EuiButton,
+  EuiPanel,
+  EuiDragDropContext,
+  EuiDraggable,
+  EuiDroppable,
+  euiDragDropReorder,
+} from '../../../../src/components';
+import { htmlIdGenerator } from '../../../../src/services';
+
+const makeId = htmlIdGenerator();
+const makeList = (number: number, start = 1) =>
+  Array.from({ length: number }, (v, k) => k + start).map((el) => {
+    return {
+      content: `Item ${el}`,
+      id: makeId(),
+    };
+  });
+
+export default () => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [list, setList] = useState(makeList(3));
+
+  return (
+    <EuiPopover
+      hasDragDrop
+      isOpen={isPopoverOpen}
+      closePopover={() => setIsPopoverOpen(false)}
+      button={
+        <EuiButton onClick={() => setIsPopoverOpen(!isPopoverOpen)}>
+          Toggle popover with drag and drop content
+        </EuiButton>
+      }
+      panelPaddingSize="none"
+      panelProps={{ css: { inlineSize: 200 } }}
+    >
+      <EuiDragDropContext
+        onDragEnd={({ source, destination }) => {
+          if (source && destination) {
+            const items = euiDragDropReorder(
+              list,
+              source.index,
+              destination.index
+            );
+            setList(items);
+          }
+        }}
+      >
+        <EuiDroppable droppableId="droppableInPopover" spacing="m">
+          {list.map(({ content, id }, idx) => (
+            <EuiDraggable spacing="m" key={id} index={idx} draggableId={id}>
+              {(provided, state) => (
+                <EuiPanel hasShadow={state.isDragging}>{content}</EuiPanel>
+              )}
+            </EuiDraggable>
+          ))}
+        </EuiDroppable>
+      </EuiDragDropContext>
+    </EuiPopover>
+  );
+};


### PR DESCRIPTION
## Summary
Adds a section to the EuiDraggable docs page to mention the special use case in popovers and the necessary additional prop.

<img width="1135" alt="" src="https://github.com/elastic/eui/assets/549407/d15499c6-d2a4-4103-9eaf-41f11e943745">

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
