### PR TITLE
[EuiDataGrid] Allow clearing the "Lines per row" input

### DIFF
--- a/src/components/datagrid/controls/display_selector.test.tsx
+++ b/src/components/datagrid/controls/display_selector.test.tsx
@@ -368,19 +368,28 @@ describe('useDataGridDisplaySelector', () => {
           expect(getLineCountNumber(component)).toEqual(3);
         });
 
-        it('does not allow zero or negative line count values', () => {
+        it('updates the input but not the grid display if an invalid number is passed', () => {
+          const onChange = jest.fn();
+
           const component = mount(
             <MockComponent
-              rowHeightsOptions={{ defaultHeight: { lineCount: 2 } }}
+              rowHeightsOptions={{ defaultHeight: { lineCount: 2 }, onChange }}
             />
           );
           openPopover(component);
 
-          setLineCountNumber(component, 0);
-          expect(getLineCountNumber(component)).toEqual(2);
+          const assertInvalidNumber = (value: number) => {
+            setLineCountNumber(component, value);
 
-          setLineCountNumber(component, -50);
-          expect(getLineCountNumber(component)).toEqual(2);
+            const input = component.find('input[type="number"]').getDOMNode();
+            expect((input as HTMLInputElement).value).toEqual(String(value));
+
+            expect(input).toBeInvalid();
+            expect(onChange).not.toHaveBeenCalled();
+          };
+
+          assertInvalidNumber(0);
+          assertInvalidNumber(-50);
         });
 
         it('correctly resets lineCount to initial developer-passed state', () => {

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -149,13 +149,15 @@ export const useDataGridDisplaySelector = (
     NonNullable<EuiRangeProps['onChange']>
   >((event) => {
     const newLineCount = Number(event.currentTarget.value);
-    if (newLineCount < 1) return; // Don't let users set a 0 or negative line count
-
     setLineCount(newLineCount);
-    setUserRowHeightsOptions({
-      rowHeights: {}, // Unset all row-specific line counts
-      defaultHeight: { lineCount: newLineCount },
-    });
+
+    // Don't let users set a 0 or negative line count
+    if (newLineCount > 0) {
+      setUserRowHeightsOptions({
+        rowHeights: {}, // Unset all row-specific line counts
+        defaultHeight: { lineCount: newLineCount },
+      });
+    }
   }, []);
 
   // Merge the developer-specified configurations with user overrides

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -87,7 +87,7 @@ const convertRowHeightsOptionsToSelection = (
   }
   return rowHeightButtonOptions[0];
 };
-const defaultLineCountValue = 2;
+const defaultLineCountValue = String(2);
 
 export const useDataGridDisplaySelector = (
   showDisplaySelector: EuiDataGridToolBarVisibilityOptions['showDisplaySelector'],
@@ -136,7 +136,7 @@ export const useDataGridDisplaySelector = (
       if (option === 'auto') {
         rowHeightsOptions.defaultHeight = 'auto';
       } else if (option === 'lineCount') {
-        rowHeightsOptions.defaultHeight = { lineCount };
+        rowHeightsOptions.defaultHeight = { lineCount: Number(lineCount) };
       } else {
         rowHeightsOptions.defaultHeight = undefined;
       }
@@ -148,8 +148,8 @@ export const useDataGridDisplaySelector = (
   const setLineCountHeight = useCallback<
     NonNullable<EuiRangeProps['onChange']>
   >((event) => {
+    setLineCount(event.currentTarget.value);
     const newLineCount = Number(event.currentTarget.value);
-    setLineCount(newLineCount);
 
     // Don't let users set a 0 or negative line count
     if (newLineCount > 0) {
@@ -358,6 +358,7 @@ export const useDataGridDisplaySelector = (
                       min={1}
                       max={20}
                       step={1}
+                      required
                       value={lineCount}
                       onChange={setLineCountHeight}
                       data-test-subj="lineCountNumber"

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -126,7 +126,7 @@ export const useDataGridDisplaySelector = (
   }, []);
 
   // Row height logic
-  const [lineCount, setLineCount] = useState(defaultLineCountValue);
+  const [lineCountInput, setLineCountInput] = useState(defaultLineCountValue);
   const setRowHeight = useCallback(
     (option: string) => {
       const rowHeightsOptions: EuiDataGridRowHeightsOptions = {
@@ -136,19 +136,19 @@ export const useDataGridDisplaySelector = (
       if (option === 'auto') {
         rowHeightsOptions.defaultHeight = 'auto';
       } else if (option === 'lineCount') {
-        rowHeightsOptions.defaultHeight = { lineCount: Number(lineCount) };
+        rowHeightsOptions.defaultHeight = { lineCount: Number(lineCountInput) };
       } else {
         rowHeightsOptions.defaultHeight = undefined;
       }
 
       setUserRowHeightsOptions(rowHeightsOptions);
     },
-    [lineCount]
+    [lineCountInput]
   );
   const setLineCountHeight = useCallback<
     NonNullable<EuiRangeProps['onChange']>
   >((event) => {
-    setLineCount(event.currentTarget.value);
+    setLineCountInput(event.currentTarget.value);
     const newLineCount = Number(event.currentTarget.value);
 
     // Don't let users set a 0 or negative line count
@@ -185,7 +185,7 @@ export const useDataGridDisplaySelector = (
   }, [rowHeightsOptions]);
 
   useEffect(() => {
-    setLineCount(
+    setLineCountInput(
       // @ts-ignore - optional chaining operator handles types & cases that aren't lineCount
       rowHeightsOptions?.defaultHeight?.lineCount || defaultLineCountValue
     );
@@ -359,7 +359,7 @@ export const useDataGridDisplaySelector = (
                       max={20}
                       step={1}
                       required
-                      value={lineCount}
+                      value={lineCountInput}
                       onChange={setLineCountHeight}
                       data-test-subj="lineCountNumber"
                     />

--- a/src/components/datagrid/controls/display_selector.tsx
+++ b/src/components/datagrid/controls/display_selector.tsx
@@ -87,6 +87,7 @@ const convertRowHeightsOptionsToSelection = (
   }
   return rowHeightButtonOptions[0];
 };
+const defaultLineCountValue = 2;
 
 export const useDataGridDisplaySelector = (
   showDisplaySelector: EuiDataGridToolBarVisibilityOptions['showDisplaySelector'],
@@ -125,7 +126,7 @@ export const useDataGridDisplaySelector = (
   }, []);
 
   // Row height logic
-  const [lineCount, setLineCount] = useState(2);
+  const [lineCount, setLineCount] = useState(defaultLineCountValue);
   const setRowHeight = useCallback(
     (option: string) => {
       const rowHeightsOptions: EuiDataGridRowHeightsOptions = {
@@ -182,8 +183,10 @@ export const useDataGridDisplaySelector = (
   }, [rowHeightsOptions]);
 
   useEffect(() => {
-    // @ts-ignore - optional chaining operator handles types & cases that aren't lineCount
-    setLineCount(rowHeightsOptions?.defaultHeight?.lineCount || 2);
+    setLineCount(
+      // @ts-ignore - optional chaining operator handles types & cases that aren't lineCount
+      rowHeightsOptions?.defaultHeight?.lineCount || defaultLineCountValue
+    );
     // @ts-ignore - same as above
   }, [rowHeightsOptions?.defaultHeight?.lineCount]);
 

--- a/upcoming_changelogs/7338.md
+++ b/upcoming_changelogs/7338.md
@@ -1,0 +1,1 @@
+- `EuiDataGrid`'s display settings popover now allows users to clear the "Lines per row" input before typing in a new number


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7336

The current EuiDataGrid lines per row number input doesn't allow users to clear it to empty before entering a new value.

![datagrid_linecount](https://github.com/elastic/eui/assets/549407/e1d9ae03-1a8b-4403-bfc8-f068816eb7b4)

I recommend [following along by commit](https://github.com/elastic/eui/pull/7338/commits), as I did some minor variable renaming while here.

## QA

- Go to https://eui.elastic.co/pr_7338/#/tabular-content/data-grid
- Click the display settings icon in the datagrid toolbar
- Click the "Custom" button
- [x] Confirm you can backspace to clear the Lines per row number input, and an invalid icon appears
- [x] Confirm you can set the Liners per Row number input to an invalid zero or negative number, and an invalid icon appears but the actual datagrid display does not change from its most recent valid setting

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A, not a consumer-facing API
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A
