### PR TITLE
[EuiButtonGroup] Remove radio group markup/behavior

### DIFF
--- a/src/components/button/button_display/_button_display.test.tsx
+++ b/src/components/button/button_display/_button_display.test.tsx
@@ -55,7 +55,7 @@ describe('EuiButtonDisplay', () => {
   });
 
   describe('element', () => {
-    const elements = ['a', 'button', 'span', 'label'] as const;
+    const elements = ['a', 'button', 'span'] as const;
 
     const getButtonElement = (container: HTMLElement) =>
       container.firstChild!.nodeName.toLowerCase();
@@ -74,7 +74,7 @@ describe('EuiButtonDisplay', () => {
 
     it('always renders a `button` element if disabled', () => {
       const { container } = render(
-        <EuiButtonDisplay element="label" isDisabled>
+        <EuiButtonDisplay element="a" isDisabled>
           Content
         </EuiButtonDisplay>
       );

--- a/src/components/button/button_display/_button_display.tsx
+++ b/src/components/button/button_display/_button_display.tsx
@@ -43,7 +43,7 @@ export type EuiButtonDisplaySizes = (typeof SIZES)[number];
 export interface EuiButtonDisplayCommonProps
   extends EuiButtonDisplayContentProps,
     CommonProps {
-  element?: 'a' | 'button' | 'span' | 'label';
+  element?: 'a' | 'button' | 'span';
   children?: ReactNode;
   size?: EuiButtonDisplaySizes;
   /**

--- a/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -92,8 +92,9 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for singl
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-compressed"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -110,19 +111,14 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for singl
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -137,17 +133,10 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for singl
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-compressed-empty-disabled"
@@ -263,8 +252,9 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-m"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-m-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -281,19 +271,14 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-m-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -308,17 +293,10 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-euiButtonGroupButton-m-uncompressed-base-disabled"
@@ -434,8 +412,9 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -452,19 +431,14 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -479,17 +453,10 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -605,8 +572,9 @@ exports[`EuiButtonGroup button props color accent is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-accent-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -623,19 +591,14 @@ exports[`EuiButtonGroup button props color accent is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-accent"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -650,17 +613,10 @@ exports[`EuiButtonGroup button props color accent is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -776,8 +732,9 @@ exports[`EuiButtonGroup button props color danger is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-danger-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -794,19 +751,14 @@ exports[`EuiButtonGroup button props color danger is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-danger"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -821,17 +773,10 @@ exports[`EuiButtonGroup button props color danger is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -947,8 +892,9 @@ exports[`EuiButtonGroup button props color primary is rendered for single 1`] = 
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-primary-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -965,19 +911,14 @@ exports[`EuiButtonGroup button props color primary is rendered for single 1`] = 
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-primary"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -992,17 +933,10 @@ exports[`EuiButtonGroup button props color primary is rendered for single 1`] = 
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -1118,8 +1052,9 @@ exports[`EuiButtonGroup button props color success is rendered for single 1`] = 
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-success-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -1136,19 +1071,14 @@ exports[`EuiButtonGroup button props color success is rendered for single 1`] = 
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-success"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -1163,17 +1093,10 @@ exports[`EuiButtonGroup button props color success is rendered for single 1`] = 
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -1289,8 +1212,9 @@ exports[`EuiButtonGroup button props color text is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -1307,19 +1231,14 @@ exports[`EuiButtonGroup button props color text is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -1334,17 +1253,10 @@ exports[`EuiButtonGroup button props color text is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -1460,8 +1372,9 @@ exports[`EuiButtonGroup button props color warning is rendered for single 1`] = 
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-warning-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -1478,19 +1391,14 @@ exports[`EuiButtonGroup button props color warning is rendered for single 1`] = 
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-warning"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -1505,17 +1413,10 @@ exports[`EuiButtonGroup button props color warning is rendered for single 1`] = 
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -1797,8 +1698,9 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -1815,19 +1717,14 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -1842,17 +1739,10 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -1968,8 +1858,9 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton euiButtonGroupButton-isIconOnly testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-iconOnly-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -1986,19 +1877,14 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__iconOnly"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-iconOnly-s-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -2013,17 +1899,10 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__iconOnly"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-iconOnly-s-uncompressed-base-disabled"
@@ -2221,8 +2100,9 @@ exports[`EuiButtonGroup type="single" idSelected 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="true"
       class="euiButtonGroupButton euiButtonGroupButton-isSelected testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-fill-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -2239,20 +2119,14 @@ exports[`EuiButtonGroup type="single" idSelected 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            checked=""
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -2267,17 +2141,10 @@ exports[`EuiButtonGroup type="single" idSelected 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"
@@ -2315,8 +2182,9 @@ exports[`EuiButtonGroup type="single" renders 1`] = `
   <div
     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-s"
   >
-    <label
+    <button
       aria-label="aria-label"
+      aria-pressed="false"
       class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
@@ -2333,19 +2201,14 @@ exports[`EuiButtonGroup type="single" renders 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option one"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button00"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option one
         </span>
       </span>
-    </label>
-    <label
+    </button>
+    <button
+      aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      data-test-subj="button01"
       title="Option two"
       type="button"
     >
@@ -2360,17 +2223,10 @@ exports[`EuiButtonGroup type="single" renders 1`] = `
           class="eui-textTruncate emotion-euiButtonGroupButton__text"
           data-text="Option two"
         >
-          <input
-            class="euiScreenReaderOnly"
-            data-test-subj="button01"
-            name="test"
-            type="radio"
-            value=""
-          />
           Option two
         </span>
       </span>
-    </label>
+    </button>
     <button
       aria-pressed="false"
       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-base-disabled"

--- a/src/components/button/button_group/button_group.test.tsx
+++ b/src/components/button/button_group/button_group.test.tsx
@@ -50,7 +50,6 @@ const requiredSingleProps: EuiButtonGroupProps = {
   legend: 'test',
   onChange: () => {},
   options,
-  name: 'test',
   idSelected: '',
 };
 

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -178,6 +178,11 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
               key={index}
               isDisabled={isDisabled}
               {...(option as EuiButtonGroupOptionProps)}
+              onClick={
+                typeIsSingle
+                  ? () => onChange(option.id, option.value)
+                  : () => onChange(option.id)
+              }
               isSelected={
                 typeIsSingle
                   ? option.id === idSelected
@@ -186,7 +191,6 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
               color={color}
               size={buttonSize}
               isIconOnly={isIconOnly}
-              onChange={onChange}
             />
           );
         })}

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -9,7 +9,7 @@
 import classNames from 'classnames';
 import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react';
 
-import { useEuiTheme, useGeneratedHtmlId } from '../../../services';
+import { useEuiTheme } from '../../../services';
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { CommonProps } from '../../common';
 
@@ -85,8 +85,7 @@ export type EuiButtonGroupProps = CommonProps & {
          */
         type?: 'single';
         /**
-         * The `name` attribute for radio inputs;
-         * Defaults to a random string
+         * @deprecated No longer needed. You can safely remove this prop entirely
          */
         name?: string;
         /**
@@ -112,6 +111,9 @@ export type EuiButtonGroupProps = CommonProps & {
          */
         onChange: (id: string) => void;
         idSelected?: never;
+        /**
+         * @deprecated
+         */
         name?: never;
       }
   );
@@ -129,7 +131,7 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
   isFullWidth = false,
   isIconOnly = false,
   legend,
-  name,
+  name, // Prevent prop from being spread
   onChange,
   options = [],
   type = 'single',
@@ -157,7 +159,6 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
   );
 
   const typeIsSingle = type === 'single';
-  const nameIfSingle = useGeneratedHtmlId({ conditionalId: name });
 
   return (
     <fieldset
@@ -175,7 +176,6 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
           return (
             <EuiButtonGroupButton
               key={index}
-              name={nameIfSingle}
               isDisabled={isDisabled}
               {...(option as EuiButtonGroupOptionProps)}
               isSelected={

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -178,7 +178,6 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
               name={nameIfSingle}
               isDisabled={isDisabled}
               {...(option as EuiButtonGroupOptionProps)}
-              element={typeIsSingle ? 'label' : 'button'}
               isSelected={
                 typeIsSingle
                   ? option.id === idSelected

--- a/src/components/button/button_group/button_group_button.styles.ts
+++ b/src/components/button/button_group/button_group_button.styles.ts
@@ -139,55 +139,29 @@ export const euiButtonGroupButtonStyles = (euiThemeContext: UseEuiTheme) => {
   };
 };
 
-/**
- * Focus utilities - made complex by the two different button styles
- * and the fact that `label`/`input` combos need :focus-within,
- * but `button` does not
- */
-const _outlineSelectors = (outlineCss: string) => {
+export const _compressedButtonFocusColor = (
+  euiThemeContext: UseEuiTheme,
+  color: _EuiButtonColor | 'disabled'
+) => {
+  const { backgroundColor } = euiButtonFillColor(euiThemeContext, color);
+
   return css`
-    &:is(button) {
-      &:focus-visible {
-        ${outlineCss}
-      }
-    }
+    &:focus-visible {
+      ${euiOutline(euiThemeContext, 'center', backgroundColor)}
 
-    &:is(label) {
-      /* Firefox fallback for :has. Delete once FF supports :has */
-      &:focus-within {
-        ${outlineCss}
-      }
-
-      @supports selector(:has(*)) {
-        &:focus-within {
-          outline: none;
-        }
-        /* Once all evergreen browsers support :has, we can remove
-           @supports and the outline: none reset just use this selector */
-        &:has(:focus-visible) {
-          ${outlineCss}
-        }
+      &:is(.euiButtonGroupButton-isSelected) {
+        outline-offset: 0;
       }
     }
   `;
 };
 
-export const _compressedButtonFocusColor = (
-  euiThemeContext: UseEuiTheme,
-  color: _EuiButtonColor | 'disabled'
-) => {
-  const { euiTheme } = euiThemeContext;
-  const { backgroundColor } = euiButtonFillColor(euiThemeContext, color);
-
-  return _outlineSelectors(
-    `outline: ${euiTheme.focus.width} solid ${backgroundColor};`
-  );
-};
-
 export const _uncompressedButtonFocus = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
-  return _outlineSelectors(
-    euiOutline(euiThemeContext, 'inset', euiTheme.colors.fullShade)
-  );
+  return css`
+    &:focus-visible {
+      ${euiOutline(euiThemeContext, 'inset', euiTheme.colors.fullShade)}
+    }
+  `;
 };

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -7,7 +7,7 @@
  */
 
 import classNames from 'classnames';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, MouseEventHandler } from 'react';
 
 import { useEuiTheme } from '../../../services';
 import { useEuiButtonColorCSS } from '../../../themes/amsterdam/global_styling/mixins/button';
@@ -41,7 +41,7 @@ type Props = EuiButtonGroupOptionProps & {
   /**
    * Inherit from EuiButtonGroup
    */
-  onChange: EuiButtonGroupProps['onChange'];
+  onClick: MouseEventHandler<HTMLButtonElement>;
 };
 
 export const EuiButtonGroupButton: FunctionComponent<Props> = ({
@@ -51,7 +51,6 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
   isIconOnly,
   isSelected = false,
   label,
-  onChange,
   size,
   value,
   color: _color = 'primary',
@@ -62,7 +61,6 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
       'data-test-subj': id,
       isSelected,
       type,
-      onClick: () => onChange(id), // TODO
     };
   }
 

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -51,19 +51,11 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
   isIconOnly,
   isSelected = false,
   label,
+  value, // Prevent prop from being spread
   size,
-  value,
   color: _color = 'primary',
-  type = 'button',
   ...rest
 }) => {
-  const elementProps = {
-      'data-test-subj': id,
-      isSelected,
-      type,
-    };
-  }
-
   const isCompressed = size === 'compressed';
   const color = isDisabled ? 'disabled' : _color;
   const display = isSelected ? 'fill' : isCompressed ? 'empty' : 'base';
@@ -122,7 +114,8 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
         'data-text': innerText,
       }}
       title={innerText}
-      {...elementProps}
+      data-test-subj={id}
+      isSelected={isSelected}
       {...rest}
     >
       {label}

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -27,14 +27,6 @@ type Props = EuiButtonGroupOptionProps & {
    */
   isSelected?: boolean;
   /**
-   * Name of the whole group for 'single'.
-   */
-  name?: string;
-  /**
-   * The value of the radio input for 'single'.
-   */
-  value?: string;
-  /**
    * Inherit from EuiButtonGroup
    */
   color: EuiButtonGroupProps['color'];
@@ -59,7 +51,6 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
   isIconOnly,
   isSelected = false,
   label,
-  name,
   onChange,
   size,
   value,

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -23,10 +23,6 @@ import {
 
 type Props = EuiButtonGroupOptionProps & {
   /**
-   * Element to display based on single or multi
-   */
-  element: 'button' | 'label';
-  /**
    * Styles the selected button to look selected (usually with `fill`)
    */
   isSelected?: boolean;
@@ -68,34 +64,14 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
   size,
   value,
   color: _color = 'primary',
-  element: _element = 'button',
   type = 'button',
   ...rest
 }) => {
-  // Force element to be a button if disabled
-  const element = isDisabled ? 'button' : _element;
-
-  let elementProps = {};
-  let singleInput;
-  if (element === 'label') {
-    singleInput = (
-      <input
-        className="euiScreenReaderOnly"
-        name={name}
-        checked={isSelected}
-        disabled={isDisabled}
-        value={value}
-        type="radio"
-        onChange={() => onChange(id, value)}
-        data-test-subj={id}
-      />
-    );
-  } else {
-    elementProps = {
+  const elementProps = {
       'data-test-subj': id,
       isSelected,
       type,
-      onClick: () => onChange(id),
+      onClick: () => onChange(id), // TODO
     };
   }
 
@@ -148,7 +124,6 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
     <EuiButtonDisplay
       css={cssStyles}
       className={buttonClasses}
-      element={element}
       isDisabled={isDisabled}
       size={size === 'compressed' ? 's' : size}
       contentProps={{ css: contentStyles }}
@@ -161,7 +136,6 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
       {...elementProps}
       {...rest}
     >
-      {singleInput}
       {label}
     </EuiButtonDisplay>
   );

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -152,7 +152,8 @@ exports[`useDataGridColumnSorting columnSorting [React 16] renders a toolbar but
                   <div
                     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
                   >
-                    <label
+                    <button
+                      aria-pressed="true"
                       class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
                       data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
                       title="Low-High"
@@ -165,19 +166,12 @@ exports[`useDataGridColumnSorting columnSorting [React 16] renders a toolbar but
                           class="eui-textTruncate emotion-euiButtonGroupButton__text"
                           data-text="Low-High"
                         >
-                          <input
-                            checked=""
-                            class="euiScreenReaderOnly"
-                            data-test-subj="columnAAsc"
-                            name="columnA"
-                            type="radio"
-                            value="asc"
-                          />
                           Low-High
                         </span>
                       </span>
-                    </label>
-                    <label
+                    </button>
+                    <button
+                      aria-pressed="false"
                       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
                       data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
                       title="High-Low"
@@ -190,17 +184,10 @@ exports[`useDataGridColumnSorting columnSorting [React 16] renders a toolbar but
                           class="eui-textTruncate emotion-euiButtonGroupButton__text"
                           data-text="High-Low"
                         >
-                          <input
-                            class="euiScreenReaderOnly"
-                            data-test-subj="columnADesc"
-                            name="columnA"
-                            type="radio"
-                            value="desc"
-                          />
                           High-Low
                         </span>
                       </span>
-                    </label>
+                    </button>
                   </div>
                 </fieldset>
               </div>
@@ -442,7 +429,8 @@ exports[`useDataGridColumnSorting columnSorting [React 17] renders a toolbar but
                   <div
                     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
                   >
-                    <label
+                    <button
+                      aria-pressed="true"
                       class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
                       data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
                       title="Low-High"
@@ -455,19 +443,12 @@ exports[`useDataGridColumnSorting columnSorting [React 17] renders a toolbar but
                           class="eui-textTruncate emotion-euiButtonGroupButton__text"
                           data-text="Low-High"
                         >
-                          <input
-                            checked=""
-                            class="euiScreenReaderOnly"
-                            data-test-subj="columnAAsc"
-                            name="columnA"
-                            type="radio"
-                            value="asc"
-                          />
                           Low-High
                         </span>
                       </span>
-                    </label>
-                    <label
+                    </button>
+                    <button
+                      aria-pressed="false"
                       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
                       data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
                       title="High-Low"
@@ -480,17 +461,10 @@ exports[`useDataGridColumnSorting columnSorting [React 17] renders a toolbar but
                           class="eui-textTruncate emotion-euiButtonGroupButton__text"
                           data-text="High-Low"
                         >
-                          <input
-                            class="euiScreenReaderOnly"
-                            data-test-subj="columnADesc"
-                            name="columnA"
-                            type="radio"
-                            value="desc"
-                          />
                           High-Low
                         </span>
                       </span>
-                    </label>
+                    </button>
                   </div>
                 </fieldset>
               </div>
@@ -732,7 +706,8 @@ exports[`useDataGridColumnSorting columnSorting [React 18] renders a toolbar but
                   <div
                     class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
                   >
-                    <label
+                    <button
+                      aria-pressed="true"
                       class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
                       data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
                       title="Low-High"
@@ -745,19 +720,12 @@ exports[`useDataGridColumnSorting columnSorting [React 18] renders a toolbar but
                           class="eui-textTruncate emotion-euiButtonGroupButton__text"
                           data-text="Low-High"
                         >
-                          <input
-                            checked=""
-                            class="euiScreenReaderOnly"
-                            data-test-subj="columnAAsc"
-                            name="columnA"
-                            type="radio"
-                            value="asc"
-                          />
                           Low-High
                         </span>
                       </span>
-                    </label>
-                    <label
+                    </button>
+                    <button
+                      aria-pressed="false"
                       class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
                       data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
                       title="High-Low"
@@ -770,17 +738,10 @@ exports[`useDataGridColumnSorting columnSorting [React 18] renders a toolbar but
                           class="eui-textTruncate emotion-euiButtonGroupButton__text"
                           data-text="High-Low"
                         >
-                          <input
-                            class="euiScreenReaderOnly"
-                            data-test-subj="columnADesc"
-                            name="columnA"
-                            type="radio"
-                            value="desc"
-                          />
                           High-Low
                         </span>
                       </span>
-                    </label>
+                    </button>
                   </div>
                 </fieldset>
               </div>

--- a/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
@@ -87,7 +87,8 @@ exports[`EuiDataGridColumnSortingDraggable [React 16] renders an EuiDraggable co
           <div
             class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
           >
-            <label
+            <button
+              aria-pressed="true"
               class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
               data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
               title="Low-High"
@@ -100,19 +101,12 @@ exports[`EuiDataGridColumnSortingDraggable [React 16] renders an EuiDraggable co
                   class="eui-textTruncate emotion-euiButtonGroupButton__text"
                   data-text="Low-High"
                 >
-                  <input
-                    checked=""
-                    class="euiScreenReaderOnly"
-                    data-test-subj="columnAAsc"
-                    name="columnA"
-                    type="radio"
-                    value="asc"
-                  />
                   Low-High
                 </span>
               </span>
-            </label>
-            <label
+            </button>
+            <button
+              aria-pressed="false"
               class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
               data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
               title="High-Low"
@@ -125,17 +119,10 @@ exports[`EuiDataGridColumnSortingDraggable [React 16] renders an EuiDraggable co
                   class="eui-textTruncate emotion-euiButtonGroupButton__text"
                   data-text="High-Low"
                 >
-                  <input
-                    class="euiScreenReaderOnly"
-                    data-test-subj="columnADesc"
-                    name="columnA"
-                    type="radio"
-                    value="desc"
-                  />
                   High-Low
                 </span>
               </span>
-            </label>
+            </button>
           </div>
         </fieldset>
       </div>
@@ -246,7 +233,8 @@ exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable co
           <div
             class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
           >
-            <label
+            <button
+              aria-pressed="true"
               class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
               data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
               title="Low-High"
@@ -259,19 +247,12 @@ exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable co
                   class="eui-textTruncate emotion-euiButtonGroupButton__text"
                   data-text="Low-High"
                 >
-                  <input
-                    checked=""
-                    class="euiScreenReaderOnly"
-                    data-test-subj="columnAAsc"
-                    name="columnA"
-                    type="radio"
-                    value="asc"
-                  />
                   Low-High
                 </span>
               </span>
-            </label>
-            <label
+            </button>
+            <button
+              aria-pressed="false"
               class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
               data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
               title="High-Low"
@@ -284,17 +265,10 @@ exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable co
                   class="eui-textTruncate emotion-euiButtonGroupButton__text"
                   data-text="High-Low"
                 >
-                  <input
-                    class="euiScreenReaderOnly"
-                    data-test-subj="columnADesc"
-                    name="columnA"
-                    type="radio"
-                    value="desc"
-                  />
                   High-Low
                 </span>
               </span>
-            </label>
+            </button>
           </div>
         </fieldset>
       </div>
@@ -405,7 +379,8 @@ exports[`EuiDataGridColumnSortingDraggable [React 18] renders an EuiDraggable co
           <div
             class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
           >
-            <label
+            <button
+              aria-pressed="true"
               class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
               data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
               title="Low-High"
@@ -418,19 +393,12 @@ exports[`EuiDataGridColumnSortingDraggable [React 18] renders an EuiDraggable co
                   class="eui-textTruncate emotion-euiButtonGroupButton__text"
                   data-text="Low-High"
                 >
-                  <input
-                    checked=""
-                    class="euiScreenReaderOnly"
-                    data-test-subj="columnAAsc"
-                    name="columnA"
-                    type="radio"
-                    value="asc"
-                  />
                   Low-High
                 </span>
               </span>
-            </label>
-            <label
+            </button>
+            <button
+              aria-pressed="false"
               class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
               data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
               title="High-Low"
@@ -443,17 +411,10 @@ exports[`EuiDataGridColumnSortingDraggable [React 18] renders an EuiDraggable co
                   class="eui-textTruncate emotion-euiButtonGroupButton__text"
                   data-text="High-Low"
                 >
-                  <input
-                    class="euiScreenReaderOnly"
-                    data-test-subj="columnADesc"
-                    name="columnA"
-                    type="radio"
-                    value="desc"
-                  />
                   High-Low
                 </span>
               </span>
-            </label>
+            </button>
           </div>
         </fieldset>
       </div>

--- a/src/components/datagrid/controls/column_sorting_draggable.test.tsx
+++ b/src/components/datagrid/controls/column_sorting_draggable.test.tsx
@@ -83,7 +83,9 @@ describe('EuiDataGridColumnSortingDraggable', () => {
       </EuiDragDropContext>
     );
 
-    fireEvent.click(getByTestSubject('columnADesc'));
+    fireEvent.click(
+      getByTestSubject('euiDataGridColumnSorting-sortColumn-columnA-desc')
+    );
 
     expect(onSort).toHaveBeenCalledWith([{ id: 'columnA', direction: 'desc' }]);
   });

--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -77,12 +77,11 @@ describe('useDataGridDisplaySelector', () => {
         const component = mount(<MockComponent />);
         openPopover(component);
 
-        // Click density 'buttons' (actually hidden radios)
-        component.find('[data-test-subj="expanded"]').simulate('change');
+        component.find('button[data-test-subj="expanded"]').simulate('click');
         expect(getSelection(component)).toEqual('expanded');
-        component.find('[data-test-subj="normal"]').simulate('change');
+        component.find('button[data-test-subj="normal"]').simulate('click');
         expect(getSelection(component)).toEqual('normal');
-        component.find('[data-test-subj="compact"]').simulate('change');
+        component.find('button[data-test-subj="compact"]').simulate('click');
         expect(getSelection(component)).toEqual('compact');
       });
 
@@ -95,7 +94,7 @@ describe('useDataGridDisplaySelector', () => {
         );
 
         openPopover(component);
-        component.find('[data-test-subj="expanded"]').simulate('change');
+        component.find('button[data-test-subj="expanded"]').simulate('click');
 
         expect(onDensityChange).toHaveBeenCalledWith({
           stripes: true,
@@ -168,7 +167,7 @@ describe('useDataGridDisplaySelector', () => {
         openPopover(component);
         expect(getSelection(component)).toEqual('expanded');
 
-        component.find('[data-test-subj="compact"]').simulate('change');
+        component.find('button[data-test-subj="compact"]').simulate('click');
         expect(getSelection(component)).toEqual('compact');
 
         component
@@ -189,7 +188,7 @@ describe('useDataGridDisplaySelector', () => {
         openPopover(component);
         expect(getSelection(component)).toEqual('undefined');
 
-        component.find('[data-test-subj="auto"]').simulate('change');
+        component.find('button[data-test-subj="auto"]').simulate('click');
         expect(getSelection(component)).toEqual('auto');
       });
 
@@ -202,7 +201,7 @@ describe('useDataGridDisplaySelector', () => {
         );
 
         openPopover(component);
-        component.find('[data-test-subj="auto"]').simulate('change');
+        component.find('button[data-test-subj="auto"]').simulate('click');
 
         expect(onRowHeightChange).toHaveBeenCalledWith({
           rowHeights: {},
@@ -287,7 +286,7 @@ describe('useDataGridDisplaySelector', () => {
         openPopover(component);
         expect(getSelection(component)).toEqual('undefined');
 
-        component.find('[data-test-subj="auto"]').simulate('change');
+        component.find('button[data-test-subj="auto"]').simulate('click');
         expect(getSelection(component)).toEqual('auto');
 
         component
@@ -322,7 +321,9 @@ describe('useDataGridDisplaySelector', () => {
             component.find('[data-test-subj="lineCountNumber"]').exists()
           ).toBe(false);
 
-          component.find('[data-test-subj="lineCount"]').simulate('change');
+          component
+            .find('button[data-test-subj="lineCount"]')
+            .simulate('click');
           expect(getSelection(component)).toEqual('lineCount');
 
           expect(
@@ -344,7 +345,9 @@ describe('useDataGridDisplaySelector', () => {
         it('defaults to a lineCount of 2 when no developer settings have been passed', () => {
           const component = mount(<MockComponent />);
           openPopover(component);
-          component.find('[data-test-subj="lineCount"]').simulate('change');
+          component
+            .find('button[data-test-subj="lineCount"]')
+            .simulate('click');
 
           expect(getLineCountNumber(component)).toEqual(2);
         });
@@ -408,8 +411,8 @@ describe('useDataGridDisplaySelector', () => {
           component.find('[data-test-subj="resetDisplaySelector"]').exists()
         ).toBe(false);
 
-        component.find('[data-test-subj="expanded"]').simulate('change');
-        component.find('[data-test-subj="auto"]').simulate('change');
+        component.find('button[data-test-subj="expanded"]').simulate('click');
+        component.find('button[data-test-subj="auto"]').simulate('click');
         expect(
           component.find('[data-test-subj="resetDisplaySelector"]').exists()
         ).toBe(true);
@@ -444,8 +447,8 @@ describe('useDataGridDisplaySelector', () => {
           component.find('[data-test-subj="resetDisplaySelector"]').exists()
         ).toBe(false);
 
-        component.find('[data-test-subj="expanded"]').simulate('change');
-        component.find('[data-test-subj="auto"]').simulate('change');
+        component.find('button[data-test-subj="expanded"]').simulate('click');
+        component.find('button[data-test-subj="auto"]').simulate('click');
         expect(
           component.find('[data-test-subj="resetDisplaySelector"]').exists()
         ).toBe(false);

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -188,7 +188,7 @@ function getColumnSortDirection(
 
   expect(columnSorter.length).toBe(1);
   const activeSort = columnSorter.find(
-    'label[className*="euiButtonGroupButton-isSelected"]'
+    'button[className*="euiButtonGroupButton-isSelected"]'
   );
 
   const sortDirection = (
@@ -276,10 +276,10 @@ function sortByColumn(
 
   if (currentSortDirection !== direction) {
     const sortButton = columnSorter.find(
-      `label[data-test-subj="euiDataGridColumnSorting-sortColumn-${columnId}-${direction}"]`
+      `button[data-test-subj="euiDataGridColumnSorting-sortColumn-${columnId}-${direction}"]`
     );
     expect(sortButton.length).toBe(1);
-    sortButton.find('input').simulate('change', [undefined, direction]);
+    sortButton.simulate('click');
   }
 
   closeColumnSorter(datagrid);

--- a/src/global_styling/mixins/__snapshots__/_states.test.ts.snap
+++ b/src/global_styling/mixins/__snapshots__/_states.test.ts.snap
@@ -34,6 +34,23 @@ exports[`useEuiFocusRing hook returns a string for each offset: 16px 1`] = `
   "
 `;
 
+exports[`useEuiFocusRing hook returns a string for each offset: center 1`] = `
+"
+    outline: 2px solid currentColor;
+    outline-offset: -1px;
+
+    // 👀 Chrome respects :focus-visible and allows coloring the \`auto\` style
+    &:focus-visible {
+      outline-style: auto;
+    }
+
+    // 🙅‍♀️ But Chrome also needs to have the outline forcefully removed from regular \`:focus\` state
+    &:not(:focus-visible) {
+      outline: none;
+    }
+  "
+`;
+
 exports[`useEuiFocusRing hook returns a string for each offset: inset 1`] = `
 "
     outline: 2px solid currentColor;

--- a/src/global_styling/mixins/_states.test.ts
+++ b/src/global_styling/mixins/_states.test.ts
@@ -23,6 +23,12 @@ describe('useEuiFocusRing hook returns a string', () => {
       ).toMatchSnapshot();
     });
 
+    it('center', () => {
+      expect(
+        renderHook(() => useEuiFocusRing('center')).result.current
+      ).toMatchSnapshot();
+    });
+
     it('16px', () => {
       expect(
         renderHook(() => useEuiFocusRing('16px')).result.current

--- a/src/global_styling/mixins/_states.ts
+++ b/src/global_styling/mixins/_states.ts
@@ -8,6 +8,7 @@
 
 import { CSSProperties } from 'react';
 import { useEuiTheme, UseEuiTheme } from '../../services';
+import { mathWithUnits } from '../functions';
 
 export type _EuiFocusRingOffset =
   | 'inset'
@@ -39,7 +40,7 @@ export const euiOutline = (
   } else if (offset === 'outset') {
     outlineOffset = `${outlineWidth}`;
   } else if (offset === 'center') {
-    outlineOffset = `calc(${outlineWidth} / -2);`;
+    outlineOffset = mathWithUnits(outlineWidth, (x) => x / -2);
   }
 
   // This is a separate function from `euiFocusRing` because some EUI components

--- a/upcoming_changelogs/7325.md
+++ b/upcoming_changelogs/7325.md
@@ -1,0 +1,7 @@
+**Accessibility**
+
+- Updated `type="single"` `EuiButtonGroup`s to render standard buttons instead of radio buttons under the hood, per recent a11y recommendations
+
+**Deprecations**
+
+- Deprecated `EuiButtonGroup`'s `name` prop. This can safely be removed.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7101

See https://lea.verou.me/blog/2022/07/button-group/ - per recent a11y/industry discussion, using `<input type="radio">` buttons for single selection/exclusive button groups is no longer recommended.

No functionality should have regressed as a result of this change, although potentially some consumers' test selectors or CSS that were targeting `label` instead of `button` will need to be updated.

### Other PR notes

FYI, I grabbed this work because it's needed to unblock the `link or button` service/logic I'm shortly going to be implementing.

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7325/commits) - I tried to separate things out atomically to make changes easier to understand.

## QA

Mostly regression testing - ensure the following links behave as before / as expected in terms of selection UX, UI appearance, and focus rings for all `color` and `size` permutations:

- [x] https://eui.elastic.co/pr_7325/#/navigation/button#button-groups
- [x] https://eui.elastic.co/pr_7325/storybook/?path=/story/euibuttongroup--single-selection
- [x] https://eui.elastic.co/pr_7325/storybook/?path=/story/euibuttongroup--multi-selection

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked in both **light and dark** modes~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
