### PR TITLE
[EuiDataGrid] Fix over-eager visual cutoff on cell contents

### DIFF
--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -100,7 +100,6 @@
 .euiDataGridRowCell__contentWrapper {
   position: relative; // Needed for .euiDataGridRowCell__actions--overlay
   height: 100%;
-  overflow: hidden;
 }
 
 .euiDataGridRowCell__defaultHeight {

--- a/upcoming_changelogs/7320.md
+++ b/upcoming_changelogs/7320.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid` cells visually cutting off overflowing content a little too quickly


### PR DESCRIPTION
## Summary

This PR will close https://github.com/elastic/kibana/issues/169757 once it's merged into Kibana main.

| Before (avatar in left column is cut off at the bottom) | After |
|--------|--------|
| <img width="635" alt="" src="https://github.com/elastic/eui/assets/549407/b9ac3478-5450-44ca-b6d7-53c6879be93e"> | <img width="637" alt="" src="https://github.com/elastic/eui/assets/549407/f3ce959b-ce9b-442c-9b7e-c70623611097"> | 

This was regressed in #7255, although interestingly enough, this behavior was already semi-broken prior to that PR, but _only_ for row heights set to `lineCount` or a static number. You can see this in [previous EUI releases](https://eui.elastic.co/v80.0.0/#/tabular-content/data-grid-style-display) when you change the grid density setting to `lineCount: 1` (as opposed to the default/single height): 

<img width="550" alt="" src="https://github.com/elastic/eui/assets/549407/277eed2f-6d40-45ad-865b-d6ac3a72d78e">

---

What happened in #7255 was at I grabbed the pre-existing inline styles being set for those row heights and refactored them to CSS shared by all heights:

https://github.com/elastic/eui/blob/976e603bf55a41e6afe665488aa812e57a3bd47c/src/components/datagrid/utils/row_heights.ts#L131-L134

Which then revealed that the `overflow: hidden` style was actually incorrect/problematic and shouldn't have been set in the first place. The parent `euiDataGridRowCell` div already has its own `overflow: hidden`, so we don't need to set one on the inside wrapper.

## QA

- Go to https://eui.elastic.co/pr_732#/tabular-content/data-grid-style-display
- [x] Confirm that the avatars are no longer cut off at the bottom
- [x] Smoke test other datagrid demos/examples and confirm they do not look broken

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist - N/A, CSS only change (dreaming of visual regression tests...)
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
