### PR TITLE
[EuiDataGrid] Cell actions redesign

### DIFF
--- a/changelogs/upcoming/7343.md
+++ b/changelogs/upcoming/7343.md
@@ -1,2 +1,6 @@
 - Updated `EuiDataGrid` cell actions to display above cells instead of within them, to avoid content clipping issues
 - Updated `EuiDataGrid` cell expansion popovers to sit on top of cells instead of below/next to them
+
+**Bug fixes**
+
+- Fixed incorrect `EuiPopover` positioning calculations when `hasArrow` was set to false

--- a/changelogs/upcoming/7343.md
+++ b/changelogs/upcoming/7343.md
@@ -1,1 +1,2 @@
 - Updated `EuiDataGrid` cell actions to display above cells instead of within them, to avoid content clipping issues
+- Updated `EuiDataGrid` cell expansion popovers to sit on top of cells instead of below/next to them

--- a/changelogs/upcoming/7343.md
+++ b/changelogs/upcoming/7343.md
@@ -1,0 +1,1 @@
+- Updated `EuiDataGrid` cell actions to display above cells instead of within them, to avoid content clipping issues

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="css-styles">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
   <title>Components App</title>
 </head>
 

--- a/src/components/combo_box/combo_box.spec.tsx
+++ b/src/components/combo_box/combo_box.spec.tsx
@@ -20,19 +20,6 @@ import {
   type EuiComboBoxOptionOption,
 } from './index';
 
