### PR TITLE
Add tiers and subscription levels to capitalization rules

### DIFF
--- a/src-docs/src/views/guidelines/writing_guidelines.js
+++ b/src-docs/src/views/guidelines/writing_guidelines.js
@@ -211,12 +211,21 @@ export const WritingGuidelines = () => {
         >
           <GuideRuleExample
             type="do"
-            text="Product and solution names are always capitalized."
+            text="Product and solution names are always capitalized. Same goes for feature tiers and subscription levels."
             minHeight={200}
           >
-            <EuiTitle size="xs">
-              <span>Elastic APM</span>
-            </EuiTitle>
+            <EuiText size="xs">
+              <span>
+                <ul>
+                  <li>Welcome to Elastic Observability</li>
+                  <li>Elastic APM</li>
+                  <li>You have chosen Security Essentials.</li>
+                  <li>
+                    This feature is available for Gold subscriptions and higher.
+                  </li>
+                </ul>
+              </span>
+            </EuiText>
           </GuideRuleExample>
           <GuideRuleExample
             type="do"

--- a/src-docs/src/views/guidelines/writing_guidelines.js
+++ b/src-docs/src/views/guidelines/writing_guidelines.js
@@ -218,7 +218,7 @@ export const WritingGuidelines = () => {
               <ul>
                 <li>Welcome to Elastic Observability</li>
                 <li>Elastic APM</li>
-                <li>You have chosen Security Essentials.</li>
+                <li>You have chosen Security Analytics Essentials.</li>
                 <li>
                   This feature is available for Gold subscriptions and higher.
                 </li>

--- a/src-docs/src/views/guidelines/writing_guidelines.js
+++ b/src-docs/src/views/guidelines/writing_guidelines.js
@@ -145,14 +145,14 @@ export const WritingGuidelines = () => {
           <GuideRuleExample
             type="do"
             text="Use sentence case in buttons, menus, titles, and tabs."
-            minHeight={200}
+            minHeight={250}
           >
             <EuiButton fill>Check for new data</EuiButton>
           </GuideRuleExample>
           <GuideRuleExample
             type="do"
             text="Use sentence case for modal and page elements."
-            minHeight={200}
+            minHeight={250}
           >
             <EuiPanel style={{ transform: 'scale(.75)' }}>
               <EuiTitle size="m">

--- a/src-docs/src/views/guidelines/writing_guidelines.js
+++ b/src-docs/src/views/guidelines/writing_guidelines.js
@@ -205,7 +205,10 @@ export const WritingGuidelines = () => {
           </GuideRuleExample>
         </GuideRule>
 
-        <GuideRule heading="Title case for products, solutions, and apps">
+        <GuideRule
+          heading="Title case for proper nouns"
+          description="Proper nouns include product names, solutions, apps, feature tiers, and subscription levels. "
+        >
           <GuideRuleExample
             type="do"
             text="Product and solution names are always capitalized."

--- a/src-docs/src/views/guidelines/writing_guidelines.js
+++ b/src-docs/src/views/guidelines/writing_guidelines.js
@@ -215,16 +215,14 @@ export const WritingGuidelines = () => {
             minHeight={200}
           >
             <EuiText size="xs">
-              <span>
-                <ul>
-                  <li>Welcome to Elastic Observability</li>
-                  <li>Elastic APM</li>
-                  <li>You have chosen Security Essentials.</li>
-                  <li>
-                    This feature is available for Gold subscriptions and higher.
-                  </li>
-                </ul>
-              </span>
+              <ul>
+                <li>Welcome to Elastic Observability</li>
+                <li>Elastic APM</li>
+                <li>You have chosen Security Essentials.</li>
+                <li>
+                  This feature is available for Gold subscriptions and higher.
+                </li>
+              </ul>
             </EuiText>
           </GuideRuleExample>
           <GuideRuleExample


### PR DESCRIPTION
## Summary

This PR is a follow-up to https://github.com/elastic/eui/pull/7300.
It adds a mention of tiers and subscription levels to the capitalization rules of the writing section.

![image](https://github.com/elastic/eui/assets/10208282/64b09401-3e98-48e7-bfe5-85204264d84e)




