### PR TITLE
[EuiBasicTable][EuiInMemoryTable] Fix collapsed custom actions rendering an extra `<button>` wrapper + cleanup

### DIFF
--- a/changelogs/upcoming/7361.md
+++ b/changelogs/upcoming/7361.md
@@ -2,4 +2,4 @@
 
 **Accessibility**
 
-- Fixed custom `EuiBasicTable`/`EuiInMemoryTable` incorrendering nested interactive custom actions
+- Fixed custom `EuiBasicTable`/`EuiInMemoryTable` rendering nested interactive custom actions

--- a/changelogs/upcoming/7361.md
+++ b/changelogs/upcoming/7361.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Fixed custom `EuiBasicTable`/`EuiInMemoryTable` incorrendering nested interactive custom actions

--- a/changelogs/upcoming/7361.md
+++ b/changelogs/upcoming/7361.md
@@ -1,3 +1,5 @@
+- Improved `EuiBasicTable`/`EuiInMemoryTable's mobile UI for custom actions
+
 **Accessibility**
 
 - Fixed custom `EuiBasicTable`/`EuiInMemoryTable` incorrendering nested interactive custom actions

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -171,6 +171,11 @@ export default () => {
               );
             },
           },
+          {
+            render: () => {
+              return <EuiLink onClick={() => {}}>Edit</EuiLink>;
+            },
+          },
           ...actions,
         ];
       }

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -47,15 +47,19 @@ exports[`CollapsedItemActions render with href and _target provided 1`] = `
   repositionToCrossAxis={true}
 >
   <EuiContextMenuPanelClass
