### PR TITLE
[EuiMarkdownEditor] Fix default processing plugins type

### DIFF
--- a/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
@@ -52,7 +52,7 @@ export type DefaultEuiMarkdownProcessingPlugins = [
 
 export const getDefaultEuiMarkdownProcessingPlugins = ({
   exclude,
-}: { exclude?: Array<'tooltip'> } = {}) => {
+}: { exclude?: Array<'tooltip'> } = {}): DefaultEuiMarkdownProcessingPlugins => {
   const excludeSet = new Set(exclude);
 
   const plugins: DefaultEuiMarkdownProcessingPlugins = [

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
@@ -52,7 +52,9 @@ export type DefaultEuiMarkdownProcessingPlugins = [
 
 export const getDefaultEuiMarkdownProcessingPlugins = ({
   exclude,
-}: { exclude?: Array<'tooltip'> } = {}): DefaultEuiMarkdownProcessingPlugins => {
+}: {
+  exclude?: Array<'tooltip'>;
+} = {}): DefaultEuiMarkdownProcessingPlugins => {
   const excludeSet = new Set(exclude);
 
   const plugins: DefaultEuiMarkdownProcessingPlugins = [

--- a/upcoming_changelogs/7221.md
+++ b/upcoming_changelogs/7221.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed a missing type in `EuiMarkdownEditor`'s default processing plugins
+


### PR DESCRIPTION
## Summary

While investigating TypeScript issues in Kibana, I stumbled over an issue that stemmed from EUI:

```shell
error TS2742: The inferred type of 'processingPlugins' cannot be named without a reference to '@elastic/eui/node_modules/mdast-util-to-hast'. This is likely not portable. A type annotation is necessary.
```

The origin of this error is `getDefaultEuiMarkdownProcessingPlugins` which does not define an explicit return type. In this PR, I'm adding the return type which should resolve the issue in Kibana. (in the meantime, I'm importing `DefaultEuiMarkdownProcessingPlugins` through the EUI source but I'll clean that up once this PR lands in Kibana)

