### PR TITLE
[BUG] Fix broken docs link for EuiProvider props.

### DIFF
--- a/src-docs/src/views/provider/provider_example.js
+++ b/src-docs/src/views/provider/provider_example.js
@@ -121,10 +121,8 @@ export const ProviderExample = {
             <EuiCode>utility</EuiCode> properties on the{' '}
             <EuiCode>cache</EuiCode> prop to further define where specific
             styles should be inserted. See{' '}
-            <Link to="#euiprovider-props">
-              the props documentation
-            </EuiLink>{' '}
-            for details.
+            <Link to="#euiprovider-props">the props documentation</Link> for
+            details.
           </p>
 
           <p>


### PR DESCRIPTION
## Summary

I found a broken link that `404's` that was tangential to https://github.com/elastic/eui/pull/7272. This PR fixes that broken link so it points to the correct `EuiProvider` props anchor.

## QA

QA will be done manually in the PR preview page for `#/utilities/provider#cache-location`

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
