### PR TITLE
[EuiSuperDatePicker] Improve `Absolute` tab input UX further

### DIFF
--- a/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_absolute_tab.scss
@@ -1,3 +1,24 @@
 .euiSuperDatePicker__absoluteDateFormRow {
   padding: 0 $euiSizeS $euiSizeS;
+
+  /* A bit of a visual trickery to make the format "hint" become an "error" text.
+     NOTE: Normally reordering visually (vs DOM) isn't super great for screen reader users,
+     but as the help text is already read out via `aria-describedby`, and the error text
+     is read out immediately via `aria-live`, we can fairly safely prioritize visuals instead */
+  .euiFormRow__fieldWrapper {
+    display: flex;
+    flex-direction: column;
+  };
+
+  .euiFormControlLayout {
+    order: 0;
+  }
+
+  .euiFormHelpText {
+    order: 1;
+  }
+
+  .euiFormErrorText {
+    order: 2;
+  }
 }

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { act, fireEvent } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../../test/rtl';
 
 import { EuiAbsoluteTab } from './absolute_tab';
@@ -29,14 +29,9 @@ describe('EuiAbsoluteTab', () => {
   };
 
   describe('user input', () => {
-    beforeAll(() => jest.useFakeTimers());
-    afterAll(() => jest.useRealTimers());
-
     const changeInput = (input: HTMLElement, value: string) => {
       fireEvent.change(input, { target: { value } });
-      act(() => {
-        jest.advanceTimersByTime(1000); // Debounce timer
-      });
+      fireEvent.keyDown(input, { key: 'Enter' });
     };
 
     it('parses the passed `dateFormat` prop', () => {

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
@@ -41,6 +41,21 @@ describe('EuiAbsoluteTab', () => {
 
       expect(queryByText(helpText)).toBeInTheDocument();
     });
+
+    it('displays the formats as a hint before parse, but as an error if invalid', () => {
+      const { getByTestSubject, queryByText } = render(
+        <EuiAbsoluteTab {...props} />
+      );
+      const formatHelpText = /Allowed formats: /;
+      expect(queryByText(formatHelpText)).not.toBeInTheDocument();
+
+      const input = getByTestSubject('superDatePickerAbsoluteDateInput');
+      fireEvent.change(input, { target: { value: 'test' } });
+      expect(queryByText(formatHelpText)).toHaveClass('euiFormHelpText');
+
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(queryByText(formatHelpText)).toHaveClass('euiFormErrorText');
+    });
   });
 
   describe('date parsing', () => {

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
@@ -56,6 +56,30 @@ describe('EuiAbsoluteTab', () => {
       fireEvent.keyDown(input, { key: 'Enter' });
       expect(queryByText(formatHelpText)).toHaveClass('euiFormErrorText');
     });
+
+    it('immediately parses pasted text without needing an extra enter keypress', () => {
+      const { getByTestSubject, queryByText } = render(
+        <EuiAbsoluteTab {...props} />
+      );
+      const input = getByTestSubject(
+        'superDatePickerAbsoluteDateInput'
+      ) as HTMLInputElement;
+
+      fireEvent.paste(input, {
+        clipboardData: { getData: () => '1970-01-01' },
+      });
+      expect(input).not.toBeInvalid();
+      expect(input.value).toContain('Jan 1, 1970');
+
+      input.value = '';
+      fireEvent.paste(input, {
+        clipboardData: { getData: () => 'not a date' },
+      });
+      expect(input).toBeInvalid();
+
+      expect(queryByText(/Allowed formats: /)).toBeInTheDocument();
+      expect(queryByText(/Press the Enter key /)).not.toBeInTheDocument();
+    });
   });
 
   describe('date parsing', () => {

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
@@ -29,6 +29,21 @@ describe('EuiAbsoluteTab', () => {
   };
 
   describe('user input', () => {
+    it('displays the enter key help text when the input has been edited and the date has not yet been parsed', () => {
+      const { getByTestSubject, queryByText } = render(
+        <EuiAbsoluteTab {...props} />
+      );
+      const helpText = 'Press the Enter key to parse as a date.';
+      expect(queryByText(helpText)).not.toBeInTheDocument();
+
+      const input = getByTestSubject('superDatePickerAbsoluteDateInput');
+      fireEvent.change(input, { target: { value: 'test' } });
+
+      expect(queryByText(helpText)).toBeInTheDocument();
+    });
+  });
+
+  describe('date parsing', () => {
     const changeInput = (input: HTMLElement, value: string) => {
       fireEvent.change(input, { target: { value } });
       fireEvent.keyDown(input, { key: 'Enter' });

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
@@ -18,6 +18,12 @@ jest.mock('../../date_picker', () => ({
 }));
 
 describe('EuiAbsoluteTab', () => {
+  // mock requestAnimationFrame to fire immediately
+  const rafSpy = jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb: Function) => cb());
+  afterAll(() => rafSpy.mockRestore());
+
   const props = {
     dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS',
     timeFormat: 'HH:mm',

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
@@ -153,19 +153,24 @@ export class EuiAbsoluteTab extends Component<
           utcOffset={utcOffset}
         />
         <EuiI18n
-          token="euiAbsoluteTab.dateFormatError"
-          default="Allowed formats: {dateFormat}, ISO 8601, RFC 2822, or Unix timestamp"
+          tokens={[
+            'euiAbsoluteTab.dateFormatHint',
+            'euiAbsoluteTab.dateFormatError',
+          ]}
+          defaults={[
+            'Press the Enter key to parse as a date.',
+            'Allowed formats: {dateFormat}, ISO 8601, RFC 2822, or Unix timestamp.',
+          ]}
           values={{ dateFormat: <EuiCode>{dateFormat}</EuiCode> }}
         >
-          {(dateFormatError: string) => (
+          {([dateFormatHint, dateFormatError]: string[]) => (
             <EuiFormRow
               className="euiSuperDatePicker__absoluteDateFormRow"
               isInvalid={isTextInvalid}
               error={isTextInvalid ? dateFormatError : undefined}
               helpText={
-                // TODO: i18n
                 hasUnparsedText
-                  ? 'Press the Enter key to parse as a date'
+                  ? dateFormatHint
                   : undefined
               }
             >

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
@@ -170,7 +170,9 @@ export class EuiAbsoluteTab extends Component<
               error={isTextInvalid ? dateFormatError : undefined}
               helpText={
                 hasUnparsedText
-                  ? dateFormatHint
+                  ? isTextInvalid
+                    ? dateFormatHint
+                    : [dateFormatHint, dateFormatError]
                   : undefined
               }
             >

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
@@ -41,6 +41,7 @@ export interface EuiAbsoluteTabProps {
 }
 
 interface EuiAbsoluteTabState {
+  hasUnparsedText: boolean;
   isTextInvalid: boolean;
   textInputValue: string;
   valueAsMoment: Moment | null;
@@ -64,6 +65,7 @@ export class EuiAbsoluteTab extends Component<
       .format(this.props.dateFormat);
 
     this.state = {
+      hasUnparsedText: false,
       isTextInvalid: false,
       textInputValue,
       valueAsMoment,
@@ -81,6 +83,7 @@ export class EuiAbsoluteTab extends Component<
     this.setState({
       valueAsMoment,
       textInputValue: valueAsMoment.format(this.props.dateFormat),
+      hasUnparsedText: false,
       isTextInvalid: false,
     });
   };
@@ -88,6 +91,7 @@ export class EuiAbsoluteTab extends Component<
   handleTextChange = (event: ChangeEvent<HTMLInputElement>) => {
     this.setState({
       textInputValue: event.target.value,
+      hasUnparsedText: true,
       isTextInvalid: false,
     });
   };
@@ -120,8 +124,9 @@ export class EuiAbsoluteTab extends Component<
       onChange(valueAsMoment.toISOString());
       this.setState({
         textInputValue: valueAsMoment.format(this.props.dateFormat),
-        isTextInvalid: false,
         valueAsMoment: valueAsMoment,
+        hasUnparsedText: false,
+        isTextInvalid: false,
       });
     } else {
       this.setState(invalidDateState);
@@ -131,7 +136,8 @@ export class EuiAbsoluteTab extends Component<
   render() {
     const { dateFormat, timeFormat, locale, utcOffset, labelPrefix } =
       this.props;
-    const { valueAsMoment, isTextInvalid, textInputValue } = this.state;
+    const { valueAsMoment, isTextInvalid, hasUnparsedText, textInputValue } =
+      this.state;
 
     return (
       <>
@@ -156,6 +162,12 @@ export class EuiAbsoluteTab extends Component<
               className="euiSuperDatePicker__absoluteDateFormRow"
               isInvalid={isTextInvalid}
               error={isTextInvalid ? dateFormatError : undefined}
+              helpText={
+                // TODO: i18n
+                hasUnparsedText
+                  ? 'Press the Enter key to parse as a date'
+                  : undefined
+              }
             >
               <EuiFieldText
                 compressed

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, ChangeEvent } from 'react';
+import React, { Component, ChangeEvent, KeyboardEvent } from 'react';
 
 import moment, { Moment, LocaleSpecifier } from 'moment'; // eslint-disable-line import/named
 
 import dateMath from '@elastic/datemath';
 
+import { keys } from '../../../../services';
 import { EuiFormRow, EuiFieldText, EuiFormLabel } from '../../../form';
 import { EuiCode } from '../../../code';
 import { EuiI18n } from '../../../i18n';
@@ -84,19 +85,16 @@ export class EuiAbsoluteTab extends Component<
     });
   };
 
-  debouncedTypeTimeout: ReturnType<typeof setTimeout> | undefined;
-
   handleTextChange = (event: ChangeEvent<HTMLInputElement>) => {
-    this.setState({ textInputValue: event.target.value });
-
-    // Add a debouncer that gives the user some time to finish typing
-    // before attempting to parse the text as a timestamp. Otherwise,
-    // typing a single digit gets parsed as a unix timestamp 😬
-    clearTimeout(this.debouncedTypeTimeout);
-    this.debouncedTypeTimeout = setTimeout(this.parseUserDateInput, 1000); // 1 second debounce
+    this.setState({
+      textInputValue: event.target.value,
+      isTextInvalid: false,
+    });
   };
 
-  parseUserDateInput = () => {
+  parseUserDateInput = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== keys.ENTER) return;
+
     const { onChange, dateFormat } = this.props;
     const { textInputValue } = this.state;
 
@@ -164,6 +162,7 @@ export class EuiAbsoluteTab extends Component<
                 isInvalid={isTextInvalid}
                 value={textInputValue}
                 onChange={this.handleTextChange}
+                onKeyDown={this.parseUserDateInput}
                 data-test-subj="superDatePickerAbsoluteDateInput"
                 prepend={<EuiFormLabel>{labelPrefix}</EuiFormLabel>}
               />

--- a/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
@@ -101,9 +101,11 @@ export class EuiAbsoluteTab extends Component<
 
   parseUserDateInput = (textInputValue: string) => {
     this.isParsing = true;
-    const finishParsing = () => {
+    // Wait a tick for state to finish updating (whatever gets returned),
+    // and then allow `onChange` user input to continue setting state
+    requestAnimationFrame(() => {
       this.isParsing = false;
-    };
+    });
 
     const invalidDateState = {
       textInputValue,
@@ -111,7 +113,7 @@ export class EuiAbsoluteTab extends Component<
       valueAsMoment: null,
     };
     if (!textInputValue) {
-      return this.setState(invalidDateState, finishParsing);
+      return this.setState(invalidDateState);
     }
 
     const { onChange, dateFormat } = this.props;
@@ -128,17 +130,14 @@ export class EuiAbsoluteTab extends Component<
 
     if (dateIsValid) {
       onChange(valueAsMoment.toISOString());
-      this.setState(
-        {
-          textInputValue: valueAsMoment.format(this.props.dateFormat),
-          valueAsMoment: valueAsMoment,
-          hasUnparsedText: false,
-          isTextInvalid: false,
-        },
-        finishParsing
-      );
+      this.setState({
+        textInputValue: valueAsMoment.format(this.props.dateFormat),
+        valueAsMoment: valueAsMoment,
+        hasUnparsedText: false,
+        isTextInvalid: false,
+      });
     } else {
-      this.setState(invalidDateState, finishParsing);
+      this.setState(invalidDateState);
     }
   };
 

--- a/src/components/i18n/__snapshots__/i18n.test.tsx.snap
+++ b/src/components/i18n/__snapshots__/i18n.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiI18n default rendering render prop with multiple tokens renders render prop result to the dom 1`] = `
+exports[`EuiI18n default rendering render prop with multiple tokens renders basic strings to the dom 1`] = `
 <EuiI18n
   defaults={
     Array [
@@ -19,6 +19,34 @@ exports[`EuiI18n default rendering render prop with multiple tokens renders rend
     This is the first basic string.
      
     This is the second basic string.
+  </div>
+</EuiI18n>
+`;
+
+exports[`EuiI18n default rendering render prop with multiple tokens renders strings with placeholders to the dom 1`] = `
+<EuiI18n
+  defaults={
+    Array [
+      "This is the first basic string.",
+      "This is the a second string with a {placeholder}.",
+    ]
+  }
+  tokens={
+    Array [
+      "test1",
+      "test2",
+    ]
+  }
+  values={
+    Object {
+      "placeholder": "value",
+    }
+  }
+>
+  <div>
+    This is the first basic string.
+     
+    This is the a second string with a value.
   </div>
 </EuiI18n>
 `;

--- a/src/components/i18n/i18n.test.tsx
+++ b/src/components/i18n/i18n.test.tsx
@@ -99,7 +99,7 @@ describe('EuiI18n', () => {
     });
 
     describe('render prop with multiple tokens', () => {
-      it('renders render prop result to the dom', () => {
+      it('renders basic strings to the dom', () => {
         const component = mount(
           <EuiI18n
             tokens={['test1', 'test2']}
@@ -107,6 +107,26 @@ describe('EuiI18n', () => {
               'This is the first basic string.',
               'This is the second basic string.',
             ]}
+          >
+            {([one, two]: ReactChild[]) => (
+              <div>
+                {one} {two}
+              </div>
+            )}
+          </EuiI18n>
+        );
+        expect(component).toMatchSnapshot();
+      });
+
+      it('renders strings with placeholders to the dom', () => {
+        const component = mount(
+          <EuiI18n
+            tokens={['test1', 'test2']}
+            defaults={[
+              'This is the first basic string.',
+              'This is the a second string with a {placeholder}.',
+            ]}
+            values={{ placeholder: 'value' }}
           >
             {([one, two]: ReactChild[]) => (
               <div>

--- a/src/components/i18n/i18n.tsx
+++ b/src/components/i18n/i18n.tsx
@@ -98,6 +98,7 @@ interface I18nTokensShape<T extends any[]> {
   tokens: string[];
   defaults: T;
   children: (x: Array<T[number]>) => ReactChild;
+  values?: Record<string, ReactChild>;
 }
 
 export type EuiI18nProps<
@@ -134,6 +135,7 @@ const EuiI18n = <
               i18nMapping: mapping,
               i18nMappingFunc: mappingFunc,
               valueDefault: props.defaults[idx],
+              values: props.values,
               render,
             })
           )

--- a/upcoming_changelogs/7341.md
+++ b/upcoming_changelogs/7341.md
@@ -1,1 +1,2 @@
+- Improved the UX of `EuiSuperDatePicker`'s Absolute tab for users manually typing in timestamps
 - Updated `Eui18n`s with multiple `tokens` to accept dynamic `values`

--- a/upcoming_changelogs/7341.md
+++ b/upcoming_changelogs/7341.md
@@ -1,0 +1,1 @@
+- Updated `Eui18n`s with multiple `tokens` to accept dynamic `values`


### PR DESCRIPTION
## Summary

> As always, I recommend [reviewing by commit](https://github.com/elastic/eui/pull/7341/commits), as there was an incidental i18n fix/missing feature that was needed along the way 

Follow up to #7331 - @mjaggard had some further excellent points/discussions that led me to revisit the UX once again. I removed the type debouncer with an `Enter` keypress UX event instead (and added more helpful hint text on user type). I also added an `onPaste` handler to automatically parse pasted timestamps without requiring the extra Enter keypress.

All in all, this ideally should be a solid win for users with multiple flows:

- Pasting in timestamps (no extra 1 second of wait time or keypress needed)
- Typing in a timestamp manually (no shenanigans for either slow or fast typers, and information about the accepted formats are now displayed _before_ an error occurs)

![superdatepicker](https://github.com/elastic/eui/assets/549407/17a710a8-29d3-4600-99ba-8659f548c58c)

## QA

- Go to https://eui.elastic.co/pr_7341/#/templates/super-date-picker
- Click the first example's `Last 30 minutes` text
- Click the `Absolute` tab
- [x] Start typing in the Start Date input and confirm that guiding help text appears 
- [x] Press the `Enter` key and confirm that the expected valid or invalid behavior occurs (If valid, the date format updates and the help text disappears. If invalid, the format message goes red and a warning icon appears)
- Paste the following text into the start date input (sourced from https://www.unixtimestamp.com), and confirm they are all immediately parsed/formatted without needing an extra `Enter` keypress:
    - [x] `2023-10-31T23:12:10Z`
    - [x] `Tue, 31 Oct 2023 23:12:10 +0000`
    - [x] `1698793930`
    - [x] `hello world` (should immediately parse invalid)
    - [x] Confirm that both Ctrl+V to paste and right click to paste work the same way

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A