### PR TITLE
[EuiInputPopover] Refactor & clean ups

### DIFF
--- a/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
+++ b/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
@@ -7,37 +7,35 @@ exports[`EuiColorPalettePicker is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -52,39 +50,37 @@ exports[`EuiColorPalettePicker is rendered with a selected custom text 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="custom"
-      />
+    <input
+      type="hidden"
+      value="custom"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          >
-            Plain text as a custom option
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          Plain text as a custom option
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -99,67 +95,65 @@ exports[`EuiColorPalettePicker is rendered with a selected fixed palette 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="paletteFixed"
-      />
+    <input
+      type="hidden"
+      value="paletteFixed"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
+          <span
+            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
           >
             <span
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              class="emotion-euiScreenReaderOnly"
             >
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                Palette 1
-              </span>
-              <span
-                aria-hidden="true"
-                class="euiColorPaletteDisplayFixed__bleedArea"
-              >
-                <span
-                  style="background-color: rgb(31, 176, 178); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(255, 219, 109); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(238, 145, 145); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(255, 255, 255); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(136, 128, 148); width: 20%;"
-                />
-              </span>
+              Palette 1
             </span>
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-          >
             <span
-              class="euiFormControlLayoutCustomIcon"
+              aria-hidden="true"
+              class="euiColorPaletteDisplayFixed__bleedArea"
             >
               <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
+                style="background-color: rgb(31, 176, 178); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(255, 219, 109); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(238, 145, 145); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(255, 255, 255); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(136, 128, 148); width: 20%;"
               />
             </span>
-          </div>
+          </span>
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
+          >
+            <span
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -174,47 +168,45 @@ exports[`EuiColorPalettePicker is rendered with a selected gradient palette 1`] 
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="paletteLinear"
-      />
+    <input
+      type="hidden"
+      value="paletteLinear"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
+          <span
+            class="emotion-euiScreenReaderOnly"
           >
-            <span
-              class="emotion-euiScreenReaderOnly"
-            >
-              Linear Gradient
-            </span>
+            Linear Gradient
+          </span>
+          <span
+            aria-hidden="true"
+            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+          />
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
+          >
             <span
               aria-hidden="true"
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
             />
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-          >
-            <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -229,47 +221,45 @@ exports[`EuiColorPalettePicker is rendered with a selected gradient palette with
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="paletteLinearStops"
-      />
+    <input
+      type="hidden"
+      value="paletteLinearStops"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
+          <span
+            class="emotion-euiScreenReaderOnly"
           >
-            <span
-              class="emotion-euiScreenReaderOnly"
-            >
-              Linear Gradient with stops
-            </span>
+            Linear Gradient with stops
+          </span>
+          <span
+            aria-hidden="true"
+            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+          />
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
+          >
             <span
               aria-hidden="true"
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
             />
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-          >
-            <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+          </span>
         </div>
       </div>
     </div>
@@ -284,39 +274,37 @@ exports[`EuiColorPalettePicker is rendered with the prop selectionDisplay set as
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="paletteFixed"
-      />
+    <input
+      type="hidden"
+      value="paletteFixed"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          >
-            Palette 1
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          Palette 1
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -331,66 +319,64 @@ exports[`EuiColorPalettePicker more props are propagated to each option 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="paletteFixed"
-      />
+    <input
+      type="hidden"
+      value="paletteFixed"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
+          data-test-subj="colorPalettePicker"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
-            data-test-subj="colorPalettePicker"
-            type="button"
+          <span
+            class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
           >
             <span
-              class="euiColorPaletteDisplay euiColorPaletteDisplay--sizeSmall"
+              class="emotion-euiScreenReaderOnly"
             >
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                Palette 1
-              </span>
-              <span
-                aria-hidden="true"
-                class="euiColorPaletteDisplayFixed__bleedArea"
-              >
-                <span
-                  style="background-color: rgb(31, 176, 178); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(255, 219, 109); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(238, 145, 145); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(255, 255, 255); width: 20%;"
-                />
-                <span
-                  style="background-color: rgb(136, 128, 148); width: 20%;"
-                />
-              </span>
+              Palette 1
             </span>
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-          >
             <span
-              class="euiFormControlLayoutCustomIcon"
+              aria-hidden="true"
+              class="euiColorPaletteDisplayFixed__bleedArea"
             >
               <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
+                style="background-color: rgb(31, 176, 178); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(255, 219, 109); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(238, 145, 145); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(255, 255, 255); width: 20%;"
+              />
+              <span
+                style="background-color: rgb(136, 128, 148); width: 20%;"
               />
             </span>
-          </div>
+          </span>
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
+          >
+            <span
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/date_picker/auto_refresh/__snapshots__/auto_refresh.test.tsx.snap
+++ b/src/components/date_picker/auto_refresh/__snapshots__/auto_refresh.test.tsx.snap
@@ -7,44 +7,42 @@ exports[`EuiAutoRefresh is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <div
-        class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+    <div
+      class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+    >
+      <button
+        class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
+        type="button"
       >
-        <button
-          class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
-          type="button"
+        <span
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
         >
           <span
-            class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-          >
-            <span
-              color="inherit"
-              data-euiicon-type="timeRefresh"
-            />
-            <span
-              class="eui-textTruncate euiButtonEmpty__text"
-            >
-              <strong>
-                <small>
-                  Auto refresh
-                </small>
-              </strong>
-            </span>
-          </span>
-        </button>
-        <div
-          class="euiFormControlLayout__childrenWrapper"
-        >
-          <input
-            aria-label="aria-label"
-            class="euiFieldText euiFieldText--inGroup"
-            data-test-subj="test subject string"
-            readonly=""
-            type="text"
-            value="Off"
+            color="inherit"
+            data-euiicon-type="timeRefresh"
           />
-        </div>
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            <strong>
+              <small>
+                Auto refresh
+              </small>
+            </strong>
+          </span>
+        </span>
+      </button>
+      <div
+        class="euiFormControlLayout__childrenWrapper"
+      >
+        <input
+          aria-label="aria-label"
+          class="euiFieldText euiFieldText--inGroup"
+          data-test-subj="test subject string"
+          readonly=""
+          type="text"
+          value="Off"
+        />
       </div>
     </div>
   </div>
@@ -58,43 +56,41 @@ exports[`EuiAutoRefresh isPaused is false 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <div
-        class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+    <div
+      class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+    >
+      <button
+        class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
+        type="button"
       >
-        <button
-          class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
-          type="button"
+        <span
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
         >
           <span
-            class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-          >
-            <span
-              color="inherit"
-              data-euiicon-type="timeRefresh"
-            />
-            <span
-              class="eui-textTruncate euiButtonEmpty__text"
-            >
-              <strong>
-                <small>
-                  Auto refresh
-                </small>
-              </strong>
-            </span>
-          </span>
-        </button>
-        <div
-          class="euiFormControlLayout__childrenWrapper"
-        >
-          <input
-            aria-label="Auto refresh"
-            class="euiFieldText euiFieldText--inGroup"
-            readonly=""
-            type="text"
-            value="1 second"
+            color="inherit"
+            data-euiicon-type="timeRefresh"
           />
-        </div>
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            <strong>
+              <small>
+                Auto refresh
+              </small>
+            </strong>
+          </span>
+        </span>
+      </button>
+      <div
+        class="euiFormControlLayout__childrenWrapper"
+      >
+        <input
+          aria-label="Auto refresh"
+          class="euiFieldText euiFieldText--inGroup"
+          readonly=""
+          type="text"
+          value="1 second"
+        />
       </div>
     </div>
   </div>
@@ -108,43 +104,41 @@ exports[`EuiAutoRefresh refreshInterval is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <div
-        class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+    <div
+      class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+    >
+      <button
+        class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
+        type="button"
       >
-        <button
-          class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
-          type="button"
+        <span
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
         >
           <span
-            class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-          >
-            <span
-              color="inherit"
-              data-euiicon-type="timeRefresh"
-            />
-            <span
-              class="eui-textTruncate euiButtonEmpty__text"
-            >
-              <strong>
-                <small>
-                  Auto refresh
-                </small>
-              </strong>
-            </span>
-          </span>
-        </button>
-        <div
-          class="euiFormControlLayout__childrenWrapper"
-        >
-          <input
-            aria-label="Auto refresh"
-            class="euiFieldText euiFieldText--inGroup"
-            readonly=""
-            type="text"
-            value="2 seconds"
+            color="inherit"
+            data-euiicon-type="timeRefresh"
           />
-        </div>
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            <strong>
+              <small>
+                Auto refresh
+              </small>
+            </strong>
+          </span>
+        </span>
+      </button>
+      <div
+        class="euiFormControlLayout__childrenWrapper"
+      >
+        <input
+          aria-label="Auto refresh"
+          class="euiFieldText euiFieldText--inGroup"
+          readonly=""
+          type="text"
+          value="2 seconds"
+        />
       </div>
     </div>
   </div>

--- a/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/__snapshots__/super_date_picker.test.tsx.snap
@@ -155,43 +155,41 @@ exports[`EuiSuperDatePicker props isAutoRefreshOnly is rendered 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
-        <div
-          class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+      <div
+        class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+      >
+        <button
+          class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
+          type="button"
         >
-          <button
-            class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-text"
-            type="button"
+          <span
+            class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
           >
             <span
-              class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-            >
-              <span
-                color="inherit"
-                data-euiicon-type="timeRefresh"
-              />
-              <span
-                class="eui-textTruncate euiButtonEmpty__text"
-              >
-                <strong>
-                  <small>
-                    Auto refresh
-                  </small>
-                </strong>
-              </span>
-            </span>
-          </button>
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              aria-label="Auto refresh"
-              class="euiFieldText euiFieldText--inGroup"
-              readonly=""
-              type="text"
-              value="Off"
+              color="inherit"
+              data-euiicon-type="timeRefresh"
             />
-          </div>
+            <span
+              class="eui-textTruncate euiButtonEmpty__text"
+            >
+              <strong>
+                <small>
+                  Auto refresh
+                </small>
+              </strong>
+            </span>
+          </span>
+        </button>
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-label="Auto refresh"
+            class="euiFieldText euiFieldText--inGroup"
+            readonly=""
+            type="text"
+            value="Off"
+          />
         </div>
       </div>
     </div>
@@ -210,45 +208,43 @@ exports[`EuiSuperDatePicker props isAutoRefreshOnly passes required props 1`] = 
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
-        <div
-          class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+      <div
+        class="euiFormControlLayout euiFormControlLayout--readOnly euiFormControlLayout--group"
+      >
+        <button
+          class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled"
+          disabled=""
+          type="button"
         >
-          <button
-            class="euiButtonEmpty euiFormControlLayout__prepend euiFormControlLayout__prepend emotion-euiButtonDisplay-euiButtonEmpty-s-empty-disabled-isDisabled"
-            disabled=""
-            type="button"
+          <span
+            class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
           >
             <span
-              class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-            >
-              <span
-                color="inherit"
-                data-euiicon-type="timeRefresh"
-              />
-              <span
-                class="eui-textTruncate euiButtonEmpty__text"
-              >
-                <strong>
-                  <small>
-                    Auto refresh
-                  </small>
-                </strong>
-              </span>
-            </span>
-          </button>
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              aria-label="Auto refresh"
-              class="euiFieldText euiFieldText--inGroup"
-              disabled=""
-              readonly=""
-              type="text"
-              value="Off"
+              color="inherit"
+              data-euiicon-type="timeRefresh"
             />
-          </div>
+            <span
+              class="eui-textTruncate euiButtonEmpty__text"
+            >
+              <strong>
+                <small>
+                  Auto refresh
+                </small>
+              </strong>
+            </span>
+          </span>
+        </button>
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-label="Auto refresh"
+            class="euiFieldText euiFieldText--inGroup"
+            disabled=""
+            readonly=""
+            type="text"
+            value="Off"
+          />
         </div>
       </div>
     </div>

--- a/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -346,34 +346,32 @@ exports[`EuiRange props loading should display when showInput="inputWithPopover"
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <input
+          aria-label="aria-label"
+          class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons euiFieldNumber-isLoading"
+          data-test-subj="test subject string"
+          id="id"
+          max="100"
+          min="0"
+          name="name"
+          step="1"
+          type="number"
+          value="8"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <input
-            aria-label="aria-label"
-            class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons euiFieldNumber-isLoading"
-            data-test-subj="test subject string"
-            id="id"
-            max="100"
-            min="0"
-            name="name"
-            step="1"
-            type="number"
-            value="8"
+          <span
+            aria-label="Loading"
+            class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
+            role="progressbar"
           />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-          >
-            <span
-              aria-label="Loading"
-              class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
-              role="progressbar"
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -421,26 +419,24 @@ exports[`EuiRange props slider should display in popover 1`] = `
       <div
         class="euiPopover__anchor css-zih94u-render"
       >
-        <div>
+        <div
+          class="euiFormControlLayout"
+        >
           <div
-            class="euiFormControlLayout"
+            class="euiFormControlLayout__childrenWrapper"
           >
-            <div
-              class="euiFormControlLayout__childrenWrapper"
-            >
-              <input
-                aria-label="aria-label"
-                class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
-                data-test-subj="test subject string"
-                id="id"
-                max="100"
-                min="0"
-                name="name"
-                step="1"
-                type="number"
-                value="8"
-              />
-            </div>
+            <input
+              aria-label="aria-label"
+              class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
+              data-test-subj="test subject string"
+              id="id"
+              max="100"
+              min="0"
+              name="name"
+              step="1"
+              type="number"
+              value="8"
+            />
           </div>
         </div>
       </div>
@@ -465,7 +461,7 @@ exports[`EuiRange props slider should display in popover 1`] = `
         data-popover-panel="true"
         data-test-subj="test"
         role="dialog"
-        style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
       >
         <p
           class="emotion-euiScreenReaderOnly"
@@ -482,28 +478,26 @@ exports[`EuiRange props slider should display in popover 1`] = `
           <div
             data-focus-lock-disabled="disabled"
           >
-            <div>
+            <div
+              class="euiRangeWrapper euiRange testClass1 testClass2 emotion-euiRangeWrapper-regular-euiRange-hasInput-euiTestCss"
+            >
               <div
-                class="euiRangeWrapper euiRange testClass1 testClass2 emotion-euiRangeWrapper-regular-euiRange-hasInput-euiTestCss"
+                aria-hidden="true"
+                class="euiRangeTrack emotion-euiRangeTrack"
               >
-                <div
+                <input
                   aria-hidden="true"
-                  class="euiRangeTrack emotion-euiRangeTrack"
-                >
-                  <input
-                    aria-hidden="true"
-                    aria-label="aria-label"
-                    class="euiRangeSlider emotion-euiRangeSlider"
-                    data-test-subj="test subject string"
-                    max="100"
-                    min="0"
-                    name="name"
-                    step="1"
-                    tabindex="-1"
-                    type="range"
-                    value="8"
-                  />
-                </div>
+                  aria-label="aria-label"
+                  class="euiRangeSlider emotion-euiRangeSlider"
+                  data-test-subj="test subject string"
+                  max="100"
+                  min="0"
+                  name="name"
+                  step="1"
+                  tabindex="-1"
+                  type="range"
+                  value="8"
+                />
               </div>
             </div>
           </div>

--- a/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -7,37 +7,35 @@ exports[`EuiSuperSelect is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -52,37 +50,35 @@ exports[`EuiSuperSelect props compressed is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout euiFormControlLayout--compressed"
+    >
       <div
-        class="euiFormControlLayout euiFormControlLayout--compressed"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--compressed testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--compressed testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -97,36 +93,34 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
+          data-test-subj="superSelect"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
-            data-test-subj="superSelect"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -145,7 +139,7 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
       class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-isAttached-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
     >
       <div>
         <div
@@ -156,65 +150,63 @@ exports[`EuiSuperSelect props custom display is propagated to dropdown 1`] = `
         <div
           data-focus-lock-disabled="false"
         >
-          <div>
-            <p
-              class="emotion-euiScreenReaderOnly"
-              id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          >
+            You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
+          </p>
+          <div
+            aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+            aria-label="Select listbox"
+            class="euiSuperSelect__listbox"
+            role="listbox"
+            tabindex="0"
+          >
+            <button
+              aria-selected="false"
+              class="euiContextMenuItem euiSuperSelect__item"
+              id="1"
+              role="option"
+              type="button"
             >
-              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
-            </p>
-            <div
-              aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-label="Select listbox"
-              class="euiSuperSelect__listbox"
-              role="listbox"
-              tabindex="0"
-            >
-              <button
-                aria-selected="false"
-                class="euiContextMenuItem euiSuperSelect__item"
-                id="1"
-                role="option"
-                type="button"
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="empty"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="empty"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Custom Display #1
-                  </span>
+                  Custom Display #1
                 </span>
-              </button>
-              <button
-                aria-selected="false"
-                class="euiContextMenuItem euiSuperSelect__item"
-                id="2"
-                role="option"
-                type="button"
+              </span>
+            </button>
+            <button
+              aria-selected="false"
+              class="euiContextMenuItem euiSuperSelect__item"
+              id="2"
+              role="option"
+              type="button"
+            >
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="empty"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="empty"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Custom Display #2
-                  </span>
+                  Custom Display #2
                 </span>
-              </button>
-            </div>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -240,37 +232,35 @@ exports[`EuiSuperSelect props fullWidth is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+    >
       <div
-        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--fullWidth testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--fullWidth testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -285,49 +275,47 @@ exports[`EuiSuperSelect props is rendered with a prepend and append 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
-      <div
-        class="euiFormControlLayout euiFormControlLayout--group"
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout euiFormControlLayout--group"
+    >
+      <label
+        class="euiFormLabel euiFormControlLayout__prepend"
       >
-        <label
-          class="euiFormLabel euiFormControlLayout__prepend"
-        >
-          prepend
-        </label>
+        prepend
+      </label>
+      <div
+        class="euiFormControlLayout__childrenWrapper"
+      >
+        <button
+          aria-haspopup="listbox"
+          aria-label="aria-label"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--inGroup testClass1 testClass2 emotion-euiTestCss"
+          data-test-subj="test subject string"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            aria-label="aria-label"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelectControl--inGroup testClass1 testClass2 emotion-euiTestCss"
-            data-test-subj="test subject string"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
-        <label
-          class="euiFormLabel euiFormControlLayout__append"
-        >
-          append
-        </label>
       </div>
+      <label
+        class="euiFormLabel euiFormControlLayout__append"
+      >
+        append
+      </label>
     </div>
   </div>
 </div>
@@ -340,38 +328,36 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="1"
-      />
+    <input
+      type="hidden"
+      value="1"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
+          data-test-subj="superSelect"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
-            data-test-subj="superSelect"
-            type="button"
-          >
-            Option #1
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          Option #1
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -390,7 +376,7 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
       class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-isAttached-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
     >
       <div>
         <div
@@ -401,68 +387,66 @@ exports[`EuiSuperSelect props more props are propogated to each option 1`] = `
         <div
           data-focus-lock-disabled="false"
         >
-          <div>
-            <p
-              class="emotion-euiScreenReaderOnly"
-              id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          >
+            You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
+          </p>
+          <div
+            aria-activedescendant="1"
+            aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+            aria-label="Select listbox"
+            class="euiSuperSelect__listbox"
+            role="listbox"
+            tabindex="0"
+          >
+            <button
+              aria-selected="true"
+              class="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
+              disabled=""
+              id="1"
+              role="option"
+              type="button"
             >
-              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
-            </p>
-            <div
-              aria-activedescendant="1"
-              aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-label="Select listbox"
-              class="euiSuperSelect__listbox"
-              role="listbox"
-              tabindex="0"
-            >
-              <button
-                aria-selected="true"
-                class="euiContextMenuItem euiSuperSelect__item euiContextMenuItem-isDisabled"
-                disabled=""
-                id="1"
-                role="option"
-                type="button"
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="check"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="check"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Option #1
-                  </span>
+                  Option #1
                 </span>
-              </button>
-              <button
-                aria-selected="false"
-                class="euiContextMenuItem euiSuperSelect__item"
-                data-test-subj="option two"
-                id="2"
-                role="option"
-                type="button"
+              </span>
+            </button>
+            <button
+              aria-selected="false"
+              class="euiContextMenuItem euiSuperSelect__item"
+              data-test-subj="option two"
+              id="2"
+              role="option"
+              type="button"
+            >
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="empty"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="empty"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Option #2
-                  </span>
+                  Option #2
                 </span>
-              </button>
-            </div>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -488,36 +472,34 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
+          data-test-subj="superSelect"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
-            data-test-subj="superSelect"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -536,7 +518,7 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
       class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-isAttached-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
     >
       <div>
         <div
@@ -547,65 +529,63 @@ exports[`EuiSuperSelect props options are rendered when select is open 1`] = `
         <div
           data-focus-lock-disabled="false"
         >
-          <div>
-            <p
-              class="emotion-euiScreenReaderOnly"
-              id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          >
+            You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
+          </p>
+          <div
+            aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+            aria-label="Select listbox"
+            class="euiSuperSelect__listbox"
+            role="listbox"
+            tabindex="0"
+          >
+            <button
+              aria-selected="false"
+              class="euiContextMenuItem euiSuperSelect__item"
+              id="1"
+              role="option"
+              type="button"
             >
-              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
-            </p>
-            <div
-              aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-label="Select listbox"
-              class="euiSuperSelect__listbox"
-              role="listbox"
-              tabindex="0"
-            >
-              <button
-                aria-selected="false"
-                class="euiContextMenuItem euiSuperSelect__item"
-                id="1"
-                role="option"
-                type="button"
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="empty"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="empty"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Option #1
-                  </span>
+                  Option #1
                 </span>
-              </button>
-              <button
-                aria-selected="false"
-                class="euiContextMenuItem euiSuperSelect__item"
-                id="2"
-                role="option"
-                type="button"
+              </span>
+            </button>
+            <button
+              aria-selected="false"
+              class="euiContextMenuItem euiSuperSelect__item"
+              id="2"
+              role="option"
+              type="button"
+            >
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="empty"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="empty"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Option #2
-                  </span>
+                  Option #2
                 </span>
-              </button>
-            </div>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -631,38 +611,36 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="2"
-      />
+    <input
+      type="hidden"
+      value="2"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
+          data-test-subj="superSelect"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons euiSuperSelect--isOpen__button"
-            data-test-subj="superSelect"
-            type="button"
-          >
-            Option #2
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          Option #2
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -681,7 +659,7 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
       class="euiPanel euiPanel--plain euiPopover__panel goes-on-popover-panel emotion-euiPanel-grow-m-plain-euiPopover__panel-isAttached-bottom"
       data-popover-panel="true"
       role="dialog"
-      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+      style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
     >
       <div>
         <div
@@ -692,66 +670,64 @@ exports[`EuiSuperSelect props renders popoverProps on the underlying EuiPopover 
         <div
           data-focus-lock-disabled="false"
         >
-          <div>
-            <p
-              class="emotion-euiScreenReaderOnly"
-              id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="euiSuperSelect__generated-id__screenreaderDescribeId"
+          >
+            You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
+          </p>
+          <div
+            aria-activedescendant="2"
+            aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
+            aria-label="Select listbox"
+            class="euiSuperSelect__listbox"
+            role="listbox"
+            tabindex="0"
+          >
+            <button
+              aria-selected="false"
+              class="euiContextMenuItem euiSuperSelect__item"
+              id="1"
+              role="option"
+              type="button"
             >
-              You are in a form selector and must select a single option. Use the Up and Down arrow keys to navigate or Escape to close.
-            </p>
-            <div
-              aria-activedescendant="2"
-              aria-describedby="euiSuperSelect__generated-id__screenreaderDescribeId"
-              aria-label="Select listbox"
-              class="euiSuperSelect__listbox"
-              role="listbox"
-              tabindex="0"
-            >
-              <button
-                aria-selected="false"
-                class="euiContextMenuItem euiSuperSelect__item"
-                id="1"
-                role="option"
-                type="button"
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="empty"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="empty"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Option #1
-                  </span>
+                  Option #1
                 </span>
-              </button>
-              <button
-                aria-selected="true"
-                class="euiContextMenuItem euiSuperSelect__item"
-                id="2"
-                role="option"
-                type="button"
+              </span>
+            </button>
+            <button
+              aria-selected="true"
+              class="euiContextMenuItem euiSuperSelect__item"
+              id="2"
+              role="option"
+              type="button"
+            >
+              <span
+                class="euiContextMenu__itemLayout"
               >
                 <span
-                  class="euiContextMenu__itemLayout"
+                  class="euiContextMenu__icon"
+                  color="inherit"
+                  data-euiicon-type="check"
+                />
+                <span
+                  class="euiContextMenuItem__text"
                 >
-                  <span
-                    class="euiContextMenu__icon"
-                    color="inherit"
-                    data-euiicon-type="check"
-                  />
-                  <span
-                    class="euiContextMenuItem__text"
-                  >
-                    Option #2
-                  </span>
+                  Option #2
                 </span>
-              </button>
-            </div>
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -777,35 +753,33 @@ exports[`EuiSuperSelect props select component is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value=""
-      />
+    <input
+      type="hidden"
+      value=""
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons"
+          type="button"
+        />
         <div
-          class="euiFormControlLayout__childrenWrapper"
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons"
-            type="button"
-          />
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>
@@ -820,37 +794,35 @@ exports[`EuiSuperSelect props valueSelected is rendered 1`] = `
   <div
     class="euiPopover__anchor css-zih94u-render"
   >
-    <div>
-      <input
-        type="hidden"
-        value="2"
-      />
+    <input
+      type="hidden"
+      value="2"
+    />
+    <div
+      class="euiFormControlLayout"
+    >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout__childrenWrapper"
       >
-        <div
-          class="euiFormControlLayout__childrenWrapper"
+        <button
+          aria-haspopup="listbox"
+          class="euiSuperSelectControl euiFormControlLayout--1icons"
+          type="button"
         >
-          <button
-            aria-haspopup="listbox"
-            class="euiSuperSelectControl euiFormControlLayout--1icons"
-            type="button"
-          >
-            Option #2
-          </button>
-          <div
-            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          Option #2
+        </button>
+        <div
+          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+        >
+          <span
+            class="euiFormControlLayoutCustomIcon"
           >
             <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <span
-                aria-hidden="true"
-                class="euiFormControlLayoutCustomIcon__icon"
-                data-euiicon-type="arrowDown"
-              />
-            </span>
-          </div>
+              aria-hidden="true"
+              class="euiFormControlLayoutCustomIcon__icon"
+              data-euiicon-type="arrowDown"
+            />
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/popover/input_popover.spec.tsx
+++ b/src/components/popover/input_popover.spec.tsx
@@ -61,25 +61,62 @@ describe('EuiPopover', () => {
     cy.get('[data-popover-panel]').should('have.css', 'left', '200px');
   });
 
-  it('correctly repositions the popover on input resize', () => {
-    cy.mount(
-      <div className="eui-textCenter">
-        <EuiInputPopover
-          {...props}
-          display="inline-block"
-          input={
-            <EuiTextArea rows={1} resize="horizontal" style={{ width: 150 }} />
-          }
-        >
-          Popover content
-        </EuiInputPopover>
-      </div>
-    );
-    cy.get('[data-popover-panel]').should('have.css', 'left', '175px');
-    cy.wait(100); // Wait a tick, otherwise Cypress returns a false positive
+  describe('on input resize', () => {
+    const initialWidth = 250;
+    const resizeProps = {
+      ...props,
+      display: 'inline-block',
+      input: (
+        <EuiTextArea
+          rows={1}
+          resize="horizontal"
+          style={{ width: initialWidth }}
+        />
+      ),
+    };
+    const resizeInput = (width: number) => {
+      // Cypress doesn't seem to have a way to mimic manual dragging/resizing, so we'll do it programmatically
+      cy.get('textarea').then(($el) => ($el[0].style.width = `${width}px`));
+    };
 
-    // Cypress doesn't seem to have a way to mimic manual dragging/resizing, so we'll do it programmatically
-    cy.get('textarea').then(($el) => ($el[0].style.width = '500px'));
-    cy.get('[data-popover-panel]').should('have.css', 'left', '50px');
+    it('repositions and resizes the popover to match the input', () => {
+      cy.mount(
+        <div className="eui-textCenter">
+          <EuiInputPopover {...resizeProps}>Popover content</EuiInputPopover>
+        </div>
+      );
+      cy.get('[data-popover-panel]')
+        .should('have.css', 'inline-size', '250px')
+        .should('have.css', 'left', '125px');
+
+      resizeInput(150);
+
+      cy.get('[data-popover-panel]')
+        .should('have.css', 'inline-size', '150px')
+        .should('have.css', 'left', '175px');
+    });
+
+    it('repositions the popover even when the popover width does not change', () => {
+      cy.mount(
+        <div className="eui-textCenter">
+          <EuiInputPopover
+            {...resizeProps}
+            panelMinWidth={initialWidth}
+            anchorPosition="downRight"
+          >
+            Popover content
+          </EuiInputPopover>
+        </div>
+      );
+      cy.get('[data-popover-panel]')
+        .should('have.css', 'inline-size', '250px')
+        .should('have.css', 'left', '125px');
+
+      resizeInput(100);
+
+      cy.get('[data-popover-panel]')
+        .should('have.css', 'inline-size', '250px')
+        .should('have.css', 'left', '50px');
+    });
   });
 });

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -14,21 +14,18 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
+import { css } from '@emotion/react';
 import classnames from 'classnames';
 import { tabbable, FocusableElement } from 'tabbable';
 
-import { CommonProps } from '../common';
-import { EuiFocusTrap } from '../focus_trap';
-import { EuiPopover, EuiPopoverProps } from './popover';
-import { EuiResizeObserver } from '../observer/resize_observer';
-import {
-  cascadingMenuKeys,
-  useCombinedRefs,
-  useEuiTheme,
-} from '../../services';
-import { euiFormVariables } from '../form/form.styles';
-import { css } from '@emotion/react';
 import { logicalCSS } from '../../global_styling';
+import { keys, useCombinedRefs, useEuiTheme } from '../../services';
+import { CommonProps } from '../common';
+import { EuiResizeObserver } from '../observer/resize_observer';
+import { EuiFocusTrap } from '../focus_trap';
+import { euiFormVariables } from '../form/form.styles';
+
+import { EuiPopover, EuiPopoverProps } from './popover';
 
 export interface _EuiInputPopoverProps
   extends Omit<EuiPopoverProps, 'button' | 'buttonRef' | 'anchorPosition'> {
@@ -104,7 +101,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   }, [setPanelWidth]);
 
   const onKeyDown = (event: React.KeyboardEvent) => {
-    if (panelEl && event.key === cascadingMenuKeys.TAB) {
+    if (panelEl && event.key === keys.TAB) {
       const tabbableItems = tabbable(panelEl).filter((el: FocusableElement) => {
         return (
           Array.from(el.attributes)

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -104,15 +104,17 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
    * Popover tab to close logic
    */
 
+  const panelPropsOnKeyDown = props.panelProps?.onKeyDown;
+
   const onKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (!panelEl) return;
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      panelPropsOnKeyDown?.(event);
 
       if (event.key === keys.TAB) {
         if (disableFocusTrap) {
           closePopover();
         } else {
-          const tabbableItems = tabbable(panelEl).filter(
+          const tabbableItems = tabbable(event.currentTarget).filter(
             (el) => !el.hasAttribute('data-focus-guard')
           );
           if (!tabbableItems.length) return;
@@ -126,7 +128,7 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
         }
       }
     },
-    [panelEl, disableFocusTrap, closePopover]
+    [disableFocusTrap, closePopover, panelPropsOnKeyDown]
   );
 
   const classes = classnames('euiInputPopover', className);
@@ -144,13 +146,14 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
       ref={popoverClassRef}
       closePopover={closePopover}
       {...props}
+      panelProps={{ ...props.panelProps, onKeyDown }}
     >
       <EuiFocusTrap
         clickOutsideDisables={true}
         disabled={disableFocusTrap}
         {...focusTrapProps}
       >
-        <div onKeyDown={onKeyDown}>{children}</div>
+        {children}
       </EuiFocusTrap>
     </EuiPopover>
   );

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -66,10 +66,19 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   panelRef: _panelRef,
   ...props
 }) => {
-  const euiThemeContext = useEuiTheme();
+  const classes = classnames('euiInputPopover', className);
+  const euiTheme = useEuiTheme();
+  const form = euiFormVariables(euiTheme);
+
+  /**
+   * Ref setup
+   */
+
+  const popoverClassRef = useRef<EuiPopover>(null);
+  // The inputEl state ensures that width is correctly tracked on initial load
   const [inputEl, setInputEl] = useState<HTMLElement | null>(null);
+  // The panelEl state ensures that width is correctly set every time the popover opens
   const [panelEl, setPanelEl] = useState<HTMLElement | null>(null);
-  const popoverClassRef = useRef<EuiPopover | null>(null);
 
   const inputRef = useCombinedRefs([setInputEl, _inputRef]);
   const panelRef = useCombinedRefs([setPanelEl, _panelRef]);
@@ -130,9 +139,6 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
     },
     [disableFocusTrap, closePopover, panelPropsOnKeyDown]
   );
-
-  const classes = classnames('euiInputPopover', className);
-  const form = euiFormVariables(euiThemeContext);
 
   return (
     <EuiPopover

--- a/src/components/suggest/__snapshots__/suggest.test.tsx.snap
+++ b/src/components/suggest/__snapshots__/suggest.test.tsx.snap
@@ -10,49 +10,47 @@ exports[`EuiSuggest is rendered 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -68,54 +66,52 @@ exports[`EuiSuggest props append 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
-          <span
-            class="euiFormControlLayout__append"
-          >
-            Appended
-          </span>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
+        <span
+          class="euiFormControlLayout__append"
         >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
+          Appended
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -131,49 +127,47 @@ exports[`EuiSuggest props isVirtualized 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -189,49 +183,47 @@ exports[`EuiSuggest props maxHeight 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -247,49 +239,47 @@ exports[`EuiSuggest props options common 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -305,49 +295,47 @@ exports[`EuiSuggest props options standard 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -363,71 +351,69 @@ exports[`EuiSuggest props remaining EuiFieldSearch props are spread to the searc
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--compressed"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--compressed"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-invalid="true"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFormControlLayout--2icons euiFieldSearch--compressed euiFieldSearch-isClearable euiFieldSearch-isInvalid euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              id="testId"
-              name="testName"
-              placeholder="Start typing"
-              type="search"
-              value="Controlled value"
-            />
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-            >
-              <button
-                aria-label="Clear input"
-                class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
-                data-test-subj="clearSearchButton"
-                type="button"
-              >
-                <span
-                  class="euiFormControlLayoutClearButton__icon"
-                  data-euiicon-type="cross"
-                />
-              </button>
-              <span
-                color="danger"
-                data-euiicon-type="warning"
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
               />
-            </div>
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-invalid="true"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFormControlLayout--2icons euiFieldSearch--compressed euiFieldSearch-isClearable euiFieldSearch-isInvalid euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            id="testId"
+            name="testName"
+            placeholder="Start typing"
+            type="search"
+            value="Controlled value"
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          >
+            <button
+              aria-label="Clear input"
+              class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
+              data-test-subj="clearSearchButton"
+              type="button"
+            >
+              <span
+                class="euiFormControlLayoutClearButton__icon"
+                data-euiicon-type="cross"
+              />
+            </button>
+            <span
+              color="danger"
+              data-euiicon-type="warning"
+            />
           </div>
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -443,58 +429,56 @@ exports[`EuiSuggest props status status: loading is rendered 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFormControlLayout--1icons euiFieldSearch--fullWidth euiFieldSearch-isLoading euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-            >
-              <span
-                aria-label="Loading"
-                class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
-                role="progressbar"
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
               />
-            </div>
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFormControlLayout--1icons euiFieldSearch--fullWidth euiFieldSearch-isLoading euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          >
+            <span
+              aria-label="Loading"
+              class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
+              role="progressbar"
+            />
           </div>
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: loading.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: loading.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -510,58 +494,56 @@ exports[`EuiSuggest props status status: saved is rendered 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
-            >
-              <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
-          </div>
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
             <span
-              class="euiSuggestInput__statusIcon"
-              color="success"
-              data-euiicon-type="checkInCircleFilled"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
+        <span
+          class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
         >
-          State: saved.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
+          <span
+            class="euiSuggestInput__statusIcon"
+            color="success"
+            data-euiicon-type="checkInCircleFilled"
+          />
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: saved.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -577,49 +559,47 @@ exports[`EuiSuggest props status status: unchanged is rendered 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -635,58 +615,56 @@ exports[`EuiSuggest props status status: unsaved is rendered 1`] = `
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
-            >
-              <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
-          </div>
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
             <span
-              class="euiSuggestInput__statusIcon"
-              color="accent"
-              data-euiicon-type="dot"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
+        <span
+          class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
         >
-          State: unsaved.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
+          <span
+            class="euiSuggestInput__statusIcon"
+            color="accent"
+            data-euiicon-type="dot"
+          />
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unsaved.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -702,58 +680,56 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: loading is r
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFormControlLayout--1icons euiFieldSearch--fullWidth euiFieldSearch-isLoading euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
-            >
-              <span
-                aria-label="Loading"
-                class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
-                role="progressbar"
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
               />
-            </div>
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFormControlLayout--1icons euiFieldSearch--fullWidth euiFieldSearch-isLoading euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
+          <div
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+          >
+            <span
+              aria-label="Loading"
+              class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
+              role="progressbar"
+            />
           </div>
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: loading.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: loading.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -769,58 +745,56 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: saved is ren
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
-            >
-              <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
-          </div>
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
             <span
-              class="euiSuggestInput__statusIcon"
-              color="success"
-              data-euiicon-type="checkInCircleFilled"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
+        <span
+          class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
         >
-          State: saved.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
+          <span
+            class="euiSuggestInput__statusIcon"
+            color="success"
+            data-euiicon-type="checkInCircleFilled"
+          />
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: saved.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -836,49 +810,47 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: unchanged is
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
+            <span
+              class="euiFormControlLayoutCustomIcon"
             >
               <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
           </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
-        >
-          State: unchanged.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unchanged.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>
@@ -894,58 +866,56 @@ exports[`EuiSuggest props tooltipContent tooltipContent for status: unsaved is r
     <div
       class="euiPopover__anchor css-zih94u-render"
     >
-      <div>
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+      >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--group"
+          class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <div
-              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
-            >
-              <span
-                class="euiFormControlLayoutCustomIcon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="euiFormControlLayoutCustomIcon__icon"
-                  data-euiicon-type="search"
-                />
-              </span>
-            </div>
-            <input
-              aria-activedescendant=""
-              aria-describedby="generated-id_instructions"
-              aria-haspopup="listbox"
-              aria-label="aria-label"
-              autocomplete="off"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
-              data-test-subj="test subject string"
-              placeholder="Filter options"
-              type="search"
-              value=""
-            />
-          </div>
-          <span
-            class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
           >
             <span
-              class="euiSuggestInput__statusIcon"
-              color="accent"
-              data-euiicon-type="dot"
-            />
-          </span>
+              class="euiFormControlLayoutCustomIcon"
+            >
+              <span
+                aria-hidden="true"
+                class="euiFormControlLayoutCustomIcon__icon"
+                data-euiicon-type="search"
+              />
+            </span>
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-describedby="generated-id_instructions"
+            aria-haspopup="listbox"
+            aria-label="aria-label"
+            autocomplete="off"
+            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--inGroup euiSelectableSearch testClass1 testClass2 emotion-euiTestCss"
+            data-test-subj="test subject string"
+            placeholder="Filter options"
+            type="search"
+            value=""
+          />
         </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id_instructions"
+        <span
+          class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
         >
-          State: unsaved.
-           
-          Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-        </p>
+          <span
+            class="euiSuggestInput__statusIcon"
+            color="accent"
+            data-euiicon-type="dot"
+          />
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        id="generated-id_instructions"
+      >
+        State: unsaved.
+         
+        Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

I'm working on pulling out some logic that `EuiComboBox` needs directly into `EuiInputPopover` for #7192, and was struggling to understand and work around some of the existing logic. Since I saw several things that bothered me/that could stand to be cleaned up, I decided to do my favorite thing - refactor and write missing tests 😅  

I've opted to make this refactor separate/standalone from my `EuiComboBox` work in order to make code review less of a headache. As always, I **strongly** recommend [following along by commit](https://github.com/elastic/eui/pull/7241/commits) and [hiding whitespace changes](https://github.com/elastic/eui/pull/7241/files?w=1) (the scary LOC diffs on this PR are literally just from indentation changes on snapshots).

### What this PR does:

- Removes an extra unnecessary `<div>` in the popover
- Updates inline width style to use logical `inline-size` property instead of `width`
- Memoizes and greatly cleans up `onKeydown` callback
- Generally tries to make the code more understandable and adds more comments as to why specific things are done a specific way
- Adds more `EuiInputPopover` tests to automatically catch if code changes/breaks something that was meant to do a specific thing a specific way

## QA

Functionally, nothing should have changed in this PR except for 2 removed `<div>` wrappers and a logical property.

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
    ~- [ ] Checked in both **light and dark** modes~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist - ❓ skipping changelog as nothing affecting end-users or consumers should have occurred, but I'd be curious to hear if y'all feel there should be one
- Designer checklist - N/A