### PR TITLE
[EuiIcon] Fix silenced test errors

### DIFF
--- a/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -4617,7 +4617,7 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
   xmlns="http://www.w3.org/2000/svg"
 >
   <defs>
-    <linearGradient
+    <lineargradient
       id="logo_apache_generated-id_a"
       x1="21.902%"
       x2="141.879%"
@@ -4636,8 +4636,8 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="83.83%"
         stop-color="#E97826"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_apache_generated-id_b"
       x1="-217.651%"
       x2="74.743%"
@@ -4660,8 +4660,8 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="100%"
         stop-color="#E97826"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_apache_generated-id_c"
       x1="-80.044%"
       x2="146.24%"
@@ -4684,8 +4684,8 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="100%"
         stop-color="#E97826"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_apache_generated-id_d"
       x1="-18.316%"
       x2="165.002%"
@@ -4708,8 +4708,8 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="94.87%"
         stop-color="#CD2032"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_apache_generated-id_e"
       x1="-109.701%"
       x2="64.617%"
@@ -4732,8 +4732,8 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="100%"
         stop-color="#E97826"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_apache_generated-id_f"
       x1="-34.88%"
       x2="110.599%"
@@ -4756,8 +4756,8 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="100%"
         stop-color="#E97826"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_apache_generated-id_g"
       x1="-13.673%"
       x2="117.858%"
@@ -4780,7 +4780,7 @@ exports[`EuiIcon props type logoApache is rendered 1`] = `
         offset="94.87%"
         stop-color="#CD2032"
       />
-    </linearGradient>
+    </lineargradient>
   </defs>
   <g
     fill="none"
@@ -5144,7 +5144,7 @@ exports[`EuiIcon props type logoDropwizard is rendered 1`] = `
     fill="#24265D"
   />
   <defs>
-    <linearGradient
+    <lineargradient
       gradientUnits="userSpaceOnUse"
       id="logo_dropwizard_generated-id_a"
       x1="33.473"
@@ -5167,8 +5167,8 @@ exports[`EuiIcon props type logoDropwizard is rendered 1`] = `
         offset="1"
         stop-color="#252761"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       gradientUnits="userSpaceOnUse"
       id="logo_dropwizard_generated-id_b"
       x1="21.028"
@@ -5191,7 +5191,7 @@ exports[`EuiIcon props type logoDropwizard is rendered 1`] = `
         offset="1"
         stop-color="#252761"
       />
-    </linearGradient>
+    </lineargradient>
   </defs>
 </svg>
 `;
@@ -5380,8 +5380,8 @@ exports[`EuiIcon props type logoGCP is rendered 1`] = `
   role="img"
   viewBox="0 0 32 32"
   width="32"
-  xlink="http://www.w3.org/1999/xlink"
   xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <defs>
     <path
@@ -5422,7 +5422,7 @@ exports[`EuiIcon props type logoGCP is rendered 1`] = `
         id="logo_gcp_generated-id_b"
       >
         <use
-          href="#logo_gcp_generated-id_a"
+          xlink:href="#logo_gcp_generated-id_a"
         />
       </mask>
       <path
@@ -5684,8 +5684,8 @@ exports[`EuiIcon props type logoGoogleG is rendered 1`] = `
   role="img"
   viewBox="0 0 32 32"
   width="32"
-  xlink="http://www.w3.org/1999/xlink"
   xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <defs>
     <path
@@ -5717,7 +5717,7 @@ exports[`EuiIcon props type logoGoogleG is rendered 1`] = `
         id="logo_google_g_generated-id_b"
       >
         <use
-          href="#logo_google_g_generated-id_a"
+          xlink:href="#logo_google_g_generated-id_a"
         />
       </mask>
       <path
@@ -5735,7 +5735,7 @@ exports[`EuiIcon props type logoGoogleG is rendered 1`] = `
         id="logo_google_g_generated-id_d"
       >
         <use
-          href="#logo_google_g_generated-id_c"
+          xlink:href="#logo_google_g_generated-id_c"
         />
       </mask>
       <path
@@ -5753,7 +5753,7 @@ exports[`EuiIcon props type logoGoogleG is rendered 1`] = `
         id="logo_google_g_generated-id_f"
       >
         <use
-          href="#logo_google_g_generated-id_e"
+          xlink:href="#logo_google_g_generated-id_e"
         />
       </mask>
       <path
@@ -5771,7 +5771,7 @@ exports[`EuiIcon props type logoGoogleG is rendered 1`] = `
         id="logo_google_g_generated-id_h"
       >
         <use
