### PR TITLE
[Storybook] General consistency pass

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -93,6 +93,7 @@ const preview: Preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     backgrounds: { disable: true }, // Use colorMode instead
+    options: { showPanel: true }, // default to showing the controls panel
     controls: {
       expanded: true,
       sort: 'requiredFirst',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,6 +38,11 @@ import { writingModeStyles } from './writing_mode.styles';
 // once all EUI components are converted to Emotion
 import '../dist/eui_theme_light.css';
 
+/**
+ * Prop controls
+ */
+
+import type { CommonProps } from '../src/components/common';
 import { hideStorybookControls } from './utils';
 
 const preview: Preview = {
@@ -104,7 +109,11 @@ const preview: Preview = {
   // aren't super useful to test - let's disable them by default and (if needed)
   // individual stories can re-enable them, e.g. by passing
   // `argTypes: { 'data-test-subj': { table: { disable: false } } }`
-  argTypes: hideStorybookControls(['css', 'className', 'data-test-subj']),
+  argTypes: hideStorybookControls<CommonProps>([
+    'css',
+    'className',
+    'data-test-subj',
+  ]),
 };
 
 export default preview;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,6 +38,8 @@ import { writingModeStyles } from './writing_mode.styles';
 // once all EUI components are converted to Emotion
 import '../dist/eui_theme_light.css';
 
+import { hideStorybookControls } from './utils';
+
 const preview: Preview = {
   decorators: [
     (Story, context) => (
@@ -100,12 +102,9 @@ const preview: Preview = {
   },
   // Due to CommonProps, these props appear on almost every Story, but generally
   // aren't super useful to test - let's disable them by default and (if needed)
-  // individual stories can re-enable them
-  argTypes: {
-    css: { table: { disable: true } },
-    className: { table: { disable: true } },
-    'data-test-subj': { table: { disable: true } },
-  },
+  // individual stories can re-enable them, e.g. by passing
+  // `argTypes: { 'data-test-subj': { table: { disable: false } } }`
+  argTypes: hideStorybookControls(['css', 'className', 'data-test-subj']),
 };
 
 export default preview;

--- a/.storybook/utils.test.ts
+++ b/.storybook/utils.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { hideStorybookControls, disableStorybookControls } from './utils';
+
+describe('hideStorybookControls', () => {
+  it('outputs the expected `argTypes` object when passed prop name strings', () => {
+    expect(
+      hideStorybookControls(['isDisabled', 'isLoading', 'isInvalid'])
+    ).toEqual({
+      isDisabled: { table: { disable: true } },
+      isLoading: { table: { disable: true } },
+      isInvalid: { table: { disable: true } },
+    });
+  });
+
+  it('throws a typescript error if a generic is passed and the prop names do not match', () => {
+    type TestComponentProps = { hello: boolean; world: boolean };
+    // No typescript error
+    hideStorybookControls<TestComponentProps>(['hello', 'world']);
+    // @ts-expect-error - will fail `yarn lint` if a TS error is *not* produced
+    hideStorybookControls<TestComponentProps>(['hello', 'world', 'error']);
+  });
+});
+
+describe('disableStorybookControls', () => {
+  it('outputs the expected `argTypes` object when passed prop name strings', () => {
+    expect(
+      disableStorybookControls(['isDisabled', 'isLoading', 'isInvalid'])
+    ).toEqual({
+      isDisabled: { control: false },
+      isLoading: { control: false },
+      isInvalid: { control: false },
+    });
+  });
+
+  it('throws a typescript error if a generic is passed and the prop names do not match', () => {
+    type TestComponentProps = { hello: boolean; world: boolean };
+    // No typescript error
+    disableStorybookControls<TestComponentProps>(['hello', 'world']);
+    // @ts-expect-error - will fail `yarn lint` if a TS error is *not* produced
+    disableStorybookControls<TestComponentProps>(['hello', 'world', 'error']);
+  });
+});

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -10,7 +10,9 @@
  * Completely hide props from Storybook's controls panel.
  * Should be passed or spread to `argTypes`
  */
-export const hideStorybookControls = (propNames: string[]) => {
+export const hideStorybookControls = <Props>(
+  propNames: Array<keyof Props>
+): Record<keyof Props, typeof HIDE_CONTROL> | {} => {
   return propNames.reduce(
     (obj, name) => ({ ...obj, [name]: HIDE_CONTROL }),
     {}
@@ -24,7 +26,9 @@ const HIDE_CONTROL = { table: { disable: true } };
  *
  * Should be passed or spread to `argTypes`
  */
-export const disableStorybookControls = (propNames: string[]) => {
+export const disableStorybookControls = <Props>(
+  propNames: Array<keyof Props>
+): Record<keyof Props, typeof DISABLE_CONTROL> | {} => {
   return propNames.reduce(
     (obj, name) => ({ ...obj, [name]: DISABLE_CONTROL }),
     {}

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Completely hide props from Storybook's controls panel.
+ * Should be passed or spread to `argTypes`
+ */
+export const hideStorybookControls = (propNames: string[]) => {
+  return propNames.reduce(
+    (obj, name) => ({ ...obj, [name]: HIDE_CONTROL }),
+    {}
+  );
+};
+const HIDE_CONTROL = { table: { disable: true } };
+
+/**
+ * Leave props visible in Storybook's controls panel, but disable them
+ * from being controllable (renders a `-`).
+ *
+ * Should be passed or spread to `argTypes`
+ */
+export const disableStorybookControls = (propNames: string[]) => {
+  return propNames.reduce(
+    (obj, name) => ({ ...obj, [name]: DISABLE_CONTROL }),
+    {}
+  );
+};
+const DISABLE_CONTROL = { control: false };

--- a/.storybook/utils.ts
+++ b/.storybook/utils.ts
@@ -7,6 +7,10 @@
  */
 
 /**
+ * argTypes configurations
+ */
+
+/**
  * Completely hide props from Storybook's controls panel.
  * Should be passed or spread to `argTypes`
  */
@@ -35,3 +39,26 @@ export const disableStorybookControls = <Props>(
   );
 };
 const DISABLE_CONTROL = { control: false };
+
+/**
+ * parameters configurations
+ */
+
+/**
+ * Will hide all props/controls. Pass to `parameters`
+ *
+ * TODO: Figure out some way to not show Storybook's "setup" text?
+ */
+export const hideAllStorybookControls = {
+  controls: { exclude: /.*/g },
+};
+
+/**
+ * Will hide the control/addon panel entirely for a specific story.
+ * Should be passed or spread to to `parameters`.
+ *
+ * Note that users can choose to re-show the panel in the UI
+ */
+export const hidePanel = {
+  options: { showPanel: false },
+};

--- a/scripts/jest/config.js
+++ b/scripts/jest/config.js
@@ -19,6 +19,7 @@ const config = {
     '<rootDir>/scripts/babel',
     '<rootDir>/scripts/tests',
     '<rootDir>/scripts/eslint-plugin',
+    '<rootDir>/.storybook',
   ],
   collectCoverageFrom: [
     'src/{components,services,global_styling}/**/*.{ts,tsx,js,jsx}',

--- a/src/components/button/button_empty/button_empty.stories.tsx
+++ b/src/components/button/button_empty/button_empty.stories.tsx
@@ -20,6 +20,16 @@ const meta: Meta<EuiButtonEmptyProps> = {
     },
     iconType: { control: 'text' },
   },
+  args: {
+    // Component defaults
+    color: 'primary',
+    size: 'm',
+    iconSize: 'm',
+    iconSide: 'left',
+    isDisabled: false,
+    isLoading: false,
+    isSelected: false,
+  },
 };
 
 export default meta;
@@ -28,12 +38,5 @@ type Story = StoryObj<EuiButtonEmptyProps>;
 export const Playground: Story = {
   args: {
     children: 'Tertiary action',
-    color: 'primary',
-    size: 'm',
-    iconSize: 'm',
-    iconSide: 'left',
-    isDisabled: false,
-    isLoading: false,
-    isSelected: false,
   },
 };

--- a/src/components/button/button_group/button_group.stories.tsx
+++ b/src/components/button/button_group/button_group.stories.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { disableStorybookControls } from '../../../../.storybook/utils';
 
 import {
   EuiButtonGroup,
@@ -19,11 +20,6 @@ const meta: Meta<EuiButtonGroupProps> = {
   title: 'EuiButtonGroup',
   // @ts-ignore This still works for Storybook controls, even though Typescript complains
   component: EuiButtonGroup,
-  parameters: {
-    controls: {
-      exclude: ['data-test-subj'],
-    },
-  },
   argTypes: {
     type: {
       options: ['single', 'multi'],
@@ -43,6 +39,15 @@ const meta: Meta<EuiButtonGroupProps> = {
     buttonSize: {
       control: 'select',
     },
+  },
+  args: {
+    // Component defaults
+    type: 'single',
+    buttonSize: 's',
+    color: 'text',
+    isDisabled: false,
+    isFullWidth: false,
+    isIconOnly: false,
   },
 };
 
@@ -76,6 +81,17 @@ const EuiButtonGroupSingle = (props: any) => {
   );
 };
 
+export const SingleSelection: Story = {
+  render: ({ ...args }) => <EuiButtonGroupSingle {...args} />,
+  args: {
+    legend: 'EuiButtonGroup - single selection',
+    options,
+    type: 'single',
+    idSelected: 'button1',
+  },
+  argTypes: disableStorybookControls(['type']),
+};
+
 const EuiButtonGroupMulti = (props: any) => {
   const [idToSelectedMap, setIdToSelectedMap] = useState<
     Record<string, boolean>
@@ -100,24 +116,13 @@ const EuiButtonGroupMulti = (props: any) => {
   );
 };
 
-export const Playground: Story = {
-  render: ({ ...args }) => {
-    if (args.type === 'multi') {
-      return <EuiButtonGroupMulti {...args} />;
-    } else {
-      return <EuiButtonGroupSingle {...args} />;
-    }
-  },
+export const MultiSelection: Story = {
+  render: ({ ...args }) => <EuiButtonGroupMulti {...args} />,
   args: {
-    legend: 'EuiButtonGroup demo',
-    type: 'single',
+    legend: 'EuiButtonGroup - multiple selections',
     options,
-    idSelected: 'button1',
+    type: 'multi',
     idToSelectedMap: { button1: true },
-    buttonSize: 's',
-    color: 'text',
-    isDisabled: false,
-    isFullWidth: false,
-    isIconOnly: false,
-  } as any,
+  },
+  argTypes: disableStorybookControls(['type']),
 };

--- a/src/components/button/button_icon/button_icon.stories.tsx
+++ b/src/components/button/button_icon/button_icon.stories.tsx
@@ -13,6 +13,16 @@ import { EuiButtonIcon, EuiButtonIconProps } from './button_icon';
 const meta: Meta<EuiButtonIconProps> = {
   title: 'EuiButtonIcon',
   component: EuiButtonIcon,
+  args: {
+    // Component defaults
+    color: 'primary',
+    display: 'empty',
+    size: 'xs',
+    iconSize: 'm',
+    isDisabled: false,
+    isLoading: false,
+    isSelected: false,
+  },
 };
 
 export default meta;
@@ -21,12 +31,5 @@ type Story = StoryObj<EuiButtonIconProps>;
 export const Playground: Story = {
   args: {
     iconType: 'faceHappy',
-    color: 'primary',
-    display: 'empty',
-    size: 'xs',
-    iconSize: 'm',
-    isDisabled: false,
-    isLoading: false,
-    isSelected: false,
   },
 };

--- a/src/components/collapsible_nav/collapsible_nav.stories.tsx
+++ b/src/components/collapsible_nav/collapsible_nav.stories.tsx
@@ -15,6 +15,13 @@ import { EuiCollapsibleNav, EuiCollapsibleNavProps } from './collapsible_nav';
 const meta: Meta<EuiCollapsibleNavProps> = {
   title: 'EuiCollapsibleNav',
   component: EuiCollapsibleNav,
+  args: {
+    // Component defaults
+    isDocked: false,
+    dockedBreakpoint: 'l',
+    showButtonIfDocked: false,
+    size: 320,
+  },
   // TODO: Improve props inherited from EuiFlyout, ideally through
   // a DRY import from `flyout.stories.tsx` once that's created
 };
@@ -43,9 +50,5 @@ export const Playground: Story = {
   args: {
     children: 'Collapsible nav content',
     isOpen: true,
-    isDocked: false,
-    dockedBreakpoint: 'l',
-    showButtonIfDocked: false,
-    size: 240,
   },
 };

--- a/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.stories.tsx
+++ b/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.stories.tsx
@@ -43,6 +43,14 @@ const meta: Meta<EuiCollapsibleNavGroupProps> = {
     isDisabled: { if: { arg: 'isCollapsible' } },
     element: { if: { arg: 'isCollapsible' } },
   },
+  args: {
+    iconType: 'logoElastic',
+    // Component defaults
+    iconSize: 'l',
+    titleSize: 'xxs',
+    titleElement: 'h3',
+    background: 'none',
+  },
 };
 
 export default meta;
@@ -51,12 +59,7 @@ type Story = StoryObj<EuiCollapsibleNavGroupProps>;
 export const Accordion: Story = {
   args: {
     children: 'This is an accordion group with a title',
-    background: 'none',
     title: 'Nav group - accordion',
-    iconType: 'logoElastic',
-    iconSize: 'l',
-    titleElement: 'h3',
-    titleSize: 'xxs',
     initialIsOpen: true,
     isCollapsible: true,
   },
@@ -65,12 +68,6 @@ export const Accordion: Story = {
 export const NonAccordion: StoryObj<EuiCollapsibleNavGroupProps> = {
   args: {
     children: 'This is a group with a title',
-    background: 'none',
-    title: 'Nav group - non-accordion',
-    iconType: 'logoElastic',
-    iconSize: 'l',
-    titleElement: 'h3',
-    titleSize: 'xxs',
     isCollapsible: false,
   },
 };
@@ -78,6 +75,5 @@ export const NonAccordion: StoryObj<EuiCollapsibleNavGroupProps> = {
 export const NoTitle: Story = {
   args: {
     children: 'This is a group without a title',
-    background: 'none',
   },
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -8,6 +8,10 @@
 
 import React, { FunctionComponent, PropsWithChildren, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import {
+  hideStorybookControls,
+  hideAllStorybookControls,
+} from '../../../.storybook/utils';
 
 import { EuiHeader, EuiHeaderSection, EuiHeaderSectionItem } from '../header';
 import { EuiPageTemplate } from '../page_template';
@@ -507,6 +511,5 @@ export const FlyoutOverlay: Story = {
       </EuiHeader>
     );
   },
-  // Hide all parameters
-  parameters: { controls: { exclude: /.*/g } },
+  parameters: hideAllStorybookControls,
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -418,77 +418,6 @@ export const SecurityExample: Story = {
   ),
 };
 
-export const MultipleFixedHeaders: Story = {
-  render: ({ ...args }) => (
-    <>
-      <EuiHeader position="fixed">First header</EuiHeader>
-      <EuiHeader position="fixed">
-        <EuiHeaderSection>
-          <EuiCollapsibleNavBeta {...args}>
-            This story tests that EuiCollapsibleNav automatically adjusts its
-            position & height for multiple fixed headers
-          </EuiCollapsibleNavBeta>
-          Second header
-        </EuiHeaderSection>
-      </EuiHeader>
-    </>
-  ),
-};
-
-const MockConsumerFlyout: FunctionComponent = () => {
-  const [flyoutIsOpen, setFlyoutOpen] = useState(false);
-  return (
-    <>
-      <EuiButton size="s" onClick={() => setFlyoutOpen(!flyoutIsOpen)}>
-        Toggle a flyout
-      </EuiButton>
-      {flyoutIsOpen && (
-        <EuiFlyout onClose={() => setFlyoutOpen(false)}>
-          <EuiCollapsibleNavBeta.Body>
-            Some other mock consumer flyout that <strong>should</strong> overlap
-            EuiCollapsibleNav
-          </EuiCollapsibleNavBeta.Body>
-        </EuiFlyout>
-      )}
-    </>
-  );
-};
-
-export const FlyoutInFixedHeaders: Story = {
-  render: ({ ...args }) => {
-    return (
-      <EuiHeader position="fixed">
-        <EuiHeaderSection>
-          <EuiCollapsibleNavBeta {...args}>Nav content</EuiCollapsibleNavBeta>
-        </EuiHeaderSection>
-        <EuiHeaderSection>
-          <EuiHeaderSectionItem>
-            <MockConsumerFlyout />
-          </EuiHeaderSectionItem>
-        </EuiHeaderSection>
-      </EuiHeader>
-    );
-  },
-};
-
-export const GlobalCSSVariable: Story = {
-  render: ({ ...args }) => (
-    <>
-      <EuiHeader position="fixed">
-        <EuiHeaderSection>
-          <EuiCollapsibleNavBeta {...args}>
-            This story tests the global `--euiCollapsibleNavOffset` CSS variable
-          </EuiCollapsibleNavBeta>
-        </EuiHeaderSection>
-      </EuiHeader>
-      <EuiBottomBar left="var(--euiCollapsibleNavOffset, 0)">
-        This text should be visible at all times and the bar position should
-        update dynamically based on the nav width (including on mobile)
-      </EuiBottomBar>
-    </>
-  ),
-};
-
 export const CollapsedStateInLocalStorage: Story = {
   render: () => {
     const key = 'EuiCollapsibleNav__isCollapsed';
@@ -515,4 +444,69 @@ export const CollapsedStateInLocalStorage: Story = {
       </>
     );
   },
+  argTypes: hideStorybookControls(['aria-label', 'side', 'width']),
+};
+
+export const GlobalCSSVariable: Story = {
+  render: ({ side, ...args }) => (
+    <>
+      <EuiHeader position="fixed">
+        <EuiHeaderSection side={side}>
+          <EuiCollapsibleNavBeta {...args} side={side}>
+            This story tests the global `--euiCollapsibleNavOffset` CSS variable
+          </EuiCollapsibleNavBeta>
+        </EuiHeaderSection>
+      </EuiHeader>
+      {/* In production, would just be `left="var(--euiCollapsibleNavOffset, 0)"` if the nav isn't changing sides */}
+      <EuiBottomBar {...{ [side!]: 'var(--euiCollapsibleNavOffset, 0)' }}>
+        This text should be visible at all times and the bar position should
+        update dynamically based on the nav width (including on mobile)
+      </EuiBottomBar>
+    </>
+  ),
+  argTypes: hideStorybookControls([
+    'aria-label',
+    'initialIsCollapsed',
+    'onCollapseToggle',
+  ]),
+};
+
+const MockConsumerFlyout: FunctionComponent = () => {
+  const [flyoutIsOpen, setFlyoutOpen] = useState(false);
+  return (
+    <>
+      <EuiButton size="s" onClick={() => setFlyoutOpen(!flyoutIsOpen)}>
+        Toggle flyout
+      </EuiButton>
+      {flyoutIsOpen && (
+        <EuiFlyout onClose={() => setFlyoutOpen(false)}>
+          <EuiCollapsibleNavBeta.Body>
+            This flyout's mask should overlay / sit on top of the collapsible
+            nav, on both desktop and mobile
+          </EuiCollapsibleNavBeta.Body>
+        </EuiFlyout>
+      )}
+    </>
+  );
+};
+
+export const FlyoutOverlay: Story = {
+  render: (_) => {
+    return (
+      <EuiHeader position="fixed">
+        <EuiHeaderSection>
+          <EuiCollapsibleNavBeta>
+            Click the "Toggle flyout" button in the top right hand corner
+          </EuiCollapsibleNavBeta>
+        </EuiHeaderSection>
+        <EuiHeaderSection>
+          <EuiHeaderSectionItem>
+            <MockConsumerFlyout />
+          </EuiHeaderSectionItem>
+        </EuiHeaderSection>
+      </EuiHeader>
+    );
+  },
+  // Hide all parameters
+  parameters: { controls: { exclude: /.*/g } },
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -34,6 +34,7 @@ const meta: Meta<EuiCollapsibleNavBetaProps> = {
     },
   },
   args: {
+    // Component defaults
     side: 'left',
     initialIsCollapsed: false,
     width: 248,

--- a/src/components/empty_prompt/empty_prompt.stories.tsx
+++ b/src/components/empty_prompt/empty_prompt.stories.tsx
@@ -21,25 +21,24 @@ import { EuiEmptyPrompt, EuiEmptyPromptProps } from './empty_prompt';
 const meta: Meta<EuiEmptyPromptProps> = {
   title: 'EuiEmptyPrompt',
   component: EuiEmptyPrompt,
+  args: {
+    // Component defaults
+    titleSize: 'm',
+    paddingSize: 'l',
+    color: 'plain', // Default is actually 'transparent', but for the purposes of easier testing in Storybook we'll set it to plain
+    layout: 'vertical',
+    hasBorder: false,
+    hasShadow: false,
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiEmptyPromptProps>;
 
-const componentDefaults: EuiEmptyPromptProps = {
-  titleSize: 'm',
-  paddingSize: 'l',
-  color: 'plain', // The component default is actually 'transparent', but for the purposes of easier testing in Storybook we'll set it to plain
-  layout: 'vertical',
-};
-
 export const Playground: Story = {
   args: {
-    ...componentDefaults,
     title: <h2>Start adding cases</h2>,
     iconType: 'logoSecurity',
-    hasBorder: false,
-    hasShadow: false,
     body: 'Add a new case or change your filter settings.', // Should be wrapped in a `<p>` in production usage, but using a string makes this easier to edit in Storybook controls
     actions: [
       <EuiButton color="primary" fill>
@@ -67,7 +66,6 @@ export const PageTemplate: Story = {
     </EuiPageTemplate>
   ),
   args: {
-    ...componentDefaults,
     title: <h2>Create your first visualization</h2>,
     layout: 'horizontal',
     icon: <EuiImage size="fullWidth" src={illustration} alt="" />,

--- a/src/components/error_boundary/error_boundary.stories.tsx
+++ b/src/components/error_boundary/error_boundary.stories.tsx
@@ -11,31 +11,26 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { EuiErrorBoundary, EuiErrorBoundaryProps } from './error_boundary';
 
-const ErrorContent = () => {
-  throw new Error(
-    "I'm here to kick butt and chew bubblegum.\n\nAnd I'm all out of gum."
-  );
-};
-
 const meta: Meta<EuiErrorBoundaryProps> = {
   title: 'EuiErrorBoundary',
-  component: () => (
-    <EuiErrorBoundary>
-      <ErrorContent />
-    </EuiErrorBoundary>
-  ),
+  component: EuiErrorBoundary,
   parameters: {
     layout: 'fullscreen',
-  },
-  argTypes: {
-    onError: {
-      description:
-        'TODO: extract prop descriptions, defaults, and types from Typescript ',
-    },
   },
 };
 
 export default meta;
 type Story = StoryObj<EuiErrorBoundaryProps>;
 
-export const Default: Story = {};
+const ErrorContent = () => {
+  throw new Error(
+    "I'm here to kick butt and chew bubblegum.\n\nAnd I'm all out of gum."
+  );
+};
+
+export const Playground: Story = {
+  args: {
+    children: <ErrorContent />,
+    onError: console.log,
+  },
+};

--- a/src/components/filter_group/filter_button.stories.tsx
+++ b/src/components/filter_group/filter_button.stories.tsx
@@ -9,20 +9,26 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { BUTTON_COLORS } from '../../themes/amsterdam/global_styling/mixins';
+
 import { EuiFilterGroup } from './filter_group';
 import { EuiFilterButton, EuiFilterButtonProps } from './filter_button';
 
 const meta: Meta<EuiFilterButtonProps> = {
   title: 'EuiFilterButton',
   component: EuiFilterButton as any,
-};
-
-const defaultProps = {
-  hasActiveFilters: true,
-  numFilters: 5,
-  iconType: 'arrowDown',
-  iconSide: 'right' as const,
-  isDisabled: false,
+  argTypes: {
+    color: { control: 'select', options: BUTTON_COLORS },
+  },
+  args: {
+    // Component defaults
+    iconSide: 'right',
+    color: 'text',
+    badgeColor: 'accent',
+    grow: true,
+    isSelected: false,
+    isDisabled: false,
+  },
 };
 
 export default meta;
@@ -34,7 +40,11 @@ export const Playground: Story = {
       <EuiFilterButton {...args}>Filter</EuiFilterButton>
     </EuiFilterGroup>
   ),
-  args: defaultProps,
+  args: {
+    hasActiveFilters: true,
+    numFilters: 5,
+    iconType: 'arrowDown',
+  },
 };
 
 export const MultipleButtons: Story = {
@@ -45,7 +55,11 @@ export const MultipleButtons: Story = {
       <EuiFilterButton {...args}>Filter three</EuiFilterButton>
     </EuiFilterGroup>
   ),
-  args: defaultProps,
+  args: {
+    hasActiveFilters: true,
+    numFilters: 5,
+    iconType: 'arrowDown',
+  },
 };
 
 export const FullWidthAndGrow: Story = {
@@ -78,5 +92,4 @@ export const FullWidthAndGrow: Story = {
       </EuiFilterButton>
     </EuiFilterGroup>
   ),
-  args: { isDisabled: false },
 };

--- a/src/components/header/header.stories.tsx
+++ b/src/components/header/header.stories.tsx
@@ -26,17 +26,17 @@ import { EuiHeader, EuiHeaderProps } from './header';
 const meta: Meta<EuiHeaderProps> = {
   title: 'EuiHeader',
   component: EuiHeader,
+  args: {
+    // Component defaults
+    position: 'static',
+    theme: 'default',
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiHeaderProps>;
 
-export const Playground: Story = {
-  args: {
-    position: 'static',
-    theme: 'default',
-  },
-};
+export const Playground: Story = {};
 
 export const Sections: Story = {
   args: {

--- a/src/components/header/header_alert/header_alert.stories.tsx
+++ b/src/components/header/header_alert/header_alert.stories.tsx
@@ -40,26 +40,24 @@ import { EuiHeaderAlert, EuiHeaderAlertProps } from './header_alert';
 const meta: Meta<EuiHeaderAlertProps> = {
   title: 'EuiHeaderAlert',
   component: EuiHeaderAlert,
+  args: {
+    // Not default props, set for demo purposes
+    title: '7.0 release notes',
+    date: 'January 1st 1970',
+    text: 'Stay up-to-date on the latest and greatest features.',
+    action: (
+      <EuiLink href="#" target="_blank">
+        Check out the docs
+      </EuiLink>
+    ),
+    badge: <EuiBadge color="hollow">7.0</EuiBadge>,
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiHeaderAlertProps>;
 
-const defaultProps = {
-  title: '7.0 release notes',
-  date: 'January 1st 1970',
-  text: 'Stay up-to-date on the latest and greatest features.',
-  action: (
-    <EuiLink href="#" target="_blank">
-      Check out the docs
-    </EuiLink>
-  ),
-  badge: <EuiBadge color="hollow">7.0</EuiBadge>,
-};
-
-export const Playground: Story = {
-  args: defaultProps,
-};
+export const Playground: Story = {};
 
 /**
  * Flyout example
@@ -121,7 +119,6 @@ const Flyout = (props: EuiHeaderAlertProps) => {
 };
 export const FlyoutExample: Story = {
   render: ({ ...args }) => <Flyout {...args} />,
-  args: defaultProps,
 };
 
 /**
@@ -182,5 +179,4 @@ const Popover = (props: any) => {
 };
 export const PopoverExample: Story = {
   render: ({ ...args }) => <Popover {...args} />,
-  args: defaultProps,
 };

--- a/src/components/header/header_links/header_links.stories.tsx
+++ b/src/components/header/header_links/header_links.stories.tsx
@@ -17,6 +17,11 @@ import { EuiHeaderLinks, EuiHeaderLinksProps } from './header_links';
 const meta: Meta<EuiHeaderLinksProps> = {
   title: 'EuiHeaderLinks',
   component: EuiHeaderLinks,
+  args: {
+    // Component defaults
+    gutterSize: 's',
+    popoverBreakpoints: ['xs', 's'],
+  },
 };
 
 export default meta;
@@ -36,8 +41,4 @@ export const Playground: Story = {
       </EuiHeaderSection>
     </EuiHeader>
   ),
-  args: {
-    gutterSize: 's',
-    popoverBreakpoints: ['xs', 's'],
-  },
 };

--- a/src/components/header/header_logo/header_logo.stories.tsx
+++ b/src/components/header/header_logo/header_logo.stories.tsx
@@ -15,6 +15,11 @@ import { EuiHeaderLogo, EuiHeaderLogoProps } from './header_logo';
 const meta: Meta<EuiHeaderLogoProps> = {
   title: 'EuiHeaderLogo',
   component: EuiHeaderLogo,
+  args: {
+    // Not default props, set for demo purposes
+    iconType: 'logoElastic',
+    children: 'Elastic',
+  },
 };
 
 export default meta;
@@ -28,10 +33,6 @@ export const Playground: Story = {
       </EuiHeaderSectionItem>
     </EuiHeader>
   ),
-  args: {
-    iconType: 'logoElastic',
-    iconTitle: 'Elastic',
-  },
 };
 
 export const WithText: Story = {
@@ -42,8 +43,4 @@ export const WithText: Story = {
       </EuiHeaderSectionItem>
     </EuiHeader>
   ),
-  args: {
-    iconType: 'logoElastic',
-    children: 'Elastic',
-  },
 };

--- a/src/components/key_pad_menu/key_pad_menu_item.stories.tsx
+++ b/src/components/key_pad_menu/key_pad_menu_item.stories.tsx
@@ -19,6 +19,12 @@ const meta: Meta<EuiKeyPadMenuItemProps> = {
   argTypes: {
     checkable: { options: [undefined, 'multi', 'single'] },
   },
+  args: {
+    label: 'Hello world', // String makes prop easier to change/toggle
+    // Component defaults
+    isDisabled: false,
+    isSelected: false,
+  },
 };
 
 export default meta;
@@ -27,9 +33,5 @@ type Story = StoryObj<EuiKeyPadMenuItemProps>;
 export const Playground: Story = {
   args: {
     children: <EuiIcon type="faceHappy" size="l" />,
-    // Make these props easier to change/toggle
-    label: 'Hello world',
-    isDisabled: false,
-    isSelected: false,
   },
 };

--- a/src/components/page/page.stories.tsx
+++ b/src/components/page/page.stories.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { hideStorybookControls } from '../../../.storybook/utils';
 
 import { EuiFlexGroup } from '../flex';
 import { EuiSkeletonText } from '../skeleton';
@@ -55,12 +56,12 @@ export const RestrictWidth: Story = {
     ...componentDefaults,
     restrictWidth: '80vw',
   },
-  argTypes: {
-    // This story displays the restrictWidth functionality; removing other props to prevent confusion
-    grow: { table: { disable: true } },
-    direction: { table: { disable: true } },
-    paddingSize: { table: { disable: true } },
-  },
+  // This story displays the restrictWidth functionality; removing other props to prevent confusion
+  argTypes: hideStorybookControls<EuiPageProps>([
+    'grow',
+    'direction',
+    'paddingSize',
+  ]),
   render: ({ ...args }) => <EuiPage {...args}>{_pageContent}</EuiPage>,
 };
 

--- a/src/components/page/page.stories.tsx
+++ b/src/components/page/page.stories.tsx
@@ -20,23 +20,22 @@ import { EuiPage, EuiPageProps } from './page';
 const meta: Meta<EuiPageProps> = {
   title: 'EuiPage',
   component: EuiPage,
+  argTypes: {
+    restrictWidth: { control: 'boolean' },
+  },
+  args: {
+    // Component defaults
+    paddingSize: 'none',
+    grow: true,
+    direction: 'row',
+    restrictWidth: false,
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiPageProps>;
 
-const componentDefaults: EuiPageProps = {
-  paddingSize: 'none',
-  grow: true,
-  direction: 'row',
-  restrictWidth: false,
-};
-
 export const Playground: Story = {
-  args: componentDefaults,
-  argTypes: {
-    restrictWidth: { control: 'boolean' },
-  },
   render: ({ ...args }) => (
     <EuiFlexGroup
       direction="column"
@@ -53,7 +52,6 @@ export const Playground: Story = {
 
 export const RestrictWidth: Story = {
   args: {
-    ...componentDefaults,
     restrictWidth: '80vw',
   },
   // This story displays the restrictWidth functionality; removing other props to prevent confusion

--- a/src/components/page/page_body/page_body.stories.tsx
+++ b/src/components/page/page_body/page_body.stories.tsx
@@ -9,28 +9,31 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { BORDER_RADII, EuiPanelProps } from '../../panel/panel';
 import { EuiSkeletonText } from '../../skeleton';
 import { EuiPage } from '../page';
 
 import { EuiPageBody, EuiPageBodyProps } from './page_body';
 
-const meta: Meta<EuiPageBodyProps> = {
+const meta: Meta<EuiPageBodyProps & Pick<EuiPanelProps, 'borderRadius'>> = {
   title: 'EuiPageBody',
   component: EuiPageBody,
+  argTypes: {
+    borderRadius: { control: 'radio', options: BORDER_RADII },
+  },
+  args: {
+    // Component defaults
+    restrictWidth: false,
+    paddingSize: 'none',
+    borderRadius: 'none',
+    component: 'main', // This is not a component default, but for the purposes of easier testing in the DOM in Storybook we'll set it to main
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiPageBodyProps>;
 
-const componentDefaults: EuiPageBodyProps = {
-  panelled: true,
-  restrictWidth: false,
-  paddingSize: 'm', // The component default is actually 'none', but for nicer visuals in Storybook we'll set it to 'm'
-  component: 'main', // This is not a component default, but for the purposes of easier testing in the DOM in Storybook we'll set it to main
-};
-
 export const Playground: Story = {
-  args: componentDefaults,
   render: ({ ...args }) => (
     <EuiPage>
       <EuiPageBody {...args}>
@@ -43,4 +46,8 @@ export const Playground: Story = {
       </EuiPageBody>
     </EuiPage>
   ),
+  args: {
+    panelled: true,
+    paddingSize: 'm',
+  },
 };

--- a/src/components/page/page_header/page_header.stories.tsx
+++ b/src/components/page/page_header/page_header.stories.tsx
@@ -24,21 +24,20 @@ const meta: Meta<EuiPageHeaderProps> = {
     breadcrumbProps: { control: 'object' },
     tabsProps: { control: 'object' },
   },
+  args: {
+    // Component defaults
+    paddingSize: 'none',
+    responsive: true,
+    restrictWidth: false,
+    alignItems: undefined,
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiPageHeaderProps>;
 
-const componentDefaults: EuiPageHeaderProps = {
-  paddingSize: 'none',
-  responsive: true,
-  restrictWidth: false,
-  alignItems: undefined,
-};
-
 export const Playground: Story = {
   args: {
-    ...componentDefaults,
     pageTitle: 'Page title',
     iconType: 'logoKibana',
     description: 'Example of a description.',

--- a/src/components/page/page_section/page_section.stories.tsx
+++ b/src/components/page/page_section/page_section.stories.tsx
@@ -19,22 +19,21 @@ const meta: Meta<EuiPageSectionProps> = {
   argTypes: {
     bottomBorder: { control: 'select', options: [true, false, 'extended'] },
   },
+  args: {
+    // Component defaults
+    restrictWidth: false,
+    color: 'plain', // The component default is actually 'transparent', but for the purposes of easier testing in Storybook we'll set it to plain
+    paddingSize: 'l',
+    alignment: 'top',
+    grow: false,
+    component: 'section', // This is not a component default, but for the purposes of easier testing in the DOM in Storybook we'll set it to section
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiPageSectionProps>;
 
-const componentDefaults: EuiPageSectionProps = {
-  restrictWidth: false,
-  color: 'plain', // The component default is actually 'transparent', but for the purposes of easier testing in Storybook we'll set it to plain
-  paddingSize: 'l',
-  alignment: 'top',
-  grow: false,
-  component: 'section', // This is not a component default, but for the purposes of easier testing in the DOM in Storybook we'll set it to section
-};
-
 export const Playground: Story = {
-  args: componentDefaults,
   render: ({ ...args }) => (
     // Block size demos the grow prop
     <EuiFlexGroup direction="column" css={{ blockSize: '100vh' }}>

--- a/src/components/page/page_sidebar/page_sidebar.stories.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.stories.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { hideStorybookControls } from '../../../../.storybook/utils';
 
 import { EuiSkeletonText } from '../../skeleton';
 import { EuiPageSection } from '../page_section';
@@ -63,12 +64,12 @@ export const StickyOffset: Story = {
     ...componentDefaults,
     sticky: { offset: 50 },
   },
-  argTypes: {
-    // This story demos the sticky functionality; removing other props to prevent confusion
-    minWidth: { table: { disable: true } },
-    paddingSize: { table: { disable: true } },
-    responsive: { table: { disable: true } },
-  },
+  // This story demos the sticky functionality; removing other props to prevent confusion
+  argTypes: hideStorybookControls<EuiPageSidebarProps>([
+    'minWidth',
+    'paddingSize',
+    'responsive',
+  ]),
   render: ({ ...args }) => (
     <EuiPage
       css={{

--- a/src/components/page/page_sidebar/page_sidebar.stories.tsx
+++ b/src/components/page/page_sidebar/page_sidebar.stories.tsx
@@ -22,23 +22,22 @@ const meta: Meta<EuiPageSidebarProps> = {
   parameters: {
     layout: 'fullscreen',
   },
+  argTypes: {
+    sticky: { control: 'boolean' },
+  },
+  args: {
+    // Component defaults
+    paddingSize: 'm', // The component default is actually 'none', but for nicer visuals in Storybook we'll set it to 'm'
+    sticky: false,
+    minWidth: 248,
+    responsive: ['xs', 's'],
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiPageSidebarProps>;
 
-const componentDefaults: EuiPageSidebarProps = {
-  paddingSize: 'm', // The component default is actually 'none', but for nicer visuals in Storybook we'll set it to 'm'
-  sticky: false,
-  minWidth: 248,
-  responsive: ['xs', 's'],
-};
-
 export const Playground: Story = {
-  args: componentDefaults,
-  argTypes: {
-    sticky: { control: 'boolean' },
-  },
   render: ({ ...args }) => (
     <EuiPage
       css={({ euiTheme }) => ({
@@ -61,15 +60,19 @@ export const Playground: Story = {
 
 export const StickyOffset: Story = {
   args: {
-    ...componentDefaults,
     sticky: { offset: 50 },
   },
-  // This story demos the sticky functionality; removing other props to prevent confusion
-  argTypes: hideStorybookControls<EuiPageSidebarProps>([
-    'minWidth',
-    'paddingSize',
-    'responsive',
-  ]),
+  argTypes: {
+    sticky: {
+      control: 'object',
+    },
+    // This story demos the sticky functionality; removing other props to prevent confusion
+    ...hideStorybookControls<EuiPageSidebarProps>([
+      'minWidth',
+      'paddingSize',
+      'responsive',
+    ]),
+  },
   render: ({ ...args }) => (
     <EuiPage
       css={{

--- a/src/components/panel/split_panel/split_panel_inner.stories.tsx
+++ b/src/components/panel/split_panel/split_panel_inner.stories.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { disableStorybookControls } from '../../../../.storybook/utils';
 
 import { COLORS } from '../panel';
 import { EuiSplitPanel, _EuiSplitPanelInnerProps } from './split_panel';
@@ -17,7 +18,7 @@ const meta: Meta<_EuiSplitPanelInnerProps> = {
   component: EuiSplitPanel.Inner,
   argTypes: {
     color: { control: 'select', options: COLORS },
-    panelRef: { control: false },
+    ...disableStorybookControls<_EuiSplitPanelInnerProps>(['panelRef']),
   },
 };
 

--- a/src/components/panel/split_panel/split_panel_inner.stories.tsx
+++ b/src/components/panel/split_panel/split_panel_inner.stories.tsx
@@ -20,18 +20,18 @@ const meta: Meta<_EuiSplitPanelInnerProps> = {
     color: { control: 'select', options: COLORS },
     ...disableStorybookControls<_EuiSplitPanelInnerProps>(['panelRef']),
   },
+  args: {
+    // Component defaults
+    color: 'transparent',
+    paddingSize: 'm',
+    grow: true,
+  },
 };
 
 export default meta;
 type Story = StoryObj<_EuiSplitPanelInnerProps>;
 
 export const SplitPanelInner: Story = {
-  args: {
-    // Default props
-    color: 'transparent',
-    paddingSize: 'm',
-    grow: true,
-  },
   render: ({ ...args }) => (
     <EuiSplitPanel.Outer css={{ blockSize: '100vh' }}>
       <EuiSplitPanel.Inner {...args}>Top panel</EuiSplitPanel.Inner>

--- a/src/components/panel/split_panel/split_panel_outer.stories.tsx
+++ b/src/components/panel/split_panel/split_panel_outer.stories.tsx
@@ -14,17 +14,17 @@ import { EuiSplitPanel, _EuiSplitPanelOuterProps } from './split_panel';
 const meta: Meta<_EuiSplitPanelOuterProps> = {
   title: 'EuiSplitPanel',
   component: EuiSplitPanel.Outer,
+  args: {
+    // Component defaults
+    direction: 'column',
+    responsive: ['xs', 's'],
+  },
 };
 
 export default meta;
 type Story = StoryObj<_EuiSplitPanelOuterProps>;
 
 export const SplitPanelOuter: Story = {
-  args: {
-    // Default props
-    direction: 'column',
-    responsive: ['xs', 's'],
-  },
   render: ({ ...args }) => (
     <EuiSplitPanel.Outer {...args}>
       <EuiSplitPanel.Inner>Top or left panel</EuiSplitPanel.Inner>

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -19,6 +19,12 @@ import {
 const meta: Meta<EuiResizableButtonProps> = {
   title: 'EuiResizableButton',
   component: EuiResizableButton,
+  args: {
+    // Component defaults
+    alignIndicator: 'center',
+    disabled: false,
+    isHorizontal: false,
+  },
 };
 
 export default meta;
@@ -30,9 +36,4 @@ export const Playground: Story = {
       <EuiResizableButton {...args} />
     </EuiPanel>
   ),
-  args: {
-    isHorizontal: true,
-    alignIndicator: 'center',
-    disabled: false,
-  },
 };

--- a/src/components/resizable_container/resizable_collapse_button.stories.tsx
+++ b/src/components/resizable_container/resizable_collapse_button.stories.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { hideStorybookControls } from '../../../.storybook/utils';
 
 import { EuiPanel } from '../panel';
 import { EuiResizableContainer } from './resizable_container';
@@ -55,12 +56,12 @@ export const ProductionUsage: Story = {
     direction: 'horizontal',
     internalPosition: 'middle',
   },
-  argTypes: {
-    // Not testable via `EuiResizableContainer`, so hide these props from the controls
-    externalPosition: { table: { disable: true } },
-    isVisible: { table: { disable: true } },
-    isCollapsed: { table: { disable: true } },
-  },
+  // Not testable via `EuiResizableContainer`, so hide these props from the controls
+  argTypes: hideStorybookControls<EuiResizableCollapseButtonProps>([
+    'externalPosition',
+    'isVisible',
+    'isCollapsed',
+  ]),
   render: ({ direction, internalPosition }) => (
     <EuiResizableContainer direction={direction} css={{ blockSize: 500 }}>
       {(EuiResizablePanel, EuiResizableButton) => (

--- a/src/components/resizable_container/resizable_collapse_button.stories.tsx
+++ b/src/components/resizable_container/resizable_collapse_button.stories.tsx
@@ -20,19 +20,20 @@ import {
 const meta: Meta<EuiResizableCollapseButtonProps> = {
   title: 'EuiResizableCollapseButton',
   component: EuiResizableCollapseButton,
+  args: {
+    isVisible: true,
+    // Component defaults
+    direction: 'horizontal',
+    externalPosition: 'before',
+    internalPosition: 'middle',
+    isCollapsed: false,
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiResizableCollapseButtonProps>;
 
 export const Playground: Story = {
-  args: {
-    direction: 'horizontal',
-    externalPosition: 'before',
-    internalPosition: 'middle',
-    isVisible: true,
-    isCollapsed: false,
-  },
   render: ({ isCollapsed, direction, ...args }) => (
     <EuiPanel
       paddingSize="none"
@@ -52,10 +53,6 @@ export const Playground: Story = {
 };
 
 export const ProductionUsage: Story = {
-  args: {
-    direction: 'horizontal',
-    internalPosition: 'middle',
-  },
   // Not testable via `EuiResizableContainer`, so hide these props from the controls
   argTypes: hideStorybookControls<EuiResizableCollapseButtonProps>([
     'externalPosition',

--- a/src/components/side_nav/side_nav.stories.tsx
+++ b/src/components/side_nav/side_nav.stories.tsx
@@ -17,6 +17,12 @@ import { EuiSideNav, EuiSideNavProps } from './side_nav';
 const meta: Meta<EuiSideNavProps> = {
   title: 'EuiSideNav',
   component: EuiSideNav,
+  args: {
+    // Component defaults
+    mobileBreakpoints: ['xs', 's'],
+    items: [],
+    isOpenOnMobile: false,
+  },
   decorators: [
     (Story) => (
       <div style={{ width: 200 }}>
@@ -29,14 +35,6 @@ const meta: Meta<EuiSideNavProps> = {
 
 export default meta;
 type Story = StoryObj<EuiSideNavProps>;
-
-const componentDefaults: EuiSideNavProps = {
-  mobileBreakpoints: ['xs', 's'],
-  items: [],
-  // mobileTitle does not have defaults; they are being set here as they are shared between examples
-  mobileTitle: 'Mobile navigation header',
-  isOpenOnMobile: false,
-};
 
 const sharedSideNavItems = [
   {
@@ -84,16 +82,15 @@ const sharedSideNavItems = [
 
 export const Playground: Story = {
   args: {
-    ...componentDefaults,
     heading: 'Elastic',
     headingProps: { element: 'h1', screenReaderOnly: false },
     items: sharedSideNavItems,
+    mobileTitle: 'Mobile navigation header',
   },
 };
 
 export const MobileSideNav: Story = {
   args: {
-    ...componentDefaults,
     isOpenOnMobile: true,
     items: sharedSideNavItems,
     mobileTitle: 'Toggle isOpenOnMobile in the controls panel',
@@ -116,7 +113,6 @@ export const MobileSideNav: Story = {
 
 export const RenderItem: Story = {
   args: {
-    ...componentDefaults,
     renderItem: ({ children }) => <EuiText color="accent">{children}</EuiText>,
     items: [
       {

--- a/src/components/side_nav/side_nav.stories.tsx
+++ b/src/components/side_nav/side_nav.stories.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { hideStorybookControls } from '../../../.storybook/utils';
 
 import { EuiText } from '../text';
 
@@ -97,15 +98,15 @@ export const MobileSideNav: Story = {
     items: sharedSideNavItems,
     mobileTitle: 'Toggle isOpenOnMobile in the controls panel',
   },
-  argTypes: {
-    // This story demos the side nav on smaller screens; removing other props to streamline controls
-    'aria-label': { table: { disable: true } },
-    heading: { table: { disable: true } },
-    headingProps: { table: { disable: true } },
-    items: { table: { disable: true } },
-    renderItem: { table: { disable: true } },
-    truncate: { table: { disable: true } },
-  },
+  // This story demos the side nav on smaller screens; removing other props to streamline controls
+  argTypes: hideStorybookControls<EuiSideNavProps>([
+    'aria-label',
+    'heading',
+    'headingProps',
+    'items',
+    'renderItem',
+    'truncate',
+  ]),
   parameters: {
     viewport: {
       defaultViewport: 'mobile1',
@@ -135,15 +136,15 @@ export const RenderItem: Story = {
       },
     ],
   },
-  argTypes: {
-    // This story demos the renderItem prop; removing other props to streamline controls
-    'aria-label': { table: { disable: true } },
-    heading: { table: { disable: true } },
-    headingProps: { table: { disable: true } },
-    toggleOpenOnMobile: { table: { disable: true } },
-    isOpenOnMobile: { table: { disable: true } },
-    mobileBreakpoints: { table: { disable: true } },
-    mobileTitle: { table: { disable: true } },
-    truncate: { table: { disable: true } },
-  },
+  // This story demos the renderItem prop; removing other props to streamline controls
+  argTypes: hideStorybookControls<EuiSideNavProps>([
+    'aria-label',
+    'heading',
+    'headingProps',
+    'toggleOpenOnMobile',
+    'isOpenOnMobile',
+    'mobileBreakpoints',
+    'mobileTitle',
+    'truncate',
+  ]),
 };

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -9,7 +9,10 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { css } from '@emotion/react';
-import { hideStorybookControls } from '../../../.storybook/utils';
+import {
+  hideStorybookControls,
+  disableStorybookControls,
+} from '../../../.storybook/utils';
 
 import { EuiHighlight, EuiMark } from '../../components';
 
@@ -70,9 +73,7 @@ export const ResizeObserver: Story = {
     ...componentDefaults,
     onResize: console.log,
   },
-  argTypes: {
-    width: { control: false },
-  },
+  argTypes: disableStorybookControls<EuiTextTruncateProps>(['width']),
 };
 
 export const StartEndAnchorForSearch: Story = {

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -25,16 +25,16 @@ const meta: Meta<EuiTextTruncateProps> = {
     truncationOffset: { if: { arg: 'truncation', neq: 'startEnd' } }, // Should also not show on `middle`, but Storybook doesn't currently support multiple if conditions :(
     truncationPosition: { if: { arg: 'truncation', eq: 'startEnd' } },
   },
+  args: {
+    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    // Component defaults
+    truncation: 'end',
+    ellipsis: '…',
+  },
 };
 
 export default meta;
 type Story = StoryObj<EuiTextTruncateProps>;
-
-const componentDefaults = {
-  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
-  truncation: 'end',
-  ellipsis: '…',
-} as const;
 
 export const Playground: Story = {
   render: (props) => (
@@ -43,7 +43,6 @@ export const Playground: Story = {
     </div>
   ),
   args: {
-    ...componentDefaults,
     width: 200,
   },
 };
@@ -70,7 +69,6 @@ export const ResizeObserver: Story = {
     </>
   ),
   args: {
-    ...componentDefaults,
     onResize: console.log,
   },
   argTypes: disableStorybookControls<EuiTextTruncateProps>(['width']),
@@ -118,7 +116,6 @@ export const StartEndAnchorForSearch: Story = {
     );
   },
   args: {
-    ...componentDefaults,
     width: 200,
     truncation: 'startEnd',
     truncationPosition: 30,

--- a/src/components/text_truncate/text_truncate.stories.tsx
+++ b/src/components/text_truncate/text_truncate.stories.tsx
@@ -9,6 +9,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { css } from '@emotion/react';
+import { hideStorybookControls } from '../../../.storybook/utils';
 
 import { EuiHighlight, EuiMark } from '../../components';
 
@@ -121,13 +122,13 @@ export const StartEndAnchorForSearch: Story = {
     truncation: 'startEnd',
     truncationPosition: 30,
   },
-  argTypes: {
+  argTypes: hideStorybookControls<EuiTextTruncateProps>([
     // Disable uncontrollable props
-    truncation: { table: { disable: true } },
-    truncationPosition: { table: { disable: true } },
+    'truncation',
+    'truncationPosition',
     // Disable props that aren't useful for this this demo
-    truncationOffset: { table: { disable: true } },
-    children: { table: { disable: true } },
-    onResize: { table: { disable: true } },
-  },
+    'truncationOffset',
+    'children',
+    'onResize',
+  ]),
 };


### PR DESCRIPTION
## Summary

This PR is a general cleanup/consistency pass on our existing stories. The way we've written stories has evolved as we've learned more tips and tricks of Storybook's API, and this attempts to elevate all existing stories to the same level.

1. Adds new `hideStorybookControls()` and `disableStorybookControls()` utils so we're not copying the same `{ table: { disable: true } }` or `{ control: false }` over and over again
   - This has the main DRY benefit of future-proofing, if someday Storybook changes the API they use to render the controls table, we can quickly update it in one place instead of find+replacing hundreds of lines

2. Standardizes how and where we list component defaults - this should now always be in the initial component `meta.args` as opposed to defining them as separate `const`s and spreading them repeatedly.
    - This has the added benefit of receiving automatic prop name/type checking as opposed to manual.

3. More opinionated cleanups of a handful of spicier components

As always, I recommend [following along with changes by commit](https://github.com/elastic/eui/pull/7245/commits), as the final diff touches a lot of files and I'm doing a few different separate clean up things here.

## QA

- Go to https://eui.elastic.co/pr_7245/storybook/ 
- Click around and confirm stories are generally working as expected with useful props tables

### General checklist

N/A, dev only