### PR TITLE
feat: TypeScript v5 prep work

### DIFF
--- a/changelogs/upcoming/7340.md
+++ b/changelogs/upcoming/7340.md
@@ -1,0 +1,2 @@
+- Updated generic types of `EuiBasicTable`, `EuiInMemoryTable` and `EuiSearchBar.Query.execute` to add `extends object` constraint
+  - This change should have no impact on your applications since the updated types only affect properties that exclusively accept object values.

--- a/src-docs/src/views/theme/color/_contrast_js.tsx
+++ b/src-docs/src/views/theme/color/_contrast_js.tsx
@@ -23,7 +23,7 @@ const textVariants = [...brandTextKeys, ...textColors];
 type ColorSection = {
   color: keyof _EuiThemeColorsMode;
   colorValue?: string;
-  minimumContrast: string | number;
+  minimumContrast: number;
   showTextVariants: boolean;
   matchPanelColor?: boolean;
   hookName?: string;
@@ -88,7 +88,7 @@ export const ColorSectionJS: FunctionComponent<ColorSection> = ({
 type ColorsContrastItem = {
   foreground: string;
   background: string;
-  minimumContrast: string | number;
+  minimumContrast: number;
   styleString?: string;
 };
 

--- a/src-docs/src/views/theme/color/_contrast_sass.tsx
+++ b/src-docs/src/views/theme/color/_contrast_sass.tsx
@@ -57,7 +57,7 @@ import { getContrastRatings } from './_contrast_utilities';
 
 type ColorSection = {
   color: string;
-  minimumContrast: string | number;
+  minimumContrast: number;
   showTextVariants: boolean;
   matchPanelColor?: boolean;
 };
@@ -114,7 +114,7 @@ export const ColorSectionSass: FunctionComponent<ColorSection> = ({
 type ColorsContrastItem = {
   foreground: string;
   background: string;
-  minimumContrast: string | number;
+  minimumContrast: number;
 };
 
 const ColorsContrastItem: FunctionComponent<ColorsContrastItem> = ({

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -12,11 +12,11 @@ import { EuiButtonIconProps } from '../button/button_icon/button_icon';
 import { EuiButtonEmptyProps } from '../button/button_empty';
 import { ExclusiveUnion } from '../common';
 
-type IconFunction<T> = (item: T) => EuiIconType;
+type IconFunction<T extends object> = (item: T) => EuiIconType;
 type ButtonColor = EuiButtonIconProps['color'] | EuiButtonEmptyProps['color'];
 type EuiButtonIconColorFunction<T> = (item: T) => ButtonColor;
 
-export interface DefaultItemActionBase<T> {
+export interface DefaultItemActionBase<T extends object> {
   /**
    * The display name of the action (will render as visible text if rendered within a collapsed menu)
    */
@@ -43,7 +43,7 @@ export interface DefaultItemActionBase<T> {
   'data-test-subj'?: string | ((item: T) => string);
 }
 
-export interface DefaultItemEmptyButtonAction<T>
+export interface DefaultItemEmptyButtonAction<T extends object>
   extends DefaultItemActionBase<T> {
   /**
    * The type of action
@@ -52,7 +52,7 @@ export interface DefaultItemEmptyButtonAction<T>
   color?: EuiButtonEmptyProps['color'] | EuiButtonIconColorFunction<T>;
 }
 
-export interface DefaultItemIconButtonAction<T>
+export interface DefaultItemIconButtonAction<T extends object>
   extends DefaultItemActionBase<T> {
   type: 'icon';
   /**
@@ -65,7 +65,7 @@ export interface DefaultItemIconButtonAction<T>
   color?: EuiButtonIconProps['color'] | EuiButtonIconColorFunction<T>;
 }
 
-export type DefaultItemAction<T> = ExclusiveUnion<
+export type DefaultItemAction<T extends object> = ExclusiveUnion<
   DefaultItemEmptyButtonAction<T>,
   DefaultItemIconButtonAction<T>
 >;
@@ -86,7 +86,9 @@ export interface CustomItemAction<T> {
   isPrimary?: boolean;
 }
 
-export type Action<T> = DefaultItemAction<T> | CustomItemAction<T>;
+export type Action<T extends object> =
+  | DefaultItemAction<T>
+  | CustomItemAction<T>;
 
 export const isCustomItemAction = <T>(
   action: DefaultItemAction<T> | CustomItemAction<T>

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -90,7 +90,7 @@ export type Action<T extends object> =
   | DefaultItemAction<T>
   | CustomItemAction<T>;
 
-export const isCustomItemAction = <T>(
+export const isCustomItemAction = <T extends object>(
   action: DefaultItemAction<T> | CustomItemAction<T>
 ): action is CustomItemAction<T> => {
   return action.hasOwnProperty('render');

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -630,9 +630,9 @@ export class EuiBasicTable<T = any> extends Component<
 
       items.push({
         name: column.name,
-        key: `_data_s_${
+        key: `_data_s_${String(
           (column as EuiTableFieldDataColumnType<T>).field
-        }_${index}`,
+        )}_${index}`,
         onSort: this.resolveColumnOnSort(column),
         isSorted: !!sortDirection,
         isSortAscending: sortDirection
@@ -854,11 +854,11 @@ export class EuiBasicTable<T = any> extends Component<
       }
       headers.push(
         <EuiTableHeaderCell
-          key={`_data_h_${field}_${index}`}
+          key={`_data_h_${String(field)}_${index}`}
           align={columnAlign}
           width={width}
           mobileOptions={mobileOptions}
-          data-test-subj={`tableHeaderCell_${field}_${index}`}
+          data-test-subj={`tableHeaderCell_${String(field)}_${index}`}
           description={description}
           {...sorting}
         >
@@ -897,7 +897,7 @@ export class EuiBasicTable<T = any> extends Component<
       if (footer) {
         footers.push(
           <EuiTableFooterCell
-            key={`footer_${field}_${footers.length - 1}`}
+            key={`footer_${String(field)}_${footers.length - 1}`}
             align={align}
           >
             {footer}
@@ -1219,7 +1219,7 @@ export class EuiBasicTable<T = any> extends Component<
   ) {
     const { field, render, dataType } = column;
 
-    const key = `_data_column_${field}_${itemId}_${columnIndex}`;
+    const key = `_data_column_${String(field)}_${itemId}_${columnIndex}`;
     const contentRenderer = render || this.getRendererForDataType(dataType);
     const value = get(item, field as string);
     const content = contentRenderer(value, item);

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -139,7 +139,7 @@ function getRowProps<T>(item: T, rowProps: RowPropsCallback<T>) {
   return {};
 }
 
-function getCellProps<T>(
+function getCellProps<T extends object>(
   item: T,
   column: EuiBasicTableColumn<T>,
   cellProps: CellPropsCallback<T>
@@ -154,7 +154,7 @@ function getCellProps<T>(
   return {};
 }
 
-function getColumnFooter<T>(
+function getColumnFooter<T extends object>(
   column: EuiBasicTableColumn<T>,
   { items, pagination }: EuiTableFooterProps<T>
 ) {
@@ -169,7 +169,7 @@ function getColumnFooter<T>(
   return undefined;
 }
 
-export type EuiBasicTableColumn<T> =
+export type EuiBasicTableColumn<T extends object> =
   | EuiTableFieldDataColumnType<T>
   | EuiTableComputedColumnType<T>
   | EuiTableActionsColumnType<T>;
@@ -201,10 +201,14 @@ export interface CriteriaWithPagination<T> extends Criteria<T> {
   };
 }
 
-type CellPropsCallback<T> = (item: T, column: EuiBasicTableColumn<T>) => object;
+type CellPropsCallback<T extends object> = (
+  item: T,
+  column: EuiBasicTableColumn<T>
+) => object;
 type RowPropsCallback<T> = (item: T) => object;
 
-interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
+interface BasicTableProps<T extends object>
+  extends Omit<EuiTableProps, 'onChange'> {
   /**
    * Describes how to extract a unique ID from each item, used for selections & expanded rows
    */
@@ -285,7 +289,7 @@ interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
   textOnly?: boolean;
 }
 
-type BasicTableWithPaginationProps<T> = Omit<
+type BasicTableWithPaginationProps<T extends object> = Omit<
   BasicTableProps<T>,
   'pagination' | 'onChange'
 > & {
@@ -293,7 +297,7 @@ type BasicTableWithPaginationProps<T> = Omit<
   onChange?: (criteria: CriteriaWithPagination<T>) => void;
 };
 
-export type EuiBasicTableProps<T> = CommonProps &
+export type EuiBasicTableProps<T extends object> = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> &
   (BasicTableProps<T> | BasicTableWithPaginationProps<T>);
 
@@ -310,13 +314,13 @@ interface SortOptions {
   readOnly?: boolean;
 }
 
-function hasPagination<T>(
+function hasPagination<T extends object>(
   x: EuiBasicTableProps<T>
 ): x is BasicTableWithPaginationProps<T> {
   return x.hasOwnProperty('pagination') && !!x.pagination;
 }
 
-export class EuiBasicTable<T = any> extends Component<
+export class EuiBasicTable<T extends object = any> extends Component<
   EuiBasicTableProps<T>,
   State<T>
 > {
@@ -331,7 +335,7 @@ export class EuiBasicTable<T = any> extends Component<
     ),
   };
 
-  static getDerivedStateFromProps<T>(
+  static getDerivedStateFromProps<T extends object>(
     nextProps: EuiBasicTableProps<T>,
     prevState: State<T>
   ) {

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -29,7 +29,7 @@ import {
 } from './action_types';
 import { ItemIdResolved } from './table_types';
 
-export interface CollapsedItemActionsProps<T extends {}> {
+export interface CollapsedItemActionsProps<T extends object> {
   actions: Array<Action<T>>;
   item: T;
   itemId: ItemIdResolved;

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -31,7 +31,7 @@ export interface DefaultItemActionProps<T extends object> {
   className?: string;
 }
 
-export const DefaultItemAction = <T,>({
+export const DefaultItemAction = <T extends object>({
   action,
   enabled,
   item,

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -24,7 +24,7 @@ import {
   callWithItemIfFunction,
 } from './action_types';
 
-export interface DefaultItemActionProps<T> {
+export interface DefaultItemActionProps<T extends object> {
   action: Action<T>;
   enabled: boolean;
   item: T;

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -18,7 +18,7 @@ import {
 } from './action_types';
 import { ItemIdResolved } from './table_types';
 
-export interface ExpandedItemActionsProps<T> {
+export interface ExpandedItemActionsProps<T extends object> {
   actions: Array<Action<T>>;
   itemId: ItemIdResolved;
   item: T;

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -47,7 +47,7 @@ interface onChangeArgument {
   error: Error | null;
 }
 
-function isEuiSearchBarProps<T>(
+function isEuiSearchBarProps<T extends object>(
   x: EuiInMemoryTableProps<T>['search']
 ): x is EuiSearchBarProps {
   return typeof x !== 'boolean';
@@ -71,7 +71,7 @@ interface SortingOptions {
 
 type Sorting = boolean | SortingOptions;
 
-type InMemoryTableProps<T> = Omit<
+type InMemoryTableProps<T extends object> = Omit<
   EuiBasicTableProps<T>,
   'pagination' | 'sorting' | 'noItemsMessage' | 'onChange'
 > & {
@@ -130,7 +130,7 @@ type InMemoryTableProps<T> = Omit<
   childrenBetween?: ReactNode;
 };
 
-type InMemoryTablePropsWithPagination<T> = Omit<
+type InMemoryTablePropsWithPagination<T extends object> = Omit<
   InMemoryTableProps<T>,
   'pagination' | 'onTableChange'
 > & {
@@ -138,10 +138,10 @@ type InMemoryTablePropsWithPagination<T> = Omit<
   onTableChange?: (nextValues: CriteriaWithPagination<T>) => void;
 };
 
-export type EuiInMemoryTableProps<T> = CommonProps &
+export type EuiInMemoryTableProps<T extends object = object> = CommonProps &
   (InMemoryTableProps<T> | InMemoryTablePropsWithPagination<T>);
 
-interface State<T> {
+interface State<T extends object> {
   prevProps: {
     items: T[];
     sortName: ReactNode;
@@ -230,7 +230,7 @@ const getInitialPagination = (
   };
 };
 
-function findColumnByProp<T>(
+function findColumnByProp<T extends object>(
   columns: Array<EuiBasicTableColumn<T>>,
   prop: 'field' | 'name',
   value: string | ReactNode
@@ -247,7 +247,7 @@ function findColumnByProp<T>(
   }
 }
 
-function findColumnByFieldOrName<T>(
+function findColumnByFieldOrName<T extends object>(
   columns: Array<EuiBasicTableColumn<T>>,
   value: string | ReactNode
 ) {
@@ -260,7 +260,7 @@ function findColumnByFieldOrName<T>(
   return column;
 }
 
-function getInitialSorting<T>(
+function getInitialSorting<T extends object>(
   columns: Array<EuiBasicTableColumn<T>>,
   sorting: Sorting | undefined
 ) {
@@ -292,7 +292,7 @@ function getInitialSorting<T>(
   };
 }
 
-export class EuiInMemoryTable<T> extends Component<
+export class EuiInMemoryTable<T extends object = object> extends Component<
   EuiInMemoryTableProps<T>,
   State<T>
 > {
@@ -305,7 +305,7 @@ export class EuiInMemoryTable<T> extends Component<
   };
   tableRef: React.RefObject<EuiBasicTable>;
 
-  static getDerivedStateFromProps<T>(
+  static getDerivedStateFromProps<T extends object>(
     nextProps: EuiInMemoryTableProps<T>,
     prevState: State<T>
   ) {

--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -132,7 +132,7 @@ export interface EuiTableComputedColumnType<T>
   readOnly?: boolean;
 }
 
-export interface EuiTableActionsColumnType<T> {
+export interface EuiTableActionsColumnType<T extends object> {
   /**
    * An array of one of the objects: #DefaultItemAction or #CustomItemAction
    */

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -46,7 +46,7 @@ export type OneOf<T, K extends keyof T> = Omit<T, K> &
 /**
  * Wraps Object.keys with proper typescript definition of the resulting array
  */
-export function keysOf<T, K extends keyof T>(obj: T): K[] {
+export function keysOf<T extends object, K extends keyof T>(obj: T): K[] {
   return Object.keys(obj) as K[];
 }
 

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -377,30 +377,31 @@ export const EuiMarkdownEditor = forwardRef<
     }, [setEditorToolbarHeight]);
 
     useEffect(() => {
-      if (isPreviewing && autoExpandPreview && height !== 'full') {
-        if (
-          currentHeight !== 'full' &&
-          previewRef.current!.scrollHeight > currentHeight
-        ) {
-          // scrollHeight does not include the border or margin
-          // so we ask for the computed value for those,
-          // which is always in pixels because getComputedValue
-          // returns the resolved values
-          const elementComputedStyle = window.getComputedStyle(
-            previewRef.current!
-          );
-          const borderWidth =
-            parseFloat(elementComputedStyle.borderTopWidth) +
-            parseFloat(elementComputedStyle.borderBottomWidth);
-          const marginWidth =
-            parseFloat(elementComputedStyle.marginTop) +
-            parseFloat(elementComputedStyle.marginBottom);
+      if (height === 'full' || currentHeight === 'full') return;
 
-          // then add an extra pixel for safety and because the scrollHeight value is rounded
-          const extraHeight = borderWidth + marginWidth + 1;
+      if (
+        isPreviewing &&
+        autoExpandPreview &&
+        previewRef.current!.scrollHeight > currentHeight
+      ) {
+        // scrollHeight does not include the border or margin
+        // so we ask for the computed value for those,
+        // which is always in pixels because getComputedValue
+        // returns the resolved values
+        const elementComputedStyle = window.getComputedStyle(
+          previewRef.current!
+        );
+        const borderWidth =
+          parseFloat(elementComputedStyle.borderTopWidth) +
+          parseFloat(elementComputedStyle.borderBottomWidth);
+        const marginWidth =
+          parseFloat(elementComputedStyle.marginTop) +
+          parseFloat(elementComputedStyle.marginBottom);
 
-          setCurrentHeight(previewRef.current!.scrollHeight + extraHeight);
-        }
+        // then add an extra pixel for safety and because the scrollHeight value is rounded
+        const extraHeight = borderWidth + marginWidth + 1;
+
+        setCurrentHeight(previewRef.current!.scrollHeight + extraHeight);
       }
     }, [currentHeight, isPreviewing, height, autoExpandPreview]);
 

--- a/src/components/markdown_editor/markdown_editor.tsx
+++ b/src/components/markdown_editor/markdown_editor.tsx
@@ -378,7 +378,10 @@ export const EuiMarkdownEditor = forwardRef<
 
     useEffect(() => {
       if (isPreviewing && autoExpandPreview && height !== 'full') {
-        if (previewRef.current!.scrollHeight > currentHeight) {
+        if (
+          currentHeight !== 'full' &&
+          previewRef.current!.scrollHeight > currentHeight
+        ) {
           // scrollHeight does not include the border or margin
           // so we ask for the computed value for those,
           // which is always in pixels because getComputedValue

--- a/src/components/page_template/bottom_bar/page_bottom_bar.tsx
+++ b/src/components/page_template/bottom_bar/page_bottom_bar.tsx
@@ -58,8 +58,8 @@ export const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = ({
         overflow: hidden;
         flex-shrink: 0;
       `}
-      // Using unknown here because of the possible conflict with overriding props and position `sticky`
-      {...(rest as unknown)}
+      // Using object here because of the possible conflict with overriding props and position `sticky`
+      {...(rest as object)}
     >
       {/* Wrapping the contents with EuiPageContentBody allows us to match the restrictWidth to keep the contents aligned */}
       <EuiPageSection paddingSize={paddingSize} restrictWidth={restrictWidth}>

--- a/src/components/search_bar/query/date_format.ts
+++ b/src/components/search_bar/query/date_format.ts
@@ -37,7 +37,7 @@ interface GranularitiesType {
   YEAR: GranularityType;
 }
 
-export const Granularity: GranularitiesType = Object.freeze({
+export const Granularity = Object.freeze<GranularitiesType>({
   DAY: {
     es: 'd',
     js: 'day',

--- a/src/components/search_bar/query/execute_ast.ts
+++ b/src/components/search_bar/query/execute_ast.ts
@@ -50,7 +50,7 @@ interface Explain {
   operator?: any; // It's not really worth specifying this at the moment
 }
 
-const defaultIsClauseMatcher = <T>(
+const defaultIsClauseMatcher = <T extends object>(
   item: T,
   clause: IsClause,
   explain?: Explain[]
@@ -65,7 +65,7 @@ const defaultIsClauseMatcher = <T>(
   return hit;
 };
 
-const fieldClauseMatcher = <T>(
+const fieldClauseMatcher = <T extends object>(
   item: T,
   field: string,
   clauses: FieldClause[] = [],
@@ -104,7 +104,7 @@ const extractStringFieldsFromItem = (item: any) => {
   }, [] as string[]);
 };
 
-const termClauseMatcher = <T>(
+const termClauseMatcher = <T extends object>(
   item: T,
   fields: string[] | undefined,
   clauses: TermClause[] = [],
@@ -215,7 +215,7 @@ interface Options {
   explain?: boolean;
 }
 
-export function executeAst<T>(
+export function executeAst<T extends object>(
   ast: _AST,
   items: T[],
   options: Options = {}

--- a/src/components/search_bar/query/query.ts
+++ b/src/components/search_bar/query/query.ts
@@ -171,7 +171,11 @@ export class Query {
    *    information about why the objects matched the query (default to `false`, mainly/only useful for
    *    debugging)
    */
-  static execute<T>(query: string | Query, items: T[], options = {}): T[] {
+  static execute<T extends object>(
+    query: string | Query,
+    items: T[],
+    options = {}
+  ): T[] {
     const q = isString(query) ? Query.parse(query) : query;
     return executeAst(q.ast, items, options);
   }

--- a/src/components/selectable/selectable_list/selectable_list_item.tsx
+++ b/src/components/selectable/selectable_list/selectable_list_item.tsx
@@ -300,7 +300,7 @@ export class EuiSelectableListItem extends Component<EuiSelectableListItemProps>
             {...defaultOnFocusBadgeProps}
           />
         );
-      } else if (!!onFocusBadge && onFocusBadge !== false) {
+      } else if (typeof onFocusBadge !== 'boolean' && !!onFocusBadge) {
         const { children, className, ...restBadgeProps } = onFocusBadge;
         onFocusBadgeNode = (
           <EuiBadge

--- a/src/components/side_nav/side_nav.tsx
+++ b/src/components/side_nav/side_nav.tsx
@@ -9,7 +9,7 @@
 import React, { Component, ReactNode, MouseEventHandler } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps } from '../common';
+import { CommonProps, PropsOf } from '../common';
 
 import { EuiSideNavItem, RenderItem } from './side_nav_item';
 import { EuiSideNavItemType } from './side_nav_types';
@@ -146,7 +146,9 @@ export class EuiSideNav<T> extends Component<EuiSideNavProps<T>> {
           items={renderedItems}
           key={id}
           depth={depth}
-          renderItem={renderItem}
+          renderItem={
+            renderItem as PropsOf<typeof EuiSideNavItem>['renderItem']
+          }
           truncate={truncate}
           childrenOnly={childrenOnly}
           {...rest}

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -183,12 +183,13 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
       if (textOnly === true) {
         modifiedChildren = <span className={childClasses}>{children}</span>;
       } else if (React.isValidElement(children)) {
-        modifiedChildren = React.Children.map(
-          children,
-          (child: ReactElement<CommonProps>) =>
-            React.cloneElement(child, {
-              className: classNames(child.props.className, childClasses),
-            })
+        modifiedChildren = React.Children.map(children, (child: ReactElement) =>
+          React.cloneElement(child, {
+            className: classNames(
+              (child.props as CommonProps).className,
+              childClasses
+            ),
+          })
         );
       }
       if (isObject(truncateText) && truncateText.lines) {

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -119,24 +119,32 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
   static contextType = EuiTreeViewContext;
   declare context: ContextType<typeof EuiTreeViewContext>;
 
-  isNested: boolean = !!this.context;
+  isNested: boolean;
 
-  state: EuiTreeViewState = {
-    openItems: this.props.expandByDefault
-      ? this.props.items
-          .map<string>(({ id, children }) =>
-            children ? id : (null as unknown as string)
-          )
-          .filter((x) => x != null)
-      : this.props.items
-          .map<string>(({ id, children, isExpanded }) =>
-            children && isExpanded ? id : (null as unknown as string)
-          )
-          .filter((x) => x != null),
-    activeItem: '',
-    treeID: getTreeId(this.props.id, this.context, this.treeIdGenerator),
-    expandChildNodes: this.props.expandByDefault || false,
-  };
+  constructor(
+    props: EuiTreeViewProps,
+    context: ContextType<typeof EuiTreeViewContext>
+  ) {
+    super(props, context);
+
+    this.isNested = !!this.context;
+    this.state = {
+      openItems: this.props.expandByDefault
+        ? this.props.items
+            .map<string>(({ id, children }) =>
+              children ? id : (null as unknown as string)
+            )
+            .filter((x) => x != null)
+        : this.props.items
+            .map<string>(({ id, children, isExpanded }) =>
+              children && isExpanded ? id : (null as unknown as string)
+            )
+            .filter((x) => x != null),
+      activeItem: '',
+      treeID: getTreeId(this.props.id, context, this.treeIdGenerator),
+      expandChildNodes: this.props.expandByDefault || false,
+    };
+  }
 
   componentDidUpdate(prevProps: EuiTreeViewProps) {
     if (this.props.id !== prevProps.id) {

--- a/src/services/sort/comparators.ts
+++ b/src/services/sort/comparators.ts
@@ -68,7 +68,10 @@ export const Comparators = Object.freeze({
     };
   },
 
-  property<T>(prop: string, comparator?: Comparator): Comparator<T> {
+  property<T extends object>(
+    prop: string,
+    comparator?: Comparator
+  ): Comparator<T> {
     return this.value((value) => get(value, prop), comparator);
   },
 });

--- a/src/utils/prop_types/is.ts
+++ b/src/utils/prop_types/is.ts
@@ -13,9 +13,7 @@ export const is = <T>(expectedValue: any) => {
     const compName = componentName || 'ANONYMOUS';
     const value = props[propName];
     if (value !== expectedValue) {
-      return new Error(`[${String(
-        propName
-      )}] property in [${compName}] component is expected to equal [${expectedValue}] but
+      return new Error(`[${propName.toString()}] property in [${compName}] component is expected to equal [${expectedValue}] but
          [${value}] was provided instead.`);
     }
     return null;
@@ -30,9 +28,7 @@ export const is = <T>(expectedValue: any) => {
     const value = props[propName];
     if (isNil(value)) {
       return new Error(
-        `[${String(
-          propName
-        )}] property in [${compName}] component is required but seems to be missing`
+        `[${propName.toString()}] property in [${compName}] component is required but seems to be missing`
       );
     }
     return validator(props, propName, componentName);

--- a/src/utils/prop_types/is.ts
+++ b/src/utils/prop_types/is.ts
@@ -13,7 +13,9 @@ export const is = <T>(expectedValue: any) => {
     const compName = componentName || 'ANONYMOUS';
     const value = props[propName];
     if (value !== expectedValue) {
-      return new Error(`[${propName}] property in [${compName}] component is expected to equal [${expectedValue}] but
+      return new Error(`[${String(
+        propName
+      )}] property in [${compName}] component is expected to equal [${expectedValue}] but
          [${value}] was provided instead.`);
     }
     return null;
@@ -28,7 +30,9 @@ export const is = <T>(expectedValue: any) => {
     const value = props[propName];
     if (isNil(value)) {
       return new Error(
-        `[${propName}] property in [${compName}] component is required but seems to be missing`
+        `[${String(
+          propName
+        )}] property in [${compName}] component is required but seems to be missing`
       );
     }
     return validator(props, propName, componentName);


### PR DESCRIPTION
## Summary

This PR adds the code changes needed for TypeScript v5 to work with EUI and not report any type errors.

I'm not upgrading to `typescript` version 5 here. It requires additional work to get `prop-loader.js` updated to use the new compiler API and will be added in a separate PR.

## QA

- [ ] Build this branch locally and use it in a local kibana instance to ensure there are no type errors there

### General checklist

- Docs site QA
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
