### PR TITLE
[EuiCollapsibleNavBeta] Remove ability for accordion/group titles to contain links

### DIFF
--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -111,7 +111,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Elasticsearch"
           icon="logoElasticsearch"
-          href="#"
           items={[
             { title: 'Get started', href: '#' },
             ...renderGroup('Explore', [
@@ -130,7 +129,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Enterprise Search"
           icon="logoEnterpriseSearch"
-          href="#"
           items={[
             { title: 'ESRE', href: '#' },
             { title: 'Vector search', href: '#' },
@@ -146,7 +144,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Observability"
           icon="logoObservability"
-          href="#"
           items={[
             { title: 'Get started', href: '#' },
             { title: 'Alerts', href: '#' },
@@ -156,7 +153,6 @@ export const KibanaExample: Story = {
               { title: 'Logs', href: '#' },
               {
                 title: 'Tracing',
-                href: '#',
                 items: [
                   { title: 'Services', href: '#' },
                   { title: 'Traces', href: '#' },
@@ -169,7 +165,6 @@ export const KibanaExample: Story = {
               { title: 'Dashboards', href: '#' },
               {
                 title: 'AIOps',
-                href: '#',
                 items: [
                   { title: 'Anomaly detection', href: '#' },
                   { title: 'Spike analysis', href: '#' },
@@ -183,7 +178,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Security"
           icon="logoSecurity"
-          href="#"
           items={[
             { title: 'Get started', href: '#' },
             { title: 'Dashboards', href: '#' },
@@ -194,7 +188,6 @@ export const KibanaExample: Story = {
             { title: 'Intelligence', href: '#' },
             {
               title: 'Explore',
-              href: '#',
               items: [
                 { title: 'Host', href: '#' },
                 { title: 'Users', href: '#' },
@@ -204,7 +197,6 @@ export const KibanaExample: Story = {
             { title: 'Assets', href: '#' },
             {
               title: 'Rules',
-              href: '#',
               items: [
                 { title: 'SIEM rules', href: '#' },
                 { title: 'Shared exception list', href: '#' },
@@ -214,7 +206,6 @@ export const KibanaExample: Story = {
             },
             {
               title: 'Machine learning',
-              href: '#',
               items: [
                 { title: 'Overview', href: '#' },
                 { title: 'Notifications', href: '#' },
@@ -226,7 +217,6 @@ export const KibanaExample: Story = {
             },
             {
               title: 'Settings',
-              href: '#',
               items: [
                 { title: 'Endpoints', href: '#' },
                 { title: 'OS query', href: '#' },
@@ -240,7 +230,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Analytics"
           icon="stats"
-          href="#"
           items={[
             { title: 'Discover', href: '#' },
             { title: 'Dashboard', href: '#' },
@@ -250,7 +239,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Machine learning"
           icon="indexMapping"
-          href="#"
           items={[
             { title: 'Overview', href: '#' },
             { title: 'Notifications', href: '#' },
@@ -280,7 +268,6 @@ export const KibanaExample: Story = {
         <EuiCollapsibleNavBeta.Item
           title="Developer tools"
           icon="editorCodeBlock"
-          href="#"
           items={[
             { title: 'Console', href: '#' },
             { title: 'Search profiler', href: '#' },

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -331,7 +331,6 @@ export const SecurityExample: Story = {
             { title: 'Intelligence', href: '#' },
             {
               title: 'Explore',
-              href: '#',
               items: [
                 { title: 'Host', href: '#' },
                 { title: 'Users', href: '#', isSelected: true },
@@ -342,7 +341,6 @@ export const SecurityExample: Story = {
             { title: 'Assets', href: '#' },
             {
               title: 'Rules',
-              href: '#',
               items: [
                 { title: 'SIEM rules', href: '#' },
                 { title: 'Shared exception list', href: '#' },
@@ -352,7 +350,6 @@ export const SecurityExample: Story = {
             },
             {
               title: 'Machine learning',
-              href: '#',
               items: [
                 { title: 'Overview', href: '#' },
                 { title: 'Notifications', href: '#' },
@@ -364,7 +361,6 @@ export const SecurityExample: Story = {
             },
             {
               title: 'Settings',
-              href: '#',
               items: [
                 { title: 'Endpoints', href: '#' },
                 { title: 'OS query', href: '#' },

--- a/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_beta.styles.ts
@@ -12,7 +12,7 @@ import { logicalCSS } from '../../global_styling';
 import { euiShadowFlat } from '../../themes';
 import { euiHeaderVariables } from '../header/header.styles';
 
-import { euiCollapsibleNavBodyStyles } from './collapsible_nav_body_footer.styles';
+import { hideScrollbars } from './collapsible_nav_body_footer.styles';
 
 export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
@@ -42,7 +42,7 @@ export const euiCollapsibleNavBetaStyles = (euiThemeContext: UseEuiTheme) => {
       ${euiShadowFlat(euiThemeContext)}
     `,
     isPushCollapsed: css`
-      ${euiCollapsibleNavBodyStyles._isPushCollapsed}
+      ${hideScrollbars}
     `,
     isOverlayFullWidth: css`
       /* Override EuiFlyout's max-width */

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
@@ -8,7 +8,7 @@
 
 import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
-import { logicalCSS } from '../../global_styling';
+import { logicalCSS, euiYScrollWithShadows } from '../../global_styling';
 
 export const euiCollapsibleNavBodyStyles = {
   // In case things get really dire responsively, ensure the footer doesn't overtake the body
@@ -34,11 +34,13 @@ export const euiCollapsibleNavBodyStyles = {
   `,
 };
 
-export const euiCollapsibleNavFooterStyles = ({ euiTheme }: UseEuiTheme) => {
+export const euiCollapsibleNavFooterStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
   return {
     euiCollapsibleNav__footer: css`
       background-color: ${euiTheme.colors.emptyShade};
       ${logicalCSS('border-top', euiTheme.border.thin)}
+      ${euiYScrollWithShadows(euiThemeContext, { side: 'end' })}
     `,
   };
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
@@ -10,26 +10,24 @@ import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
 import { logicalCSS, euiYScrollWithShadows } from '../../global_styling';
 
+// Hide the scrollbar for docked mode (while still keeping the nav scrollable)
+// Otherwise if scrollbars are visible, button icon visibility suffers.
+export const hideScrollbars = `
+  scrollbar-width: none; /* Firefox */
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Edge, & Safari */
+  }
+`;
+
 export const euiCollapsibleNavBodyStyles = {
   // In case things get really dire responsively, ensure the footer doesn't overtake the body
   euiCollapsibleNav__body: css`
     ${logicalCSS('min-height', '50%')}
   `,
-  get isPushCollapsed() {
-    return css`
-      .euiFlyoutBody__overflow {
-        ${this._isPushCollapsed}
-      }
-    `;
-  },
-  // CSS is reused by main euiCollapsibleNav styles in case the body component isn't used
-  _isPushCollapsed: `
-    /* Hide the scrollbar for docked mode (while still keeping the nav scrollable)
-       Otherwise if scrollbars are visible, button icon visibility suffers. */
-    scrollbar-width: none; /* Firefox */
-
-    &::-webkit-scrollbar {
-      display: none; /* Chrome, Edge, & Safari */
+  isPushCollapsed: css`
+    .euiFlyoutBody__overflow {
+      ${hideScrollbars}
     }
   `,
 };
@@ -41,6 +39,9 @@ export const euiCollapsibleNavFooterStyles = (euiThemeContext: UseEuiTheme) => {
       background-color: ${euiTheme.colors.emptyShade};
       ${logicalCSS('border-top', euiTheme.border.thin)}
       ${euiYScrollWithShadows(euiThemeContext, { side: 'end' })}
+    `,
+    isPushCollapsed: css`
+      ${hideScrollbars}
     `,
   };
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.tsx
@@ -61,9 +61,13 @@ export const EuiCollapsibleNavFooter: EuiFlyoutFooterProps = ({
 }) => {
   const classes = classNames('euiCollapsibleNav__footer', className);
 
+  const { isCollapsed, isPush } = useContext(EuiCollapsibleNavContext);
   const euiTheme = useEuiTheme();
   const styles = euiCollapsibleNavFooterStyles(euiTheme);
-  const cssStyles = [styles.euiCollapsibleNav__footer];
+  const cssStyles = [
+    styles.euiCollapsibleNav__footer,
+    isCollapsed && isPush && styles.isPushCollapsed,
+  ];
 
   return <EuiFlyoutFooter className={classes} css={cssStyles} {...props} />;
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_group/collapsible_nav_group.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_group/collapsible_nav_group.stories.tsx
@@ -32,7 +32,6 @@ const meta: Meta<EuiCollapsibleNavGroupProps> = {
       { title: 'Dashboards', href: '#' },
       {
         title: 'Explore',
-        href: '#',
         items: [
           { title: 'Hello', href: '#' },
           { title: 'World', href: '#' },

--- a/src/components/collapsible_nav_beta/collapsible_nav_group/collapsible_nav_group.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_group/collapsible_nav_group.stories.tsx
@@ -87,7 +87,4 @@ export const EdgeCaseTesting: Story = {
       <EuiCollapsibleNavBeta.Group {...args} />
     </CollapsibleNavTemplate>
   ),
-  args: {
-    href: '#',
-  },
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_group/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_group/collapsible_nav_group.tsx
@@ -16,29 +16,24 @@ import { EuiCollapsibleNavContext } from '../context';
 import {
   EuiCollapsibleNavItem,
   EuiCollapsibleNavSubItems,
-  EuiCollapsibleNavSubItemProps,
-  EuiCollapsibleNavItemProps,
+  type EuiCollapsibleNavItemProps,
+  type _SharedEuiCollapsibleNavItemProps,
 } from '../collapsible_nav_item/collapsible_nav_item';
 import { EuiCollapsedNavPopover } from '../collapsible_nav_item/collapsed/collapsed_nav_popover';
 
 import { euiCollapsibleNavGroupStyles } from './collapsible_nav_group.styles';
 
-export type EuiCollapsibleNavGroupProps = Omit<
-  EuiCollapsibleNavItemProps,
-  'items' | 'accordionProps'
-> & {
-  /**
-   * Will render an array of `EuiCollapsibleNavItems`.
-   *
-   * Accepts any #EuiCollapsibleNavItemProps. Or, to render completely custom
-   * subitem content, pass an object with a `renderItem` callback.
-   */
-  items: EuiCollapsibleNavSubItemProps[];
-  /**
-   * Optional props to pass to the wrapping div
-   */
-  wrapperProps?: HTMLAttributes<HTMLDivElement> & CommonProps;
-};
+export type EuiCollapsibleNavGroupProps = _SharedEuiCollapsibleNavItemProps &
+  Pick<
+    EuiCollapsibleNavItemProps,
+    'title' | 'titleElement' | 'icon' | 'iconProps'
+  > &
+  Required<Pick<EuiCollapsibleNavItemProps, 'items'>> & {
+    /**
+     * Optional props to pass to the wrapping div
+     */
+    wrapperProps?: HTMLAttributes<HTMLDivElement> & CommonProps;
+  };
 
 /**
  * This component should only ever be used as a **top-level component**, and not as a sub-item.

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
@@ -7,10 +7,12 @@ exports[`EuiCollapsibleNavAccordion renders as a sub item 1`] = `
   <div
     class="euiAccordion__triggerWrapper emotion-EuiAccordionTrigger"
   >
-    <div
+    <button
       aria-controls="generated-id"
+      aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
+      type="button"
     >
       <span
         class="euiAccordion__buttonContent"
@@ -21,13 +23,13 @@ exports[`EuiCollapsibleNavAccordion renders as a sub item 1`] = `
           Accordion header
         </span>
       </span>
-    </div>
+    </button>
     <button
       aria-controls="generated-id"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__arrow emotion-euiButtonIcon-xs-empty-text-euiAccordion__arrow-right-isClosed-euiCollapsibleNavAccordion__arrow"
-      tabindex="0"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -77,10 +79,12 @@ exports[`EuiCollapsibleNavAccordion renders as a top level item 1`] = `
   <div
     class="euiAccordion__triggerWrapper emotion-EuiAccordionTrigger"
   >
-    <div
+    <button
       aria-controls="generated-id"
+      aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
+      type="button"
     >
       <span
         class="euiAccordion__buttonContent"
@@ -91,13 +95,13 @@ exports[`EuiCollapsibleNavAccordion renders as a top level item 1`] = `
           Accordion header
         </span>
       </span>
-    </div>
+    </button>
     <button
       aria-controls="generated-id"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__arrow emotion-euiButtonIcon-xs-empty-text-euiAccordion__arrow-right-isClosed-euiCollapsibleNavAccordion__arrow"
-      tabindex="0"
+      tabindex="-1"
       type="button"
     >
       <span

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -135,19 +135,3 @@ exports[`EuiCollapsibleNavItem renders a top level group if items exist and \`is
   </div>
 </div>
 `;
-
-exports[`EuiCollapsibleNavItem renders a top level link if items are missing or empty 1`] = `
-<a
-  aria-label="aria-label"
-  class="euiLink euiCollapsibleNavLink euiCollapsibleNavItem testClass1 testClass2 emotion-euiLink-primary-euiCollapsibleNavLink-isTopItem-isNotAccordion-isInteractive-euiTestCss"
-  data-test-subj="test subject string"
-  href="#"
-  rel="noreferrer"
->
-  <span
-    class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
-  >
-    Item
-  </span>
-</a>
-`;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -31,10 +31,12 @@ exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] 
   <div
     class="euiAccordion__triggerWrapper emotion-EuiAccordionTrigger"
   >
-    <div
+    <button
       aria-controls="generated-id"
+      aria-expanded="false"
       class="euiAccordion__button emotion-euiAccordion__button"
       id="generated-id"
+      type="button"
     >
       <span
         class="euiAccordion__buttonContent"
@@ -49,13 +51,13 @@ exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] 
           </span>
         </span>
       </span>
-    </div>
+    </button>
     <button
       aria-controls="generated-id"
       aria-expanded="false"
       aria-labelledby="generated-id"
       class="euiButtonIcon euiAccordion__arrow emotion-euiButtonIcon-xs-empty-text-euiAccordion__arrow-right-isClosed-euiCollapsibleNavAccordion__arrow"
-      tabindex="0"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -94,6 +96,42 @@ exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] 
         </span>
       </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`EuiCollapsibleNavItem renders a top level group if items exist and \`isCollapsible\` is set to false 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiCollapsibleNavGroup euiCollapsibleNavItem testClass1 testClass2 emotion-euiCollapsibleNavGroup-isTopItem-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <span
+    class="euiCollapsibleNavLink emotion-euiCollapsibleNavLink-isTopItem"
+    id="generated-id"
+  >
+    <span
+      class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+    >
+      Item
+    </span>
+  </span>
+  <div
+    aria-labelledby="generated-id"
+    class="euiCollapsibleNavItem__items euiCollapsibleNavGroup__children emotion-euiCollapsibleNavItem__items-isTopItem"
+    role="group"
+  >
+    <span
+      aria-label="aria-label"
+      class="euiCollapsibleNavLink euiCollapsibleNavSubItem testClass1 testClass2 emotion-euiCollapsibleNavLink-isSubItem-euiTestCss"
+      data-test-subj="test subject string"
+    >
+      <span
+        class="euiCollapsibleNavItem__title eui-textTruncate emotion-euiCollapsibleNavItem__title"
+      >
+        Sub-item
+      </span>
+    </span>
   </div>
 </div>
 `;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCollapsedNavItem renders a popover if items exist 1`] = `
+exports[`EuiCollapsedNavItem renders a popover if items are passed 1`] = `
 <div
   class="euiPopover euiCollapsedNavItem testClass1 testClass2 emotion-euiPopover-block-euiTestCss"
   data-test-subj="test subject string"
@@ -25,7 +25,7 @@ exports[`EuiCollapsedNavItem renders a popover if items exist 1`] = `
 </div>
 `;
 
-exports[`EuiCollapsedNavItem renders an icon button/link if items are missing or empty 1`] = `
+exports[`EuiCollapsedNavItem renders an icon button/link if href is passed 1`] = `
 <span
   aria-label="aria-label"
   class="euiToolTipAnchor euiCollapsedNavItem testClass1 testClass2 emotion-euiToolTipAnchor-block-euiTestCss"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiCollapsedNavPopover renders the title and sub-items within the popover 1`] = `
+exports[`EuiCollapsedNavPopover renders 1`] = `
 <body>
   <div>
     <div
@@ -65,18 +65,11 @@ exports[`EuiCollapsedNavPopover renders the title and sub-items within the popov
           <div
             class="euiPopoverTitle emotion-euiPopoverTitle-none"
           >
-            <a
-              class="euiLink emotion-euiLink-text-euiCollapsedNavPopover__title-link"
-              data-test-subj="popoverTitle"
-              href="#"
-              rel="noreferrer"
+            <h3
+              class="eui-textTruncate emotion-euiCollapsedNavPopover__title"
             >
-              <span
-                class="eui-textTruncate"
-              >
-                Item
-              </span>
-            </a>
+              Item
+            </h3>
           </div>
           <div
             class="emotion-euiCollapsedNavPopover__items"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -25,8 +25,11 @@ import {
 } from './collapsed_nav_button.styles';
 
 export const EuiCollapsedNavButton: FunctionComponent<
-  EuiCollapsibleNavItemProps & {
-    hideToolTip?: boolean;
+  Omit<
+    EuiCollapsibleNavItemProps,
+    'items' | 'isCollapsible' | 'accordionProps'
+  > & {
+    hideToolTip?: boolean; // Used by EuiCollapsedNavPopover to prevent tooltip/popover overlap
   }
 > = ({
   href, // eslint-disable-line local/href-with-rel
@@ -37,11 +40,7 @@ export const EuiCollapsedNavButton: FunctionComponent<
   onClick,
   hideToolTip,
   linkProps,
-  // Extracted to avoid spreading to ...rest
-  isCollapsible,
-  accordionProps,
-  titleElement,
-  items,
+  titleElement, // Extracted to avoid spreading to ...rest
   ...rest
 }) => {
   const euiTheme = useEuiTheme();

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -38,6 +38,7 @@ export const EuiCollapsedNavButton: FunctionComponent<
   hideToolTip,
   linkProps,
   // Extracted to avoid spreading to ...rest
+  isCollapsible,
   accordionProps,
   titleElement,
   items,

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof EuiCollapsedNavItem> = {
 export default meta;
 type Story = StoryObj<typeof EuiCollapsedNavItem>;
 
-export const Playground: Story = {
+export const Link: Story = {
   render: ({ ...args }) => (
     <div className="eui-displayInlineBlock">
       <EuiCollapsedNavItem {...args} />
@@ -32,11 +32,22 @@ export const Playground: Story = {
     icon: 'home',
     href: '#',
     linkProps: { target: '_blank' },
+  },
+};
+
+export const Accordion: Story = {
+  render: ({ ...args }) => (
+    <div className="eui-displayInlineBlock">
+      <EuiCollapsedNavItem {...args} />
+    </div>
+  ),
+  args: {
+    title: 'Collapsed nav item',
+    icon: 'home',
     items: [
       { title: 'Popover link A', href: '#', linkProps: { target: '_blank' } },
       { title: 'Popover link B', href: '#' },
       { title: 'Popover link C', href: '#' },
     ],
-    isCollapsible: false,
   },
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.stories.tsx
@@ -29,13 +29,14 @@ export const Playground: Story = {
   ),
   args: {
     title: 'Collapsed nav item',
+    icon: 'home',
     href: '#',
     linkProps: { target: '_blank' },
-    icon: 'home',
     items: [
       { title: 'Popover link A', href: '#', linkProps: { target: '_blank' } },
       { title: 'Popover link B', href: '#' },
       { title: 'Popover link C', href: '#' },
     ],
+    isCollapsible: false,
   },
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.test.tsx
@@ -13,7 +13,7 @@ import { requiredProps } from '../../../../test';
 import { EuiCollapsedNavItem } from './collapsed_nav_item';
 
 describe('EuiCollapsedNavItem', () => {
-  it('renders a popover if items exist', () => {
+  it('renders a popover if items are passed', () => {
     const { container } = render(
       <EuiCollapsedNavItem
         {...requiredProps}
@@ -26,14 +26,9 @@ describe('EuiCollapsedNavItem', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders an icon button/link if items are missing or empty', () => {
+  it('renders an icon button/link if href is passed', () => {
     const { container } = render(
-      <EuiCollapsedNavItem
-        {...requiredProps}
-        title="Item"
-        href="#"
-        items={[]}
-      />
+      <EuiCollapsedNavItem {...requiredProps} title="Item" href="#" />
     );
 
     expect(container.firstChild).toHaveClass('euiToolTipAnchor');

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_item.tsx
@@ -23,14 +23,26 @@ import classNames from 'classnames';
 
 export const EuiCollapsedNavItem: FunctionComponent<
   EuiCollapsibleNavItemProps
-> = ({ items, className, ...props }) => {
+> = ({
+  className,
+  href, // eslint-disable-line local/href-with-rel
+  linkProps,
+  items,
+  // Extracted to avoid spreading to DOM node
+  accordionProps,
+  isCollapsible,
+  ...props
+}) => {
   const classes = classNames('euiCollapsedNavItem', className);
 
-  const hasItems = items && items.length > 0;
-
-  return hasItems ? (
+  return items ? (
     <EuiCollapsedNavPopover items={items} className={classes} {...props} />
   ) : (
-    <EuiCollapsedNavButton className={classes} {...props} />
+    <EuiCollapsedNavButton
+      href={href}
+      linkProps={linkProps}
+      className={classes}
+      {...props}
+    />
   );
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.styles.ts
@@ -15,8 +15,6 @@ import {
   euiYScrollWithShadows,
 } from '../../../../global_styling';
 
-import { euiCollapsibleNavItemVariables } from '../collapsible_nav_item.styles';
-
 export const euiCollapsedNavPopoverStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
@@ -27,6 +25,11 @@ export const euiCollapsedNavPopoverStyles = (euiThemeContext: UseEuiTheme) => {
         mathWithUnits(euiTheme.size.base, (x) => x * 15)
       )}
     `,
+    euiCollapsedNavPopover__title: css`
+      display: block;
+      padding: ${euiTheme.size.m};
+      font-weight: ${euiTheme.font.weight.bold};
+    `,
     euiCollapsedNavPopover__items: css`
       ${euiYScrollWithShadows(euiThemeContext)}
       padding-block: ${euiTheme.size.s};
@@ -36,35 +39,6 @@ export const euiCollapsedNavPopoverStyles = (euiThemeContext: UseEuiTheme) => {
       @media (max-height: ${euiTheme.breakpoint.s}px) {
         ${logicalCSS('max-height', '75vh')}
       }
-    `,
-  };
-};
-
-export const euiCollapsedNavPopoverTitleStyles = (
-  euiThemeContext: UseEuiTheme
-) => {
-  const { euiTheme } = euiThemeContext;
-  const sharedStyles = euiCollapsibleNavItemVariables(euiThemeContext);
-
-  return {
-    euiCollapsedNavPopover__title: css`
-      padding: ${euiTheme.size.m};
-      font-weight: ${euiTheme.font.weight.bold};
-    `,
-    link: css`
-      /* Vertically align the external icon */
-      display: flex;
-      align-items: center;
-
-      /* Horizontally align with other external link icons */
-      [class*='euiLink__externalIcon'] {
-        ${logicalCSS('margin-left', 'auto')}
-        ${logicalCSS('margin-right', euiTheme.size.xxs)}
-        color: ${sharedStyles.rightIconColor};
-      }
-    `,
-    span: css`
-      display: block;
     `,
   };
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.test.tsx
@@ -22,70 +22,28 @@ describe('EuiCollapsedNavPopover', () => {
   shouldRenderCustomStyles(
     <EuiCollapsedNavPopover title="title" items={[{ title: 'subitem' }]} />
   );
-  shouldRenderCustomStyles(
-    <EuiCollapsedNavPopover
-      title="title"
-      items={[{ title: 'subitem' }]}
-      isCollapsible={false}
-      href="#"
-    />,
-    {
-      childProps: ['linkProps'],
-      renderCallback: async ({ getByTestSubject }) => {
-        fireEvent.click(getByTestSubject('euiCollapsedNavButton'));
-        await waitForEuiPopoverOpen();
-      },
-    }
-  );
 
-  it('renders the title and sub-items within the popover', async () => {
-    const { baseElement, getByTestSubject } = render(
+  it('renders', async () => {
+    const { baseElement, getByTestSubject, getByText } = render(
       <EuiCollapsedNavPopover
         {...requiredProps}
         title="Item"
-        href="#"
-        linkProps={{ 'data-test-subj': 'popoverTitle' }}
+        titleElement="h3"
         items={[
           { title: 'Sub-item A', href: '#', 'data-test-subj': 'A' },
           { title: 'Sub-item B', href: '#', 'data-test-subj': 'B' },
         ]}
-        // Non-collapsible groups allow link titles
-        isCollapsible={false}
       />
     );
     fireEvent.click(getByTestSubject('euiCollapsedNavButton'));
     await waitForEuiPopoverOpen();
 
     expect(baseElement).toMatchSnapshot();
-    expect(getByTestSubject('popoverTitle')).toHaveTextContent('Item');
+    expect(getByText('Item').nodeName).toEqual('H3');
     expect(getByTestSubject('A')).toHaveTextContent('Sub-item A');
     expect(getByTestSubject('B')).toHaveTextContent('Sub-item B');
 
     fireEvent.keyDown(baseElement, { key: 'Escape' });
     await waitForEuiPopoverClose();
-  });
-
-  it('renders popover titles without links', async () => {
-    const { getByText, getByTestSubject } = render(
-      <EuiCollapsedNavPopover
-        {...requiredProps}
-        title="Popover title"
-        titleElement="h3"
-        items={[{ title: 'Subitem' }]}
-        // Accordions do not allow link titles (carryover from desktop non-collapsed behavior)
-        href="#"
-        linkProps={requiredProps}
-      />
-    );
-    fireEvent.click(getByTestSubject('euiCollapsedNavButton'));
-    await waitForEuiPopoverOpen();
-
-    expect(getByText('Popover title')).toMatchInlineSnapshot(`
-      <h3
-        class="eui-textTruncate emotion-euiCollapsedNavPopover__title-span"
-      >
-        Popover title
-      </h3>
-    `);
   });
 });

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.test.tsx
@@ -25,8 +25,9 @@ describe('EuiCollapsedNavPopover', () => {
   shouldRenderCustomStyles(
     <EuiCollapsedNavPopover
       title="title"
-      href="#"
       items={[{ title: 'subitem' }]}
+      isCollapsible={false}
+      href="#"
     />,
     {
       childProps: ['linkProps'],
@@ -48,6 +49,8 @@ describe('EuiCollapsedNavPopover', () => {
           { title: 'Sub-item A', href: '#', 'data-test-subj': 'A' },
           { title: 'Sub-item B', href: '#', 'data-test-subj': 'B' },
         ]}
+        // Non-collapsible groups allow link titles
+        isCollapsible={false}
       />
     );
     fireEvent.click(getByTestSubject('euiCollapsedNavButton'));
@@ -62,14 +65,16 @@ describe('EuiCollapsedNavPopover', () => {
     await waitForEuiPopoverClose();
   });
 
-  it('renders popver titles without links', async () => {
+  it('renders popover titles without links', async () => {
     const { getByText, getByTestSubject } = render(
       <EuiCollapsedNavPopover
         {...requiredProps}
         title="Popover title"
         titleElement="h3"
         items={[{ title: 'Subitem' }]}
-        linkProps={requiredProps} // Should not spread to non-links
+        // Accordions do not allow link titles (carryover from desktop non-collapsed behavior)
+        href="#"
+        linkProps={requiredProps}
       />
     );
     fireEvent.click(getByTestSubject('euiCollapsedNavButton'));

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.tsx
@@ -10,7 +10,6 @@ import React, { FunctionComponent, useState, useCallback } from 'react';
 
 import { useEuiTheme } from '../../../../services';
 
-import { EuiLink, EuiLinkAnchorProps } from '../../../link';
 import { EuiPopover, EuiPopoverTitle } from '../../../popover';
 
 import {
@@ -19,27 +18,20 @@ import {
 } from '../collapsible_nav_item';
 
 import { EuiCollapsedNavButton } from './collapsed_nav_button';
-import {
-  euiCollapsedNavPopoverStyles,
-  euiCollapsedNavPopoverTitleStyles,
-} from './collapsed_nav_popover.styles';
+import { euiCollapsedNavPopoverStyles } from './collapsed_nav_popover.styles';
 
 export const EuiCollapsedNavPopover: FunctionComponent<
-  EuiCollapsibleNavItemProps & {
-    items: EuiCollapsibleNavItemProps['items'];
-  }
+  Omit<
+    EuiCollapsibleNavItemProps,
+    'isCollapsible' | 'accordionProps' | 'href' | 'linkProps'
+  >
 > = ({
   items,
-  href, // eslint-disable-line local/href-with-rel
-  linkProps,
   title,
-  titleElement,
+  titleElement: TitleElement = 'span',
   icon,
   iconProps,
   isSelected,
-  isCollapsible = true,
-  // Extracted to avoid spreading to ...rest
-  accordionProps,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -68,62 +60,23 @@ export const EuiCollapsedNavPopover: FunctionComponent<
           isSelected={isSelected}
           onClick={togglePopover}
           hideToolTip={isPopoverOpen}
-          // Note: do not pass `linkProps` to buttons that toggle popovers
         />
       }
       {...rest}
     >
-      <EuiCollapsedNavPopoverTitle
-        title={title}
-        titleElement={titleElement}
-        // Only nav groups should have links - accordions should not
-        href={!isCollapsible ? href : undefined}
-        linkProps={!isCollapsible ? linkProps : undefined}
-      />
+      <EuiPopoverTitle>
+        <TitleElement
+          css={styles.euiCollapsedNavPopover__title}
+          className="eui-textTruncate"
+        >
+          {title}
+        </TitleElement>
+      </EuiPopoverTitle>
       <div css={styles.euiCollapsedNavPopover__items}>
         {items!.map((item, index) => (
           <EuiCollapsibleNavSubItem key={index} {...item} />
         ))}
       </div>
     </EuiPopover>
-  );
-};
-
-const EuiCollapsedNavPopoverTitle: FunctionComponent<
-  Pick<
-    EuiCollapsibleNavItemProps,
-    'title' | 'titleElement' | 'href' | 'linkProps'
-  >
-> = ({
-  title,
-  titleElement: TitleElement = 'span',
-  href, // eslint-disable-line local/href-with-rel
-  linkProps,
-}) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiCollapsedNavPopoverTitleStyles(euiTheme);
-  const cssStyles = [
-    styles.euiCollapsedNavPopover__title,
-    href ? styles.link : styles.span,
-    href && linkProps?.css,
-  ];
-
-  return (
-    <EuiPopoverTitle>
-      {href ? (
-        <EuiLink
-          href={href}
-          color="text"
-          {...(linkProps as EuiLinkAnchorProps)} // ExclusiveUnion shenanigans :|
-          css={cssStyles}
-        >
-          <TitleElement className="eui-textTruncate">{title}</TitleElement>
-        </EuiLink>
-      ) : (
-        <TitleElement css={cssStyles} className="eui-textTruncate">
-          {title}
-        </TitleElement>
-      )}
-    </EuiPopoverTitle>
   );
 };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_popover.tsx
@@ -37,6 +37,7 @@ export const EuiCollapsedNavPopover: FunctionComponent<
   icon,
   iconProps,
   isSelected,
+  isCollapsible = true,
   // Extracted to avoid spreading to ...rest
   accordionProps,
   ...rest
@@ -75,8 +76,9 @@ export const EuiCollapsedNavPopover: FunctionComponent<
       <EuiCollapsedNavPopoverTitle
         title={title}
         titleElement={titleElement}
-        href={href}
-        linkProps={linkProps}
+        // Only nav groups should have links - accordions should not
+        href={!isCollapsible ? href : undefined}
+        linkProps={!isCollapsible ? linkProps : undefined}
       />
       <div css={styles.euiCollapsedNavPopover__items}>
         {items!.map((item, index) => (

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
@@ -52,6 +52,9 @@ export const euiCollapsibleNavAccordionStyles = (
             outline: none;
           }
         }
+
+        /* Weird workaround for Safari showing a strange focus ring bump around the arrow */
+        overflow: hidden;
       }
 
       .euiAccordion__buttonContent {

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
@@ -97,8 +97,11 @@ export const euiCollapsibleNavAccordionStyles = (
     `,
     // Arrow element
     euiCollapsibleNavAccordion__arrow: css`
+      /* Ensure there's no non-clickable deadzones in the accordion trigger wrapper */
+      margin: 0;
+      ${logicalCSS('height', sharedStyles.height)}
       /* Slight visual offset from edge of entire item */
-      ${logicalCSS('margin-right', euiTheme.size.xs)}
+      ${logicalCSS('width', euiTheme.size.xl)}
 
       /* Rotate the arrow icon, not the button itself -
        * otherwise the background rotates and looks a bit silly */

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.styles.ts
@@ -25,21 +25,32 @@ export const euiCollapsibleNavAccordionStyles = (
     euiCollapsibleNavAccordion: css`
       .euiAccordion__button {
         overflow: hidden; /* Title text truncation doesn't work otherwise */
-
-        /* unset accordion underline - only show for EuiLinks (which display their own underlines)
-         * so that behavior between link accordions and non-link accordions is consistent */
-        &:hover,
-        &:focus {
-          cursor: default;
-          text-decoration: none;
-        }
       }
 
-      .euiAccordion__triggerWrapper {
+      & > .euiAccordion__triggerWrapper {
         border-radius: ${sharedStyles.borderRadius};
 
         ${euiCanAnimate} {
           transition: background-color ${sharedStyles.animation};
+        }
+
+        &:hover,
+        &:focus-within {
+          background-color: ${sharedStyles.backgroundHoverColor};
+
+          .euiAccordion__arrow .euiIcon {
+            color: ${sharedStyles.color};
+          }
+        }
+
+        /* Move the keyboard focus outline to the entire trigger wrapper */
+        &:has(:focus-visible) {
+          outline-style: auto;
+          outline-offset: -${euiTheme.focus.width};
+
+          *:focus {
+            outline: none;
+          }
         }
       }
 
@@ -54,23 +65,18 @@ export const euiCollapsibleNavAccordionStyles = (
         ${logicalCSS('width', '100%')}
       }
     `,
-    isTopItem: css`
-      margin: ${sharedStyles.padding};
-
-      & > .euiAccordion__triggerWrapper {
-        &:hover {
-          background-color: ${sharedStyles.backgroundHoverColor};
-        }
-      }
-    `,
     isSelected: css`
       & > .euiAccordion__triggerWrapper {
         background-color: ${sharedStyles.backgroundSelectedColor};
 
-        &:hover {
+        &:hover,
+        &:focus-within {
           background-color: ${sharedStyles.backgroundSelectedColor};
         }
       }
+    `,
+    isTopItem: css`
+      margin: ${sharedStyles.padding};
     `,
     isSubItem: css`
       /* Adds extra spacing to the bottom of the accordion while open. Notes:
@@ -91,20 +97,6 @@ export const euiCollapsibleNavAccordionStyles = (
       /* Slight visual offset from edge of entire item */
       ${logicalCSS('margin-right', euiTheme.size.xs)}
 
-      /* Give the arrow button its own clearer hover animation to indicate its hitbox */
-      ${euiCanAnimate} {
-        transition: background-color ${sharedStyles.animation};
-      }
-
-      &:hover,
-      &:focus-visible {
-        background-color: ${euiTheme.colors.lightShade};
-
-        & > .euiIcon {
-          color: ${sharedStyles.color};
-        }
-      }
-
       /* Rotate the arrow icon, not the button itself -
        * otherwise the background rotates and looks a bit silly */
       transform: none !important; /* stylelint-disable-line declaration-no-important */
@@ -122,6 +114,12 @@ export const euiCollapsibleNavAccordionStyles = (
       &.euiAccordion__arrow[aria-expanded='true'] > .euiIcon {
         color: ${sharedStyles.color};
         transform: rotate(-90deg);
+      }
+
+      /* Unset default accordion arrow style */
+      &:hover,
+      &:focus {
+        background-color: transparent;
       }
     `,
   };

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.test.tsx
@@ -22,7 +22,6 @@ describe('EuiCollapsibleNavAccordion', () => {
 
   shouldRenderCustomStyles(<EuiCollapsibleNavAccordion {...props} />, {
     childProps: [
-      'linkProps',
       'accordionProps',
       'accordionProps.arrowProps',
       'accordionProps.buttonProps',
@@ -53,26 +52,28 @@ describe('EuiCollapsibleNavAccordion', () => {
     );
   });
 
-  describe('when the accordion header is a link and the link is clicked', () => {
-    it('does not trigger the accordion opening', () => {
-      const { getByTestSubject, container } = render(
-        <EuiCollapsibleNavAccordion
-          {...props}
-          href="#"
-          linkProps={{ 'data-test-subj': 'link' }}
-          accordionProps={{ arrowProps: { 'data-test-subj': 'toggle' } }}
-        />
-      );
+  it('triggers the accordion opening', () => {
+    const { getByTestSubject, container } = render(
+      <EuiCollapsibleNavAccordion
+        {...props}
+        accordionProps={{
+          buttonProps: { 'data-test-subj': 'button' },
+          arrowProps: { 'data-test-subj': 'arrow' },
+        }}
+      />
+    );
+    expect(
+      container.querySelector('.euiAccordion__childWrapper')
+    ).toHaveStyleRule('opacity', '0');
 
-      fireEvent.click(getByTestSubject('link'));
-      expect(
-        container.querySelector('.euiAccordion__childWrapper')
-      ).toHaveStyleRule('opacity', '0');
+    fireEvent.click(getByTestSubject('button'));
+    expect(
+      container.querySelector('.euiAccordion__childWrapper')
+    ).toHaveStyleRule('opacity', '1');
 
-      fireEvent.click(getByTestSubject('toggle'));
-      expect(
-        container.querySelector('.euiAccordion__childWrapper')
-      ).toHaveStyleRule('opacity', '1');
-    });
+    fireEvent.click(getByTestSubject('arrow'));
+    expect(
+      container.querySelector('.euiAccordion__childWrapper')
+    ).toHaveStyleRule('opacity', '0');
   });
 });

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_accordion.tsx
@@ -6,33 +6,26 @@
  * Side Public License, v 1.
  */
 
-import React, {
-  FunctionComponent,
-  ReactNode,
-  MouseEvent,
-  useCallback,
-} from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from 'classnames';
 
 import { useEuiTheme, useGeneratedHtmlId } from '../../../services';
 import { EuiAccordion } from '../../accordion';
 
 import {
+  type _SharedEuiCollapsibleNavItemProps,
+  type _EuiCollapsibleNavItemDisplayProps,
+  type EuiCollapsibleNavItemProps,
   EuiCollapsibleNavSubItems,
-  EuiCollapsibleNavSubItemProps,
-  _SharedEuiCollapsibleNavItemProps,
-  _EuiCollapsibleNavItemDisplayProps,
 } from './collapsible_nav_item';
 import { EuiCollapsibleNavLink } from './collapsible_nav_link';
 import { euiCollapsibleNavAccordionStyles } from './collapsible_nav_accordion.styles';
 
-type EuiCollapsibleNavAccordionProps = Omit<
-  _SharedEuiCollapsibleNavItemProps,
-  'items' | 'isCollapsible'
-> &
-  _EuiCollapsibleNavItemDisplayProps & {
+type EuiCollapsibleNavAccordionProps = _SharedEuiCollapsibleNavItemProps &
+  _EuiCollapsibleNavItemDisplayProps &
+  Pick<EuiCollapsibleNavItemProps, 'accordionProps'> &
+  Required<Pick<EuiCollapsibleNavItemProps, 'items'>> & {
     buttonContent: ReactNode;
-    items: EuiCollapsibleNavSubItemProps[];
   };
 
 /**
@@ -48,10 +41,8 @@ export const EuiCollapsibleNavAccordion: FunctionComponent<
   id,
   className,
   items,
-  href, // eslint-disable-line local/href-with-rel
   isSubItem,
   isSelected,
-  linkProps,
   accordionProps,
   buttonContent,
   children: _children, // Make sure this isn't spread
@@ -69,32 +60,16 @@ export const EuiCollapsibleNavAccordion: FunctionComponent<
     accordionProps?.css,
   ];
 
-  const isTitleInteractive = !!(href || linkProps?.onClick);
-
-  // Stop propagation on the title so that the accordion toggle doesn't occur on click
-  // (should only occur on accordion arrow click for UX consistency)
-  const stopPropagationClick = useCallback(
-    (e: MouseEvent<HTMLAnchorElement> & MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation();
-      linkProps?.onClick?.(e);
-    },
-    [linkProps?.onClick] // eslint-disable-line react-hooks/exhaustive-deps
-  );
-
   return (
     <EuiAccordion
       id={groupID}
       className={classes}
       initialIsOpen={isSelected}
-      buttonElement="div"
       buttonContent={
         <EuiCollapsibleNavLink
-          href={href}
-          {...linkProps}
           isSelected={isSelected}
           isSubItem={isSubItem}
-          onClick={stopPropagationClick}
-          isInteractive={isTitleInteractive}
+          isInteractive={false}
         >
           {buttonContent}
         </EuiCollapsibleNavLink>

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_group.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_group.test.tsx
@@ -19,9 +19,7 @@ describe('EuiCollapsibleNavGroup', () => {
     items: [{ title: 'sub item' }],
   };
 
-  shouldRenderCustomStyles(<EuiCollapsibleNavGroup {...props} />, {
-    childProps: ['linkProps'],
-  });
+  shouldRenderCustomStyles(<EuiCollapsibleNavGroup {...props} />);
 
   it('renders as a top level item', () => {
     const { container } = render(
@@ -44,13 +42,5 @@ describe('EuiCollapsibleNavGroup', () => {
     );
     const header = container.querySelector('.euiCollapsibleNavLink');
     expect(header?.className).toContain('isSelected');
-  });
-
-  it('renders interactive headers', () => {
-    const { container } = render(
-      <EuiCollapsibleNavGroup {...props} href="#'" />
-    );
-    const header = container.querySelector('.euiCollapsibleNavLink');
-    expect(header?.nodeName).toEqual('A');
   });
 });

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_group.tsx
@@ -22,7 +22,6 @@ import { EuiCollapsibleNavLink } from './collapsible_nav_link';
 
 type EuiCollapsibleNavGroupProps = _SharedEuiCollapsibleNavItemProps &
   _EuiCollapsibleNavItemDisplayProps &
-  Pick<EuiCollapsibleNavItemProps, 'href' | 'linkProps'> &
   Required<Pick<EuiCollapsibleNavItemProps, 'items'>> & {
     header: ReactNode;
   };
@@ -40,11 +39,9 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
 > = ({
   className,
   header,
-  href, // eslint-disable-line local/href-with-rel
   items,
   isSubItem,
   isSelected,
-  linkProps,
   children: _children, // Make sure this isn't spread
   ...rest
 }) => {
@@ -66,12 +63,10 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
   return (
     <div className={classes} {...cssStyles} {...rest}>
       <EuiCollapsibleNavLink
-        href={href}
         id={labelledById}
-        {...linkProps}
         isSelected={isSelected}
         isSubItem={isSubItem}
-        isInteractive={!!(href || rest.onClick || linkProps?.onClick)}
+        isInteractive={false}
       >
         {header}
       </EuiCollapsibleNavLink>
@@ -80,7 +75,7 @@ export const EuiCollapsibleNavGroup: FunctionComponent<
         isSubItem={isSubItem}
         className="euiCollapsibleNavGroup__children"
         role="group"
-        aria-labelledby={linkProps?.id || labelledById}
+        aria-labelledby={labelledById}
       />
     </div>
   );

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_group.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_group.tsx
@@ -12,21 +12,19 @@ import classNames from 'classnames';
 import { useEuiTheme, useGeneratedHtmlId } from '../../../services';
 
 import {
+  type _SharedEuiCollapsibleNavItemProps,
+  type _EuiCollapsibleNavItemDisplayProps,
+  type EuiCollapsibleNavItemProps,
   EuiCollapsibleNavSubItems,
-  EuiCollapsibleNavSubItemProps,
-  _SharedEuiCollapsibleNavItemProps,
-  _EuiCollapsibleNavItemDisplayProps,
 } from './collapsible_nav_item';
 import { euiCollapsibleNavItemVariables } from './collapsible_nav_item.styles';
 import { EuiCollapsibleNavLink } from './collapsible_nav_link';
 
-type EuiCollapsibleNavGroupProps = Omit<
-  _SharedEuiCollapsibleNavItemProps,
-  'items' | 'accordionProps'
-> &
-  _EuiCollapsibleNavItemDisplayProps & {
+type EuiCollapsibleNavGroupProps = _SharedEuiCollapsibleNavItemProps &
+  _EuiCollapsibleNavItemDisplayProps &
+  Pick<EuiCollapsibleNavItemProps, 'href' | 'linkProps'> &
+  Required<Pick<EuiCollapsibleNavItemProps, 'items'>> & {
     header: ReactNode;
-    items: EuiCollapsibleNavSubItemProps[];
   };
 
 /**

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -152,33 +152,13 @@ export const EdgeCaseTesting: Story = {
         />
         <EuiCollapsibleNavItem
           {...args}
-          title="Accordion with no items and link"
-          items={[]}
-          href="#"
-        />
-        <EuiCollapsibleNavItem
-          {...args}
-          title="Accordion with link"
-          items={[{ title: 'Link should be ignored' }]}
-          href="#"
-        />
-        <EuiCollapsibleNavItem
-          {...args}
           title="Group with no items"
           items={[]}
         />
         <EuiCollapsibleNavItem
           {...args}
-          title="Group with no items and link"
-          items={[]}
-          href="#"
-        />
-        <EuiCollapsibleNavItem
-          {...args}
-          title="Group with icon and external link"
+          title="Group with icon"
           icon="link"
-          href="#"
-          linkProps={{ target: '_blank' }}
           isCollapsible={false}
           items={[
             { ...args, title: 'Link', href: '#' },

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.stories.tsx
@@ -112,17 +112,14 @@ export const EdgeCaseTesting: Story = {
             { ...args, title: 'Not a link' },
             {
               ...args,
-              title: 'Nested accordion - span',
+              title: 'Nested accordion',
               items: [{ title: 'grandchild' }, { title: 'grandchild 2' }],
             },
             {
               ...args,
-              title: 'Nested accordion - link',
-              href: '#',
-              items: [
-                { title: 'grandchild', href: '#' },
-                { title: 'grandchild 2', href: '#' },
-              ],
+              title: 'Nested group',
+              isCollapsible: false,
+              items: [{ title: 'grandchild' }, { title: 'grandchild 2' }],
             },
             { renderItem: () => <EuiSpacer size="m" /> },
             {
@@ -150,33 +147,31 @@ export const EdgeCaseTesting: Story = {
         />
         <EuiCollapsibleNavItem
           {...args}
-          title="Accordion with icon and link"
-          href="#"
-          items={[
-            { ...args, title: 'Link with no icon', href: '#' },
-            { ...args, title: 'Link with icon', href: '#', icon: 'alert' },
-          ]}
-        />
-        <EuiCollapsibleNavItem
-          {...args}
-          title="Accordion with icon and external link"
-          href="#"
-          linkProps={{ target: '_blank' }} // hmm
-          items={[
-            { ...args, title: 'Link with no icon', href: '#' },
-            { ...args, title: 'Link with icon', href: '#', icon: 'alert' },
-          ]}
-        />
-        <EuiCollapsibleNavItem
-          {...args}
           title="Accordion with no items"
-          href="#"
           items={[]}
         />
         <EuiCollapsibleNavItem
           {...args}
-          title="Accordion with no items and no link"
+          title="Accordion with no items and link"
           items={[]}
+          href="#"
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Accordion with link"
+          items={[{ title: 'Link should be ignored' }]}
+          href="#"
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Group with no items"
+          items={[]}
+        />
+        <EuiCollapsibleNavItem
+          {...args}
+          title="Group with no items and link"
+          items={[]}
+          href="#"
         />
         <EuiCollapsibleNavItem
           {...args}

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
@@ -15,13 +15,12 @@ import { EuiCollapsibleNavContext } from '../context';
 import { EuiCollapsibleNavItem } from './collapsible_nav_item';
 
 describe('EuiCollapsibleNavItem', () => {
+  shouldRenderCustomStyles(<EuiCollapsibleNavItem title="Title" href="#" />, {
+    childProps: ['linkProps'],
+  });
   shouldRenderCustomStyles(
-    <EuiCollapsibleNavItem
-      title="Title"
-      href="#"
-      items={[{ title: 'Sub-item' }]}
-    />,
-    { childProps: ['linkProps', 'accordionProps'] }
+    <EuiCollapsibleNavItem title="Title" items={[{ title: 'Sub-item' }]} />,
+    { childProps: ['accordionProps'] }
   );
 
   it('renders a top level accordion if items exist', () => {
@@ -34,6 +33,40 @@ describe('EuiCollapsibleNavItem', () => {
     );
 
     expect(container.firstChild).toHaveClass('euiAccordion');
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('warns if a dev tries to pass a link/href to an accordion', () => {
+    const consoleWarnSpy = jest
+      .spyOn(window.console, 'warn')
+      .mockImplementation(() => {});
+
+    render(
+      <EuiCollapsibleNavItem
+        {...requiredProps}
+        title="Item"
+        items={[{ title: 'Sub-item', ...requiredProps }]}
+        href="#"
+      />
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'When rendering a collapsible accordion with `items`, the `href` prop is ignored'
+    );
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('renders a top level group if items exist and `isCollapsible` is set to false', () => {
+    const { container } = render(
+      <EuiCollapsibleNavItem
+        {...requiredProps}
+        title="Item"
+        items={[{ title: 'Sub-item', ...requiredProps }]}
+        isCollapsible={false}
+      />
+    );
+
+    expect(container.firstChild).toHaveClass('euiCollapsibleNavGroup');
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
@@ -36,12 +36,9 @@ describe('EuiCollapsibleNavItem', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('warns if a dev tries to pass a link/href to an accordion', () => {
-    const consoleWarnSpy = jest
-      .spyOn(window.console, 'warn')
-      .mockImplementation(() => {});
-
-    render(
+  it('does not pass the `href` prop to the accordion/group title', () => {
+    const { container } = render(
+      // @ts-expect-error - should warn about `href`
       <EuiCollapsibleNavItem
         {...requiredProps}
         title="Item"
@@ -49,11 +46,8 @@ describe('EuiCollapsibleNavItem', () => {
         href="#"
       />
     );
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'When rendering a collapsible accordion with `items`, the `href` prop is ignored'
-    );
 
-    consoleWarnSpy.mockRestore();
+    expect(container.querySelector('a')).not.toBeInTheDocument();
   });
 
   it('renders a top level group if items exist and `isCollapsible` is set to false', () => {
@@ -67,20 +61,6 @@ describe('EuiCollapsibleNavItem', () => {
     );
 
     expect(container.firstChild).toHaveClass('euiCollapsibleNavGroup');
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  it('renders a top level link if items are missing or empty', () => {
-    const { container } = render(
-      <EuiCollapsibleNavItem
-        {...requiredProps}
-        title="Item"
-        href="#"
-        items={[]}
-      />
-    );
-
-    expect(container.firstChild).toHaveClass('euiLink');
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -60,41 +60,46 @@ export type EuiCollapsibleNavItemProps = _SharedEuiCollapsibleNavItemProps & {
    * Optional props to pass to the title icon
    */
   iconProps?: Partial<EuiIconProps>;
-  /**
-   * The nav item link.
-   *
-   * If not included, and no `onClick` is specified, the nav item
-   * will render as an non-interactive `<span>`.
-   *
-   * Should not be used in conjunction with a collapsible accordion, as the
-   * title will trigger the accordion collapse/expand action instead of a link.
-   */
-  href?: string;
-  /**
-   * If a `href` is specified, use this prop to pass any prop that `EuiLink` accepts
-   */
-  linkProps?: Partial<EuiLinkProps>;
-  /**
-   * Will render either an accordion or group of nested child item links.
-   *
-   * Accepts any #EuiCollapsibleNavItemProps. Or, to render completely custom
-   * subitem content, pass an object with a `renderItem` callback.
-   */
-  items?: EuiCollapsibleNavSubItemProps[];
-  /**
-   * If set to false, will (visually) render an always-open accordion that cannot
-   * be toggled closed. Ignored if `items` is not passed.
-   *
-   * @default true
-   */
-  isCollapsible?: boolean;
-  /**
-   * If `items` is specified, and `isCollapsible` is not set to false, you may
-   * use this prop to pass any prop that `EuiAccordion` accepts, including props
-   * that control the toggled state of the accordion (e.g. `initialIsOpen`, `forceState`)
-   */
-  accordionProps?: Partial<EuiAccordionProps>;
-};
+} & ExclusiveUnion<
+    {
+      /**
+       * The nav item link.
+       *
+       * If not included, and no `onClick` is specified, the nav item
+       * will render as an non-interactive `<span>`.
+       *
+       * Should not be used together with `items`, as the title will
+       * trigger the accordion collapse/expand action instead of a link.
+       */
+      href?: string;
+      /**
+       * If a `href` is specified, use this prop to pass any prop that `EuiLink` accepts
+       */
+      linkProps?: Partial<EuiLinkProps>;
+    },
+    {
+      /**
+       * Will render either an accordion or group of nested child item links.
+       *
+       * Accepts any #EuiCollapsibleNavItemProps. Or, to render completely custom
+       * subitem content, pass an object with a `renderItem` callback.
+       */
+      items: EuiCollapsibleNavSubItemProps[];
+      /**
+       * If set to false, will (visually) render an always-open accordion that cannot
+       * be toggled closed. Ignored if `items` is not passed.
+       *
+       * @default true
+       */
+      isCollapsible?: boolean;
+      /**
+       * If `items` is specified, and `isCollapsible` is not set to false, you may
+       * use this prop to pass any prop that `EuiAccordion` accepts, including props
+       * that control the toggled state of the accordion (e.g. `initialIsOpen`, `forceState`)
+       */
+      accordionProps?: Partial<EuiAccordionProps>;
+    }
+  >;
 
 export type EuiCollapsibleNavCustomSubItem = {
   renderItem: () => ReactNode;
@@ -143,10 +148,7 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
     />
   );
 
-  if (items && items.length > 0) {
-    if (href) {
-      console.warn('When rendering with `items`, the `href` prop is ignored');
-    }
+  if (items) {
     if (isCollapsible) {
       return (
         <EuiCollapsibleNavAccordion

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -144,12 +144,10 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
   );
 
   if (items && items.length > 0) {
+    if (href) {
+      console.warn('When rendering with `items`, the `href` prop is ignored');
+    }
     if (isCollapsible) {
-      if (href) {
-        console.warn(
-          'When rendering a collapsible accordion with `items`, the `href` prop is ignored'
-        );
-      }
       return (
         <EuiCollapsibleNavAccordion
           buttonContent={headerContent}
@@ -164,8 +162,6 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
         <EuiCollapsibleNavGroup
           header={headerContent}
           items={items}
-          href={href}
-          linkProps={linkProps}
           {...props}
           isSubItem={isSubItem}
         />

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -126,9 +126,11 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
   titleElement,
   icon,
   iconProps,
+  href, // eslint-disable-line local/href-with-rel
+  linkProps,
   items,
   isCollapsible = true,
-  accordionProps, // Ensure this isn't spread to non-accordions
+  accordionProps,
   children, // Ensure children isn't spread
   ...props
 }) => {
@@ -143,6 +145,11 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
 
   if (items && items.length > 0) {
     if (isCollapsible) {
+      if (href) {
+        console.warn(
+          'When rendering a collapsible accordion with `items`, the `href` prop is ignored'
+        );
+      }
       return (
         <EuiCollapsibleNavAccordion
           buttonContent={headerContent}
@@ -157,6 +164,8 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
         <EuiCollapsibleNavGroup
           header={headerContent}
           items={items}
+          href={href}
+          linkProps={linkProps}
           {...props}
           isSubItem={isSubItem}
         />
@@ -166,12 +175,12 @@ const EuiCollapsibleNavItemDisplay: FunctionComponent<
 
   return (
     <EuiCollapsibleNavLink
+      href={href}
+      linkProps={linkProps}
       {...(props as EuiLinkProps)} // EuiLink ExclusiveUnion type shenanigans
       isSubItem={isSubItem}
       isNotAccordion
-      isInteractive={
-        !!(props.href || props.onClick || props.linkProps?.onClick)
-      }
+      isInteractive={!!(href || props.onClick || linkProps?.onClick)}
     >
       {headerContent}
     </EuiCollapsibleNavLink>

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -35,43 +35,13 @@ import {
 export type _SharedEuiCollapsibleNavItemProps = HTMLAttributes<HTMLElement> &
   CommonProps & {
     /**
-     * The nav item link.
-     * If not included, and no `onClick` is specified, the nav item
-     * will render as an non-interactive `<span>`.
-     */
-    href?: string;
-    /**
-     * Will render either an accordion or group of nested child item links.
-     *
-     * Accepts any #EuiCollapsibleNavItemProps. Or, to render completely custom
-     * subitem content, pass an object with a `renderItem` callback.
-     */
-    items?: EuiCollapsibleNavSubItemProps[];
-    /**
-     * If set to false, will (visually) render an always-open accordion that cannot
-     * be toggled closed. Ignored if `items` is not passed.
-     *
-     * @default true
-     */
-    isCollapsible?: boolean;
-    /**
-     * If `items` is specified, and `isCollapsible` is not set to false, you may
-     * use this prop to pass any prop that `EuiAccordion` accepts, including props
-     * that control the toggled state of the accordion (e.g. `initialIsOpen`, `forceState`)
-     */
-    accordionProps?: Partial<EuiAccordionProps>;
-    /**
-     * If a `href` is specified, use this prop to pass any prop that `EuiLink` accepts
-     */
-    linkProps?: Partial<EuiLinkProps>;
-    /**
      * Highlights whether an item is currently selected, e.g.
      * if the user is on the same page as the nav link
      */
     isSelected?: boolean;
   };
 
-export type EuiCollapsibleNavItemProps = {
+export type EuiCollapsibleNavItemProps = _SharedEuiCollapsibleNavItemProps & {
   /**
    * Required text to render as the nav item title
    */
@@ -90,7 +60,41 @@ export type EuiCollapsibleNavItemProps = {
    * Optional props to pass to the title icon
    */
   iconProps?: Partial<EuiIconProps>;
-} & _SharedEuiCollapsibleNavItemProps;
+  /**
+   * The nav item link.
+   *
+   * If not included, and no `onClick` is specified, the nav item
+   * will render as an non-interactive `<span>`.
+   *
+   * Should not be used in conjunction with a collapsible accordion, as the
+   * title will trigger the accordion collapse/expand action instead of a link.
+   */
+  href?: string;
+  /**
+   * If a `href` is specified, use this prop to pass any prop that `EuiLink` accepts
+   */
+  linkProps?: Partial<EuiLinkProps>;
+  /**
+   * Will render either an accordion or group of nested child item links.
+   *
+   * Accepts any #EuiCollapsibleNavItemProps. Or, to render completely custom
+   * subitem content, pass an object with a `renderItem` callback.
+   */
+  items?: EuiCollapsibleNavSubItemProps[];
+  /**
+   * If set to false, will (visually) render an always-open accordion that cannot
+   * be toggled closed. Ignored if `items` is not passed.
+   *
+   * @default true
+   */
+  isCollapsible?: boolean;
+  /**
+   * If `items` is specified, and `isCollapsible` is not set to false, you may
+   * use this prop to pass any prop that `EuiAccordion` accepts, including props
+   * that control the toggled state of the accordion (e.g. `initialIsOpen`, `forceState`)
+   */
+  accordionProps?: Partial<EuiAccordionProps>;
+};
 
 export type EuiCollapsibleNavCustomSubItem = {
   renderItem: () => ReactNode;

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_link.tsx
@@ -15,15 +15,14 @@ import { EuiLink, EuiLinkProps } from '../../link';
 import type {
   _SharedEuiCollapsibleNavItemProps,
   _EuiCollapsibleNavItemDisplayProps,
+  EuiCollapsibleNavItemProps,
 } from './collapsible_nav_item';
 import { euiCollapsibleNavLinkStyles } from './collapsible_nav_link.styles';
 
 type EuiCollapsibleNavLinkProps = Omit<EuiLinkProps, 'children'> &
-  Omit<
-    _SharedEuiCollapsibleNavItemProps,
-    'items' | 'isCollapsible' | 'accordionProps'
-  > &
-  _EuiCollapsibleNavItemDisplayProps & {
+  _SharedEuiCollapsibleNavItemProps &
+  _EuiCollapsibleNavItemDisplayProps &
+  Pick<EuiCollapsibleNavItemProps, 'href' | 'linkProps'> & {
     children: ReactNode;
     isInteractive?: boolean;
     isNotAccordion?: boolean;


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/kibana/issues/168484

Hover/mouse states:

![collapsible_nav_beta_mouse](https://github.com/elastic/eui/assets/549407/a1d044c3-84bd-4847-b364-e69c6efa796b)

Focus/keyboard states:

![collapsible_nav_beta_keyboard](https://github.com/elastic/eui/assets/549407/8aea4900-5e69-4e24-8d1b-056176caa1b3)

## QA

- https://eui.elastic.co/pr_7337/storybook/?path=/story/euicollapsiblenavbeta--kibana-example
- [x] Confirm the accordion titles toggle on the entire button/text, not just on the arrow
- [x] Confirm that when interacting with the accordion titles with the mouse, no outlines appear, but outlines do appear on keyboard tab
- Go to https://eui.elastic.co/pr_7337/storybook/?path=/story/euicollapsiblenavitem--edge-case-testing
- [x] Confirm all nav items behave as expected (all accordion titles trigger open/close, no group titles have links)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A, beta component
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist - N/A, beta component
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~