### PR TITLE
Render extraAction button in EuiListGroupItem when showToolTip is true

### DIFF
--- a/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
+++ b/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
@@ -129,6 +129,38 @@ exports[`EuiListGroupItem props extraAction is rendered 1`] = `
 </li>
 `;
 
+exports[`EuiListGroupItem props extraAction is rendered with showToolTip 1`] = `
+<li
+  class="euiListGroupItem emotion-euiListGroupItem-m"
+>
+  <span
+    class="euiToolTipAnchor euiListGroupItem__tooltip emotion-euiToolTipAnchor-inlineBlock-euiListGroupItem__tooltip"
+  >
+    <span
+      class="euiListGroupItem__text emotion-euiListGroupItem__inner-m-text"
+    >
+      <span
+        class="euiListGroupItem__label emotion-euiListGroupItem__label-truncate"
+      >
+        Label
+      </span>
+    </span>
+  </span>
+  <button
+    aria-label="label"
+    class="euiButtonIcon euiListGroupItemExtraAction emotion-euiButtonIcon-xs-empty-text-euiListGroupItemExtraAction-alwaysShow"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="empty"
+    />
+  </button>
+</li>
+`;
+
 exports[`EuiListGroupItem props href and onClick is rendered 1`] = `
 <li
   class="euiListGroupItem emotion-euiListGroupItem-text-m"

--- a/src/components/list_group/list_group_item.test.tsx
+++ b/src/components/list_group/list_group_item.test.tsx
@@ -160,6 +160,22 @@ describe('EuiListGroupItem', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
 
+      test('is rendered with showToolTip', () => {
+        const { container } = render(
+          <EuiListGroupItem
+            label="Label"
+            showToolTip
+            extraAction={{
+              iconType: 'empty',
+              alwaysShow: true,
+              'aria-label': 'label',
+            }}
+          />
+        );
+
+        expect(container.firstChild).toMatchSnapshot();
+      });
+
       test('can be disabled', () => {
         const { container } = render(
           <EuiListGroupItem

--- a/src/components/list_group/list_group_item.tsx
+++ b/src/components/list_group/list_group_item.tsx
@@ -354,6 +354,7 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
         >
           {itemContent}
         </EuiToolTip>
+        {extraActionNode}
       </li>
     );
   } else {


### PR DESCRIPTION
## Summary

Renders the `extraAction` button in the `EuiListGroupItem` when `showToolTip === true`. 

When providing a list of links in an `EuiListGroup` I wanted to show which links opened in a new tab by adding the `popout` icon, similar to [external links in `EuiLink`](https://elastic.github.io/eui/#/navigation/link#external-links). However, the `extraAction` button was not rendering when the `showToolTip` prop was included.

Here is an example testing this PR where I am showing the links I'm creating with tooltips and the external icon indicator. Notice how the Dashboard links have tooltips and the first link can also show the extra action button. The second link does not include the `extraAction` prop so the button is not rendered.


https://github.com/elastic/eui/assets/1638483/e198c6b7-92ae-44ae-9c15-4c81dfe777f1


Using the extra action button to show that the link will pop open a new tab is maybe a bit of a hack. The extra action button accomplishes the same effect as clicking the link. But I do prefer how the button is still visible while the text may be truncated since users can change the size of the links panel on the dashboard.


https://github.com/elastic/eui/assets/1638483/e0185d4e-45ed-44bc-a6b0-cd9b72ade259


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [x] Checked in both **light and dark** modes
- [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
