### PR TITLE
[EuiFieldNumber] Improve `step` validation 

### DIFF
--- a/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
@@ -1,14 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiFieldNumber is rendered 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="false"
-  icon="warning"
-  inputid="1"
-  isloading="false"
+<div
+  class="euiFormControlLayout"
 >
-  <eui-validatable-control>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
+    <div
+      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+    >
+      <span
+        class="euiFormControlLayoutCustomIcon"
+      >
+        <span
+          aria-hidden="true"
+          class="euiFormControlLayoutCustomIcon__icon"
+          data-euiicon-type="warning"
+        />
+      </span>
+    </div>
     <input
       aria-label="aria-label"
       class="euiFieldNumber testClass1 testClass2 emotion-euiTestCss euiFieldNumber--withIcon"
@@ -21,47 +32,42 @@ exports[`EuiFieldNumber is rendered 1`] = `
       type="number"
       value="1"
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+  </div>
+</div>
 `;
 
 exports[`EuiFieldNumber props controlOnly is rendered 1`] = `
-<eui-validatable-control>
-  <input
-    class="euiFieldNumber"
-    step="any"
-    type="number"
-    value=""
-  />
-</eui-validatable-control>
+<input
+  class="euiFieldNumber"
+  step="any"
+  type="number"
+  value=""
+/>
 `;
 
 exports[`EuiFieldNumber props fullWidth is rendered 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="true"
-  isloading="false"
+<div
+  class="euiFormControlLayout euiFormControlLayout--fullWidth"
 >
-  <eui-validatable-control>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
     <input
       class="euiFieldNumber euiFieldNumber--fullWidth"
       step="any"
       type="number"
       value=""
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+  </div>
+</div>
 `;
 
 exports[`EuiFieldNumber props isInvalid is rendered from a prop 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="false"
-  isinvalid="true"
-  isloading="false"
+<div
+  class="euiFormControlLayout"
 >
-  <eui-validatable-control
-    isinvalid="true"
+  <div
+    class="euiFormControlLayout__childrenWrapper"
   >
     <input
       aria-invalid="true"
@@ -70,35 +76,51 @@ exports[`EuiFieldNumber props isInvalid is rendered from a prop 1`] = `
       type="number"
       value=""
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+    <div
+      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+    >
+      <span
+        color="danger"
+        data-euiicon-type="warning"
+      />
+    </div>
+  </div>
+</div>
 `;
 
 exports[`EuiFieldNumber props isLoading is rendered 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="false"
-  isloading="true"
+<div
+  class="euiFormControlLayout"
 >
-  <eui-validatable-control>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
     <input
       class="euiFieldNumber euiFormControlLayout--1icons euiFieldNumber-isLoading"
       step="any"
       type="number"
       value=""
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+    <div
+      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+    >
+      <span
+        aria-label="Loading"
+        class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
 `;
 
 exports[`EuiFieldNumber props readOnly is rendered 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="false"
-  isloading="false"
-  readonly="true"
+<div
+  class="euiFormControlLayout euiFormControlLayout--readOnly"
 >
-  <eui-validatable-control>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
     <input
       class="euiFieldNumber"
       readonly=""
@@ -106,40 +128,40 @@ exports[`EuiFieldNumber props readOnly is rendered 1`] = `
       type="number"
       value=""
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+  </div>
+</div>
 `;
 
 exports[`EuiFieldNumber props value no initial value 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="false"
-  isloading="false"
+<div
+  class="euiFormControlLayout"
 >
-  <eui-validatable-control>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
     <input
       class="euiFieldNumber"
       step="any"
       type="number"
       value=""
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+  </div>
+</div>
 `;
 
 exports[`EuiFieldNumber props value value is number 1`] = `
-<eui-form-control-layout
-  compressed="false"
-  fullwidth="false"
-  isloading="false"
+<div
+  class="euiFormControlLayout"
 >
-  <eui-validatable-control>
+  <div
+    class="euiFormControlLayout__childrenWrapper"
+  >
     <input
       class="euiFieldNumber"
       step="any"
       type="number"
       value="0"
     />
-  </eui-validatable-control>
-</eui-form-control-layout>
+  </div>
+</div>
 `;

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -14,16 +14,16 @@ import React from 'react';
 import { EuiFieldNumber } from './field_number';
 
 describe('EuiFieldNumber', () => {
-  describe('isNativelyInvalid', () => {
-    const checkIsValid = () => {
-      cy.get('[aria-invalid="true"]').should('not.exist');
-      cy.get('.euiFormControlLayoutIcons').should('not.exist');
-    };
-    const checkIsInvalid = () => {
-      cy.get('[aria-invalid="true"]').should('exist');
-      cy.get('.euiFormControlLayoutIcons').should('exist');
-    };
+  const checkIsValid = () => {
+    cy.get('[aria-invalid="true"]').should('not.exist');
+    cy.get('.euiFormControlLayoutIcons').should('not.exist');
+  };
+  const checkIsInvalid = () => {
+    cy.get('[aria-invalid="true"]').should('exist');
+    cy.get('.euiFormControlLayoutIcons').should('exist');
+  };
 
+  describe('isNativelyInvalid', () => {
     it('when the value is not a valid number', () => {
       cy.mount(<EuiFieldNumber />);
       checkIsValid();
@@ -45,13 +45,6 @@ describe('EuiFieldNumber', () => {
       checkIsInvalid();
     });
 
-    it('sets invalid state when the value is not a valid step', () => {
-      cy.mount(<EuiFieldNumber step={3} />);
-      checkIsValid();
-      cy.get('input').click().type('2');
-      checkIsInvalid();
-    });
-
     it('shows invalid state on blur', () => {
       cy.mount(<EuiFieldNumber max={1} value={2} />);
       checkIsValid();
@@ -59,11 +52,30 @@ describe('EuiFieldNumber', () => {
       cy.get('body').click('bottomRight');
       checkIsInvalid();
     });
+  });
 
+  describe('isStepInvalid', () => {
     it('does not show invalid state on decimal values by default', () => {
       cy.mount(<EuiFieldNumber />);
       checkIsValid();
       cy.get('input').click().type('1.5');
+      checkIsValid();
+    });
+
+    it('shows invalid state on user input', () => {
+      cy.mount(<EuiFieldNumber step={1} />);
+      checkIsValid();
+      cy.get('input').click().type('1.5');
+      cy.get('body').click('bottomRight');
+      checkIsInvalid();
+    });
+
+    it('restores valid state when step is corrected', () => {
+      cy.mount(<EuiFieldNumber step={3} />);
+      checkIsValid();
+      cy.get('input').click().type('2');
+      checkIsInvalid();
+      cy.realType('{backspace}3');
       checkIsValid();
     });
   });

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -88,5 +88,42 @@ describe('EuiFieldNumber', () => {
       cy.realType('{backspace}3');
       checkIsValid();
     });
+
+    describe('invalid step/values on mount', () => {
+      beforeEach(() => {
+        cy.window().then((win) => {
+          cy.wrap(cy.spy(win.console, 'warn')).as('spyConsoleWarn');
+        });
+      });
+
+      it('warns and does not validate step if an invalid step/value combo is passed', () => {
+        cy.mount(<EuiFieldNumber step={10} value={5} />);
+        checkIsValid();
+        cy.get('@spyConsoleWarn').should(
+          'be.calledOnceWith',
+          'Disabling step validity checking. The passed `step` value does not match the initial component value.'
+        );
+      });
+
+      it('warns and does not validate step if an invalid step/defaultValue combo is passed', () => {
+        cy.mount(<EuiFieldNumber step={3} defaultValue={4} />);
+        checkIsValid();
+
+        // Default browser behavior: browsers will automatically adjust the valid internal `step` value
+        cy.get('input').click().type('{backspace}2');
+        checkIsInvalid();
+        checkHasInvalidMessage(
+          'Please enter a valid value. The two nearest valid values are 1 and 4.'
+        );
+        cy.get('input').click().type('{backspace}7');
+        checkIsValid();
+
+        // Console warn should only have been called once on mount
+        cy.get('@spyConsoleWarn').should(
+          'be.calledOnceWith',
+          'Disabling step validity checking. The passed `step` value does not match the initial component value.'
+        );
+      });
+    });
   });
 });

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -55,6 +55,13 @@ describe('EuiFieldNumber', () => {
   });
 
   describe('isStepInvalid', () => {
+    const checkHasInvalidMessage = (message: string) => {
+      cy.get('input[type="number"]').should(($el) => {
+        const inputEl = $el[0] as HTMLInputElement;
+        expect(inputEl.validationMessage).to.equal(message);
+      });
+    };
+
     it('does not show invalid state on decimal values by default', () => {
       cy.mount(<EuiFieldNumber />);
       checkIsValid();
@@ -68,6 +75,9 @@ describe('EuiFieldNumber', () => {
       cy.get('input').click().type('1.5');
       cy.get('body').click('bottomRight');
       checkIsInvalid();
+      checkHasInvalidMessage(
+        'Please enter a valid value. The two nearest valid values are 1 and 2.'
+      );
     });
 
     it('restores valid state when step is corrected', () => {

--- a/src/components/form/field_number/field_number.test.tsx
+++ b/src/components/form/field_number/field_number.test.tsx
@@ -13,17 +13,6 @@ import { requiredProps } from '../../../test/required_props';
 import { EuiForm } from '../form';
 import { EuiFieldNumber } from './field_number';
 
-jest.mock('../form_control_layout', () => {
-  const formControlLayout = jest.requireActual('../form_control_layout');
-  return {
-    ...formControlLayout,
-    EuiFormControlLayout: 'eui-form-control-layout',
-  };
-});
-jest.mock('../validatable_control', () => ({
-  EuiValidatableControl: 'eui-validatable-control',
-}));
-
 describe('EuiFieldNumber', () => {
   test('is rendered', () => {
     const { container } = render(

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -112,7 +112,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   // Attempt to determine additional invalid state. The native number input
   // will set :invalid state automatically, but we need to also set
   // `aria-invalid` as well as display an icon. We also want to *not* set this on
-  // EuiValidatableControl, in order to not override custom validity messages
+  // EuiValidatableControl, otherwise native invalidity never gets cleared
   const [isNativelyInvalid, setIsNativelyInvalid] = useState(false);
 
   const checkNativeValidity = useCallback((inputEl: HTMLInputElement) => {
@@ -155,7 +155,13 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   });
 
   const control = (
-    <EuiValidatableControl isInvalid={isInvalidFromProps || isStepInvalid}>
+    <EuiValidatableControl
+      // Already handles native validity and should not be passed `isNativelyInvalid`
+      isInvalid={isInvalidFromProps || isStepInvalid}
+      invalidMessage={
+        isStepInvalid || isNativelyInvalid ? 'browser' : undefined
+      }
+    >
       <input
         type="number"
         id={id}

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -94,7 +94,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     max,
     step = 'any',
     value,
-    isInvalid,
+    isInvalid: isInvalidFromProps,
     fullWidth = defaultFullWidth,
     isLoading = false,
     compressed = false,
@@ -113,14 +113,10 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   // will set :invalid state automatically, but we need to also set
   // `aria-invalid` as well as display an icon. We also want to *not* set this on
   // EuiValidatableControl, in order to not override custom validity messages
-  const [isNativelyInvalid, setIsNativelyInvalid] = useState<
-    true | undefined
-  >();
+  const [isNativelyInvalid, setIsNativelyInvalid] = useState(false);
 
   const checkNativeValidity = useCallback((inputEl: HTMLInputElement) => {
-    // Prefer `undefined` over `false` so that the `aria-invalid` prop unsets completely
-    const isInvalid = !inputEl.validity.valid || undefined;
-    setIsNativelyInvalid(isInvalid);
+    setIsNativelyInvalid(!inputEl.validity.valid);
   }, []);
 
   // Unfortunately, the native number input handles `step` validity incredibly unintuitively
@@ -137,10 +133,16 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     [step, hasValidStep]
   );
 
+  const isInvalid = !!(
+    isInvalidFromProps ||
+    isStepInvalid ||
+    isNativelyInvalid
+  );
+
   const numIconsClass = controlOnly
     ? false
     : getFormControlClassNameForIconCount({
-        isInvalid: isInvalid || isStepInvalid || isNativelyInvalid,
+        isInvalid,
         isLoading,
       });
 
@@ -153,7 +155,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   });
 
   const control = (
-    <EuiValidatableControl isInvalid={isInvalid || isStepInvalid}>
+    <EuiValidatableControl isInvalid={isInvalidFromProps || isStepInvalid}>
       <input
         type="number"
         id={id}
@@ -166,7 +168,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
         readOnly={readOnly}
         className={classes}
         ref={inputRef}
-        aria-invalid={isInvalid || isStepInvalid || isNativelyInvalid}
+        aria-invalid={isInvalid || undefined} // Unset the prop completely if valid
         onChange={(e) => {
           onChange?.(e);
           checkStepValidity(Number(e.currentTarget.value));
@@ -196,7 +198,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
       icon={icon}
       fullWidth={fullWidth}
       isLoading={isLoading}
-      isInvalid={isInvalid || isStepInvalid || isNativelyInvalid}
+      isInvalid={isInvalid}
       compressed={compressed}
       readOnly={readOnly}
       prepend={prepend}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7180

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7202/commits) as this PR contains some incidental cleanup.

## QA

- Go to https://eui.elastic.co/pr_7202/#/forms/form-controls#number-field
- Open the Playground flyout (bottom right hand corner of the demo)
- Set the `step` input to any number
- Type a value into the playground demo that is not divisible by the step
- [ ] Confirm that an error icon shows up, and does not go away when clicking outside the input ([unlike production](https://eui.elastic.co/#/forms/form-controls#number-field))
- [ ] Hover over the error icon/input and confirm that you see a meaningful error message in the input tooltip
    <img width="741" alt="" src="https://github.com/elastic/eui/assets/549407/189f5c6b-9ec7-4e1b-9eb8-fe2ec1342138">
- Type a new value into the demo that is divisible by the step
- [ ] Confirm the error icon is removed
- On a Webkit browser, go to the playground and set the step to `1`
- [ ] Type in `5.99999999999` into the input and confirm the error icon still remains

### General checklist

- Browser QA
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    -  Skipped all docs steps, as the prop docs for `step` feels sufficient/accurate to the new behavior - LMK if you'd rather see more docs
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.