-          href="#logo_google_g_generated-id_g"
+          xlink:href="#logo_google_g_generated-id_g"
         />
       </mask>
       <path
@@ -5861,14 +5861,14 @@ exports[`EuiIcon props type logoHAproxy is rendered 1`] = `
     />
   </g>
   <defs>
-    <clipPath
+    <clippath
       id="logo_haproxy_generated-id_a"
     >
       <path
         d="M0 0h32v32H0V0Z"
         fill="#fff"
       />
-    </clipPath>
+    </clippath>
   </defs>
 </svg>
 `;
@@ -5886,7 +5886,7 @@ exports[`EuiIcon props type logoIBM is rendered 1`] = `
   xmlns="http://www.w3.org/2000/svg"
 >
   <defs>
-    <linearGradient
+    <lineargradient
       id="logo_ibm_generated-id_a"
       x1="8.005%"
       x2="53.33%"
@@ -5907,8 +5907,8 @@ exports[`EuiIcon props type logoIBM is rendered 1`] = `
         offset="100%"
         stop-color="#21A2EF"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_ibm_generated-id_b"
       x1="19.496%"
       x2="71.309%"
@@ -5924,8 +5924,8 @@ exports[`EuiIcon props type logoIBM is rendered 1`] = `
         stop-color="#6EAFF1"
         stop-opacity="0"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_ibm_generated-id_c"
       x1="21.909%"
       x2="21.909%"
@@ -5950,8 +5950,8 @@ exports[`EuiIcon props type logoIBM is rendered 1`] = `
         stop-color="#5CCFE5"
         stop-opacity="0"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_ibm_generated-id_d"
       x1="96.205%"
       x2="-1.172%"
@@ -5976,8 +5976,8 @@ exports[`EuiIcon props type logoIBM is rendered 1`] = `
         stop-color="#5CCFE5"
         stop-opacity="0"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_ibm_generated-id_e"
       x1="9.408%"
       x2="80.589%"
@@ -5992,7 +5992,7 @@ exports[`EuiIcon props type logoIBM is rendered 1`] = `
         offset="100%"
         stop-color="#21A1EF"
       />
-    </linearGradient>
+    </lineargradient>
   </defs>
   <g
     fill="none"
@@ -6213,7 +6213,7 @@ exports[`EuiIcon props type logoMemcached is rendered 1`] = `
   xmlns="http://www.w3.org/2000/svg"
 >
   <defs>
-    <radialGradient
+    <radialgradient
       cx="41.406%"
       cy="42.708%"
       fx="41.406%"
@@ -6229,8 +6229,8 @@ exports[`EuiIcon props type logoMemcached is rendered 1`] = `
         offset="100%"
         stop-color="#C83737"
       />
-    </radialGradient>
-    <radialGradient
+    </radialgradient>
+    <radialgradient
       cx="44.271%"
       cy="42.708%"
       fx="44.271%"
@@ -6246,8 +6246,8 @@ exports[`EuiIcon props type logoMemcached is rendered 1`] = `
         offset="100%"
         stop-color="#C83737"
       />
-    </radialGradient>
-    <linearGradient
+    </radialgradient>
+    <lineargradient
       id="logo_memcached_generated-id_a"
       x1="50%"
       x2="50%"
@@ -6262,8 +6262,8 @@ exports[`EuiIcon props type logoMemcached is rendered 1`] = `
         offset="100%"
         stop-color="#80716D"
       />
-    </linearGradient>
-    <linearGradient
+    </lineargradient>
+    <lineargradient
       id="logo_memcached_generated-id_b"
       x1="88.778%"
       x2="30.149%"
@@ -6278,7 +6278,7 @@ exports[`EuiIcon props type logoMemcached is rendered 1`] = `
         offset="100%"
         stop-color="#2EA19E"
       />
-    </linearGradient>
+    </lineargradient>
   </defs>
   <g
     fill="none"
@@ -6530,8 +6530,8 @@ exports[`EuiIcon props type logoPhp is rendered 1`] = `
   role="img"
   viewBox="0 0 32 32"
   width="32"
-  xlink="http://www.w3.org/1999/xlink"
   xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
 >
   <defs>
     <path