+    className="euiBasicTable__collapsedActions"
     items={
       Array [
         <EuiContextMenuItem
+          className="euiBasicTable__collapsedAction"
           disabled={false}
           onClick={[Function]}
         >
           default1
         </EuiContextMenuItem>,
-        <EuiContextMenuItem>
+        <EuiContextMenuItem
+          className="euiBasicTable__collapsedCustomAction"
+        >
           <span
             onClick={[Function]}
           >
@@ -63,6 +67,7 @@ exports[`CollapsedItemActions render with href and _target provided 1`] = `
           </span>
         </EuiContextMenuItem>,
         <EuiContextMenuItem
+          className="euiBasicTable__collapsedAction"
           disabled={false}
           href="https://www.elastic.co/"
           onClick={[Function]}

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -55,10 +55,12 @@ exports[`CollapsedItemActions render with href and _target provided 1`] = `
         >
           default1
         </EuiContextMenuItem>,
-        <EuiContextMenuItem
-          onClick={[Function]}
-        >
-          <div />
+        <EuiContextMenuItem>
+          <span
+            onClick={[Function]}
+          >
+            <div />
+          </span>
         </EuiContextMenuItem>,
         <EuiContextMenuItem
           disabled={false}

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -1,6 +1,219 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CollapsedItemActions render 1`] = `
+exports[`CollapsedItemActions custom actions 1`] = `
+<body>
+  <div>
+    <div
+      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
+      id="id-actions"
+    >
+      <span
+        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+      >
+        <button
+          aria-label="All actions"
+          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+          data-test-subj="euiCollapsedItemActionsButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="boxesHorizontal"
+          />
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-light-isOpen-hasTransform-left"
+        data-autofocus="true"
+        data-popover-open="true"
+        data-popover-panel="true"
+        role="dialog"
+        style="top: -22px; left: -16px; z-index: 2000;"
+        tabindex="0"
+      >
+        <div
+          class="euiPopover__arrow emotion-euiPopoverArrow-left"
+          data-popover-arrow="left"
+          style="left: 0px; top: 10px;"
+        />
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
+        </p>
+        <div>
+          <div
+            class="euiContextMenuPanel euiBasicTable__collapsedActions emotion-euiContextMenuPanel"
+            tabindex="-1"
+          >
+            <div>
+              <div
+                class="euiContextMenuItem euiBasicTable__collapsedCustomAction emotion-euiContextMenuItem-m-center"
+              >
+                <span
+                  class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                >
+                  <span>
+                    <button
+                      data-test-subj="customAction"
+                    >
+                      hello
+                    </button>
+                  </span>
+                </span>
+              </div>
+              <div
+                class="euiContextMenuItem euiBasicTable__collapsedCustomAction emotion-euiContextMenuItem-m-center"
+              >
+                <span
+                  class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                >
+                  <span>
+                    <a
+                      href="#"
+                    >
+                      world
+                    </a>
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`CollapsedItemActions default actions 1`] = `
+<body>
+  <div>
+    <div
+      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
+      id="id-actions"
+    >
+      <span
+        class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+      >
+        <button
+          aria-label="All actions"
+          class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+          data-test-subj="euiCollapsedItemActionsButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="boxesHorizontal"
+          />
+        </button>
+      </span>
+    </div>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-light-isOpen-hasTransform-left"
+        data-autofocus="true"
+        data-popover-open="true"
+        data-popover-panel="true"
+        role="dialog"
+        style="top: -22px; left: -16px; z-index: 2000;"
+        tabindex="0"
+      >
+        <div
+          class="euiPopover__arrow emotion-euiPopoverArrow-left"
+          data-popover-arrow="left"
+          style="left: 0px; top: 10px;"
+        />
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
+        </p>
+        <div>
+          <div
+            class="euiContextMenuPanel euiBasicTable__collapsedActions emotion-euiContextMenuPanel"
+            tabindex="-1"
+          >
+            <div>
+              <button
+                class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
+                data-test-subj="defaultAction"
+                type="button"
+              >
+                <span
+                  class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                >
+                  default1
+                </span>
+              </button>
+              <a
+                class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
+                href="https://www.elastic.co/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <span
+                  class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                >
+                  default2
+                </span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`CollapsedItemActions renders 1`] = `
 <div
   class="euiPopover emotion-euiPopover-inline-block"
   id="id-actions"
@@ -23,60 +236,4 @@ exports[`CollapsedItemActions render 1`] = `
     </button>
   </span>
 </div>
-`;
-
-exports[`CollapsedItemActions render with href and _target provided 1`] = `
-<EuiPopover
-  anchorPosition="leftCenter"
-  button={
-    <EuiI18n
-      default="All actions"
-      token="euiCollapsedItemActions.allActions"
-    >
-      [Function]
-    </EuiI18n>
-  }
-  closePopover={[Function]}
-  display="inline-block"
-  hasArrow={true}
-  id="id-actions"
-  isOpen={true}
-  ownFocus={true}
-  panelPaddingSize="none"
-  popoverRef={[Function]}
-  repositionToCrossAxis={true}
->
-  <EuiContextMenuPanelClass
-    className="euiBasicTable__collapsedActions"
-    items={
-      Array [
-        <EuiContextMenuItem
-          className="euiBasicTable__collapsedAction"
-          disabled={false}
-          onClick={[Function]}
-        >
-          default1
-        </EuiContextMenuItem>,
-        <EuiContextMenuItem
-          className="euiBasicTable__collapsedCustomAction"
-        >
-          <span
-            onClick={[Function]}
-          >
-            <div />
-          </span>
-        </EuiContextMenuItem>,
-        <EuiContextMenuItem
-          className="euiBasicTable__collapsedAction"
-          disabled={false}
-          href="https://www.elastic.co/"
-          onClick={[Function]}
-          target="_blank"
-        >
-          default2
-        </EuiContextMenuItem>,
-      ]
-    }
-  />
-</EuiPopover>
 `;

--- a/src/components/basic_table/__snapshots__/custom_item_action.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/custom_item_action.test.tsx.snap
@@ -4,10 +4,7 @@ exports[`CustomItemAction render 1`] = `
 <div
   className="test"
 >
-  <span
-    onBlur={[Function]}
-    onFocus={[Function]}
-  >
+  <span>
     test
   </span>
 </div>

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -72,7 +72,7 @@ export type DefaultItemAction<T> = ExclusiveUnion<
 
 export interface CustomItemAction<T> {
   /**
-   * The function that renders the action. Note that the returned node is expected to have `onFocus` and `onBlur` functions
+   * Allows rendering a totally custom action
    */
   render: (item: T, enabled: boolean) => ReactElement;
   /**

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -111,7 +111,10 @@ export class CollapsedItemActions<T> extends Component<
             // Do not put the `onClick` on the EuiContextMenuItem itself - otherwise
             // it renders a <button> tag instead of a <div>, and we end up with nested
             // interactive elements
-            <EuiContextMenuItem key={key}>
+            <EuiContextMenuItem
+              key={key}
+              className="euiBasicTable__collapsedCustomAction"
+            >
               <span onClick={() => this.onClickItem()}>{actionControl}</span>
             </EuiContextMenuItem>
           );
@@ -134,6 +137,7 @@ export class CollapsedItemActions<T> extends Component<
           controls.push(
             <EuiContextMenuItem
               key={key}
+              className="euiBasicTable__collapsedAction"
               disabled={!enabled}
               href={href}
               target={target}
@@ -190,7 +194,10 @@ export class CollapsedItemActions<T> extends Component<
         panelPaddingSize="none"
         anchorPosition="leftCenter"
       >
-        <EuiContextMenuPanel items={controls} />
+        <EuiContextMenuPanel
+          className="euiBasicTable__collapsedActions"
+          items={controls}
+        />
       </EuiPopover>
     );
   }

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, FocusEvent, ReactNode, ReactElement } from 'react';
+import React, { Component, ReactNode, ReactElement } from 'react';
 import { isString } from '../../services/predicate';
 import { EuiContextMenuItem, EuiContextMenuPanel } from '../context_menu';
 import { EuiPopover } from '../popover';
@@ -22,8 +22,6 @@ export interface CollapsedItemActionsProps<T> {
   itemId: ItemIdResolved;
   actionEnabled: (action: Action<T>) => boolean;
   className?: string;
-  onFocus?: (event: FocusEvent) => void;
-  onBlur?: () => void;
 }
 
 interface CollapsedItemActionsState {
@@ -40,8 +38,6 @@ export class CollapsedItemActions<T> extends Component<
   CollapsedItemActionsProps<T>,
   CollapsedItemActionsState
 > {
-  private popoverDiv: HTMLDivElement | null = null;
-
   state = { popoverOpen: false };
 
   togglePopover = () => {
@@ -52,45 +48,13 @@ export class CollapsedItemActions<T> extends Component<
     this.setState({ popoverOpen: false });
   };
 
-  onPopoverBlur = () => {
-    // you must be asking... WTF? I know... but this timeout is
-    // required to make sure we process the onBlur events after the initial
-    // event cycle. Reference:
-    // https://medium.com/@jessebeach/dealing-with-focus-and-blur-in-a-composite-widget-in-react-90d3c3b49a9b
-    window.requestAnimationFrame(() => {
-      if (
-        !this.popoverDiv!.contains(document.activeElement) &&
-        this.props.onBlur
-      ) {
-        this.props.onBlur();
-      }
-    });
-  };
-
-  registerPopoverDiv = (popoverDiv: HTMLDivElement | null) => {
-    if (!this.popoverDiv) {
-      this.popoverDiv = popoverDiv;
-      this.popoverDiv &&
-        this.popoverDiv.addEventListener('focusout', this.onPopoverBlur);
-    }
-  };
-
-  componentWillUnmount() {
-    if (this.popoverDiv) {
-      this.popoverDiv.removeEventListener('focusout', this.onPopoverBlur);
-    }
-  }
-
   onClickItem = (onClickAction?: () => void) => {
     this.closePopover();
-    if (onClickAction) {
-      onClickAction();
-    }
+    onClickAction?.();
   };
 
   render() {
-    const { actions, itemId, item, actionEnabled, onFocus, className } =
-      this.props;
+    const { actions, itemId, item, actionEnabled, className } = this.props;
 
     const isOpen = this.state.popoverOpen;
 
@@ -166,7 +130,6 @@ export class CollapsedItemActions<T> extends Component<
             color="text"
             isDisabled={allDisabled}
             onClick={this.togglePopover.bind(this)}
-            onFocus={onFocus}
             data-test-subj="euiCollapsedItemActionsButton"
           />
         )}
@@ -186,7 +149,6 @@ export class CollapsedItemActions<T> extends Component<
     return (
       <EuiPopover
         className={className}
-        popoverRef={this.registerPopoverDiv}
         id={`${itemId}-actions`}
         isOpen={isOpen}
         button={withTooltip || popoverButton}

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -81,7 +81,7 @@ export class CollapsedItemActions<T> extends Component<
     }
   }
 
-  onClickItem = (onClickAction: (() => void) | undefined) => {
+  onClickItem = (onClickAction?: () => void) => {
     this.closePopover();
     if (onClickAction) {
       onClickAction();
@@ -107,20 +107,12 @@ export class CollapsedItemActions<T> extends Component<
         if (actionIsCustomItemAction(action)) {
           const customAction = action as CustomItemAction<T>;
           const actionControl = customAction.render(item, enabled);
-          const actionControlOnClick =
-            actionControl && actionControl.props && actionControl.props.onClick;
           controls.push(
-            <EuiContextMenuItem
-              key={key}
-              onClick={() =>
-                this.onClickItem(
-                  actionControlOnClick
-                    ? () => actionControlOnClick(item)
-                    : undefined
-                )
-              }
-            >
-              {actionControl}
+            // Do not put the `onClick` on the EuiContextMenuItem itself - otherwise
+            // it renders a <button> tag instead of a <div>, and we end up with nested
+            // interactive elements
+            <EuiContextMenuItem key={key}>
+              <span onClick={() => this.onClickItem()}>{actionControl}</span>
             </EuiContextMenuItem>
           );
         } else {

--- a/src/components/basic_table/custom_item_action.tsx
+++ b/src/components/basic_table/custom_item_action.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Component } from 'react';
+import React from 'react';
 import { CustomItemAction as Action } from './action_types';
 
 export interface CustomItemActionProps<T> {
@@ -17,16 +17,11 @@ export interface CustomItemActionProps<T> {
   index?: number;
 }
 
-interface CustomItemActionState {
-  hasFocus: boolean;
-}
-
-export class CustomItemAction<T> extends Component<
-  CustomItemActionProps<T>,
-  CustomItemActionState
-> {
-  render() {
-    const { action, enabled, item, className } = this.props;
-    return <div className={className}>{action.render(item, enabled)}</div>;
-  }
-}
+export const CustomItemAction = <T,>({
+  action,
+  enabled,
+  item,
+  className,
+}: CustomItemActionProps<T>) => (
+  <div className={className}>{action.render(item, enabled)}</div>
+);

--- a/src/components/basic_table/custom_item_action.tsx
+++ b/src/components/basic_table/custom_item_action.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, cloneElement } from 'react';
+import React, { Component } from 'react';
 import { CustomItemAction as Action } from './action_types';
 
 export interface CustomItemActionProps<T> {
@@ -25,58 +25,8 @@ export class CustomItemAction<T> extends Component<
   CustomItemActionProps<T>,
   CustomItemActionState
 > {
-  private mounted: boolean;
-
-  constructor(props: CustomItemActionProps<T>) {
-    super(props);
-    this.state = { hasFocus: false };
-
-    // while generally considered an anti-pattern, here we require
-    // to do that as the onFocus/onBlur events of the action controls
-    // may trigger while this component is unmounted. An alternative
-    // (at least the workarounds suggested by react is to unregister
-    // the onFocus/onBlur listeners from the action controls... this
-    // unfortunately will lead to unnecessarily complex code... so we'll
-    // stick to this approach for now)
-    this.mounted = false;
-  }
-
-  componentDidMount() {
-    this.mounted = true;
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  onFocus = () => {
-    if (this.mounted) {
-      this.setState({ hasFocus: true });
-    }
-  };
-
-  onBlur = () => {
-    if (this.mounted) {
-      this.setState({ hasFocus: false });
-    }
-  };
-
-  hasFocus = () => {
-    return this.state.hasFocus;
-  };
-
   render() {
     const { action, enabled, item, className } = this.props;
-    const tool = action.render(item, enabled);
-    const clonedTool = cloneElement(tool, {
-      onFocus: this.onFocus,
-      onBlur: this.onBlur,
-    });
-    const style = this.hasFocus() ? { opacity: 1 } : undefined;
-    return (
-      <div style={style} className={className}>
-        {clonedTool}
-      </div>
-    );
+    return <div className={className}>{action.render(item, enabled)}</div>;
   }
 }

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -99,6 +99,25 @@
         }
       }
 
+      // Custom actions
+      &:not(.euiTableRow-hasActions) .euiTableRowCell--hasActions:last-child {
+        width: 100%;
+
+        &::before {
+          content: '';
+          position: absolute;
+          left: 0;
+          right: 0;
+          height: $euiBorderWidthThin;
+          background-color: $euiTableActionsBorderColor;
+        }
+
+        .euiTableCellContent {
+          position: relative;
+          top: $euiSizeXS;
+        }
+      }
+
       &.euiTableRow-hasActions.euiTableRow-isExpandable {
         .euiTableRowCell--isExpander {
           top: auto;


### PR DESCRIPTION
## Summary

Flagged in Slack today - on production, both basic and memory tables are incorrectly rendering double wrapping `<button>`s, which is definitely an axe/a11y violation.

| Before | After |
|--------|--------|
| <img width="512" alt="" src="https://github.com/elastic/eui/assets/549407/4a471544-7eb2-4adc-9571-d4037d45c63d"> | <img width="521" alt="" src="https://github.com/elastic/eui/assets/549407/785338e6-5f8d-48dc-8720-b7eb1da276fe"> |

⚠️ **Please follow along by commit** - the first 3 commits are the only required fixes, everything else is tech debt (rewriting tests to RTL, removing some totally unnecessary logic I noticed while here, then converted the files from class to function components because why not).

I also noticed that the mobile UI/UX of custom actions looked pretty meh, and improved that while here (last commit)

| Before | After |
|--------|--------|
| <img width="250" alt="" src="https://github.com/elastic/eui/assets/549407/51cb7418-bb81-44f5-8981-6856430e4745"> | <img width="250" alt="" src="https://github.com/elastic/eui/assets/549407/f9827cf9-525d-46ac-87aa-7368699fa8f0"> |

## QA

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A, bugfix
- Code quality checklist - Updated snapshots, but did not add new tests
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
