### PR TITLE
[EuiCollapsibleNavBeta] Fix accordion open animation bug

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -177,7 +177,6 @@ export const KibanaExample: Story = {
                   { title: 'Notifications', href: '#' },
                 ],
               },
-              { title: 'Add data', href: '#' },
             ]),
           ]}
         />

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
@@ -73,8 +73,17 @@ export const euiCollapsibleNavAccordionStyles = (
       }
     `,
     isSubItem: css`
-      &.euiAccordion-isOpen {
-        ${logicalCSS('margin-bottom', euiTheme.size.m)}
+      /* Adds extra spacing to the bottom of the accordion while open. Notes:
+         1. This uses a pseudo element instead of margin-bottom on the accordion,
+            because otherwise the height calculations the accordion uses will be off
+            and cause buggy animation behavior
+         2. Setting a margin or padding bottom on .euiAccordion__children does not
+            seem to work correctly and gets collapsed instead of stacking
+       */
+      &.euiAccordion-isOpen .euiAccordion__children::after {
+        content: '';
+        display: block;
+        ${logicalCSS('height', euiTheme.size.m)}
       }
     `,
     // Arrow element


### PR DESCRIPTION
## Summary

> ⚠️ Quick note about this bug: it **only** occurs when toggling an EuiAccordion that's the **last** item in the `items` array.

| Before | After |
|--------|--------|
| Note the "Get started" item jumping on every open | "Get started" item does not jump |
| ![before](https://github.com/elastic/eui/assets/549407/0ad82a7c-1aee-4c02-a829-801a49d4d273) | ![after](https://github.com/elastic/eui/assets/549407/d23e5503-570c-4da7-84df-40e058d503ee) | 

## QA

- Go to http://eui.elastic.co/pr_7317/?path=/story/euicollapsiblenavbeta--kibana-example
- Click the `Observability` accordion arrow
- Scroll down to `AIOps` and click that accordion arrow
- [x] Confirm that repeatedly opening and closing that toggle does not produce any weird visual bugs or jumping

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    ~- [ ] Checked in both **light and dark** modes~
- Docs site QA - N/A, beta component
- Code quality checklist - N/A, CSS change
- Release checklist - N/A, beta component
- Designer checklist - N/A, beta component
