### PR TITLE
[EuiFlexGroup][EuiFlexGrid] Fix `m` gutter size spacing

### DIFF
--- a/src/components/flex/flex_grid.styles.ts
+++ b/src/components/flex/flex_grid.styles.ts
@@ -55,7 +55,7 @@ export const euiFlexGridStyles = (
         gap: ${euiTheme.size.s};
       `,
       m: css`
-        gap: ${euiTheme.size.m};
+        gap: ${euiTheme.size.base};
       `,
       l: css`
         gap: ${euiTheme.size.l};

--- a/src/components/flex/flex_group.styles.ts
+++ b/src/components/flex/flex_group.styles.ts
@@ -40,7 +40,7 @@ export const euiFlexGroupStyles = (euiThemeContext: UseEuiTheme) => {
         gap: ${euiTheme.size.s};
       `,
       m: css`
-        gap: ${euiTheme.size.m};
+        gap: ${euiTheme.size.base};
       `,
       l: css`
         gap: ${euiTheme.size.l};

--- a/upcoming_changelogs/7251.md
+++ b/upcoming_changelogs/7251.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFlexGroup` and `EuiFlexGrid's `m` gutter size


### PR DESCRIPTION
## Summary

Regressed in #6270. Should be `16px` and not `12px`. closes #7244

## QA

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist - N/A, if only we had visual screenshot regression tests :')
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
