### PR TITLE
[EuiInlineEdit] End Beta Phase

### DIFF
--- a/src-docs/src/views/inline_edit/inline_edit_example.js
+++ b/src-docs/src/views/inline_edit/inline_edit_example.js
@@ -106,7 +106,6 @@ const inlineEditModePropsSnippet = `<EuiInlineEditText
 
 export const InlineEditExample = {
   title: 'Inline edit',
-  isBeta: true,
   intro: (
     <>
       <EuiText>


### PR DESCRIPTION
## Summary
This PR removes the `isBeta` flag from `EuiInlineEdit` to signify the end of the 'beta' period for the component. 

<img width="599" alt="image" src="https://github.com/elastic/eui/assets/40739624/cddc359a-6674-4768-af7b-8c11fb21dd00">

## QA
- Check the [PR Preview](https://eui.elastic.co/pr_7181/#/forms/inline-edit) and confirm that the `isBeta` flag no longer exists in the side nav and on the component page header.
