### PR TITLE
Switch `pre-commit` hook to `pre-push`; fix Jest `--findRelatedTests` behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "**/@types/react": "^18",
     "react-focus-lock": "^2.9.5"
   },
-  "pre-commit": [
+  "pre-push": [
     "test-staged"
   ],
   "dependencies": {
@@ -220,7 +220,7 @@
     "postcss-inline-svg": "^4.1.0",
     "postcss-loader": "^7.0.1",
     "postcss-styled-syntax": "^0.4.0",
-    "pre-commit": "^1.2.2",
+    "pre-push": "^0.1.4",
     "prettier": "^2.8.8",
     "process": "^0.11.10",
     "prop-types": "^15.6.0",

--- a/scripts/test-staged.js
+++ b/scripts/test-staged.js
@@ -1,7 +1,9 @@
 const { execSync } = require('child_process');
 
 // find names of staged files
-const stagedFiles = execSync('git diff --cached --name-only --diff-filter=ACMR')
+const stagedFiles = execSync(
+  'git diff main...HEAD --name-only --diff-filter=ACMR'
+)
   .toString()
   .split(/[\r\n]+/g);
 

--- a/scripts/test-staged.js
+++ b/scripts/test-staged.js
@@ -1,13 +1,6 @@
 const { execSync } = require('child_process');
 
-// find names of staged files
-const stagedFiles = execSync(
-  'git diff main...HEAD --name-only --diff-filter=ACMR'
-)
-  .toString()
-  .split(/[\r\n]+/g);
-
-// execute tests related to the staged files
-execSync(`yarn test-unit --findRelatedTests ${stagedFiles.join(' ')}`, {
+// https://jestjs.io/docs/cli#--changedsince
+execSync(`yarn test-unit --changedSince main`, {
   stdio: 'inherit',
 });

--- a/scripts/tests/test-staged.test.js
+++ b/scripts/tests/test-staged.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const euiRoot = path.resolve(__dirname, '../../'); // NOTE: CI lists the EUI project root as app/ instead of eui/
+
+describe('test-staged.js', () => {
+  it('does not have --findRelatedTests regressions due to imports from src/components', () => {
+    const outputString = execSync(
+      'yarn test-unit --findRelatedTests --listTests src/components/beacon/beacon.tsx',
+      { cwd: euiRoot }
+    ).toString();
+    const output = outputString
+      .split('\n')
+      .filter((item) => item.endsWith('test.tsx'));
+
+    expect(
+      output[0].endsWith('src/components/tour/tour_step.test.tsx')
+    ).toBeTruthy();
+    expect(
+      output[1].endsWith('src/components/beacon/beacon.test.tsx')
+    ).toBeTruthy();
+
+    expect(output[2]).toBeUndefined();
+  });
+});

--- a/src-docs/src/components/guide_section/_utils.test.js
+++ b/src-docs/src/components/guide_section/_utils.test.js
@@ -1,5 +1,5 @@
-const dedent = require('dedent');
-const { renderJsSourceCode } = require('./_utils.js');
+import dedent from 'dedent';
+import { renderJsSourceCode } from './_utils';
 
 describe('renderJsSourceCode', () => {
   describe('EUI imports', () => {
@@ -41,8 +41,8 @@ describe('renderJsSourceCode', () => {
       expect(
         renderJsSourceCode({
           default: dedent(`
-            import { EuiButton, EuiFlexGroup, EuiFlexItem } from '../../../src/components';
-            import { useGeneratedHtmlId } from '../../../src/services';
+            import { EuiButton, EuiFlexGroup, EuiFlexItem } from '../../src/components';
+            import { useGeneratedHtmlId } from '../../src/services';
   
             export default () => <EuiCode>{useGeneratedHtmlId()}</EuiCode>;`),
         })

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -7,7 +7,7 @@
  */
 
 import { css } from '@emotion/react';
-import { EuiCardProps } from '..';
+
 import {
   euiPaddingSize,
   euiSupportsHas,
@@ -18,6 +18,7 @@ import {
 import { UseEuiTheme } from '../../services';
 import { euiButtonColor } from '../../themes/amsterdam/global_styling/mixins';
 
+import { EuiCardProps } from './card';
 const paddingKey = 'm';
 const halfPaddingKey = 's';
 

--- a/src/components/card/card.test.tsx
+++ b/src/components/card/card.test.tsx
@@ -12,10 +12,12 @@ import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { render } from '../../test/rtl';
 
-import { EuiCard, ALIGNMENTS } from './card';
-
-import { EuiIcon, EuiAvatar, EuiI18n } from '../../components';
+import { EuiIcon } from '../icon';
+import { EuiAvatar } from '../avatar';
+import { EuiI18n } from '../i18n';
 import { COLORS, SIZES } from '../panel/panel';
+
+import { EuiCard, ALIGNMENTS } from './card';
 
 describe('EuiCard', () => {
   test('is rendered', () => {

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -15,21 +15,23 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, ExclusiveUnion } from '../common';
 import {
   getSecureRelForTarget,
   useEuiTheme,
   cloneElementWithCss,
 } from '../../services';
+import { useGeneratedHtmlId } from '../../services/accessibility';
+import { validateHref } from '../../services/security/href_validator';
+
+import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiText } from '../text';
 import { EuiTitle } from '../title';
 import { EuiBetaBadge, EuiBetaBadgeProps } from '../badge/beta_badge';
 import { EuiIconProps } from '../icon';
-import { EuiCardSelect, EuiCardSelectProps } from './card_select';
-import { useGeneratedHtmlId } from '../../services/accessibility';
-import { validateHref } from '../../services/security/href_validator';
 import { EuiPanel, EuiPanelProps } from '../panel';
 import { EuiSpacer } from '../spacer';
+
+import { EuiCardSelect, EuiCardSelectProps } from './card_select';
 import {
   euiCardBetaBadgeStyles,
   euiCardStyles,

--- a/src/components/popover/popover.test.tsx
+++ b/src/components/popover/popover.test.tsx
@@ -12,7 +12,9 @@ import { act } from '@testing-library/react';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
 import { render } from '../../test/rtl';
-import { EuiFocusTrap } from '../';
+
+import { keys } from '../../services';
+import { EuiFocusTrap } from '../focus_trap';
 
 import {
   EuiPopover,
@@ -20,8 +22,6 @@ import {
   getPopoverAlignFromAnchorPosition,
   PopoverAnchorPosition,
 } from './popover';
-
-import { keys } from '../../services';
 
 const actAdvanceTimersByTime = (time: number) =>
   act(() => jest.advanceTimersByTime(time));

--- a/src/global_styling/functions/typography.test.tsx
+++ b/src/global_styling/functions/typography.test.tsx
@@ -9,7 +9,7 @@
 import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react';
 
-import { EuiProvider } from '../../components';
+import { EuiProvider } from '../../components/provider';
 import { useEuiTheme } from '../../services';
 import { EuiThemeFontScales, EuiThemeFontUnits } from '../variables/typography';
 

--- a/src/services/theme/hooks.test.tsx
+++ b/src/services/theme/hooks.test.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react';
 import { renderHook } from '../../test/rtl';
 
-import { EuiProvider } from '../../components';
+import { EuiProvider } from '../../components/provider';
 
 import { setEuiDevProviderWarning } from './warning';
 import {

--- a/src/test/internal/render_custom_styles.tsx
+++ b/src/test/internal/render_custom_styles.tsx
@@ -12,7 +12,7 @@ import { get, set } from 'lodash';
 
 import { render } from '../rtl';
 import { cloneElementWithCss } from '../../services';
-import { keysOf } from '../../components';
+import { keysOf } from '../../components/common';
 
 export const customStyles = {
   className: 'hello',

--- a/src/test/rtl/custom_render.ts
+++ b/src/test/rtl/custom_render.ts
@@ -16,7 +16,7 @@ import {
   within,
 } from '@testing-library/react';
 
-import { EuiProvider } from '../../components';
+import { EuiProvider } from '../../components/provider';
 
 import * as dataTestSubjQueries from './data_test_subj_queries';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17532,10 +17532,10 @@ postcss@^8.4.24:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-pre-commit@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
-  integrity sha1-287g7p3nI15X95xW186UZBpp7sY=
+pre-push@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/pre-push/-/pre-push-0.1.4.tgz#48e7a29e15d3d7a83b62d5a02e10ba5dc40ab3aa"
+  integrity sha512-bIdVuDQR3r5AWV7bM6OMHD3mCXA53Ql0LXmW5UfcSmJZq+J+TytqZ5YJcTmMLcojJysN65vcFIeCqRn6YidA+Q==
   dependencies:
     cross-spawn "^5.0.1"
     spawn-sync "^1.0.15"


### PR DESCRIPTION
## Summary

After a recent meeting, the EUI team discussed the friction point of the current `pre-commit` hook and that we feel it currently hinders developers more than it helps. We agreed to move it to a `pre-push` hook instead, ~and additionally switch it to only linting and not running unit tests.~ (see below git thread)

Note - if absolutely necessary, this hook can be skipped via `git push --no-verify`.

## QA

NOTE: Once this PR merges, devs will need to manually run `rm -rf .git/hooks/pre-commit` from the EUI project root

### General checklist

N/A, tech debt/dev-only