-// CI doesn't have access to the Inter font, so we need to manually include it
-// for truncation font calculations to work correctly
-before(() => {
-  const linkElem = document.createElement('link');
-  linkElem.setAttribute('rel', 'stylesheet');
-  linkElem.setAttribute(
-    'href',
-    'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap'
-  );
-  document.head.appendChild(linkElem);
-  cy.wait(1000); // Wait a second to give the font time to load/swap in
-});
-
 describe('EuiComboBox', () => {
   describe('focus management', () => {
     it('keeps focus on the input box when clicking a disabled item', () => {

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -689,7 +689,7 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="0"
@@ -700,26 +700,22 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 1
-                </p>
+                0, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 1
+              </p>
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="0"
@@ -730,26 +726,22 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 1
-                </p>
+                0, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 1
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="1"
@@ -760,26 +752,22 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 2
-                </p>
+                1, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 2
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="1"
@@ -790,26 +778,22 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 2
-                </p>
+                1, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 2
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="2"
@@ -820,26 +804,22 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 3
-                </p>
+                2, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 3
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="2"
@@ -850,22 +830,18 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 3
-                </p>
+                2, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 3
+              </p>
             </div>
           </div>
         </div>
@@ -1164,7 +1140,7 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
               data-gridcell-row-index="0"
@@ -1183,22 +1159,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                 data-focus-lock-disabled="disabled"
               >
                 <div
-                  class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                  class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight"
+                  data-datagrid-cellcontent="true"
                 >
-                  <div
-                    class="euiDataGridRowCell__content"
-                    data-datagrid-cellcontent="true"
-                  >
-                    0
-                  </div>
-                  <p
-                    class="emotion-euiScreenReaderOnly"
-                    hidden=""
-                  >
-                    - 
-                    leading, column 1, row 1
-                  </p>
+                  0
                 </div>
+                <p
+                  class="emotion-euiScreenReaderOnly"
+                  hidden=""
+                >
+                  - 
+                  leading, column 1, row 1
+                </p>
               </div>
               <div
                 data-focus-guard="true"
@@ -1208,7 +1180,7 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
               data-gridcell-row-index="0"
@@ -1219,26 +1191,22 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 2, row 1
-                </p>
+                0, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 2, row 1
+              </p>
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
               data-gridcell-row-index="0"
@@ -1249,26 +1217,22 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 3, row 1
-                </p>
+                0, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 3, row 1
+              </p>
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
               data-gridcell-row-index="0"
@@ -1287,22 +1251,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                 data-focus-lock-disabled="disabled"
               >
                 <div
-                  class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                  class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight"
+                  data-datagrid-cellcontent="true"
                 >
-                  <div
-                    class="euiDataGridRowCell__content"
-                    data-datagrid-cellcontent="true"
-                  >
-                    0
-                  </div>
-                  <p
-                    class="emotion-euiScreenReaderOnly"
-                    hidden=""
-                  >
-                    - 
-                    trailing, column 4, row 1
-                  </p>
+                  0
                 </div>
+                <p
+                  class="emotion-euiScreenReaderOnly"
+                  hidden=""
+                >
+                  - 
+                  trailing, column 4, row 1
+                </p>
               </div>
               <div
                 data-focus-guard="true"
@@ -1312,7 +1272,7 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
               data-gridcell-row-index="1"
@@ -1331,22 +1291,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                 data-focus-lock-disabled="disabled"
               >
                 <div
-                  class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                  class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight"
+                  data-datagrid-cellcontent="true"
                 >
-                  <div
-                    class="euiDataGridRowCell__content"
-                    data-datagrid-cellcontent="true"
-                  >
-                    1
-                  </div>
-                  <p
-                    class="emotion-euiScreenReaderOnly"
-                    hidden=""
-                  >
-                    - 
-                    leading, column 1, row 2
-                  </p>
+                  1
                 </div>
+                <p
+                  class="emotion-euiScreenReaderOnly"
+                  hidden=""
+                >
+                  - 
+                  leading, column 1, row 2
+                </p>
               </div>
               <div
                 data-focus-guard="true"
@@ -1356,7 +1312,7 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
               data-gridcell-row-index="1"
@@ -1367,26 +1323,22 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 2, row 2
-                </p>
+                1, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 2, row 2
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
               data-gridcell-row-index="1"
@@ -1397,26 +1349,22 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 3, row 2
-                </p>
+                1, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 3, row 2
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
               data-gridcell-row-index="1"
@@ -1435,22 +1383,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                 data-focus-lock-disabled="disabled"
               >
                 <div
-                  class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                  class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight"
+                  data-datagrid-cellcontent="true"
                 >
-                  <div
-                    class="euiDataGridRowCell__content"
-                    data-datagrid-cellcontent="true"
-                  >
-                    1
-                  </div>
-                  <p
-                    class="emotion-euiScreenReaderOnly"
-                    hidden=""
-                  >
-                    - 
-                    trailing, column 4, row 2
-                  </p>
+                  1
                 </div>
+                <p
+                  class="emotion-euiScreenReaderOnly"
+                  hidden=""
+                >
+                  - 
+                  trailing, column 4, row 2
+                </p>
               </div>
               <div
                 data-focus-guard="true"
@@ -1460,7 +1404,7 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="leading"
               data-gridcell-column-index="0"
               data-gridcell-row-index="2"
@@ -1479,22 +1423,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                 data-focus-lock-disabled="disabled"
               >
                 <div
-                  class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                  class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight"
+                  data-datagrid-cellcontent="true"
                 >
-                  <div
-                    class="euiDataGridRowCell__content"
-                    data-datagrid-cellcontent="true"
-                  >
-                    2
-                  </div>
-                  <p
-                    class="emotion-euiScreenReaderOnly"
-                    hidden=""
-                  >
-                    - 
-                    leading, column 1, row 3
-                  </p>
+                  2
                 </div>
+                <p
+                  class="emotion-euiScreenReaderOnly"
+                  hidden=""
+                >
+                  - 
+                  leading, column 1, row 3
+                </p>
               </div>
               <div
                 data-focus-guard="true"
@@ -1504,7 +1444,7 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
               data-gridcell-column-id="A"
               data-gridcell-column-index="1"
               data-gridcell-row-index="2"
@@ -1515,26 +1455,22 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 2, row 3
-                </p>
+                2, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 2, row 3
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
               data-gridcell-column-id="B"
               data-gridcell-column-index="2"
               data-gridcell-row-index="2"
@@ -1545,26 +1481,22 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 3, row 3
-                </p>
+                2, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 3, row 3
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn euiDataGridRowCell--controlColumn"
               data-gridcell-column-id="trailing"
               data-gridcell-column-index="3"
               data-gridcell-row-index="2"
@@ -1583,22 +1515,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                 data-focus-lock-disabled="disabled"
               >
                 <div
-                  class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                  class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight"
+                  data-datagrid-cellcontent="true"
                 >
-                  <div
-                    class="euiDataGridRowCell__content"
-                    data-datagrid-cellcontent="true"
-                  >
-                    2
-                  </div>
-                  <p
-                    class="emotion-euiScreenReaderOnly"
-                    hidden=""
-                  >
-                    - 
-                    trailing, column 4, row 3
-                  </p>
+                  2
                 </div>
+                <p
+                  class="emotion-euiScreenReaderOnly"
+                  hidden=""
+                >
+                  - 
+                  trailing, column 4, row 3
+                </p>
               </div>
               <div
                 data-focus-guard="true"
@@ -1864,7 +1792,7 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="0"
@@ -1875,26 +1803,22 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 1
-                </p>
+                0, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 1
+              </p>
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="0"
@@ -1905,26 +1829,22 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 1
-                </p>
+                0, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 1
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="1"
@@ -1935,26 +1855,22 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 2
-                </p>
+                1, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 2
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="1"
@@ -1965,26 +1881,22 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 2
-                </p>
+                1, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 2
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="2"
@@ -1995,26 +1907,22 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 3
-                </p>
+                2, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 3
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="2"
@@ -2025,22 +1933,18 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 3
-                </p>
+                2, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 3
+              </p>
             </div>
           </div>
         </div>
@@ -2298,7 +2202,7 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="0"
@@ -2309,26 +2213,22 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 1
-                </p>
+                0, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 1
+              </p>
             </div>
             <div
               aria-rowindex="1"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="0"
@@ -2339,26 +2239,22 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  0, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 1
-                </p>
+                0, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 1
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="1"
@@ -2369,26 +2265,22 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 2
-                </p>
+                1, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 2
+              </p>
             </div>
             <div
               aria-rowindex="2"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="1"
@@ -2399,26 +2291,22 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  1, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 2
-                </p>
+                1, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 2
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--firstColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn"
               data-gridcell-column-id="A"
               data-gridcell-column-index="0"
               data-gridcell-row-index="2"
@@ -2429,26 +2317,22 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, A
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  A, column 1, row 3
-                </p>
+                2, A
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                A, column 1, row 3
+              </p>
             </div>
             <div
               aria-rowindex="3"
-              class="euiDataGridRowCell euiDataGridRowCell--lastColumn"
+              class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn"
               data-gridcell-column-id="B"
               data-gridcell-column-index="1"
               data-gridcell-row-index="2"
@@ -2459,22 +2343,18 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
               tabindex="-1"
             >
               <div
-                class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+                class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+                data-datagrid-cellcontent="true"
               >
-                <div
-                  class="euiDataGridRowCell__content eui-textTruncate"
-                  data-datagrid-cellcontent="true"
-                >
-                  2, B
-                </div>
-                <p
-                  class="emotion-euiScreenReaderOnly"
-                  hidden=""
-                >
-                  - 
-                  B, column 2, row 3
-                </p>
+                2, B
               </div>
+              <p
+                class="emotion-euiScreenReaderOnly"
+                hidden=""
+              >
+                - 
+                B, column 2, row 3
+              </p>
             </div>
           </div>
         </div>

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -63,7 +63,7 @@
 
   // if a cell is not hovered nor focused nor open via popover, don't show buttons in general
   &:not(:hover):not(:focus):not(.euiDataGridRowCell--open) {
-    .euiDataGridRowCell__actionButtonIcon {
+    .euiDataGridRowCell__actions {
       display: none;
     }
   }
@@ -114,47 +114,60 @@
 
 // Cell actions
 .euiDataGridRowCell__actions {
+  z-index: $euiZDataGridCellPopover;
+  position: absolute;
+  left: 0;
+  bottom: 100%;
+  margin-bottom: -$euiBorderWidthThin; // Vertical alignment
   display: flex;
+  gap: $euiSizeXS / 2;
+  padding-inline: $euiSizeXS / 2;
+  background-color: $euiColorPrimary;
+  color: $euiColorEmptyShade;
+  border: $euiBorderWidthThin solid $euiColorPrimary;
+  border-top-left-radius: $euiBorderRadius / 2;
+  border-top-right-radius: $euiBorderRadius / 2;
 
-  &--overlay {
-    position: absolute;
+  .euiDataGridRowCell--numeric &,
+  .euiDataGridRowCell--currency & {
+    left: auto;
     right: 0;
-    top: 0;
-    padding: $euiDataGridCellPaddingM 0;
-    background-color: $euiColorEmptyShade;
   }
 }
 
 .euiDataGridRowCell__actionButtonIcon {
-  height: $euiSizeM;
-  border-radius: $euiBorderRadius / 2;
-  width: 0;
-  overflow: hidden;
-  // Have to take out the generic transition so it is instaneous on focus
-  transition: none;
-  // Disable filled button box-shadows on legacy theme - they're unnecessary when this small in a datagrid
-  box-shadow: none !important; // stylelint-disable-line declaration-no-important
-  // Remove filled button borders on legacy theme - this way we don't need to animate the border
-  border: none;
+  height: $euiSize + $euiSizeXS;
+  width: $euiSize;
+  border-radius: 0;
+
+  /* Force all cell action buttons to match EUI colors */
+  &,
+  svg {
+    // stylelint-disable declaration-no-important
+    background-color: transparent !important;
+    color: currentColor !important;
+    fill: currentColor !important;
+    // stylelint-enable declaration-no-important
+  }
+
+  /* Manually increase the size of the expand cell icon - it's a bit small by default */
+  &.euiDataGridRowCell__expandCell .euiIcon {
+    width: 120%;
+    height: 100%;
+  }
 }
 
 // Row stripes
 @include euiDataGridStyles(stripes) {
   .euiDataGridRow--striped {
-    &,
-    .euiDataGridRowCell__actions--overlay {
-      background-color: $euiColorLightestShade;
-    }
+    background-color: $euiColorLightestShade;
   }
 }
 
 // Row highlights
 @include euiDataGridStyles(rowHoverHighlight) {
   .euiDataGridRow:hover {
-    &,
-    .euiDataGridRowCell__actions--overlay {
-      background-color: $euiColorHighlight;
-    }
+    background-color: $euiColorHighlight;
   }
 }
 
@@ -203,17 +216,6 @@
     .euiDataGridRowCell__content {
       padding: $euiDataGridCellPaddingL;
     }
-  }
-}
-
-// Compressed density grids - height tweaks
-@include euiDataGridStyles(fontSizeSmall, paddingSmall) {
-  .euiDataGridRowCell__actions--overlay {
-    padding: ($euiDataGridCellPaddingS / 2) 0;
-  }
-
-  .euiDataGridRowCell__defaultHeight .euiDataGridRowCell__actions {
-    transform: translateY(1px);
   }
 }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -133,7 +133,7 @@
 
 // Cell actions
 .euiDataGridRowCell__actions {
-  z-index: $euiZDataGridCellPopover;
+  z-index: $euiZDataGridCellPopover - 2; // Sit below sticky column headers
   position: absolute;
   left: 0;
   bottom: 100%;
@@ -153,6 +153,12 @@
   .euiDataGridRowCell--currency & {
     left: auto;
     right: 0;
+  }
+
+  // The first row of cell actions need to be visible above the cell headers,
+  // but other cell actions that scroll past the sticky headers should not
+  .euiDataGridRowCell[data-gridcell-visible-row-index='0'] > & {
+    z-index: $euiZDataGridCellPopover - 1;
   }
 }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -32,8 +32,22 @@
   }
 
   &:focus {
-    position: relative;
     @include euiDataGridCellFocus;
+
+    // Tweak outline border radius to account for cell actions
+    &:has(.euiDataGridRowCell__actions) {
+      &:not(.euiDataGridRowCell--numeric, .euiDataGridRowCell--currency) {
+        &::after {
+          border-top-left-radius: 0;
+        }
+      }
+
+      &:is(.euiDataGridRowCell--numeric, .euiDataGridRowCell--currency) {
+        &::after {
+          border-top-right-radius: 0;
+        }
+      }
+    }
   }
 
   // Only add the transition effect on hover, so that it is instantaneous on focus

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -68,7 +68,6 @@
   // On hover & focus, show cell action buttons
   &:hover,
   &:focus,
-  // Prevent the animation from flickering after cell popover close when focus is restored the expansion button
   &:focus-within,
   // Always make the cell actions visible when the cell popover is open
   &.euiDataGridRowCell--open {
@@ -131,12 +130,22 @@
   align-items: center;
 }
 
-// Cell actions
+// Positioning for cell actions & the cell expansion popover
+.euiDataGridRowCell__actions,
+.euiDataGridRowCell__actions + [data-euiportal] > .euiPopover {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+
+  .euiDataGridRowCell--numeric &,
+  .euiDataGridRowCell--currency & {
+    left: auto;
+    right: 0;
+  }
+}
+
 .euiDataGridRowCell__actions {
   z-index: $euiZDataGridCellPopover - 2; // Sit below sticky column headers
-  position: absolute;
-  left: 0;
-  bottom: 100%;
   margin-bottom: -$euiBorderWidthThin; // Vertical alignment
   display: flex;
   gap: $euiSizeXS / 2;
@@ -148,12 +157,6 @@
   border-top-right-radius: $euiBorderRadius / 2;
   transform: scaleY(0);
   transform-origin: bottom;
-
-  .euiDataGridRowCell--numeric &,
-  .euiDataGridRowCell--currency & {
-    left: auto;
-    right: 0;
-  }
 
   // The first row of cell actions need to be visible above the cell headers,
   // but other cell actions that scroll past the sticky headers should not

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -33,25 +33,20 @@
 
   &:hover,
   &:focus {
+    --euiDataGridCellOutlineColor: #{$euiColorPrimary};
     @include euiDataGridCellFocus;
   }
 
   // On hover
   &:hover:not(:focus, :focus-within, .euiDataGridRowCell--open) {
+    // Color the actions and focus ring grayscale on hover
+    // (Actions look odd without the ring on grids without cell borders)
+    --euiDataGridCellOutlineColor: #{$euiColorDarkShade};
+
     .euiDataGridRowCell__actions {
       // Delay the actions showing on hover
       // (Note: the focus ring show instantly on hover & the actions show instantly on focus)
       animation-delay: $euiAnimSpeedSlow;
-
-      // Color the actions and focus ring grayscale on hover
-      // (Actions look odd without the ring on grids without cell borders)
-      background-color: $euiColorDarkShade;
-      border-color: $euiColorDarkShade;
-      color: $euiColorEmptyShade;
-    }
-
-    &::after {
-      border-color: $euiColorDarkShade;
     }
   }
 
@@ -143,9 +138,9 @@
   display: flex;
   gap: $euiSizeXS / 2;
   padding-inline: $euiSizeXS / 2;
-  background-color: $euiColorPrimary;
+  background-color: var(--euiDataGridCellOutlineColor);
   color: $euiColorEmptyShade;
-  border: $euiBorderWidthThin solid $euiColorPrimary;
+  border: $euiBorderWidthThin solid var(--euiDataGridCellOutlineColor);
   border-top-left-radius: $euiBorderRadius / 2;
   border-top-right-radius: $euiBorderRadius / 2;
   transform: scaleY(0);
@@ -164,7 +159,7 @@
     top: 100%;
     height: $euiBorderWidthThick;
     width: $euiBorderWidthThick;
-    background-color: red; // TODO - DRY out background-color
+    background-color: var(--euiDataGridCellOutlineColor);
 
     .euiDataGridRowCell--alignLeft & {
       left: -$euiBorderWidthThin;

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -50,28 +50,18 @@
     }
   }
 
-  // Only add the transition effect on hover, so that it is instantaneous on focus
-  // Long delays on hover to mitigate the accordion effect
-  &:hover {
-    .euiDataGridRowCell__actionButtonIcon {
-      animation-duration: $euiAnimSpeedExtraFast;
-      animation-name: euiDataGridCellActionsSlideIn;
-      animation-iteration-count: 1;
-      animation-delay: $euiAnimSpeedNormal;
-      animation-fill-mode: forwards;
-    }
-  }
-
-  // On focus, directly show action buttons (without animation)
+  // On hover & focus, show cell action buttons
+  &:hover,
   &:focus,
   // Prevent the animation from flickering after cell popover close when focus is restored the expansion button
   &:focus-within,
   // Always make the cell actions visible when the cell popover is open
   &.euiDataGridRowCell--open {
-    .euiDataGridRowCell__actionButtonIcon {
-      animation: none;
-      margin-left: $euiDataGridCellPaddingM;
-      width: $euiSizeM;
+    .euiDataGridRowCell__actions {
+      animation-duration: $euiAnimSpeedExtraFast;
+      animation-name: euiDataGridCellActionsSlideIn;
+      animation-iteration-count: 1;
+      animation-fill-mode: forwards;
     }
   }
 
@@ -141,6 +131,8 @@
   border: $euiBorderWidthThin solid $euiColorPrimary;
   border-top-left-radius: $euiBorderRadius / 2;
   border-top-right-radius: $euiBorderRadius / 2;
+  transform: scaleY(0);
+  transform-origin: bottom;
 
   .euiDataGridRowCell--numeric &,
   .euiDataGridRowCell--currency & {
@@ -234,13 +226,6 @@
 }
 
 @keyframes euiDataGridCellActionsSlideIn {
-  from {
-    margin-left: 0;
-    width: 0;
-  }
-
-  to {
-    margin-left: $euiDataGridCellPaddingM;
-    width: $euiSizeM;
-  }
+  from { transform: scaleY(0); }
+  to { transform: scaleY(1); }
 }

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -57,7 +57,7 @@
     .euiDataGridRowCell__actions {
       // Delay the actions showing on hover
       // (Note: the focus ring show instantly on hover & the actions show instantly on focus)
-      animation-delay: $euiAnimSpeedNormal;
+      animation-delay: $euiAnimSpeedSlow;
 
       // Color the actions and focus ring grayscale on hover
       // (Actions look odd without the ring on grids without cell borders)

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -31,6 +31,7 @@
     border-right-color: $euiBorderColor;
   }
 
+  &:hover,
   &:focus {
     @include euiDataGridCellFocus;
 
@@ -47,6 +48,20 @@
           border-top-right-radius: 0;
         }
       }
+    }
+  }
+
+  // On hover, color the cell actions more subdued and show a same-colored focus ring
+  // so the cell actions look less weird on datagrids without cell borders
+  &:hover:not(:focus, :focus-within, .euiDataGridRowCell--open) {
+    .euiDataGridRowCell__actions {
+      background-color: $euiBorderColor;
+      border-color: $euiBorderColor;
+      color: $euiColorFullShade;
+    }
+
+    &::after {
+      border-color: $euiBorderColor;
     }
   }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -34,20 +34,21 @@
   &:hover,
   &:focus {
     @include euiDataGridCellFocus;
+  }
 
-    // Tweak outline border radius to account for cell actions
-    &:has(.euiDataGridRowCell__actions) {
-      &:not(.euiDataGridRowCell--numeric, .euiDataGridRowCell--currency) {
-        &::after {
-          border-top-left-radius: 0;
-        }
-      }
+  // Tweak outline border radius to account for left cell actions
+  &--alignLeft:hover,
+  &--alignLeft:focus {
+    &::after {
+      border-top-left-radius: 0;
+    }
+  }
 
-      &:is(.euiDataGridRowCell--numeric, .euiDataGridRowCell--currency) {
-        &::after {
-          border-top-right-radius: 0;
-        }
-      }
+  // Tweak outline border radius to account for right cell actions
+  &--alignRight:hover,
+  &--alignRight:focus {
+    &::after {
+      border-top-right-radius: 0;
     }
   }
 
@@ -135,11 +136,12 @@
 .euiDataGridRowCell__actions + [data-euiportal] > .euiPopover {
   position: absolute;
   bottom: 100%;
-  left: 0;
 
-  .euiDataGridRowCell--numeric &,
-  .euiDataGridRowCell--currency & {
-    left: auto;
+  .euiDataGridRowCell--alignLeft & {
+    left: 0;
+  }
+
+  .euiDataGridRowCell--alignRight & {
     right: 0;
   }
 }

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -36,22 +36,6 @@
     @include euiDataGridCellFocus;
   }
 
-  // Tweak outline border radius to account for left cell actions
-  &--alignLeft:hover,
-  &--alignLeft:focus {
-    &::after {
-      border-top-left-radius: 0;
-    }
-  }
-
-  // Tweak outline border radius to account for right cell actions
-  &--alignRight:hover,
-  &--alignRight:focus {
-    &::after {
-      border-top-right-radius: 0;
-    }
-  }
-
   // On hover
   &:hover:not(:focus, :focus-within, .euiDataGridRowCell--open) {
     .euiDataGridRowCell__actions {
@@ -171,6 +155,24 @@
   // but other cell actions that scroll past the sticky headers should not
   .euiDataGridRowCell[data-gridcell-visible-row-index='0'] > & {
     z-index: $euiZDataGridCellPopover - 1;
+  }
+
+  // Visual trickery - fill in the gap between the cell outline border-radius & the actions
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    height: $euiBorderWidthThick;
+    width: $euiBorderWidthThick;
+    background-color: red; // TODO - DRY out background-color
+
+    .euiDataGridRowCell--alignLeft & {
+      left: -$euiBorderWidthThin;
+    }
+
+    .euiDataGridRowCell--alignRight & {
+      right: -$euiBorderWidthThin;
+    }
   }
 }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -52,17 +52,22 @@
     }
   }
 
-  // On hover, color the cell actions more subdued and show a same-colored focus ring
-  // so the cell actions look less weird on datagrids without cell borders
+  // On hover
   &:hover:not(:focus, :focus-within, .euiDataGridRowCell--open) {
     .euiDataGridRowCell__actions {
-      background-color: $euiBorderColor;
-      border-color: $euiBorderColor;
-      color: $euiColorFullShade;
+      // Delay the actions showing on hover
+      // (Note: the focus ring show instantly on hover & the actions show instantly on focus)
+      animation-delay: $euiAnimSpeedNormal;
+
+      // Color the actions and focus ring grayscale on hover
+      // (Actions look odd without the ring on grids without cell borders)
+      background-color: $euiColorDarkShade;
+      border-color: $euiColorDarkShade;
+      color: $euiColorEmptyShade;
     }
 
     &::after {
-      border-color: $euiBorderColor;
+      border-color: $euiColorDarkShade;
     }
   }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -118,6 +118,12 @@
   // since we don't use the popover arrow in any case for cell popovers
   filter: none;
   @include euiBottomShadow; // TODO: Convert to euiShadowMedium() in Emotion
+
+  // For some reason, the normal popover opacity transition doesn't work for datagrid popovers
+  // so we'll force it via an animation. If we don't, cells constrained by the inline max-width
+  // style that we set will see a flash of unwanted content before repositioning
+  animation-duration: $euiAnimSpeedNormal;
+  animation-name: euiDataGridCellPopover;
 }
 
 .euiDataGridRowCell--controlColumn .euiDataGridRowCell__content {
@@ -250,4 +256,9 @@
 @keyframes euiDataGridCellActionsSlideIn {
   from { transform: scaleY(0); }
   to { transform: scaleY(1); }
+}
+
+@keyframes euiDataGridCellPopover {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -111,11 +111,7 @@
 .euiDataGridRowCell__popover {
   @include euiScrollBar;
   overflow: auto;
-  // stylelint-disable declaration-no-important
-  max-width: 400px !important;
-  max-height: 400px !important;
-  z-index: $euiZDataGridCellPopover !important;
-  // stylelint-enable declaration-no-important
+  z-index: $euiZDataGridCellPopover !important; // stylelint-disable-line declaration-no-important
   // Workaround for a Safari CSS bug when using both `overflow: auto` & `filter: drop-shadow`
   // (see https://github.com/elastic/eui/issues/6151)
   // Disables the default EuiPopover filter drop-shadow and uses box-shadow instead,

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -3,12 +3,14 @@
 }
 
 @include euiDataGridRowCell {
-  @include euiFontSizeS;
-
-  padding: $euiDataGridCellPaddingM;
+  position: relative; // Needed for .euiDataGridRowCell__actions
   border-right: $euiDataGridVerticalBorder;
   border-bottom: $euiBorderThin;
-  overflow: hidden;
+
+  .euiDataGridRowCell__content {
+    @include euiFontSizeS;
+    padding: $euiDataGridCellPaddingM;
+  }
 
   // Hack to allow focus trap to still stretch to full row height on defined heights
   > * {
@@ -97,29 +99,11 @@
   @include euiBottomShadow; // TODO: Convert to euiShadowMedium() in Emotion
 }
 
-.euiDataGridRowCell__contentWrapper {
-  position: relative; // Needed for .euiDataGridRowCell__actions--overlay
-  height: 100%;
-}
-
-.euiDataGridRowCell__defaultHeight {
-  display: flex;
-  align-items: baseline;
-  max-width: 100%;
-
-  .euiDataGridRowCell__content {
-    flex-grow: 1;
-  }
-
-  .euiDataGridRowCell__actions {
-    flex-grow: 0;
-  }
-
-  .euiDataGridRowCell--controlColumn & {
-    height: 100%;
-    align-items: center;
-  }
-}
+// TODO
+// .euiDataGridRowCell--controlColumn & {
+//   height: 100%;
+//   align-items: center;
+// }
 
 .euiDataGridRowCell__numericalHeight {
   // Without this rule, popover anchors content that overflows off the page
@@ -192,26 +176,34 @@
 // Font alternates
 @include euiDataGridStyles(fontSizeSmall) {
   @include euiDataGridRowCell {
-    @include euiFontSizeXS;
+    .euiDataGridRowCell__content {
+      @include euiFontSizeXS;
+    }
   }
 }
 
 @include euiDataGridStyles(fontSizeLarge) {
   @include euiDataGridRowCell {
-    @include euiFontSize;
+    .euiDataGridRowCell__content {
+      @include euiFontSize;
+    }
   }
 }
 
 // Padding alternates
 @include euiDataGridStyles(paddingSmall) {
   @include euiDataGridRowCell {
-    padding: $euiDataGridCellPaddingS;
+    .euiDataGridRowCell__content {
+      padding: $euiDataGridCellPaddingS;
+    }
   }
 }
 
 @include euiDataGridStyles(paddingLarge) {
   @include euiDataGridRowCell {
-    padding: $euiDataGridCellPaddingL;
+    .euiDataGridRowCell__content {
+      padding: $euiDataGridCellPaddingL;
+    }
   }
 }
 

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -10,10 +10,16 @@
   .euiDataGridRowCell__content {
     @include euiFontSizeS;
     padding: $euiDataGridCellPaddingM;
+    height: 100%;
+    overflow: hidden;
+
+    &--autoHeight {
+      height: auto;
+    }
   }
 
   // Hack to allow focus trap to still stretch to full row height on defined heights
-  > * {
+  > [data-focus-lock-disabled] {
     height: 100%;
   }
 
@@ -99,18 +105,11 @@
   @include euiBottomShadow; // TODO: Convert to euiShadowMedium() in Emotion
 }
 
-// TODO
-// .euiDataGridRowCell--controlColumn & {
-//   height: 100%;
-//   align-items: center;
-// }
-
-.euiDataGridRowCell__numericalHeight {
-  // Without this rule, popover anchors content that overflows off the page
-  [data-euiportal],
-  .euiPopover {
-    height: 100%;
-  }
+.euiDataGridRowCell--controlColumn .euiDataGridRowCell__content {
+  max-height: 100%;
+  height: auto;
+  display: flex;
+  align-items: center;
 }
 
 // Cell actions

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -65,7 +65,7 @@ $euiDataGridStyles: (
     top: 0;
     left: 0;
     border: $euiBorderWidthThick solid $euiFocusRingColor;
-    border-radius: $euiBorderRadiusSmall;
+    border-radius: $euiBorderRadius / 2;
     z-index: 2; // We want this to be on top of all the content
     pointer-events: none; // Because we put it with a higher z-index we don't want to make it clickable this way we allow selecting the content behind
   }

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -64,7 +64,7 @@ $euiDataGridStyles: (
     position: absolute;
     top: 0;
     left: 0;
-    border: $euiBorderWidthThick solid $euiFocusRingColor;
+    border: $euiBorderWidthThick solid var(--euiDataGridCellOutlineColor, $euiFocusRingColor);
     border-radius: $euiBorderRadius / 2;
     z-index: 2; // We want this to be on top of all the content
     pointer-events: none; // Because we put it with a higher z-index we don't want to make it clickable this way we allow selecting the content behind

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -115,7 +115,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
   >
     <div
       aria-rowindex="1"
-      class="euiDataGridRowCell euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
+      class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
       data-gridcell-column-id="columnA"
       data-gridcell-column-index="0"
       data-gridcell-row-index="0"
@@ -126,26 +126,22 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
       tabindex="-1"
     >
       <div
-        class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+        class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+        data-datagrid-cellcontent="true"
       >
-        <div
-          class="euiDataGridRowCell__content eui-textTruncate"
-          data-datagrid-cellcontent="true"
-        >
-          hello
-        </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          hidden=""
-        >
-          - 
-          columnA, column 1, row 1
-        </p>
+        hello
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        hidden=""
+      >
+        - 
+        columnA, column 1, row 1
+      </p>
     </div>
     <div
       aria-rowindex="1"
-      class="euiDataGridRowCell euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
+      class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
       data-gridcell-column-id="columnB"
       data-gridcell-column-index="1"
       data-gridcell-row-index="0"
@@ -156,22 +152,18 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
       tabindex="-1"
     >
       <div
-        class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+        class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+        data-datagrid-cellcontent="true"
       >
-        <div
-          class="euiDataGridRowCell__content eui-textTruncate"
-          data-datagrid-cellcontent="true"
-        >
-          world
-        </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          hidden=""
-        >
-          - 
-          columnB, column 2, row 1
-        </p>
+        world
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        hidden=""
+      >
+        - 
+        columnB, column 2, row 1
+      </p>
     </div>
   </div>
   <div
@@ -179,7 +171,7 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
   >
     <div
       aria-rowindex="2"
-      class="euiDataGridRowCell euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
+      class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
       data-gridcell-column-id="columnA"
       data-gridcell-column-index="0"
       data-gridcell-row-index="1"
@@ -190,26 +182,22 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
       tabindex="-1"
     >
       <div
-        class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+        class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+        data-datagrid-cellcontent="true"
       >
-        <div
-          class="euiDataGridRowCell__content eui-textTruncate"
-          data-datagrid-cellcontent="true"
-        >
-          lorem
-        </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          hidden=""
-        >
-          - 
-          columnA, column 1, row 2
-        </p>
+        lorem
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        hidden=""
+      >
+        - 
+        columnA, column 1, row 2
+      </p>
     </div>
     <div
       aria-rowindex="2"
-      class="euiDataGridRowCell euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
+      class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
       data-gridcell-column-id="columnB"
       data-gridcell-column-index="1"
       data-gridcell-row-index="1"
@@ -220,22 +208,18 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
       tabindex="-1"
     >
       <div
-        class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+        class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+        data-datagrid-cellcontent="true"
       >
-        <div
-          class="euiDataGridRowCell__content eui-textTruncate"
-          data-datagrid-cellcontent="true"
-        >
-          ipsum
-        </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          hidden=""
-        >
-          - 
-          columnB, column 2, row 2
-        </p>
+        ipsum
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        hidden=""
+      >
+        - 
+        columnB, column 2, row 2
+      </p>
     </div>
   </div>
 </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
     </div>
     <div
       aria-rowindex="1"
-      class="euiDataGridRowCell euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
+      class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--boolean euiDataGridRowCell--firstColumn"
       data-gridcell-column-id="columnA"
       data-gridcell-column-index="0"
       data-gridcell-row-index="0"
@@ -127,28 +127,24 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
       tabindex="-1"
     >
       <div
-        class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+        class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+        data-datagrid-cellcontent="true"
       >
-        <div
-          class="euiDataGridRowCell__content eui-textTruncate"
-          data-datagrid-cellcontent="true"
-        >
-          <span>
-            cell content
-          </span>
-        </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          hidden=""
-        >
-          - 
-          columnA, column 1, row 1
-        </p>
+        <span>
+          cell content
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        hidden=""
+      >
+        - 
+        columnA, column 1, row 1
+      </p>
     </div>
     <div
       aria-rowindex="1"
-      class="euiDataGridRowCell euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
+      class="euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--string euiDataGridRowCell--lastColumn"
       data-gridcell-column-id="columnB"
       data-gridcell-column-index="1"
       data-gridcell-row-index="0"
@@ -159,24 +155,20 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
       tabindex="-1"
     >
       <div
-        class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+        class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+        data-datagrid-cellcontent="true"
       >
-        <div
-          class="euiDataGridRowCell__content eui-textTruncate"
-          data-datagrid-cellcontent="true"
-        >
-          <span>
-            cell content
-          </span>
-        </div>
-        <p
-          class="emotion-euiScreenReaderOnly"
-          hidden=""
-        >
-          - 
-          columnB, column 2, row 1
-        </p>
+        <span>
+          cell content
+        </span>
       </div>
+      <p
+        class="emotion-euiScreenReaderOnly"
+        hidden=""
+      >
+        - 
+        columnB, column 2, row 1
+      </p>
     </div>
   </div>
 </div>

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`EuiDataGridCell componentDidUpdate handles the cell popover by forwardi
 exports[`EuiDataGridCell renders 1`] = `
 <div
   aria-rowindex="1"
-  class="euiDataGridRowCell"
+  class="euiDataGridRowCell euiDataGridRowCell--alignLeft"
   data-gridcell-column-id="someColumn"
   data-gridcell-column-index="0"
   data-gridcell-row-index="0"

--- a/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_cell.test.tsx.snap
@@ -49,34 +49,30 @@ exports[`EuiDataGridCell renders 1`] = `
   tabindex="-1"
 >
   <div
-    class="euiDataGridRowCell__contentWrapper euiDataGridRowCell__defaultHeight"
+    class="euiDataGridRowCell__content euiDataGridRowCell__content--defaultHeight eui-textTruncate"
+    data-datagrid-cellcontent="true"
   >
-    <div
-      class="euiDataGridRowCell__content eui-textTruncate"
-      data-datagrid-cellcontent="true"
-    >
-      <div>
-        <button
-          data-datagrid-interactable="true"
-          tabindex="-1"
-        >
-          hello
-        </button>
-        <button
-          data-datagrid-interactable="true"
-          tabindex="-1"
-        >
-          world
-        </button>
-      </div>
+    <div>
+      <button
+        data-datagrid-interactable="true"
+        tabindex="-1"
+      >
+        hello
+      </button>
+      <button
+        data-datagrid-interactable="true"
+        tabindex="-1"
+      >
+        world
+      </button>
     </div>
-    <p
-      class="emotion-euiScreenReaderOnly"
-      hidden=""
-    >
-      - 
-      someColumn, column 1, row 1
-    </p>
   </div>
+  <p
+    class="emotion-euiScreenReaderOnly"
+    hidden=""
+  >
+    - 
+    someColumn, column 1, row 1
+  </p>
 </div>
 `;

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -26,6 +26,7 @@ describe('EuiDataGridCell', () => {
     closeCellPopover: jest.fn(),
     openCellPopover: jest.fn(),
     setPopoverAnchor: jest.fn(),
+    setPopoverAnchorPosition: jest.fn(),
     setPopoverContent: jest.fn(),
     setCellPopoverProps: () => {},
   };
@@ -216,6 +217,7 @@ describe('EuiDataGridCell', () => {
     it('resets cell props when the cell is moved (columnId) or sorted (rowIndex)', () => {
       const setState = jest.spyOn(EuiDataGridCell.prototype, 'setState');
       const component = mount(<EuiDataGridCell {...requiredProps} />);
+      setState.mockClear();
 
       component.setProps({ columnId: 'newColumnId' });
       expect(setState).toHaveBeenCalledWith({ cellProps: {} });

--- a/src/components/datagrid/body/data_grid_cell.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell.test.tsx
@@ -727,7 +727,7 @@ describe('EuiDataGridCell', () => {
       );
 
       expect(
-        component.find('.euiDataGridRowCell__defaultHeight').exists()
+        component.find('.euiDataGridRowCell__content--defaultHeight').exists()
       ).toBe(true);
       expect(component.find('.eui-textTruncate').exists()).toBe(true);
     });
@@ -740,9 +740,9 @@ describe('EuiDataGridCell', () => {
         />
       );
 
-      expect(component.find('.euiDataGridRowCell__autoHeight').exists()).toBe(
-        true
-      );
+      expect(
+        component.find('.euiDataGridRowCell__content--autoHeight').exists()
+      ).toBe(true);
       expect(component.find('.eui-textBreakWord').exists()).toBe(true);
     });
 
@@ -755,7 +755,7 @@ describe('EuiDataGridCell', () => {
       );
 
       expect(
-        component.find('.euiDataGridRowCell__numericalHeight').exists()
+        component.find('.euiDataGridRowCell__content--numericalHeight').exists()
       ).toBe(true);
       expect(component.find('.eui-textBreakWord').exists()).toBe(true);
     });
@@ -769,7 +769,7 @@ describe('EuiDataGridCell', () => {
       );
 
       expect(
-        component.find('.euiDataGridRowCell__lineCountHeight').exists()
+        component.find('.euiDataGridRowCell__content--lineCountHeight').exists()
       ).toBe(true);
       expect(component.find('.eui-textBreakWord').exists()).toBe(true);
       expect(component.find('.euiTextBlockTruncate').exists()).toBe(true);

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -54,7 +54,6 @@ const EuiDataGridCellContent: FunctionComponent<
     isFocused: boolean;
     ariaRowIndex: number;
     rowHeight?: EuiDataGridRowHeightOption;
-    cellHeightType: string;
     cellActions?: ReactNode;
   }
 > = memo(
@@ -69,13 +68,15 @@ const EuiDataGridCellContent: FunctionComponent<
     rowHeightUtils,
     isControlColumn,
     isFocused,
-    cellHeightType,
     cellActions,
     ...rest
   }) => {
     // React is more permissible than the TS types indicate
     const CellElement =
       renderCellValue as JSXElementConstructor<EuiDataGridCellValueElementProps>;
+
+    const cellHeightType =
+      rowHeightUtils?.getHeightType(rowHeight) || 'default';
 
     const classes = classNames(
       'euiDataGridRowCell__content',
@@ -711,15 +712,12 @@ export class EuiDataGridCell extends Component<
       rowIndex,
       rowHeightsOptions
     );
-    const cellHeightType =
-      rowHeightUtils?.getHeightType(rowHeight) || 'default';
 
     const cellContentProps = {
       ...rest,
       setCellProps: this.setCellProps,
       column,
       columnType,
-      cellHeightType,
       isExpandable,
       isExpanded: popoverIsOpen,
       isDetails: false,
@@ -739,7 +737,6 @@ export class EuiDataGridCell extends Component<
           rowIndex={rowIndex}
           colIndex={colIndex}
           column={column}
-          cellHeightType={cellHeightType}
           onExpandClick={() => {
             if (popoverIsOpen) {
               closeCellPopover();

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -430,7 +430,7 @@ export class EuiDataGridCell extends Component<
       this.contentObserver.disconnect();
     }
     this.preventTabbing();
-    this.getCellTextAlign();
+    this.setCellTextAlign();
   };
 
   onFocus = (e: FocusEvent<HTMLDivElement>) => {
@@ -489,7 +489,7 @@ export class EuiDataGridCell extends Component<
     }
   };
 
-  getCellTextAlign = () => {
+  setCellTextAlign = () => {
     if (this.cellContentsRef) {
       const { columnType } = this.props;
       if (!columnType) {

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -79,13 +79,9 @@ const EuiDataGridCellContent: FunctionComponent<
     const CellElement =
       renderCellValue as JSXElementConstructor<EuiDataGridCellValueElementProps>;
 
-    const wrapperClasses = classNames(
-      'euiDataGridRowCell__contentWrapper',
-      `euiDataGridRowCell__${cellHeightType}Height`
-    );
-
     const classes = classNames(
       'euiDataGridRowCell__content',
+      `euiDataGridRowCell__content--${cellHeightType}Height`,
       !isControlColumn && {
         'eui-textBreakWord': cellHeightType !== 'default',
         'eui-textTruncate': cellHeightType === 'default',
@@ -96,15 +92,7 @@ const EuiDataGridCellContent: FunctionComponent<
       <div
         ref={(el) => {
           setCellContentsRef(el);
-          setPopoverAnchorRef.current =
-            cellHeightType === 'default'
-              ? // Default height cells need the popover to be anchored on the wrapper,
-                // in order for the popover to centered on the full cell width (as content
-                // width is affected by the width of cell actions)
-                (el?.parentElement as HTMLDivElement)
-              : // Numerical height cells need the popover anchor to be below the wrapper
-                // class, in order to set height: 100% on the portalled popover div wrappers
-                el;
+          setPopoverAnchorRef.current = el;
         }}
         data-datagrid-cellcontent
         className={classes}
@@ -146,11 +134,11 @@ const EuiDataGridCellContent: FunctionComponent<
     );
 
     return (
-      <div className={wrapperClasses}>
+      <>
         {cellContent}
         {screenReaderText}
         {cellActions}
-      </div>
+      </>
     );
   }
 );

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -49,7 +49,6 @@ const EuiDataGridCellContent: FunctionComponent<
   EuiDataGridCellValueProps & {
     setCellProps: EuiDataGridCellValueElementProps['setCellProps'];
     setCellContentsRef: EuiDataGridCell['setCellContentsRef'];
-    setPopoverAnchorRef: MutableRefObject<HTMLDivElement | null>;
     isExpanded: boolean;
     isControlColumn: boolean;
     isFocused: boolean;
@@ -63,7 +62,6 @@ const EuiDataGridCellContent: FunctionComponent<
     renderCellValue,
     column,
     setCellContentsRef,
-    setPopoverAnchorRef,
     rowIndex,
     colIndex,
     ariaRowIndex,
@@ -90,10 +88,7 @@ const EuiDataGridCellContent: FunctionComponent<
 
     let cellContent = (
       <div
-        ref={(el) => {
-          setCellContentsRef(el);
-          setPopoverAnchorRef.current = el;
-        }}
+        ref={setCellContentsRef}
         data-datagrid-cellcontent
         className={classes}
       >
@@ -699,7 +694,6 @@ export class EuiDataGridCell extends Component<
       isDetails: false,
       isFocused: this.state.isFocused,
       setCellContentsRef: this.setCellContentsRef,
-      setPopoverAnchorRef: this.popoverAnchorRef,
       rowHeight,
       rowHeightUtils,
       isControlColumn: cellClasses.includes(
@@ -709,19 +703,28 @@ export class EuiDataGridCell extends Component<
     };
 
     const cellActions = showCellActions && (
-      <EuiDataGridCellActions
-        rowIndex={rowIndex}
-        colIndex={colIndex}
-        column={column}
-        cellHeightType={cellHeightType}
-        onExpandClick={() => {
-          if (popoverIsOpen) {
-            closeCellPopover();
-          } else {
-            openCellPopover({ rowIndex: visibleRowIndex, colIndex });
-          }
-        }}
-      />
+      <>
+        <EuiDataGridCellActions
+          rowIndex={rowIndex}
+          colIndex={colIndex}
+          column={column}
+          cellHeightType={cellHeightType}
+          onExpandClick={() => {
+            if (popoverIsOpen) {
+              closeCellPopover();
+            } else {
+              openCellPopover({ rowIndex: visibleRowIndex, colIndex });
+            }
+          }}
+        />
+        {/* Give the cell expansion popover a separate div/ref - otherwise the
+            extra popover wrappers mess up the absolute positioning and cause
+            animation stuttering */}
+        <div
+          ref={this.popoverAnchorRef}
+          data-test-subject="cellPopoverAnchor"
+        />
+      </>
     );
 
     const cellContent = isExpandable ? (

--- a/src/components/datagrid/body/data_grid_cell_actions.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.test.tsx
@@ -49,11 +49,11 @@ describe('EuiDataGridCellActions', () => {
     expect(button('expandButtonTitle')).toMatchInlineSnapshot(`
       <EuiButtonIcon
         aria-hidden={true}
-        className="euiDataGridRowCell__actionButtonIcon"
+        className="euiDataGridRowCell__actionButtonIcon euiDataGridRowCell__expandCell"
         color="primary"
         data-test-subj="euiDataGridCellExpandButton"
         display="fill"
-        iconSize="s"
+        iconSize="m"
         iconType="expandMini"
         onClick={[MockFunction]}
         title="expandButtonTitle"
@@ -74,8 +74,11 @@ describe('EuiDataGridCellActions', () => {
       <EuiButtonIcon
         aria-hidden={true}
         className="euiDataGridRowCell__actionButtonIcon"
+        color="primary"
+        display="fill"
         iconSize="s"
         iconType="eye"
+        size="xs"
       />
     `);
   });

--- a/src/components/datagrid/body/data_grid_cell_actions.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.test.tsx
@@ -8,7 +8,6 @@
 
 import React from 'react';
 import { shallow } from 'enzyme';
-import { render } from '../../../test/rtl';
 
 import { EuiDataGridColumnCellAction } from '../data_grid_types';
 import {
@@ -112,17 +111,6 @@ describe('EuiDataGridCellActions', () => {
         </EuiI18n>
       </div>
     `);
-  });
-
-  it('renders with overlay positioning for non default height cells', () => {
-    const { container } = render(
-      <EuiDataGridCellActions {...requiredProps} cellHeightType="auto" />
-    );
-
-    // TODO: Switch to `.toHaveStyle({ position: 'absolute' })` once on Emotion
-    expect(container.firstChild).toHaveClass(
-      'euiDataGridRowCell__actions--overlay'
-    );
   });
 
   describe('visible cell actions limit', () => {

--- a/src/components/datagrid/body/data_grid_cell_actions.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.tsx
@@ -18,20 +18,17 @@ import { EuiButtonIcon, EuiButtonIconProps } from '../../button/button_icon';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button/button_empty';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiPopoverFooter } from '../../popover';
-import classNames from 'classnames';
 
 export const EuiDataGridCellActions = ({
   onExpandClick,
   column,
   rowIndex,
   colIndex,
-  cellHeightType,
 }: {
   onExpandClick: () => void;
   column?: EuiDataGridColumn;
   rowIndex: number;
   colIndex: number;
-  cellHeightType: string;
 }) => {
   // Note: The cell expand button/expansion popover is *always* rendered if
   // column.cellActions is present (regardless of column.isExpandable).
@@ -98,11 +95,11 @@ export const EuiDataGridCellActions = ({
     );
   }, [column, colIndex, rowIndex]);
 
-  const classes = classNames('euiDataGridRowCell__actions', {
-    'euiDataGridRowCell__actions--overlay': cellHeightType !== 'default',
-  });
-
-  return <div className={classes}>{[...additionalButtons, expandButton]}</div>;
+  return (
+    <div className="euiDataGridRowCell__actions">
+      {[...additionalButtons, expandButton]}
+    </div>
+  );
 };
 
 export const EuiDataGridCellPopoverActions = ({

--- a/src/components/datagrid/body/data_grid_cell_actions.tsx
+++ b/src/components/datagrid/body/data_grid_cell_actions.tsx
@@ -45,11 +45,11 @@ export const EuiDataGridCellActions = ({
     >
       {(expandButtonTitle: string) => (
         <EuiButtonIcon
-          display="fill"
-          className="euiDataGridRowCell__actionButtonIcon"
+          className="euiDataGridRowCell__actionButtonIcon euiDataGridRowCell__expandCell"
           data-test-subj="euiDataGridCellExpandButton"
+          display="fill"
           color="primary"
-          iconSize="s"
+          iconSize="m"
           iconType="expandMini"
           aria-hidden
           onClick={onExpandClick}
@@ -67,7 +67,11 @@ export const EuiDataGridCellActions = ({
         {...props}
         aria-hidden
         className="euiDataGridRowCell__actionButtonIcon"
+        // Don't allow consumers to override sizes or colors for cell actions on hover/focus
+        size="xs"
         iconSize="s"
+        display="fill"
+        color="primary"
       />
     );
 

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -16,12 +16,12 @@ import { EuiDataGrid, EuiDataGridProps } from '../';
 const baseProps: EuiDataGridProps = {
   'aria-label': 'Grid cell popover test',
   height: 300,
-  width: 300,
-  columns: [{ id: 'A' }, { id: 'B' }],
+  width: 400,
+  columns: [{ id: 'A' }, { id: 'B' }, { id: 'C', schema: 'numeric' }],
   rowCount: 2,
   renderCellValue: ({ rowIndex, columnId }) => `${columnId}, ${rowIndex}`,
   columnVisibility: {
-    visibleColumns: ['A', 'B'],
+    visibleColumns: ['A', 'B', 'C'],
     setVisibleColumns: () => {},
   },
 };
@@ -136,10 +136,13 @@ describe('EuiDataGridCellPopover', () => {
       ...baseProps,
       rowCount: 1,
       renderCellValue: ({ columnId }) => {
-        if (columnId === 'A') {
-          return 'short text';
-        } else {
-          return 'Very long text that should get cut off because it is so long';
+        switch (columnId) {
+          case 'A':
+            return 'short text';
+          case 'B':
+            return 'Very long text that should get cut off because it is so long';
+          case 'C':
+            return 'right aligned text';
         }
       },
     };
@@ -167,6 +170,18 @@ describe('EuiDataGridCellPopover', () => {
       cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
         .should('have.css', 'left', '109px')
         .should('have.css', 'top', '73px');
+    });
+
+    it('right aligned popover', () => {
+      cy.realMount(<EuiDataGrid {...props} />);
+
+      openCellPopover('C');
+
+      // Matchers used due to subpixel rendering shenanigans
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
+        .should('have.css', 'top', '73px')
+        .should('have.css', 'left')
+        .and('match', /^254[.\d]+px$/);
     });
   });
 });

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -151,61 +151,22 @@ describe('EuiDataGridCellPopover', () => {
       cy.realPress('Enter');
     };
 
-    it('default row height', () => {
+    it('small popover', () => {
+      cy.realMount(<EuiDataGrid {...props} />);
+
+      openCellPopover('A');
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
+        .should('have.css', 'left', '1px')
+        .should('have.css', 'top', '73px');
+    });
+
+    it('large popover', () => {
       cy.realMount(<EuiDataGrid {...props} />);
 
       openCellPopover('B');
       cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
-        .should('have.css', 'left', '24.5px')
-        .should('have.css', 'top')
-        .and('match', /^(104|103)px/); // CI is off by 1 px
-    });
-
-    it('lineCount row height', () => {
-      cy.realMount(
-        <EuiDataGrid
-          {...props}
-          rowHeightsOptions={{ defaultHeight: { lineCount: 2 } }}
-        />
-      );
-      openCellPopover('B');
-
-      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
-        .should('have.css', 'left', '24.5px')
-        .should('have.css', 'top')
-        .and('match', /^(127|126)px/); // CI is off by 1 px
-    });
-
-    it('numerical row height', () => {
-      cy.realMount(
-        <EuiDataGrid {...props} rowHeightsOptions={{ defaultHeight: 40 }} />
-      );
-      openCellPopover('B');
-
-      // Should not be anchored to the bottom of the overflowing text
-      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
-        .should('have.css', 'left', '24.5px')
-        .should('have.css', 'top')
-        .and('match', /^(106|105)px/); // CI is off by 1 px
-    });
-
-    it('auto row height', () => {
-      cy.realMount(
-        <EuiDataGrid {...props} rowHeightsOptions={{ defaultHeight: 'auto' }} />
-      );
-
-      openCellPopover('B');
-      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
-        .should('have.css', 'left', '24.5px')
-        .should('have.css', 'top')
-        .and('match', /^(151|150)px/); // CI is off by 1 px
-
-      // The shorter cell content should not have the same top position
-      openCellPopover('A');
-      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
-        .should('have.css', 'left', '19px')
-        .should('have.css', 'top')
-        .and('match', /^(103|102)px/); // CI is off by 1 px
+        .should('have.css', 'left', '109px')
+        .should('have.css', 'top', '73px');
     });
   });
 });

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -53,7 +53,7 @@ describe('EuiDataGridCellPopover', () => {
         '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
       ).realClick();
 
-      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
       cy.focused().should(
         'have.attr',
         'data-test-subj',
@@ -73,7 +73,7 @@ describe('EuiDataGridCellPopover', () => {
         '[data-gridcell-row-index="1"][data-gridcell-column-index="1"]'
       ).realClick();
 
-      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
       cy.focused().should(
         'have.attr',
         'data-test-subj',
@@ -93,12 +93,12 @@ describe('EuiDataGridCellPopover', () => {
       '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
     ).realClick();
 
-    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
+    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
     cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
 
     cy.get(
       '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
-    ).realClick();
+    ).realClick({ position: 'right' });
     cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
       'not.exist'
     );
@@ -126,7 +126,7 @@ describe('EuiDataGridCellPopover', () => {
     cy.get(
       '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
     ).realClick();
-    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').realClick();
+    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
 
     cy.get('.euiDataGridRowCell__popover.hello.world').should('exist');
   });
@@ -150,7 +150,7 @@ describe('EuiDataGridCellPopover', () => {
     const openCellPopover = (id: string) => {
       cy.get(
         `[data-gridcell-row-index="0"][data-gridcell-column-id="${id}"]`
-      ).realClick();
+      ).click();
       cy.realPress('Enter');
     };
 

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -140,7 +140,7 @@ describe('EuiDataGridCellPopover', () => {
           case 'A':
             return 'short text';
           case 'B':
-            return 'Very long text that should get cut off because it is so long';
+            return 'Very long text that should get cut off because it is so long, lorem ipsum dolor sit amet words words words';
           case 'C':
             return 'right aligned text';
         }
@@ -160,7 +160,8 @@ describe('EuiDataGridCellPopover', () => {
       openCellPopover('A');
       cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
         .should('have.css', 'left', '1px')
-        .should('have.css', 'top', '73px');
+        .should('have.css', 'top', '73px')
+        .should('have.css', 'width', '112px');
     });
 
     it('large popover', () => {
@@ -169,7 +170,8 @@ describe('EuiDataGridCellPopover', () => {
       openCellPopover('B');
       cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
         .should('have.css', 'left', '109px')
-        .should('have.css', 'top', '73px');
+        .should('have.css', 'top', '73px')
+        .should('have.css', 'width', '375px');
     });
 
     it('right aligned popover', () => {
@@ -182,6 +184,47 @@ describe('EuiDataGridCellPopover', () => {
         .should('have.css', 'top', '73px')
         .should('have.css', 'left')
         .and('match', /^254[.\d]+px$/);
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
+        .should('have.css', 'width')
+        .and('match', /^144[.\d]+px$/);
+    });
+
+    describe('max popover dimensions', () => {
+      it('never exceeds 75% of the viewport width or 50% of the viewport height', () => {
+        cy.viewport(300, 200);
+        cy.realMount(<EuiDataGrid {...props} />);
+
+        openCellPopover('B');
+        cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
+          .should('have.css', 'width', '225px') // 300 * .75
+          .should('have.css', 'height', '100px'); // 200 * .5
+      });
+
+      it('does not exceed 400px width if the column width is smaller than 400px', () => {
+        cy.viewport(1000, 500);
+        cy.realMount(<EuiDataGrid {...props} />);
+
+        openCellPopover('B');
+        cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
+          .should('have.css', 'width', '400px')
+          .should('have.css', 'height', '88px');
+      });
+
+      it('matches the width of the column if the column width is larger than 400px', () => {
+        cy.viewport(1000, 500);
+        cy.realMount(
+          <EuiDataGrid
+            {...props}
+            width={500}
+            columns={[{ id: 'B', initialWidth: 500 }]}
+          />
+        );
+
+        openCellPopover('B');
+        cy.get('[data-test-subj="euiDataGridExpansionPopover"]')
+          .should('have.css', 'width', '500px')
+          .should('have.css', 'height', '64px');
+      });
     });
   });
 });

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -114,6 +114,13 @@ describe('useCellPopover', () => {
               "data-test-subj": "euiDataGridExpansionPopover",
             }
           }
+          panelStyle={
+            Object {
+              "maxBlockSize": "50vh",
+              "maxInlineSize": "min(75vw, max(0px, 400px))",
+            }
+          }
+          repositionToCrossAxis={false}
         >
           <div
             data-test-subj="mockPopover"

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -31,6 +31,9 @@ describe('useCellPopover', () => {
     });
 
     it('does nothing if called again on a popover that is already open', () => {
+      const mockAnchor = document.createElement('div');
+      document.body.appendChild(mockAnchor);
+
       const { result } = renderHook(useCellPopover);
       expect(result.current.cellPopover).toBeFalsy();
 
@@ -39,9 +42,7 @@ describe('useCellPopover', () => {
           rowIndex: 0,
           colIndex: 0,
         });
-        result.current.cellPopoverContext.setPopoverAnchor(
-          document.createElement('div')
-        );
+        result.current.cellPopoverContext.setPopoverAnchor(mockAnchor);
       });
       expect(result.current.cellPopover).not.toBeFalsy();
 
@@ -94,9 +95,15 @@ describe('useCellPopover', () => {
       populateCellPopover(result.current.cellPopoverContext);
       expect(result.current.cellPopover).toMatchInlineSnapshot(`
         <EuiWrappingPopover
+          anchorPosition="downLeft"
           button={<div />}
           closePopover={[Function]}
           display="block"
+          focusTrapProps={
+            Object {
+              "onClickOutside": [Function],
+            }
+          }
           hasArrow={false}
           isOpen={true}
           onKeyDown={[Function]}

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -78,6 +78,20 @@ export const useCellPopover = (): {
     setCellPopoverProps,
   };
 
+  // Override the default EuiPopover `onClickOutside` behavior, since the toggling
+  // popover button isn't actually the DOM node we pass to `button`. Otherwise,
+  // clicking the expansion cell action triggers an outside click
+  const onClickOutside = useCallback(
+    (event: Event) => {
+      if (!popoverAnchor) return;
+      const cellActions = popoverAnchor.previousElementSibling;
+      if (cellActions?.contains(event.target as Node) === false) {
+        closeCellPopover();
+      }
+    },
+    [popoverAnchor, closeCellPopover]
+  );
+
   // Note that this popover is rendered once at the top grid level, rather than one popover per cell
   const cellPopover = popoverIsOpen && popoverAnchor && (
     <EuiWrappingPopover
@@ -85,7 +99,9 @@ export const useCellPopover = (): {
       display="block"
       hasArrow={false}
       panelPaddingSize="s"
+      anchorPosition="downLeft"
       {...cellPopoverProps}
+      focusTrapProps={{ onClickOutside }}
       panelProps={{
         'data-test-subj': 'euiDataGridExpansionPopover',
         ...(cellPopoverProps.panelProps || {}),

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -105,6 +105,7 @@ export const useCellPopover = (): {
       hasArrow={false}
       panelPaddingSize="s"
       anchorPosition={popoverAnchorPosition}
+      repositionToCrossAxis={false}
       {...cellPopoverProps}
       focusTrapProps={{ onClickOutside }}
       panelProps={{
@@ -116,6 +117,12 @@ export const useCellPopover = (): {
         cellPopoverProps.panelClassName,
         cellPopoverProps.panelProps?.className
       )}
+      panelStyle={{
+        maxInlineSize: `min(75vw, max(${
+          popoverAnchor.parentElement!.offsetWidth
+        }px, 400px))`,
+        maxBlockSize: '50vh',
+      }}
       onKeyDown={(event) => {
         if (event.key === keys.F2 || event.key === keys.ESCAPE) {
           event.preventDefault();

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -23,6 +23,7 @@ export const DataGridCellPopoverContext =
     openCellPopover: () => {},
     closeCellPopover: () => {},
     setPopoverAnchor: () => {},
+    setPopoverAnchorPosition: () => {},
     setPopoverContent: () => {},
     setCellPopoverProps: () => {},
   });
@@ -39,6 +40,9 @@ export const useCellPopover = (): {
   });
   // Popover anchor & content are passed by individual `EuiDataGridCell`s
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
+  const [popoverAnchorPosition, setPopoverAnchorPosition] = useState<
+    'downLeft' | 'downRight'
+  >('downLeft');
   const [popoverContent, setPopoverContent] = useState<ReactNode>();
   // Allow customization of most (not all) popover props by consumers
   const [cellPopoverProps, setCellPopoverProps] = useState<
@@ -74,6 +78,7 @@ export const useCellPopover = (): {
     openCellPopover,
     cellLocation,
     setPopoverAnchor,
+    setPopoverAnchorPosition,
     setPopoverContent,
     setCellPopoverProps,
   };
@@ -99,7 +104,7 @@ export const useCellPopover = (): {
       display="block"
       hasArrow={false}
       panelPaddingSize="s"
-      anchorPosition="downLeft"
+      anchorPosition={popoverAnchorPosition}
       {...cellPopoverProps}
       focusTrapProps={{ onClickOutside }}
       panelProps={{

--- a/src/components/datagrid/body/footer/data_grid_footer_row.test.tsx
+++ b/src/components/datagrid/body/footer/data_grid_footer_row.test.tsx
@@ -52,6 +52,7 @@ describe('EuiDataGridFooterRow', () => {
               "popoverIsOpen": false,
               "setCellPopoverProps": [Function],
               "setPopoverAnchor": [Function],
+              "setPopoverAnchorPosition": [Function],
               "setPopoverContent": [Function],
             }
           }
@@ -79,6 +80,7 @@ describe('EuiDataGridFooterRow', () => {
               "popoverIsOpen": false,
               "setCellPopoverProps": [Function],
               "setPopoverAnchor": [Function],
+              "setPopoverAnchorPosition": [Function],
               "setPopoverContent": [Function],
             }
           }
@@ -132,6 +134,7 @@ describe('EuiDataGridFooterRow', () => {
                 "popoverIsOpen": false,
                 "setCellPopoverProps": [Function],
                 "setPopoverAnchor": [Function],
+                "setPopoverAnchorPosition": [Function],
                 "setPopoverContent": [Function],
               }
             }
@@ -184,6 +187,7 @@ describe('EuiDataGridFooterRow', () => {
                 "popoverIsOpen": false,
                 "setCellPopoverProps": [Function],
                 "setPopoverAnchor": [Function],
+                "setPopoverAnchorPosition": [Function],
                 "setPopoverContent": [Function],
               }
             }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -1,6 +1,6 @@
 .euiDataGridHeader {
   display: flex;
-  z-index: 3; // Needs to sit above the content and focused cells
+  z-index: $euiZDataGridCellPopover - 1; // Needs to sit above the content and focused cells
   background: $euiColorEmptyShade;
   position: sticky;
   top: 0;

--- a/src/components/datagrid/data_grid.test.tsx
+++ b/src/components/datagrid/data_grid.test.tsx
@@ -537,7 +537,7 @@ describe('EuiDataGrid', () => {
         Array [
           Object {
             "aria-rowindex": 1,
-            "className": "euiDataGridRowCell euiDataGridRowCell--firstColumn customClass",
+            "className": "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn customClass",
             "data-gridcell-column-id": "A",
             "data-gridcell-column-index": 0,
             "data-gridcell-row-index": 0,
@@ -563,7 +563,7 @@ describe('EuiDataGrid', () => {
           },
           Object {
             "aria-rowindex": 1,
-            "className": "euiDataGridRowCell euiDataGridRowCell--lastColumn customClass",
+            "className": "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn customClass",
             "data-gridcell-column-id": "B",
             "data-gridcell-column-index": 1,
             "data-gridcell-row-index": 0,
@@ -589,7 +589,7 @@ describe('EuiDataGrid', () => {
           },
           Object {
             "aria-rowindex": 2,
-            "className": "euiDataGridRowCell euiDataGridRowCell--firstColumn customClass",
+            "className": "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--firstColumn customClass",
             "data-gridcell-column-id": "A",
             "data-gridcell-column-index": 0,
             "data-gridcell-row-index": 1,
@@ -615,7 +615,7 @@ describe('EuiDataGrid', () => {
           },
           Object {
             "aria-rowindex": 2,
-            "className": "euiDataGridRowCell euiDataGridRowCell--lastColumn customClass",
+            "className": "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn customClass",
             "data-gridcell-column-id": "B",
             "data-gridcell-column-index": 1,
             "data-gridcell-row-index": 1,
@@ -778,17 +778,17 @@ describe('EuiDataGrid', () => {
         expect(gridCellClassNames).toMatchInlineSnapshot(`
           Array [
             "euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignRight euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
             "euiDataGridRowCell--lastColumn",
-            "euiDataGridRowCell euiDataGridRowCell--customFormatName euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--customFormatName euiDataGridRowCell--lastColumn",
             "euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignRight euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
             "euiDataGridRowCell--lastColumn",
-            "euiDataGridRowCell euiDataGridRowCell--customFormatName euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--customFormatName euiDataGridRowCell--lastColumn",
             "euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignRight euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
             "euiDataGridRowCell--lastColumn",
-            "euiDataGridRowCell euiDataGridRowCell--customFormatName euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--customFormatName euiDataGridRowCell--lastColumn",
           ]
         `);
       });
@@ -821,12 +821,12 @@ describe('EuiDataGrid', () => {
           .map((x) => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
           Array [
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--boolean",
-            "euiDataGridRowCell euiDataGridRowCell--lastColumn",
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--boolean",
-            "euiDataGridRowCell euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--boolean",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--boolean",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--lastColumn",
           ]
         `);
       });
@@ -853,10 +853,10 @@ describe('EuiDataGrid', () => {
           .map((x) => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
           Array [
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--alphanumeric euiDataGridRowCell--lastColumn",
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--alphanumeric euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--alphanumeric euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--alphanumeric euiDataGridRowCell--lastColumn",
           ]
         `);
       });
@@ -890,13 +890,13 @@ describe('EuiDataGrid', () => {
           .map((x) => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
           Array [
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--boolean",
-            "euiDataGridRowCell euiDataGridRowCell--currency",
-            "euiDataGridRowCell euiDataGridRowCell--datetime",
-            "euiDataGridRowCell euiDataGridRowCell--datetime",
-            "euiDataGridRowCell euiDataGridRowCell--datetime",
-            "euiDataGridRowCell euiDataGridRowCell--datetime euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--boolean",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--currency",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--datetime",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--datetime",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--datetime",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--datetime euiDataGridRowCell--lastColumn",
           ]
         `);
       });
@@ -939,8 +939,8 @@ describe('EuiDataGrid', () => {
           .map((x) => x.props().className);
         expect(gridCellClassNames).toMatchInlineSnapshot(`
           Array [
-            "euiDataGridRowCell euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
-            "euiDataGridRowCell euiDataGridRowCell--ipaddress euiDataGridRowCell--lastColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--numeric euiDataGridRowCell--firstColumn",
+            "euiDataGridRowCell euiDataGridRowCell--alignLeft euiDataGridRowCell--ipaddress euiDataGridRowCell--lastColumn",
           ]
         `);
       });

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -222,6 +222,7 @@ export interface DataGridCellPopoverContextShape {
   openCellPopover(args: { rowIndex: number; colIndex: number }): void;
   closeCellPopover(): void;
   setPopoverAnchor(anchor: HTMLElement): void;
+  setPopoverAnchorPosition(position: 'downLeft' | 'downRight'): void;
   setPopoverContent(content: ReactNode): void;
   setCellPopoverProps: EuiDataGridCellPopoverElementProps['setCellPopoverProps'];
 }
@@ -626,6 +627,7 @@ export interface EuiDataGridCellState {
   isEntered: boolean; // enables focus trap for non-expandable cells with multiple interactive elements
   enableInteractions: boolean; // cell got hovered at least once, so cell button and popover interactions are rendered
   disableCellTabIndex: boolean; // disables tabIndex on the wrapping cell, used for focus management of a single interactive child
+  cellTextAlign: 'Left' | 'Right'; // determines the cell actions and cell popover expansion position
 }
 
 export type EuiDataGridCellValueProps = Omit<

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -773,9 +773,14 @@ export interface EuiDataGridColumnCellActionProps {
    */
   columnId: string;
   /**
-   * React component representing the action displayed in the cell
+   * React component representing the action displayed in the cell.
+   *
+   * On cell hover/focus, an EuiButtonIcon will be displayed that cannot
+   * have its size or color customized, only its icon.
+   *
+   * On cell expand, an EuiButtonEmpty will be displayed in the cell popover
+   * that can have any sizing, color, or text.
    */
-  // Component: ComponentType<EuiButtonEmptyProps | EuiButtonProps>;
   Component: typeof EuiButtonEmpty | typeof EuiButtonIcon;
   /**
    * Determines whether the cell's action is displayed expanded (in the Popover)

--- a/src/components/datagrid/utils/row_heights.test.ts
+++ b/src/components/datagrid/utils/row_heights.test.ts
@@ -296,17 +296,16 @@ describe('RowHeightUtils', () => {
         rowHeightUtils.setRowHeight(5, 'd', undefined, 0);
 
         // @ts-ignore this var is private, but we're inspecting it for the sake of the unit test
-        expect(rowHeightUtils.heightsCache.get(5)?.get('a')).toEqual(62); // @ts-ignore-line
-        expect(rowHeightUtils.heightsCache.get(5)?.get('b')).toEqual(46); // @ts-ignore-line
-        expect(rowHeightUtils.heightsCache.get(5)?.get('c')).toEqual(112); // @ts-ignore-line
-        expect(rowHeightUtils.heightsCache.get(5)?.get('d')).toEqual(46); // Falls back default row height
-        // NB: The cached heights have padding added to them
+        expect(rowHeightUtils.heightsCache.get(5)?.get('a')).toEqual(50); // @ts-ignore-line
+        expect(rowHeightUtils.heightsCache.get(5)?.get('b')).toEqual(34); // @ts-ignore-line
+        expect(rowHeightUtils.heightsCache.get(5)?.get('c')).toEqual(100); // @ts-ignore-line
+        expect(rowHeightUtils.heightsCache.get(5)?.get('d')).toEqual(34); // Falls back default row height
       });
     });
 
     describe('getRowHeight', () => {
       it('returns the highest height value stored for the specificed row', () => {
-        expect(rowHeightUtils.getRowHeight(5)).toEqual(112); // 100 + cell padding
+        expect(rowHeightUtils.getRowHeight(5)).toEqual(100);
       });
 
       it('returns 0 if the passed row does not have any existing heights', () => {
@@ -320,7 +319,7 @@ describe('RowHeightUtils', () => {
           { id: 'a' },
           { id: 'b' },
         ]);
-        expect(rowHeightUtils.getRowHeight(5)).toEqual(62);
+        expect(rowHeightUtils.getRowHeight(5)).toEqual(50);
         expect(didModify).toEqual(true);
       });
 
@@ -665,8 +664,8 @@ describe('useRowHeightUtils', () => {
     expect(result.current.heightsCache).toMatchInlineSnapshot(`
       Map {
         0 => Map {
-          "A" => 42,
-          "B" => 62,
+          "A" => 30,
+          "B" => 50,
         },
       }
     `);
@@ -677,7 +676,7 @@ describe('useRowHeightUtils', () => {
     expect(result.current.heightsCache).toMatchInlineSnapshot(`
       Map {
         0 => Map {
-          "A" => 42,
+          "A" => 30,
         },
       }
     `);

--- a/src/components/datagrid/utils/row_heights.ts
+++ b/src/components/datagrid/utils/row_heights.ts
@@ -186,9 +186,7 @@ export class RowHeightUtils {
   ) {
     const rowHeights =
       this.heightsCache.get(rowIndex) || new Map<string, number>();
-    const adaptedHeight = Math.ceil(
-      height + this.styles.paddingTop + this.styles.paddingBottom
-    );
+    const adaptedHeight = Math.ceil(height);
 
     if (rowHeights.get(colId) === adaptedHeight) {
       return false;

--- a/src/components/datagrid/utils/scrolling.spec.tsx
+++ b/src/components/datagrid/utils/scrolling.spec.tsx
@@ -65,7 +65,7 @@ describe('useScroll', () => {
 
     it('handles setFocusedCell being called manually on cells out of view', () => {
       const ref = createRef<EuiDataGridRefProps>();
-      cy.mount(<EuiDataGrid {...baseProps} ref={ref} />);
+      cy.realMount(<EuiDataGrid {...baseProps} ref={ref} />);
 
       // Wait for the grid to finish rendering and pass back the ref
       cy.get('[data-test-subj="euiDataGridBody"]').then(() => {
@@ -80,7 +80,7 @@ describe('useScroll', () => {
   describe('cell popover', () => {
     it('handles openCellPopover being called manually on cells out of view', () => {
       const ref = createRef<EuiDataGridRefProps>();
-      cy.mount(<EuiDataGrid {...baseProps} ref={ref} />);
+      cy.realMount(<EuiDataGrid {...baseProps} ref={ref} />);
 
       // Wait for the grid to finish rendering and pass back the ref
       cy.get('[data-test-subj="euiDataGridBody"]').then(() => {

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -534,10 +534,9 @@ export class EuiPopover extends Component<Props, State> {
         : this.props.hasArrow
         ? 16 + offset
         : 8 + offset,
-      arrowConfig: {
-        arrowWidth: 24,
-        arrowBuffer: 10,
-      },
+      arrowConfig: this.props.hasArrow
+        ? { arrowWidth: 24, arrowBuffer: 10 }
+        : { arrowWidth: 0, arrowBuffer: 0 },
       returnBoundingBox: this.props.attachToAnchor,
       allowCrossAxis: this.props.repositionToCrossAxis,
       buffer: this.props.buffer,

--- a/src/components/text_truncate/text_truncate.spec.tsx
+++ b/src/components/text_truncate/text_truncate.spec.tsx
@@ -21,19 +21,6 @@ describe('EuiTextTruncate', () => {
     width: 200,
   };
 
-  // CI doesn't have access to the Inter font, so we need to manually include it
-  // for font calculations to work correctly
-  before(() => {
-    const linkElem = document.createElement('link');
-    linkElem.setAttribute('rel', 'stylesheet');
-    linkElem.setAttribute(
-      'href',
-      'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap'
-    );
-    document.head.appendChild(linkElem);
-    cy.wait(1000); // Wait a second to give the font time to load/swap in
-  });
-
   const getTruncatedText = (selector = '#text') =>
     cy.get(`${selector} [data-test-subj="truncatedText"]`);
 

--- a/src/components/text_truncate/utils.spec.tsx
+++ b/src/components/text_truncate/utils.spec.tsx
@@ -12,19 +12,7 @@
 
 import { TruncationUtils } from './utils';
 
-// CI doesn't have access to the Inter font, so we need to manually include it
-// for font calculations to work correctly
 const font = '14px Inter';
-before(() => {
-  const linkElem = document.createElement('link');
-  linkElem.setAttribute('rel', 'stylesheet');
-  linkElem.setAttribute(
-    'href',
-    'https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap'
-  );
-  document.head.appendChild(linkElem);
-  cy.wait(1000); // Wait a second to give the font time to load/swap in
-});
 
 describe('Truncation utils', () => {
   const params = {


### PR DESCRIPTION
## Summary

- closes https://github.com/elastic/eui/issues/5828, https://github.com/elastic/kibana/issues/133739, and https://github.com/elastic/kibana/issues/99312
- closes https://github.com/elastic/eui/issues/5686

This PR redesigns the cell actions UI/UX to sit outside the cell instead of inside (which resolves several issues with actions clipping content), and additionally repositions the cell popover to sit on top of the cell instead of next to it or below it.

> ⚠️ Worth noting: this change enabled us to remove an extra DOM wrapper within the `<EuiDataGridCell>`, specifically the `.euiDataGridRowCell__contentWrapper` node. While this is good news in terms of relatively cleaner HTML/CSS, it may also cause breakages to datagrid CSS overrides in Kibana.

### Before screencaps

| Hover state | Focus state | Cell popover |
|--------|--------|--------|
| <img width="244" alt="" src="https://github.com/elastic/eui/assets/549407/26cf8e2c-308f-4c39-9b11-403421f209f2"> | <img width="245" alt="" src="https://github.com/elastic/eui/assets/549407/b779adea-1fb3-4ef8-b4e0-5d8820548aaa"> | <img width="268" alt="" src="https://github.com/elastic/eui/assets/549407/5b5edaa2-171c-4a06-bde8-ecae91e9c2da"> | 

### After screencaps

| Hover state | Focus state | Cell popover |
|--------|--------|--------|
| <img width="298" alt="" src="https://github.com/elastic/eui/assets/549407/fb175b23-e84e-4d66-8c93-4aaa0b35a838"> | <img width="192" alt="" src="https://github.com/elastic/eui/assets/549407/8c950931-f571-444b-ad18-6e6c7f887fb5"> | <img width="215" alt="" src="https://github.com/elastic/eui/assets/549407/0b3a62ad-8893-4bb8-9629-fddd900b266f"> |
| <img src="https://github.com/elastic/eui/assets/549407/50cf8bf0-0add-4038-8575-4c97c2ff718d" alt=""> | <img src="https://github.com/elastic/eui/assets/549407/d4f9da8e-091e-4989-ac77-9892a3a70e3e" alt=""> | <img src="https://github.com/elastic/eui/assets/549407/7e8aed34-09b9-4537-9e99-be4567d4133e" alt=""> | 

**Cell popover extending to larger column width** (see #5686):

![popover_large](https://github.com/elastic/eui/assets/549407/224f3459-4f38-4f1b-8720-c1170892e978)

### Code review

This was a lot of incredibly technical CSS changes, so as always, I strongly recommend [following along by commit](https://github.com/elastic/eui/pull/7343/commits) 😬 

## QA

- [x] Go to https://eui.elastic.co/pr_7343/#/tabular-content/data-grid and confirm default cell actions/cell popovers behave as expected
- [x] Go to https://eui.elastic.co/pr_7343/#/tabular-content/data-grid-cells-popovers#completely-customizing-cell-popover-rendering and confirm that custom popovers still render 
- [x] Go to https://eui.elastic.co/pr_7343/#/tabular-content/data-grid-style-display#auto-heights-for-rows and confirm that the cell popover expands to the width of the column

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile** (_DEV NOTE: The small cell actions are a bit of a pain to tap on phones, but IMO this is not worse than it already was in production_)
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
- Docs site QA - N/A, no APIs/props changed
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart