### PR TITLE
[EuiAccordion] Fix focus behavior on user interaction open/close vs `forceState` open/close

### DIFF
--- a/src/components/accordion/accordion.spec.tsx
+++ b/src/components/accordion/accordion.spec.tsx
@@ -74,30 +74,58 @@ describe('EuiAccordion', () => {
       expectChildrenIsFocused();
     });
 
-    it('does not focus the accordion when programmatically toggled via forceState', () => {
-      const ControlledComponent = () => {
-        const [accordionOpen, setAccordionOpen] = useState(false);
-        return (
-          <>
-            <button
-              data-test-subj="toggleForceState"
-              onClick={() => setAccordionOpen(!accordionOpen)}
-            >
-              Control accordion
-            </button>
+    describe('forceState', () => {
+      it('does not focus the accordion when `forceState` prevents the accordion from opening', () => {
+        cy.realMount(<EuiAccordion {...sharedProps} forceState="closed" />);
+
+        cy.contains('Click me to toggle').realClick();
+        cy.focused()
+          .should('not.have.class', 'euiAccordion__childWrapper')
+          .contains('Click me to toggle');
+      });
+
+      it('does not focus the accordion when programmatically toggled from outside the accordion', () => {
+        const ControlledComponent = () => {
+          const [accordionOpen, setAccordionOpen] = useState(false);
+          return (
+            <>
+              <button
+                data-test-subj="toggleForceState"
+                onClick={() => setAccordionOpen(!accordionOpen)}
+              >
+                Control accordion
+              </button>
+              <EuiAccordion
+                {...sharedProps}
+                forceState={accordionOpen ? 'open' : 'closed'}
+              />
+            </>
+          );
+        };
+        cy.realMount(<ControlledComponent />);
+
+        cy.get('[data-test-subj="toggleForceState"]').realClick();
+        cy.focused()
+          .should('not.have.class', 'euiAccordion__childWrapper')
+          .should('have.attr', 'data-test-subj', 'toggleForceState');
+      });
+
+      it('attempts to focus the accordion children when `onToggle` controls `forceState`', () => {
+        const ControlledComponent = () => {
+          const [accordionOpen, setAccordionOpen] = useState(false);
+          return (
             <EuiAccordion
               {...sharedProps}
+              onToggle={(open) => setAccordionOpen(open)}
               forceState={accordionOpen ? 'open' : 'closed'}
             />
-          </>
-        );
-      };
-      cy.realMount(<ControlledComponent />);
+          );
+        };
+        cy.realMount(<ControlledComponent />);
 
-      cy.get('[data-test-subj="toggleForceState"]').realClick();
-      cy.focused()
-        .should('not.have.class', 'euiAccordion__childWrapper')
-        .should('have.attr', 'data-test-subj', 'toggleForceState');
+        cy.contains('Click me to toggle').realClick();
+        expectChildrenIsFocused();
+      });
     });
   });
 });

--- a/src/components/accordion/accordion.spec.tsx
+++ b/src/components/accordion/accordion.spec.tsx
@@ -10,63 +10,43 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../cypress/support" />
 
-import React from 'react';
+import React, { useState } from 'react';
 import { EuiAccordion, EuiAccordionProps } from './index';
-import { EuiPanel } from '../../components/panel';
-import { htmlIdGenerator } from '../../services';
 
