### PR TITLE
[EuiTabs] Fix incorrectly wrapping tab content

### DIFF
--- a/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -339,7 +339,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
               type="button"
             >
               <span
-                class="euiTab__content emotion-euiTab__content-l"
+                class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
               >
                 Tab 1
               </span>
@@ -351,7 +351,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
               type="button"
             >
               <span
-                class="euiTab__content emotion-euiTab__content-l"
+                class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
               >
                 Tab 2
               </span>

--- a/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -299,7 +299,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
             type="button"
           >
             <span
-              class="euiTab__content emotion-euiTab__content-l"
+              class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
             >
               Tab 1
             </span>
@@ -311,7 +311,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
             type="button"
           >
             <span
-              class="euiTab__content emotion-euiTab__content-l"
+              class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
             >
               Tab 2
             </span>
@@ -588,7 +588,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
           >
             Tab 1
           </span>
@@ -600,7 +600,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
           >
             Tab 2
           </span>
@@ -639,7 +639,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
           >
             Tab 1
           </span>
@@ -651,7 +651,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
           >
             Tab 2
           </span>

--- a/src/components/tabs/__snapshots__/tab.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tab.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`EuiTab props append is rendered 1`] = `
     Append
   </span>
   <span
-    class="euiTab__content emotion-euiTab__content-m"
+    class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
   >
     children
   </span>
@@ -29,7 +29,7 @@ exports[`EuiTab props disabled and selected 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m"
+    class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
   >
     Click Me
   </span>
@@ -45,7 +45,7 @@ exports[`EuiTab props disabled is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m"
+    class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
   >
     Click Me
   </span>
@@ -78,7 +78,7 @@ exports[`EuiTab props isSelected is rendered 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m"
+    class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
   >
     children
   </span>
@@ -95,7 +95,7 @@ exports[`EuiTab props onClick renders button 1`] = `
   type="button"
 >
   <span
-    class="euiTab__content emotion-euiTab__content-m"
+    class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
   >
     children
   </span>
@@ -115,7 +115,7 @@ exports[`EuiTab props prepend is rendered 1`] = `
     Prepend
   </span>
   <span
-    class="euiTab__content emotion-euiTab__content-m"
+    class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
   >
     children
   </span>

--- a/src/components/tabs/__snapshots__/tabs.test.tsx.snap
+++ b/src/components/tabs/__snapshots__/tabs.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`EuiTabs props expand passes down to EuiTab children 1`] = `
     type="button"
   >
     <span
-      class="euiTab__content emotion-euiTab__content-m"
+      class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
     >
       Tab
     </span>
@@ -32,7 +32,7 @@ exports[`EuiTabs props size l renders and passes down to EuiTab children 1`] = `
     type="button"
   >
     <span
-      class="euiTab__content emotion-euiTab__content-l"
+      class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
     >
       Tab
     </span>
@@ -52,7 +52,7 @@ exports[`EuiTabs props size m renders and passes down to EuiTab children 1`] = `
     type="button"
   >
     <span
-      class="euiTab__content emotion-euiTab__content-m"
+      class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
     >
       Tab
     </span>
@@ -72,7 +72,7 @@ exports[`EuiTabs props size s renders and passes down to EuiTab children 1`] = `
     type="button"
   >
     <span
-      class="euiTab__content emotion-euiTab__content-s"
+      class="euiTab__content eui-textTruncate emotion-euiTab__content-s"
     >
       Tab
     </span>
@@ -92,7 +92,7 @@ exports[`EuiTabs props size xl renders and passes down to EuiTab children 1`] = 
     type="button"
   >
     <span
-      class="euiTab__content emotion-euiTab__content-xl"
+      class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
     >
       Tab
     </span>

--- a/src/components/tabs/tab.tsx
+++ b/src/components/tabs/tab.tsx
@@ -127,7 +127,10 @@ export const EuiTab: FunctionComponent<Props> = ({
       {...(rest as ButtonHTMLAttributes<HTMLButtonElement>)}
     >
       {prependNode}
-      <span className="euiTab__content" css={cssTabContentStyles}>
+      <span
+        className="euiTab__content eui-textTruncate"
+        css={cssTabContentStyles}
+      >
         {children}
       </span>
       {appendNode}

--- a/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -35,7 +35,7 @@ exports[`EuiTabbedContent behavior when selected tab state isn't controlled by t
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -75,7 +75,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -95,7 +95,7 @@ exports[`EuiTabbedContent behavior when uncontrolled, the selected tab should up
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -139,7 +139,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -159,7 +159,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -199,7 +199,7 @@ exports[`EuiTabbedContent props autoFocus initial is rendered 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -219,7 +219,7 @@ exports[`EuiTabbedContent props autoFocus initial is rendered 1`] = `
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -259,7 +259,7 @@ exports[`EuiTabbedContent props autoFocus selected is rendered 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -279,7 +279,7 @@ exports[`EuiTabbedContent props autoFocus selected is rendered 1`] = `
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -319,7 +319,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -339,7 +339,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -379,7 +379,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         Elasticsearch
       </span>
@@ -399,7 +399,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-m"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
       >
         <strong>
           Kibana
@@ -439,7 +439,7 @@ exports[`EuiTabbedContent props size can be small 1`] = `
       type="button"
     >
       <span
-        class="euiTab__content emotion-euiTab__content-s"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-s"
       >
         Elasticsearch
       </span>
@@ -459,7 +459,7 @@ exports[`EuiTabbedContent props size can be small 1`] = `
         prepend
       </span>
       <span
-        class="euiTab__content emotion-euiTab__content-s"
+        class="euiTab__content eui-textTruncate emotion-euiTab__content-s"
       >
         <strong>
           Kibana

--- a/upcoming_changelogs/7309.md
+++ b/upcoming_changelogs/7309.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiTabs` incorrectly wrapping text when it should instead either scroll or truncate


### PR DESCRIPTION
## Summary

This has been broken since #6311 (viewable by browsing EUI at <v60.x)

| Before | After |
|--------|--------|
| <img width="458" alt="" src="https://github.com/elastic/eui/assets/549407/9348e61d-eb38-43d7-94e0-bc4e84e3d4b5"> | <img width="461" alt="" src="https://github.com/elastic/eui/assets/549407/4643648d-678b-438d-8800-c7eec02b8d24"> | 

## QA

- Go to https://eui.elastic.co/pr_7309/#/navigation/context-menu#using-panels-with-mixed-items-content
- Click the last/bottom-most button
- Click the `See more` item
- [x] Confirm that width-limited EuiTabs example in the popover correctly scrolls horizontally instead of wrapping text

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    ~- [ ] Checked in both **light and dark** modes~
- Docs site QA - N/A
- Code quality checklist - N/A, although we do need visual regression tests
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
