### PR TITLE
[EuiComboBox] Allow `ComboBoxPill` components to truncate when displaying long text

### DIFF
--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -435,7 +435,11 @@ Array [
             Pre
           </span>
         </span>
-        1
+        <span
+          class="eui-textTruncate"
+        >
+          1
+        </span>
       </span>
       <button
         aria-label="Remove 1 from selection in this group"
@@ -462,7 +466,11 @@ Array [
       <span
         class="euiBadge__text emotion-euiBadge__text"
       >
-        2
+        <span
+          class="eui-textTruncate"
+        >
+          2
+        </span>
         <span
           class="euiComboBoxPill__append"
         >
@@ -504,7 +512,11 @@ exports[`props option.prepend & option.append renders in single selection 1`] = 
       Pre
     </span>
   </span>
-  1
+  <span
+    class="eui-textTruncate"
+  >
+    1
+  </span>
 </span>
 `;
 

--- a/src/components/combo_box/combo_box_input/_combo_box_pill.scss
+++ b/src/components/combo_box/combo_box_input/_combo_box_pill.scss
@@ -24,7 +24,6 @@
 
   &--plainText {
     @include euiFont;
-    @include euiTextTruncate;
 
     line-height: $euiSizeL;
     font-size: $euiFontSizeS;

--- a/src/components/combo_box/combo_box_input/combo_box_pill.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_pill.tsx
@@ -71,7 +71,10 @@ export class EuiComboBoxPill<T> extends Component<EuiComboBoxPillProps<T>> {
         {option.prepend && (
           <span className="euiComboBoxPill__prepend">{option.prepend}</span>
         )}
-        {children}
+        {/* .euiBadge__text normally text truncates, but because we set it to flex to align prepend/append
+          it breaks and we need to restore it manually
+         */}
+        <span className="eui-textTruncate">{children}</span>
         {option.append && (
           <span className="euiComboBoxPill__append">{option.append}</span>
         )}

--- a/upcoming_changelogs/7193.md
+++ b/upcoming_changelogs/7193.md
@@ -1,0 +1,5 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` to correctly truncate selected items when displayed as pills and plain text
+
+


### PR DESCRIPTION
Closes #7173 

## Summary
This PR fixes the truncation for selected `EuiComboBox` items in two parts:
1. Truncation added for combo boxes that have `singleSelection: {{ asPlainText: true }}`
2. Truncation restored for all combo box pills when the length of the text exceeds with width of the pill

## QA

1. View the basic combo box demo (https://eui.elastic.co/pr_7193/#/forms/combo-box) and add the option beginning with `Pandora` to your selected options. This pill should truncate.
2. View the single selection demo (https://eui.elastic.co/pr_7193/#/forms/combo-box#single-selection) and add the option beginning with `Pandora`. This plain text should truncate.

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [ ] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
    - [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
