### PR TITLE
[Tech debt] Remove `defaultProps` from function components

### DIFF
--- a/src-docs/src/components/guide_rule/guide_rule_example.js
+++ b/src-docs/src/components/guide_rule/guide_rule_example.js
@@ -22,7 +22,7 @@ const typeToSubtitleTextMap = {
 export const GuideRuleExample = ({
   children,
   className,
-  type,
+  type = 'default',
   text,
   minHeight,
   style,
@@ -102,8 +102,4 @@ GuideRuleExample.propTypes = {
   text: PropTypes.node,
   minHeight: PropTypes.number,
   panelProps: PropTypes.any,
-};
-
-GuideRuleExample.defaultProps = {
-  type: 'default',
 };

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import { Helmet } from 'react-helmet';
 import { useSelector } from 'react-redux';
@@ -84,13 +83,4 @@ export const AppContext = ({ children }) => {
       <EuiContext i18n={i18n}>{children}</EuiContext>
     </EuiProvider>
   );
-};
-
-AppContext.propTypes = {
-  children: PropTypes.any,
-  currentRoute: PropTypes.object.isRequired,
-};
-
-AppContext.defaultProps = {
-  currentRoute: {},
 };

--- a/src-docs/src/views/app_view.js
+++ b/src-docs/src/views/app_view.js
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
@@ -17,7 +16,7 @@ import {
   EuiScreenReaderLive,
 } from '../../../src/components';
 
-export const AppView = ({ children, currentRoute }) => {
+export const AppView = ({ children, currentRoute = {} }) => {
   const dispatch = useDispatch();
   const toggleLocale = (locale) => dispatch(_toggleLocale(locale));
   const locale = useSelector((state) => getLocale(state));
@@ -64,13 +63,4 @@ export const AppView = ({ children, currentRoute }) => {
       </EuiPageTemplate>
     </LinkWrapper>
   );
-};
-
-AppView.propTypes = {
-  children: PropTypes.any,
-  currentRoute: PropTypes.object.isRequired,
-};
-
-AppView.defaultProps = {
-  currentRoute: {},
 };

--- a/src/components/form/field_password/field_password.tsx
+++ b/src/components/form/field_password/field_password.tsx
@@ -82,8 +82,8 @@ export const EuiFieldPassword: FunctionComponent<EuiFieldPasswordProps> = (
     value,
     isInvalid,
     fullWidth = defaultFullWidth,
-    isLoading,
-    compressed,
+    isLoading = false,
+    compressed = false,
     inputRef: _inputRef,
     prepend,
     append,
@@ -190,10 +190,4 @@ export const EuiFieldPassword: FunctionComponent<EuiFieldPasswordProps> = (
       </EuiValidatableControl>
     </EuiFormControlLayout>
   );
-};
-
-EuiFieldPassword.defaultProps = {
-  value: undefined,
-  isLoading: false,
-  compressed: false,
 };

--- a/src/components/popover/input_popover.tsx
+++ b/src/components/popover/input_popover.tsx
@@ -64,7 +64,13 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   children,
   className,
   closePopover,
+  anchorPosition = 'downLeft',
+  attachToAnchor = true,
+  repositionToCrossAxis = false,
+  display = 'block',
+  panelPaddingSize = 's',
   closeOnScroll = false,
+  ownFocus = false,
   disableFocusTrap = false,
   focusTrapProps,
   input,
@@ -189,15 +195,19 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
 
   return (
     <EuiPopover
+      className={classes}
       css={css(fullWidth ? undefined : logicalCSS('max-width', form.maxWidth))}
-      repositionToCrossAxis={false}
-      ownFocus={false}
+      display={display}
       button={input}
       buttonRef={inputRef}
       panelRef={panelRef}
-      className={classes}
       ref={popoverClassRef}
       closePopover={closePopover}
+      anchorPosition={anchorPosition}
+      attachToAnchor={attachToAnchor}
+      repositionToCrossAxis={repositionToCrossAxis}
+      panelPaddingSize={panelPaddingSize}
+      ownFocus={ownFocus}
       {...props}
       panelProps={{ ...props.panelProps, onKeyDown }}
     >
@@ -212,11 +222,4 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
       </EuiFocusTrap>
     </EuiPopover>
   );
-};
-
-EuiInputPopover.defaultProps = {
-  anchorPosition: 'downLeft',
-  attachToAnchor: true,
-  display: 'block',
-  panelPaddingSize: 's',
 };


### PR DESCRIPTION
## Summary

See https://github.com/elastic/eui/issues/7287 (NOTE: Does not close the issue fully - we need https://github.com/elastic/eui/pull/7296 for that as well)

React 18 is deprecating support for `defaultProps` - this PR removes all instances of function component `defaultProps`, and also checks that all props tables in our docs work as expected.

## QA

- Go to https://eui.elastic.co/pr_7297/#/forms/form-controls#password-field 
    - [x] Confirm the props table shows a default value of `false` for `isLoading` and `compressed`
- Go to https://eui.elastic.co/pr_7297/#/layout/popover#popover-attached-to-input-element 
    - [x] Confirm the props table shows the correct default values for `anchorPosition`, `attachToAnchor`, `repositionToCrossAxis`, `display`, `panelPaddingSize`, and `ownFocus` (compare to the default `EuiPopover` props)

### General checklist

- Browser QA - N/A
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist - N/A, current tests passing should suffice
- Release checklist - N/A, this should not have any consumer or user facing impact
- Designer checklist - N/A