### PR TITLE
[EuiImage] Allow hover on full screen

### DIFF
--- a/i18ntokens.json
+++ b/i18ntokens.json
@@ -7007,14 +7007,14 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 126,
+        "line": 129,
         "column": 12,
-        "index": 3723
+        "index": 3829
       },
       "end": {
-        "line": 129,
+        "line": 132,
         "column": 14,
-        "index": 3854
+        "index": 3960
       }
     },
     "filepath": "src/components/table/table_pagination/table_pagination.tsx"
@@ -7025,14 +7025,14 @@
     "highlighting": "string",
     "loc": {
       "start": {
-        "line": 131,
+        "line": 134,
         "column": 12,
-        "index": 3883
+        "index": 3989
       },
       "end": {
-        "line": 135,
+        "line": 138,
         "column": 14,
-        "index": 4067
+        "index": 4173
       }
     },
     "filepath": "src/components/table/table_pagination/table_pagination.tsx"

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -145,8 +145,8 @@ export const ImageExample = {
       ],
       text: (
         <p>
-          Apply the <EuiCode>allowFullScreenOnHover</EuiCode> prop to make the image
-          Hover-able and show a fullscreen version.
+          Apply the <EuiCode>allowFullScreenOnHover</EuiCode> prop to make the image Hover-able and show a fullscreen
+          version.
         </p>
       ),
       demo: <ImageZoomOnHover />,

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -38,6 +38,15 @@ const imageZoomSnippet = `<EuiImage
 />
 `;
 
