### PR TITLE
[Docs] Update CodeSandbox link in nav to use Typescript

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -73,14 +73,14 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
   function renderCodeSandbox() {
     const label = 'Codesandbox';
     return isMobileSize ? (
-      <CodeSandboxLink key="codesandbox">
+      <CodeSandboxLink type="tsx">
         <EuiButtonEmpty size="s" flush="both" iconType="logoCodesandbox">
           {label}
         </EuiButtonEmpty>
       </CodeSandboxLink>
     ) : (
       <EuiToolTip content="Codesandbox" key="codesandbox">
-        <CodeSandboxLink>
+        <CodeSandboxLink type="tsx">
           <EuiHeaderSectionItemButton aria-label="Codesandbox">
             <EuiIcon type="logoCodesandbox" aria-hidden="true" />
           </EuiHeaderSectionItemButton>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7171

## QA

- Go to https://eui.elastic.co/pr_7184/#/
- Click on the codesandbox logo in the top right hand corner of the nav
- [x] Confirm that the demo opened is a `.tsx` file extension and not `.js`