-const baseProps: EuiAccordionProps = {
+const sharedProps: EuiAccordionProps = {
   buttonContent: 'Click me to toggle',
-  id: htmlIdGenerator()(),
+  id: 'cypress-accordion',
   initialIsOpen: false,
+  children: (
+    <>
+      Test accordion content.{' '}
+      <a data-test-subj="childLink" href="#">
+        Focusable link inside content
+      </a>
+    </>
+  ),
 };
 
-const noArrow = { arrowDisplay: 'none' };
-const noArrowProps: EuiAccordionProps = Object.assign(baseProps, noArrow);
-
 describe('EuiAccordion', () => {
-  describe('Keyboard and screen reader accessibility', () => {
-    it('renders with required props', () => {
-      cy.realMount(
-        <EuiAccordion {...baseProps}>
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here.
-          </EuiPanel>
-        </EuiAccordion>
-      );
+  describe('keyboard and screen reader accessibility', () => {
+    it('does not tab to the arrow if the button is interactive', () => {
+      cy.realMount(<EuiAccordion {...sharedProps} initialIsOpen={true} />);
       cy.realPress('Tab');
       cy.focused().contains('Click me to toggle');
+      cy.realPress('Tab');
+      cy.focused().contains('Focusable link inside content');
     });
 
-    it('opens and closes on ENTER keypress', () => {
-      cy.realMount(
-        <EuiAccordion {...baseProps}>
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here.
-          </EuiPanel>
-        </EuiAccordion>
-      );
+    it('does tab to the arrow if the button is not interactive', () => {
+      cy.realMount(<EuiAccordion {...sharedProps} buttonElement="div" />);
       cy.realPress('Tab');
-      cy.focused().contains('Click me to toggle').realPress('Enter');
-      cy.realPress(['Shift', 'Tab']);
-      cy.focused().invoke('attr', 'aria-expanded').should('equal', 'true');
+      cy.focused().should('have.class', 'euiAccordion__arrow');
+    });
+
+    it('opens and closes the accordion on keypress', () => {
+      cy.realMount(<EuiAccordion {...sharedProps} />);
+      cy.realPress('Tab');
       cy.realPress('Enter');
-      cy.focused().invoke('attr', 'aria-expanded').should('equal', 'false');
-    });
-
-    it('opens and closes on SPACE keypress', () => {
-      cy.realMount(
-        <EuiAccordion {...baseProps}>
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here.
-          </EuiPanel>
-        </EuiAccordion>
-      );
-      cy.realPress('Tab');
-      cy.focused().contains('Click me to toggle').realPress('Space');
       cy.realPress(['Shift', 'Tab']);
       cy.focused().invoke('attr', 'aria-expanded').should('equal', 'true');
       cy.realPress('Space');
@@ -74,65 +54,50 @@ describe('EuiAccordion', () => {
     });
   });
 
-  describe('Props and navigation', () => {
-    it('should not have an arrow', () => {
-      cy.realMount(
-        <EuiAccordion {...noArrowProps}>
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here.
-          </EuiPanel>
-        </EuiAccordion>
-      );
-      cy.get('.euiAccordion__arrow').should('not.exist');
+  describe('focus management', () => {
+    const expectChildrenIsFocused = () => {
+      cy.focused()
+        .should('have.class', 'euiAccordion__childWrapper')
+        .should('have.attr', 'tabindex', '-1');
+    };
+
+    it('focuses the accordion content when the arrow is clicked', () => {
+      cy.realMount(<EuiAccordion {...sharedProps} />);
+      cy.get('.euiAccordion__arrow').realClick();
+      expectChildrenIsFocused();
     });
 
-    it('manages focus when panel is clicked', () => {
-      cy.realMount(
-        <EuiAccordion {...noArrowProps}>
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here.
-          </EuiPanel>
-        </EuiAccordion>
-      );
-      cy.get('button').contains('Click me to toggle').realClick();
-      cy.focused().invoke('attr', 'tabindex').should('equal', '-1');
-      cy.focused().contains('Any content inside of EuiAccordion');
-    });
-
-    it('manages focus when panel is opened by keyboard interaction', () => {
-      cy.realMount(
-        <EuiAccordion {...noArrowProps}>
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here. We will include <a href="#">a link</a> to confirm focus.
-          </EuiPanel>
-        </EuiAccordion>
-      );
+    it('focuses the accordion content when the button is clicked', () => {
+      cy.realMount(<EuiAccordion {...sharedProps} />);
       cy.realPress('Tab');
       cy.focused().contains('Click me to toggle').realPress('Enter');
-      cy.focused().invoke('attr', 'tabindex').should('equal', '-1');
-      cy.focused().contains('Any content inside of EuiAccordion');
-      cy.realPress('Tab');
-      cy.focused().contains('a link');
+      expectChildrenIsFocused();
     });
 
-    it('manages focus when forceState is open', () => {
-      cy.realMount(
-        <EuiAccordion {...noArrowProps} forceState="open">
-          <EuiPanel color="subdued">
-            Any content inside of <strong>EuiAccordion</strong> will appear
-            here. We will include <a href="#">a link</a> to confirm focus.
-          </EuiPanel>
-        </EuiAccordion>
-      );
-      cy.realPress('Tab');
-      cy.focused().contains('Click me to toggle');
-      cy.focused().invoke('attr', 'aria-expanded').should('equal', 'true');
-      cy.focused().invoke('attr', 'tabindex').should('not.exist');
-      cy.realPress('Tab');
-      cy.focused().contains('a link');
+    it('does not focus the accordion when programmatically toggled via forceState', () => {
+      const ControlledComponent = () => {
+        const [accordionOpen, setAccordionOpen] = useState(false);
+        return (
+          <>
+            <button
+              data-test-subj="toggleForceState"
+              onClick={() => setAccordionOpen(!accordionOpen)}
+            >
+              Control accordion
+            </button>
+            <EuiAccordion
+              {...sharedProps}
+              forceState={accordionOpen ? 'open' : 'closed'}
+            />
+          </>
+        );
+      };
+      cy.realMount(<ControlledComponent />);
+
+      cy.get('[data-test-subj="toggleForceState"]').realClick();
+      cy.focused()
+        .should('not.have.class', 'euiAccordion__childWrapper')
+        .should('have.attr', 'data-test-subj', 'toggleForceState');
     });
   });
 });

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -141,7 +141,18 @@ export class EuiAccordionClass extends Component<
   onToggle = () => {
     const { forceState } = this.props;
     if (forceState) {
-      this.props.onToggle?.(forceState === 'open' ? false : true);
+      const nextState = !this.isOpen;
+      this.props.onToggle?.(nextState);
+
+      // If the accordion should theoretically be opened, wait a tick (allows
+      // consumer state to update) and attempt to focus the child content.
+      // NOTE: Even if the accordion does not actually open, this is fine -
+      // the `inert` property on the hidden children will prevent focus
+      if (nextState === true) {
+        requestAnimationFrame(() => {
+          this.accordionChildrenEl?.focus();
+        });
+      }
     } else {
       this.setState(
         (prevState) => ({
@@ -149,6 +160,9 @@ export class EuiAccordionClass extends Component<
         }),
         () => {
           this.props.onToggle?.(this.state.isOpen);
+
+          // If the accordion is open, programmatically move focus
+          // from the accordion trigger to the child content
           if (this.state.isOpen) {
             this.accordionChildrenEl?.focus();
           }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -149,9 +149,18 @@ export class EuiAccordionClass extends Component<
         }),
         () => {
           this.props.onToggle?.(this.state.isOpen);
+          if (this.state.isOpen) {
+            this.accordionChildrenEl?.focus();
+          }
         }
       );
     }
+  };
+
+  // Used to focus the accordion children on user trigger click only (vs controlled/programmatic open)
+  accordionChildrenEl: HTMLDivElement | null = null;
+  accordionChildrenRef = (node: HTMLDivElement | null) => {
+    this.accordionChildrenEl = node;
   };
 
   generatedId = htmlIdGenerator()();
@@ -222,6 +231,7 @@ export class EuiAccordionClass extends Component<
           isLoading={isLoading}
           isLoadingMessage={isLoadingMessage}
           isOpen={this.isOpen}
+          accordionChildrenRef={this.accordionChildrenRef}
         >
           {children}
         </EuiAccordionChildren>

--- a/src/components/accordion/accordion_children/accordion_children.tsx
+++ b/src/components/accordion/accordion_children/accordion_children.tsx
@@ -9,14 +9,14 @@
 import React, {
   FunctionComponent,
   HTMLAttributes,
-  useRef,
+  Ref,
   useCallback,
   useMemo,
   useState,
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme, useUpdateEffect } from '../../../services';
+import { useEuiTheme } from '../../../services';
 import { EuiResizeObserver } from '../../observer/resize_observer';
 
 import { EuiAccordionProps } from '../accordion';
@@ -32,11 +32,13 @@ type _EuiAccordionChildrenProps = HTMLAttributes<HTMLDivElement> &
     'children' | 'paddingSize' | 'isLoading' | 'isLoadingMessage'
   > & {
     isOpen: boolean;
+    accordionChildrenRef: Ref<HTMLDivElement>;
   };
 export const EuiAccordionChildren: FunctionComponent<
   _EuiAccordionChildrenProps
 > = ({
   children,
+  accordionChildrenRef,
   paddingSize,
   isLoading,
   isLoadingMessage,
@@ -67,8 +69,6 @@ export const EuiAccordionChildren: FunctionComponent<
     isOpen ? wrapperStyles.isOpen : wrapperStyles.isClosed,
   ];
 
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-
   /**
    * Update the accordion wrapper height whenever the accordion opens, and also
    * whenever the child content updates (which will change the height)
@@ -83,21 +83,13 @@ export const EuiAccordionChildren: FunctionComponent<
     [isOpen, contentHeight]
   );
 
-  /**
-   * Focus the children wrapper when the accordion is opened,
-   * but not if the accordion is initially open on mount
-   */
-  useUpdateEffect(() => {
-    if (isOpen) wrapperRef.current?.focus();
-  }, [isOpen]);
-
   return (
     <div
       {...rest}
       className="euiAccordion__childWrapper"
       css={wrapperCssStyles}
       style={heightInlineStyle}
-      ref={wrapperRef}
+      ref={accordionChildrenRef}
       role="region"
       tabIndex={-1}
       // @ts-expect-error - inert property not yet available in React TS defs. TODO: Remove this once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822 is merged

--- a/upcoming_changelogs/7314.md
+++ b/upcoming_changelogs/7314.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- `EuiAccordion`s no longer attempt to focus child content when the accordion is externally opened via `forceState`, but will continue to focus expanded content when users click the toggle button.


### PR DESCRIPTION
## Summary

Required for https://github.com/elastic/kibana/issues/167330

I (partially) regressed this in #7161 when I converted EuiAccordion's constituent parts into sub-functional components. Specifically, this logic:

https://github.com/elastic/eui/blob/fb7c3975efb71720641bbd04241979702bedaed1/src/components/accordion/accordion_children/accordion_children.tsx#L86-L92

I thought was more React-y rather than calling a declarative `.focus()` when the trigger button was clicked. However, I now realize that the click behavior is necessary to determine user open vs programmatic open for predictable focus behavior. It does not necessarily make any sense for focus to jump to the accordion just because it was opened on the page by another event (e.g. async loading) - but it always makes sense for focus to move if the user made an action on the trigger button.

The new behavior in this PR **only** moves focus onto the child content on user click of the toggle button/arrow. However, it works for **both** controlled (`forceState`) and uncontrolled accordions.

| Previous behavior ([v88.x](https://eui.elastic.co/v88.0.0/#/layout/accordion#controlling-toggled-state)) | Production behavior ([v89.x](https://eui.elastic.co/v89.0.0/#/layout/accordion#controlling-toggled-state)) | New behavior ([Staging](https://eui.elastic.co/pr_7314/#/layout/accordion#controlling-toggled-state)) |
|--------|--------|--------|
| <img src="https://github.com/elastic/eui/assets/549407/aa8dc706-fcf0-44ee-b67d-63adb2dac97a" width="300" alt=""> | <img src="https://github.com/elastic/eui/assets/549407/b72761f1-3688-4b9b-b8c1-cb37f84c6d6f" width="300" alt=""> | <img src="https://github.com/elastic/eui/assets/549407/a2f230c2-8284-4afd-b142-b73935f7838c" width="300" alt=""> | 
| Notice that focus is **never** moved to the child content | Notice that focus is **always** moved to the child content, jumping from the external switch/toggle to the content | Notice that focus is now **only** moved to the child content when the accordion toggle is clicked, and is **not** moved to the child content when the external switch/toggle is used |

## QA

- Go to https://eui.elastic.co/pr_7314/#/layout/accordion#controlling-toggled-state
- [x] Confirm that when toggling the `Open/Closed` button group control, focus **is not** moved away from the control to the accordion
- [x] Confirm that when toggling the accordion arrow/button, focus **is** moved into the accordion children on open
- Smoke testing
    - [x] Confirm that all other uncontrolled accordions on the page still focus into the accordion children on open

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A