### PR TITLE
[EuiHeader] Update to set a new global `--euiFixedHeadersOffset` CSS variable

### DIFF
--- a/src-docs/src/components/guide_page/_guide_page.scss
+++ b/src-docs/src/components/guide_page/_guide_page.scss
@@ -1,22 +1,5 @@
 @import '../../../../src/global_styling/mixins/helpers';
 
-@include euiHeaderAffordForFixed;
-
-.guideBody {
-  // Override euiHeaderAffordForFixed mixin since the page template handles this now
-  padding-top: 0 !important; // stylelint-disable-line declaration-no-important
-}
-
-.euiBody--headerIsFixed--double {
-  @include euiHeaderAffordForFixed($euiHeaderHeightCompensation * 2);
-
-  .euiHeader:not([data-fixed-header]) {
-    // Force headers below the fullscreen.
-    // This shouldn't be necessary in consuming applications because headers should always be at the top of the page
-    z-index: 0;
-  }
-}
-
 .guideSideNav {
   @include euiSideNavEmbellish;
 }

--- a/src-docs/src/components/guide_page/guide_page_chrome.js
+++ b/src-docs/src/components/guide_page/guide_page_chrome.js
@@ -69,7 +69,7 @@ export class GuidePageChrome extends Component {
   scrollNavSectionIntoView = () => {
     // wait a bit for react to blow away and re-create the DOM
     // then scroll the selected nav section into view
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       const sideNav = document.querySelector('.guideSideNav__content');
       const isMobile = sideNav?.querySelector('.euiSideNav__mobileToggle');
 

--- a/src-docs/src/views/header/header_elastic_pattern.tsx
+++ b/src-docs/src/views/header/header_elastic_pattern.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -52,14 +52,6 @@ export default () => {
   const guideHeaderDeploymentPopoverId = useGeneratedHtmlId({
     prefix: 'guideHeaderDeploymentPopover',
   });
-
-  useEffect(() => {
-    document.body.classList.add('euiBody--headerIsFixed--double');
-
-    return () => {
-      document.body.classList.remove('euiBody--headerIsFixed--double');
-    };
-  }, []);
 
   /**
    * Collapsible Nav

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -300,8 +300,8 @@ export const HeaderExample = {
             Most consumers need a header that does not scroll away with the page
             contents. You can set this display by applying the property{' '}
             <EuiCode language="ts">{'position="fixed"'}</EuiCode>. Multiple
-            fixed headers will automatically stack underneath one another. 
-            No manual positioning is required.
+            fixed headers will automatically stack underneath one another. No
+            manual positioning is required.
           </p>
           <p>
             If you're using{' '}

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -298,10 +298,10 @@ export const HeaderExample = {
         <>
           <p>
             Most consumers need a header that does not scroll away with the page
-            contents. You can apply this display by applying the property{' '}
+            contents. You can set this display by applying the property{' '}
             <EuiCode language="ts">{'position="fixed"'}</EuiCode>. Multiple
-            fixed headers will automatically stack underneath one another
-            without manual positioning required.
+            fixed headers will automatically stack underneath one another. 
+            No manual positioning is required.
           </p>
           <p>
             If you're using{' '}

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -299,23 +299,34 @@ export const HeaderExample = {
           <p>
             Most consumers need a header that does not scroll away with the page
             contents. You can apply this display by applying the property{' '}
-            <EuiCode language="ts">{'position="fixed"'}</EuiCode>. This will
-            also add a class of <EuiCode>.euiBody--headerIsFixed</EuiCode> to
-            the window body.
+            <EuiCode language="ts">{'position="fixed"'}</EuiCode>. Multiple
+            fixed headers will automatically stack underneath one another
+            without manual positioning required.
           </p>
           <p>
-            You will then need to apply your own padding to this body class to
-            afford for the header height. EUI supplies a helper mixin that also
-            accounts for this height in flyouts and the collapsible nav. Simply
-            add{' '}
-            <EuiCode language="sass">@include euiHeaderAffordForFixed;</EuiCode>{' '}
-            anywhere in your SASS.
+            If you're using{' '}
+            <Link to="/templates/page-template">
+              <strong>EuiPageTemplate</strong>
+            </Link>
+            , a padding top will be automatically set based on the number of
+            fixed headers on the page.{' '}
+            <Link to="/layout/flyout">
+              <strong>EuiFlyouts</strong>
+            </Link>{' '}
+            will also automatically account for and sit below fixed headers.
+          </p>
+          <p>
+            If you're using your own custom layout, or have custom UI that needs
+            to sit below your fixed header(s), EUI provides a global CSS{' '}
+            <EuiCode language="css">var(--euiFixedHeadersOffset)</EuiCode>{' '}
+            variable. You can use this variable anywhere, or even override it,
+            to correctly offset any and all fixed header heights.
           </p>
         </>
       ),
       snippet: [
         '<EuiHeader position="fixed" />',
-        '@include euiHeaderAffordForFixed;',
+        'body { padding-block-start: var(--euiFixedHeadersOffset, 0) }',
       ],
       demo: <HeaderPosition />,
       demoPanelProps: {
@@ -446,17 +457,12 @@ export const HeaderExample = {
       text: (
         <p>
           Stacking multiple headers provides a great way to separate global
-          navigation concerns. However, the{' '}
-          <EuiCode language="ts">{'position="fixed"'}</EuiCode> option will not
-          be aware of the number of headers. If you do need fixed{' '}
-          <strong>and</strong> stacked headers, you will need to apply the SASS
-          helper mixin and pass in the correct height to afford for.
+          navigation concerns.
         </p>
       ),
       snippet: [
         `<EuiHeader theme="dark" position="fixed" />
 <EuiHeader position="fixed" />`,
-        '@include euiHeaderAffordForFixed($euiHeaderHeightCompensation * 2);',
       ],
       demo: <HeaderStacked />,
       demoPanelProps: {

--- a/src-docs/src/views/header/header_stacked.tsx
+++ b/src-docs/src/views/header/header_stacked.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiBreadcrumb,
@@ -26,14 +26,6 @@ export default () => {
       text: 'Users',
     },
   ];
-
-  useEffect(() => {
-    if (isFixed) document.body.classList.add('euiBody--headerIsFixed--double');
-
-    return () => {
-      document.body.classList.remove('euiBody--headerIsFixed--double');
-    };
-  }, [isFixed]);
 
   const headers = (
     <>

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -404,8 +404,8 @@ export const MultipleFixedHeaders: Story = {
       <EuiHeader position="fixed">
         <EuiHeaderSection>
           <EuiCollapsibleNavBeta {...args}>
-            This story tests that EuiCollapsibleNav's fixed header detection &
-            offsetting works as expected
+            This story tests that EuiCollapsibleNav automatically adjusts its
+            position & height for multiple fixed headers
           </EuiCollapsibleNavBeta>
           Second header
         </EuiHeaderSection>

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
@@ -10,18 +10,30 @@ import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
 import { logicalCSS, euiYScroll } from '../../global_styling';
 import { euiShadowFlat } from '../../themes';
+import { euiHeaderVariables } from '../header/header.styles';
 
 export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
+  // At least for serverless, EuiCollapsibleNav is only going to be used with 1
+  // fixed header. For those scenarios, we can prevent a minor layout jump on
+  // page load by setting the CSS var fallback to the height of a single header
+  const defaultHeaderHeight = euiHeaderVariables(euiThemeContext).height;
+  const fixedHeaderOffset = `var(--euiFixedHeadersOffset, ${defaultHeaderHeight})`;
+
   return {
     euiCollapsibleNavBeta: css`
+      /* Fixed header affordance */
+      ${logicalCSS('top', fixedHeaderOffset)}
+      ${logicalCSS('height', `calc(100% - ${fixedHeaderOffset})`)}
+
       /* This extra padding is needed for EuiPopovers to have enough
          space to render with the right anchorPosition */
       ${logicalCSS('padding-bottom', euiTheme.size.xs)}
 
-      /* Allow the nav to scroll, in case consumers don't use EuiFlyoutBody/EuiFyoutFooter */
-      ${euiYScroll(euiThemeContext)}
+      /* Allow the nav to scroll, in case consumers don't use EuiFlyoutBody/EuiFyoutFooter
+         Height is already set by header affordance above */
+      ${euiYScroll(euiThemeContext, { height: false })}
 
       /* In case things get really dire responsively, ensure the footer doesn't overtake the body */
       .euiFlyoutBody {

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -12,8 +12,6 @@ import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test';
 
-import { EuiHeader } from '../header';
-
 import { EuiCollapsibleNavBeta } from './collapsible_nav_beta';
 
 describe('EuiCollapsibleNavBeta', () => {
@@ -64,20 +62,6 @@ describe('EuiCollapsibleNavBeta', () => {
     expect(onCollapseToggle).toHaveBeenLastCalledWith(false);
     fireEvent.click(getByTestSubject('euiCollapsibleNavButton'));
     expect(onCollapseToggle).toHaveBeenLastCalledWith(true);
-  });
-
-  it('automatically accounts for fixed EuiHeaders in its positioning', () => {
-    const { getByTestSubject } = render(
-      <EuiHeader position="fixed">
-        <EuiCollapsibleNavBeta data-test-subj="nav">
-          Nav content
-        </EuiCollapsibleNavBeta>
-      </EuiHeader>
-    );
-    expect(getByTestSubject('nav')).toHaveStyle({
-      'inset-block-start': '48px',
-      'block-size': 'calc(100% - 48px)',
-    });
   });
 
   describe('responsive behavior', () => {

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -19,7 +19,6 @@ import React, {
 import classNames from 'classnames';
 
 import { useEuiTheme, useGeneratedHtmlId, throttle } from '../../services';
-import { mathWithUnits, logicalStyle } from '../../global_styling';
 
 import { CommonProps } from '../common';
 import { EuiFlyout, EuiFlyoutProps } from '../flyout';
@@ -83,7 +82,6 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   id,
   children,
   className,
-  style,
   initialIsCollapsed = false,
   onCollapseToggle,
   width: _width = 248,
@@ -145,32 +143,6 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
   }, [_width, isOverlayFullWidth, isPush, isCollapsed, headerHeight]);
 
   /**
-   * Header affordance
-   */
-  const [fixedHeadersCount, setFixedHeadersCount] = useState<number | false>(
-    false
-  );
-  useEffect(() => {
-    setFixedHeadersCount(
-      document.querySelectorAll('.euiHeader[data-fixed-header]').length
-    );
-  }, []);
-
-  const stylesWithHeaderOffset = useMemo(() => {
-    if (!fixedHeadersCount) return style;
-
-    const headersOffset = mathWithUnits(
-      headerHeight,
-      (x) => x * fixedHeadersCount
-    );
-    return {
-      ...style,
-      ...logicalStyle('top', headersOffset),
-      ...logicalStyle('height', `calc(100% - ${headersOffset})`),
-    };
-  }, [fixedHeadersCount, style, headerHeight]);
-
-  /**
    * Prop setup
    */
   const flyoutID = useGeneratedHtmlId({
@@ -205,15 +177,13 @@ export const EuiCollapsibleNavBeta: FunctionComponent<
     isOverlayFullWidth && styles.isOverlayFullWidth,
   ];
 
-  // Wait for any fixed headers to be queried before rendering (prevents position jumping)
-  const flyout = fixedHeadersCount !== false && (
+  const flyout = (
     <EuiFlyout
       aria-label={defaultAriaLabel}
       {...rest} // EuiCollapsibleNav is significantly less permissive than EuiFlyout
       id={flyoutID}
       css={cssStyles}
       className={classes}
-      style={stylesWithHeaderOffset}
       size={width}
       side={side}
       focusTrapProps={focusTrapProps}

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -49,12 +49,21 @@
 }
 
 // This is used to remove extra scrollbars on the body when fullscreen is enabled
+// and tweak any components that account for fixed headers
 .euiDataGrid__restrictBody {
   height: 100vh;
   overflow: hidden;
 
-  .euiHeader {
-    z-index: $euiZHeaderBelowDataGrid;
+  .euiHeader[data-fixed-header] {
+    // !important needed to override header inline styles
+    z-index: $euiZHeaderBelowDataGrid !important; // stylelint-disable-line declaration-no-important 
+  }
+  .euiOverlayMask[data-relative-to-header='below'] {
+    top: 0;
+  }
+  .euiFlyout {
+    top: 0;
+    height: 100%;
   }
 }
 

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -56,11 +56,13 @@
 
   .euiHeader[data-fixed-header] {
     // !important needed to override header inline styles
-    z-index: $euiZHeaderBelowDataGrid !important; // stylelint-disable-line declaration-no-important 
+    z-index: $euiZHeaderBelowDataGrid !important; // stylelint-disable-line declaration-no-important
   }
+
   .euiOverlayMask[data-relative-to-header='below'] {
     top: 0;
   }
+
   .euiFlyout {
     top: 0;
     height: 100%;

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -1086,12 +1086,12 @@ Array [
 exports[`EuiFlyout renders extra screen reader instructions when fixed EuiHeaders headers exist on the page 1`] = `
 <body
   class="euiBody--headerIsFixed euiBody--hasFlyout"
-  data-fixed-headers="1"
 >
   <div>
     <div
       class="euiHeader emotion-euiHeader-fixed-default"
       data-fixed-header="true"
+      style="inset-block-start: 0px;"
     />
     <div>
       <div

--- a/src/components/flyout/flyout.styles.ts
+++ b/src/components/flyout/flyout.styles.ts
@@ -98,9 +98,9 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     euiFlyout: css`
       position: fixed;
-      ${logicalCSS('top', 0)}
       ${logicalCSS('bottom', 0)}
-      ${logicalCSS('height', '100%')}
+      ${logicalCSS('top', 'var(--euiFixedHeadersOffset, 0)')}
+      ${logicalCSS('height', 'calc(100% - var(--euiFixedHeadersOffset, 0))')}
       z-index: ${euiTheme.levels.flyout};
       background: ${euiTheme.colors.emptyShade};
       display: flex;

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`EuiHeader renders in fixed position 1`] = `
 <div
   class="euiHeader emotion-euiHeader-fixed-default"
   data-fixed-header="true"
+  style="inset-block-start: 0px;"
 >
   <span>
     Hello!

--- a/src/components/header/header.stories.tsx
+++ b/src/components/header/header.stories.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import {
@@ -16,6 +16,9 @@ import {
   EuiHeaderLink,
   EuiIcon,
   EuiAvatar,
+  EuiButton,
+  EuiFlyout,
+  EuiPageTemplate,
 } from '../../components';
 
 import { EuiHeader, EuiHeaderProps } from './header';
@@ -78,5 +81,77 @@ export const Sections: Story = {
         ],
       },
     ],
+  },
+};
+
+export const MultipleFixedHeaders: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => {
+    const [fixedHeadersCount, setFixedHeadersCount] = useState(3); // eslint-disable-line react-hooks/rules-of-hooks
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(false); // eslint-disable-line react-hooks/rules-of-hooks
+
+    const sections = [
+      {
+        items: [
+          <EuiHeaderLogo
+            iconType="logoElastic"
+            href="#"
+            aria-label="Go to home page"
+          />,
+        ],
+      },
+      {
+        items: [
+          <EuiButton size="s" onClick={() => setIsFlyoutOpen(!isFlyoutOpen)}>
+            Toggle flyout
+          </EuiButton>,
+        ],
+      },
+    ];
+
+    return (
+      <EuiPageTemplate>
+        <EuiPageTemplate.Section>
+          The page template and flyout should automatically adjust dynamically
+          to the number of fixed headers on the page.
+          {isFlyoutOpen && (
+            <EuiFlyout onClose={() => setIsFlyoutOpen(false)}>
+              The flyout position and mask should automatically adjust
+              dynamically to the number of fixed headers on the page.
+            </EuiFlyout>
+          )}
+          <br />
+          <br />
+          <EuiButton
+            iconType="minusInCircle"
+            disabled={fixedHeadersCount <= 0}
+            onClick={() => setFixedHeadersCount((count) => count - 1)}
+          >
+            Remove a fixed header
+          </EuiButton>
+          &emsp;
+          <EuiButton
+            fill
+            iconType="plusInCircle"
+            onClick={() => setFixedHeadersCount((count) => count + 1)}
+          >
+            Add a fixed header
+          </EuiButton>
+          <br />
+          <br />
+          {/* Always render at least one static header so we can toggle/test the flyout */}
+          <EuiHeader
+            position={fixedHeadersCount ? 'fixed' : 'static'}
+            sections={sections}
+          />
+          {/* Conditionally render additional fixed headers */}
+          {Array.from({ length: fixedHeadersCount - 1 }).map((_, i) => (
+            <EuiHeader key={i} position="fixed" sections={sections} />
+          ))}
+        </EuiPageTemplate.Section>
+      </EuiPageTemplate>
+    );
   },
 };

--- a/src/components/header/header.styles.ts
+++ b/src/components/header/header.styles.ts
@@ -57,10 +57,6 @@ export const euiHeaderStyles = (euiThemeContext: UseEuiTheme) => {
       position: fixed;
       ${logicalCSS('top', 0)}
       ${logicalCSS('horizontal', 0)}
-
-      & + [data-fixed-header] {
-        ${logicalCSS('top', height)}
-      }
     `,
     // Theme
     default: css`

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -146,4 +146,24 @@ describe('EuiFixedHeader', () => {
       expect(document.body.className).not.toContain('euiBody--headerIsFixed');
     });
   });
+
+  it('sets the inline position styles of headers', () => {
+    const { getByTestSubject } = render(
+      <>
+        <EuiFixedHeader data-test-subj="first" />
+        <EuiFixedHeader data-test-subj="second" />
+        <EuiFixedHeader data-test-subj="last" />
+      </>
+    );
+    expect(getByTestSubject('first')).toHaveStyle('inset-block-start: 0px');
+    expect(getByTestSubject('second')).toHaveStyle('inset-block-start: 48px');
+    expect(getByTestSubject('last')).toHaveStyle('inset-block-start: 96px');
+  });
+
+  it('allows consumers to override inline styles as needed', () => {
+    const { container } = render(
+      <EuiFixedHeader style={{ insetBlockStart: '20px' }} />
+    );
+    expect(container.firstElementChild).toHaveStyle('inset-block-start: 20px');
+  });
 });

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -11,7 +11,7 @@ import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
-import { euiHeaderFixedCounter, EuiFixedHeader, EuiHeader } from './header';
+import { euiFixedHeadersCount, EuiFixedHeader, EuiHeader } from './header';
 
 describe('EuiHeader', () => {
   shouldRenderCustomStyles(<EuiHeader />);
@@ -136,12 +136,12 @@ describe('EuiFixedHeader', () => {
           <EuiFixedHeader />
         </>
       );
-      expect(euiHeaderFixedCounter).toEqual(3);
+      expect(euiFixedHeadersCount).toEqual(3);
       // TODO: we're not yet on a jsdom version that supports inspecting :root
       expect(document.body.className).toContain('euiBody--headerIsFixed');
 
       unmount();
-      expect(euiHeaderFixedCounter).toEqual(0);
+      expect(euiFixedHeadersCount).toEqual(0);
       // TODO: we're not yet on a jsdom version that supports inspecting :root
       expect(document.body.className).not.toContain('euiBody--headerIsFixed');
     });

--- a/src/components/header/header.test.tsx
+++ b/src/components/header/header.test.tsx
@@ -11,7 +11,7 @@ import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
-import { EuiHeader } from './header';
+import { euiHeaderFixedCounter, EuiFixedHeader, EuiHeader } from './header';
 
 describe('EuiHeader', () => {
   shouldRenderCustomStyles(<EuiHeader />);
@@ -122,6 +122,28 @@ describe('EuiHeader', () => {
         'cannot accept both `children` and `sections`'
       );
       expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});
+
+describe('EuiFixedHeader', () => {
+  describe('on mount/unmount', () => {
+    it('updates the fixed headers count and body className', () => {
+      const { unmount } = render(
+        <>
+          <EuiFixedHeader />
+          <EuiFixedHeader />
+          <EuiFixedHeader />
+        </>
+      );
+      expect(euiHeaderFixedCounter).toEqual(3);
+      // TODO: we're not yet on a jsdom version that supports inspecting :root
+      expect(document.body.className).toContain('euiBody--headerIsFixed');
+
+      unmount();
+      expect(euiHeaderFixedCounter).toEqual(0);
+      // TODO: we're not yet on a jsdom version that supports inspecting :root
+      expect(document.body.className).not.toContain('euiBody--headerIsFixed');
     });
   });
 });

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -66,9 +66,6 @@ export type EuiHeaderProps = CommonProps &
     theme?: 'default' | 'dark';
   };
 
-// Start a counter to manage the total number of fixed headers that need the body class
-let euiHeaderFixedCounter = 0;
-
 export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
   children,
   className,
@@ -82,24 +79,6 @@ export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
   const euiTheme = useEuiTheme();
   const styles = euiHeaderStyles(euiTheme);
   const cssStyles = [styles.euiHeader, styles[position], styles[theme]];
-
-  useEffect(() => {
-    if (position === 'fixed') {
-      // Increment fixed header counter for each fixed header
-      euiHeaderFixedCounter++;
-      document.body.classList.add('euiBody--headerIsFixed');
-      document.body.dataset.fixedHeaders = String(euiHeaderFixedCounter);
-
-      return () => {
-        // Both decrement the fixed counter AND then check if there are none
-        if (--euiHeaderFixedCounter === 0) {
-          // If there are none, THEN remove class
-          document.body.classList.remove('euiBody--headerIsFixed');
-          delete document.body.dataset.fixedHeaders;
-        }
-      };
-    }
-  }, [position]);
 
   let contents;
   if (sections) {
@@ -137,14 +116,51 @@ export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
     contents = children;
   }
 
+  return position === 'fixed' ? (
+    <EuiFixedHeader css={cssStyles} className={classes} {...rest}>
+      {contents}
+    </EuiFixedHeader>
+  ) : (
+    <div css={cssStyles} className={classes} {...rest}>
+      {contents}
+    </div>
+  );
+};
+
+/**
+ * Fixed headers - logic around dynamically calculating the total
+ * page offset and setting the `top` position of subsequent headers
+ */
+
+// Start a counter to manage the total number of fixed headers that need the body class
+let euiHeaderFixedCounter = 0;
+
+const EuiFixedHeader: FunctionComponent<EuiHeaderProps> = ({
+  children,
+  ...rest
+}) => {
+  useEffect(() => {
+    // Increment fixed header counter for each fixed header
+    euiHeaderFixedCounter++;
+    document.body.classList.add('euiBody--headerIsFixed');
+    document.body.dataset.fixedHeaders = String(euiHeaderFixedCounter);
+
+    return () => {
+      // Both decrement the fixed counter AND then check if there are none
+      if (--euiHeaderFixedCounter === 0) {
+        // If there are none, THEN remove class
+        document.body.classList.remove('euiBody--headerIsFixed');
+        delete document.body.dataset.fixedHeaders;
+      }
+    };
+  }, []);
+
   return (
     <div
-      css={cssStyles}
-      className={classes}
-      data-fixed-header={position === 'fixed' || undefined} // Used by EuiFlyouts as a query selector
+      data-fixed-header={true} // Used by EuiFlyouts as a query selector
       {...rest}
     >
-      {contents}
+      {children}
     </div>
   );
 };

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -6,11 +6,17 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes, useEffect } from 'react';
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  useEffect,
+  useState,
+  useMemo,
+} from 'react';
 import classNames from 'classnames';
 
 import { useEuiTheme, useEuiThemeCSSVariables } from '../../services';
-import { mathWithUnits } from '../../global_styling';
+import { mathWithUnits, logicalStyles } from '../../global_styling';
 import { CommonProps } from '../common';
 import { EuiBreadcrumb, EuiBreadcrumbsProps } from '../breadcrumbs';
 
@@ -140,13 +146,20 @@ export let euiHeaderFixedCounter = 0;
 // Exported for unit testing only
 export const EuiFixedHeader: FunctionComponent<EuiHeaderProps> = ({
   children,
+  style,
   ...rest
 }) => {
   const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
   const euiTheme = useEuiTheme();
   const headerHeight = euiHeaderVariables(euiTheme).height;
+  const [topPosition, setTopPosition] = useState<string | undefined>();
 
   useEffect(() => {
+    // Get the top position from the offset of previous header(s)
+    setTopPosition(
+      mathWithUnits(headerHeight, (x) => x * euiHeaderFixedCounter)
+    );
+
     // Increment fixed header counter for each fixed header
     euiHeaderFixedCounter++;
     setGlobalCSSVariables({
@@ -171,9 +184,15 @@ export const EuiFixedHeader: FunctionComponent<EuiHeaderProps> = ({
     };
   }, [headerHeight, setGlobalCSSVariables]);
 
+  const inlineStyles = useMemo(
+    () => logicalStyles({ top: topPosition, ...style }),
+    [topPosition, style]
+  );
+
   return (
     <div
       data-fixed-header={true} // Used by EuiFlyouts as a query selector
+      style={inlineStyles}
       {...rest}
     >
       {children}

--- a/src/components/overlay_mask/overlay_mask.styles.ts
+++ b/src/components/overlay_mask/overlay_mask.styles.ts
@@ -29,7 +29,6 @@ export const euiOverlayMaskStyles = ({ euiTheme }: UseEuiTheme) => ({
   `,
   belowHeader: css`
     z-index: ${euiTheme.levels.maskBelowHeader};
-    /* TODO: use size variable when EuiHeader is converted */
-    ${logicalCSS('top', `${euiTheme.base * 3}px`)}
+    ${logicalCSS('top', 'var(--euiFixedHeadersOffset, 0)')}
   `,
 });

--- a/src/components/overlay_mask/overlay_mask.test.tsx
+++ b/src/components/overlay_mask/overlay_mask.test.tsx
@@ -54,7 +54,7 @@ describe('EuiOverlayMask', () => {
       </EuiOverlayMask>
     );
     expect(getClassName()).toMatchInlineSnapshot(
-      `"euiOverlayMask css-1sm7f9p-euiOverlayMask-belowHeader world"`
+      `"euiOverlayMask css-1j0pa91-euiOverlayMask-belowHeader world"`
     );
   });
 

--- a/src/components/page/page_sidebar/page_sidebar.test.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.test.tsx
@@ -66,14 +66,15 @@ describe('EuiPageSidebar', () => {
       const component = mount(
         <EuiPageSidebar sticky data-test-subj="sidebar" />
       );
+      const expectedStyles = {
+        insetBlockStart: 'var(--euiFixedHeadersOffset, 0)',
+        maxBlockSize: 'calc(100vh - var(--euiFixedHeadersOffset, 0))',
+        minInlineSize: 248,
+      };
 
       expect(
         component.find('[data-test-subj="sidebar"]').last().prop('style')
-      ).toEqual({
-        insetBlockStart: 0,
-        maxBlockSize: 'calc(100vh - 0px)',
-        minInlineSize: 248,
-      });
+      ).toEqual(expectedStyles);
 
       component.setProps({ style: { color: 'red' } });
       component.update();
@@ -82,9 +83,7 @@ describe('EuiPageSidebar', () => {
         component.find('[data-test-subj="sidebar"]').last().prop('style')
       ).toEqual({
         color: 'red',
-        insetBlockStart: 0,
-        maxBlockSize: 'calc(100vh - 0px)',
-        minInlineSize: 248,
+        ...expectedStyles,
       });
     });
   });

--- a/src/components/page/page_sidebar/page_sidebar.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.tsx
@@ -87,19 +87,15 @@ export const EuiPageSidebar: FunctionComponent<EuiPageSidebarProps> = ({
     };
 
     if (sticky) {
-      const euiHeaderFixedCounter = Number(
-        document.body.dataset.fixedHeaders ?? 0
-      );
-
       const offset =
         typeof sticky === 'object'
-          ? sticky?.offset
-          : themeContext.euiTheme.base * 3 * euiHeaderFixedCounter;
+          ? `${sticky?.offset}px`
+          : 'var(--euiFixedHeadersOffset, 0)';
 
       updatedStyles = {
         ...updatedStyles,
         ...logicalStyle('top', offset),
-        ...logicalStyle('max-height', `calc(100vh - ${offset}px)`),
+        ...logicalStyle('max-height', `calc(100vh - ${offset})`),
       };
     }
 

--- a/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiPageTemplate _EuiPageInnerProps is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <div
     class="customClassName emotion-euiPageInner-left"
@@ -15,7 +15,7 @@ exports[`EuiPageTemplate _EuiPageInnerProps is rendered 1`] = `
 exports[`EuiPageTemplate _EuiPageInnerProps renders as panelled 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <div
     class="emotion-euiPageInner-panelled"
@@ -27,7 +27,7 @@ exports[`EuiPageTemplate _EuiPageInnerProps renders as panelled 1`] = `
 exports[`EuiPageTemplate _EuiPageOuterProps is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-column-grow"
-  style="min-block-size: 460px; padding-block-start: 0;"
+  style="min-block-size: 460px; padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -39,7 +39,7 @@ exports[`EuiPageTemplate _EuiPageOuterProps is rendered 1`] = `
 exports[`EuiPageTemplate bottomBorder is rendered as extended 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -51,7 +51,7 @@ exports[`EuiPageTemplate bottomBorder is rendered as extended 1`] = `
 exports[`EuiPageTemplate bottomBorder is rendered as true 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -65,7 +65,7 @@ exports[`EuiPageTemplate children detects sidebars and does not place them in th
   aria-label="aria-label"
   class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <div
     class="emotion-euiPageSidebar-l"
@@ -87,7 +87,7 @@ exports[`EuiPageTemplate children renders all other types within the main EuiPag
   aria-label="aria-label"
   class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -128,7 +128,7 @@ exports[`EuiPageTemplate is rendered 1`] = `
   aria-label="aria-label"
   class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
   data-test-subj="test subject string"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -140,7 +140,7 @@ exports[`EuiPageTemplate is rendered 1`] = `
 exports[`EuiPageTemplate minHeight is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(40vh, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(40vh, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -164,7 +164,7 @@ exports[`EuiPageTemplate offset is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize l is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -176,7 +176,7 @@ exports[`EuiPageTemplate paddingSize l is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize m is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -188,7 +188,7 @@ exports[`EuiPageTemplate paddingSize m is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize none is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -200,7 +200,7 @@ exports[`EuiPageTemplate paddingSize none is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize s is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -212,7 +212,7 @@ exports[`EuiPageTemplate paddingSize s is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize xl is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -224,7 +224,7 @@ exports[`EuiPageTemplate paddingSize xl is rendered 1`] = `
 exports[`EuiPageTemplate paddingSize xs is rendered 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -236,7 +236,7 @@ exports[`EuiPageTemplate paddingSize xs is rendered 1`] = `
 exports[`EuiPageTemplate restrict width can be set to a custom number 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -248,7 +248,7 @@ exports[`EuiPageTemplate restrict width can be set to a custom number 1`] = `
 exports[`EuiPageTemplate restrict width can be set to a custom value and measurement 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"
@@ -260,7 +260,7 @@ exports[`EuiPageTemplate restrict width can be set to a custom value and measure
 exports[`EuiPageTemplate restrict width can be set to a default 1`] = `
 <div
   class="euiPageTemplate emotion-euiPageOuter-row-grow"
-  style="min-block-size: max(460px, 100vh); padding-block-start: 0;"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
 >
   <main
     class="emotion-euiPageInner"

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -12,8 +12,6 @@ import React, {
   FunctionComponent,
   HTMLAttributes,
   useContext,
-  useEffect,
-  useState,
 } from 'react';
 import classNames from 'classnames';
 
@@ -37,7 +35,7 @@ import {
 } from '../page';
 import { _EuiPageRestrictWidth } from '../page/_restrict_width';
 import { _EuiPageBottomBorder } from '../page/_bottom_border';
-import { useEuiTheme, useGeneratedHtmlId } from '../../services';
+import { useGeneratedHtmlId } from '../../services';
 import { logicalStyle } from '../../global_styling';
 import { CommonProps } from '../common';
 
@@ -79,13 +77,6 @@ export type EuiPageTemplateProps = _EuiPageOuterProps &
     component?: ComponentTypes;
   };
 
-const calculateOffset = (base: number): number => {
-  if (typeof document === 'undefined') return 0; // SSR catch
-
-  const euiHeaderFixedCounter = Number(document.body.dataset.fixedHeaders ?? 0);
-  return base * 3 * euiHeaderFixedCounter;
-};
-
 /**
  * Consumed via `EuiPageTemplate`,
  * it controls and propogates most of the shared props per direct child
@@ -98,7 +89,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   paddingSize = 'l',
   grow = true,
   bottomBorder,
-  offset: _offset,
+  offset,
   panelled,
   // Inner props
   contentBorder,
@@ -109,11 +100,6 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   minHeight = '460px',
   ...rest
 }) => {
-  const { euiTheme } = useEuiTheme();
-
-  const [offset, setOffset] = useState(
-    () => _offset ?? calculateOffset(euiTheme.base)
-  );
   const templateContext = useContext(TemplateContext);
 
   // Used as a target to insert the bottom bar component
@@ -121,12 +107,6 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
     prefix: 'EuiPageTemplateInner',
     conditionalId: mainProps?.id,
   });
-
-  useEffect(() => {
-    if (_offset === undefined) {
-      setOffset(calculateOffset(euiTheme.base));
-    }
-  }, [_offset, euiTheme.base]);
 
   // Sections include page header
   const sections: React.ReactElement[] = [];
@@ -194,7 +174,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   const classes = classNames('euiPageTemplate', className);
   const pageStyle = {
     ...logicalStyle('min-height', _minHeight),
-    ...logicalStyle('padding-top', offset),
+    ...logicalStyle('padding-top', offset ?? 'var(--euiFixedHeadersOffset, 0)'),
     ...rest.style,
   };
 

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -1,7 +1,7 @@
 @import '../variables/header';
 
 @mixin euiHeaderAffordForFixed($headerHeight: $euiHeaderHeightCompensation) {
-  @warn "This mixin will shortly be deprecated. Use the CSS variable var(--euiFixedHeadersOffset) instead, which updates dynamically based on the number of fixed headers on the page.";
+  @warn 'This mixin will shortly be deprecated. Use the CSS variable var(--euiFixedHeadersOffset) instead, which updates dynamically based on the number of fixed headers on the page.';
 
   // The `@at-root #{&}` allows for grouping alongside another specific body class.
   // When not applied inside of another selector, it simply renders with the single class

--- a/src/global_styling/mixins/_header.scss
+++ b/src/global_styling/mixins/_header.scss
@@ -1,6 +1,8 @@
 @import '../variables/header';
 
 @mixin euiHeaderAffordForFixed($headerHeight: $euiHeaderHeightCompensation) {
+  @warn "This mixin will shortly be deprecated. Use the CSS variable var(--euiFixedHeadersOffset) instead, which updates dynamically based on the number of fixed headers on the page.";
+
   // The `@at-root #{&}` allows for grouping alongside another specific body class.
   // When not applied inside of another selector, it simply renders with the single class
   @at-root #{&}.euiBody--headerIsFixed {

--- a/src/global_styling/mixins/_helpers.ts
+++ b/src/global_styling/mixins/_helpers.ts
@@ -126,14 +126,14 @@ const euiOverflowShadowStyles = (
  *    Others like Safari, won't show anything at all.
  */
 interface _EuiYScroll {
-  height?: CSSProperties['height'];
+  height?: CSSProperties['height'] | false;
 }
 export const euiYScroll = (
   euiTheme: UseEuiTheme,
   { height }: _EuiYScroll = {}
 ) => `
   ${euiScrollBarStyles(euiTheme)}
-  ${logicalCSS('height', height || '100%')}
+  ${height !== false ? logicalCSS('height', height || '100%') : ''}
   ${logicalCSSWithFallback('overflow-y', 'auto')}
   ${logicalCSSWithFallback('overflow-x', 'hidden')}
   &:focus {

--- a/upcoming_changelogs/7144.md
+++ b/upcoming_changelogs/7144.md
@@ -1,0 +1,8 @@
+- Fixed-positioned `EuiHeader`s now set a global CSS `--euiFixedHeadersOffset` variable, which updates dynamically based on the number of fixed headers on the page.
+- `EuiFlyout`s now dynamically set their position, height, and mask based on the number of fixed headers on the page.
+- Sticky-positioned `EuiPageSidebar`s now dynamically set their position and height based on the number of fixed headers on the page. This can still be overridden via the `sticky.offset` prop if needed.
+- `EuiPageTemplate` now dynamically offsets content from any fixed headers on the page. This can still be overridden via the `offset` prop if needed.
+
+**Deprecations**
+
+- Deprecated the Sass `euiHeaderAffordForFixed` mixin. Use the new global CSS `var(--euiFixedHeadersOffset)` variable instead.


### PR DESCRIPTION
## Summary

![screencap](https://github.com/elastic/eui/assets/549407/fe4a2fb1-cdfa-4cc6-b047-f5bfea5fd777)

This logic allows `EuiHeader` to afford for any number of fixed headers (although it's likely that consumers will not use more than two). The most important aspect of this refactor that other EUI components can access this CSS variable globally with no extra JS logic or rerendering on their end, which removes a significant amount of duplicated `useEffects` from components affected by fixed headers (`EuiPageTemplate`, `EuiSideBar`, and `EuiCollapsibleNavBeta`), and for other components (`EuiFlyout` and `EuiOverlayMask`), it allows them to correctly and dynamically set their top position and height instead of relying on a static Sass mixin to work as expected.

I strongly recommend [reviewing by commit](https://github.com/elastic/eui/pull/7144/commits) as multiple downstream components/usages were updated separately.

## QA

- `gh pr checkout 7144 && yarn storybook`
- Go to http://localhost:6006/?path=/story/euiheader--multiple-fixed-headers
- [x] Dynamically add and remove headers, and confirm that each time, the page template and flyout mask correctly accounts for the number of fixed headers on the page, including when that number is 0
- Go to https://eui.elastic.co/pr_7144/#/layout/header#fixed-header
- [x] Confirm that toggling the demo header appends the fixed header below the existing docs header

### General checklist

- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
