### PR TITLE
[INFRA] Parallelize Buildkite test job, take 3

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -1,9 +1,72 @@
 # 🏠/.buildkite/pipelines/pipeline_pull_request_test.yml
 
 steps:
-  - agents:
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":typescript: Linting"
+    agents:
       provider: "gcp"
-    command: .buildkite/scripts/pipeline_test.sh
-    if: build.branch != "main" # We're skipping testing commits in main for now to maintain parity with previous Jenkins setup
+    env:
+      TEST_TYPE: 'lint'
+    if: build.branch != "main" # This job is triggered by the combined test and deploy docs for every PR
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":jest: TS unit tests"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'unit:ts'
+    if: build.branch != "main"
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":jest: TSX unit tests on React 16"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'unit:tsx:16'
+    if: build.branch != "main"
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":jest: TSX unit tests on React 17"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'unit:tsx:17'
+    if: build.branch != "main"
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":jest: TSX unit tests on React 18"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'unit:tsx'
+    if: build.branch != "main"
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":cypress: Cypress tests on React 16"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'cypress:16'
+    if: build.branch != "main"
+    artifact_paths:
+      - "cypress/screenshots/**/*.png"
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":cypress: Cypress tests on React 17"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'cypress:17'
+    if: build.branch != "main"
+    artifact_paths:
+      - "cypress/screenshots/**/*.png"
+  
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":cypress: Cypress tests on React 18"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'cypress:18'
+    if: build.branch != "main"
     artifact_paths:
       - "cypress/screenshots/**/*.png"

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -20,22 +20,22 @@ case $TEST_TYPE in
     ;;
 
   unit:ts)
-    echo "[TASK]: Running .ts unit tests"
+    echo "[TASK]: Running .ts and .js unit tests"
     DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --testMatch=non-react")
     ;;
 
   unit:tsx:16)
-    echo "[TASK]: Running .tsx unit tests"
+    echo "[TASK]: Running Jest .tsx tests against React 16"
     DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --react-version=16 --testMatch=react")
     ;;
   
   unit:tsx:17)
-    echo "[TASK]: Running .tsx unit tests"
+    echo "[TASK]: Running Jest .tsx tests against React 17"
     DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --react-version=17 --testMatch=react")
     ;;
   
   unit:tsx)
-    echo "[TASK]: Running .tsx unit tests"
+    echo "[TASK]: Running Jest .tsx tests against React 18"
     DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --testMatch=react")
     ;;
 

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -41,17 +41,17 @@ case $TEST_TYPE in
 
   cypress:16)
     echo "[TASK]: Running Cypress tests against React 16"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn install cypress && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=16")
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=16")
     ;;
 
   cypress:17)
     echo "[TASK]: Running Cypress tests against React 17"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn install cypress && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=17")
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=17")
     ;;
 
   cypress:18)
     echo "[TASK]: Running Cypress tests against React 18"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn install cypress && yarn test-cypress --node-options=--max_old_space_size=2048")
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048")
     ;;
 
   *)

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -41,17 +41,17 @@ case $TEST_TYPE in
 
   cypress:16)
     echo "[TASK]: Running Cypress tests against React 16"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=16")
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn install cypress && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=16")
     ;;
 
   cypress:17)
     echo "[TASK]: Running Cypress tests against React 17"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=17")
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn install cypress && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=17")
     ;;
 
   cypress:18)
     echo "[TASK]: Running Cypress tests against React 18"
-    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048")
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn install cypress && yarn test-cypress --node-options=--max_old_space_size=2048")
     ;;
 
   *)

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -2,17 +2,63 @@
 
 set -euo pipefail
 
-docker run \
-  -i --rm \
-  --env GIT_COMMITTER_NAME=test \
-  --env GIT_COMMITTER_EMAIL=test \
-  --env HOME=/tmp \
-  --user="$(id -u):$(id -g)" \
-  --volume="$(pwd):/app" \
-  --workdir=/app \
-  docker.elastic.co/eui/ci:5.3 \
-  bash -c "/opt/yarn*/bin/yarn \
-  && yarn cypress install \
-  && yarn lint \
-  && yarn test-unit --node-options=--max_old_space_size=2048 \
-  && yarn test-cypress --node-options=--max_old_space_size=2048"
+DOCKER_OPTIONS=(
+  -i --rm
+  --env GIT_COMMITTER_NAME=test
+  --env GIT_COMMITTER_EMAIL=test
+  --env HOME=/tmp
+  --user="$(id -u):$(id -g)"
+  --volume="$(pwd):/app"
+  --workdir=/app
+  docker.elastic.co/eui/ci:5.3
+)
+
+case $TEST_TYPE in
+  lint)
+    echo "[TASK]: Running linters"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn lint")
+    ;;
+
+  unit:ts)
+    echo "[TASK]: Running .ts unit tests"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --testMatch=non-react")
+    ;;
+
+  unit:tsx:16)
+    echo "[TASK]: Running .tsx unit tests"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --react-version=16 --testMatch=react")
+    ;;
+  
+  unit:tsx:17)
+    echo "[TASK]: Running .tsx unit tests"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --react-version=17 --testMatch=react")
+    ;;
+  
+  unit:tsx)
+    echo "[TASK]: Running .tsx unit tests"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-unit --node-options=--max_old_space_size=2048 --testMatch=react")
+    ;;
+
+  cypress:16)
+    echo "[TASK]: Running Cypress tests against React 16"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=16")
+    ;;
+
+  cypress:17)
+    echo "[TASK]: Running Cypress tests against React 17"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048 --react-version=17")
+    ;;
+
+  cypress:18)
+    echo "[TASK]: Running Cypress tests against React 18"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn test-cypress --node-options=--max_old_space_size=2048")
+    ;;
+
+  *)
+    echo "[ERROR]: Unknown task"
+    echo "Exit code: 1"
+    exit 1
+    ;;
+esac
+
+docker run "${DOCKER_OPTIONS[@]}"

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -34,11 +34,14 @@ const testIcon = (props: PropsOf<typeof EuiIcon>) => async () => {
   act(() => {
     render(<EuiIcon {...props} />);
   });
-  await waitFor(() => {
-    const icon = document.querySelector(`[data-icon-type=${props.type}]`);
-    expect(icon).toHaveAttribute('data-is-loaded', 'true');
-    expect(icon).toMatchSnapshot();
-  });
+  await waitFor(
+    () => {
+      const icon = document.querySelector(`[data-icon-type=${props.type}]`);
+      expect(icon).toHaveAttribute('data-is-loaded', 'true');
+      expect(icon).toMatchSnapshot();
+    },
+    { timeout: 3000 } // CI will sometimes time out if the icon doesn't load fast enough
+  );
 };
 
 describe('EuiIcon', () => {


### PR DESCRIPTION
## Summary

This PR is a second attempt to split our Buildkite `test` job and run the linter, unit tests, and Cypress tests in parallel. It switches back to using `npm` instead of `yarn`. This allows us to allocate more resources in Node to prevent test failures. See https://github.com/elastic/eui/pull/7209 for the previous iteration of this PR. I will close the previous PR when this one merges.

This improved version will split Jest TSX tests and Cypress tests to run against React version `[16, 17, 18]`.

## QA

QA will be done manually by verifying the test runs on Buildkite UI.

- [x] Linter ran successfully
- [x] Jest `(.ts && .js)` unit tests ran
- [x] Jest `.tsx` ran on React 16
- [x] Jest `.tsx` ran on React 17
- [x] Jest `.tsx` ran on React 18
- [x] Cypress ran on React 16
- [x] Cypress ran on React 17
- [x] Cypress ran on React 18