### PR TITLE
[CHORE] Add Cypress `a11y` tests to Buildkite CI

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -81,3 +81,6 @@ steps:
     env:
       TEST_TYPE: 'cypress:a11y'
     if: build.branch != "main"
+    artifact_paths:
+      - "cypress/screenshots/**/*.png"
+      - "cypress/videos/**/*.mp4"

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -73,3 +73,11 @@ steps:
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+
+  - command: .buildkite/scripts/pipeline_test.sh
+    label: ":axe: Cypress accessibility (a11y) tests on React 18"
+    agents:
+      provider: "gcp"
+    env:
+      TEST_TYPE: 'cypress:a11y'
+    if: build.branch != "main"

--- a/.buildkite/scripts/pipeline_test.sh
+++ b/.buildkite/scripts/pipeline_test.sh
@@ -54,6 +54,11 @@ case $TEST_TYPE in
     DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && yarn test-cypress --node-options=--max_old_space_size=2048")
     ;;
 
+  cypress:a11y)
+    echo "[TASK]: Running Cypress accessibility tests against React 18"
+    DOCKER_OPTIONS+=(bash -c "/opt/yarn*/bin/yarn && yarn cypress install && yarn test-cypress-a11y --node-options=--max_old_space_size=2048")
+    ;;
+
   *)
     echo "[ERROR]: Unknown task"
     echo "Exit code: 1"

--- a/src/components/header/header.a11y.tsx
+++ b/src/components/header/header.a11y.tsx
@@ -404,7 +404,7 @@ describe('EuiHeader', () => {
     });
 
     it('has zero violations when a hidden breadcrumb is expanded', () => {
-      cy.get('button[aria-label="See collapsed breadcrumbs"]').realClick();
+      cy.get('button[title="See collapsed breadcrumbs"]').realClick();
       cy.get('a[data-test-subj="cy-breadcrumb-hidden"]').should('exist');
       cy.checkAxe();
     });

--- a/src/components/key_pad_menu/key_pad_menu.a11y.tsx
+++ b/src/components/key_pad_menu/key_pad_menu.a11y.tsx
@@ -121,10 +121,9 @@ describe('EuiKeyPadMenu', () => {
 
     it('has zero violations on item click', () => {
       cy.get('a[data-test-subj="cy-keypad-link-2"]').realClick();
-      cy.get('a[data-test-subj="cy-keypad-link-2"]').should(
-        'have.class',
-        'euiKeyPadMenuItem-isSelected'
-      );
+      cy.get('a[data-test-subj="cy-keypad-link-2"]')
+        .should('have.attr', 'aria-current')
+        .should('equal', 'true');
       cy.checkAxe();
     });
 
@@ -134,24 +133,21 @@ describe('EuiKeyPadMenu', () => {
         'have.focus'
       );
       cy.realPress('Space');
-      cy.get('button[data-test-subj="cy-keypad-button-3"]').should(
-        'have.class',
-        'euiKeyPadMenuItem-isSelected'
-      );
+      cy.get('button[data-test-subj="cy-keypad-button-3"]')
+        .should('have.attr', 'aria-pressed')
+        .should('equal', 'true');
       cy.checkAxe();
       cy.realPress(['Shift', 'Tab']);
       cy.get('button[data-test-subj="cy-keypad-button-2"]').should(
         'have.focus'
       );
       cy.realPress('Space');
-      cy.get('button[data-test-subj="cy-keypad-button-2"]').should(
-        'have.class',
-        'euiKeyPadMenuItem-isSelected'
-      );
-      cy.get('button[data-test-subj="cy-keypad-button-3"]').should(
-        'not.have.class',
-        'euiKeyPadMenuItem-isSelected'
-      );
+      cy.get('button[data-test-subj="cy-keypad-button-2"]')
+        .should('have.attr', 'aria-pressed')
+        .should('equal', 'true');
+      cy.get('button[data-test-subj="cy-keypad-button-3"]')
+        .should('have.attr', 'aria-pressed')
+        .should('equal', 'false');
       cy.checkAxe();
     });
   });


### PR DESCRIPTION
## Summary

PR adds our Cypress a11y test suite to the Buildkite `test` job now that tests are running in parallel. PR closes #7306.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Code quality checklist
    - [ ] Verified all tests pass in Buildkite CI 
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist

---
**Local test run**

<img width="989" alt="Screen Shot 2023-10-23 at 5 09 23 PM" src="https://github.com/elastic/eui/assets/934879/d0112bbf-2480-4585-bfb4-1d215c0daded">
