### PR TITLE
[Emotion] Convert `EuiDroppable` & `EuiDraggable`

### DIFF
--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -80,20 +80,20 @@ exports[`useDataGridColumnSelector columnSelector [React 17] renders a toolbar b
         class="euiDataGrid__controlScroll"
       >
         <div
-          class="euiDroppable euiDroppable--noGrow"
+          class="euiDroppable emotion-euiDroppable-noGrow"
           data-rfd-droppable-context-id="0"
           data-rfd-droppable-id="columnOrder"
           data-test-subj="droppable"
         >
           <div
-            class="euiDraggable euiDraggable--hasCustomDragHandle"
+            class="euiDraggable emotion-euiDraggable"
             data-rfd-draggable-context-id="0"
             data-rfd-draggable-id="columnA"
             data-test-subj="draggable"
             role="group"
           >
             <div
-              class="euiDataGridColumnSelector__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
               data-test-subj="dataGridColumnSelectorColumnItem-columnA"
             >
               <div
@@ -163,14 +163,14 @@ exports[`useDataGridColumnSelector columnSelector [React 17] renders a toolbar b
             </div>
           </div>
           <div
-            class="euiDraggable euiDraggable--hasCustomDragHandle"
+            class="euiDraggable emotion-euiDraggable"
             data-rfd-draggable-context-id="0"
             data-rfd-draggable-id="columnB"
             data-test-subj="draggable"
             role="group"
           >
             <div
-              class="euiDataGridColumnSelector__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
               data-test-subj="dataGridColumnSelectorColumnItem-columnB"
             >
               <div
@@ -375,20 +375,20 @@ exports[`useDataGridColumnSelector columnSelector [React 18] renders a toolbar b
         class="euiDataGrid__controlScroll"
       >
         <div
-          class="euiDroppable euiDroppable--noGrow"
+          class="euiDroppable emotion-euiDroppable-noGrow"
           data-rfd-droppable-context-id=":r0:"
           data-rfd-droppable-id="columnOrder"
           data-test-subj="droppable"
         >
           <div
-            class="euiDraggable euiDraggable--hasCustomDragHandle"
+            class="euiDraggable emotion-euiDraggable"
             data-rfd-draggable-context-id=":r0:"
             data-rfd-draggable-id="columnA"
             data-test-subj="draggable"
             role="group"
           >
             <div
-              class="euiDataGridColumnSelector__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
               data-test-subj="dataGridColumnSelectorColumnItem-columnA"
             >
               <div
@@ -458,14 +458,14 @@ exports[`useDataGridColumnSelector columnSelector [React 18] renders a toolbar b
             </div>
           </div>
           <div
-            class="euiDraggable euiDraggable--hasCustomDragHandle"
+            class="euiDraggable emotion-euiDraggable"
             data-rfd-draggable-context-id=":r0:"
             data-rfd-draggable-id="columnB"
             data-test-subj="draggable"
             role="group"
           >
             <div
-              class="euiDataGridColumnSelector__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
               data-test-subj="dataGridColumnSelectorColumnItem-columnB"
             >
               <div

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -61,20 +61,20 @@ exports[`useDataGridColumnSorting columnSorting [React 17] renders a toolbar but
       role="region"
     >
       <div
-        class="euiDroppable euiDroppable--noGrow"
+        class="euiDroppable emotion-euiDroppable-noGrow"
         data-rfd-droppable-context-id="0"
         data-rfd-droppable-id="columnSorting"
         data-test-subj="droppable"
       >
         <div
-          class="euiDraggable euiDraggable--hasCustomDragHandle"
+          class="euiDraggable emotion-euiDraggable"
           data-rfd-draggable-context-id="0"
           data-rfd-draggable-id="columnA"
           data-test-subj="draggable"
           role="group"
         >
           <div
-            class="euiDataGridColumnSorting__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+            class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
           >
             <p
               class="emotion-euiScreenReaderOnly"
@@ -351,20 +351,20 @@ exports[`useDataGridColumnSorting columnSorting [React 18] renders a toolbar but
       role="region"
     >
       <div
-        class="euiDroppable euiDroppable--noGrow"
+        class="euiDroppable emotion-euiDroppable-noGrow"
         data-rfd-droppable-context-id=":r0:"
         data-rfd-droppable-id="columnSorting"
         data-test-subj="droppable"
       >
         <div
-          class="euiDraggable euiDraggable--hasCustomDragHandle"
+          class="euiDraggable emotion-euiDraggable"
           data-rfd-draggable-context-id=":r0:"
           data-rfd-draggable-id="columnA"
           data-test-subj="draggable"
           role="group"
         >
           <div
-            class="euiDataGridColumnSorting__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+            class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
           >
             <p
               class="emotion-euiScreenReaderOnly"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable component of a single column that is currently being sorted 1`] = `
 <div
-  class="euiDraggable euiDraggable--hasCustomDragHandle"
+  class="euiDraggable emotion-euiDraggable"
   data-rfd-draggable-context-id="0"
   data-rfd-draggable-id="columnA"
   data-test-subj="draggable"
   role="group"
 >
   <div
-    class="euiDataGridColumnSorting__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+    class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
   >
     <p
       class="emotion-euiScreenReaderOnly"
@@ -161,14 +161,14 @@ exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable co
 
 exports[`EuiDataGridColumnSortingDraggable [React 18] renders an EuiDraggable component of a single column that is currently being sorted 1`] = `
 <div
-  class="euiDraggable euiDraggable--hasCustomDragHandle"
+  class="euiDraggable emotion-euiDraggable"
   data-rfd-draggable-context-id=":r0:"
   data-rfd-draggable-id="columnA"
   data-test-subj="draggable"
   role="group"
 >
   <div
-    class="euiDataGridColumnSorting__item false euiDraggable__item euiDraggable__item--hasCustomDragHandle"
+    class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
   >
     <p
       class="emotion-euiScreenReaderOnly"

--- a/src/components/datagrid/controls/column_selector.tsx
+++ b/src/components/datagrid/controls/column_selector.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, {
-  Fragment,
   useState,
   useMemo,
   useCallback,
@@ -15,6 +14,7 @@ import React, {
   ChangeEvent,
 } from 'react';
 import classNames from 'classnames';
+
 import { EuiPopover, EuiPopoverFooter, EuiPopoverTitle } from '../../popover';
 import { EuiI18n, useEuiI18n } from '../../i18n';
 import { EuiButtonEmpty } from '../../button';
@@ -197,7 +197,7 @@ export const useDataGridColumnSelector = (
                 droppableId="columnOrder"
                 isDropDisabled={!isDragEnabled}
               >
-                <Fragment>
+                <>
                   {filteredColumns.map((id, index) => (
                     <EuiDraggable
                       key={id}
@@ -209,10 +209,13 @@ export const useDataGridColumnSelector = (
                     >
                       {(provided, state) => (
                         <div
-                          className={`euiDataGridColumnSelector__item ${
-                            state.isDragging &&
-                            'euiDataGridColumnSelector__item-isDragging'
-                          }`}
+                          className={classNames(
+                            'euiDataGridColumnSelector__item',
+                            {
+                              'euiDataGridColumnSelector__item-isDragging':
+                                state.isDragging,
+                            }
+                          )}
                           data-test-subj={`dataGridColumnSelectorColumnItem-${id}`}
                         >
                           <EuiFlexGroup
@@ -272,7 +275,7 @@ export const useDataGridColumnSelector = (
                       )}
                     </EuiDraggable>
                   ))}
-                </Fragment>
+                </>
               </EuiDroppable>
             </EuiDragDropContext>
           </div>

--- a/src/components/datagrid/controls/column_sorting_draggable.tsx
+++ b/src/components/datagrid/controls/column_sorting_draggable.tsx
@@ -7,6 +7,8 @@
  */
 
 import React, { FunctionComponent } from 'react';
+import classNames from 'classnames';
+
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { EuiButtonGroup, EuiButtonIcon } from '../../button';
 import { EuiDraggable } from '../../drag_and_drop';
@@ -78,9 +80,9 @@ export const EuiDataGridColumnSortingDraggable: FunctionComponent<
     >
       {(provided, state) => (
         <div
-          className={`euiDataGridColumnSorting__item ${
-            state.isDragging && 'euiDataGridColumnSorting__item-isDragging'
-          }`}
+          className={classNames('euiDataGridColumnSorting__item', {
+            'euiDataGridColumnSorting__item-isDragging': state.isDragging,
+          })}
         >
           <EuiScreenReaderOnly>
             <p>

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -1813,7 +1813,7 @@ describe('EuiDataGrid', () => {
       let popover = openColumnSelector(component);
       expect(
         popover
-          .find('.euiDataGridColumnSelector__item')
+          .find('div.euiDataGridColumnSelector__item')
           .map((item) => item.text())
       ).toEqual(['A', 'B']);
       closeColumnSelector(component);
@@ -1831,7 +1831,7 @@ describe('EuiDataGrid', () => {
       popover = openColumnSelector(component);
       expect(
         popover
-          .find('.euiDataGridColumnSelector__item')
+          .find('div.euiDataGridColumnSelector__item')
           .map((item) => item.text())
       ).toEqual(['A', 'C']);
       closeColumnSelector(component);

--- a/src/components/drag_and_drop/__snapshots__/drag_drop_context.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/drag_drop_context.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiDragDropContext is rendered 1`] = `<div />`;
+exports[`EuiDragDropContext renders 1`] = `<div />`;

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -3,18 +3,18 @@
 exports[`[React 17] EuiDraggable renders 1`] = `
 <div
   class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id="0"
+  data-rfd-droppable-context-id="2"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >
   <div
-    aria-describedby="rfd-hidden-text-0-hidden-text-0"
-    class="euiDraggable emotion-euiDraggable"
-    data-rfd-drag-handle-context-id="0"
+    aria-describedby="rfd-hidden-text-2-hidden-text-6"
+    class="euiDraggable testClass1 testClass2 emotion-euiDraggable-euiTestCss"
+    data-rfd-drag-handle-context-id="2"
     data-rfd-drag-handle-draggable-id="testDraggable"
-    data-rfd-draggable-context-id="0"
+    data-rfd-draggable-context-id="2"
     data-rfd-draggable-id="testDraggable"
-    data-test-subj="draggable"
+    data-test-subj="test subject string"
     draggable="false"
     role="button"
     tabindex="0"
@@ -34,18 +34,18 @@ exports[`[React 17] EuiDraggable renders 1`] = `
 exports[`[React 18] EuiDraggable renders 1`] = `
 <div
   class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id=":r0:"
+  data-rfd-droppable-context-id=":r8:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >
   <div
-    aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-    class="euiDraggable emotion-euiDraggable"
-    data-rfd-drag-handle-context-id=":r0:"
+    aria-describedby="rfd-hidden-text-:r8:-hidden-text-:r9:"
+    class="euiDraggable testClass1 testClass2 emotion-euiDraggable-euiTestCss"
+    data-rfd-drag-handle-context-id=":r8:"
     data-rfd-drag-handle-draggable-id="testDraggable"
-    data-rfd-draggable-context-id=":r0:"
+    data-rfd-draggable-context-id=":r8:"
     data-rfd-draggable-id="testDraggable"
-    data-test-subj="draggable"
+    data-test-subj="test subject string"
     draggable="false"
     role="button"
     tabindex="0"

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`[React 17] EuiDraggable renders 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >
   <div
     aria-describedby="rfd-hidden-text-0-hidden-text-0"
-    class="euiDraggable emotion-euiDraggable-none"
+    class="euiDraggable emotion-euiDraggable"
     data-rfd-drag-handle-context-id="0"
     data-rfd-drag-handle-draggable-id="testDraggable"
     data-rfd-draggable-context-id="0"
@@ -33,14 +33,14 @@ exports[`[React 17] EuiDraggable renders 1`] = `
 
 exports[`[React 18] EuiDraggable renders 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id=":r0:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
 >
   <div
     aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-    class="euiDraggable emotion-euiDraggable-none"
+    class="euiDraggable emotion-euiDraggable"
     data-rfd-drag-handle-context-id=":r0:"
     data-rfd-drag-handle-draggable-id="testDraggable"
     data-rfd-draggable-context-id=":r0:"

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`[React 17] EuiDraggable renders 1`] = `
 >
   <div
     aria-describedby="rfd-hidden-text-0-hidden-text-0"
-    class="euiDraggable"
+    class="euiDraggable emotion-euiDraggable-none"
     data-rfd-drag-handle-context-id="0"
     data-rfd-drag-handle-draggable-id="testDraggable"
     data-rfd-draggable-context-id="0"
@@ -20,7 +20,7 @@ exports[`[React 17] EuiDraggable renders 1`] = `
     tabindex="0"
   >
     <div
-      class="euiDraggable__item"
+      class="euiDraggable__item emotion-euiDraggable__item"
     >
       Hello
     </div>

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`[React 18] EuiDraggable renders 1`] = `
     tabindex="0"
   >
     <div
-      class="euiDraggable__item"
+      class="euiDraggable__item emotion-euiDraggable__item"
     >
       Hello
     </div>

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`[React 18] EuiDraggable renders 1`] = `
 >
   <div
     aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-    class="euiDraggable"
