### PR TITLE
[EuiDataGrid] Introduce a renderCustomToolbar render prop

### DIFF
--- a/src-docs/src/views/datagrid/advanced/custom_toolbar.tsx
+++ b/src-docs/src/views/datagrid/advanced/custom_toolbar.tsx
@@ -1,0 +1,170 @@
+import React, { useCallback, useState } from 'react';
+import { faker } from '@faker-js/faker';
+
+import {
+  EuiDataGrid,
+  EuiDataGridColumnCellActionProps,
+  EuiButtonIcon,
+  EuiDataGridPaginationProps,
+  EuiDataGridSorting,
+  EuiDataGridColumnSortingConfig,
+  EuiPopover,
+  EuiDataGridCustomToolbarProps,
+  EuiFormRow,
+  EuiRange,
+} from '../../../../../src';
+
+const raw_data: Array<{ [key: string]: string }> = [];
+for (let i = 1; i < 100; i++) {
+  raw_data.push({
+    name: `${faker.name.lastName()}, ${faker.name.firstName()}`,
+    email: faker.internet.email(),
+    location: `${faker.address.city()}, ${faker.address.country()}`,
+    date: `${faker.date.past()}`,
+    amount: faker.commerce.price(1, 1000, 2, '$'),
+  });
+}
+
+const columns = [
+  {
+    id: 'name',
+    displayAsText: 'Name',
+    cellActions: [
+      ({ Component }: EuiDataGridColumnCellActionProps) => (
+        <Component
+          onClick={() => alert('action')}
+          iconType="faceHappy"
+          aria-label="Some action"
+        >
+          Some action
+        </Component>
+      ),
+    ],
+  },
+  {
+    id: 'email',
+    displayAsText: 'Email address',
+    initialWidth: 130,
+  },
+  {
+    id: 'location',
+    displayAsText: 'Location',
+  },
+  {
+    id: 'date',
+    displayAsText: 'Date',
+  },
+  {
+    id: 'amount',
+    displayAsText: 'Amount',
+  },
+];
+
+export default () => {
+  // Column visibility
+  const [visibleColumns, setVisibleColumns] = useState(() =>
+    columns.map(({ id }) => id)
+  );
+
+  // Pagination
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
+  const onChangePage = useCallback<EuiDataGridPaginationProps['onChangePage']>(
+    (pageIndex) => {
+      setPagination((pagination) => ({ ...pagination, pageIndex }));
+    },
+    []
+  );
+  const onChangePageSize = useCallback<
+    EuiDataGridPaginationProps['onChangeItemsPerPage']
+  >((pageSize) => {
+    setPagination((pagination) => ({ ...pagination, pageSize }));
+  }, []);
+
+  // Sorting
+  const [sortingColumns, setSortingColumns] = useState<
+    EuiDataGridColumnSortingConfig[]
+  >([]);
+  const onSort = useCallback<EuiDataGridSorting['onSort']>((sortingColumns) => {
+    setSortingColumns(sortingColumns);
+  }, []);
+  const [isDisplaySelectorOpen, setIsDisplaySelectorOpen] = useState(false);
+
+  // Custom toolbar body renderer
+  const RenderCustomToolbar = ({
+    fullScreenSelector,
+    keyboardShortcuts,
+    rowHeightsControls,
+    densityControls,
+    columnSelector,
+    columnSorting,
+  }: EuiDataGridCustomToolbarProps) => {
+    return (
+      <div className="euiDataGrid__controls" data-test-subj="dataGridControls">
+        <div className="euiDataGrid__leftControls">
+          Always look at the left side of grid!
+        </div>
+        <div className="euiDataGrid__rightControls">
+          {fullScreenSelector}
+          {keyboardShortcuts}
+          <EuiPopover
+            button={
+              <EuiButtonIcon
+                iconType="controlsHorizontal"
+                aria-label="Custom grid controls"
+                onClick={() => setIsDisplaySelectorOpen(true)}
+              />
+            }
+            isOpen={isDisplaySelectorOpen}
+            data-test-subj="dataGridDisplaySelectorPopover"
+            closePopover={() => setIsDisplaySelectorOpen(false)}
+            anchorPosition="downRight"
+            panelPaddingSize="s"
+            panelClassName="euiDataGrid__displayPopoverPanel"
+          >
+            {rowHeightsControls}
+            {densityControls}
+
+            <EuiFormRow label="Random Sample Size" display="columnCompressed">
+              <EuiRange
+                compressed
+                fullWidth
+                showInput
+                min={1}
+                max={100}
+                step={1}
+                value={10}
+                data-test-subj="randomSampleSize"
+              />
+            </EuiFormRow>
+          </EuiPopover>
+          {columnSorting}
+          {columnSelector}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <EuiDataGrid
+        aria-label="Data grid custom body renderer demo"
+        columns={columns}
+        columnVisibility={{ visibleColumns, setVisibleColumns }}
+        sorting={{ columns: sortingColumns, onSort }}
+        inMemory={{ level: 'sorting' }}
+        pagination={{
+          ...pagination,
+          onChangePage: onChangePage,
+          onChangeItemsPerPage: onChangePageSize,
+        }}
+        rowCount={raw_data.length}
+        renderCellValue={({ rowIndex, columnId }) =>
+          raw_data[rowIndex][columnId]
+        }
+        renderCustomToolbar={RenderCustomToolbar}
+        height={undefined}
+        gridStyle={{ border: 'none', header: 'underline' }}
+      />
+    </>
+  );
+};

--- a/src-docs/src/views/datagrid/advanced/datagrid_advanced_example.js
+++ b/src-docs/src/views/datagrid/advanced/datagrid_advanced_example.js
@@ -8,6 +8,7 @@ import {
   EuiCallOut,
   EuiTitle,
   EuiLink,
+  EuiDataGridCustomToolbarProps,
 } from '../../../../../src/components';
 
 import {
@@ -36,7 +37,9 @@ dataGridRef.current.closeCellPopover();
 `;
 
 import CustomRenderer from './custom_renderer';
+import CustomToolbarRenderer from './custom_toolbar';
 const customRendererSource = require('!!raw-loader!./custom_renderer');
+const customToolbarSource = require('!!raw-loader!./custom_toolbar');
 const customRendererSnippet = `const CustomGridBody = ({ visibleColumns, visibleRowData, Cell }) => {
   const visibleRows = raw_data.slice(
     visibleRowData.startRow,
@@ -252,6 +255,27 @@ export const DataGridAdvancedExample = {
       demo: <CustomRenderer />,
       snippet: customRendererSnippet,
       props: { EuiDataGridCustomBodyProps },
+    },
+    {
+      title: 'Custom toolbar renderer',
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: customToolbarSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            For advanced use cases, the <EuiCode>renderCustomToolbar</EuiCode>{' '}
+            prop may be used to take complete control over rendering the
+            toolbar. This may be useful where custom row layouts (e.g., all
+            button on the right side) are required.
+          </p>
+        </>
+      ),
+      demo: <CustomToolbarRenderer />,
+      props: { EuiDataGridCustomToolbarProps },
     },
   ],
 };

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -95,7 +95,13 @@ export const useDataGridDisplaySelector = (
   showDisplaySelector: EuiDataGridToolBarVisibilityOptions['showDisplaySelector'],
   initialStyles: EuiDataGridStyle,
   initialRowHeightsOptions?: EuiDataGridRowHeightsOptions
-): [ReactNode, EuiDataGridStyle, EuiDataGridRowHeightsOptions] => {
+): [
+  ReactNode,
+  EuiDataGridStyle,
+  EuiDataGridRowHeightsOptions,
+  ReactNode,
+  ReactNode
+] => {
   const [isOpen, setIsOpen] = useState(false);
 
   const showDensityControls = getNestedObjectOptions(
@@ -107,11 +113,6 @@ export const useDataGridDisplaySelector = (
     showDisplaySelector,
     'allowRowHeight'
   );
-
-  const additionalDisplaySettings =
-    typeof showDisplaySelector === 'boolean'
-      ? null
-      : showDisplaySelector?.additionalDisplaySettings ?? null;
 
   // Track styles specified by the user at run time
   const [userGridStyles, setUserGridStyles] = useState({});
@@ -221,6 +222,107 @@ export const useDataGridDisplaySelector = (
     'Reset to default'
   );
 
+  const rowHeightsControls = (
+    <EuiI18n
+      tokens={[
+        'euiDisplaySelector.rowHeightLabel',
+        'euiDisplaySelector.labelSingle',
+        'euiDisplaySelector.labelAuto',
+        'euiDisplaySelector.labelCustom',
+        'euiDisplaySelector.lineCountLabel',
+      ]}
+      defaults={['Row height', 'Single', 'Auto fit', 'Custom', 'Lines per row']}
+    >
+      {([
+        rowHeightLabel,
+        labelSingle,
+        labelAuto,
+        labelCustom,
+        lineCountLabel,
+      ]: string[]) => (
+        <>
+          <EuiFormRow label={rowHeightLabel} display="columnCompressed">
+            <EuiButtonGroup
+              legend={rowHeightLabel}
+              buttonSize="compressed"
+              isFullWidth
+              options={[
+                {
+                  id: rowHeightButtonOptions[0],
+                  label: labelSingle,
+                },
+                {
+                  id: rowHeightButtonOptions[1],
+                  label: labelAuto,
+                },
+                {
+                  id: rowHeightButtonOptions[2],
+                  label: labelCustom,
+                },
+              ]}
+              onChange={setRowHeight}
+              idSelected={rowHeightSelection}
+              data-test-subj="rowHeightButtonGroup"
+            />
+          </EuiFormRow>
+          {rowHeightSelection === rowHeightButtonOptions[2] && (
+            <EuiFormRow label={lineCountLabel} display="columnCompressed">
+              <EuiRange
+                compressed
+                fullWidth
+                showInput
+                min={1}
+                max={20}
+                step={1}
+                value={lineCount}
+                onChange={setLineCountHeight}
+                data-test-subj="lineCountNumber"
+              />
+            </EuiFormRow>
+          )}
+        </>
+      )}
+    </EuiI18n>
+  );
+  const densityControls = (
+    <EuiI18n
+      tokens={[
+        'euiDisplaySelector.densityLabel',
+        'euiDisplaySelector.labelCompact',
+        'euiDisplaySelector.labelNormal',
+        'euiDisplaySelector.labelExpanded',
+      ]}
+      defaults={['Density', 'Compact', 'Normal', 'Expanded']}
+    >
+      {([densityLabel, labelCompact, labelNormal, labelExpanded]: string[]) => (
+        <EuiFormRow label={densityLabel} display="columnCompressed">
+          <EuiButtonGroup
+            legend={densityLabel}
+            buttonSize="compressed"
+            isFullWidth
+            options={[
+              {
+                id: densityOptions[0],
+                label: labelCompact,
+              },
+              {
+                id: densityOptions[1],
+                label: labelNormal,
+              },
+              {
+                id: densityOptions[2],
+                label: labelExpanded,
+              },
+            ]}
+            onChange={setGridStyles}
+            idSelected={gridDensity}
+            data-test-subj="densityButtonGroup"
+          />
+        </EuiFormRow>
+      )}
+    </EuiI18n>
+  );
+
   const displaySelector =
     showDensityControls || showRowHeightControls ? (
       <EuiPopover
@@ -248,119 +350,8 @@ export const useDataGridDisplaySelector = (
           </EuiToolTip>
         }
       >
-        {showDensityControls && (
-          <EuiI18n
-            tokens={[
-              'euiDisplaySelector.densityLabel',
-              'euiDisplaySelector.labelCompact',
-              'euiDisplaySelector.labelNormal',
-              'euiDisplaySelector.labelExpanded',
-            ]}
-            defaults={['Density', 'Compact', 'Normal', 'Expanded']}
-          >
-            {([
-              densityLabel,
-              labelCompact,
-              labelNormal,
-              labelExpanded,
-            ]: string[]) => (
-              <EuiFormRow label={densityLabel} display="columnCompressed">
-                <EuiButtonGroup
-                  legend={densityLabel}
-                  buttonSize="compressed"
-                  isFullWidth
-                  options={[
-                    {
-                      id: densityOptions[0],
-                      label: labelCompact,
-                    },
-                    {
-                      id: densityOptions[1],
-                      label: labelNormal,
-                    },
-                    {
-                      id: densityOptions[2],
-                      label: labelExpanded,
-                    },
-                  ]}
-                  onChange={setGridStyles}
-                  idSelected={gridDensity}
-                  data-test-subj="densityButtonGroup"
-                />
-              </EuiFormRow>
-            )}
-          </EuiI18n>
-        )}
-        {showRowHeightControls && (
-          <EuiI18n
-            tokens={[
-              'euiDisplaySelector.rowHeightLabel',
-              'euiDisplaySelector.labelSingle',
-              'euiDisplaySelector.labelAuto',
-              'euiDisplaySelector.labelCustom',
-              'euiDisplaySelector.lineCountLabel',
-            ]}
-            defaults={[
-              'Row height',
-              'Single',
-              'Auto fit',
-              'Custom',
-              'Lines per row',
-            ]}
-          >
-            {([
-              rowHeightLabel,
-              labelSingle,
-              labelAuto,
-              labelCustom,
-              lineCountLabel,
-            ]: string[]) => (
-              <>
-                <EuiFormRow label={rowHeightLabel} display="columnCompressed">
-                  <EuiButtonGroup
-                    legend={rowHeightLabel}
-                    buttonSize="compressed"
-                    isFullWidth
-                    options={[
-                      {
-                        id: rowHeightButtonOptions[0],
-                        label: labelSingle,
-                      },
-                      {
-                        id: rowHeightButtonOptions[1],
-                        label: labelAuto,
-                      },
-                      {
-                        id: rowHeightButtonOptions[2],
-                        label: labelCustom,
-                      },
-                    ]}
-                    onChange={setRowHeight}
-                    idSelected={rowHeightSelection}
-                    data-test-subj="rowHeightButtonGroup"
-                  />
-                </EuiFormRow>
-                {rowHeightSelection === rowHeightButtonOptions[2] && (
-                  <EuiFormRow label={lineCountLabel} display="columnCompressed">
-                    <EuiRange
-                      compressed
-                      fullWidth
-                      showInput
-                      min={1}
-                      max={20}
-                      step={1}
-                      value={lineCount}
-                      onChange={setLineCountHeight}
-                      data-test-subj="lineCountNumber"
-                    />
-                  </EuiFormRow>
-                )}
-              </>
-            )}
-          </EuiI18n>
-        )}
-        {additionalDisplaySettings}
-
+        {showDensityControls && densityControls}
+        {showRowHeightControls && rowHeightsControls}
         {showResetButton && (
           <EuiPopoverFooter>
             <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
@@ -382,5 +373,11 @@ export const useDataGridDisplaySelector = (
       </EuiPopover>
     ) : null;
 
-  return [displaySelector, gridStyles, rowHeightsOptions];
+  return [
+    displaySelector,
+    gridStyles,
+    rowHeightsOptions,
+    rowHeightsControls,
+    densityControls,
+  ];
 };

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -129,6 +129,7 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
       rowHeightsOptions: _rowHeightsOptions,
       virtualizationOptions,
       renderCustomGridBody,
+      renderCustomToolbar,
       ...rest
     } = props;
 
@@ -203,15 +204,20 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
       );
     }, [columns]);
 
-    const [displaySelector, gridStyles, rowHeightsOptions] =
-      useDataGridDisplaySelector(
-        checkOrDefaultToolBarDisplayOptions(
-          toolbarVisibility,
-          'showDisplaySelector'
-        ),
-        gridStyleWithDefaults,
-        _rowHeightsOptions
-      );
+    const [
+      displaySelector,
+      gridStyles,
+      rowHeightsOptions,
+      rowHeightsControls,
+      densityControls,
+    ] = useDataGridDisplaySelector(
+      checkOrDefaultToolBarDisplayOptions(
+        toolbarVisibility,
+        'showDisplaySelector'
+      ),
+      gridStyleWithDefaults,
+      _rowHeightsOptions
+    );
 
     /**
      * Column order & visibility
@@ -389,19 +395,36 @@ export const EuiDataGrid = forwardRef<EuiDataGridRefProps, EuiDataGridProps>(
                 ref={setResizeRef}
                 {...rest}
               >
-                {showToolbar && (
-                  <EuiDataGridToolbar
-                    gridWidth={gridWidth}
-                    minSizeForControls={minSizeForControls}
-                    toolbarVisibility={toolbarVisibility}
-                    isFullScreen={isFullScreen}
-                    fullScreenSelector={fullScreenSelector}
-                    keyboardShortcuts={keyboardShortcuts}
-                    displaySelector={displaySelector}
-                    columnSelector={columnSelector}
-                    columnSorting={columnSorting}
-                  />
-                )}
+                <>
+                  {showToolbar &&
+                    renderCustomToolbar &&
+                    renderCustomToolbar({
+                      gridWidth,
+                      minSizeForControls,
+                      toolbarVisibility,
+                      isFullScreen,
+                      fullScreenSelector,
+                      keyboardShortcuts,
+                      displaySelector,
+                      columnSelector,
+                      columnSorting,
+                      rowHeightsControls,
+                      densityControls,
+                    })}
+                  {showToolbar && !renderCustomToolbar && (
+                    <EuiDataGridToolbar
+                      gridWidth={gridWidth}
+                      minSizeForControls={minSizeForControls}
+                      toolbarVisibility={toolbarVisibility}
+                      isFullScreen={isFullScreen}
+                      fullScreenSelector={fullScreenSelector}
+                      keyboardShortcuts={keyboardShortcuts}
+                      displaySelector={displaySelector}
+                      columnSelector={columnSelector}
+                      columnSorting={columnSorting}
+                    />
+                  )}
+                </>
                 {inMemory ? (
                   <EuiDataGridInMemoryRenderer
                     inMemory={inMemory}

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -281,6 +281,15 @@ export type CommonGridProps = CommonProps &
      */
     renderCustomGridBody?: (args: EuiDataGridCustomBodyProps) => ReactNode;
     /**
+     * An optional function called to completely customize and control the rendering of
+     * EuiDataGrid's toolbar.  This can be used to add custom buttons, reorder existing ones.
+     *
+     * Behind the scenes, this function is treated as a React component,
+     * allowing hooks, context, and other React concepts to be used.
+     * It receives #EuiDataGridCustomBodyProps as its only argument.
+     */
+    renderCustomToolbar?: (args: EuiDataGridCustomToolbarProps) => ReactNode;
+    /**
      * Defines the initial style of the grid. Accepts a partial #EuiDataGridStyle object.
      * Settings provided may be overwritten or merged with user defined preferences if `toolbarVisibility.showDisplaySelector.allowDensity = true` (which is the default).
      */
@@ -482,6 +491,12 @@ export interface EuiDataGridCustomBodyProps {
    */
   setCustomGridBodyProps: (props: EuiDataGridSetCustomGridBodyProps) => void;
 }
+
+export interface EuiDataGridCustomToolbarProps extends EuiDataGridToolbarProps {
+  rowHeightsControls: ReactNode;
+  densityControls: ReactNode;
+}
+
 export type EuiDataGridSetCustomGridBodyProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     ref?: MutableRefObject<HTMLDivElement> | Ref<HTMLDivElement>;


### PR DESCRIPTION
## Summary

This PR is introducing a renderCustomToolbar render prop allowing the customize EuiDataGrid

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Checked in both **light and dark** modes
- [ ] Checked in **mobile**
- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] Checked for **breaking changes** and labeled appropriately
- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
