### PR TITLE
[wiki] Include dependency upgrades in changelog

### DIFF
--- a/generator-eui/changelog/index.js
+++ b/generator-eui/changelog/index.js
@@ -53,6 +53,12 @@ module.exports = class extends Generator {
         type: 'confirm',
         default: false,
       },
+      {
+        message: 'Does your PR contain dependency updates?',
+        name: 'dependencyUpdates',
+        type: 'confirm',
+        default: false,
+      },
     ];
 
     return this.prompt(prompts).then((answers) => {

--- a/generator-eui/changelog/templates/changelog.md
+++ b/generator-eui/changelog/templates/changelog.md
@@ -25,3 +25,8 @@
 
 - Converted `EuiComponent` to Emotion; Removed `$euiComponentSassVariable`
 <%_ } -%>
+<%_ if (dependencyUpdates) { -%>
+**Dependency updates**
+
+- Updated `dependency` to v10.20.30
+<%_ } -%>

--- a/upcoming_changelogs/_template.md
+++ b/upcoming_changelogs/_template.md
@@ -15,3 +15,7 @@
 **CSS-in-JS conversions**
 
 - Converted `EuiComponent` to Emotion; Removed `$euiComponentSassVariable`
+
+**Dependency updates**
+
+- Updated `dependency` to v10.20.30

--- a/wiki/contributing-to-eui/documenting/changelogs.md
+++ b/wiki/contributing-to-eui/documenting/changelogs.md
@@ -13,6 +13,7 @@ Changes that do not impact consumers or end-users may use the `skip-changelog` l
 
 - Documentation-only changes (e.g. changes to `wiki/` or `src-docs/`)
 - Infra/dev-only changes (e.g. changes to `.github/` or `scripts/`)
+- Test-only changes (e.g. changes to `*.test.tsx`, `*.spec.tsx`, or `*.stories.tsx` files)
 - `dev-dependency` upgrades in package.json
 
 ## How to write a changelog

--- a/wiki/contributing-to-eui/documenting/changelogs.md
+++ b/wiki/contributing-to-eui/documenting/changelogs.md
@@ -1,12 +1,19 @@
 # Changelogs
 
+All upcoming changelogs should go into the [upcoming_changelogs/](../../../upcoming_changelogs/_template.md) directory. Our release script automatically handles collating these files into our main [CHANGELOG.md](../../../CHANGELOG.md) on new EUI versions.
+
 ## When to write a changelog
 
-Any updates to the `src/` folder require a new [upcoming changelog](../../../upcoming_changelogs/_template.md) file. Our release script handles collating upcoming changelog files into our main [CHANGELOG.md](../../../CHANGELOG.md) on new EUI versions.
+- Any updates to the `src/` folder should include a changelog
+- `dependency` upgrades in package.json should contain a changelog
 
 ## When to skip a changelog
 
-Changes that do not impact consumers or end-users (e.g. documentation-only changes to `wiki/` or `src-docs/`) or infra/dev-only changes (e.g. changes to `.github/` or `scripts/`) do not require a changelog entry. You may use the `skip-changelog` label on your PR to bypass CI checks.
+Changes that do not impact consumers or end-users may use the `skip-changelog` label on PRs to bypass CI checks. Examples of these types of changes:
+
+- Documentation-only changes (e.g. changes to `wiki/` or `src-docs/`)
+- Infra/dev-only changes (e.g. changes to `.github/` or `scripts/`)
+- `dev-dependency` upgrades in package.json
 
 ## How to write a changelog
 


### PR DESCRIPTION
## Summary

This process change is a direct result of https://github.com/elastic/kibana/pull/163961#discussion_r1297420672, where confusion arose from a downstream snapshot change that resulted due to a dependency upgrade not listed in our changelog.

I've added a new section to our changelog template and yeoman generator for dependency upgrades specifically.

If we do want to list _developer_ dependency updates in our changelog, it might be worth taking a leaf from, e.g.: https://github.com/hello-pangea/dnd/blob/main/CHANGELOG.md#1630-2023-06-30

## QA

N/A, internal/dev-only