### PR TITLE
[INFRA] Parallelize the Buildkite `test` job on PR

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -3,7 +3,11 @@
 steps:
   - agents:
       provider: "gcp"
-    command: .buildkite/scripts/pipeline_test.sh
+  - command: .buildkite/scripts/pipeline_test.sh
+    env:
+      TEST_TYPE: 'lint'
     if: build.branch != "main" # We're skipping testing commits in main for now to maintain parity with previous Jenkins setup
-    artifact_paths:
-      - "cypress/screenshots/**/*.png"
+  - command: .buildkite/scripts/pipeline_test.sh
+    env:
+      TEST_TYPE: 'unit'
+    if: build.branch != "main" # We're skipping testing commits in main for now to maintain parity with previous Jenkins setup

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -2,15 +2,35 @@
 
 set -euo pipefail
 
-docker run \
-  -i --rm \
-  --env GIT_COMMITTER_NAME=test \
-  --env GIT_COMMITTER_EMAIL=test \
-  --env HOME=/tmp \
-  --user="$(id -u):$(id -g)" \
-  --volume="$(pwd):/app" \
-  --workdir=/app \
-  docker.elastic.co/eui/ci:5.3 \
-  bash -c "/opt/yarn*/bin/yarn \
-  && yarn cypress install \
-  && NODE_OPTIONS=\"--max-old-space-size=2048\" npm run test-ci"
+TEST_TYPE='unit'
+
+DOCKER_OPTIONS=(
+  -i --rm
+  --env GIT_COMMITTER_NAME=test
+  --env GIT_COMMITTER_EMAIL=test
+  --env HOME=/tmp
+  --user="$(id -u):$(id -g)"
+  --volume="$(pwd):/app"
+  --workdir=/app
+  docker.elastic.co/eui/ci:5.3
+  bash -c "/opt/yarn*/bin/yarn"
+)
+
+if [[ "${TEST_TYPE}" == 'lint' ]]; then
+  echo "[TASK]: Running linters"
+  DOCKER_OPTIONS+=("NODE_OPTIONS=\"--max-old-space-size=2048\" yarn lint")
+elif [[ "${TEST_TYPE}" == 'unit' ]]; then
+  echo "[TASK]: Running unit tests"
+  DOCKER_OPTIONS+=("NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-unit")
+elif [[ "${TEST_TYPE}" == 'cypress:16' ]]; then
+  echo "[TASK]: Running Cypress tests against React 16"
+  DOCKER_OPTIONS+=("yarn cypress install" "NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-cypress --react-version 16")
+elif [[ "${TEST_TYPE}" == 'cypress:17' ]]; then
+  echo "[TASK]: Running Cypress tests against React 17"
+  DOCKER_OPTIONS+=("yarn cypress install" "NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-cypress --react-version 17")
+elif [[ "${TEST_TYPE}" == 'cypress:18' ]]; then
+  echo "[TASK]: Running Cypress tests against React 18"
+  DOCKER_OPTIONS+=("yarn cypress install" "NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-cypress --react-version 18")
+fi
+
+docker run "${DOCKER_OPTIONS[@]}"


### PR DESCRIPTION
## Summary

This job will update our Buildkite `test` to parallelize linting, unit testing, and Cypress e2e testing against React `[16, 17, 18]`.

## QA

QA will be done manually by verifying the test runs on Buildkite UI.