### PR TITLE
[BUG] Add write permission to Buildkite community bot.

### DIFF
--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -12,7 +12,7 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: "Check for org membership"
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user


### PR DESCRIPTION
## Summary

My Buildkite community contribution bot threw a `403 Forbidden` error when I tested it with a non-org member contribution. I traced the root cause to my action having `read` permission for pull requests instead of `write`. This was a mis-understanding of how the REST API and Actions differ in their handling of issues vs. pull requests.

> https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
>
> `pull requests`
>
> Work with pull requests. For example, pull-requests: write permits an action to add a label to a pull request.

## QA

QA will be done manually. I'll open a new PR from my test account (not an Elastic org member) and verify the community bot adds a comment and a label without erroring.