### PR TITLE
[EuiComboBox] Fix new input size util not resetting correctly

### DIFF
--- a/src/components/combo_box/combo_box.spec.tsx
+++ b/src/components/combo_box/combo_box.spec.tsx
@@ -68,6 +68,26 @@ describe('EuiComboBox', () => {
       );
     });
 
+    it('correctly resets the input size when the search value is cleared', () => {
+      cy.realMount(<EuiComboBox options={[{ label: 'Test 1 2 3' }]} />);
+      cy.get('[data-test-subj="comboBoxSearchInput"]').realClick();
+
+      cy.realType('Test 1 2 3');
+      cy.get('[data-test-subj="comboBoxSearchInput"]').should(
+        'have.attr',
+        'style',
+        'inline-size: 67px;'
+      );
+
+      cy.realPress('{downarrow}');
+      cy.realPress('Enter');
+      cy.get('[data-test-subj="comboBoxSearchInput"]').should(
+        'have.attr',
+        'style',
+        'inline-size: 2px;'
+      );
+    });
+
     it('does not exceed the maximum possible width of the input wrapper', () => {
       cy.realMount(<EuiComboBox options={[]} />);
       cy.get('[data-test-subj="comboBoxSearchInput"]').realClick();

--- a/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -8,7 +8,6 @@
 
 import React, {
   Component,
-  ChangeEventHandler,
   FocusEventHandler,
   KeyboardEventHandler,
   RefCallback,
@@ -44,9 +43,9 @@ export interface EuiComboBoxInputProps<T> extends CommonProps {
   isListOpen: boolean;
   noIcon: boolean;
   onBlur?: FocusEventHandler<HTMLInputElement>;
-  onChange?: (searchValue: string) => void;
+  onChange: (searchValue: string) => void;
   onClear?: () => void;
-  onClick?: () => void;
+  onClick: () => void;
   onCloseListClick: () => void;
   onFocus: FocusEventHandler<HTMLInputElement>;
   onOpenListClick: () => void;
@@ -147,21 +146,14 @@ export class EuiComboBoxInput<T> extends Component<
   };
 
   componentDidUpdate(prevProps: EuiComboBoxInputProps<T>) {
-    const { searchValue } = prevProps;
+    if (prevProps.searchValue !== this.props.searchValue) {
+      this.updateInputSize(this.props.searchValue);
 
-    // We need to update the position of everything if the user enters enough input to change
-    // the size of the input.
-    if (searchValue !== this.props.searchValue) {
+      // We need to update the position of everything if the user enters enough input to change
+      // the size of the input.
       this.updatePosition();
     }
   }
-
-  inputOnChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    const { value } = event.target;
-
-    this.updateInputSize(value);
-    this.props.onChange?.(value);
-  };
 
   render() {
     const {
@@ -173,6 +165,7 @@ export class EuiComboBoxInput<T> extends Component<
       isDisabled,
       isListOpen,
       noIcon,
+      onChange,
       onClear,
       onClick,
       onCloseListClick,
@@ -350,7 +343,7 @@ export class EuiComboBoxInput<T> extends Component<
             disabled={isDisabled}
             id={id}
             onBlur={this.onBlur}
-            onChange={this.inputOnChange}
+            onChange={(event) => onChange(event.target.value)}
             onFocus={this.onFocus}
             onKeyDown={this.onKeyDown}
             ref={this.inputRefCallback}

--- a/upcoming_changelogs/7240.md
+++ b/upcoming_changelogs/7240.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` search input width not resetting correctly on selection


### PR DESCRIPTION
## Summary

😬 I introduced this bug in #7215... but at least I caught it fairly quickly, right?

## Repro steps

- Go to https://eui.elastic.co/v88.5.1/#/forms/combo-box
- In the first example, type some really long sentence that goes past the width of the input, e.g `You must add an accessible label to each instance of EuiComboBox` 
- Press enter to add the custom option
- Delete the custom added option, and notice that the input caret is still incorrectly on the next line when it shouldn't be, and that the input width is still large even though it does not contain content:
<img width="498" alt="before" src="https://github.com/elastic/eui/assets/549407/69f06439-bae9-4029-a01a-abe4aa661897">

## QA

- Go to https://eui.elastic.co/pr_7240/#/forms/combo-box
- In the first example, type some really long sentence that goes past the width of the input, e.g `You must add an accessible label to each instance of EuiComboBox`
- Press enter to add the custom option
- Delete the custom added option, and confirm the input caret is now correctly where it should be, and the input width is 2px:
<img width="483" alt="" src="https://github.com/elastic/eui/assets/549407/14c53e09-a140-475a-97e9-32114b147bf3">

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A