### PR TITLE
[EuiDescriptionListTitle] Misc compressed style fixes

### DIFF
--- a/src/components/description_list/__snapshots__/description_list_title.test.tsx.snap
+++ b/src/components/description_list/__snapshots__/description_list_title.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`EuiDescriptionListTitle EuiDescriptionListTitle prop variations type co
 
 exports[`EuiDescriptionListTitle EuiDescriptionListTitle prop variations type inline is rendered 1`] = `
 <dt
-  class="euiDescriptionList__title emotion-euiDescriptionList__title-inline-normal-s"
+  class="euiDescriptionList__title emotion-euiDescriptionList__title-inline-normal"
 />
 `;
 

--- a/src/components/description_list/description_list_title.styles.ts
+++ b/src/components/description_list/description_list_title.styles.ts
@@ -66,7 +66,8 @@ export const euiDescriptionListTitleStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
       `,
       compressed: css`
-        ${euiFontSize(euiThemeContext, 'xs')}
+        font-size: ${euiFontSize(euiThemeContext, 'xs').fontSize};
+        line-height: ${euiTheme.font.lineHeightMultiplier};
         ${logicalCSS('padding-vertical', '0')}
         ${logicalCSS('padding-horizontal', euiTheme.size.xs)}
       `,

--- a/src/components/description_list/description_list_title.tsx
+++ b/src/components/description_list/description_list_title.tsx
@@ -40,7 +40,6 @@ export const EuiDescriptionListTitle: FunctionComponent<
       conditionalStyles = compressed
         ? [styles.inlineStyles.compressed]
         : [styles.inlineStyles.normal];
-      conditionalStyles.push(styles[rowGutterSize]);
       break;
     case 'row':
       conditionalStyles.push(styles[rowGutterSize]);

--- a/src/themes/amsterdam/overrides/_description_list.scss
+++ b/src/themes/amsterdam/overrides/_description_list.scss
@@ -1,7 +1,0 @@
-.euiDescriptionList {
-  &.euiDescriptionList--inline.euiDescriptionList--compressed {
-    .euiDescriptionList__title {
-      line-height: $euiLineHeight;
-    }
-  }
-}

--- a/src/themes/amsterdam/overrides/_index.scss
+++ b/src/themes/amsterdam/overrides/_index.scss
@@ -1,6 +1,5 @@
 @import 'combo_box';
 @import 'data_grid';
-@import 'description_list';
 @import 'form_control_layout';
 @import 'form_control_layout_delimited';
 @import 'form_controls';

--- a/upcoming_changelogs/7185.md
+++ b/upcoming_changelogs/7185.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed the inline compressed styles of `EuiDescriptionListTitle` to use a taller line-height for readability
+


### PR DESCRIPTION
## Summary

- e44a951d345e2fbeda3101364a613be780f2bd8e - Fixes a Sass Amsterdam override for `inline compressed` titles that was missed in #5971 
- b1b7a098a71b6b176ae3264790040894b803c299 - Fixes an unnecessary margin-top style applied to all inline titles when it does nothing (missed in #7062)

## QA

- Go to https://eui.elastic.co/pr_7185/#/display/description-list#customizing-appearance
- [x] Inspect the inline title and confirm that the line height is set to `1.5` (taller than production)
    <img width="506" alt="" src="https://github.com/elastic/eui/assets/549407/558d01cf-1155-4c7b-a4d1-b6f7b938f8fa">
- [x] Inspect the second title and confirm there is no unnecessary `margin-block-start` (top) set on it, unlike [production](https://eui.elastic.co/#/display/description-list#customizing-appearance)

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - Skipped
- Code quality checklist - Skipped except for snapshot updates
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist~
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
