### PR TITLE
[docs] Add header badge for PR staging instances

### DIFF
--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -21,6 +21,8 @@ import { GuideThemeSelector, GuideFigmaLink } from '../guide_theme_selector';
 
 import { VersionSwitcher } from './version_switcher';
 
+const GITHUB_URL = 'https://github.com/elastic/eui';
+
 export type GuidePageHeaderProps = {
   onToggleLocale: () => {};
   selectedLocale: string;
@@ -42,24 +44,42 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
 
   const environmentBadge = useMemo(() => {
     const isLocal = window.location.host.includes('803');
+    const isPRStaging = window.location.pathname.startsWith('/pr_');
 
     if (isLocal) {
       return <EuiBadge color="accent">Local</EuiBadge>;
     }
-    // TODO: PR staging badge
+    if (isPRStaging) {
+      const prId = window.location.pathname.split('/')[1].split('pr_')[1];
+      return (
+        <EuiBadge
+          color="hollow"
+          iconType="popout"
+          iconSide="right"
+          href={`${GITHUB_URL}/pull/${prId}`}
+          target="_blank"
+        >
+          Staging
+        </EuiBadge>
+      );
+    }
     return <VersionSwitcher />;
   }, []);
 
   const github = useMemo(() => {
-    const href = 'https://github.com/elastic/eui';
     const label = 'EUI GitHub repo';
     return isMobileSize ? (
-      <EuiButtonEmpty size="s" flush="both" iconType="logoGithub" href={href}>
+      <EuiButtonEmpty
+        size="s"
+        flush="both"
+        iconType="logoGithub"
+        href={GITHUB_URL}
+      >
         {label}
       </EuiButtonEmpty>
     ) : (
       <EuiToolTip content="Github">
-        <EuiHeaderSectionItemButton aria-label={label} href={href}>
+        <EuiHeaderSectionItemButton aria-label={label} href={GITHUB_URL}>
           <EuiIcon type="logoGithub" aria-hidden="true" />
         </EuiHeaderSectionItemButton>
       </EuiToolTip>

--- a/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react';
-import { FixedSizeList } from 'react-window';
 
 import {
   EuiBadge,
@@ -10,7 +9,6 @@ import {
   EuiHeaderLogo,
   EuiHeaderSectionItemButton,
   EuiIcon,
-  EuiListGroupItem,
   EuiPopover,
   EuiToolTip,
 } from '../../../../src/components';
@@ -21,11 +19,7 @@ import { CodeSandboxLink } from '../../components/codesandbox/link';
 import logoEUI from '../../images/logo-eui.svg';
 import { GuideThemeSelector, GuideFigmaLink } from '../guide_theme_selector';
 
-const { euiVersions } = require('./versions.json');
-const currentVersion = require('../../../../package.json').version;
-const pronounceVersion = (version: string) => {
-  return `version ${version.replaceAll('.', ' point ')}`; // NVDA pronounciation issue
-};
+import { VersionSwitcher } from './version_switcher';
 
 export type GuidePageHeaderProps = {
   onToggleLocale: () => {};
@@ -46,66 +40,15 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
     );
   }, []);
 
-  const [isVersionPopoverOpen, setIsVersionPopoverOpen] = useState(false);
-  const versionBadge = useMemo(() => {
-    const isLocalDev = window.location.host.includes('803');
-    return (
-      <EuiBadge
-        onClick={() => setIsVersionPopoverOpen((isOpen) => !isOpen)}
-        onClickAriaLabel={`${
-          isLocalDev ? 'Local' : pronounceVersion(currentVersion)
-        }. Click to switch versions`}
-        color={isLocalDev ? 'accent' : 'default'}
-      >
-        {isLocalDev ? 'Local' : `v${currentVersion}`}
-      </EuiBadge>
-    );
+  const environmentBadge = useMemo(() => {
+    const isLocal = window.location.host.includes('803');
+
+    if (isLocal) {
+      return <EuiBadge color="accent">Local</EuiBadge>;
+    }
+    // TODO: PR staging badge
+    return <VersionSwitcher />;
   }, []);
-  const versionSwitcher = useMemo(() => {
-    return (
-      <EuiPopover
-        isOpen={isVersionPopoverOpen}
-        closePopover={() => setIsVersionPopoverOpen(false)}
-        button={versionBadge}
-        repositionOnScroll
-        panelPaddingSize="xs"
-      >
-        <FixedSizeList
-          className="eui-yScroll"
-          itemCount={euiVersions.length}
-          itemSize={24}
-          height={200}
-          width={120}
-          innerElementType="ul"
-        >
-          {({ index, style }) => {
-            const version = euiVersions[index];
-            const screenReaderVersion = pronounceVersion(version);
-            return (
-              <EuiListGroupItem
-                style={style}
-                size="xs"
-                label={`v${version}`}
-                aria-label={screenReaderVersion}
-                href={`https://eui.elastic.co/v${version}/`}
-                extraAction={{
-                  'aria-label': `View release notes for ${screenReaderVersion}`,
-                  title: 'View release',
-                  iconType: 'package',
-                  iconSize: 's',
-                  // @ts-ignore - this is valid
-                  href: `https://github.com/elastic/eui/releases/tag/v${version}`,
-                  target: '_blank',
-                }}
-                isActive={version === currentVersion}
-                color={version === currentVersion ? 'primary' : 'text'}
-              />
-            );
-          }}
-        </FixedSizeList>
-      </EuiPopover>
-    );
-  }, [isVersionPopoverOpen, versionBadge]);
 
   const github = useMemo(() => {
     const href = 'https://github.com/elastic/eui';
@@ -200,7 +143,7 @@ export const GuidePageHeader: React.FunctionComponent<GuidePageHeaderProps> = ({
         position="fixed"
         theme="dark"
         sections={[
-          { items: [logo, versionSwitcher] },
+          { items: [logo, environmentBadge] },
           { items: rightSideItems },
         ]}
       />

--- a/src-docs/src/components/guide_page/version_switcher.tsx
+++ b/src-docs/src/components/guide_page/version_switcher.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useMemo } from 'react';
+import { FixedSizeList } from 'react-window';
+
+import {
+  EuiBadge,
+  EuiPopover,
+  EuiListGroupItem,
+} from '../../../../src/components';
+
+const { euiVersions } = require('./versions.json');
+const currentVersion = require('../../../../package.json').version;
+
+const pronounceVersion = (version: string) => {
+  return `version ${version.replaceAll('.', ' point ')}`; // NVDA pronounciation issue
+};
+
+export const VersionSwitcher = () => {
+  const [isVersionPopoverOpen, setIsVersionPopoverOpen] = useState(false);
+
+  const versionBadge = useMemo(() => {
+    return (
+      <EuiBadge
+        onClick={() => setIsVersionPopoverOpen((isOpen) => !isOpen)}
+        onClickAriaLabel={`${pronounceVersion(
+          currentVersion
+        )}. Click to switch versions`}
+        color="default"
+      >
+        v{currentVersion}
+      </EuiBadge>
+    );
+  }, []);
+
+  return (
+    <EuiPopover
+      isOpen={isVersionPopoverOpen}
+      closePopover={() => setIsVersionPopoverOpen(false)}
+      button={versionBadge}
+      repositionOnScroll
+      panelPaddingSize="xs"
+    >
+      <FixedSizeList
+        className="eui-yScroll"
+        itemCount={euiVersions.length}
+        itemSize={24}
+        height={200}
+        width={120}
+        innerElementType="ul"
+      >
+        {({ index, style }) => {
+          const version = euiVersions[index];
+          const screenReaderVersion = pronounceVersion(version);
+          return (
+            <EuiListGroupItem
+              style={style}
+              size="xs"
+              label={`v${version}`}
+              aria-label={screenReaderVersion}
+              href={`https://eui.elastic.co/v${version}/`}
+              extraAction={{
+                'aria-label': `View release notes for ${screenReaderVersion}`,
+                title: 'View release',
+                iconType: 'package',
+                iconSize: 's',
+                // @ts-ignore - this is valid
+                href: `https://github.com/elastic/eui/releases/tag/v${version}`,
+                target: '_blank',
+              }}
+              isActive={version === currentVersion}
+              color={version === currentVersion ? 'primary' : 'text'}
+            />
+          );
+        }}
+      </FixedSizeList>
+    </EuiPopover>
+  );
+};


### PR DESCRIPTION
## Summary

It occurred to me on a whim today that our PR staging instances (e.g. https://eui.elastic.co/pr_7347) should likely show some affordance for what they are (a staging server) rather than using the plain old version switcher (#7298). Here's my proposal for the different environments:

### Staging (link goes back to the originating GitHub PR)

<img width="243" alt="" src="https://github.com/elastic/eui/assets/549407/af9012ab-e05f-4dd2-a2d0-5e23a653eac5">

### Local (no link/switcher)

<img width="222" alt="" src="https://github.com/elastic/eui/assets/549407/2320f113-2fac-46fb-8469-f2d21246fbfa">

### Production (version switcher)

<img width="325" alt="" src="https://github.com/elastic/eui/assets/549407/0c525b1b-9170-472c-86a8-56979c38195f">

## QA

Check it out! https://eui.elastic.co/pr_7347/#/

### General checklist

N/A, docs only