### PR TITLE
[EuiCollapsibleNavItem] Prevent DOM errors about `accordionProps` being passed to non-accordions

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -115,6 +115,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
   icon,
   iconProps,
   items,
+  accordionProps, // Ensure this isn't spread to non-accordions
   children, // Ensure children isn't spread
   ...props
 }) => {
@@ -133,6 +134,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
       <EuiCollapsibleNavAccordion
         buttonContent={headerContent}
         items={items}
+        accordionProps={accordionProps}
         {...props}
         isSubItem={isSubItem}
       />


### PR DESCRIPTION
## Summary

See https://github.com/elastic/kibana/issues/168301

## QA

### General checklist

N/A, this is a beta component