### PR TITLE
[EuiFieldNumber] Fix native validity state when controlled `value` changes

### DIFF
--- a/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
+++ b/src/components/form/field_number/__snapshots__/field_number.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`EuiFieldNumber is rendered 1`] = `
       max="8"
       min="1"
       name="elastic"
-      step="1"
+      step="any"
       type="number"
       value="1"
     />

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -10,7 +10,8 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../../cypress/support" />
 
-import React from 'react';
+import React, { useState } from 'react';
+
 import { EuiFieldNumber } from './field_number';
 
 describe('EuiFieldNumber', () => {
@@ -64,6 +65,35 @@ describe('EuiFieldNumber', () => {
       cy.mount(<EuiFieldNumber />);
       checkIsValid();
       cy.get('input').click().type('1.5');
+      checkIsValid();
+    });
+
+    it('checks/updates invalid state for controlled components', () => {
+      const ControlledEuiFieldNumber = () => {
+        const [value, setValue] = useState('0');
+        return (
+          <>
+            <EuiFieldNumber
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              min={0}
+              max={5}
+            />
+            <button id="setToInvalidValue" onClick={() => setValue('10')}>
+              Set to invalid value
+            </button>
+            <button id="setToValidValue" onClick={() => setValue('3')}>
+              Set to valid value
+            </button>
+          </>
+        );
+      };
+      cy.mount(<ControlledEuiFieldNumber />);
+
+      checkIsValid();
+      cy.get('#setToInvalidValue').click();
+      checkIsInvalid();
+      cy.get('#setToValidValue').click();
       checkIsValid();
     });
   });

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -89,11 +89,18 @@ describe('EuiFieldNumber', () => {
         );
       };
       cy.mount(<ControlledEuiFieldNumber />);
-
       checkIsValid();
+
+      // Controlled value changes should work as expected
       cy.get('#setToInvalidValue').click();
       checkIsInvalid();
       cy.get('#setToValidValue').click();
+      checkIsValid();
+
+      // (regression test) User input changes should still work as expected w/ onChange
+      cy.get('input').clear().type('-2');
+      checkIsInvalid();
+      cy.get('input').clear().type('2');
       checkIsValid();
     });
   });

--- a/src/components/form/field_number/field_number.spec.tsx
+++ b/src/components/form/field_number/field_number.spec.tsx
@@ -53,14 +53,6 @@ describe('EuiFieldNumber', () => {
       checkIsInvalid();
     });
 
-    it('shows invalid state on blur', () => {
-      cy.mount(<EuiFieldNumber max={1} value={2} />);
-      checkIsValid();
-      cy.get('input').click();
-      cy.get('body').click('bottomRight');
-      checkIsInvalid();
-    });
-
     it('does not show invalid state on decimal values by default', () => {
       cy.mount(<EuiFieldNumber />);
       checkIsValid();
@@ -102,6 +94,83 @@ describe('EuiFieldNumber', () => {
       checkIsInvalid();
       cy.get('input').clear().type('2');
       checkIsValid();
+    });
+
+    describe('checks/updates invalid state when props that would affect validity change', () => {
+      it('min', () => {
+        const UpdatedEuiFieldNumber = () => {
+          const [min, setMin] = useState<number | undefined>();
+          return (
+            <>
+              <EuiFieldNumber min={min} />
+              <button id="setInvalidMin" onClick={() => setMin(100)}>
+                Set invalid min
+              </button>
+              <button id="setValidMin" onClick={() => setMin(0)}>
+                Change valid min
+              </button>
+            </>
+          );
+        };
+        cy.mount(<UpdatedEuiFieldNumber />);
+        cy.get('input').type('1');
+        checkIsValid();
+
+        cy.get('#setInvalidMin').click();
+        checkIsInvalid();
+        cy.get('#setValidMin').click();
+        checkIsValid();
+      });
+
+      it('max', () => {
+        const UpdatedEuiFieldNumber = () => {
+          const [max, setMax] = useState<number | undefined>();
+          return (
+            <>
+              <EuiFieldNumber max={max} />
+              <button id="setInvalidMax" onClick={() => setMax(0)}>
+                Set invalid max
+              </button>
+              <button id="setValidMax" onClick={() => setMax(10)}>
+                Change valid max
+              </button>
+            </>
+          );
+        };
+        cy.mount(<UpdatedEuiFieldNumber />);
+        cy.get('input').type('1');
+        checkIsValid();
+
+        cy.get('#setInvalidMax').click();
+        checkIsInvalid();
+        cy.get('#setValidMax').click();
+        checkIsValid();
+      });
+
+      it('step', () => {
+        const UpdatedEuiFieldNumber = () => {
+          const [step, setStep] = useState<number | undefined>();
+          return (
+            <>
+              <EuiFieldNumber step={step} />
+              <button id="setInvalidStep" onClick={() => setStep(1.5)}>
+                Set invalid step
+              </button>
+              <button id="setValidStep" onClick={() => setStep(1)}>
+                Change valid step
+              </button>
+            </>
+          );
+        };
+        cy.mount(<UpdatedEuiFieldNumber />);
+        cy.get('input').type('1');
+        checkIsValid();
+
+        cy.get('#setInvalidStep').click();
+        checkIsInvalid();
+        cy.get('#setValidStep').click();
+        checkIsValid();
+      });
     });
   });
 });

--- a/src/components/form/field_number/field_number.stories.tsx
+++ b/src/components/form/field_number/field_number.stories.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiFieldNumber, EuiFieldNumberProps } from './field_number';
+
+const meta: Meta<EuiFieldNumberProps> = {
+  title: 'EuiFieldNumber',
+  component: EuiFieldNumber,
+  argTypes: {
+    step: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiFieldNumberProps>;
+
+export const Playground: Story = {};
+
+export const ControlledComponent: Story = {
+  args: {
+    value: 0,
+  },
+  argTypes: {
+    value: { control: 'number' },
+    onChange: () => {},
+  },
+};

--- a/src/components/form/field_number/field_number.test.tsx
+++ b/src/components/form/field_number/field_number.test.tsx
@@ -32,7 +32,10 @@ describe('EuiFieldNumber', () => {
         name="elastic"
         min={1}
         max={8}
-        step={1}
+        // TODO: Restore this once we upgrade Jest/jsdom to v15+. Right now passing
+        // a `step` prop always leads to jsdom thinking that validity.valid is false
+        // @see https://github.com/jsdom/jsdom/issues/2288
+        // step={1}
         value={1}
         icon="warning"
         onChange={() => {}}

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -107,7 +107,6 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     readOnly,
     controlOnly,
     onKeyUp,
-    onBlur,
     ...rest
   } = props;
 
@@ -128,13 +127,12 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     setIsNativelyInvalid(isInvalid);
   }, []);
 
-  // Ensure controlled `value/onChange` fields are checked for native validity
+  // Re-check validity whenever props that might affect validity are updated
   useEffect(() => {
-    const isControlledValue = value != null;
-    if (isControlledValue && _inputRef.current) {
+    if (_inputRef.current) {
       checkNativeValidity(_inputRef.current);
     }
-  }, [value, checkNativeValidity]);
+  }, [value, min, max, step, checkNativeValidity]);
 
   const numIconsClass = controlOnly
     ? false
@@ -170,11 +168,6 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
           // Note that we can't use `onChange` because browsers don't emit change events
           // for invalid text - see https://github.com/facebook/react/issues/16554
           onKeyUp?.(e);
-          checkNativeValidity(e.currentTarget);
-        }}
-        onBlur={(e) => {
-          // Browsers can also set/determine validity (e.g. when `step` is undefined) on focus blur
-          onBlur?.(e);
           checkNativeValidity(e.currentTarget);
         }}
         {...rest}

--- a/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
@@ -224,7 +224,8 @@ exports[`EuiDualRange props maxInputProps allows overriding default props 1`] = 
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
+        aria-invalid="true"
+        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons"
         max="100"
         min="1"
         name="undefined-maxValue"
@@ -233,6 +234,14 @@ exports[`EuiDualRange props maxInputProps allows overriding default props 1`] = 
         type="number"
         value="123"
       />
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+      >
+        <span
+          color="danger"
+          data-euiicon-type="warning"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -318,8 +327,9 @@ exports[`EuiDualRange props maxInputProps applies passed props to max input 1`] 
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
+        aria-invalid="true"
         aria-label="Max value"
-        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
+        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons"
         max="100"
         min="1"
         name="undefined-maxValue"
@@ -328,6 +338,14 @@ exports[`EuiDualRange props maxInputProps applies passed props to max input 1`] 
         type="number"
         value="8"
       />
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+      >
+        <span
+          color="danger"
+          data-euiicon-type="warning"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -344,7 +362,8 @@ exports[`EuiDualRange props minInputProps allows overriding default props 1`] = 
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        class="euiFieldNumber euiRangeInput euiRangeInput--min emotion-euiRangeInput"
+        aria-invalid="true"
+        class="euiFieldNumber euiRangeInput euiRangeInput--min emotion-euiRangeInput euiFormControlLayout--1icons"
         max="8"
         min="0"
         name="undefined-minValue"
@@ -353,6 +372,14 @@ exports[`EuiDualRange props minInputProps allows overriding default props 1`] = 
         type="number"
         value="123"
       />
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+      >
+        <span
+          color="danger"
+          data-euiicon-type="warning"
+        />
+      </div>
     </div>
   </div>
   <div
@@ -413,7 +440,8 @@ exports[`EuiDualRange props minInputProps allows overriding default props 1`] = 
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
+        aria-invalid="true"
+        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons"
         max="100"
         min="1"
         name="undefined-maxValue"
@@ -422,6 +450,14 @@ exports[`EuiDualRange props minInputProps allows overriding default props 1`] = 
         type="number"
         value="8"
       />
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+      >
+        <span
+          color="danger"
+          data-euiicon-type="warning"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -508,7 +544,8 @@ exports[`EuiDualRange props minInputProps applies passed props to min input 1`] 
       class="euiFormControlLayout__childrenWrapper"
     >
       <input
-        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput"
+        aria-invalid="true"
+        class="euiFieldNumber euiRangeInput euiRangeInput--max emotion-euiRangeInput euiFormControlLayout--1icons"
         max="100"
         min="1"
         name="undefined-maxValue"
@@ -517,6 +554,14 @@ exports[`EuiDualRange props minInputProps applies passed props to min input 1`] 
         type="number"
         value="8"
       />
+      <div
+        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right euiFormControlLayoutIcons--absolute"
+      >
+        <span
+          color="danger"
+          data-euiicon-type="warning"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/upcoming_changelogs/7291.md
+++ b/upcoming_changelogs/7291.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed controlled `EuiFieldNumbers` not correctly updating native validity state


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7281

> ⚠️ NOTE: There is a slight gotcha to this PR in that our current version jsdom (11.x) incorrectly thinks that any input with a `step` passed to it is natively invalid. Upgrading to jsdom v15+ will fix this issue (and a few of our snapshots) in the future.

## QA

- Go to https://eui.elastic.co/pr_7291/storybook/?path=/story/euifieldnumber--controlled-component
- Scroll down to the `value` prop control and change it to, e.g. 5
- Change the `min` prop, to, e.g. 10
- [x] Confirm that the input correctly updates to show invalid state
- Change the `value` prop to satisfy `min`, e.g. 100
- [x] Confirm the input correctly updates to no longer be invalid
- (Optional) Test other props that would affect validity (e.g. `max`, `step`) as well to confirm that updating those props will correctly update the input's invalid state

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A