### PR TITLE
[EuiBasicTable][EuiInMemoryTable] Add new `truncationText` line API

### DIFF
--- a/src-docs/src/views/tables/auto/auto.tsx
+++ b/src-docs/src/views/tables/auto/auto.tsx
@@ -83,11 +83,12 @@ const columns: Array<EuiTableFieldDataColumnType<User>> = [
   {
     field: 'jobTitle',
     name: 'Job title',
+    truncateText: true,
   },
   {
     field: 'address',
     name: 'Address',
-    truncateText: true,
+    truncateText: { lines: 2 },
   },
 ];
 
@@ -147,11 +148,12 @@ const alignButtons: EuiButtonGroupOptionProps[] = [
 
 export default () => {
   const [tableLayout, setTableLayout] = useState('tableLayoutFixed');
-  const [vAlign, setVAlign] = useState('columnVAlignTop');
+  const [vAlign, setVAlign] = useState('columnVAlignMiddle');
   const [align, setAlign] = useState('columnAlignLeft');
 
   const onTableLayoutChange = (id: string, value: string) => {
     setTableLayout(id);
+    columns[4].width = value === 'custom' ? '100px' : undefined;
     columns[5].width = value === 'custom' ? '20%' : undefined;
   };
 
@@ -169,14 +171,16 @@ export default () => {
 
   switch (tableLayout) {
     case 'tableLayoutFixed':
-      callOutText = 'Address has truncateText set to true';
+      callOutText =
+        'Job title has truncateText set to true. Address is set to { lines: 2 }';
       break;
     case 'tableLayoutAuto':
       callOutText =
-        'Address has truncateText set to true which is not applied since tableLayout is set to auto';
+        'Job title will not wrap or truncate since tableLayout is set to auto. Address will truncate if necessary';
       break;
     case 'tableLayoutCustom':
-      callOutText = 'Address has truncateText set to true and width set to 20%';
+      callOutText =
+        'Job title has a custom column width of 100px. Address has a custom column width of 20%';
       break;
   }
 

--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -12,7 +12,10 @@ import { Pagination } from './pagination_bar';
 import { Action } from './action_types';
 import { Primitive } from '../../services/sort/comparators';
 import { CommonProps } from '../common';
-import { EuiTableRowCellMobileOptionsShape } from '../table/table_row_cell';
+import {
+  EuiTableRowCellProps,
+  EuiTableRowCellMobileOptionsShape,
+} from '../table/table_row_cell';
 
 export type ItemId<T> = string | number | ((item: T) => string);
 export type ItemIdResolved = string | number;
@@ -68,9 +71,12 @@ export interface EuiTableFieldDataColumnType<T>
    */
   align?: HorizontalAlignment;
   /**
-   * Indicates whether this column should truncate its content when it doesn't fit
+   * Indicates whether this column should truncate overflowing text content.
+   * - Set to `true` to enable single-line truncation.
+   * - To enable multi-line truncation, use a configuration object with `lines`
+   * set to a number of lines to truncate to.
    */
-  truncateText?: boolean;
+  truncateText?: EuiTableRowCellProps['truncateText'];
   mobileOptions?: Omit<EuiTableRowCellMobileOptionsShape, 'render'> & {
     render?: (item: T) => ReactNode;
   };

--- a/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
@@ -112,7 +112,21 @@ exports[`truncateText defaults to false 1`] = `
 </td>
 `;
 
-exports[`truncateText is rendered when specified 1`] = `
+exports[`truncateText renders lines configuration 1`] = `
+<td
+  class="euiTableRowCell euiTableRowCell--middle"
+>
+  <div
+    class="euiTableCellContent"
+  >
+    <span
+      class="euiTableCellContent__text euiTextBlockTruncate emotion-euiTextBlockTruncate"
+    />
+  </div>
+</td>
+`;
+
+exports[`truncateText renders true 1`] = `
 <td
   class="euiTableRowCell euiTableRowCell--middle"
 >

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -78,15 +78,32 @@ describe('textOnly', () => {
 });
 
 describe('truncateText', () => {
-  test('defaults to false', () => {
+  it('defaults to false', () => {
     const { container } = render(<EuiTableRowCell />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('is rendered when specified', () => {
+  it('renders true', () => {
     const { container } = render(<EuiTableRowCell truncateText={true} />);
 
+    expect(
+      container.querySelector('.euiTableCellContent--truncateText')
+    ).toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('renders lines configuration', () => {
+    const { container } = render(
+      <EuiTableRowCell truncateText={{ lines: 2 }} />
+    );
+
+    expect(
+      container.querySelector('.euiTableCellContent--truncateText')
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('.euiTableCellContent__text')).toHaveClass(
+      'euiTextBlockTruncate'
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -42,9 +42,12 @@ interface EuiTableRowCellSharedPropsShape {
    */
   textOnly?: boolean;
   /**
-   * Don't allow line breaks within cells
+   * Indicates whether this column should truncate overflowing text content.
+   * - Set to `true` to enable single-line truncation.
+   * - To enable multi-line truncation, use a configuration object with `lines`
+   * set to a number of lines to truncate to.
    */
-  truncateText?: boolean;
+  truncateText?: boolean | { lines: number };
   width?: CSSProperties['width'];
 }
 

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -8,7 +8,6 @@
 
 import React, {
   CSSProperties,
-  Fragment,
   FunctionComponent,
   ReactElement,
   ReactNode,
@@ -16,8 +15,8 @@ import React, {
   useCallback,
 } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../common';
 
+import { CommonProps } from '../common';
 import {
   HorizontalAlignment,
   LEFT_ALIGNMENT,
@@ -239,14 +238,14 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
 
         {/* Content depending on mobile render existing */}
         {mobileOptions.render ? (
-          <Fragment>
+          <>
             <div className={`${mobileContentClasses} ${showForMobileClasses}`}>
               {modifyChildren(mobileOptions.render)}
             </div>
             <div className={`${contentClasses} ${hideForMobileClasses}`}>
               {childrenNode}
             </div>
-          </Fragment>
+          </>
         ) : (
           <div className={contentClasses}>{childrenNode}</div>
         )}

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -24,6 +24,8 @@ import {
   CENTER_ALIGNMENT,
   useIsWithinBreakpoints,
 } from '../../services';
+import { isObject } from '../../services/predicate';
+import { EuiTextBlockTruncate } from '../text_truncate';
 
 import { resolveWidthAsStyle } from './utils';
 
@@ -141,7 +143,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     'euiTableCellContent--alignRight': align === RIGHT_ALIGNMENT,
     'euiTableCellContent--alignCenter': align === CENTER_ALIGNMENT,
     'euiTableCellContent--showOnHover': showOnHover,
-    'euiTableCellContent--truncateText': truncateText,
+    'euiTableCellContent--truncateText': truncateText === true,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
     // purposes for the time-being.
     'euiTableCellContent--overflowingContent': textOnly !== true,
@@ -186,6 +188,13 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
           React.cloneElement(child, {
             className: classNames(child.props.className, childClasses),
           })
+      );
+    }
+    if (isObject(truncateText) && truncateText.lines) {
+      modifiedChildren = (
+        <EuiTextBlockTruncate lines={truncateText.lines} cloneElement>
+          {modifiedChildren}
+        </EuiTextBlockTruncate>
       );
     }
 

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -13,6 +13,7 @@ import React, {
   ReactElement,
   ReactNode,
   TdHTMLAttributes,
+  useCallback,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
@@ -176,30 +177,33 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
 
   const styleObj = resolveWidthAsStyle(style, widthValue);
 
-  function modifyChildren(children: ReactNode) {
-    let modifiedChildren = children;
+  const modifyChildren = useCallback(
+    (children: ReactNode) => {
+      let modifiedChildren = children;
 
-    if (textOnly === true) {
-      modifiedChildren = <span className={childClasses}>{children}</span>;
-    } else if (React.isValidElement(children)) {
-      modifiedChildren = React.Children.map(
-        children,
-        (child: ReactElement<CommonProps>) =>
-          React.cloneElement(child, {
-            className: classNames(child.props.className, childClasses),
-          })
-      );
-    }
-    if (isObject(truncateText) && truncateText.lines) {
-      modifiedChildren = (
-        <EuiTextBlockTruncate lines={truncateText.lines} cloneElement>
-          {modifiedChildren}
-        </EuiTextBlockTruncate>
-      );
-    }
+      if (textOnly === true) {
+        modifiedChildren = <span className={childClasses}>{children}</span>;
+      } else if (React.isValidElement(children)) {
+        modifiedChildren = React.Children.map(
+          children,
+          (child: ReactElement<CommonProps>) =>
+            React.cloneElement(child, {
+              className: classNames(child.props.className, childClasses),
+            })
+        );
+      }
+      if (isObject(truncateText) && truncateText.lines) {
+        modifiedChildren = (
+          <EuiTextBlockTruncate lines={truncateText.lines} cloneElement>
+            {modifiedChildren}
+          </EuiTextBlockTruncate>
+        );
+      }
 
-    return modifiedChildren;
-  }
+      return modifiedChildren;
+    },
+    [childClasses, textOnly, truncateText]
+  );
 
   const childrenNode = modifyChildren(children);
 

--- a/upcoming_changelogs/7254.md
+++ b/upcoming_changelogs/7254.md
@@ -1,0 +1,1 @@
+- Updated `EuiBasicTable` and `EuiInMemoryTable` to support multi-line truncation. This can be set via `truncateText.lines` in the `columns` prop.


### PR DESCRIPTION
## Summary

> As always, I recommend [reviewing by commit](https://github.com/elastic/eui/pull/7254/commits) to sort out feature work from cleanups.

closes #7226

Proposed API:
```tsx
<EuiBasicTable
  columns={[
    {
      field: 'myField',
      name: 'My field',
      truncateText: { lines: 2 },
    }
  ]}
/>
```

Single (`true`) vs multi-line truncation:

<img width="386" alt="" src="https://github.com/elastic/eui/assets/549407/d04ad6c4-010f-4081-968b-09f91549c848">

## QA

- Go to https://eui.elastic.co/pr_7254/#/tabular-content/tables#table-layout
- [x] Confirm the `Address` column truncates after 2 lines (and does not truncate if the address is short enough) on all layouts

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
