### PR TITLE
[EuiGlobalToastList] Add configurable `role` prop and default to `log` role

### DIFF
--- a/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
+++ b/src/components/toast/__snapshots__/global_toast_list.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiGlobalToastList is rendered 1`] = `
   aria-live="polite"
   class="euiGlobalToastList testClass1 testClass2 emotion-euiGlobalToastList-right-euiTestCss"
   data-test-subj="test subject string"
-  role="region"
+  role="log"
 />
 `;
 
@@ -14,7 +14,7 @@ exports[`EuiGlobalToastList props side can be changed to left 1`] = `
 <div
   aria-live="polite"
   class="euiGlobalToastList emotion-euiGlobalToastList-left"
-  role="region"
+  role="log"
 >
   <div
     class="euiToast euiGlobalToastListItem emotion-euiToast-success-euiGlobalToastListItem"
@@ -117,7 +117,7 @@ exports[`EuiGlobalToastList props toasts is rendered 1`] = `
 <div
   aria-live="polite"
   class="euiGlobalToastList emotion-euiGlobalToastList-right"
-  role="region"
+  role="log"
 >
   <div
     class="euiToast euiGlobalToastListItem emotion-euiToast-success-euiGlobalToastListItem"

--- a/src/components/toast/global_toast_list.test.tsx
+++ b/src/components/toast/global_toast_list.test.tsx
@@ -271,5 +271,18 @@ describe('EuiGlobalToastList', () => {
         expect(sharedProps.dismissToast).toHaveBeenCalledTimes(TOAST_COUNT);
       });
     });
+
+    test('role', () => {
+      const { queryByRole } = render(
+        <EuiGlobalToastList
+          dismissToast={() => {}}
+          toastLifeTimeMs={5}
+          role="alert"
+        />
+      );
+
+      expect(queryByRole('alert')).toBeInTheDocument();
+      expect(queryByRole('log')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -8,6 +8,7 @@
 
 import React, {
   FunctionComponent,
+  HTMLAttributes,
   ReactChild,
   useCallback,
   useEffect,
@@ -63,6 +64,16 @@ export interface EuiGlobalToastListProps extends CommonProps {
    * Optional callback that fires when a user clicks the "Clear all" button.
    */
   onClearAllToasts?: () => void;
+  /**
+   * Defaults to the [log role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/log_role).
+   *
+   * The [alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
+   * can be considered only if *all* toasts in this list will require immediate user attention.
+   * Several alerts at once, and unnecessary alerts, will a create bad screen reader user experience.
+   *
+   * @default log
+   */
+  role?: HTMLAttributes<HTMLElement>['role'];
 }
 
 export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
@@ -345,7 +356,7 @@ export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
   return (
     <div
       aria-live="polite"
-      role="region"
+      role="log"
       ref={listElement}
       css={cssStyles}
       className={classes}

--- a/src/components/toast/global_toast_list.tsx
+++ b/src/components/toast/global_toast_list.tsx
@@ -9,7 +9,7 @@
 import React, {
   FunctionComponent,
   HTMLAttributes,
-  ReactChild,
+  ReactNode,
   useCallback,
   useEffect,
   useRef,
@@ -41,7 +41,7 @@ export const CLEAR_ALL_TOASTS_THRESHOLD_DEFAULT = 3;
 
 export interface Toast extends EuiToastProps {
   id: string;
-  text?: ReactChild;
+  text?: ReactNode;
   toastLifeTimeMs?: number;
 }
 

--- a/upcoming_changelogs/7328.md
+++ b/upcoming_changelogs/7328.md
@@ -1,0 +1,5 @@
+- Added a configurable `role` prop to `EuiGlobalToastList`
+
+**Accessibility**
+
+- `EuiGlobalToastList` now defaults to a `log` role. If your toasts will always require immediate user action, consider (with caution) using the `alert` role instead.


### PR DESCRIPTION
## Summary

#7316 got me searching through EUI for more `region` roles that didn't feel quite right to me. I found this one, and then I found the [log role on MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/log_role) that seems to far more closely fit the bill!

[`role="alert"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) could also qualify, but since we can't guarantee toast content, we should default to the less aggressive role and allow consumers to set their own role if they know their toasts will only be used for notifications that require immediate action.

## QA

- https://eui.elastic.co/pr_7328/#/display/toast

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - Skipped as I think props docs adequately covers this, but LMK if you disagree
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A