### PR TITLE
[Emotion] Remove `.euiAccordionForm` styles

### DIFF
--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -408,21 +408,13 @@ export const AccordionExample = {
       text: (
         <>
           <p>
-            Since accordions are unstyled by default, EUI also provides a few
-            classes you can add to parts of the EuiAccordion to give it more
-            style, like when using with forms.
+            Accordions are unstyled by default, but{' '}
+            <strong>EuiAccordion</strong> supports several props around padding
+            sizes and borders, as well as letting you pass in your own custom
+            CSS styles. See the snippet tab below for a quick preview of said
+            props, and the and the demo code tab below for custom hover and
+            focus CSS overrides.
           </p>
-          <ul>
-            <li>
-              <EuiCode>.euiAccordionForm</EuiCode>: Applied to the{' '}
-              <EuiCode>className</EuiCode>, adds top and bottom borders
-            </li>
-            <li>
-              <EuiCode>.euiAccordionForm__button</EuiCode>: Applied to the{' '}
-              <EuiCode>buttonClassName</EuiCode>, adds extra padding to the
-              button for better spacing
-            </li>
-          </ul>
           <p>
             We also recommend creating a fieldset/legend combination for better
             accessibility and DOM structure by passing{' '}
@@ -436,12 +428,13 @@ export const AccordionExample = {
       ),
       demo: <AccordionForm />,
       snippet: `<EuiAccordion
-  id={accordionId4}
-  className="euiAccordionForm"
+  id={accordionId}
   element="fieldset"
-  buttonClassName="euiAccordionForm__button"
+  paddingSize="l"
+  borders="horizontal"
+  buttonProps={{ paddingSize: 'm' }}
   buttonContent={buttonContent}
-  paddingSize="l">
+>
   <!-- Content to show when expanded -->
 </EuiAccordion>`,
     },

--- a/src-docs/src/views/accordion/accordion_example.js
+++ b/src-docs/src/views/accordion/accordion_example.js
@@ -422,11 +422,6 @@ export const AccordionExample = {
               <EuiCode>buttonClassName</EuiCode>, adds extra padding to the
               button for better spacing
             </li>
-            <li>
-              <EuiCode>.euiAccordionForm__extraAction</EuiCode>: Applied to the
-              button passed to <EuiCode>extraAction</EuiCode>, will visually
-              hide it until hover or focus
-            </li>
           </ul>
           <p>
             We also recommend creating a fieldset/legend combination for better
@@ -446,12 +441,6 @@ export const AccordionExample = {
   element="fieldset"
   buttonClassName="euiAccordionForm__button"
   buttonContent={buttonContent}
-  extraAction={<EuiButtonIcon
-    iconType="cross"
-    color="danger"
-    className="euiAccordionForm__extraAction"
-    aria-label="Delete"
-  />}
   paddingSize="l">
   <!-- Content to show when expanded -->
 </EuiAccordion>`,

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -70,6 +70,12 @@ const buttonContent = (
     </EuiText>
   </div>
 );
+// Custom trigger button CSS
+const buttonCss = css`
+  &:hover {
+    text-decoration: none;
+  }
+`;
 
 // Custom CSS to make the extra action only appear on hover or focus
 // Useful if there's multiple accordions in a row to reduce visual overwhelm
@@ -110,7 +116,7 @@ export default () => {
         id={formAccordionId__1}
         element="fieldset"
         className="euiAccordionForm"
-        buttonClassName="euiAccordionForm__button"
+        buttonProps={{ paddingSize: 'm', css: buttonCss }}
         buttonContent={buttonContent}
         extraAction={extraAction}
         paddingSize="l"
@@ -122,7 +128,7 @@ export default () => {
         id={formAccordionId__2}
         element="fieldset"
         className="euiAccordionForm"
-        buttonClassName="euiAccordionForm__button"
+        buttonProps={{ paddingSize: 'm', css: buttonCss }}
         buttonContent={buttonContent}
         extraAction={extraAction}
         paddingSize="l"

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -111,7 +111,7 @@ export default () => {
   });
 
   return (
-    <div>
+    <>
       <EuiAccordion
         id={formAccordionId__1}
         element="fieldset"
@@ -135,6 +135,6 @@ export default () => {
       >
         {repeatableForm}
       </EuiAccordion>
-    </div>
+    </>
   );
 };

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from '@emotion/react';
 
 import {
   EuiAccordion,
@@ -17,6 +18,7 @@ import {
   EuiButtonIcon,
 } from '../../../../src/components';
 import { useGeneratedHtmlId } from '../../../../src/services';
+import { euiCanAnimate } from '../../../../src/global_styling';
 
 const repeatableForm = (
   <EuiForm component="form">
@@ -69,12 +71,26 @@ const buttonContent = (
   </div>
 );
 
+// Custom CSS to make the extra action only appear on hover or focus
+// Useful if there's multiple accordions in a row to reduce visual overwhelm
 const extraAction = (
   <EuiButtonIcon
+    aria-label="Delete"
     iconType="cross"
     color="danger"
-    className="euiAccordionForm__extraAction"
-    aria-label="Delete"
+    css={({ euiTheme }) => css`
+      opacity: 0;
+
+      &:focus,
+      .euiAccordion:hover & {
+        opacity: 1;
+      }
+
+      ${euiCanAnimate} {
+        transition: opacity ${euiTheme.animation.normal}
+          ${euiTheme.animation.resistance};
+      }
+    `}
   />
 );
 

--- a/src-docs/src/views/accordion/accordion_form.js
+++ b/src-docs/src/views/accordion/accordion_form.js
@@ -115,7 +115,7 @@ export default () => {
       <EuiAccordion
         id={formAccordionId__1}
         element="fieldset"
-        className="euiAccordionForm"
+        borders="horizontal"
         buttonProps={{ paddingSize: 'm', css: buttonCss }}
         buttonContent={buttonContent}
         extraAction={extraAction}
@@ -127,7 +127,7 @@ export default () => {
       <EuiAccordion
         id={formAccordionId__2}
         element="fieldset"
-        className="euiAccordionForm"
+        borders="horizontal"
         buttonProps={{ paddingSize: 'm', css: buttonCss }}
         buttonContent={buttonContent}
         extraAction={extraAction}

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -716,6 +716,159 @@ exports[`EuiAccordion props buttonProps is rendered 1`] = `
 </div>
 `;
 
+exports[`EuiAccordion props buttonProps paddingSize l 1`] = `
+<div
+  class="euiAccordion"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="7"
+      aria-expanded="false"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+    <button
+      aria-controls="7"
+      aria-expanded="false"
+      class="euiAccordion__button emotion-euiAccordion__button-l-arrowLeft"
+      data-test-subj="button"
+      id="generated-id"
+      type="button"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
+    id="7"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiAccordion props buttonProps paddingSize m 1`] = `
+<div
+  class="euiAccordion"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="6"
+      aria-expanded="false"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+    <button
+      aria-controls="6"
+      aria-expanded="false"
+      class="euiAccordion__button emotion-euiAccordion__button-m-arrowLeft"
+      data-test-subj="button"
+      id="generated-id"
+      type="button"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
+    id="6"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiAccordion props buttonProps paddingSize s 1`] = `
+<div
+  class="euiAccordion"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="5"
+      aria-expanded="false"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+    <button
+      aria-controls="5"
+      aria-expanded="false"
+      class="euiAccordion__button emotion-euiAccordion__button-s-arrowLeft"
+      data-test-subj="button"
+      id="generated-id"
+      type="button"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
+    id="5"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiAccordion props element is rendered 1`] = `
 <fieldset
   class="euiAccordion"

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`EuiAccordion behavior closes when clicked twice 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="20"
+      aria-controls="25"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
@@ -23,7 +23,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
       />
     </button>
     <button
-      aria-controls="20"
+      aria-controls="25"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -37,7 +37,7 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="20"
+    id="25"
     role="region"
     tabindex="-1"
   >
@@ -56,13 +56,13 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
 
 exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="18"
+      aria-controls="23"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiAccordion__iconButton"
@@ -78,7 +78,7 @@ exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
       />
     </button>
     <button
-      aria-controls="18"
+      aria-controls="23"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button-disabled"
       disabled=""
@@ -93,7 +93,7 @@ exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="18"
+    id="23"
     role="region"
     tabindex="-1"
   >
@@ -112,13 +112,13 @@ exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
 
 exports[`EuiAccordion behavior opens when clicked once 1`] = `
 <div
-  class="euiAccordion euiAccordion-isOpen"
+  class="euiAccordion euiAccordion-isOpen emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="17"
+      aria-controls="22"
       aria-expanded="true"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-isOpen"
@@ -133,7 +133,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
       />
     </button>
     <button
-      aria-controls="17"
+      aria-controls="22"
       aria-expanded="true"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -147,7 +147,7 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper-isOpen"
-    id="17"
+    id="22"
     role="region"
     tabindex="-1"
   >
@@ -166,13 +166,13 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
 
 exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`] = `
 <div
-  class="euiAccordion euiAccordion-isOpen"
+  class="euiAccordion euiAccordion-isOpen emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="19"
+      aria-controls="24"
       aria-expanded="true"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-isOpen"
@@ -187,7 +187,7 @@ exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`]
       />
     </button>
     <button
-      aria-controls="19"
+      aria-controls="24"
       aria-expanded="true"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -201,7 +201,7 @@ exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`]
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper-isOpen"
-    id="19"
+    id="24"
     role="region"
     tabindex="-1"
   >
@@ -274,7 +274,7 @@ exports[`EuiAccordion behavior sets tabbable children to \`tabIndex={-1}\` when 
 exports[`EuiAccordion is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAccordion testClass1 testClass2 emotion-euiTestCss"
+  class="euiAccordion testClass1 testClass2 emotion-euiAccordion-euiTestCss"
   data-test-subj="test subject string"
 >
   <div
@@ -325,13 +325,13 @@ exports[`EuiAccordion is rendered 1`] = `
 
 exports[`EuiAccordion isDisabled is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="16"
+      aria-controls="21"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-disabled-isDisabled-euiAccordion__iconButton"
@@ -347,7 +347,7 @@ exports[`EuiAccordion isDisabled is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="16"
+      aria-controls="21"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button-disabled"
       disabled=""
@@ -362,7 +362,7 @@ exports[`EuiAccordion isDisabled is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="16"
+    id="21"
     role="region"
     tabindex="-1"
   >
@@ -377,13 +377,13 @@ exports[`EuiAccordion isDisabled is rendered 1`] = `
 
 exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="9"
+      aria-controls="14"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -397,7 +397,7 @@ exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="9"
+    id="14"
     role="region"
     tabindex="-1"
   >
@@ -412,13 +412,13 @@ exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
 
 exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="8"
+      aria-controls="13"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -429,7 +429,7 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="8"
+      aria-controls="13"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton--right emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-arrowRight"
@@ -447,7 +447,7 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="8"
+    id="13"
     role="region"
     tabindex="-1"
   >
@@ -462,13 +462,13 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
 
 exports[`EuiAccordion props arrowProps is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="10"
+      aria-controls="15"
       aria-expanded="false"
       aria-label="aria-label"
       aria-labelledby="generated-id"
@@ -485,7 +485,7 @@ exports[`EuiAccordion props arrowProps is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="10"
+      aria-controls="15"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -499,7 +499,7 @@ exports[`EuiAccordion props arrowProps is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="10"
+    id="15"
     role="region"
     tabindex="-1"
   >
@@ -514,7 +514,7 @@ exports[`EuiAccordion props arrowProps is rendered 1`] = `
 
 exports[`EuiAccordion props buttonContent is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -568,7 +568,7 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
 
 exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -618,13 +618,13 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
 
 exports[`EuiAccordion props buttonElement is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="5"
+      aria-controls="10"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
@@ -639,7 +639,7 @@ exports[`EuiAccordion props buttonElement is rendered 1`] = `
       />
     </button>
     <div
-      aria-controls="5"
+      aria-controls="10"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
     >
@@ -651,7 +651,7 @@ exports[`EuiAccordion props buttonElement is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="5"
+    id="10"
     role="region"
     tabindex="-1"
   >
@@ -666,7 +666,7 @@ exports[`EuiAccordion props buttonElement is rendered 1`] = `
 
 exports[`EuiAccordion props buttonProps is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -718,7 +718,7 @@ exports[`EuiAccordion props buttonProps is rendered 1`] = `
 
 exports[`EuiAccordion props buttonProps paddingSize l 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -769,7 +769,7 @@ exports[`EuiAccordion props buttonProps paddingSize l 1`] = `
 
 exports[`EuiAccordion props buttonProps paddingSize m 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -820,7 +820,7 @@ exports[`EuiAccordion props buttonProps paddingSize m 1`] = `
 
 exports[`EuiAccordion props buttonProps paddingSize s 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -871,7 +871,7 @@ exports[`EuiAccordion props buttonProps paddingSize s 1`] = `
 
 exports[`EuiAccordion props element is rendered 1`] = `
 <fieldset
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -919,13 +919,13 @@ exports[`EuiAccordion props element is rendered 1`] = `
 
 exports[`EuiAccordion props extraAction is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="6"
+      aria-controls="11"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
@@ -940,7 +940,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="6"
+      aria-controls="11"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -961,7 +961,7 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="6"
+    id="11"
     role="region"
     tabindex="-1"
   >
@@ -976,13 +976,13 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
 
 exports[`EuiAccordion props forceState closed is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="11"
+      aria-controls="16"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
@@ -997,7 +997,7 @@ exports[`EuiAccordion props forceState closed is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="11"
+      aria-controls="16"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -1011,7 +1011,7 @@ exports[`EuiAccordion props forceState closed is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="11"
+    id="16"
     role="region"
     tabindex="-1"
   >
@@ -1030,7 +1030,61 @@ exports[`EuiAccordion props forceState closed is rendered 1`] = `
 
 exports[`EuiAccordion props forceState open is rendered 1`] = `
 <div
-  class="euiAccordion euiAccordion-isOpen"
+  class="euiAccordion euiAccordion-isOpen emotion-euiAccordion"
+>
+  <div
+    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
+  >
+    <button
+      aria-controls="17"
+      aria-expanded="true"
+      aria-labelledby="generated-id"
+      class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-isOpen"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="arrowRight"
+      />
+    </button>
+    <button
+      aria-controls="17"
+      aria-expanded="true"
+      class="euiAccordion__button emotion-euiAccordion__button"
+      id="generated-id"
+      type="button"
+    >
+      <span
+        class="euiAccordion__buttonContent"
+      />
+    </button>
+  </div>
+  <div
+    aria-labelledby="generated-id"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper-isOpen"
+    id="17"
+    role="region"
+    tabindex="-1"
+  >
+    <div>
+      <div
+        class="euiAccordion__children emotion-euiAccordion__children"
+      >
+        <p>
+          You can see me
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
+<div
+  class="euiAccordion euiAccordion-isOpen emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -1074,60 +1128,6 @@ exports[`EuiAccordion props forceState open is rendered 1`] = `
         class="euiAccordion__children emotion-euiAccordion__children"
       >
         <p>
-          You can see me
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
-<div
-  class="euiAccordion euiAccordion-isOpen"
->
-  <div
-    class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
-  >
-    <button
-      aria-controls="7"
-      aria-expanded="true"
-      aria-labelledby="generated-id"
-      class="euiButtonIcon euiAccordion__iconButton euiAccordion__iconButton-isOpen emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton-isOpen"
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        aria-hidden="true"
-        class="euiButtonIcon__icon"
-        color="inherit"
-        data-euiicon-type="arrowRight"
-      />
-    </button>
-    <button
-      aria-controls="7"
-      aria-expanded="true"
-      class="euiAccordion__button emotion-euiAccordion__button"
-      id="generated-id"
-      type="button"
-    >
-      <span
-        class="euiAccordion__buttonContent"
-      />
-    </button>
-  </div>
-  <div
-    aria-labelledby="generated-id"
-    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper-isOpen"
-    id="7"
-    role="region"
-    tabindex="-1"
-  >
-    <div>
-      <div
-        class="euiAccordion__children emotion-euiAccordion__children"
-      >
-        <p>
           You can see me.
         </p>
       </div>
@@ -1138,13 +1138,13 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
 
 exports[`EuiAccordion props isLoading is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="14"
+      aria-controls="19"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
@@ -1159,7 +1159,7 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="14"
+      aria-controls="19"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -1182,7 +1182,7 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="14"
+    id="19"
     role="region"
     tabindex="-1"
   >
@@ -1197,13 +1197,13 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
 
 exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
 <div
-  class="euiAccordion"
+  class="euiAccordion emotion-euiAccordion"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
   >
     <button
-      aria-controls="15"
+      aria-controls="20"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__iconButton emotion-euiButtonIcon-xs-empty-text-euiAccordion__iconButton"
@@ -1218,7 +1218,7 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
       />
     </button>
     <button
-      aria-controls="15"
+      aria-controls="20"
       aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
@@ -1241,7 +1241,7 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
   <div
     aria-labelledby="generated-id"
     class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper"
-    id="15"
+    id="20"
     role="region"
     tabindex="-1"
   >

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -1,12 +1,3 @@
-.euiAccordionForm__extraAction {
-  opacity: 0;
-  transition: opacity $euiAnimSpeedNormal $euiAnimSlightResistance;
-
-  &:focus {
-    opacity: 1;
-  }
-}
-
 .euiAccordionForm__button {
   padding: $euiSize $euiSize $euiSize 0;
 
@@ -21,12 +12,5 @@
 
   & + .euiAccordionForm {
     border-top: none;
-  }
-
-  &:hover {
-    .euiAccordionForm__extraAction {
-      opacity: 1;
-      visibility: visible;
-    }
   }
 }

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -1,11 +1,3 @@
-.euiAccordionForm__button {
-  padding: $euiSize $euiSize $euiSize 0;
-
-  &:hover {
-    text-decoration: none;
-  }
-}
-
 .euiAccordionForm {
   border-top: $euiBorderThin;
   border-bottom: $euiBorderThin;

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -1,8 +1,0 @@
-.euiAccordionForm {
-  border-top: $euiBorderThin;
-  border-bottom: $euiBorderThin;
-
-  & + .euiAccordionForm {
-    border-top: none;
-  }
-}

--- a/src/components/accordion/_accordion_form.scss
+++ b/src/components/accordion/_accordion_form.scss
@@ -7,19 +7,11 @@
   }
 }
 
-.euiAccordionForm__title {
-  display: inline-block;
-}
-
 .euiAccordionForm__button {
   padding: $euiSize $euiSize $euiSize 0;
 
   &:hover {
     text-decoration: none;
-
-    .euiAccordionForm__title {
-      text-decoration: underline;
-    }
   }
 }
 

--- a/src/components/accordion/_index.scss
+++ b/src/components/accordion/_index.scss
@@ -1,1 +1,0 @@
-@import 'accordion_form';

--- a/src/components/accordion/accordion.styles.ts
+++ b/src/components/accordion/accordion.styles.ts
@@ -33,7 +33,6 @@ export const euiAccordionButtonStyles = (euiThemeContext: UseEuiTheme) => {
         text-decoration: underline;
       }
     `,
-
     // Triggering button needs separate `disabled` key because the element that renders may not support `:disabled`;
     // Hover pseudo selector for specificity
     disabled: css`
@@ -43,6 +42,23 @@ export const euiAccordionButtonStyles = (euiThemeContext: UseEuiTheme) => {
         color: ${euiTheme.colors.disabledText};
         text-decoration: none;
       }
+    `,
+    // Optional padding sizes
+    s: css`
+      padding: ${euiTheme.size.s};
+    `,
+    m: css`
+      padding: ${euiTheme.size.base};
+    `,
+    l: css`
+      padding: ${euiTheme.size.l};
+    `,
+    // Remove padding from the accordion button on the side that the arrow is on
+    arrowLeft: css`
+      ${logicalCSS('padding-left', 0)}
+    `,
+    arrowRight: css`
+      ${logicalCSS('padding-left', 0)}
     `,
   };
 };

--- a/src/components/accordion/accordion.styles.ts
+++ b/src/components/accordion/accordion.styles.ts
@@ -15,6 +15,27 @@ import {
   logicalTextAlignCSS,
 } from '../../global_styling';
 
+export const euiAccordionStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    euiAccordion: css``,
+    // Borders
+    borders: {
+      // Prevent border repeats
+      borders: css`
+        & + [class*='euiAccordion-borders'] {
+          ${logicalCSS('border-top', 'none')}
+        }
+      `,
+      horizontal: css`
+        border-block: ${euiTheme.border.thin};
+      `,
+      all: css`
+        border: ${euiTheme.border.thin};
+      `,
+    },
+  };
+};
+
 export const euiAccordionButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
   return {

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -76,6 +76,47 @@ describe('EuiAccordion', () => {
 
         expect(container.firstChild).toMatchSnapshot();
       });
+
+      describe('paddingSize', () => {
+        (['s', 'm', 'l'] as const).forEach((paddingSize) => {
+          it(paddingSize, () => {
+            const { container, getByTestSubject } = render(
+              <EuiAccordion
+                id={getId()}
+                buttonProps={{ paddingSize, 'data-test-subj': 'button' }}
+              />
+            );
+            expect(container.firstChild).toMatchSnapshot();
+            expect(getByTestSubject('button').className).toContain(paddingSize);
+          });
+        });
+      });
+
+      describe('arrow padding affordance', () => {
+        it('removes the padding next to the side the arrow is on', () => {
+          const { getByTestSubject } = render(
+            <EuiAccordion
+              id={getId()}
+              buttonProps={{ paddingSize: 'm', 'data-test-subj': 'button' }}
+              arrowDisplay="right"
+            />
+          );
+          expect(getByTestSubject('button').className).toContain('arrowRight');
+        });
+
+        it('does not remove any padding if no arrow is displayed', () => {
+          const { getByTestSubject } = render(
+            <EuiAccordion
+              id={getId()}
+              buttonProps={{ paddingSize: 'm', 'data-test-subj': 'button' }}
+              arrowDisplay="none"
+            />
+          );
+          const buttonClass = getByTestSubject('button').className;
+          expect(buttonClass).not.toContain('arrowRight');
+          expect(buttonClass).not.toContain('arrowLeft');
+        });
+      });
     });
 
     describe('buttonElement', () => {

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -49,9 +49,13 @@ export type EuiAccordionProps = CommonProps &
      */
     buttonClassName?: string;
     /**
-     * Apply more props to the triggering button
+     * Apply more props to the triggering button.
+     *
+     * Includes optional `paddingSize` prop which allows sizes of `s`, `m`, or `l`.
+     * Note: Padding will not be present on the side closest to the accordion arrow.
      */
-    buttonProps?: CommonProps & HTMLAttributes<HTMLElement>;
+    buttonProps?: CommonProps &
+      HTMLAttributes<HTMLElement> & { paddingSize?: 's' | 'm' | 'l' };
     /**
      * Class that will apply to the trigger content for the accordion.
      */
@@ -268,12 +272,18 @@ export class EuiAccordionClass extends Component<
       isLoading,
       isLoadingMessage,
       isDisabled,
-      buttonProps,
+      buttonProps: _buttonProps,
       buttonElement: _ButtonElement = 'button',
       arrowProps,
       theme,
       ...rest
     } = this.props;
+    const {
+      paddingSize: buttonPaddingSize,
+      className: buttonPropsClassName,
+      css: buttonPropsCss,
+      ...buttonProps
+    } = _buttonProps || {};
 
     // Force button element to be a legend if the element is a fieldset
     const ButtonElement = Element === 'fieldset' ? 'legend' : _ButtonElement;
@@ -300,7 +310,7 @@ export class EuiAccordionClass extends Component<
     const buttonClasses = classNames(
       'euiAccordion__button',
       buttonClassName,
-      buttonProps?.className
+      buttonPropsClassName
     );
 
     const buttonContentClasses = classNames(
@@ -322,7 +332,14 @@ export class EuiAccordionClass extends Component<
     const cssButtonStyles = [
       buttonStyles.euiAccordion__button,
       isDisabled && buttonStyles.disabled,
-      buttonProps?.css,
+      ...(buttonPaddingSize
+        ? [
+            buttonStyles[buttonPaddingSize],
+            arrowDisplay === 'left' && buttonStyles.arrowLeft,
+            arrowDisplay === 'right' && buttonStyles.arrowRight,
+          ]
+        : []),
+      buttonPropsCss,
     ];
 
     const childrenStyles = euiAccordionChildrenStyles(theme);
@@ -360,7 +377,7 @@ export class EuiAccordionClass extends Component<
     ];
 
     let iconButton;
-    const buttonId = buttonProps?.id ?? this.generatedId;
+    const buttonId = buttonProps.id ?? this.generatedId;
     if (_arrowDisplay !== 'none') {
       iconButton = (
         <EuiButtonIcon

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../services';
 import { EuiButtonIcon, EuiButtonIconProps } from '../button';
 import {
+  euiAccordionStyles,
   euiAccordionButtonStyles,
   euiAccordionChildrenStyles,
   euiAccordionChildWrapperStyles,
@@ -96,6 +97,10 @@ export type EuiAccordionProps = CommonProps &
      */
     arrowDisplay?: 'left' | 'right' | 'none';
     /**
+     * Optional border styling. Defaults to 'none'.
+     */
+    borders?: 'horizontal' | 'all' | 'none';
+    /**
      * Control the opening of accordion via prop
      */
     forceState?: 'closed' | 'open';
@@ -123,6 +128,7 @@ export class EuiAccordionClass extends Component<
 > {
   static defaultProps = {
     initialIsOpen: false,
+    borders: 'none' as const,
     paddingSize: 'none' as const,
     arrowDisplay: 'left' as const,
     isLoading: false,
@@ -266,6 +272,7 @@ export class EuiAccordionClass extends Component<
       buttonContentClassName,
       extraAction,
       paddingSize,
+      borders,
       initialIsOpen,
       arrowDisplay,
       forceState,
@@ -302,6 +309,13 @@ export class EuiAccordionClass extends Component<
       },
       className
     );
+
+    const styles = euiAccordionStyles(theme);
+    const cssStyles = [
+      styles.euiAccordion,
+      borders !== 'none' && styles.borders.borders,
+      borders !== 'none' && styles.borders[borders!],
+    ];
 
     const childrenClasses = classNames('euiAccordion__children', {
       'euiAccordion__children-isLoading': isLoading,
@@ -450,7 +464,7 @@ export class EuiAccordionClass extends Component<
     );
 
     return (
-      <Element className={classes} {...rest}>
+      <Element className={classes} css={cssStyles} {...rest}>
         <div
           className="euiAccordion__triggerWrapper"
           css={cssTriggerWrapperStyles}

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`EuiCollapsibleNavGroup throws a warning if iconType is passed without a
 exports[`EuiCollapsibleNavGroup when isCollapsible is true accepts accordion props 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAccordion euiCollapsibleNavGroup testClass1 testClass2 emotion-euiCollapsibleNavGroup-isCollapsible-none-euiTestCss"
+  class="euiAccordion euiCollapsibleNavGroup testClass1 testClass2 emotion-euiAccordion-euiCollapsibleNavGroup-isCollapsible-none-euiTestCss"
   data-test-subj="test subject string"
 >
   <div
@@ -267,7 +267,7 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true accepts accordion pro
 
 exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accordion 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavGroup emotion-euiCollapsibleNavGroup-isCollapsible-none"
+  class="euiAccordion euiCollapsibleNavGroup emotion-euiAccordion-euiCollapsibleNavGroup-isCollapsible-none"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiCollapsibleNavAccordion renders as a sub item 1`] = `
 <div
-  class="euiAccordion euiCollapsibleNavAccordion emotion-euiCollapsibleNavAccordion-isSubItem"
+  class="euiAccordion euiCollapsibleNavAccordion emotion-euiAccordion-euiCollapsibleNavAccordion-isSubItem"
 >
   <div
     class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"
@@ -71,7 +71,7 @@ exports[`EuiCollapsibleNavAccordion renders as a sub item 1`] = `
 exports[`EuiCollapsibleNavAccordion renders as a top level item 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAccordion euiCollapsibleNavAccordion testClass1 testClass2 emotion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
+  class="euiAccordion euiCollapsibleNavAccordion testClass1 testClass2 emotion-euiAccordion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`EuiCollapsibleNavItem renders a collapsed button icon when in a collaps
 exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAccordion euiCollapsibleNavAccordion euiCollapsibleNavItem testClass1 testClass2 emotion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
+  class="euiAccordion euiCollapsibleNavAccordion euiCollapsibleNavItem testClass1 testClass2 emotion-euiAccordion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
   data-test-subj="test subject string"
 >
   <div

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -1,6 +1,5 @@
 // Components
 
-@import 'accordion/index';
 @import 'color_picker/index';
 @import 'combo_box/index';
 @import 'context_menu/index';

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -506,7 +506,7 @@ exports[`EuiNotificationEvent props multiple messages are rendered 1`] = `
         </p>
       </div>
       <div
-        class="euiAccordion euiNotificationEventMessages__accordion"
+        class="euiAccordion euiNotificationEventMessages__accordion emotion-euiAccordion"
       >
         <div
           class="euiAccordion__triggerWrapper emotion-euiAccordion__triggerWrapper"

--- a/upcoming_changelogs/7154.md
+++ b/upcoming_changelogs/7154.md
@@ -1,0 +1,10 @@
+- Updated `EuiAccordion` with a new `borders` prop
+- Updated `EuiAccordion` with a new `buttonProps.paddingSize` prop
+
+**CSS-in-JS conversions**
+
+- Except for generic CSS utilities, EUI is moving away from providing global `classNames` that are component-specific. As part of this effort, we have removed the following `EuiAccordion`-specific classes:
+  - Removed `.euiAccordionForm` styles. Use the `borders="horizontal"` prop instead
+  - Removed `.euiAccordionForm__button` styles. Use the `buttonProps={{ paddingSize: 'm' }}` prop instead
+  - Removed `.euiAccordionForm__extraAction` styles. Convert this to your own custom CSS if necessary.
+  - Removed `.euiAccordionForm__title` styles. Convert this to your own custom CSS if necessary.


### PR DESCRIPTION
## Summary

closes #6386

This was a tricky PR to "convert" because none of these Sass-generated classes are actually used in EUI itself; they're classes we generated and told consumers to use directly on EuiAccordion (an architecture we're trying to move away from with Emotion).

Thankfully, there's just 4 or so internal Elastic usages of these classes - 3 in Kibana and 1 in support portal. I based my decisions on what to turn into a generic prop on those usages. Please follow along by commit if possible.

## QA

- Go to https://eui.elastic.co/pr_7154/#/layout/accordion#styled-for-forms
- [x] Confirm no visual regressions compared to [production](https://eui.elastic.co/#/layout/accordion#styled-for-forms)

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **mobile**
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ - thankfully it looks like this pattern isn't in our Figma library
- [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately

Skipping the Emotion checklist for this since it's almost entirely all Kibana downstream updates