@@ -6546,7 +6546,7 @@ exports[`EuiIcon props type logoPhp is rendered 1`] = `
       d="M0 17.43h30.987V0H0z"
       id="logo_php_generated-id_f"
     />
-    <radialGradient
+    <radialgradient
       cx="30.02%"
       cy="82.422%"
       fx="30.02%"
@@ -6571,7 +6571,7 @@ exports[`EuiIcon props type logoPhp is rendered 1`] = `
         offset="100%"
         stop-color="#484C89"
       />
-    </radialGradient>
+    </radialgradient>
   </defs>
   <g
     fill="none"
@@ -6586,7 +6586,7 @@ exports[`EuiIcon props type logoPhp is rendered 1`] = `
         id="logo_php_generated-id_c"
       >
         <use
-          href="#logo_php_generated-id_a"
+          xlink:href="#logo_php_generated-id_a"
         />
       </mask>
       <g
@@ -6604,7 +6604,7 @@ exports[`EuiIcon props type logoPhp is rendered 1`] = `
       id="logo_php_generated-id_e"
     >
       <use
-        href="#logo_php_generated-id_d"
+        xlink:href="#logo_php_generated-id_d"
       />
     </mask>
     <g
@@ -6621,7 +6621,7 @@ exports[`EuiIcon props type logoPhp is rendered 1`] = `
       id="logo_php_generated-id_g"
     >
       <use
-        href="#logo_php_generated-id_f"
+        xlink:href="#logo_php_generated-id_f"
       />
     </mask>
     <g

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -7,10 +7,13 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
+import { act, waitFor } from '@testing-library/react';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
-import cheerio from 'cheerio';
+
+import { PropsOf } from '../common';
+
 import {
   EuiIcon,
   SIZES,
@@ -19,7 +22,6 @@ import {
   clearIconComponentCache,
   appendIconComponentCache,
 } from './icon';
-import { PropsOf } from '../common';
 import { icon as EuiIconVideoPlayer } from './assets/videoPlayer';
 
 jest.mock('./icon', () => {
@@ -28,50 +30,21 @@ jest.mock('./icon', () => {
 
 beforeEach(() => clearIconComponentCache());
 
-const prettyHtml = cheerio.load('');
-
-function testIcon(props: PropsOf<typeof EuiIcon>) {
-  return () => {
-    expect.assertions(1);
-    return new Promise<void>((resolve) => {
-      const onIconLoad = () => {
-        component.update();
-        expect(prettyHtml(component.html())).toMatchSnapshot();
-        resolve();
-      };
-      const component = mount(<EuiIcon {...props} onIconLoad={onIconLoad} />);
-    });
+const testIcon = (props: PropsOf<typeof EuiIcon>) => async () => {
+  let container: HTMLElement;
+  const onIconLoad = () => {
+    expect(container.firstChild).toMatchSnapshot();
   };
-}
+  act(() => {
+    ({ container } = render(<EuiIcon {...props} onIconLoad={onIconLoad} />));
+  });
+  await waitFor(() => {
+    expect(container.firstChild).not.toHaveAttribute('data-is-loading');
+  });
+  expect.assertions(3);
+};
 
 describe('EuiIcon', () => {
-  let consoleErrorOverride: jest.SpyInstance;
-  beforeAll(() => {
-    // Ignore EuiIcon update not wrapped in act() warnings as they are triggered
-    // directly from the component componentDidUpdate() and loadIconComponent()
-    // TODO: Refactor EuiIcon to not cause this issue and think of a simpler
-    //  implementation based on modern JS bundlers features instead of
-    //  the EuiIcon caching layer.
-    const originalConsoleError: typeof console.error = console.error;
-    consoleErrorOverride = jest
-      .spyOn(console, 'error')
-      .mockImplementation((message, ...args) => {
-        if (
-          message?.startsWith(
-            'Warning: An update to %s inside a test was not wrapped in act(...).'
-          )
-        ) {
-          return;
-        }
-
-        originalConsoleError(message, ...args);
-      });
-  });
-
-  afterAll(() => {
-    consoleErrorOverride.mockRestore();
-  });
-
   test('is rendered', testIcon({ type: 'search', ...requiredProps }));
 
   shouldRenderCustomStyles(<EuiIcon type="customImg" />);
@@ -156,31 +129,30 @@ describe('EuiIcon', () => {
         </span>
       );
     };
-    const component = mount(<EuiIcon type={CustomIcon} />);
-    expect(prettyHtml(component.html())).toMatchSnapshot();
+    const { container } = render(<EuiIcon type={CustomIcon} />);
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   describe('appendIconComponentCache', () => {
     it('does nothing if not called', () => {
-      const component = mount(<EuiIcon type="videoPlayer" />);
-      expect(component.find('svg').prop('data-is-loading')).toEqual(true);
+      const { container } = render(<EuiIcon type="videoPlayer" />);
+      expect(container.firstChild).toHaveAttribute('data-is-loading');
     });
 
     it('preloads the specified icon into the cache', () => {
       appendIconComponentCache({
         videoPlayer: EuiIconVideoPlayer,
       });
-      const component = mount(<EuiIcon type="videoPlayer" />);
-      // Should not have either data-is-loading attr set to true, because it was pre-loaded
-      expect(component.find('svg').prop('data-is-loading')).not.toEqual(true);
+      const { container } = render(<EuiIcon type="videoPlayer" />);
+      expect(container.firstChild).not.toHaveAttribute('data-is-loading');
     });
 
     it('does not impact non-loaded icons', () => {
       appendIconComponentCache({
         videoPlayer: EuiIconVideoPlayer,
       });
-      const component = mount(<EuiIcon type="accessibility" />);
-      expect(component.find('svg').prop('data-is-loading')).toEqual(true);
+      const { container } = render(<EuiIcon type="accessibility" />);
+      expect(container.firstChild).toHaveAttribute('data-is-loading');
     });
   });
 });

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -36,7 +36,7 @@ const testIcon = (props: PropsOf<typeof EuiIcon>) => async () => {
   });
   await waitFor(() => {
     const icon = document.querySelector(`[data-icon-type=${props.type}]`);
-    expect(icon).toHaveAttribute('data-is-loaded');
+    expect(icon).toHaveAttribute('data-is-loaded', 'true');
     expect(icon).toMatchSnapshot();
   });
 };
@@ -144,7 +144,7 @@ describe('EuiIcon', () => {
   describe('appendIconComponentCache', () => {
     it('does nothing if not called', () => {
       const { container } = render(<EuiIcon type="videoPlayer" />);
-      expect(container.firstChild).toHaveAttribute('data-is-loading');
+      expect(container.firstChild).toHaveAttribute('data-is-loading', 'true');
     });
 
     it('preloads the specified icon into the cache', () => {
@@ -160,7 +160,7 @@ describe('EuiIcon', () => {
         videoPlayer: EuiIconVideoPlayer,
       });
       const { container } = render(<EuiIcon type="accessibility" />);
-      expect(container.firstChild).toHaveAttribute('data-is-loading');
+      expect(container.firstChild).toHaveAttribute('data-is-loading', 'true');
     });
   });
 });

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -31,17 +31,14 @@ jest.mock('./icon', () => {
 beforeEach(() => clearIconComponentCache());
 
 const testIcon = (props: PropsOf<typeof EuiIcon>) => async () => {
-  let container: HTMLElement;
-  const onIconLoad = () => {
-    expect(container.firstChild).toMatchSnapshot();
-  };
   act(() => {
-    ({ container } = render(<EuiIcon {...props} onIconLoad={onIconLoad} />));
+    render(<EuiIcon {...props} />);
   });
   await waitFor(() => {
-    expect(container.firstChild).not.toHaveAttribute('data-is-loading');
+    const icon = document.querySelector(`[data-icon-type=${props.type}]`);
+    expect(icon).toHaveAttribute('data-is-loaded');
+    expect(icon).toMatchSnapshot();
   });
-  expect.assertions(3);
 };
 
 describe('EuiIcon', () => {
@@ -57,6 +54,17 @@ describe('EuiIcon', () => {
   });
 
   describe('props', () => {
+    test('onIconLoad', async () => {
+      const onIconLoad = jest.fn();
+
+      render(<EuiIcon type="search" onIconLoad={onIconLoad} />);
+      expect(onIconLoad).toHaveBeenCalledTimes(0);
+
+      await waitFor(() => {
+        expect(onIconLoad).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('other props', () => {
       test(
         'are passed through to the icon',


### PR DESCRIPTION
## Summary

@1Copenut is attempting to parallelize our React tests, and icons appear to be failing/flaky. Our current hunch is that the silenced act warnings/async nature of the icon component is causing those failures. This PR should (🤞) hopefully address that

## QA

- [x] `yarn test-unit icon/icon.test.tsx --react-version=16` passes with no errors
- [x] `yarn test-unit icon/icon.test.tsx --react-version=17` passes with no errors
- [x] `yarn test-unit icon/icon.test.tsx --react-version=18` passes with no errors

### General checklist

N/A, tech debt only