### PR TITLE
[EuiSuperDatePicker] Fix inline date picker width

### DIFF
--- a/src/components/date_picker/super_date_picker/date_popover/_date_popover_content.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_date_popover_content.scss
@@ -1,4 +1,5 @@
-.euiDatePopoverContent {
+.euiDatePopoverContent,
+.euiDatePopoverContent .react-datepicker {
   width: $euiFormMaxWidth;
   max-width: 100%;
 }

--- a/upcoming_changelogs/7313.md
+++ b/upcoming_changelogs/7313.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed the width of `EuiSuperDatePicker`'s Absolute date picker


### PR DESCRIPTION
## Summary

I broke this in #6795 🥲 We have got to get visual regression tests y'all

| Before | After (same as  [EUI v80.x](https://eui.elastic.co/v80.0.0/#/templates/super-date-picker))  |
|--------|--------|
| <img width="300" alt="" src="https://github.com/elastic/eui/assets/549407/6629f8a4-4a3b-42ba-a977-eef5779dab7c"> | <img width="300" alt="" src="https://github.com/elastic/eui/assets/549407/59b541b0-a9b6-4781-bec2-95c7f7743d20"> |

## QA

- Go to https://eui.elastic.co/pr_7313/#/templates/super-date-picker
- Click `Last 30 minutes` of the first example, switch to the `Absolute` tab
- [x] Confirm the datepicker renders at full width

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A