+    class="euiDraggable emotion-euiDraggable-none"
     data-rfd-drag-handle-context-id=":r0:"
     data-rfd-drag-handle-draggable-id="testDraggable"
     data-rfd-draggable-context-id=":r0:"

--- a/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/draggable.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`[React 17] EuiDraggable renders 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -33,7 +33,7 @@ exports[`[React 17] EuiDraggable renders 1`] = `
 
 exports[`[React 18] EuiDraggable renders 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id=":r0:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"

--- a/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`[React 17] EuiDroppable can be given ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -16,7 +16,7 @@ exports[`[React 17] EuiDroppable can be given ReactElement children 1`] = `
 
 exports[`[React 17] EuiDroppable can be given multiple ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -32,7 +32,7 @@ exports[`[React 17] EuiDroppable can be given multiple ReactElement children 1`]
 
 exports[`[React 17] EuiDroppable is rendered 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -46,7 +46,7 @@ exports[`[React 17] EuiDroppable is rendered 1`] = `
 
 exports[`[React 18] EuiDroppable can be given ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id=":r3:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -60,7 +60,7 @@ exports[`[React 18] EuiDroppable can be given ReactElement children 1`] = `
 
 exports[`[React 18] EuiDroppable can be given multiple ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id=":r6:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -76,7 +76,7 @@ exports[`[React 18] EuiDroppable can be given multiple ReactElement children 1`]
 
 exports[`[React 18] EuiDroppable is rendered 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow"
+  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
   data-rfd-droppable-context-id=":r0:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"

--- a/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
@@ -1,89 +1,93 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[React 17] EuiDroppable can be given ReactElement children 1`] = `
-<div
-  class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id="0"
-  data-rfd-droppable-id="testDroppable"
-  data-test-subj="droppable"
->
-  <div />
+exports[`[React 17] EuiDroppable renders 1`] = `
+<body>
   <div
-    class="euiDroppable__placeholder"
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rfd-announcement-0"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
   />
-</div>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rfd-announcement-1"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div>
+    <div
+      class="euiDroppable testClass1 testClass2 emotion-euiDroppable-noGrow-euiTestCss"
+      data-rfd-droppable-context-id="0"
+      data-rfd-droppable-id="testDroppable"
+      data-test-subj="test subject string"
+    >
+      <div />
+      <div
+        class="euiDroppable__placeholder"
+      />
+    </div>
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rfd-announcement-0"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div
+    id="rfd-hidden-text-0-hidden-text-0"
+    style="display: none;"
+  >
+    
+  Press space bar to start a drag.
+  When dragging you can use the arrow keys to move the item around and escape to cancel.
+  Some screen readers may require you to be in focus mode or to use your pass through key
+
+  </div>
+</body>
 `;
 
-exports[`[React 17] EuiDroppable can be given multiple ReactElement children 1`] = `
-<div
-  class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id="0"
-  data-rfd-droppable-id="testDroppable"
-  data-test-subj="droppable"
->
-  <div />
-  <div />
-  <div />
+exports[`[React 18] EuiDroppable renders 1`] = `
+<body>
   <div
-    class="euiDroppable__placeholder"
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rfd-announcement-:r0:"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
   />
-</div>
-`;
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rfd-announcement-:r3:"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div>
+    <div
+      class="euiDroppable testClass1 testClass2 emotion-euiDroppable-noGrow-euiTestCss"
+      data-rfd-droppable-context-id=":r6:"
+      data-rfd-droppable-id="testDroppable"
+      data-test-subj="test subject string"
+    >
+      <div />
+      <div
+        class="euiDroppable__placeholder"
+      />
+    </div>
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rfd-announcement-:r6:"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div
+    id="rfd-hidden-text-:r6:-hidden-text-:r7:"
+    style="display: none;"
+  >
+    
+  Press space bar to start a drag.
+  When dragging you can use the arrow keys to move the item around and escape to cancel.
+  Some screen readers may require you to be in focus mode or to use your pass through key
 
-exports[`[React 17] EuiDroppable is rendered 1`] = `
-<div
-  class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id="0"
-  data-rfd-droppable-id="testDroppable"
-  data-test-subj="droppable"
->
-  <div />
-  <div
-    class="euiDroppable__placeholder"
-  />
-</div>
-`;
-
-exports[`[React 18] EuiDroppable can be given ReactElement children 1`] = `
-<div
-  class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id=":r3:"
-  data-rfd-droppable-id="testDroppable"
-  data-test-subj="droppable"
->
-  <div />
-  <div
-    class="euiDroppable__placeholder"
-  />
-</div>
-`;
-
-exports[`[React 18] EuiDroppable can be given multiple ReactElement children 1`] = `
-<div
-  class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id=":r6:"
-  data-rfd-droppable-id="testDroppable"
-  data-test-subj="droppable"
->
-  <div />
-  <div />
-  <div />
-  <div
-    class="euiDroppable__placeholder"
-  />
-</div>
-`;
-
-exports[`[React 18] EuiDroppable is rendered 1`] = `
-<div
-  class="euiDroppable emotion-euiDroppable-noGrow"
-  data-rfd-droppable-context-id=":r0:"
-  data-rfd-droppable-id="testDroppable"
-  data-test-subj="droppable"
->
-  <div />
-  <div
-    class="euiDroppable__placeholder"
-  />
-</div>
+  </div>
+</body>
 `;

--- a/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
+++ b/src/components/drag_and_drop/__snapshots__/droppable.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`[React 17] EuiDroppable can be given ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -16,7 +16,7 @@ exports[`[React 17] EuiDroppable can be given ReactElement children 1`] = `
 
 exports[`[React 17] EuiDroppable can be given multiple ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -32,7 +32,7 @@ exports[`[React 17] EuiDroppable can be given multiple ReactElement children 1`]
 
 exports[`[React 17] EuiDroppable is rendered 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id="0"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -46,7 +46,7 @@ exports[`[React 17] EuiDroppable is rendered 1`] = `
 
 exports[`[React 18] EuiDroppable can be given ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id=":r3:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -60,7 +60,7 @@ exports[`[React 18] EuiDroppable can be given ReactElement children 1`] = `
 
 exports[`[React 18] EuiDroppable can be given multiple ReactElement children 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id=":r6:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"
@@ -76,7 +76,7 @@ exports[`[React 18] EuiDroppable can be given multiple ReactElement children 1`]
 
 exports[`[React 18] EuiDroppable is rendered 1`] = `
 <div
-  class="euiDroppable euiDroppable--noGrow emotion-euiDroppable"
+  class="euiDroppable emotion-euiDroppable-noGrow"
   data-rfd-droppable-context-id=":r0:"
   data-rfd-droppable-id="testDroppable"
   data-test-subj="droppable"

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -1,6 +1,0 @@
-.euiDraggable {
-  &:focus > .euiDraggable__item,
-  &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle]:focus {
-    @include euiFocusRing;
-  }
-}

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -1,19 +1,4 @@
 .euiDraggable {
-  &.euiDraggable--isDragging {
-    // Overriding inline styles on JS-inserted HTML elements
-    z-index: $euiZLevel9 !important; // stylelint-disable-line declaration-no-important
-  }
-
-  &.euiDraggable--hasClone:not(.euiDraggable--isDragging) {
-    // Overriding inline styles on JS-inserted HTML elements
-    transform: none !important; // stylelint-disable-line declaration-no-important
-  }
-
-  &.euiDraggable--withoutDropAnimation {
-    // Overriding inline styles on JS-inserted HTML elements
-    transition-duration: .001s !important; // stylelint-disable-line declaration-no-important
-  }
-
   &:focus > .euiDraggable__item,
   &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle]:focus {
     @include euiFocusRing;

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -33,9 +33,3 @@
     }
   }
 }
-
-@each $size, $spacing in $euiDragAndDropSpacing {
-  .euiDraggable--#{$size} {
-    padding: $spacing;
-  }
-}

--- a/src/components/drag_and_drop/_draggable.scss
+++ b/src/components/drag_and_drop/_draggable.scss
@@ -3,18 +3,4 @@
   &.euiDraggable--hasCustomDragHandle > .euiDraggable__item [data-react-beautiful-dnd-drag-handle]:focus {
     @include euiFocusRing;
   }
-
-  .euiDraggable__item {
-    &.euiDraggable__item--isDisabled {
-      cursor: not-allowed;
-    }
-
-    &.euiDraggable__item--isDragging {
-      // TODO: Resolve below
-      // Commenting this out for now,
-      // I'm thinking about adding an optional prop to auto-add these styles versus always having them
-      // @include euiBottomShadow;
-      // @include euiFocusRing;
-    }
-  }
 }

--- a/src/components/drag_and_drop/_droppable.scss
+++ b/src/components/drag_and_drop/_droppable.scss
@@ -1,11 +1,3 @@
-.euiDroppable {
-  .euiDroppable__placeholder {
-    &.euiDroppable__placeholder--isHidden {
-      // Overriding inline styles on JS-inserted HTML elements
-      display: none !important; // stylelint-disable-line declaration-no-important
-    }
-  }
-}
 
 @include euiPanel($selector: '.euiDroppable--withPanel');
 

--- a/src/components/drag_and_drop/_droppable.scss
+++ b/src/components/drag_and_drop/_droppable.scss
@@ -1,15 +1,4 @@
 .euiDroppable {
-  $euiDroppableColor: $euiColorSuccess;
-  transition: background-color $euiAnimSpeedExtraSlow ease;
-
-  &.euiDroppable--isDraggingType:not(.euiDroppable--isDisabled) {
-    background-color: transparentize($euiDroppableColor, .9);
-
-    &.euiDroppable--isDraggingOver {
-      background-color: transparentize($euiDroppableColor, .75);
-    }
-  }
-
   .euiDroppable__placeholder {
     &.euiDroppable__placeholder--isHidden {
       // Overriding inline styles on JS-inserted HTML elements
@@ -23,18 +12,4 @@
 .euiDroppable--withPanel {
   @include euiBottomShadowMedium;
   border-radius: $euiBorderRadius;
-}
-
-.euiDroppable--noGrow {
-  flex-grow: 0;
-}
-
-.euiDroppable--grow {
-  flex-grow: 1;
-}
-
-@each $size, $spacing in $euiDragAndDropSpacing {
-  .euiDroppable--#{$size} {
-    padding: $spacing;
-  }
 }

--- a/src/components/drag_and_drop/_droppable.scss
+++ b/src/components/drag_and_drop/_droppable.scss
@@ -1,7 +1,0 @@
-
-@include euiPanel($selector: '.euiDroppable--withPanel');
-
-.euiDroppable--withPanel {
-  @include euiBottomShadowMedium;
-  border-radius: $euiBorderRadius;
-}

--- a/src/components/drag_and_drop/_index.scss
+++ b/src/components/drag_and_drop/_index.scss
@@ -1,3 +1,0 @@
-@import 'variables';
-@import 'draggable';
-@import 'droppable';

--- a/src/components/drag_and_drop/_variables.scss
+++ b/src/components/drag_and_drop/_variables.scss
@@ -1,5 +1,0 @@
-$euiDragAndDropSpacing: (
-  s: ($euiSizeXS / 2),
-  m: ($euiSizeS / 2),
-  l: ($euiSize / 2),
-);

--- a/src/components/drag_and_drop/drag_drop_context.test.tsx
+++ b/src/components/drag_and_drop/drag_drop_context.test.tsx
@@ -7,59 +7,40 @@
  */
 
 import React from 'react';
-import { mount, ReactWrapper } from 'enzyme';
-
-import { findTestSubject } from '../../test';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 
-import { EuiDragDropContext } from './';
-import { EuiDragDropContextContext } from './drag_drop_context';
-
-function snapshotDragDropContext(component: ReactWrapper) {
-  // Get the Portal's sibling and return its html
-  const renderedHtml = component.html();
-  const container = document.createElement('div');
-  container.innerHTML = renderedHtml;
-  return container.firstChild;
-}
+import {
+  EuiDragDropContext,
+  EuiDragDropContextContext,
+} from './drag_drop_context';
 
 describe('EuiDragDropContext', () => {
-  test('is rendered', () => {
-    const handler = jest.fn();
-    const component = mount(
-      <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
+  it('renders', () => {
+    const { container } = render(
+      <EuiDragDropContext onDragEnd={() => {}} {...requiredProps}>
         <div />
       </EuiDragDropContext>
     );
 
-    expect(snapshotDragDropContext(component)).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  describe('custom behavior', () => {
-    describe('isDraggingType', () => {
-      test('is set on proprietary context', () => {
-        jest.mock('react', () => {
-          const react = jest.requireActual('react');
-          return {
-            ...react,
-            useLayoutEffect: react.useEffect,
-          };
-        });
-        const handler = jest.fn();
-        const component = mount(
-          <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
-            <EuiDragDropContextContext.Consumer>
-              {(value) => (
-                <div data-test-subj="child">
-                  {value.hasOwnProperty('isDraggingType') ? 'true' : 'false'}
-                </div>
-              )}
-            </EuiDragDropContextContext.Consumer>
-          </EuiDragDropContext>
-        );
+  describe('isDraggingType', () => {
+    test('is set on proprietary context', () => {
+      const { getByTestSubject } = render(
+        <EuiDragDropContext onDragEnd={() => {}}>
+          <EuiDragDropContextContext.Consumer>
+            {(value) => (
+              <div data-test-subj="child">
+                {value.hasOwnProperty('isDraggingType') ? 'true' : 'false'}
+              </div>
+            )}
+          </EuiDragDropContextContext.Consumer>
+        </EuiDragDropContext>
+      );
 
-        expect(findTestSubject(component, 'child').text()).toBe('true');
-      });
+      expect(getByTestSubject('child')).toHaveTextContent('true');
     });
   });
 });

--- a/src/components/drag_and_drop/draggable.styles.ts
+++ b/src/components/drag_and_drop/draggable.styles.ts
@@ -43,3 +43,10 @@ export const euiDraggableStyles = (euiThemeContext: UseEuiTheme) => {
     },
   };
 };
+
+export const euiDraggableItemStyles = {
+  euiDraggable__item: css``,
+  disabled: css`
+    cursor: not-allowed;
+  `,
+};

--- a/src/components/drag_and_drop/draggable.styles.ts
+++ b/src/components/drag_and_drop/draggable.styles.ts
@@ -16,6 +16,14 @@ export const euiDraggableStyles = (euiThemeContext: UseEuiTheme) => {
 
   return {
     euiDraggable: css`
+      &:focus {
+        outline: none;
+
+        & > .euiDraggable__item {
+          outline: auto;
+        }
+      }
+
       /* !importants in this file override inline styles on JS-inserted HTML elements */
       /* stylelint-disable declaration-no-important */
     `,

--- a/src/components/drag_and_drop/draggable.styles.ts
+++ b/src/components/drag_and_drop/draggable.styles.ts
@@ -15,7 +15,20 @@ export const euiDraggableStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
   return {
-    euiDraggable: css``,
+    euiDraggable: css`
+      /* !importants in this file override inline styles on JS-inserted HTML elements */
+      /* stylelint-disable declaration-no-important */
+    `,
+    isDragging: css`
+      z-index: ${euiTheme.levels.toast} !important;
+    `,
+    hasClone: css`
+      transform: none !important;
+    `,
+    isRemovable: css`
+      /* Removes the drop animation */
+      transition-duration: 0.001s !important;
+    `,
     spacing: {
       none: css``,
       s: css`

--- a/src/components/drag_and_drop/draggable.styles.ts
+++ b/src/components/drag_and_drop/draggable.styles.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+import { mathWithUnits } from '../../global_styling';
+
+export const euiDraggableStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiDraggable: css``,
+    spacing: {
+      none: css``,
+      s: css`
+        padding: ${euiTheme.size.xxs};
+      `,
+      m: css`
+        padding: ${mathWithUnits(euiTheme.size.m, (x) => x / 2)};
+      `,
+      l: css`
+        padding: ${euiTheme.size.m};
+      `,
+    },
+  };
+};

--- a/src/components/drag_and_drop/draggable.styles.ts
+++ b/src/components/drag_and_drop/draggable.styles.ts
@@ -9,7 +9,7 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import { mathWithUnits } from '../../global_styling';
+import { sharedSpacingPadding } from './droppable.styles';
 
 export const euiDraggableStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
@@ -37,18 +37,7 @@ export const euiDraggableStyles = (euiThemeContext: UseEuiTheme) => {
       /* Removes the drop animation */
       transition-duration: 0.001s !important;
     `,
-    spacing: {
-      none: css``,
-      s: css`
-        padding: ${euiTheme.size.xxs};
-      `,
-      m: css`
-        padding: ${mathWithUnits(euiTheme.size.m, (x) => x / 2)};
-      `,
-      l: css`
-        padding: ${euiTheme.size.m};
-      `,
-    },
+    spacing: sharedSpacingPadding(euiThemeContext),
   };
 };
 

--- a/src/components/drag_and_drop/draggable.test.tsx
+++ b/src/components/drag_and_drop/draggable.test.tsx
@@ -7,84 +7,90 @@
  */
 
 import React from 'react';
-import { render, screen } from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
-import { describeByReactVersion } from '../../test/internal';
-import { EuiDragDropContext, EuiDraggable, EuiDroppable } from './';
+import {
+  shouldRenderCustomStyles,
+  describeByReactVersion,
+} from '../../test/internal';
+
+import { EuiDragDropContext, EuiDroppable } from './';
+import { EuiDraggable } from './draggable';
 
 describeByReactVersion('EuiDraggable', () => {
-  it('renders', () => {
-    const handler = jest.fn();
+  const TestContextWrapper = ({ children }: { children: any }) => (
+    <EuiDragDropContext onDragEnd={() => {}}>
+      <EuiDroppable droppableId="testDroppable">{children}</EuiDroppable>
+    </EuiDragDropContext>
+  );
 
+  shouldRenderCustomStyles(
+    <EuiDraggable draggableId="testDraggable" index={0}>
+      {() => <div>Hello</div>}
+    </EuiDraggable>,
+    { wrapper: TestContextWrapper }
+  );
+
+  it('renders', () => {
     const { container } = render(
-      <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
-        <EuiDroppable droppableId="testDroppable">
-          <EuiDraggable draggableId="testDraggable" index={0}>
-            {() => <div>Hello</div>}
-          </EuiDraggable>
-        </EuiDroppable>
-      </EuiDragDropContext>
+      <TestContextWrapper>
+        <EuiDraggable draggableId="testDraggable" index={0} {...requiredProps}>
+          {() => <div>Hello</div>}
+        </EuiDraggable>
+      </TestContextWrapper>
     );
 
-    expect(screen.getByTestSubject('draggable')).toBeVisible();
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders with render prop children', () => {
-    const handler = jest.fn();
-
-    render(
-      <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
-        <EuiDroppable droppableId="testDroppable">
-          <EuiDraggable draggableId="testDraggable" index={0}>
-            {() => <div>Hello</div>}
-          </EuiDraggable>
-        </EuiDroppable>
-      </EuiDragDropContext>
+    const { getByTestSubject } = render(
+      <TestContextWrapper>
+        <EuiDraggable draggableId="testDraggable" index={0}>
+          {() => <div>Hello</div>}
+        </EuiDraggable>
+      </TestContextWrapper>
     );
 
-    expect(screen.getByText('Hello')).toBeVisible();
+    expect(getByTestSubject('draggable')).toHaveTextContent('Hello');
   });
 
   it('renders with react element children', () => {
-    const handler = jest.fn();
-
-    render(
-      <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
-        <EuiDroppable droppableId="testDroppable">
-          <EuiDraggable draggableId="testDraggable" index={0}>
-            <div>Hello</div>
-          </EuiDraggable>
-        </EuiDroppable>
-      </EuiDragDropContext>
+    const { getByTestSubject } = render(
+      <TestContextWrapper>
+        <EuiDraggable draggableId="testDraggable" index={0}>
+          <div>Hello</div>
+        </EuiDraggable>
+      </TestContextWrapper>
     );
 
-    expect(screen.getByText('Hello')).toBeVisible();
+    expect(getByTestSubject('draggable')).toHaveTextContent('Hello');
   });
 
   it('should render with role="group" and no tabIndex when hasInteractiveChildren is true', () => {
-    const handler = jest.fn();
+    const Test = ({
+      hasInteractiveChildren,
+    }: {
+      hasInteractiveChildren: boolean;
+    }) => (
+      <TestContextWrapper>
+        <EuiDraggable
+          hasInteractiveChildren={hasInteractiveChildren}
+          draggableId="testDraggable"
+          index={0}
+        >
+          <div>Hello</div>
+        </EuiDraggable>
+      </TestContextWrapper>
+    );
 
-    const doRender = (hasInteractiveChildren: boolean) =>
-      render(
-        <EuiDragDropContext onDragEnd={handler} {...requiredProps}>
-          <EuiDroppable droppableId="testDroppable">
-            <EuiDraggable
-              hasInteractiveChildren={hasInteractiveChildren}
-              draggableId="testDraggable"
-              index={0}
-            >
-              <div>Hello</div>
-            </EuiDraggable>
-          </EuiDroppable>
-        </EuiDragDropContext>
-      );
+    const { queryByRole, rerender } = render(
+      <Test hasInteractiveChildren={false} />
+    );
+    expect(queryByRole('group')).toBeNull();
 
-    doRender(false);
-    expect(screen.queryByRole('group')).toBeNull();
-
-    doRender(true);
-    expect(screen.getByRole('group')).toBeVisible();
-    expect(screen.getByRole('group')).not.toHaveAttribute('tabindex', 0);
+    rerender(<Test hasInteractiveChildren={true} />);
+    expect(queryByRole('group')).toBeVisible();
+    expect(queryByRole('group')).not.toHaveAttribute('tabindex', 0);
   });
 });

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -15,17 +15,15 @@ import React, {
 } from 'react';
 import { Draggable, DraggableProps } from '@hello-pangea/dnd';
 import classNames from 'classnames';
+
+import { useEuiTheme } from '../../services';
 import { CommonProps } from '../common';
+
 import { EuiDroppableContext } from './droppable';
+import { euiDraggableStyles } from './draggable.styles';
 
-const spacingToClassNameMap = {
-  none: null,
-  s: 'euiDraggable--s',
-  m: 'euiDraggable--m',
-  l: 'euiDraggable--l',
-};
-
-export type EuiDraggableSpacing = keyof typeof spacingToClassNameMap;
+const SPACINGS = ['none', 's', 'm', 'l'] as const;
+export type EuiDraggableSpacing = (typeof SPACINGS)[number];
 
 export interface EuiDraggableProps
   extends CommonProps,
@@ -71,6 +69,9 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
 }) => {
   const { cloneItems } = useContext(EuiDroppableContext);
 
+  const euiTheme = useEuiTheme();
+  const styles = euiDraggableStyles(euiTheme);
+
   return (
     <Draggable
       draggableId={draggableId}
@@ -79,6 +80,8 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
       {...rest}
     >
       {(provided, snapshot, rubric) => {
+        const cssStyles = [styles.euiDraggable, styles.spacing[spacing]];
+
         const classes = classNames(
           'euiDraggable',
           {
@@ -87,7 +90,6 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
             'euiDraggable--isDragging': snapshot.isDragging,
             'euiDraggable--withoutDropAnimation': isRemovable,
           },
-          spacingToClassNameMap[spacing],
           className
         );
         const childClasses = classNames('euiDraggable__item', {
@@ -108,6 +110,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
               ref={provided.innerRef}
               data-test-subj={dataTestSubj}
               className={classes}
+              css={cssStyles}
               style={{ ...style, ...provided.draggableProps.style }}
               // We use [role="group"] instead of [role="button"] when we expect a nested
               // interactive element. Screen readers will cue users that this is a container

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -80,23 +80,28 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
       {...rest}
     >
       {(provided, snapshot, rubric) => {
-        const cssStyles = [styles.euiDraggable, styles.spacing[spacing]];
+        const { isDragging, isDropAnimating } = snapshot;
+
+        const cssStyles = [
+          styles.euiDraggable,
+          cloneItems && !isDragging && styles.hasClone,
+          isDragging && styles.isDragging,
+          isRemovable && styles.isRemovable,
+          styles.spacing[spacing],
+        ];
 
         const classes = classNames(
           'euiDraggable',
           {
-            'euiDraggable--hasClone': cloneItems,
             'euiDraggable--hasCustomDragHandle': customDragHandle,
-            'euiDraggable--isDragging': snapshot.isDragging,
-            'euiDraggable--withoutDropAnimation': isRemovable,
           },
           className
         );
         const childClasses = classNames('euiDraggable__item', {
           'euiDraggable__item--hasCustomDragHandle': customDragHandle,
           'euiDraggable__item--isDisabled': isDragDisabled,
-          'euiDraggable__item--isDragging': snapshot.isDragging,
-          'euiDraggable__item--isDropAnimating': snapshot.isDropAnimating,
+          'euiDraggable__item--isDragging': isDragging,
+          'euiDraggable__item--isDropAnimating': isDropAnimating,
         });
         const DraggableElement: ReactElement =
           typeof children === 'function'
@@ -135,7 +140,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
                 ),
               })}
             </div>
-            {cloneItems && snapshot.isDragging && (
+            {cloneItems && isDragging && (
               <div className={classNames(classes, 'euiDraggable--clone')}>
                 {DraggableElement}
               </div>

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -79,7 +79,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
       {...rest}
     >
       {(provided, snapshot, rubric) => {
-        const { isDragging, isDropAnimating } = snapshot;
+        const { isDragging } = snapshot;
 
         const cssStyles = [
           styles.euiDraggable,
@@ -89,18 +89,9 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
           styles.spacing[spacing],
         ];
 
-        const classes = classNames(
-          'euiDraggable',
-          {
-            'euiDraggable--hasCustomDragHandle': customDragHandle,
-          },
-          className
-        );
+        const classes = classNames('euiDraggable', className);
         const childClasses = classNames('euiDraggable__item', {
-          'euiDraggable__item--hasCustomDragHandle': customDragHandle,
-          'euiDraggable__item--isDisabled': isDragDisabled,
-          'euiDraggable__item--isDragging': isDragging,
-          'euiDraggable__item--isDropAnimating': isDropAnimating,
+          'euiDraggable__item-isDisabled': isDragDisabled,
         });
         const DraggableElement: ReactElement =
           typeof children === 'function'
@@ -144,7 +135,10 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
               })}
             </div>
             {cloneItems && isDragging && (
-              <div className={classNames(classes, 'euiDraggable--clone')}>
+              <div
+                className={classNames(classes, 'euiDraggable--clone')}
+                css={cssStyles}
+              >
                 {DraggableElement}
               </div>
             )}

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -8,7 +8,6 @@
 
 import React, {
   CSSProperties,
-  Fragment,
   FunctionComponent,
   ReactElement,
   cloneElement,
@@ -102,7 +101,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
             ? (children(provided, snapshot, rubric) as ReactElement)
             : children;
         return (
-          <Fragment>
+          <>
             <div
               {...provided.draggableProps}
               {...(!customDragHandle ? provided.dragHandleProps : {})}
@@ -138,7 +137,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
                 {DraggableElement}
               </div>
             )}
-          </Fragment>
+          </>
         );
       }}
     </Draggable>

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -10,17 +10,16 @@ import React, {
   CSSProperties,
   FunctionComponent,
   ReactElement,
-  cloneElement,
   useContext,
 } from 'react';
 import { Draggable, DraggableProps } from '@hello-pangea/dnd';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiTheme, cloneElementWithCss } from '../../services';
 import { CommonProps } from '../common';
 
 import { EuiDroppableContext } from './droppable';
-import { euiDraggableStyles } from './draggable.styles';
+import { euiDraggableStyles, euiDraggableItemStyles } from './draggable.styles';
 
 const SPACINGS = ['none', 's', 'm', 'l'] as const;
 export type EuiDraggableSpacing = (typeof SPACINGS)[number];
@@ -133,11 +132,15 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
                   : provided.dragHandleProps?.tabIndex
               }
             >
-              {cloneElement(DraggableElement, {
+              {cloneElementWithCss(DraggableElement, {
                 className: classNames(
                   DraggableElement.props.className,
                   childClasses
                 ),
+                css: [
+                  euiDraggableItemStyles.euiDraggable__item,
+                  isDragDisabled && euiDraggableItemStyles.disabled,
+                ],
               })}
             </div>
             {cloneItems && isDragging && (

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -18,11 +18,8 @@ import classNames from 'classnames';
 import { useEuiTheme, cloneElementWithCss } from '../../services';
 import { CommonProps } from '../common';
 
-import { EuiDroppableContext } from './droppable';
+import { EuiDroppableContext, SPACINGS } from './droppable';
 import { euiDraggableStyles, euiDraggableItemStyles } from './draggable.styles';
-
-const SPACINGS = ['none', 's', 'm', 'l'] as const;
-export type EuiDraggableSpacing = (typeof SPACINGS)[number];
 
 export interface EuiDraggableProps
   extends CommonProps,
@@ -48,7 +45,7 @@ export interface EuiDraggableProps
   /**
    * Adds padding to the draggable item
    */
-  spacing?: EuiDraggableSpacing;
+  spacing?: (typeof SPACINGS)[number];
   style?: CSSProperties;
 }
 

--- a/src/components/drag_and_drop/droppable.styles.ts
+++ b/src/components/drag_and_drop/droppable.styles.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+
+export const euiDroppableStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiDroppable: css``,
+    spacing: sharedSpacingPadding(euiThemeContext),
+  };
+};
+
+// Droppable and draggable components both have the same shared spacing/padding values
+export const sharedSpacingPadding = ({ euiTheme }: UseEuiTheme) => ({
+  none: null,
+  s: css`
+    padding: ${euiTheme.size.xxs};
+  `,
+  m: css`
+    padding: ${euiTheme.size.xs};
+  `,
+  l: css`
+    padding: ${euiTheme.size.s};
+  `,
+});

--- a/src/components/drag_and_drop/droppable.styles.ts
+++ b/src/components/drag_and_drop/droppable.styles.ts
@@ -8,13 +8,32 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, transparentize } from '../../services';
+import { euiCanAnimate } from '../../global_styling';
 
 export const euiDroppableStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
+  const droppableColor = euiTheme.colors.success;
+
   return {
-    euiDroppable: css``,
+    euiDroppable: css`
+      ${euiCanAnimate} {
+        transition: background-color ${euiTheme.animation.slow} ease;
+      }
+    `,
+    isDragging: css`
+      background-color: ${transparentize(droppableColor, 0.1)};
+    `,
+    isDraggingOver: css`
+      background-color: ${transparentize(droppableColor, 0.25)};
+    `,
+    grow: css`
+      flex-grow: 1;
+    `,
+    noGrow: css`
+      flex-grow: 0;
+    `,
     spacing: sharedSpacingPadding(euiThemeContext),
   };
 };

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -106,7 +106,7 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
 
         const classes = classNames(
           'euiDroppable',
-          { 'euiDroppable--isDisabled': dropIsDisabled },
+          { 'euiDroppable-isDisabled': dropIsDisabled },
           className
         );
 

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -14,17 +14,14 @@ import React, {
 } from 'react';
 import { Droppable, DroppableProps } from '@hello-pangea/dnd';
 import classNames from 'classnames';
+
+import { useEuiTheme } from '../../services';
 import { CommonProps } from '../common';
+
 import { EuiDragDropContextContext } from './drag_drop_context';
+import { euiDroppableStyles } from './droppable.styles';
 
-const spacingToClassNameMap = {
-  none: null,
-  s: 'euiDroppable--s',
-  m: 'euiDroppable--m',
-  l: 'euiDroppable--l',
-};
-
-export type EuiDroppableSpacing = keyof typeof spacingToClassNameMap;
+export const SPACINGS = ['none', 's', 'm', 'l'] as const;
 
 export interface EuiDroppableProps
   extends CommonProps,
@@ -42,7 +39,7 @@ export interface EuiDroppableProps
   /**
    * Adds padding to the droppable area
    */
-  spacing?: EuiDroppableSpacing;
+  spacing?: (typeof SPACINGS)[number];
   /**
    * Adds an EuiPanel style to the droppable area
    */
@@ -74,6 +71,10 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
 }) => {
   const { isDraggingType } = useContext(EuiDragDropContextContext);
   const dropIsDisabled: boolean = cloneDraggables ? true : isDropDisabled;
+
+  const euiTheme = useEuiTheme();
+  const styles = euiDroppableStyles(euiTheme);
+
   return (
     <Droppable
       isDropDisabled={dropIsDisabled}
@@ -83,6 +84,8 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
       {...rest}
     >
       {(provided, snapshot) => {
+        const cssStyles = [styles.euiDroppable, styles.spacing[spacing]];
+
         const classes = classNames(
           'euiDroppable',
           {
@@ -93,7 +96,6 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
             'euiDroppable--grow': grow,
             'euiDroppable--noGrow': !grow,
           },
-          spacingToClassNameMap[spacing],
           className
         );
         const placeholderClasses = classNames('euiDroppable__placeholder', {
@@ -110,6 +112,7 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
             style={style}
             data-test-subj={dataTestSubj}
             className={classes}
+            css={cssStyles}
           >
             <EuiDroppableContext.Provider
               value={{

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -84,17 +84,21 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
       {...rest}
     >
       {(provided, snapshot) => {
-        const cssStyles = [styles.euiDroppable, styles.spacing[spacing]];
+        const { isDraggingOver } = snapshot;
+
+        const cssStyles = [
+          styles.euiDroppable,
+          isDraggingType === type && !dropIsDisabled && styles.isDragging,
+          isDraggingOver && styles.isDraggingOver,
+          grow ? styles.grow : styles.noGrow,
+          styles.spacing[spacing],
+        ];
 
         const classes = classNames(
           'euiDroppable',
           {
             'euiDroppable--isDisabled': dropIsDisabled,
-            'euiDroppable--isDraggingOver': snapshot.isDraggingOver,
-            'euiDroppable--isDraggingType': isDraggingType === type,
             'euiDroppable--withPanel': withPanel,
-            'euiDroppable--grow': grow,
-            'euiDroppable--noGrow': !grow,
           },
           className
         );

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -17,6 +17,7 @@ import classNames from 'classnames';
 
 import { useEuiTheme } from '../../services';
 import { CommonProps } from '../common';
+import { EuiPanel } from '../panel';
 
 import { EuiDragDropContextContext } from './drag_drop_context';
 import { euiDroppableStyles } from './droppable.styles';
@@ -86,6 +87,15 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
       {(provided, snapshot) => {
         const { isDraggingOver } = snapshot;
 
+        const PanelOrDiv = withPanel ? EuiPanel : 'div';
+        const panelOrDivProps = withPanel
+          ? {
+              panelRef: provided.innerRef,
+              hasShadow: true,
+              paddingSize: 'none' as const,
+            }
+          : { ref: provided.innerRef };
+
         const cssStyles = [
           styles.euiDroppable,
           isDraggingType === type && !dropIsDisabled && styles.isDragging,
@@ -96,20 +106,19 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
 
         const classes = classNames(
           'euiDroppable',
-          {
-            'euiDroppable--isDisabled': dropIsDisabled,
-            'euiDroppable--withPanel': withPanel,
-          },
+          { 'euiDroppable--isDisabled': dropIsDisabled },
           className
         );
+
         const DroppableElement =
           typeof children === 'function'
             ? children(provided, snapshot)
             : children;
+
         return (
-          <div
+          <PanelOrDiv
             {...provided.droppableProps}
-            ref={provided.innerRef}
+            {...panelOrDivProps}
             style={style}
             data-test-subj={dataTestSubj}
             className={classes}
@@ -125,7 +134,7 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
             <div className="euiDroppable__placeholder" hidden={cloneDraggables}>
               {provided.placeholder}
             </div>
-          </div>
+          </PanelOrDiv>
         );
       }}
     </Droppable>

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -102,9 +102,6 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
           },
           className
         );
-        const placeholderClasses = classNames('euiDroppable__placeholder', {
-          'euiDroppable__placeholder--isHidden': cloneDraggables,
-        });
         const DroppableElement =
           typeof children === 'function'
             ? children(provided, snapshot)
@@ -125,7 +122,9 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
             >
               {DroppableElement}
             </EuiDroppableContext.Provider>
-            <div className={placeholderClasses}>{provided.placeholder}</div>
+            <div className="euiDroppable__placeholder" hidden={cloneDraggables}>
+              {provided.placeholder}
+            </div>
           </div>
         );
       }}

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -6,7 +6,6 @@
 @import 'control_bar/index';
 @import 'date_picker/index';
 @import 'datagrid/index';
-@import 'drag_and_drop/index';
 @import 'empty_prompt/index';
 @import 'form/index';
 @import 'markdown_editor/index';

--- a/upcoming_changelogs/7187.md
+++ b/upcoming_changelogs/7187.md
@@ -1,0 +1,3 @@
+**CSS-in-JS conversions**
+
+- Converted `EuiDroppable` and `EuiDraggable` to Emotion; Removed `$euiDragAndDropSpacing` Sass variables


### PR DESCRIPTION
## Summary

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7187/commits) as this PR contains some cleanup/tech debt tasks around tests etc.

This PR additionally contains a very small focus outline placement fix in https://github.com/elastic/eui/pull/7187/commits/6e1823e6661f7c05995f386d2bfc8b653a56f98a:

**Before:**
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/53ded70c-761c-46d5-bb2a-1d9dda4e5ca0">

**After:**
<img width="400" alt="" src="https://github.com/elastic/eui/assets/549407/2d84c35d-5d31-4d04-9f45-aa7b1be15731">

## QA

- Go to https://eui.elastic.co/pr_7187/#/display/drag-and-drop
- [x] Smoke test each docs example and confirm display is the [same as production](https://eui.elastic.co/#/display/drag-and-drop)
- Go to https://eui.elastic.co/pr_7187/#/tabular-content/data-grid
- [x] Smoke test the **columns** and **sorting** toolbar popovers (add a sort to test dragging/dropping sort order) and confirm they work as expected (you should be able to drag the handle icons and the column titles, but not interactive elements such as switches)

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - skipped
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist~
    - ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~

<details><summary><h3>Emotion checklist</h3></summary>

**Kibana usage**

- [x] Pre-emptively check how your conversion will impact the next Kibana upgrade. This entails searching/grepping through Kibana (excluding `**/target, **/*.snap, **/*.storyshot` for less noise) for `eui{Component}` (case sensitive) to find:
- [x] Search Kibana's codebase for `{euiComponent}-` (case sensitive) to check for usage of modifier classes - **Two modifier usages:** [1](https://github.com/elastic/kibana/blob/c6770af9a6bbd2e513b2e1579c7ed200732a8c67/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts#L51), [2](https://github.com/elastic/kibana/blob/e16953e71a1166cc75fe42167e576345ae137588/x-pack/plugins/enterprise_search/public/applications/shared/tables/reorderable_table/reorderable_table.scss#L23)
- [x] Any test/query selectors that will need to be updated - **None**
- [x] Any Sass or CSS that will need to be updated, particularly if a component Sass var was deleted - **None**
- [x] Any direct className usages that will need to be refactored (e.g. someone calling the `euiBadge` class on a div instead of simply using the `EuiBadge` component) - **None**

---

**General**

- [x] Output CSS matches the previous CSS (works as expected in all browsers)
- [x] Rendered `className(s)` read as expected in snapshots and browsers
- ~[ ] Checked component playground~ No playground, but added Storybooks

---

**Unit tests**

- [x] [`shouldRenderCustomStyles()`](https://github.com/elastic/eui/blob/6054e9b8310bdb106371c0c9ff8bc48e3e0e594b/src/test/internal/render_custom_styles.tsx) test was added and passes with parent component and any nested `childProps` (e.g. `tooltipProps`)
- [x] Enzyme tests converted to RTL

---

**Sass/Emotion conversion process**

- [x] Converted all global Sass vars/mixins to JS (e.g. `$euiSize` to `euiTheme.size.base`)
- [x] Removed ~or converted~ component-specific Sass vars/mixins ~to exported JS versions~
- [x] Listed var/mixin removals in changelog
- ~[ ] Ran `yarn compile-scss` to update var/mixin [JSON files](https://github.com/elastic/eui/tree/main/src-docs/src/views/theme/_json)~
- ~[ ] Simplified `calc()` to `mathWithUnits` if possible (if mixing different unit types, this may not be possible)~
- ~[ ] Added an `@warn` deprecation message within the `global_styling/mixins/{component}.scss` file~
- [x] All SCSS files have been removed from the component(s) directory
- ~[ ] All SCSS overrides have been removed from the Amsterdam theme~ No overrides

---

**CSS tech debt**

- [x] Wrapped all animations or transitions in `euiCanAnimate`
- ~[ ] Used `gap` property to add margin between items if using flex~
- ~[ ] Converted side specific padding, margin, and position to `-inline` and `-block` [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) (check inline styles as well as CSS)~

---

**DOM Cleanup**

- [x] Did **NOT** remove any block/element classNames (e.g. `euiComponent`, `euiComponent__child`) - _Note: removed an unused **modifier class** on a child `euiDroppable__placeholder` element_
- [x] **SEARCH KIBANA FIRST**: Deleted any modifier classNames or maps if not being used in Kibana. 

---

**Extras/nice-to-have**

- [x] Reduced specificity where possible (usually by reducing nesting and class name chaining)
- ~[ ] Documentation pass~
- ~[ ] Check for issues in the backlog that could be a quick fix for that component~
- ~[ ] Optional component/code cleanup: consider splitting up the component into multiple children if it's overly verbose or difficult to reason about~
</details>