### PR TITLE
[GitHub] Add breaking change specific checklist, organize general PR checklist template 

### DIFF
--- a/.github/config/label_commenter_config.yml
+++ b/.github/config/label_commenter_config.yml
@@ -21,4 +21,4 @@ labels:
           - 🔍 Tip: When searching through Kibana, consider excluding `**/target, **/*.snap, **/*.storyshot` files to reduce noise and only look at source code usages
           - ⚠️ For extremely risky changes, the EUI team should potentially consider the following precautions:
               - Using a [pre-release](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/releasing-versions.md#pre-release-process) release candidate to test Kibana CI ahead of time
-              - Using `kibana-a-la-carte` for manual QA, and to give other Kibana teams a staging server to quickly test against
+              - Using [`kibana-a-la-carte`](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#testing-in-the-cloud) for manual QA, and to give other Kibana teams a staging server to quickly test against

--- a/.github/config/label_commenter_config.yml
+++ b/.github/config/label_commenter_config.yml
@@ -7,3 +7,18 @@ labels:
     labeled:
       issue:
         body: 👋 Thank you for your suggestion or request! While the EUI team agrees that it's valid, it's unlikely that we will prioritize this issue on our roadmap. We'll leave the issue open if you or anyone else in the community wants to implement it by contributing to EUI. If not, this issue will auto close in one year.
+  - name: breaking change
+    labeled:
+      pr:
+        body: |
+          This PR contains breaking changes. The opener of this pull request is asked to perform the following due diligence steps below, to assist EUI in our next Kibana upgrade:
+          - If this PR contains **prop/API changes**:
+              - [ ] Search through Kibana for `<EuiComponent` usages ([example search](https://github.com/search?q=repo%3Aelastic%2Fkibana+%3CEuiAccordion&type=code))
+              - [ ] In the PR description or in a PR comment, include a count or list with the number of component usages in Kibana that will need to be updated (if that amount is "none", include that information as well)
+          - If this PR contains **CSS changes**:
+              - [ ] Search through Kibana for the changed EUI selectors, e.g. `.euiComponent` ([example search](https://github.com/search?q=repo%3Aelastic%2Fkibana+.euiAccordion&type=code))
+              - [ ] In the PR description or in a PR comment, include a count or list with the number of custom CSS overrides in Kibana that will need to be updated (if that amount is "none", include that information as well)
+          - 🔍 Tip: When searching through Kibana, consider excluding `**/target, **/*.snap, **/*.storyshot` files to reduce noise and only look at source code usages
+          - ⚠️ For extremely risky changes, the EUI team should potentially consider the following precautions:
+              - Using a [pre-release](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/releasing-versions.md#pre-release-process) release candidate to test Kibana CI ahead of time
+              - Using `kibana-a-la-carte` for manual QA, and to give other Kibana teams a staging server to quickly test against

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,6 @@ Remove or strikethrough items that do not apply to your PR.
     - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
 - Release checklist
     - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
-    - [ ] If applicable, added the **breaking change** issue label
+    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
 - Designer checklist
     - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.
 
-If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://learning-notes.mistermicheels.com/processes-techniques/small-commits-pull-requests/) wiki guide.
+If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
 
 ## QA
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 Provide a detailed summary of your PR. Explain how you arrived at your solution. If it includes changes to UI elements include a screenshot or gif.
 
+If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://learning-notes.mistermicheels.com/processes-techniques/small-commits-pull-requests/) wiki guide.
+
 ## QA
 
 Remove or strikethrough items that do not apply to your PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,14 +8,19 @@ Remove or strikethrough items that do not apply to your PR.
 
 ### General checklist
 
-- [ ] Checked in both **light and dark** modes
-- [ ] Checked in **mobile**
-- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
-- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
-- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
-- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
-- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
-- [ ] Checked for **breaking changes** and labeled appropriately
-- [ ] Checked for **accessibility** including keyboard-only and screenreader modes
-- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
-- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
+- Browser QA
+    - [ ] Checked in both **light and dark** modes
+    - [ ] Checked in **mobile**
+    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
+    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
+- Docs site QA
+    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
+    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
+    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
+- Code quality checklist
+    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
+- Release checklist
+    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
+    - [ ] If applicable, added the **breaking change** issue label
+- Designer checklist
+    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart

--- a/wiki/contributing-to-eui/README.md
+++ b/wiki/contributing-to-eui/README.md
@@ -15,10 +15,11 @@ EUI is built primarily by employees of Elastic. We try to do this in the open as
 To help the maintainers of EUI better respond to your pull requests please try to adhere to the following:
 
 1. Follow the guidelines outlined in this wiki folder, from [development](./developing) to [documentation](./documenting) to [testing](./testing).
-2. Include screenshots and a summary of your changes in the PR description
-3. Fill out the checklist, using ~strikethroughs~ to mark any items that are not applicable
-4. Make sure your changes are documented on the demo site and include liberal code comments
-5. Treat each other professionally and assume best intent in each others work and suggestions
+2. Prefer [atomic commits and small pull requests](https://learning-notes.mistermicheels.com/processes-techniques/small-commits-pull-requests/). Try to limit each commit and each PR to one concern/one issue only. PRs will be significantly easier to QA and review this way.
+3. Include screenshots and a summary of your changes in the PR description
+4. Fill out the checklist, using ~strikethroughs~ to mark any items that are not applicable
+5. Make sure your changes are documented on the demo site and include code comments for unintuitive changes
+6. Treat each other professionally and assume best intent in each others work and suggestions
 
 Generally you can expect feedback and a review of your pull request from our team within a week. Contributors should limit themselves to three or less active PRs at any one time, which helps us focus review time towards PRs that are close to a merge event. Sometimes it is unclear who has the next step in getting a pull request over the line and the review can lag as a result. If this is the case, feel free to leave a new comment and ask for guidance.
 


### PR DESCRIPTION
## Summary

See below for an example of the newly-organized PR checklist template

## QA

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
