### PR TITLE
[EuiComboBox] Blur upon selection when `singleSelection` is defined

### DIFF
--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -457,6 +457,8 @@ export class EuiComboBox<T> extends Component<
       this.comboBoxRefInstance &&
       this.comboBoxRefInstance.contains(relatedTarget);
 
+    const singleSelection = Boolean(this.props.singleSelection);
+
     if (!focusedInOptionsList && !focusedInInput) {
       this.props.onBlur?.(event);
       this.closeList();
@@ -467,7 +469,7 @@ export class EuiComboBox<T> extends Component<
       if (!this.hasActiveOption()) {
         this.setCustomOptions(true);
       }
-    } else if (focusedInOptionsList) {
+    } else if (focusedInOptionsList && !singleSelection) {
       // https://github.com/elastic/eui/issues/5179
       // need to restore focus to the input box when clicking non-interactive elements
 
@@ -567,7 +569,7 @@ export class EuiComboBox<T> extends Component<
     this.clearSearchValue();
     this.clearActiveOption();
 
-    if (!isContainerBlur) {
+    if (!isContainerBlur && !singleSelection) {
       this.searchInputRefInstance?.focus();
     }
 

--- a/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -175,9 +175,7 @@ export class EuiComboBoxInput<T> extends Component<
 
     const singleSelection = Boolean(singleSelectionProp);
     const asPlainText =
-      (singleSelectionProp &&
-        typeof singleSelectionProp === 'object' &&
-        singleSelectionProp.asPlainText) ||
+      (singleSelectionProp as EuiComboBoxSingleSelectionShape).asPlainText ??
       false;
 
     const pills = selectedOptions


### PR DESCRIPTION
## Summary

This PR changes the blur behavior of the `EuiComboBox` for single selections.

Now when `singleSelection` is set, either `asPlainText` or not - Upon selection of a value the refocusing of the `EuiComboBoxInput` is prevented effectively blurring the `EuiComboBox`.

Fixes #7169

### Before

![Screen Recording 2023-10-11 at 12 13 17 PM](https://github.com/elastic/eui/assets/19007109/049778de-c86b-49e3-b2f7-406c615787b1)


### After

![Screen Recording 2023-10-11 at 12 11 07 PM](https://github.com/elastic/eui/assets/19007109/0231856f-32ce-4e19-b2e1-3b843b7d8292)


### Context

I did **not** implement a `blur` and `focus` method on the `EuiComboBox` itself as I suggested in the issue, because I think this type of change should be applied to all custom input elements and not just the `EuiComboBox`.

## QA

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
