### PR TITLE
[Storybook] Fix emotion styles being applied twice

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -26,7 +26,6 @@ const config: StorybookConfig = {
       use: [
         {
           loader: require.resolve('babel-loader'),
-          options: { plugins: ['@emotion/babel-plugin'] },
         },
       ],
     });


### PR DESCRIPTION
## Summary

The upgrade to latest Storybook (#7092) broke Emotion styling and required a webpack override for Emotion to work again. It turns out I didn't check "working" closely enough, because the new setup is actually applying styles twice 💀 

## QA

### Before

- On main, run `yarn storybook`
- Inspect any story's components and look at the output class styles - each one is repeated twice:
    <img width="756" alt="before" src="https://github.com/elastic/eui/assets/549407/f524a023-02e4-4a53-b27b-317be4e29b30">

### After 
- `gh checkout pr 7155`
- Stop the any running storybook instances and re-start `yarn storybook`
- Re-inspect any story's component and confirm the output class styles are no longer repeated:
    <img width="763" alt="after" src="https://github.com/elastic/eui/assets/549407/9621a53b-a383-49af-9ff8-e82eb8402234">

### General checklist

N/A, internal dev only