### PR TITLE
[EuiSelectableTemplateSitewide] Fix React wrappers breaking `popoverButton` behavior

### DIFF
--- a/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
+++ b/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import {
-  EuiHeader,
-  EuiHeaderSectionItem,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -13,7 +11,6 @@ import {
   EuiSelectableTemplateSitewide,
   EuiSelectableTemplateSitewideOption,
   useEuiTheme,
-  EuiThemeProvider,
 } from '../../../../../src';
 
 export default () => {
@@ -93,61 +90,50 @@ export default () => {
   const { euiTheme } = useEuiTheme();
 
   return (
-    <EuiHeader theme="dark">
-      <EuiHeaderSectionItem>
-        <EuiSelectableTemplateSitewide
-          isLoading={isLoading}
-          onChange={onChange}
-          options={searchValueExists ? searchData : recentsWithIcon}
-          searchProps={{
-            append: '⌘K',
-            onKeyUpCapture: onKeyUpCapture,
-            className: 'customSearchClass',
-            inputRef: setSearchRef,
-          }}
-          listProps={{
-            className: 'customListClass',
-            css: css`
-              .euiSelectableTemplateSitewide__optionMeta--PINK {
-                font-weight: ${euiTheme.font.weight.medium};
-                color: ${euiTheme.colors.accentText};
-              }
-            `,
-          }}
-          popoverProps={{
-            className: 'customPopoverClass',
-          }}
-          popoverButton={
-            <EuiThemeProvider
-              colorMode="dark"
-              wrapperProps={{ cloneElement: true }}
-            >
-              <EuiButton color="text">Mobile toggle</EuiButton>
-            </EuiThemeProvider>
+    <EuiSelectableTemplateSitewide
+      isLoading={isLoading}
+      onChange={onChange}
+      options={searchValueExists ? searchData : recentsWithIcon}
+      searchProps={{
+        append: '⌘K',
+        onKeyUpCapture: onKeyUpCapture,
+        className: 'customSearchClass',
+        inputRef: setSearchRef,
+      }}
+      listProps={{
+        className: 'customListClass',
+        css: css`
+          .euiSelectableTemplateSitewide__optionMeta--PINK {
+            font-weight: ${euiTheme.font.weight.medium};
+            color: ${euiTheme.colors.accentText};
           }
-          popoverButtonBreakpoints={['xl']}
-          popoverFooter={
-            <EuiText color="subdued" size="xs">
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-                responsive={false}
-                wrap
-              >
-                <EuiFlexItem grow={false}>
-                  {searchValueExists && <EuiLink>View more results</EuiLink>}
-                </EuiFlexItem>
-                <EuiFlexItem />
-                <EuiFlexItem grow={false}>Quickly search using</EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiBadge>Command + K</EuiBadge>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiText>
-          }
-        />
-      </EuiHeaderSectionItem>
-    </EuiHeader>
+        `,
+      }}
+      popoverProps={{
+        className: 'customPopoverClass',
+      }}
+      popoverButton={<EuiButton>Mobile toggle</EuiButton>}
+      popoverButtonBreakpoints={['xs', 's']}
+      popoverFooter={
+        <EuiText color="subdued" size="xs">
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
+            responsive={false}
+            wrap
+          >
+            <EuiFlexItem grow={false}>
+              {searchValueExists && <EuiLink>View more results</EuiLink>}
+            </EuiFlexItem>
+            <EuiFlexItem />
+            <EuiFlexItem grow={false}>Quickly search using</EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiBadge>Command + K</EuiBadge>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiText>
+      }
+    />
   );
 };
 

--- a/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
+++ b/src-docs/src/views/selectable/selectable_templates/sitewide_search.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import {
+  EuiHeader,
+  EuiHeaderSectionItem,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -11,6 +13,7 @@ import {
   EuiSelectableTemplateSitewide,
   EuiSelectableTemplateSitewideOption,
   useEuiTheme,
+  EuiThemeProvider,
 } from '../../../../../src';
 
 export default () => {
@@ -90,50 +93,61 @@ export default () => {
   const { euiTheme } = useEuiTheme();
 
   return (
-    <EuiSelectableTemplateSitewide
-      isLoading={isLoading}
-      onChange={onChange}
-      options={searchValueExists ? searchData : recentsWithIcon}
-      searchProps={{
-        append: '⌘K',
-        onKeyUpCapture: onKeyUpCapture,
-        className: 'customSearchClass',
-        inputRef: setSearchRef,
-      }}
-      listProps={{
-        className: 'customListClass',
-        css: css`
-          .euiSelectableTemplateSitewide__optionMeta--PINK {
-            font-weight: ${euiTheme.font.weight.medium};
-            color: ${euiTheme.colors.accentText};
+    <EuiHeader theme="dark">
+      <EuiHeaderSectionItem>
+        <EuiSelectableTemplateSitewide
+          isLoading={isLoading}
+          onChange={onChange}
+          options={searchValueExists ? searchData : recentsWithIcon}
+          searchProps={{
+            append: '⌘K',
+            onKeyUpCapture: onKeyUpCapture,
+            className: 'customSearchClass',
+            inputRef: setSearchRef,
+          }}
+          listProps={{
+            className: 'customListClass',
+            css: css`
+              .euiSelectableTemplateSitewide__optionMeta--PINK {
+                font-weight: ${euiTheme.font.weight.medium};
+                color: ${euiTheme.colors.accentText};
+              }
+            `,
+          }}
+          popoverProps={{
+            className: 'customPopoverClass',
+          }}
+          popoverButton={
+            <EuiThemeProvider
+              colorMode="dark"
+              wrapperProps={{ cloneElement: true }}
+            >
+              <EuiButton color="text">Mobile toggle</EuiButton>
+            </EuiThemeProvider>
           }
-        `,
-      }}
-      popoverProps={{
-        className: 'customPopoverClass',
-      }}
-      popoverButton={<EuiButton>Mobile toggle</EuiButton>}
-      popoverButtonBreakpoints={['xs', 's']}
-      popoverFooter={
-        <EuiText color="subdued" size="xs">
-          <EuiFlexGroup
-            alignItems="center"
-            gutterSize="s"
-            responsive={false}
-            wrap
-          >
-            <EuiFlexItem grow={false}>
-              {searchValueExists && <EuiLink>View more results</EuiLink>}
-            </EuiFlexItem>
-            <EuiFlexItem />
-            <EuiFlexItem grow={false}>Quickly search using</EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiBadge>Command + K</EuiBadge>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiText>
-      }
-    />
+          popoverButtonBreakpoints={['xl']}
+          popoverFooter={
+            <EuiText color="subdued" size="xs">
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+                responsive={false}
+                wrap
+              >
+                <EuiFlexItem grow={false}>
+                  {searchValueExists && <EuiLink>View more results</EuiLink>}
+                </EuiFlexItem>
+                <EuiFlexItem />
+                <EuiFlexItem grow={false}>Quickly search using</EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge>Command + K</EuiBadge>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiText>
+          }
+        />
+      </EuiHeaderSectionItem>
+    </EuiHeader>
   );
 };
 

--- a/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
+++ b/src/components/selectable/selectable_templates/__snapshots__/selectable_template_sitewide.test.tsx.snap
@@ -51,56 +51,6 @@ exports[`EuiSelectableTemplateSitewide is rendered 1`] = `
 </div>
 `;
 
-exports[`EuiSelectableTemplateSitewide props popoverButton is not rendered with popoverButtonBreakpoints xs 1`] = `
-<div
-  class="euiSelectable euiSelectableTemplateSitewide"
->
-  <div
-    class="euiPopover emotion-euiPopover-block"
-  >
-    <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
-    >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
-      >
-        <div
-          class="euiFormControlLayoutIcons euiFormControlLayoutIcons--left euiFormControlLayoutIcons--absolute"
-        >
-          <span
-            class="euiFormControlLayoutCustomIcon"
-          >
-            <span
-              aria-hidden="true"
-              class="euiFormControlLayoutCustomIcon__icon"
-              data-euiicon-type="search"
-            />
-          </span>
-        </div>
-        <input
-          aria-activedescendant=""
-          aria-describedby="generated-id_instructions"
-          aria-haspopup="listbox"
-          aria-label="Filter options"
-          autocomplete="off"
-          class="euiFieldSearch euiFieldSearch--fullWidth euiSelectableSearch euiSelectableTemplateSitewide__search"
-          placeholder="Search for anything..."
-          type="search"
-          value=""
-        />
-      </div>
-    </div>
-    <p
-      class="emotion-euiScreenReaderOnly"
-      id="generated-id_instructions"
-    >
-       
-      Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.
-    </p>
-  </div>
-</div>
-`;
-
 exports[`EuiSelectableTemplateSitewide props popoverButton is rendered 1`] = `
 <div
   class="euiSelectable euiSelectableTemplateSitewide"
@@ -108,23 +58,15 @@ exports[`EuiSelectableTemplateSitewide props popoverButton is rendered 1`] = `
   <div
     class="euiPopover emotion-euiPopover-inline-block"
   >
-    <button>
-      Button
-    </button>
-  </div>
-</div>
-`;
-
-exports[`EuiSelectableTemplateSitewide props popoverButton is rendered with popoverButtonBreakpoints m 1`] = `
-<div
-  class="euiSelectable euiSelectableTemplateSitewide"
->
-  <div
-    class="euiPopover emotion-euiPopover-inline-block"
-  >
-    <button>
-      Button
-    </button>
+    <span
+      class="euiSelectableTemplateSitewide__popoverTrigger"
+    >
+      <button
+        data-test-subj="mobilePopoverButton"
+      >
+        Button
+      </button>
+    </span>
   </div>
 </div>
 `;

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -137,7 +137,7 @@ describe('EuiSelectableTemplateSitewide', () => {
         const { container } = render(
           <EuiSelectableTemplateSitewide
             options={options}
-            popoverButton={<button>Button</button>}
+            popoverButton={button}
           />
         );
 
@@ -145,27 +145,29 @@ describe('EuiSelectableTemplateSitewide', () => {
       });
 
       test('is rendered with popoverButtonBreakpoints m', () => {
-        const { container } = render(
+        const { getByTestSubject } = render(
           <EuiSelectableTemplateSitewide
             options={options}
-            popoverButton={<button>Button</button>}
+            popoverButton={button}
             popoverButtonBreakpoints={['xs', 's', 'm']}
           />
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(getByTestSubject('mobilePopoverButton')).toBeInTheDocument();
       });
 
       test('is not rendered with popoverButtonBreakpoints xs', () => {
-        const { container } = render(
+        const { queryByTestSubject } = render(
           <EuiSelectableTemplateSitewide
             options={options}
-            popoverButton={<button>Button</button>}
+            popoverButton={button}
             popoverButtonBreakpoints={['xs']}
           />
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(
+          queryByTestSubject('mobilePopoverButton')
+        ).not.toBeInTheDocument();
       });
 
       test('toggles the selectable popover for keyboard users', () => {

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.test.tsx
@@ -7,9 +7,11 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, waitForEuiPopoverOpen } from '../../../test/rtl';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 import { requiredProps } from '../../../test/required_props';
-import { render } from '../../../test/rtl';
 
 import { EuiSelectableTemplateSitewide } from './selectable_template_sitewide';
 import { EuiSelectableTemplateSitewideOption } from './selectable_template_sitewide_option';
@@ -127,6 +129,10 @@ describe('EuiSelectableTemplateSitewide', () => {
       beforeAll(() => (window.innerWidth = 670));
       afterAll(() => 1024); // reset to jsdom's default
 
+      const button = (
+        <button data-test-subj="mobilePopoverButton">Button</button>
+      );
+
       test('is rendered', () => {
         const { container } = render(
           <EuiSelectableTemplateSitewide
@@ -160,6 +166,34 @@ describe('EuiSelectableTemplateSitewide', () => {
         );
 
         expect(container.firstChild).toMatchSnapshot();
+      });
+
+      test('toggles the selectable popover for keyboard users', () => {
+        const { getByTestSubject } = render(
+          <EuiSelectableTemplateSitewide
+            options={options}
+            popoverButton={<div>{button}</div>}
+          />
+        );
+        // fireEvent doesn't seem to work: https://github.com/testing-library/user-event/issues/179#issuecomment-1125146667
+        getByTestSubject('mobilePopoverButton').focus();
+        userEvent.keyboard('{enter}');
+        waitForEuiPopoverOpen();
+
+        expect(getByTestSubject('euiSelectableList')).toBeInTheDocument();
+      });
+
+      test('toggles the selectable popover even when a wrapper exists around the button', () => {
+        const { getByTestSubject } = render(
+          <EuiSelectableTemplateSitewide
+            options={options}
+            popoverButton={<>{button}</>}
+          />
+        );
+        fireEvent.click(getByTestSubject('mobilePopoverButton'));
+        waitForEuiPopoverOpen();
+
+        expect(getByTestSubject('euiSelectableList')).toBeInTheDocument();
       });
     });
   });

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -11,6 +11,7 @@ import React, {
   ReactNode,
   useState,
   useMemo,
+  useCallback,
   CSSProperties,
   ReactElement,
 } from 'react';
@@ -106,9 +107,9 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<
     _closePopover && _closePopover();
   };
 
-  const togglePopover = () => {
-    setPopoverIsOpen(!popoverIsOpen);
-  };
+  const togglePopover = useCallback(() => {
+    setPopoverIsOpen((isOpen) => !isOpen);
+  }, []);
 
   // Width applied to the internal div
   const popoverWidth: CSSProperties['width'] = width || 600;
@@ -195,9 +196,9 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<
     return popoverButtonBreakpoints.includes(currentBreakpoint);
   }, [currentBreakpoint, popoverButtonBreakpoints]);
 
-  let popoverTrigger: ReactElement;
-  if (popoverButton && canShowPopoverButton) {
-    popoverTrigger = (
+  const popoverTrigger = useMemo(() => {
+    if (!popoverButton || !canShowPopoverButton) return;
+    return (
       <span
         className="euiSelectableTemplateSitewide__popoverTrigger"
         onClick={togglePopover}
@@ -206,7 +207,7 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<
         {popoverButton}
       </span>
     );
-  }
+  }, [popoverButton, canShowPopoverButton, togglePopover]);
 
   return (
     <EuiSelectable

--- a/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -197,14 +197,15 @@ export const EuiSelectableTemplateSitewide: FunctionComponent<
 
   let popoverTrigger: ReactElement;
   if (popoverButton && canShowPopoverButton) {
-    popoverTrigger = React.cloneElement(popoverButton, {
-      ...popoverButton.props,
-      onClick: togglePopover,
-      onKeyDown: (e: KeyboardEvent) => {
-        // Selectable preventsDefault on Enter which kills browser controls for pressing the button
-        e.stopPropagation();
-      },
-    });
+    popoverTrigger = (
+      <span
+        className="euiSelectableTemplateSitewide__popoverTrigger"
+        onClick={togglePopover}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        {popoverButton}
+      </span>
+    );
   }
 
   return (

--- a/upcoming_changelogs/7339.md
+++ b/upcoming_changelogs/7339.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiSelectableTemplateSitewide` bug where the `popoverButton` behavior would break if passed a non-DOM React wrapper


### PR DESCRIPTION
## Summary

The Support Portal folks (CC @pickypg) have a selectable sitewide search button in an always-dark `EuiHeader`, and they need to be able to wrap an `<EuiThemeProvider colorMode="dark">` to replace the now removed `color="ghost"` prop (#7296).

But it turns out because the sitewide component was using `React.cloneElement`, this would break the popover toggle behavior. This PR fixes that bug by always wrapping the mobile popover toggle in a span wrapper that has the desired click/keyboard events set.

| Before (clicking does nothing) | After |
|--------|--------|
| ![sitewide_before](https://github.com/elastic/eui/assets/549407/086f67ad-f19c-483c-8161-5866f20e0db1) | ![sitewide_after](https://github.com/elastic/eui/assets/549407/50b75f36-329b-4524-893c-287e2eb9b6cc) | 

## QA

- Go to https://eui.elastic.co/pr_7339/#/templates/sitewide-search, scroll down to "Popover toggle and responsiveness"
- [x] Confirm that the button is correctly in dark mode (matching the header), but the selectable popover itself matches the rest of the page
- [x] Confirm that clicking the button toggles the popover
- [x] Confirm that tabbing and pressing keyboard enter/space on the button toggles the popover

### General checklist

- [x] Revert [REVERT ME] commit
- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A