### PR TITLE
[EuiFlyout] Allow push flyouts to have slide in animations

### DIFF
--- a/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <nav
-      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNav-push"
+      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px;"
     />
@@ -353,7 +353,7 @@ exports[`EuiCollapsibleNav props showButtonIfDocked 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <nav
-      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNav-push"
+      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px;"
     />

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
     >
       <nav
         aria-label="aria-label"
-        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left-isPush-euiTestCss"
+        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNavBeta-left-isPush-euiTestCss"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
         style="inline-size: 248px;"
@@ -89,7 +89,7 @@ exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
     >
       <nav
         aria-label="Site menu"
-        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-left-euiCollapsibleNavBeta-left-isPush-isPushCollapsed"
+        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNavBeta-left-isPush-isPushCollapsed"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
         style="inline-size: 48px;"

--- a/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -758,6 +758,27 @@ Array [
 ]
 `;
 
+exports[`EuiFlyout props push flyouts renders 1`] = `
+<div
+  class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-noAnimation-right"
+  data-test-subj="flyout"
+>
+  <button
+    aria-label="Close this dialog"
+    class="euiButtonIcon euiFlyout__closeButton emotion-euiButtonIcon-xs-empty-text-euiFlyout__closeButton-inside"
+    data-test-subj="euiFlyoutCloseButton"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="cross"
+    />
+  </button>
+</div>
+`;
+
 exports[`EuiFlyout props sides left is rendered 1`] = `
 Array [
   <div>
@@ -1044,42 +1065,6 @@ Array [
       tabindex="0"
     />
   </div>,
-]
-`;
-
-exports[`EuiFlyout props type=push is rendered 1`] = `
-Array [
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />,
-  <div
-    data-focus-lock-disabled="disabled"
-  >
-    <div
-      class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-right"
-    >
-      <button
-        aria-label="Close this dialog"
-        class="euiButtonIcon euiFlyout__closeButton emotion-euiButtonIcon-xs-empty-text-euiFlyout__closeButton-inside"
-        data-test-subj="euiFlyoutCloseButton"
-        type="button"
-      >
-        <span
-          aria-hidden="true"
-          class="euiButtonIcon__icon"
-          color="inherit"
-          data-euiicon-type="cross"
-        />
-      </button>
-    </div>
-  </div>,
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />,
 ]
 `;
 

--- a/src/components/flyout/flyout.stories.tsx
+++ b/src/components/flyout/flyout.stories.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { hideStorybookControls } from '../../../.storybook/utils';
+
+import { EuiButton, EuiText } from '../index';
+
+import { EuiFlyout, EuiFlyoutProps, EuiFlyoutBody } from './index';
+
+const meta: Meta<EuiFlyoutProps> = {
+  title: 'EuiFlyout',
+  component: EuiFlyout,
+  args: {
+    // Component defaults
+    type: 'overlay',
+    side: 'right',
+    size: 'm',
+    paddingSize: 'l',
+    pushMinBreakpoint: 'l',
+    closeButtonPosition: 'inside',
+    hideCloseButton: false,
+    ownFocus: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiFlyoutProps>;
+
+const StatefulFlyout = (props: Partial<EuiFlyoutProps>) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <>
+      <EuiButton size="s" onClick={() => setIsOpen(!isOpen)}>
+        Toggle flyout
+      </EuiButton>
+      {isOpen && <EuiFlyout {...props} onClose={() => setIsOpen(false)} />}
+    </>
+  );
+};
+
+export const Playground: Story = {
+  render: ({ ...args }) => <StatefulFlyout {...args} />,
+};
+
+export const PushFlyouts: Story = {
+  render: ({ ...args }) => {
+    const fillerText = (
+      <EuiText>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu
+          condimentum ipsum, nec ornare metus. Sed egestas elit nec placerat
+          suscipit. Cras pulvinar nisi eget enim sodales fringilla. Aliquam
+          lobortis lorem at ornare aliquet. Mauris laoreet laoreet mollis.
+          Pellentesque aliquet tortor dui, non luctus turpis pulvinar vitae.
+          Nunc ultrices scelerisque erat eu rutrum. Nam at ligula enim. Ut nec
+          nisl faucibus, euismod neque ut, aliquam nisl. Donec eu ante ut arcu
+          rutrum blandit nec ac nisl. In elementum id enim vitae aliquam. In
+          sagittis, neque vitae ultricies interdum, sapien justo efficitur
+          ligula, sit amet fermentum nisl magna sit amet turpis. Nulla facilisi.
+          Proin nec viverra mi. Morbi dolor arcu, ornare non consequat et,
+          viverra dapibus tellus.
+        </p>
+      </EuiText>
+    );
+    return (
+      <>
+        <StatefulFlyout {...args}>
+          <EuiFlyoutBody>{fillerText}</EuiFlyoutBody>
+        </StatefulFlyout>
+        {fillerText}
+      </>
+    );
+  },
+  args: {
+    type: 'push',
+    pushAnimation: false,
+    pushMinBreakpoint: 'xs',
+  },
+  argTypes: hideStorybookControls([
+    'onClose',
+    'aria-label',
+    'as',
+    'closeButtonPosition',
+    'closeButtonProps',
+    'focusTrapProps',
+    'hideCloseButton',
+    'includeFixedHeadersInFocusTrap',
+    'maskProps',
+    'maxWidth',
+    'outsideClickCloses',
+    'ownFocus',
+    'paddingSize',
+    'style',
+  ]),
+};

--- a/src/components/flyout/flyout.styles.ts
+++ b/src/components/flyout/flyout.styles.ts
@@ -161,8 +161,6 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
     push: {
       push: css`
         clip-path: none;
-        /* Don't animate on loading a docked nav */
-        animation-duration: 0s !important; /* stylelint-disable-line declaration-no-important */
         /* Make sure the header shadows are above */
         z-index: ${Number(euiTheme.levels.flyout) - 1};
       `,
@@ -171,6 +169,10 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       `,
       left: css`
         ${logicalCSS('border-right', euiTheme.border.thick)}
+      `,
+      noAnimation: css`
+        /* Don't animate on loading a docked nav */
+        animation-duration: 0s !important; /* stylelint-disable-line declaration-no-important */
       `,
     },
 

--- a/src/components/flyout/flyout.styles.ts
+++ b/src/components/flyout/flyout.styles.ts
@@ -158,14 +158,14 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
     overlay: css`
       ${euiShadowXLarge(euiThemeContext)}
     `,
-    push: css`
-      clip-path: none;
-      /* Don't animate on loading a docked nav */
-      animation-duration: 0s !important; /* stylelint-disable-line declaration-no-important */
-      /* Make sure the header shadows are above */
-      z-index: ${Number(euiTheme.levels.flyout) - 1};
-    `,
-    pushSide: {
+    push: {
+      push: css`
+        clip-path: none;
+        /* Don't animate on loading a docked nav */
+        animation-duration: 0s !important; /* stylelint-disable-line declaration-no-important */
+        /* Make sure the header shadows are above */
+        z-index: ${Number(euiTheme.levels.flyout) - 1};
+      `,
       right: css`
         ${logicalCSS('border-left', euiTheme.border.thick)}
       `,

--- a/src/components/flyout/flyout.test.tsx
+++ b/src/components/flyout/flyout.test.tsx
@@ -139,15 +139,34 @@ describe('EuiFlyout', () => {
       });
     });
 
-    describe('type=push', () => {
-      test('is rendered', () => {
-        const component = mount(
-          <EuiFlyout onClose={() => {}} type="push" pushMinBreakpoint="xs" />
+    describe('push flyouts', () => {
+      it('renders', () => {
+        const { getByTestSubject } = render(
+          <EuiFlyout
+            data-test-subj="flyout"
+            onClose={() => {}}
+            type="push"
+            pushMinBreakpoint="xs"
+          />
         );
 
-        expect(
-          takeMountedSnapshot(component, { hasArrayOutput: true })
-        ).toMatchSnapshot();
+        expect(getByTestSubject('flyout')).toMatchSnapshot();
+      });
+
+      it('can render with animations', () => {
+        const { getByTestSubject } = render(
+          <EuiFlyout
+            data-test-subj="flyout"
+            onClose={() => {}}
+            type="push"
+            pushMinBreakpoint="xs"
+            pushAnimation={true}
+          />
+        );
+
+        expect(getByTestSubject('flyout').className).not.toContain(
+          'noAnimation'
+        );
       });
     });
 

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -131,6 +131,11 @@ interface _EuiFlyoutProps {
    * @default l
    */
   pushMinBreakpoint?: EuiBreakpointSize;
+  /**
+   * Enables a slide in animation on push flyouts
+   * @default false
+   */
+  pushAnimation?: boolean;
   style?: CSSProperties;
   /**
    * Object of props passed to EuiFocusTrap.
@@ -181,6 +186,7 @@ export const EuiFlyout = forwardRef(
       type = 'overlay',
       outsideClickCloses,
       pushMinBreakpoint = 'l',
+      pushAnimation = false,
       focusTrapProps: _focusTrapProps = {},
       includeFixedHeadersInFocusTrap = true,
       'aria-describedby': _ariaDescribedBy,
@@ -268,6 +274,7 @@ export const EuiFlyout = forwardRef(
       maxWidth === false && styles.noMaxWidth,
       isPushed ? styles.push.push : styles.overlay,
       isPushed && styles.push[side],
+      isPushed && !pushAnimation && styles.push.noAnimation,
       styles[side],
     ];
 

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -216,20 +216,18 @@ export const EuiFlyout = forwardRef(
       /**
        * Accomodate for the `isPushed` state by adding padding to the body equal to the width of the element
        */
-      if (type === 'push') {
-        if (isPushed) {
-          if (side === 'right') {
-            document.body.style.paddingRight = `${dimensions.width}px`;
-          } else if (side === 'left') {
-            document.body.style.paddingLeft = `${dimensions.width}px`;
-          }
+      if (isPushed) {
+        if (side === 'right') {
+          document.body.style.paddingRight = `${dimensions.width}px`;
+        } else if (side === 'left') {
+          document.body.style.paddingLeft = `${dimensions.width}px`;
         }
       }
 
       return () => {
         document.body.classList.remove('euiBody--hasFlyout');
 
-        if (type === 'push') {
+        if (isPushed) {
           if (side === 'right') {
             document.body.style.paddingRight = '';
           } else if (side === 'left') {
@@ -237,7 +235,7 @@ export const EuiFlyout = forwardRef(
           }
         }
       };
-    }, [type, side, dimensions, isPushed]);
+    }, [side, dimensions, isPushed]);
 
     /**
      * ESC key closes flyout (always?)
@@ -268,8 +266,8 @@ export const EuiFlyout = forwardRef(
       styles.paddingSizes[paddingSize],
       isEuiFlyoutSizeNamed(size) && styles[size],
       maxWidth === false && styles.noMaxWidth,
-      styles[type],
-      type === 'push' && styles.pushSide[side],
+      isPushed ? styles.push.push : styles.overlay,
+      isPushed && styles.push[side],
       styles[side],
     ];
 

--- a/upcoming_changelogs/7239.md
+++ b/upcoming_changelogs/7239.md
@@ -1,0 +1,1 @@
+- Added new `pushAnimation` prop to push `EuiFlyout`s, which enables a slide in animation


### PR DESCRIPTION
## Summary

closes #7205

![screencap](https://github.com/elastic/eui/assets/549407/acfce4e3-e34d-4634-969e-d7e98e756d68)

## QA

- Go to https://eui.elastic.co/pr_7239/storybook/index.html?path=/story/euiflyout--push-flyouts
- Toggle the `pushAnimation` control to "True"
- [x] Click the blue "Toggle flyout" button and confirm the push flyout now slides with an animation
- [x] Set the `side` control to "left" and confirm that slide in animation also works as expected

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [x] ~Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ Added Storybook
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - skipped - IIRC Figma doesn't have animations?
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
