### PR TITLE
[a11y] More `role="region"` cleanup

### DIFF
--- a/src-docs/src/views/scroll/full_height.tsx
+++ b/src-docs/src/views/scroll/full_height.tsx
@@ -38,13 +38,7 @@ export default () => {
               responsive={false}
             >
               <EuiFlexItem>
-                <EuiPanel
-                  className="eui-yScroll"
-                  color="warning"
-                  tabIndex={0}
-                  role="region"
-                  aria-label="Example 1 for full height region"
-                >
+                <EuiPanel className="eui-yScroll" color="warning" tabIndex={0}>
                   <EuiText size="s">
                     <p>
                       Orbiting this at a distance of roughly ninety-two million
@@ -57,13 +51,7 @@ export default () => {
                 </EuiPanel>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiPanel
-                  className="eui-yScroll"
-                  color="warning"
-                  tabIndex={0}
-                  role="region"
-                  aria-label="Example 2 for full height region"
-                >
+                <EuiPanel className="eui-yScroll" color="warning" tabIndex={0}>
                   <EuiText size="s">
                     <p>
                       Orbiting this at a distance of roughly ninety-two million
@@ -83,11 +71,11 @@ export default () => {
     className="eui-fullHeight" responsive={false}>
     <EuiFlexItem>
       <BodyScroll
-        className="eui-yScroll" tabIndex={0} role="region" aria-label=""/>
+        className="eui-yScroll" tabIndex={0} />
     </EuiFlexItem>
     <EuiFlexItem>
       <BodyScroll
-        className="eui-yScroll" tabIndex={0} role="region" aria-label=""/>
+        className="eui-yScroll" tabIndex={0} />
     </EuiFlexItem>
   </EuiFlexGroup>
 </BodyContent>`}

--- a/src-docs/src/views/scroll/scroll.tsx
+++ b/src-docs/src/views/scroll/scroll.tsx
@@ -41,8 +41,6 @@ export default () => {
         example={
           <div
             tabIndex={0}
-            role="region"
-            aria-label="Example of eui-scrollBar region"
             className="eui-scrollBar"
             style={{
               overflowY: 'auto',
@@ -53,12 +51,7 @@ export default () => {
             <ScrollContent />
           </div>
         }
-        snippet={`<div
-  tabIndex={0}
-  role="region"
-  aria-label=""
-  className="eui-scrollBar"
->
+        snippet={`<div tabIndex={0} className="eui-scrollBar">
   <EuiPanel />
   <EuiPanel />
   <EuiPanel />
@@ -88,8 +81,6 @@ export default () => {
           example={
             <div
               tabIndex={0}
-              role="region"
-              aria-label="Example of useEuiScrollBar region"
               css={css`
                 ${useEuiScrollBar()}
                 ${logicalCSSWithFallback('overflow-y', 'auto')}
@@ -125,12 +116,7 @@ export default () => {
             paddingSize: 'none',
           }}
           example={
-            <div
-              tabIndex={0}
-              role="region"
-              aria-label="Example of euiScrollBar region"
-              className="guideSass__euiScrollBar"
-            >
+            <div tabIndex={0} className="guideSass__euiScrollBar">
               <ScrollContent />
             </div>
           }

--- a/src-docs/src/views/scroll/scroll_example.js
+++ b/src-docs/src/views/scroll/scroll_example.js
@@ -26,10 +26,7 @@ export const ScrollExample = {
         <p>
           To ensure keyboard-only users have access to the scrollable regions,
           the optimal solution is to apply <EuiCode>{'tabIndex="0"'}</EuiCode>{' '}
-          to the region. Add{' '}
-          <EuiCode language="html">{'role="region"'}</EuiCode> and supply an
-          accessible name by using <EuiCode language="html">aria-label</EuiCode>{' '}
-          or another method.{' '}
+          to the region.{' '}
           <EuiLink href="https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable">
             Learn more about the <EuiCode>scrollable-region-focusable</EuiCode>{' '}
             rule at Deque.

--- a/src-docs/src/views/scroll/scroll_x.tsx
+++ b/src-docs/src/views/scroll/scroll_x.tsx
@@ -51,20 +51,13 @@ export default () => {
         example={
           <div
             tabIndex={0}
-            role="region"
-            aria-label="Example of eui-xScroll region"
             className="eui-xScrollWithShadows"
             style={{ padding: euiTheme.size.base }}
           >
             {scrollingContent}
           </div>
         }
-        snippet={`<div
-  tabIndex={0}
-  role="region"
-  aria-label=""
-  className="eui-xScrollWithShadows"
->
+        snippet={`<div tabIndex={0} className="eui-xScrollWithShadows">
   <EuiPanel />
   <EuiPanel />
   <EuiPanel />
@@ -94,8 +87,6 @@ export default () => {
           example={
             <div
               tabIndex={0}
-              role="region"
-              aria-label="Example of useEuiOverflowScroll(x) region"
               css={css`
                 ${useEuiOverflowScroll('x', true)};
                 padding: ${euiTheme.size.base};
@@ -130,12 +121,7 @@ export default () => {
             paddingSize: 'none',
           }}
           example={
-            <div
-              tabIndex={0}
-              role="region"
-              aria-label="Example of euiXScrollWithShadows region"
-              className="guideSass__overflowShadowsX"
-            >
+            <div tabIndex={0} className="guideSass__overflowShadowsX">
               {scrollingContent}
             </div>
           }

--- a/src-docs/src/views/scroll/scroll_y.tsx
+++ b/src-docs/src/views/scroll/scroll_y.tsx
@@ -35,20 +35,13 @@ export default () => {
         example={
           <div
             tabIndex={0}
-            role="region"
-            aria-label="Example of eui-yScroll region"
             className="eui-yScrollWithShadows"
             style={{ height: 180 }}
           >
             <ScrollContent />
           </div>
         }
-        snippet={`<div
-  tabIndex={0}
-  role="region"
-  aria-label=""
-  className="eui-yScrollWithShadows"
->
+        snippet={`<div tabIndex={0} className="eui-yScrollWithShadows">
   <EuiPanel />
   <EuiPanel />
   <EuiPanel />
@@ -78,8 +71,6 @@ export default () => {
           example={
             <div
               tabIndex={0}
-              role="region"
-              aria-label="Example of useEuiOverflowScroll(y) region"
               css={css`
                 ${useEuiOverflowScroll('y', true)}
                 ${logicalCSS('height', '180px')}
@@ -114,12 +105,7 @@ export default () => {
             paddingSize: 'none',
           }}
           example={
-            <div
-              tabIndex={0}
-              role="region"
-              aria-label="Example of euiYScrollWithShadows region"
-              className="guideSass__overflowShadowsY"
-            >
+            <div tabIndex={0} className="guideSass__overflowShadowsY">
               <ScrollContent />
             </div>
           }

--- a/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -51,195 +51,189 @@ exports[`useDataGridColumnSelector columnSelector [React 16] renders a toolbar b
     You are in a dialog. Press Escape, or tap/click outside the dialog to close.
   </p>
   <div>
-    <div>
+    <div
+      class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
+    >
       <div
-        class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--compressed"
+          class="euiFormControlLayout__childrenWrapper"
         >
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              aria-label="Search columns"
-              class="euiFieldText euiFieldText--compressed"
-              data-test-subj="dataGridColumnSelectorSearch"
-              placeholder="Search"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__controlScroll"
-      >
-        <div
-          class="euiDroppable emotion-euiDroppable-noGrow"
-          data-rfd-droppable-context-id="0"
-          data-rfd-droppable-id="columnOrder"
-          data-test-subj="droppable"
-        >
-          <div
-            class="euiDraggable emotion-euiDraggable"
-            data-rfd-draggable-context-id="0"
-            data-rfd-draggable-id="columnA"
-            data-test-subj="draggable"
-            role="group"
-          >
-            <div
-              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
-              data-test-subj="dataGridColumnSelectorColumnItem-columnA"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <div
-                    class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
-                  >
-                    <button
-                      aria-checked="true"
-                      aria-label="columnA"
-                      class="euiSwitch__button"
-                      data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
-                      id="generated-id"
-                      name="columnA"
-                      role="switch"
-                      type="button"
-                    >
-                      <span
-                        class="euiSwitch__body"
-                      >
-                        <span
-                          class="euiSwitch__thumb"
-                        />
-                        <span
-                          class="euiSwitch__track"
-                        />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-hidden="true"
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnA"
-                  draggable="false"
-                  role="button"
-                  tabindex="-1"
-                >
-                  <span
-                    class="euiDataGridColumnSelector__itemLabel"
-                  >
-                    columnA
-                  </span>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-label="Drag handle"
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnA"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <span
-                    color="subdued"
-                    data-euiicon-type="grab"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiDraggable emotion-euiDraggable"
-            data-rfd-draggable-context-id="0"
-            data-rfd-draggable-id="columnB"
-            data-test-subj="draggable"
-            role="group"
-          >
-            <div
-              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
-              data-test-subj="dataGridColumnSelectorColumnItem-columnB"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <div
-                    class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
-                  >
-                    <button
-                      aria-checked="true"
-                      aria-label="columnB"
-                      class="euiSwitch__button"
-                      data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
-                      id="generated-id"
-                      name="columnB"
-                      role="switch"
-                      type="button"
-                    >
-                      <span
-                        class="euiSwitch__body"
-                      >
-                        <span
-                          class="euiSwitch__thumb"
-                        />
-                        <span
-                          class="euiSwitch__track"
-                        />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-hidden="true"
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnB"
-                  draggable="false"
-                  role="button"
-                  tabindex="-1"
-                >
-                  <span
-                    class="euiDataGridColumnSelector__itemLabel"
-                  >
-                    columnB
-                  </span>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-label="Drag handle"
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnB"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <span
-                    color="subdued"
-                    data-euiicon-type="grab"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiDroppable__placeholder"
+          <input
+            aria-label="Search columns"
+            class="euiFieldText euiFieldText--compressed"
+            data-test-subj="dataGridColumnSelectorSearch"
+            placeholder="Search"
+            type="text"
+            value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      class="euiDroppable euiDataGrid__controlScroll emotion-euiDroppable-noGrow"
+      data-rfd-droppable-context-id="0"
+      data-rfd-droppable-id="columnOrder"
+      data-test-subj="droppable"
+    >
+      <div
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id="0"
+        data-rfd-draggable-id="columnA"
+        data-test-subj="draggable"
+        role="group"
+      >
+        <div
+          class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
+          data-test-subj="dataGridColumnSelectorColumnItem-columnA"
+        >
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
+          >
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
+              >
+                <button
+                  aria-checked="true"
+                  aria-label="columnA"
+                  class="euiSwitch__button"
+                  data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
+                  id="generated-id"
+                  name="columnA"
+                  role="switch"
+                  type="button"
+                >
+                  <span
+                    class="euiSwitch__body"
+                  >
+                    <span
+                      class="euiSwitch__thumb"
+                    />
+                    <span
+                      class="euiSwitch__track"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-hidden="true"
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                class="euiDataGridColumnSelector__itemLabel"
+              >
+                columnA
+              </span>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id="0"
+        data-rfd-draggable-id="columnB"
+        data-test-subj="draggable"
+        role="group"
+      >
+        <div
+          class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
+          data-test-subj="dataGridColumnSelectorColumnItem-columnB"
+        >
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
+          >
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
+              >
+                <button
+                  aria-checked="true"
+                  aria-label="columnB"
+                  class="euiSwitch__button"
+                  data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
+                  id="generated-id"
+                  name="columnB"
+                  role="switch"
+                  type="button"
+                >
+                  <span
+                    class="euiSwitch__body"
+                  >
+                    <span
+                      class="euiSwitch__thumb"
+                    />
+                    <span
+                      class="euiSwitch__track"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-hidden="true"
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnB"
+              draggable="false"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                class="euiDataGridColumnSelector__itemLabel"
+              >
+                columnB
+              </span>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnB"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiDroppable__placeholder"
+      />
     </div>
     <div
       class="euiPopoverFooter emotion-euiPopoverFooter-s-s"
@@ -342,195 +336,189 @@ exports[`useDataGridColumnSelector columnSelector [React 17] renders a toolbar b
     You are in a dialog. Press Escape, or tap/click outside the dialog to close.
   </p>
   <div>
-    <div>
+    <div
+      class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
+    >
       <div
-        class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--compressed"
+          class="euiFormControlLayout__childrenWrapper"
         >
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              aria-label="Search columns"
-              class="euiFieldText euiFieldText--compressed"
-              data-test-subj="dataGridColumnSelectorSearch"
-              placeholder="Search"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__controlScroll"
-      >
-        <div
-          class="euiDroppable emotion-euiDroppable-noGrow"
-          data-rfd-droppable-context-id="0"
-          data-rfd-droppable-id="columnOrder"
-          data-test-subj="droppable"
-        >
-          <div
-            class="euiDraggable emotion-euiDraggable"
-            data-rfd-draggable-context-id="0"
-            data-rfd-draggable-id="columnA"
-            data-test-subj="draggable"
-            role="group"
-          >
-            <div
-              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
-              data-test-subj="dataGridColumnSelectorColumnItem-columnA"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <div
-                    class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
-                  >
-                    <button
-                      aria-checked="true"
-                      aria-label="columnA"
-                      class="euiSwitch__button"
-                      data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
-                      id="generated-id"
-                      name="columnA"
-                      role="switch"
-                      type="button"
-                    >
-                      <span
-                        class="euiSwitch__body"
-                      >
-                        <span
-                          class="euiSwitch__thumb"
-                        />
-                        <span
-                          class="euiSwitch__track"
-                        />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-hidden="true"
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnA"
-                  draggable="false"
-                  role="button"
-                  tabindex="-1"
-                >
-                  <span
-                    class="euiDataGridColumnSelector__itemLabel"
-                  >
-                    columnA
-                  </span>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-label="Drag handle"
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnA"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <span
-                    color="subdued"
-                    data-euiicon-type="grab"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiDraggable emotion-euiDraggable"
-            data-rfd-draggable-context-id="0"
-            data-rfd-draggable-id="columnB"
-            data-test-subj="draggable"
-            role="group"
-          >
-            <div
-              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
-              data-test-subj="dataGridColumnSelectorColumnItem-columnB"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <div
-                    class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
-                  >
-                    <button
-                      aria-checked="true"
-                      aria-label="columnB"
-                      class="euiSwitch__button"
-                      data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
-                      id="generated-id"
-                      name="columnB"
-                      role="switch"
-                      type="button"
-                    >
-                      <span
-                        class="euiSwitch__body"
-                      >
-                        <span
-                          class="euiSwitch__thumb"
-                        />
-                        <span
-                          class="euiSwitch__track"
-                        />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-hidden="true"
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnB"
-                  draggable="false"
-                  role="button"
-                  tabindex="-1"
-                >
-                  <span
-                    class="euiDataGridColumnSelector__itemLabel"
-                  >
-                    columnB
-                  </span>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                  aria-label="Drag handle"
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                  data-rfd-drag-handle-context-id="0"
-                  data-rfd-drag-handle-draggable-id="columnB"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <span
-                    color="subdued"
-                    data-euiicon-type="grab"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiDroppable__placeholder"
+          <input
+            aria-label="Search columns"
+            class="euiFieldText euiFieldText--compressed"
+            data-test-subj="dataGridColumnSelectorSearch"
+            placeholder="Search"
+            type="text"
+            value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      class="euiDroppable euiDataGrid__controlScroll emotion-euiDroppable-noGrow"
+      data-rfd-droppable-context-id="0"
+      data-rfd-droppable-id="columnOrder"
+      data-test-subj="droppable"
+    >
+      <div
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id="0"
+        data-rfd-draggable-id="columnA"
+        data-test-subj="draggable"
+        role="group"
+      >
+        <div
+          class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
+          data-test-subj="dataGridColumnSelectorColumnItem-columnA"
+        >
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
+          >
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
+              >
+                <button
+                  aria-checked="true"
+                  aria-label="columnA"
+                  class="euiSwitch__button"
+                  data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
+                  id="generated-id"
+                  name="columnA"
+                  role="switch"
+                  type="button"
+                >
+                  <span
+                    class="euiSwitch__body"
+                  >
+                    <span
+                      class="euiSwitch__thumb"
+                    />
+                    <span
+                      class="euiSwitch__track"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-hidden="true"
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                class="euiDataGridColumnSelector__itemLabel"
+              >
+                columnA
+              </span>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id="0"
+        data-rfd-draggable-id="columnB"
+        data-test-subj="draggable"
+        role="group"
+      >
+        <div
+          class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
+          data-test-subj="dataGridColumnSelectorColumnItem-columnB"
+        >
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
+          >
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
+              >
+                <button
+                  aria-checked="true"
+                  aria-label="columnB"
+                  class="euiSwitch__button"
+                  data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
+                  id="generated-id"
+                  name="columnB"
+                  role="switch"
+                  type="button"
+                >
+                  <span
+                    class="euiSwitch__body"
+                  >
+                    <span
+                      class="euiSwitch__thumb"
+                    />
+                    <span
+                      class="euiSwitch__track"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-hidden="true"
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnB"
+              draggable="false"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                class="euiDataGridColumnSelector__itemLabel"
+              >
+                columnB
+              </span>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnB"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiDroppable__placeholder"
+      />
     </div>
     <div
       class="euiPopoverFooter emotion-euiPopoverFooter-s-s"
@@ -633,195 +621,189 @@ exports[`useDataGridColumnSelector columnSelector [React 18] renders a toolbar b
     You are in a dialog. Press Escape, or tap/click outside the dialog to close.
   </p>
   <div>
-    <div>
+    <div
+      class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
+    >
       <div
-        class="euiPopoverTitle emotion-euiPopoverTitle-s-s"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--compressed"
+          class="euiFormControlLayout__childrenWrapper"
         >
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              aria-label="Search columns"
-              class="euiFieldText euiFieldText--compressed"
-              data-test-subj="dataGridColumnSelectorSearch"
-              placeholder="Search"
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiDataGrid__controlScroll"
-      >
-        <div
-          class="euiDroppable emotion-euiDroppable-noGrow"
-          data-rfd-droppable-context-id=":r0:"
-          data-rfd-droppable-id="columnOrder"
-          data-test-subj="droppable"
-        >
-          <div
-            class="euiDraggable emotion-euiDraggable"
-            data-rfd-draggable-context-id=":r0:"
-            data-rfd-draggable-id="columnA"
-            data-test-subj="draggable"
-            role="group"
-          >
-            <div
-              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
-              data-test-subj="dataGridColumnSelectorColumnItem-columnA"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <div
-                    class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
-                  >
-                    <button
-                      aria-checked="true"
-                      aria-label="columnA"
-                      class="euiSwitch__button"
-                      data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
-                      id="generated-id"
-                      name="columnA"
-                      role="switch"
-                      type="button"
-                    >
-                      <span
-                        class="euiSwitch__body"
-                      >
-                        <span
-                          class="euiSwitch__thumb"
-                        />
-                        <span
-                          class="euiSwitch__track"
-                        />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-                  aria-hidden="true"
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
-                  data-rfd-drag-handle-context-id=":r0:"
-                  data-rfd-drag-handle-draggable-id="columnA"
-                  draggable="false"
-                  role="button"
-                  tabindex="-1"
-                >
-                  <span
-                    class="euiDataGridColumnSelector__itemLabel"
-                  >
-                    columnA
-                  </span>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-                  aria-label="Drag handle"
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                  data-rfd-drag-handle-context-id=":r0:"
-                  data-rfd-drag-handle-draggable-id="columnA"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <span
-                    color="subdued"
-                    data-euiicon-type="grab"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiDraggable emotion-euiDraggable"
-            data-rfd-draggable-context-id=":r0:"
-            data-rfd-draggable-id="columnB"
-            data-test-subj="draggable"
-            role="group"
-          >
-            <div
-              class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
-              data-test-subj="dataGridColumnSelectorColumnItem-columnB"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <div
-                    class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
-                  >
-                    <button
-                      aria-checked="true"
-                      aria-label="columnB"
-                      class="euiSwitch__button"
-                      data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
-                      id="generated-id"
-                      name="columnB"
-                      role="switch"
-                      type="button"
-                    >
-                      <span
-                        class="euiSwitch__body"
-                      >
-                        <span
-                          class="euiSwitch__thumb"
-                        />
-                        <span
-                          class="euiSwitch__track"
-                        />
-                      </span>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-                  aria-hidden="true"
-                  class="euiFlexItem emotion-euiFlexItem-grow-1"
-                  data-rfd-drag-handle-context-id=":r0:"
-                  data-rfd-drag-handle-draggable-id="columnB"
-                  draggable="false"
-                  role="button"
-                  tabindex="-1"
-                >
-                  <span
-                    class="euiDataGridColumnSelector__itemLabel"
-                  >
-                    columnB
-                  </span>
-                </div>
-                <div
-                  aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-                  aria-label="Drag handle"
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                  data-rfd-drag-handle-context-id=":r0:"
-                  data-rfd-drag-handle-draggable-id="columnB"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <span
-                    color="subdued"
-                    data-euiicon-type="grab"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiDroppable__placeholder"
+          <input
+            aria-label="Search columns"
+            class="euiFieldText euiFieldText--compressed"
+            data-test-subj="dataGridColumnSelectorSearch"
+            placeholder="Search"
+            type="text"
+            value=""
           />
         </div>
       </div>
+    </div>
+    <div
+      class="euiDroppable euiDataGrid__controlScroll emotion-euiDroppable-noGrow"
+      data-rfd-droppable-context-id=":r0:"
+      data-rfd-droppable-id="columnOrder"
+      data-test-subj="droppable"
+    >
+      <div
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id=":r0:"
+        data-rfd-draggable-id="columnA"
+        data-test-subj="draggable"
+        role="group"
+      >
+        <div
+          class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
+          data-test-subj="dataGridColumnSelectorColumnItem-columnA"
+        >
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
+          >
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
+              >
+                <button
+                  aria-checked="true"
+                  aria-label="columnA"
+                  class="euiSwitch__button"
+                  data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnA"
+                  id="generated-id"
+                  name="columnA"
+                  role="switch"
+                  type="button"
+                >
+                  <span
+                    class="euiSwitch__body"
+                  >
+                    <span
+                      class="euiSwitch__thumb"
+                    />
+                    <span
+                      class="euiSwitch__track"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
+              aria-hidden="true"
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id=":r0:"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                class="euiDataGridColumnSelector__itemLabel"
+              >
+                columnA
+              </span>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id=":r0:"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id=":r0:"
+        data-rfd-draggable-id="columnB"
+        data-test-subj="draggable"
+        role="group"
+      >
+        <div
+          class="euiDataGridColumnSelector__item euiDraggable__item emotion-euiDraggable__item"
+          data-test-subj="dataGridColumnSelectorColumnItem-columnB"
+        >
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-s-flexStart-center-row"
+          >
+            <div
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <div
+                class="euiSwitch euiSwitch--compressed euiSwitch--mini emotion-euiSwitch"
+              >
+                <button
+                  aria-checked="true"
+                  aria-label="columnB"
+                  class="euiSwitch__button"
+                  data-test-subj="dataGridColumnSelectorToggleColumnVisibility-columnB"
+                  id="generated-id"
+                  name="columnB"
+                  role="switch"
+                  type="button"
+                >
+                  <span
+                    class="euiSwitch__body"
+                  >
+                    <span
+                      class="euiSwitch__thumb"
+                    />
+                    <span
+                      class="euiSwitch__track"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
+              aria-hidden="true"
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id=":r0:"
+              data-rfd-drag-handle-draggable-id="columnB"
+              draggable="false"
+              role="button"
+              tabindex="-1"
+            >
+              <span
+                class="euiDataGridColumnSelector__itemLabel"
+              >
+                columnB
+              </span>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id=":r0:"
+              data-rfd-drag-handle-draggable-id="columnB"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiDroppable__placeholder"
+      />
     </div>
     <div
       class="euiPopoverFooter emotion-euiPopoverFooter-s-s"

--- a/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -52,163 +52,157 @@ exports[`useDataGridColumnSorting columnSorting [React 16] renders a toolbar but
   </p>
   <div>
     <div
-      aria-live="assertive"
-      class="euiDataGrid__controlScroll"
-      role="region"
+      class="euiDroppable euiDataGrid__controlScroll emotion-euiDroppable-noGrow"
+      data-rfd-droppable-context-id="0"
+      data-rfd-droppable-id="columnSorting"
+      data-test-subj="droppable"
     >
       <div
-        class="euiDroppable emotion-euiDroppable-noGrow"
-        data-rfd-droppable-context-id="0"
-        data-rfd-droppable-id="columnSorting"
-        data-test-subj="droppable"
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id="0"
+        data-rfd-draggable-id="columnA"
+        data-test-subj="draggable"
+        role="group"
       >
         <div
-          class="euiDraggable emotion-euiDraggable"
-          data-rfd-draggable-context-id="0"
-          data-rfd-draggable-id="columnA"
-          data-test-subj="draggable"
-          role="group"
+          class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
         >
-          <div
-            class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
+          <p
+            class="emotion-euiScreenReaderOnly"
           >
-            <p
-              class="emotion-euiScreenReaderOnly"
-            >
-              Column A is sorting this data grid
-            </p>
+            Column A is sorting this data grid
+          </p>
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
+            data-test-subj="euiDataGridColumnSorting-sortColumn-columnA"
+          >
             <div
-              class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
-              data-test-subj="euiDataGridColumnSorting-sortColumn-columnA"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <button
+                aria-label="Remove Column A from data grid sort"
+                class="euiButtonIcon euiDataGridColumnSorting__button emotion-euiButtonIcon-xs-empty-text"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="euiButtonIcon__icon"
+                  color="inherit"
+                  data-euiicon-type="cross"
+                />
+              </button>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-hidden="true"
+              class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="-1"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button
-                  aria-label="Remove Column A from data grid sort"
-                  class="euiButtonIcon euiDataGridColumnSorting__button emotion-euiButtonIcon-xs-empty-text"
-                  type="button"
-                >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="cross"
-                  />
-                </button>
-              </div>
-              <div
-                aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                aria-hidden="true"
-                class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
-                data-rfd-drag-handle-context-id="0"
-                data-rfd-drag-handle-draggable-id="columnA"
-                draggable="false"
-                role="button"
-                tabindex="-1"
+                class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                  <span
+                    class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
                   >
                     <span
-                      class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
-                    >
-                      <span
-                        data-euiicon-type="tokenNumber"
-                      />
-                    </span>
-                  </div>
+                      data-euiicon-type="tokenNumber"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    class="euiText emotion-euiText-xs"
                   >
-                    <div
-                      class="euiText emotion-euiText-xs"
-                    >
-                      <p>
-                        Column A
-                      </p>
-                    </div>
+                    <p>
+                      Column A
+                    </p>
                   </div>
                 </div>
               </div>
-              <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+            >
+              <fieldset
+                class="euiButtonGroup euiDataGridColumnSorting__order emotion-euiButtonGroup-fullWidth"
               >
-                <fieldset
-                  class="euiButtonGroup euiDataGridColumnSorting__order emotion-euiButtonGroup-fullWidth"
+                <legend
+                  class="emotion-euiScreenReaderOnly"
                 >
-                  <legend
-                    class="emotion-euiScreenReaderOnly"
+                  Select sorting method for Column A
+                </legend>
+                <div
+                  class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
+                >
+                  <button
+                    aria-pressed="true"
+                    class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+                    data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
+                    title="Low-High"
+                    type="button"
                   >
-                    Select sorting method for Column A
-                  </legend>
-                  <div
-                    class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
-                  >
-                    <button
-                      aria-pressed="true"
-                      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
-                      data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
-                      title="Low-High"
-                      type="button"
+                    <span
+                      class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
                     >
                       <span
-                        class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
+                        class="eui-textTruncate emotion-euiButtonGroupButton__text"
+                        data-text="Low-High"
                       >
-                        <span
-                          class="eui-textTruncate emotion-euiButtonGroupButton__text"
-                          data-text="Low-High"
-                        >
-                          Low-High
-                        </span>
+                        Low-High
                       </span>
-                    </button>
-                    <button
-                      aria-pressed="false"
-                      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
-                      data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
-                      title="High-Low"
-                      type="button"
+                    </span>
+                  </button>
+                  <button
+                    aria-pressed="false"
+                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                    data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
+                    title="High-Low"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
                     >
                       <span
-                        class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
+                        class="eui-textTruncate emotion-euiButtonGroupButton__text"
+                        data-text="High-Low"
                       >
-                        <span
-                          class="eui-textTruncate emotion-euiButtonGroupButton__text"
-                          data-text="High-Low"
-                        >
-                          High-Low
-                        </span>
+                        High-Low
                       </span>
-                    </button>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                aria-label="Drag handle"
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-                data-rfd-drag-handle-context-id="0"
-                data-rfd-drag-handle-draggable-id="columnA"
-                draggable="false"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  color="subdued"
-                  data-euiicon-type="grab"
-                />
-              </div>
+                    </span>
+                  </button>
+                </div>
+              </fieldset>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
             </div>
           </div>
         </div>
-        <div
-          class="euiDroppable__placeholder"
-        />
       </div>
+      <div
+        class="euiDroppable__placeholder"
+      />
     </div>
     <div
       class="euiPopoverFooter emotion-euiPopoverFooter-s-s"
@@ -321,163 +315,157 @@ exports[`useDataGridColumnSorting columnSorting [React 17] renders a toolbar but
   </p>
   <div>
     <div
-      aria-live="assertive"
-      class="euiDataGrid__controlScroll"
-      role="region"
+      class="euiDroppable euiDataGrid__controlScroll emotion-euiDroppable-noGrow"
+      data-rfd-droppable-context-id="0"
+      data-rfd-droppable-id="columnSorting"
+      data-test-subj="droppable"
     >
       <div
-        class="euiDroppable emotion-euiDroppable-noGrow"
-        data-rfd-droppable-context-id="0"
-        data-rfd-droppable-id="columnSorting"
-        data-test-subj="droppable"
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id="0"
+        data-rfd-draggable-id="columnA"
+        data-test-subj="draggable"
+        role="group"
       >
         <div
-          class="euiDraggable emotion-euiDraggable"
-          data-rfd-draggable-context-id="0"
-          data-rfd-draggable-id="columnA"
-          data-test-subj="draggable"
-          role="group"
+          class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
         >
-          <div
-            class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
+          <p
+            class="emotion-euiScreenReaderOnly"
           >
-            <p
-              class="emotion-euiScreenReaderOnly"
-            >
-              Column A is sorting this data grid
-            </p>
+            Column A is sorting this data grid
+          </p>
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
+            data-test-subj="euiDataGridColumnSorting-sortColumn-columnA"
+          >
             <div
-              class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
-              data-test-subj="euiDataGridColumnSorting-sortColumn-columnA"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <button
+                aria-label="Remove Column A from data grid sort"
+                class="euiButtonIcon euiDataGridColumnSorting__button emotion-euiButtonIcon-xs-empty-text"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="euiButtonIcon__icon"
+                  color="inherit"
+                  data-euiicon-type="cross"
+                />
+              </button>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-hidden="true"
+              class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="-1"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button
-                  aria-label="Remove Column A from data grid sort"
-                  class="euiButtonIcon euiDataGridColumnSorting__button emotion-euiButtonIcon-xs-empty-text"
-                  type="button"
-                >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="cross"
-                  />
-                </button>
-              </div>
-              <div
-                aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                aria-hidden="true"
-                class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
-                data-rfd-drag-handle-context-id="0"
-                data-rfd-drag-handle-draggable-id="columnA"
-                draggable="false"
-                role="button"
-                tabindex="-1"
+                class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                  <span
+                    class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
                   >
                     <span
-                      class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
-                    >
-                      <span
-                        data-euiicon-type="tokenNumber"
-                      />
-                    </span>
-                  </div>
+                      data-euiicon-type="tokenNumber"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    class="euiText emotion-euiText-xs"
                   >
-                    <div
-                      class="euiText emotion-euiText-xs"
-                    >
-                      <p>
-                        Column A
-                      </p>
-                    </div>
+                    <p>
+                      Column A
+                    </p>
                   </div>
                 </div>
               </div>
-              <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+            >
+              <fieldset
+                class="euiButtonGroup euiDataGridColumnSorting__order emotion-euiButtonGroup-fullWidth"
               >
-                <fieldset
-                  class="euiButtonGroup euiDataGridColumnSorting__order emotion-euiButtonGroup-fullWidth"
+                <legend
+                  class="emotion-euiScreenReaderOnly"
                 >
-                  <legend
-                    class="emotion-euiScreenReaderOnly"
+                  Select sorting method for Column A
+                </legend>
+                <div
+                  class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
+                >
+                  <button
+                    aria-pressed="true"
+                    class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+                    data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
+                    title="Low-High"
+                    type="button"
                   >
-                    Select sorting method for Column A
-                  </legend>
-                  <div
-                    class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
-                  >
-                    <button
-                      aria-pressed="true"
-                      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
-                      data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
-                      title="Low-High"
-                      type="button"
+                    <span
+                      class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
                     >
                       <span
-                        class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
+                        class="eui-textTruncate emotion-euiButtonGroupButton__text"
+                        data-text="Low-High"
                       >
-                        <span
-                          class="eui-textTruncate emotion-euiButtonGroupButton__text"
-                          data-text="Low-High"
-                        >
-                          Low-High
-                        </span>
+                        Low-High
                       </span>
-                    </button>
-                    <button
-                      aria-pressed="false"
-                      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
-                      data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
-                      title="High-Low"
-                      type="button"
+                    </span>
+                  </button>
+                  <button
+                    aria-pressed="false"
+                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                    data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
+                    title="High-Low"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
                     >
                       <span
-                        class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
+                        class="eui-textTruncate emotion-euiButtonGroupButton__text"
+                        data-text="High-Low"
                       >
-                        <span
-                          class="eui-textTruncate emotion-euiButtonGroupButton__text"
-                          data-text="High-Low"
-                        >
-                          High-Low
-                        </span>
+                        High-Low
                       </span>
-                    </button>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                aria-describedby="rfd-hidden-text-0-hidden-text-0"
-                aria-label="Drag handle"
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-                data-rfd-drag-handle-context-id="0"
-                data-rfd-drag-handle-draggable-id="columnA"
-                draggable="false"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  color="subdued"
-                  data-euiicon-type="grab"
-                />
-              </div>
+                    </span>
+                  </button>
+                </div>
+              </fieldset>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-0-hidden-text-0"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id="0"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
             </div>
           </div>
         </div>
-        <div
-          class="euiDroppable__placeholder"
-        />
       </div>
+      <div
+        class="euiDroppable__placeholder"
+      />
     </div>
     <div
       class="euiPopoverFooter emotion-euiPopoverFooter-s-s"
@@ -590,163 +578,157 @@ exports[`useDataGridColumnSorting columnSorting [React 18] renders a toolbar but
   </p>
   <div>
     <div
-      aria-live="assertive"
-      class="euiDataGrid__controlScroll"
-      role="region"
+      class="euiDroppable euiDataGrid__controlScroll emotion-euiDroppable-noGrow"
+      data-rfd-droppable-context-id=":r0:"
+      data-rfd-droppable-id="columnSorting"
+      data-test-subj="droppable"
     >
       <div
-        class="euiDroppable emotion-euiDroppable-noGrow"
-        data-rfd-droppable-context-id=":r0:"
-        data-rfd-droppable-id="columnSorting"
-        data-test-subj="droppable"
+        class="euiDraggable emotion-euiDraggable"
+        data-rfd-draggable-context-id=":r0:"
+        data-rfd-draggable-id="columnA"
+        data-test-subj="draggable"
+        role="group"
       >
         <div
-          class="euiDraggable emotion-euiDraggable"
-          data-rfd-draggable-context-id=":r0:"
-          data-rfd-draggable-id="columnA"
-          data-test-subj="draggable"
-          role="group"
+          class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
         >
-          <div
-            class="euiDataGridColumnSorting__item euiDraggable__item emotion-euiDraggable__item"
+          <p
+            class="emotion-euiScreenReaderOnly"
           >
-            <p
-              class="emotion-euiScreenReaderOnly"
-            >
-              Column A is sorting this data grid
-            </p>
+            Column A is sorting this data grid
+          </p>
+          <div
+            class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
+            data-test-subj="euiDataGridColumnSorting-sortColumn-columnA"
+          >
             <div
-              class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
-              data-test-subj="euiDataGridColumnSorting-sortColumn-columnA"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+            >
+              <button
+                aria-label="Remove Column A from data grid sort"
+                class="euiButtonIcon euiDataGridColumnSorting__button emotion-euiButtonIcon-xs-empty-text"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="euiButtonIcon__icon"
+                  color="inherit"
+                  data-euiicon-type="cross"
+                />
+              </button>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
+              aria-hidden="true"
+              class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
+              data-rfd-drag-handle-context-id=":r0:"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="-1"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button
-                  aria-label="Remove Column A from data grid sort"
-                  class="euiButtonIcon euiDataGridColumnSorting__button emotion-euiButtonIcon-xs-empty-text"
-                  type="button"
-                >
-                  <span
-                    aria-hidden="true"
-                    class="euiButtonIcon__icon"
-                    color="inherit"
-                    data-euiicon-type="cross"
-                  />
-                </button>
-              </div>
-              <div
-                aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-                aria-hidden="true"
-                class="euiFlexItem euiDataGridColumnSorting__name emotion-euiFlexItem-grow-1"
-                data-rfd-drag-handle-context-id=":r0:"
-                data-rfd-drag-handle-draggable-id="columnA"
-                draggable="false"
-                role="button"
-                tabindex="-1"
+                class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
               >
                 <div
-                  class="euiFlexGroup emotion-euiFlexGroup-xs-flexStart-center-row"
+                  class="euiFlexItem emotion-euiFlexItem-growZero"
                 >
-                  <div
-                    class="euiFlexItem emotion-euiFlexItem-growZero"
+                  <span
+                    class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
                   >
                     <span
-                      class="euiToken emotion-euiToken-square-light-s-euiColorVis0"
-                    >
-                      <span
-                        data-euiicon-type="tokenNumber"
-                      />
-                    </span>
-                  </div>
+                      data-euiicon-type="tokenNumber"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="euiFlexItem emotion-euiFlexItem-grow-1"
+                >
                   <div
-                    class="euiFlexItem emotion-euiFlexItem-grow-1"
+                    class="euiText emotion-euiText-xs"
                   >
-                    <div
-                      class="euiText emotion-euiText-xs"
-                    >
-                      <p>
-                        Column A
-                      </p>
-                    </div>
+                    <p>
+                      Column A
+                    </p>
                   </div>
                 </div>
               </div>
-              <div
-                class="euiFlexItem emotion-euiFlexItem-grow-1"
+            </div>
+            <div
+              class="euiFlexItem emotion-euiFlexItem-grow-1"
+            >
+              <fieldset
+                class="euiButtonGroup euiDataGridColumnSorting__order emotion-euiButtonGroup-fullWidth"
               >
-                <fieldset
-                  class="euiButtonGroup euiDataGridColumnSorting__order emotion-euiButtonGroup-fullWidth"
+                <legend
+                  class="emotion-euiScreenReaderOnly"
                 >
-                  <legend
-                    class="emotion-euiScreenReaderOnly"
+                  Select sorting method for Column A
+                </legend>
+                <div
+                  class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
+                >
+                  <button
+                    aria-pressed="true"
+                    class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+                    data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
+                    title="Low-High"
+                    type="button"
                   >
-                    Select sorting method for Column A
-                  </legend>
-                  <div
-                    class="euiButtonGroup__buttons emotion-euiButtonGroup__buttons-fullWidth-compressed"
-                  >
-                    <button
-                      aria-pressed="true"
-                      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
-                      data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
-                      title="Low-High"
-                      type="button"
+                    <span
+                      class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
                     >
                       <span
-                        class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
+                        class="eui-textTruncate emotion-euiButtonGroupButton__text"
+                        data-text="Low-High"
                       >
-                        <span
-                          class="eui-textTruncate emotion-euiButtonGroupButton__text"
-                          data-text="Low-High"
-                        >
-                          Low-High
-                        </span>
+                        Low-High
                       </span>
-                    </button>
-                    <button
-                      aria-pressed="false"
-                      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
-                      data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
-                      title="High-Low"
-                      type="button"
+                    </span>
+                  </button>
+                  <button
+                    aria-pressed="false"
+                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                    data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
+                    title="High-Low"
+                    type="button"
+                  >
+                    <span
+                      class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
                     >
                       <span
-                        class="emotion-euiButtonDisplayContent-euiButtonGroupButton__content-compressed"
+                        class="eui-textTruncate emotion-euiButtonGroupButton__text"
+                        data-text="High-Low"
                       >
-                        <span
-                          class="eui-textTruncate emotion-euiButtonGroupButton__text"
-                          data-text="High-Low"
-                        >
-                          High-Low
-                        </span>
+                        High-Low
                       </span>
-                    </button>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
-                aria-label="Drag handle"
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-                data-rfd-drag-handle-context-id=":r0:"
-                data-rfd-drag-handle-draggable-id="columnA"
-                draggable="false"
-                role="button"
-                tabindex="0"
-              >
-                <span
-                  color="subdued"
-                  data-euiicon-type="grab"
-                />
-              </div>
+                    </span>
+                  </button>
+                </div>
+              </fieldset>
+            </div>
+            <div
+              aria-describedby="rfd-hidden-text-:r0:-hidden-text-:r1:"
+              aria-label="Drag handle"
+              class="euiFlexItem emotion-euiFlexItem-growZero"
+              data-rfd-drag-handle-context-id=":r0:"
+              data-rfd-drag-handle-draggable-id="columnA"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                color="subdued"
+                data-euiicon-type="grab"
+              />
             </div>
           </div>
         </div>
-        <div
-          class="euiDroppable__placeholder"
-        />
       </div>
+      <div
+        class="euiDroppable__placeholder"
+      />
     </div>
     <div
       class="euiPopoverFooter emotion-euiPopoverFooter-s-s"

--- a/src/components/datagrid/controls/column_selector.tsx
+++ b/src/components/datagrid/controls/column_selector.tsx
@@ -166,120 +166,114 @@ export const useDataGridColumnSelector = (
           </EuiButtonEmpty>
         }
       >
-        <div>
-          {allowColumnHiding && (
-            <EuiPopoverTitle>
-              <EuiI18n
-                tokens={[
-                  'euiColumnSelector.search',
-                  'euiColumnSelector.searchcolumns',
-                ]}
-                defaults={['Search', 'Search columns']}
-              >
-                {([search, searchcolumns]: string[]) => (
-                  <EuiFieldText
-                    compressed
-                    placeholder={search}
-                    aria-label={searchcolumns}
-                    value={columnSearchText}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                      setColumnSearchText(e.currentTarget.value)
-                    }
-                    data-test-subj="dataGridColumnSelectorSearch"
-                  />
-                )}
-              </EuiI18n>
-            </EuiPopoverTitle>
-          )}
-          <div className="euiDataGrid__controlScroll">
-            <EuiDragDropContext onDragEnd={onDragEnd}>
-              <EuiDroppable
-                droppableId="columnOrder"
-                isDropDisabled={!isDragEnabled}
-              >
-                <>
-                  {filteredColumns.map((id, index) => (
-                    <EuiDraggable
-                      key={id}
-                      draggableId={id}
-                      index={index}
-                      isDragDisabled={!isDragEnabled}
-                      hasInteractiveChildren
-                      customDragHandle
+        {allowColumnHiding && (
+          <EuiPopoverTitle>
+            <EuiI18n
+              tokens={[
+                'euiColumnSelector.search',
+                'euiColumnSelector.searchcolumns',
+              ]}
+              defaults={['Search', 'Search columns']}
+            >
+              {([search, searchcolumns]: string[]) => (
+                <EuiFieldText
+                  compressed
+                  placeholder={search}
+                  aria-label={searchcolumns}
+                  value={columnSearchText}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setColumnSearchText(e.currentTarget.value)
+                  }
+                  data-test-subj="dataGridColumnSelectorSearch"
+                />
+              )}
+            </EuiI18n>
+          </EuiPopoverTitle>
+        )}
+        <EuiDragDropContext onDragEnd={onDragEnd}>
+          <EuiDroppable
+            droppableId="columnOrder"
+            isDropDisabled={!isDragEnabled}
+            className="euiDataGrid__controlScroll"
+          >
+            <>
+              {filteredColumns.map((id, index) => (
+                <EuiDraggable
+                  key={id}
+                  draggableId={id}
+                  index={index}
+                  isDragDisabled={!isDragEnabled}
+                  hasInteractiveChildren
+                  customDragHandle
+                >
+                  {(provided, state) => (
+                    <div
+                      className={classNames('euiDataGridColumnSelector__item', {
+                        'euiDataGridColumnSelector__item-isDragging':
+                          state.isDragging,
+                      })}
+                      data-test-subj={`dataGridColumnSelectorColumnItem-${id}`}
                     >
-                      {(provided, state) => (
-                        <div
-                          className={classNames(
-                            'euiDataGridColumnSelector__item',
-                            {
-                              'euiDataGridColumnSelector__item-isDragging':
-                                state.isDragging,
-                            }
-                          )}
-                          data-test-subj={`dataGridColumnSelectorColumnItem-${id}`}
+                      <EuiFlexGroup
+                        responsive={false}
+                        gutterSize="s"
+                        alignItems="center"
+                      >
+                        {allowColumnHiding && (
+                          <EuiFlexItem grow={false}>
+                            <EuiSwitch
+                              name={id}
+                              label={displayValues[id] || id}
+                              showLabel={false}
+                              checked={visibleColumnIds.has(id)}
+                              compressed
+                              className="euiSwitch--mini"
+                              onChange={(event) => {
+                                const {
+                                  target: { checked },
+                                } = event;
+                                const nextVisibleColumns = sortedColumns.filter(
+                                  (columnId) =>
+                                    checked
+                                      ? visibleColumnIds.has(columnId) ||
+                                        id === columnId
+                                      : visibleColumnIds.has(columnId) &&
+                                        id !== columnId
+                                );
+                                setVisibleColumns(nextVisibleColumns);
+                              }}
+                              data-test-subj={`dataGridColumnSelectorToggleColumnVisibility-${id}`}
+                            />
+                          </EuiFlexItem>
+                        )}
+                        <EuiFlexItem
+                          // This extra column name flex item affords the column more grabbable real estate
+                          // for mouse users, while hiding repetition for keyboard/screen reader users
+                          {...provided.dragHandleProps}
+                          aria-hidden
+                          tabIndex={-1}
                         >
-                          <EuiFlexGroup
-                            responsive={false}
-                            gutterSize="s"
-                            alignItems="center"
+                          <span className="euiDataGridColumnSelector__itemLabel">
+                            {displayValues[id] || id}
+                          </span>
+                        </EuiFlexItem>
+                        {isDragEnabled && (
+                          <EuiFlexItem
+                            grow={false}
+                            {...provided.dragHandleProps}
+                            aria-label={dragHandleAriaLabel}
                           >
-                            {allowColumnHiding && (
-                              <EuiFlexItem grow={false}>
-                                <EuiSwitch
-                                  name={id}
-                                  label={displayValues[id] || id}
-                                  showLabel={false}
-                                  checked={visibleColumnIds.has(id)}
-                                  compressed
-                                  className="euiSwitch--mini"
-                                  onChange={(event) => {
-                                    const {
-                                      target: { checked },
-                                    } = event;
-                                    const nextVisibleColumns =
-                                      sortedColumns.filter((columnId) =>
-                                        checked
-                                          ? visibleColumnIds.has(columnId) ||
-                                            id === columnId
-                                          : visibleColumnIds.has(columnId) &&
-                                            id !== columnId
-                                      );
-                                    setVisibleColumns(nextVisibleColumns);
-                                  }}
-                                  data-test-subj={`dataGridColumnSelectorToggleColumnVisibility-${id}`}
-                                />
-                              </EuiFlexItem>
-                            )}
-                            <EuiFlexItem
-                              // This extra column name flex item affords the column more grabbable real estate
-                              // for mouse users, while hiding repetition for keyboard/screen reader users
-                              {...provided.dragHandleProps}
-                              aria-hidden
-                              tabIndex={-1}
-                            >
-                              <span className="euiDataGridColumnSelector__itemLabel">
-                                {displayValues[id] || id}
-                              </span>
-                            </EuiFlexItem>
-                            {isDragEnabled && (
-                              <EuiFlexItem
-                                grow={false}
-                                {...provided.dragHandleProps}
-                                aria-label={dragHandleAriaLabel}
-                              >
-                                <EuiIcon type="grab" color="subdued" />
-                              </EuiFlexItem>
-                            )}
-                          </EuiFlexGroup>
-                        </div>
-                      )}
-                    </EuiDraggable>
-                  ))}
-                </>
-              </EuiDroppable>
-            </EuiDragDropContext>
-          </div>
-        </div>
+                            <EuiIcon type="grab" color="subdued" />
+                          </EuiFlexItem>
+                        )}
+                      </EuiFlexGroup>
+                    </div>
+                  )}
+                </EuiDraggable>
+              ))}
+            </>
+          </EuiDroppable>
+        </EuiDragDropContext>
         {allowColumnHiding && (
           <EuiPopoverFooter>
             <EuiFlexGroup

--- a/src/components/datagrid/controls/column_sorting.tsx
+++ b/src/components/datagrid/controls/column_sorting.tsx
@@ -7,7 +7,7 @@
  */
 
 import classNames from 'classnames';
-import React, { Fragment, ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { DropResult } from '@hello-pangea/dnd';
 import { EuiButtonEmpty } from '../../button';
 import {
@@ -158,32 +158,29 @@ export const useDataGridColumnSorting = (
       }
     >
       {sorting.columns.length > 0 ? (
-        <div
-          role="region"
-          aria-live="assertive"
-          className="euiDataGrid__controlScroll"
-        >
-          <EuiDragDropContext onDragEnd={onDragEnd}>
-            <EuiDroppable droppableId="columnSorting">
-              <Fragment>
-                {sorting.columns.map(({ id, direction }, index) => {
-                  return (
-                    <EuiDataGridColumnSortingDraggable
-                      key={id}
-                      id={id}
-                      display={displayValues[id]}
-                      direction={direction}
-                      index={index}
-                      sorting={sorting}
-                      schema={schema}
-                      schemaDetectors={schemaDetectors}
-                    />
-                  );
-                })}
-              </Fragment>
-            </EuiDroppable>
-          </EuiDragDropContext>
-        </div>
+        <EuiDragDropContext onDragEnd={onDragEnd}>
+          <EuiDroppable
+            droppableId="columnSorting"
+            className="euiDataGrid__controlScroll"
+          >
+            <>
+              {sorting.columns.map(({ id, direction }, index) => {
+                return (
+                  <EuiDataGridColumnSortingDraggable
+                    key={id}
+                    id={id}
+                    display={displayValues[id]}
+                    direction={direction}
+                    index={index}
+                    sorting={sorting}
+                    schema={schema}
+                    schemaDetectors={schemaDetectors}
+                  />
+                );
+              })}
+            </>
+          </EuiDroppable>
+        </EuiDragDropContext>
       ) : (
         <EuiText size="s" color="subdued">
           <p role="alert">

--- a/upcoming_changelogs/7327.md
+++ b/upcoming_changelogs/7327.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Reduced screen reader noisiness when sorting `EuiDataGrid` columns via toolbar


### PR DESCRIPTION
## Summary

See https://github.com/elastic/eui/issues/7316 for more discussion and sources on why not to overuse `role="region"`. Also see individual git commit messages for more rationale on specific changes.

Note: most of the line diffs in this PR come from indentation, so please [turn off whitespace changes](https://github.com/elastic/eui/pull/7327/files?w=1).

## QA

- Start a screenreader
- Go to https://eui.elastic.co/pr_7327/#/tabular-content/data-grid
- Click the `Sort fields` button in the datagrid toolbar
- Pick at least 2 fields to sort by
- Tab back to the drag handles on those fields and re-order one of them
- [x] Confirm the experience still works and our drag/drop library still reads out status updates
- Go to https://eui.elastic.co/pr_7327/#/utilities/scroll
- [x] Confirm that each scrollable example can still be tabbed to and scrolled via arrow keys
- [x] In screen reader Landmarks navigation, confirm each individual example is no longer in the list ([compared to prod](https://eui.elastic.co/v89.1.0/#/utilities/scroll))

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) snapshots ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A