+import ImageZoomOnHover from './image_zoom_on_hover';
+const imageZoomOnHoverSource = require('!!raw-loader!./image_zoom_on_hover');
+const imageZoomOnHoverSnippet = `<EuiImage
+  allowFullScreenOnHover
+  alt={alt}
+  src={src}
+/>
+`;
+
 import ImageSvg from './image_svg';
 const imageSvgSource = require('!!raw-loader!./image_svg');
 const imageSvgSnippet = `<EuiImage
@@ -125,6 +134,23 @@ export const ImageExample = {
       ),
       demo: <ImageZoom />,
       snippet: imageZoomSnippet,
+    },
+    {
+      title: 'Hover an image for a fullscreen version',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: imageZoomOnHoverSource,
+        },
+      ],
+      text: (
+        <p>
+          Apply the <EuiCode>allowFullScreenOnHover</EuiCode> prop to make the image
+          Hover-able and show a fullscreen version.
+        </p>
+      ),
+      demo: <ImageZoomOnHover  />,
+      snippet: imageZoomOnHoverSnippet,
     },
     {
       title: 'Images can be sized',

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -145,8 +145,8 @@ export const ImageExample = {
       ],
       text: (
         <p>
-          Apply the <EuiCode>allowFullScreenOnHover</EuiCode> prop to make the image Hover-able and show a fullscreen
-          version.
+          Apply the <EuiCode>allowFullScreenOnHover</EuiCode> prop to make the
+          image Hover-able and show a fullscreen version.
         </p>
       ),
       demo: <ImageZoomOnHover />,

--- a/src-docs/src/views/image/image_example.js
+++ b/src-docs/src/views/image/image_example.js
@@ -149,7 +149,7 @@ export const ImageExample = {
           Hover-able and show a fullscreen version.
         </p>
       ),
-      demo: <ImageZoomOnHover  />,
+      demo: <ImageZoomOnHover />,
       snippet: imageZoomOnHoverSnippet,
     },
     {

--- a/src-docs/src/views/image/image_zoom_on_hover.tsx
+++ b/src-docs/src/views/image/image_zoom_on_hover.tsx
@@ -37,7 +37,7 @@ export default () => (
         src="https://upload.wikimedia.org/wikipedia/commons/a/a2/Wikimedia_browser_share_pie_chart.png"
         fullScreenIconColor="dark"
         size={300}
-        style={{padding: '20px 30px', background: 'white'}}
+        style={ {padding: '20px 30px', background: 'white'} }
       />
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/image/image_zoom_on_hover.tsx
+++ b/src-docs/src/views/image/image_zoom_on_hover.tsx
@@ -37,7 +37,7 @@ export default () => (
         src="https://upload.wikimedia.org/wikipedia/commons/a/a2/Wikimedia_browser_share_pie_chart.png"
         fullScreenIconColor="dark"
         size={300}
-        style={ {padding: '20px 30px', background: 'white'} }
+        style={{ padding: '20px 30px', background: 'white' }}
       />
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/src-docs/src/views/image/image_zoom_on_hover.tsx
+++ b/src-docs/src/views/image/image_zoom_on_hover.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import {
+  EuiImage,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiFlexGroup justifyContent="spaceEvenly">
+    <EuiFlexItem grow={false}>
+      <EuiImage
+        size="m"
+        hasShadow
+        allowFullScreenOnHover
+        caption="Albert Einstein, theoretical physicist"
+        alt="" // Because this image is sufficiently described by its caption, there is no need to repeat it via alt text
+        src="https://upload.wikimedia.org/wikipedia/commons/d/d3/Albert_Einstein_Head.jpg"
+      />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiImage
+        allowFullScreenOnHover
+        caption={
+          <>
+            Browser usage on{' '}
+            <EuiLink
+              href="https://commons.wikimedia.org/wiki/File:Wikimedia_browser_share_pie_chart.png"
+              target="_blank"
+            >
+              Wikimedia (CC BY 3.0)
+            </EuiLink>
+          </>
+        }
+        alt="Pie chart describing browser usage on Wikimedia on October 2011. Internet Explorer occupies 34 percent, Firefox occupies 23 percent, Chrome occupies 20 percent, Safari occupies 11 percent, Opera occupies 5%, Android occupies 1.9 percent, and other browsers occupy 3.5 percent."
+        src="https://upload.wikimedia.org/wikipedia/commons/a/a2/Wikimedia_browser_share_pie_chart.png"
+        fullScreenIconColor="dark"
+        size={300}
+        style={{padding: '20px 30px', background: 'white'}}
+      />
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -17,6 +17,7 @@ import { EuiImageFullScreenWrapper } from './image_fullscreen_wrapper';
 import type { EuiImageProps, EuiImageSize } from './image_types';
 
 import { SIZES } from './image_types';
+import { EuiPopover } from '../popover';
 
 export const EuiImage: FunctionComponent<EuiImageProps> = ({
   className,
@@ -33,9 +34,11 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
   float,
   margin,
   onFullScreen,
+  allowFullScreenOnHover,
   ...rest
 }) => {
   const [isFullScreen, setIsFullScreen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
 
   const isNamedSize =
     typeof size === 'string' && SIZES.includes(size as EuiImageSize);
@@ -79,6 +82,8 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
     float,
     margin,
     onFullScreen,
+    allowFullScreenOnHover,
+    setIsHovered,
   };
 
   const commonImgProps = {
@@ -87,17 +92,20 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
     ...rest,
   };
 
+  const buttonNode = (
+    <EuiImageWrapper {...commonWrapperProps}>
+      <img
+        alt={alt}
+        css={cssStyles}
+        style={imageStyleWithCustomSize}
+        {...commonImgProps}
+      />
+    </EuiImageWrapper>
+  );
+
   return (
     <>
-      <EuiImageWrapper {...commonWrapperProps}>
-        <img
-          alt={alt}
-          css={cssStyles}
-          style={imageStyleWithCustomSize}
-          {...commonImgProps}
-        />
-      </EuiImageWrapper>
-
+      {!allowFullScreenOnHover && buttonNode}
       {allowFullScreen && isFullScreen && (
         <EuiImageFullScreenWrapper {...commonWrapperProps}>
           <img
@@ -107,6 +115,22 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
             {...commonImgProps}
           />
         </EuiImageFullScreenWrapper>
+      )}
+
+      {allowFullScreenOnHover && (
+        <EuiPopover
+          data-test-subj="imagePopver"
+          isOpen={isHovered}
+          button={buttonNode}
+          closePopover={() => setIsHovered(false)}
+        >
+          <img
+            alt={alt}
+            css={cssIsFullScreenStyles}
+            style={style}
+            {...commonImgProps}
+          />
+        </EuiPopover>
       )}
     </>
   );

--- a/src/components/image/image_types.ts
+++ b/src/components/image/image_types.ts
@@ -88,6 +88,12 @@ export type EuiImageProps = CommonProps &
      * Props to add to the wrapping figure element
      */
     wrapperProps?: CommonProps & HTMLAttributes<HTMLDivElement>;
+
+    /**
+     * When set to `true` will show a preview of the image when hovered.
+     */
+
+    allowFullScreenOnHover?: boolean;
   };
 
 export type EuiImageWrapperProps = PropsWithChildren &
@@ -105,6 +111,8 @@ export type EuiImageWrapperProps = PropsWithChildren &
   > & {
     isFullWidth: boolean;
     setIsFullScreen: (isFullScreen: boolean) => void;
+    setIsHovered: (isFullScreen: boolean) => void;
+    allowFullScreenOnHover?: boolean;
   };
 
 export type EuiImageButtonProps = PropsWithChildren &
@@ -114,6 +122,8 @@ export type EuiImageButtonProps = PropsWithChildren &
     onKeyDown?: (e: React.KeyboardEvent) => void;
     isFullWidth: boolean;
     isFullScreen?: boolean;
+    onMouseEnter?: () => void;
+    onMouseLeave?: () => void;
   };
 
 export type EuiImageCaptionProps = Pick<EuiImageProps, 'caption'> & {

--- a/src/components/image/image_wrapper.tsx
+++ b/src/components/image/image_wrapper.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import classNames from 'classnames';
 
 import { useEuiTheme } from '../../services';
@@ -31,6 +31,8 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
   fullScreenIconColor,
   isFullWidth,
   onFullScreen,
+  allowFullScreenOnHover,
+  setIsHovered,
 }) => {
   const openFullScreen = () => {
     setIsFullScreen(true);
@@ -49,12 +51,27 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
     styles.euiImageWrapper,
     float && styles[float],
     margin && styles[margin],
-    allowFullScreen && styles.allowFullScreen,
+    (allowFullScreen || allowFullScreenOnHover) && styles.allowFullScreen,
     isFullWidth && styles.fullWidth,
     wrapperProps?.css,
   ];
 
   const [optionalCaptionRef, optionalCaptionText] = useInnerText();
+
+  const onMouseEnter = useCallback(() => {
+    setIsHovered(true);
+  }, [setIsHovered]);
+
+  const onMouseLeave = useCallback(() => {
+    setIsHovered(false);
+  }, [setIsHovered]);
+
+  const hoverProps = allowFullScreenOnHover
+    ? {
+        onMouseEnter,
+        onMouseLeave,
+      }
+    : {};
 
   return (
     <figure
@@ -63,7 +80,7 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
       className={classes}
       css={cssFigureStyles}
     >
-      {allowFullScreen ? (
+      {allowFullScreen || allowFullScreenOnHover ? (
         <>
           <EuiImageButton
             hasAlt={!!alt}
@@ -72,6 +89,7 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
             data-test-subj="activateFullScreenButton"
             isFullWidth={isFullWidth}
             fullScreenIconColor={fullScreenIconColor}
+            {...hoverProps}
           >
             {children}
           </EuiImageButton>


### PR DESCRIPTION
## Summary

Added a new prop `allowFullScreenOnHover` which will show fullscreen version onHover. We are adding a popover in few places in kibana to show fullscreen on thumbnail on hover.

<img width="1722" alt="image" src="https://github.com/elastic/eui/assets/3505601/c38f10d7-a03f-4082-bf44-227a337aa84c">

## QA

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
