### PR TITLE
[EuiText] Remove opinionated styles on child `img` tags

### DIFF
--- a/changelogs/upcoming/7360.md
+++ b/changelogs/upcoming/7360.md
@@ -1,0 +1,1 @@
+- Updated `EuiText` to no longer set any opinionated styles on child `<img>` tags - use `EuiImage` for image display within text instead

--- a/src/components/text/__snapshots__/text.styles.test.ts.snap
+++ b/src/components/text/__snapshots__/text.styles.test.ts.snap
@@ -81,7 +81,6 @@ exports[`euiTextStyles sizes m 1`] = `
     p,
     dl,
     blockquote,
-    img,
     pre,
     > ul,
     > ol {
@@ -243,7 +242,6 @@ exports[`euiTextStyles sizes relative 1`] = `
     p,
     dl,
     blockquote,
-    img,
     pre,
     > ul,
     > ol {
@@ -390,7 +388,6 @@ exports[`euiTextStyles sizes s 1`] = `
     p,
     dl,
     blockquote,
-    img,
     pre,
     > ul,
     > ol {
@@ -537,7 +534,6 @@ exports[`euiTextStyles sizes xs 1`] = `
     p,
     dl,
     blockquote,
-    img,
     pre,
     > ul,
     > ol {

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -144,7 +144,6 @@ const euiScaleText = (
     p,
     dl,
     blockquote,
-    img,
     pre,
     > ul,
     > ol {

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -248,11 +248,6 @@ export const euiTextStyles = (euiThemeContext: UseEuiTheme) => {
         ${euiLinkCSS(euiThemeContext)}
       }
 
-      img {
-        display: block;
-        ${logicalCSS('max-width', '100%')}
-      }
-
       ul {
         list-style: disc;
       }


### PR DESCRIPTION
## Summary

closes #7356

The removed `margin-bottom` CSS was inadvertently affecting `EuiIcon`s with custom SVG content (which generate `<img>` tags rather than `<svg>` tags).

I opted to make this opinionated change because it was affecting a production Kibana usage of custom SVGs in an `EuiCallOut` ([example CodeSandBox](https://codesandbox.io/s/old-shadow-vlxpgt?file=/demo.tsx)). In comparison, the number of production usages of images within `EuiText` in Kibana is very likely none.

Consumers who want this extra margin bottom back on images within EuiText can do any of the following:

1. Use an `<EuiImage width="fullSize" margin="l" />` component
2. Use an `<EuiSpacer />`
3. Wrap your `<img>` in a `<p>` tag

## QA

- [x] Search through EUI repo and confirm no impacted usages of the `<img>` tag
- [x] Search through Kibana (_~<20 results, most of which are used within tables/cards and not within a text/paragraph context)

### General checklist

- Browser QA - N/A, skipping because this change is straightforward
- Docs site QA - N/A, CSS-only change
- Code quality checklist - N/A, CSS-only change
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
