### PR TITLE
[CHORE] Bumping axe-core to v4.8.2. Matches Kibana version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "argparse": "^2.0.1",
     "assert": "^2.0.0",
     "autoprefixer": "^9.8.6",
-    "axe-core": "^4.4.1",
+    "axe-core": "^4.8.2",
     "babel-jest": "^24.1.0",
     "babel-loader": "^9.1.2",
     "babel-plugin-add-module-exports": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6472,15 +6472,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
-  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
-
 axe-core@^4.6.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
+
+axe-core@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae"
+  integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
 
 axios@^0.18.0, axios@^0.18.1:
   version "0.18.1"


### PR DESCRIPTION
## Summary

Bumping our axe-core ruleset to the current version. This matches [Kibana's recent merge](https://github.com/elastic/kibana/pull/171055) to latest.

PR closes #7357 

## QA

QA will be done in Buildkite CI. We will know PR is ready to review when all Cypress a11y tests pass green.