### PR TITLE
fix: color errors due to `fillColor` changes in `v54.0.0`

### DIFF
--- a/src-docs/src/views/elastic_charts/accessibility_sunburst.js
+++ b/src-docs/src/views/elastic_charts/accessibility_sunburst.js
@@ -61,7 +61,7 @@ export default () => {
             {
               groupByRollup: ({ fruit }) => fruit,
               shape: {
-                fillColor: ({ sortIndex }) =>
+                fillColor: (key, sortIndex) =>
                   vizColors[sortIndex % vizColors.length],
               },
             },

--- a/src-docs/src/views/elastic_charts/pie.js
+++ b/src-docs/src/views/elastic_charts/pie.js
@@ -56,8 +56,8 @@ export default () => {
                 {
                   groupByRollup: (d) => d.status,
                   shape: {
-                    fillColor: (d) =>
-                      euiChartTheme.theme.colors.vizColors[d.sortIndex],
+                    fillColor: (key, sortIndex) =>
+                      euiChartTheme.theme.colors.vizColors[sortIndex],
                   },
                 },
               ]}
@@ -95,8 +95,8 @@ export default () => {
                 {
                   groupByRollup: (d) => d.language,
                   shape: {
-                    fillColor: (d) =>
-                      euiChartTheme.theme.colors.vizColors[d.sortIndex],
+                    fillColor: (key, sortIndex) =>
+                      euiChartTheme.theme.colors.vizColors[sortIndex],
                   },
                 },
               ]}

--- a/src-docs/src/views/elastic_charts/pie_example.js
+++ b/src-docs/src/views/elastic_charts/pie_example.js
@@ -217,7 +217,7 @@ const euiChartTheme = isDarkTheme ? EUI_CHARTS_THEME_DARK : EUI_CHARTS_THEME_LIG
       {
         groupByRollup: d => d.category,
         shape: {
-          fillColor: d => euiChartTheme.theme.colors.vizColors[d.sortIndex],
+          fillColor: (key, sortIndex) => euiChartTheme.theme.colors.vizColors[sortIndex],
         },
       },
     ]}

--- a/src-docs/src/views/elastic_charts/pie_slices.js
+++ b/src-docs/src/views/elastic_charts/pie_slices.js
@@ -167,8 +167,8 @@ export default () => {
               {
                 groupByRollup: (d) => d.browser,
                 shape: {
-                  fillColor: (d) =>
-                    euiChartTheme.theme.colors.vizColors[d.sortIndex],
+                  fillColor: (key, sortIndex) =>
+                    euiChartTheme.theme.colors.vizColors[sortIndex],
                 },
               },
             ]}
@@ -308,7 +308,7 @@ export default () => {
       {
         groupByRollup: d => d.browser,
         shape: {
-          fillColor: d => euiChartTheme.theme.colors.vizColors[d.sortIndex],
+          fillColor: (key, sortIndex) => euiChartTheme.theme.colors.vizColors[sortIndex],
         },
       },
     ]}

--- a/src-docs/src/views/elastic_charts/treemap.js
+++ b/src-docs/src/views/elastic_charts/treemap.js
@@ -68,14 +68,15 @@ export default () => {
                 {
                   groupByRollup: (d) => d.vizType,
                   shape: {
-                    fillColor: (d) => groupedPalette[d.sortIndex * 3],
+                    fillColor: (key, sortIndex) =>
+                      groupedPalette[sortIndex * 3],
                   },
                 },
                 {
                   groupByRollup: (d) => d.issueType,
                   shape: {
-                    fillColor: (d) =>
-                      groupedPalette[d.parent.sortIndex * 3 + d.sortIndex + 1],
+                    fillColor: (key, sortIndex, { parent }) =>
+                      groupedPalette[parent.sortIndex * 3 + sortIndex + 1],
                   },
                 },
               ]}
@@ -101,7 +102,8 @@ export default () => {
                 {
                   groupByRollup: (d) => d.vizType,
                   shape: {
-                    fillColor: (d) => groupedPalette[d.sortIndex * 3],
+                    fillColor: (key, sortIndex) =>
+                      groupedPalette[sortIndex * 3],
                   },
                   fillLabel: {
                     valueFormatter: () => '',
@@ -111,8 +113,8 @@ export default () => {
                 {
                   groupByRollup: (d) => d.issueType,
                   shape: {
-                    fillColor: (d) =>
-                      groupedPalette[d.parent.sortIndex * 3 + d.sortIndex],
+                    fillColor: (key, sortIndex, { parent }) =>
+                      groupedPalette[parent.sortIndex * 3 + sortIndex],
                   },
                 },
               ]}


### PR DESCRIPTION
## Summary

This PR fixes errors in partition chart coloring due to `fillColor` api changes in [`v54.0.0`](https://github.com/elastic/elastic-charts/releases/tag/v54.0.0) (from https://github.com/elastic/elastic-charts/pull/1956).

We missed this change in updating chart in https://github.com/elastic/eui/pull/6641 with 6 breaking changes. Also we have become accustom to typescript flagging errors like this but all errors in this case were in js files 😭.

This changed the API where the first param of the `fillColor` function is the `Key` of the layer and not the entire `Node`. The second param is now the `sortIndex` used in many places in the EUI docs.

```diff
- export type NodeColorAccessor = (d: ShapeTreeNode, index: number, array: HierarchyOfArrays) => string;
+ export type NodeColorAccessor = (key: Key, sortIndex: number, node: ArrayNode, tree: HierarchyOfArrays) => string
```

