### PR TITLE
Fix release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -79,7 +79,7 @@ if (args.dry_run) {
 
   if (args.steps.indexOf('tag') > -1) {
     // push the version commit & tag to upstream
-    execSync('git push upstream --tags', execOptions);
+    execSync('git push upstream --follow-tags', execOptions);
   }
 
   if (args.steps.indexOf('publish') > -1) {


### PR DESCRIPTION
🤦 I totally forgot in #7213 when I removed the `sync-docs` step that that step was doing the final push of all release commits. We need to re-add the push step somewhere, and I figured bogarting/using our existing push step for tags made the most sense