### PR TITLE
[EuiComboBox] Fixes/reversions for Kibana FTR

### DIFF
--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -547,6 +547,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
           id="generated-id__option-0"
           role="option"
           style="position: absolute; left: 0px; top: 0px; height: 29px; width: 100%;"
+          title="1"
           type="button"
         >
           <span
@@ -597,6 +598,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
           id="generated-id__option-1"
           role="option"
           style="position: absolute; left: 0px; top: 29px; height: 29px; width: 100%;"
+          title="2"
           type="button"
         >
           <span
@@ -729,6 +731,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-0"
             role="option"
             style="position: absolute; left: 0px; top: 0px; height: 29px; width: 100%;"
+            title="Titan"
             type="button"
           >
             <span
@@ -770,6 +773,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-1"
             role="option"
             style="position: absolute; left: 0px; top: 29px; height: 29px; width: 100%;"
+            title="Enceladus"
             type="button"
           >
             <span
@@ -811,6 +815,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-2"
             role="option"
             style="position: absolute; left: 0px; top: 58px; height: 29px; width: 100%;"
+            title="Mimas"
             type="button"
           >
             <span
@@ -852,6 +857,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-3"
             role="option"
             style="position: absolute; left: 0px; top: 87px; height: 29px; width: 100%;"
+            title="Dione"
             type="button"
           >
             <span
@@ -893,6 +899,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-4"
             role="option"
             style="position: absolute; left: 0px; top: 116px; height: 29px; width: 100%;"
+            title="Iapetus"
             type="button"
           >
             <span
@@ -934,6 +941,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-5"
             role="option"
             style="position: absolute; left: 0px; top: 145px; height: 29px; width: 100%;"
+            title="Phoebe"
             type="button"
           >
             <span
@@ -975,6 +983,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-6"
             role="option"
             style="position: absolute; left: 0px; top: 174px; height: 29px; width: 100%;"
+            title="Rhea"
             type="button"
           >
             <span
@@ -1016,6 +1025,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-7"
             role="option"
             style="position: absolute; left: 0px; top: 203px; height: 29px; width: 100%;"
+            title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
             type="button"
           >
             <span
@@ -1057,6 +1067,7 @@ exports[`props options list is rendered 1`] = `
             id="generated-id__option-8"
             role="option"
             style="position: absolute; left: 0px; top: 232px; height: 29px; width: 100%;"
+            title="Tethys"
             type="button"
           >
             <span

--- a/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -571,22 +571,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
                 <span
                   class="euiComboBoxOption__content"
                 >
-                  <div
-                    class="emotion-euiTextTruncate"
-                    title="1"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="css-1dore6v-truncatedText"
-                      data-test-subj="truncatedText"
-                    />
-                    <span
-                      class="css-1kxt4rj-fullText"
-                      data-test-subj="fullText"
-                    >
-                      1
-                    </span>
-                  </div>
+                  1
                 </span>
               </span>
             </span>
@@ -613,22 +598,7 @@ exports[`props option.prepend & option.append renders in the options dropdown 1`
                 <span
                   class="euiComboBoxOption__content"
                 >
-                  <div
-                    class="emotion-euiTextTruncate"
-                    title="2"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="css-1dore6v-truncatedText"
-                      data-test-subj="truncatedText"
-                    />
-                    <span
-                      class="css-1kxt4rj-fullText"
-                      data-test-subj="fullText"
-                    >
-                      2
-                    </span>
-                  </div>
+                  2
                 </span>
                 <span
                   class="euiComboBoxOption__append"
@@ -746,22 +716,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Titan"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Titan
-                      </span>
-                    </div>
+                    Titan
                   </span>
                 </span>
               </span>
@@ -788,22 +743,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Enceladus"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Enceladus
-                      </span>
-                    </div>
+                    Enceladus
                   </span>
                 </span>
               </span>
@@ -830,22 +770,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Mimas"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Mimas
-                      </span>
-                    </div>
+                    Mimas
                   </span>
                 </span>
               </span>
@@ -872,22 +797,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Dione"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Dione
-                      </span>
-                    </div>
+                    Dione
                   </span>
                 </span>
               </span>
@@ -914,22 +824,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Iapetus"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Iapetus
-                      </span>
-                    </div>
+                    Iapetus
                   </span>
                 </span>
               </span>
@@ -956,22 +851,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Phoebe"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Phoebe
-                      </span>
-                    </div>
+                    Phoebe
                   </span>
                 </span>
               </span>
@@ -998,22 +878,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Rhea"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Rhea
-                      </span>
-                    </div>
+                    Rhea
                   </span>
                 </span>
               </span>
@@ -1040,22 +905,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Pandora is one of Saturn's moons, named for a Titaness of Greek mythology"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
-                      </span>
-                    </div>
+                    Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
                   </span>
                 </span>
               </span>
@@ -1082,22 +932,7 @@ exports[`props options list is rendered 1`] = `
                   <span
                     class="euiComboBoxOption__content"
                   >
