### PR TITLE
Revert parallelize the Buildkite `test` job

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -1,44 +1,9 @@
 # 🏠/.buildkite/pipelines/pipeline_pull_request_test.yml
 
 steps:
-  - command: .buildkite/scripts/pipeline_test.sh
-    label: ":typescript: Linting"
-    agents:
+  - agents:
       provider: "gcp"
-    env:
-      TEST_TYPE: 'lint'
-    if: build.branch != "main" # This job is triggered by the combined test and deploy docs for every PR
-  - command: .buildkite/scripts/pipeline_test.sh
-    label: ":jest: Unit tests"
-    agents:
-      provider: "gcp"
-    env:
-      TEST_TYPE: 'unit'
-    if: build.branch != "main"
-  - command: .buildkite/scripts/pipeline_test.sh
-    label: ":cypress: Cypress tests on React 16"
-    agents:
-      provider: "gcp"
-    env:
-      TEST_TYPE: 'cypress:16'
-    if: build.branch != "main"
+    command: .buildkite/scripts/pipeline_test.sh
+    if: build.branch != "main" # We're skipping testing commits in main for now to maintain parity with previous Jenkins setup
     artifact_paths:
-      - "cypress/react16/screenshots/**/*.png"
-  - command: .buildkite/scripts/pipeline_test.sh
-    label: ":cypress: Cypress tests on React 17"
-    agents:
-      provider: "gcp"
-    env:
-      TEST_TYPE: 'cypress:17'
-    if: build.branch != "main"
-    artifact_paths:
-      - "cypress/react17/screenshots/**/*.png"
-  - command: .buildkite/scripts/pipeline_test.sh
-    label: ":cypress: Cypress tests on React 18"
-    agents:
-      provider: "gcp"
-    env:
-      TEST_TYPE: 'cypress:18'
-    if: build.branch != "main"
-    artifact_paths:
-      - "cypress/react18/screenshots/**/*.png"
+      - "cypress/screenshots/**/*.png"

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -2,48 +2,15 @@
 
 set -euo pipefail
 
-DOCKER_OPTIONS=(
-  -i --rm
-  --env GIT_COMMITTER_NAME=test
-  --env GIT_COMMITTER_EMAIL=test
-  --env HOME=/tmp
-  --user="$(id -u):$(id -g)"
-  --volume="$(pwd):/app"
-  --workdir=/app
-  docker.elastic.co/eui/ci:5.3
-)
-
-case $TEST_TYPE in
-  lint)
-    echo "[TASK]: Running linters"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && NODE_OPTIONS=\"--max-old-space-size=2048\" yarn lint")
-    ;;
-
-  unit)
-    echo "[TASK]: Running unit tests"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-unit")
-    ;;
-
-  cypress:16)
-    echo "[TASK]: Running Cypress tests against React 16"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-cypress --react-version 16")
-    ;;
-
-  cypress:17)
-    echo "[TASK]: Running Cypress tests against React 17"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-cypress --react-version 17")
-    ;;
-
-  cypress:18)
-    echo "[TASK]: Running Cypress tests against React 18"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && NODE_OPTIONS=\"--max-old-space-size=2048\" yarn test-cypress")
-    ;;
-
-  *)
-    echo "[ERROR]: Unknown task"
-    echo "Exit code: 1"
-    exit 1
-    ;;
-esac
-
-docker run "${DOCKER_OPTIONS[@]}"
+docker run \
+  -i --rm \
+  --env GIT_COMMITTER_NAME=test \
+  --env GIT_COMMITTER_EMAIL=test \
+  --env HOME=/tmp \
+  --user="$(id -u):$(id -g)" \
+  --volume="$(pwd):/app" \
+  --workdir=/app \
+  docker.elastic.co/eui/ci:5.3 \
+  bash -c "/opt/yarn*/bin/yarn \
+  && yarn cypress install \
+  && NODE_OPTIONS=\"--max-old-space-size=2048\" npm run test-ci"


### PR DESCRIPTION
## Description
Reverts elastic/eui#7197

## Issue
This PR broke out individual test commands and used `yarn` to call them in Buildkite where we'd previously used `npm`. This created an issue for the Cypress tests, so I'll rework the original PR.