### PR TITLE
[EuiFlyout] Memoize various internals to reduce rerenders

### DIFF
--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -261,13 +261,18 @@ export const EuiFlyout = forwardRef(
     /**
      * Set inline styles
      */
-    let newStyle = style;
-    if (typeof maxWidth !== 'boolean') {
-      newStyle = { ...newStyle, ...logicalStyle('max-width', maxWidth) };
-    }
-    if (!isEuiFlyoutSizeNamed(size)) {
-      newStyle = { ...newStyle, ...logicalStyle('width', size) };
-    }
+    const inlineStyles = useMemo(() => {
+      const widthStyle =
+        !isEuiFlyoutSizeNamed(size) && logicalStyle('width', size);
+      const maxWidthStyle =
+        typeof maxWidth !== 'boolean' && logicalStyle('max-width', maxWidth);
+
+      return {
+        ...style,
+        ...widthStyle,
+        ...maxWidthStyle,
+      };
+    }, [style, maxWidth, size]);
 
     const euiTheme = useEuiTheme();
     const styles = euiFlyoutStyles(euiTheme);
@@ -429,7 +434,7 @@ export const EuiFlyout = forwardRef(
         <Element
           className={classes}
           css={cssStyles}
-          style={newStyle}
+          style={inlineStyles}
           ref={setRef}
           {...(rest as ComponentPropsWithRef<T>)}
           role={!isPushed ? 'dialog' : rest.role}

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -10,6 +10,7 @@ import React, {
   useEffect,
   useRef,
   useMemo,
+  useCallback,
   useState,
   forwardRef,
   ComponentPropsWithRef,
@@ -247,12 +248,15 @@ export const EuiFlyout = forwardRef(
     /**
      * ESC key closes flyout (always?)
      */
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!isPushed && event.key === keys.ESCAPE) {
-        event.preventDefault();
-        onClose(event);
-      }
-    };
+    const onKeyDown = useCallback(
+      (event: KeyboardEvent) => {
+        if (!isPushed && event.key === keys.ESCAPE) {
+          event.preventDefault();
+          onClose(event);
+        }
+      },
+      [onClose, isPushed]
+    );
 
     /**
      * Set inline styles
@@ -397,19 +401,22 @@ export const EuiFlyout = forwardRef(
      * or if `outsideClickCloses={true}` to close on clicks that target
      * (both mousedown and mouseup) the overlay mask.
      */
-    const onClickOutside = (event: MouseEvent | TouchEvent) => {
-      // Do not close the flyout for any external click
-      if (outsideClickCloses === false) return undefined;
-      if (hasOverlayMask) {
-        // The overlay mask is present, so only clicks on the mask should close the flyout, regardless of outsideClickCloses
-        if (event.target === maskRef.current) return onClose(event);
-      } else {
-        // No overlay mask is present, so any outside clicks should close the flyout
-        if (outsideClickCloses === true) return onClose(event);
-      }
-      // Otherwise if ownFocus is false and outsideClickCloses is undefined, outside clicks should not close the flyout
-      return undefined;
-    };
+    const onClickOutside = useCallback(
+      (event: MouseEvent | TouchEvent) => {
+        // Do not close the flyout for any external click
+        if (outsideClickCloses === false) return undefined;
+        if (hasOverlayMask) {
+          // The overlay mask is present, so only clicks on the mask should close the flyout, regardless of outsideClickCloses
+          if (event.target === maskRef.current) return onClose(event);
+        } else {
+          // No overlay mask is present, so any outside clicks should close the flyout
+          if (outsideClickCloses === true) return onClose(event);
+        }
+        // Otherwise if ownFocus is false and outsideClickCloses is undefined, outside clicks should not close the flyout
+        return undefined;
+      },
+      [onClose, hasOverlayMask, outsideClickCloses]
+    );
 
     let flyout = (
       <EuiFocusTrap

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -290,8 +290,9 @@ export const EuiFlyout = forwardRef(
 
     const classes = classnames('euiFlyout', className);
 
-    let closeButton;
-    if (onClose && !hideCloseButton) {
+    const closeButton = useMemo(() => {
+      if (hideCloseButton || !onClose) return null;
+
       const closeButtonClasses = classnames(
         'euiFlyout__closeButton',
         closeButtonProps?.className
@@ -306,7 +307,7 @@ export const EuiFlyout = forwardRef(
         closeButtonProps?.css,
       ];
 
-      closeButton = (
+      return (
         <EuiI18n token="euiFlyout.closeAriaLabel" default="Close this dialog">
           {(closeAriaLabel: string) => (
             <EuiButtonIcon
@@ -326,7 +327,14 @@ export const EuiFlyout = forwardRef(
           )}
         </EuiI18n>
       );
-    }
+    }, [
+      onClose,
+      hideCloseButton,
+      closeButtonPosition,
+      closeButtonProps,
+      side,
+      euiTheme,
+    ]);
 
     /*
      * If not disabled, automatically add fixed EuiHeaders as shards

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -9,6 +9,7 @@
 import React, {
   useEffect,
   useRef,
+  useMemo,
   useState,
   forwardRef,
   ComponentPropsWithRef,
@@ -187,7 +188,7 @@ export const EuiFlyout = forwardRef(
       outsideClickCloses,
       pushMinBreakpoint = 'l',
       pushAnimation = false,
-      focusTrapProps: _focusTrapProps = {},
+      focusTrapProps: _focusTrapProps,
       includeFixedHeadersInFocusTrap = true,
       'aria-describedby': _ariaDescribedBy,
       ...rest
@@ -345,10 +346,13 @@ export const EuiFlyout = forwardRef(
       }
     }, [includeFixedHeadersInFocusTrap, resizeRef]);
 
-    const focusTrapProps: EuiFlyoutProps['focusTrapProps'] = {
-      ..._focusTrapProps,
-      shards: [...fixedHeaders, ...(_focusTrapProps.shards || [])],
-    };
+    const focusTrapProps: EuiFlyoutProps['focusTrapProps'] = useMemo(
+      () => ({
+        ..._focusTrapProps,
+        shards: [...fixedHeaders, ...(_focusTrapProps?.shards || [])],
+      }),
+      [fixedHeaders, _focusTrapProps]
+    );
 
     /*
      * Provide meaningful screen reader instructions/details

--- a/upcoming_changelogs/7259.md
+++ b/upcoming_changelogs/7259.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed focus trap rerender issues in `EuiFlyout` with memoization


### PR DESCRIPTION
## Summary

The first commit is the primary one needed to resolve https://github.com/elastic/kibana/issues/168164, the other following commits are just extra nice-to-haves.

Here's what I _think_ is happening: the unmemoized `focusTrapProps` is causing `<EuiFocusTrap>` the underlying focus trap library to re-mount fully when it shouldn't, which then causes the focus issues because the focus trap will auto-focus the flyout wrapper on mount.

The remount is occurring because Security's flyouts are wrapped in a `<Formik>` lib that, on validation, cascades the state update down to the wrapped `EuiFlyout` and rerenders it.

## QA

Fix testing
- Go to https://cee-chen-branch-main.kbndev.co/app/management/security/api_keys
- Log in with dev/local elastic credentials
- Click the "Create API key" button
- Once the flyout opens, click into the Name field and then press the tab key
- [x] Confirm an invalid error shows up
- [x] Confirm that you can continue to tab past the Name field and through the rest of the flyout, but that focus correctly traps and cycles back to the fixed headers and then back into the flyout

![screencap_fix](https://github.com/elastic/eui/assets/549407/56b0a941-7b26-4226-8f04-de6ea7704d2e)

Regression testing
- Go to https://eui.elastic.co/pr_7259/#/layout/flyout
- [x] Confirm all flyouts on the page behave as before, particularly closing (click + Escape to close)
- Go to https://eui.elastic.co/pr_7259/#/layout/flyout#understanding-max-width
- [x] Confirm all flyouts have the expected inline widths & max width styles / same as production
- Go to https://eui.elastic.co/pr_7259/storybook/?path=/story/euiflyout--playground
- [x] Confirm adding `style`, `size` (number) and `maxWidth` (number) controls concatenates all the inline styles as expected

### General checklist

- Browser QA - N/A, above QA should be sufficient
- Docs site QA - N/A
- Code quality checklist - N/A, should be sufficient for regressions if existing tests pass
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A