-                    <div
-                      class="emotion-euiTextTruncate"
-                      title="Tethys"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="css-1dore6v-truncatedText"
-                        data-test-subj="truncatedText"
-                      />
-                      <span
-                        class="css-1kxt4rj-fullText"
-                        data-test-subj="fullText"
-                      >
-                        Tethys
-                      </span>
-                    </div>
+                    Tethys
                   </span>
                 </span>
               </span>

--- a/src/components/combo_box/combo_box.spec.tsx
+++ b/src/components/combo_box/combo_box.spec.tsx
@@ -58,16 +58,13 @@ describe('EuiComboBox', () => {
       ],
     };
 
-    it('defaults to end truncation', () => {
+    it('defaults to CSS truncation', () => {
       cy.realMount(<EuiComboBox {...sharedProps} />);
       cy.get('[data-test-subj="comboBoxInput"]').realClick();
-      cy.get('[data-test-subj="truncatedText"]').should(
-        'have.text',
-        'Lorem ipsum dolor sit a…'
-      );
+      cy.get('.euiTextTruncate').should('not.exist');
     });
 
-    it('allows customizing truncationProps', () => {
+    it('renders EuiTextTruncate when truncationProps are passed', () => {
       cy.realMount(
         <EuiComboBox
           {...sharedProps}
@@ -75,6 +72,7 @@ describe('EuiComboBox', () => {
         />
       );
       cy.get('[data-test-subj="comboBoxInput"]').realClick();
+      cy.get('.euiTextTruncate').should('exist');
       cy.get('[data-test-subj="truncatedText"]').should(
         'have.text',
         'Lorem ipsum …piscing elit.'

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -67,14 +67,19 @@ const options: TitanOption[] = [
 describe('EuiComboBox', () => {
   shouldRenderCustomStyles(<EuiComboBox />);
 
-  shouldRenderCustomStyles(<EuiComboBox options={[{ label: 'test' }]} />, {
-    skip: { parentTest: true },
-    childProps: ['truncationProps', 'options[0]'],
-    renderCallback: async ({ getByTestSubject, findAllByTestSubject }) => {
-      fireEvent.click(getByTestSubject('comboBoxToggleListButton'));
-      await findAllByTestSubject('truncatedText');
-    },
-  });
+  shouldRenderCustomStyles(
+    <EuiComboBox
+      options={[{ label: 'test', truncationProps: { truncation: 'middle' } }]}
+    />,
+    {
+      skip: { parentTest: true },
+      childProps: ['truncationProps', 'options[0]'],
+      renderCallback: async ({ getByTestSubject, findAllByTestSubject }) => {
+        fireEvent.click(getByTestSubject('comboBoxToggleListButton'));
+        await findAllByTestSubject('truncatedText');
+      },
+    }
+  );
 
   test('is rendered', () => {
     const { container } = render(<EuiComboBox {...requiredProps} />);

--- a/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
+++ b/src/components/combo_box/combo_box_options_list/_combo_box_options_list.scss
@@ -10,6 +10,14 @@
   .euiFilterSelectItem__content {
     margin-block: 0 !important; // stylelint-disable-line declaration-no-important
   }
+
+  /* Kibana FTR affordance - without this, Selenium complains about the overlaid
+     text intercepting the button click. Since `title` is always present, and
+     users can't highlight or copy combobox options anyway, we might as well
+     disable clicks on text */
+  .euiTextTruncate {
+    pointer-events: none;
+  }
 }
 
 .euiComboBoxOptionsList__empty {

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -233,11 +233,12 @@ export class EuiComboBoxOptionsList<T> extends Component<
       searchValue,
       rootId,
     } = this.props;
-    // Individual truncation settings should override component prop
-    const truncationProps = {
-      ...this.props.truncationProps,
-      ..._truncationProps,
-    };
+
+    const hasTruncationProps = this.props.truncationProps || _truncationProps;
+    const truncationProps = hasTruncationProps
+      ? // Individual truncation settings should override component prop
+        { ...this.props.truncationProps, ..._truncationProps }
+      : undefined;
 
     if (isGroupLabelOption) {
       return (
@@ -307,12 +308,18 @@ export class EuiComboBoxOptionsList<T> extends Component<
 
   renderTruncatedOption = (
     text: string,
-    truncationProps: EuiComboBoxOptionsListProps<T>['truncationProps']
+    truncationProps?: EuiComboBoxOptionsListProps<T>['truncationProps']
   ) => {
-    if (!this.props.searchValue) {
+    const searchValue = this.props.searchValue.trim();
+
+    if (!truncationProps && !searchValue) {
+      // Default to CSS text-overflow
+      return text;
+    }
+
+    if (!searchValue) {
       return (
         <EuiTextTruncate
-          truncation="end"
           width={this.optionWidth}
           onResize={this.setOptionWidth}
           {...truncationProps}
@@ -323,7 +330,6 @@ export class EuiComboBoxOptionsList<T> extends Component<
       );
     }
 
-    const searchValue = this.props.searchValue.trim();
     const searchPositionStart = this.props.isCaseSensitive
       ? text.indexOf(searchValue)
       : text.toLowerCase().indexOf(searchValue.toLowerCase());

--- a/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -275,6 +275,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
         checked={checked}
         showIcons={singleSelection ? true : false}
         id={rootId(`_option-${index}`)}
+        title={label}
         {...rest}
       >
         <span className="euiComboBoxOption__contentWrapper">

--- a/src/components/text_truncate/__snapshots__/text_truncate.test.tsx.snap
+++ b/src/components/text_truncate/__snapshots__/text_truncate.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`EuiTextTruncate renders 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiTextTruncate-euiTestCss"
+  class="euiTextTruncate testClass1 testClass2 emotion-euiTextTruncate-euiTestCss"
   data-test-subj="test subject string"
 >
   <span
+    class="euiTextTruncate__fullText"
     data-test-subj="fullText"
   >
     Hello world

--- a/src/components/text_truncate/text_truncate.styles.ts
+++ b/src/components/text_truncate/text_truncate.styles.ts
@@ -25,13 +25,13 @@ export const euiTextTruncateStyles = {
    * and there'll be no need for the entire component at that point 🙏
    */
   // Makes the truncated text unselectable/un-clickable
-  truncatedText: css`
+  euiTextTruncate__truncatedText: css`
     user-select: none;
     pointer-events: none;
   `,
   // Positions the full text on top of the truncated text (so that clicking targets it)
   // and gives it a color opacity of 0 so that it's not actually visible
-  fullText: css`
+  euiTextTruncate__fullText: css`
     position: absolute;
     inset: 0;
     overflow: hidden;

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -15,6 +15,7 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
+import classNames from 'classnames';
 
 import { useCombinedRefs } from '../../services';
 import {
@@ -24,7 +25,7 @@ import {
 import type { CommonProps } from '../common';
 
 import { TruncationUtilsWithDOM, TruncationUtilsWithCanvas } from './utils';
-import { euiTextTruncateStyles } from './text_truncate.styles';
+import { euiTextTruncateStyles as styles } from './text_truncate.styles';
 
 const TRUNCATION_TYPES = ['end', 'start', 'startEnd', 'middle'] as const;
 export type EuiTextTruncationTypes = (typeof TRUNCATION_TYPES)[number];
@@ -129,6 +130,7 @@ const EuiTextTruncateWithWidth: FunctionComponent<
   ellipsis = '…',
   containerRef,
   measurementRenderAPI = 'dom',
+  className,
   ...rest
 }) => {
   // Note: This needs to be a state and not a ref to trigger a rerender on mount
@@ -214,7 +216,8 @@ const EuiTextTruncateWithWidth: FunctionComponent<
 
   return (
     <div
-      css={euiTextTruncateStyles.euiTextTruncate}
+      className={classNames('euiTextTruncate', className)}
+      css={styles.euiTextTruncate}
       ref={refs}
       title={isTruncating ? text : undefined}
       {...rest}
@@ -222,18 +225,25 @@ const EuiTextTruncateWithWidth: FunctionComponent<
       {isTruncating ? (
         <>
           <span
-            css={euiTextTruncateStyles.truncatedText}
+            className="euiTextTruncate__truncatedText"
+            css={styles.euiTextTruncate__truncatedText}
             aria-hidden
             data-test-subj="truncatedText"
           >
             {children ? children(truncatedText) : truncatedText}
           </span>
-          <span css={euiTextTruncateStyles.fullText} data-test-subj="fullText">
+          <span
+            className="euiTextTruncate__fullText"
+            css={styles.euiTextTruncate__fullText}
+            data-test-subj="fullText"
+          >
             {text}
           </span>
         </>
       ) : (
-        <span data-test-subj="fullText">{text}</span>
+        <span className="euiTextTruncate__fullText" data-test-subj="fullText">
+          {children ? children(text) : text}
+        </span>
       )}
     </div>
   );

--- a/upcoming_changelogs/7212.md
+++ b/upcoming_changelogs/7212.md
@@ -1,0 +1,5 @@
+**Bug fixes**
+
+- Fixed missing `className`s on `EuiTextTruncate`
+- Fixed `title`s on `EuiComboBox` dropdown options to always be present
+- Fixed `EuiComboBox` truncation issues when search is an empty space


### PR DESCRIPTION
## Summary

It turns out Kibana's FTR test service is _incredibly_ [dependent on the title attribute](https://github.com/elastic/kibana/blob/main/test/functional/services/combo_box.ts#L95-L98) to select combobox options by so me removing that in #7028 was A Huge Mistake 😭 

While here, I've decided to address https://github.com/elastic/eui/pull/7028#pullrequestreview-1607433096 after all by not instantiating the truncation component (and letting CSS `text-overflow: ellipsis` do its thing) if no custom `truncationProps` configuration(s) are passed.

Also EuiTextTruncate was missing `className`s (yay, betas 💀) so I added those while here.

## QA

- Go to https://eui.elastic.co/pr_7212/#/forms/combo-box#truncation
- [x] Confirm the various truncation options still render correctly/as expected
- [x] Go to the first example on the page, and confirm the long option (Pandora) still truncates at the end via CSS
- [x] Confirm all options, including options without truncation, have `title` tooltips

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.