### PR TITLE
[GitHub] Fix `breaking change` PR bot auto-responder

### DIFF
--- a/.github/workflows/label_commenter.yml
+++ b/.github/workflows/label_commenter.yml
@@ -3,6 +3,8 @@ name: Auto-respond to issues with comments based on labels
 on:
   issues:
     types: [labeled]
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

🤦 The _other_ reason why https://github.com/elastic/eui/pull/7178#issuecomment-1714564168 wasn't working was because I hadn't actually configured the GH action to run on PRs

## QA

N/A, infra/dev only