### PR TITLE
[EuiDataGrid] Redesign grid header

### DIFF
--- a/changelogs/upcoming/7371.md
+++ b/changelogs/upcoming/7371.md
@@ -1,0 +1,3 @@
+- Updated styles of `EuiDataGridHeaderCell` component to show the sorting icon after the cell text
+- Changed additional actions icon in `EuiDataGridHeaderCell` to `boxesVertical`
+- Changed alignment of text in `EuiDataGridHeaderCell` to the right for numeric columns

--- a/changelogs/upcoming/7371.md
+++ b/changelogs/upcoming/7371.md
@@ -1,3 +1,6 @@
-- Updated styles of `EuiDataGridHeaderCell` component to show the sorting icon after the cell text
-- Changed additional actions icon in `EuiDataGridHeaderCell` to `boxesVertical`
-- Changed alignment of text in `EuiDataGridHeaderCell` to the right for numeric columns
+- Updated `EuiDataGrid` column header cells to show the sort arrow after the heading text, instead of before
+- Updated `EuiDataGrid`'s column header actions icon from a chevron to `boxesVertical`
+
+**Bug fixes**
+
+- Fixed `EuiDataGrid`'s numeric and currency column heading cells to be correctly right-aligned

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -612,10 +612,10 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="A"
                       >
                         A
@@ -669,10 +669,10 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="B"
                       >
                         B
@@ -1082,10 +1082,10 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="A"
                       >
                         A
@@ -1139,10 +1139,10 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="B"
                       >
                         B
@@ -1813,10 +1813,10 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="A"
                       >
                         Column A
@@ -1870,10 +1870,10 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="B"
                       >
                         <div>
@@ -2263,10 +2263,10 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="A"
                       >
                         A
@@ -2320,10 +2320,10 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content"
+                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
                     >
                       <div
-                        class="euiDataGridHeaderCell__title"
+                        class="euiDataGridHeaderCell__innerTruncatedContent"
                         title="B"
                       >
                         B

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -621,12 +621,15 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                         A
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-A"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-A"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -675,12 +678,15 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                         B
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-B"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-B"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -1085,12 +1091,15 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                         A
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-A"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-A"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -1139,12 +1148,15 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                         B
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-B"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-B"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -1810,12 +1822,15 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                         Column A
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-A"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-A"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -1866,12 +1881,15 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                         </div>
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-B"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-B"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -2254,12 +2272,15 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                         A
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-A"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-A"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p
@@ -2308,12 +2329,15 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                         B
                       </div>
                     </div>
-                    <span
+                    <div
                       class="euiDataGridHeaderCell__icon"
-                      color="text"
-                      data-euiicon-type="boxesVertical"
-                      data-test-subj="dataGridHeaderCellActionButton-B"
-                    />
+                    >
+                      <span
+                        color="text"
+                        data-euiicon-type="boxesVertical"
+                        data-test-subj="dataGridHeaderCellActionButton-B"
+                      />
+                    </div>
                   </button>
                 </div>
                 <p

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -612,14 +612,10 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="A"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="A"
-                      >
-                        A
-                      </div>
+                      A
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"
@@ -669,14 +665,10 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="B"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="B"
-                      >
-                        B
-                      </div>
+                      B
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"
@@ -1058,14 +1050,10 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="A"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="A"
-                      >
-                        A
-                      </div>
+                      A
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"
@@ -1115,14 +1103,10 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="B"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="B"
-                      >
-                        B
-                      </div>
+                      B
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"
@@ -1741,14 +1725,10 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="A"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="A"
-                      >
-                        Column A
-                      </div>
+                      Column A
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"
@@ -1798,15 +1778,11 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="B"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="B"
-                      >
-                        <div>
-                          More Elements
-                        </div>
+                      <div>
+                        More Elements
                       </div>
                     </div>
                     <div
@@ -2167,14 +2143,10 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="A"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="A"
-                      >
-                        A
-                      </div>
+                      A
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"
@@ -2224,14 +2196,10 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                     tabindex="-1"
                   >
                     <div
-                      class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+                      class="euiDataGridHeaderCell__content"
+                      title="B"
                     >
-                      <div
-                        class="euiDataGridHeaderCell__innerTruncatedContent"
-                        title="B"
-                      >
-                        B
-                      </div>
+                      B
                     </div>
                     <div
                       class="euiDataGridHeaderCell__icon"

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -613,14 +613,18 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="A"
                     >
-                      A
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="A"
+                      >
+                        A
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-A"
                     />
                   </button>
@@ -663,14 +667,18 @@ exports[`EuiDataGrid rendering renders additional toolbar controls 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="B"
                     >
-                      B
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="B"
+                      >
+                        B
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-B"
                     />
                   </button>
@@ -1069,14 +1077,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="A"
                     >
-                      A
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="A"
+                      >
+                        A
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-A"
                     />
                   </button>
@@ -1119,14 +1131,18 @@ exports[`EuiDataGrid rendering renders control columns 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="B"
                     >
-                      B
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="B"
+                      >
+                        B
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-B"
                     />
                   </button>
@@ -1786,14 +1802,18 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="A"
                     >
-                      Column A
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="A"
+                      >
+                        Column A
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-A"
                     />
                   </button>
@@ -1836,16 +1856,20 @@ exports[`EuiDataGrid rendering renders custom column headers 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="B"
                     >
-                      <div>
-                        More Elements
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="B"
+                      >
+                        <div>
+                          More Elements
+                        </div>
                       </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-B"
                     />
                   </button>
@@ -2222,14 +2246,18 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="A"
                     >
-                      A
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="A"
+                      >
+                        A
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-A"
                     />
                   </button>
@@ -2272,14 +2300,18 @@ exports[`EuiDataGrid rendering renders with common and div attributes 1`] = `
                   >
                     <div
                       class="euiDataGridHeaderCell__content"
-                      title="B"
                     >
-                      B
+                      <div
+                        class="euiDataGridHeaderCell__title"
+                        title="B"
+                      >
+                        B
+                      </div>
                     </div>
                     <span
                       class="euiDataGridHeaderCell__icon"
                       color="text"
-                      data-euiicon-type="arrowDown"
+                      data-euiicon-type="boxesVertical"
                       data-test-subj="dataGridHeaderCellActionButton-B"
                     />
                   </button>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -44,12 +44,15 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
               columnA
             </div>
           </div>
-          <span
+          <div
             class="euiDataGridHeaderCell__icon"
-            color="text"
-            data-euiicon-type="boxesVertical"
-            data-test-subj="dataGridHeaderCellActionButton-columnA"
-          />
+          >
+            <span
+              color="text"
+              data-euiicon-type="boxesVertical"
+              data-test-subj="dataGridHeaderCellActionButton-columnA"
+            />
+          </div>
         </button>
       </div>
       <p
@@ -98,12 +101,15 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
               columnB
             </div>
           </div>
-          <span
+          <div
             class="euiDataGridHeaderCell__icon"
-            color="text"
-            data-euiicon-type="boxesVertical"
-            data-test-subj="dataGridHeaderCellActionButton-columnB"
-          />
+          >
+            <span
+              color="text"
+              data-euiicon-type="boxesVertical"
+              data-test-subj="dataGridHeaderCellActionButton-columnB"
+            />
+          </div>
         </button>
       </div>
       <p

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -35,10 +35,10 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           tabindex="-1"
         >
           <div
-            class="euiDataGridHeaderCell__content"
+            class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
           >
             <div
-              class="euiDataGridHeaderCell__title"
+              class="euiDataGridHeaderCell__innerTruncatedContent"
               title="columnA"
             >
               columnA
@@ -92,10 +92,10 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           tabindex="-1"
         >
           <div
-            class="euiDataGridHeaderCell__content"
+            class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
           >
             <div
-              class="euiDataGridHeaderCell__title"
+              class="euiDataGridHeaderCell__innerTruncatedContent"
               title="columnB"
             >
               columnB

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -35,14 +35,10 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           tabindex="-1"
         >
           <div
-            class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+            class="euiDataGridHeaderCell__content"
+            title="columnA"
           >
-            <div
-              class="euiDataGridHeaderCell__innerTruncatedContent"
-              title="columnA"
-            >
-              columnA
-            </div>
+            columnA
           </div>
           <div
             class="euiDataGridHeaderCell__icon"
@@ -92,14 +88,10 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
           tabindex="-1"
         >
           <div
-            class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+            class="euiDataGridHeaderCell__content"
+            title="columnB"
           >
-            <div
-              class="euiDataGridHeaderCell__innerTruncatedContent"
-              title="columnB"
-            >
-              columnB
-            </div>
+            columnB
           </div>
           <div
             class="euiDataGridHeaderCell__icon"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_custom.test.tsx.snap
@@ -36,14 +36,18 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
         >
           <div
             class="euiDataGridHeaderCell__content"
-            title="columnA"
           >
-            columnA
+            <div
+              class="euiDataGridHeaderCell__title"
+              title="columnA"
+            >
+              columnA
+            </div>
           </div>
           <span
             class="euiDataGridHeaderCell__icon"
             color="text"
-            data-euiicon-type="arrowDown"
+            data-euiicon-type="boxesVertical"
             data-test-subj="dataGridHeaderCellActionButton-columnA"
           />
         </button>
@@ -86,14 +90,18 @@ exports[`EuiDataGridBodyCustomRender treats \`renderCustomGridBody\` as a render
         >
           <div
             class="euiDataGridHeaderCell__content"
-            title="columnB"
           >
-            columnB
+            <div
+              class="euiDataGridHeaderCell__title"
+              title="columnB"
+            >
+              columnB
+            </div>
           </div>
           <span
             class="euiDataGridHeaderCell__icon"
             color="text"
-            data-euiicon-type="arrowDown"
+            data-euiicon-type="boxesVertical"
             data-test-subj="dataGridHeaderCellActionButton-columnB"
           />
         </button>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -40,14 +40,18 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
           >
             <div
               class="euiDataGridHeaderCell__content"
-              title="columnA"
             >
-              columnA
+              <div
+                class="euiDataGridHeaderCell__title"
+                title="columnA"
+              >
+                columnA
+              </div>
             </div>
             <span
               class="euiDataGridHeaderCell__icon"
               color="text"
-              data-euiicon-type="arrowDown"
+              data-euiicon-type="boxesVertical"
               data-test-subj="dataGridHeaderCellActionButton-columnA"
             />
           </button>
@@ -90,14 +94,18 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
           >
             <div
               class="euiDataGridHeaderCell__content"
-              title="columnB"
             >
-              columnB
+              <div
+                class="euiDataGridHeaderCell__title"
+                title="columnB"
+              >
+                columnB
+              </div>
             </div>
             <span
               class="euiDataGridHeaderCell__icon"
               color="text"
-              data-euiicon-type="arrowDown"
+              data-euiicon-type="boxesVertical"
               data-test-subj="dataGridHeaderCellActionButton-columnB"
             />
           </button>

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -39,14 +39,10 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
             tabindex="-1"
           >
             <div
-              class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+              class="euiDataGridHeaderCell__content"
+              title="columnA"
             >
-              <div
-                class="euiDataGridHeaderCell__innerTruncatedContent"
-                title="columnA"
-              >
-                columnA
-              </div>
+              columnA
             </div>
             <div
               class="euiDataGridHeaderCell__icon"
@@ -96,14 +92,10 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
             tabindex="-1"
           >
             <div
-              class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+              class="euiDataGridHeaderCell__content"
+              title="columnB"
             >
-              <div
-                class="euiDataGridHeaderCell__innerTruncatedContent"
-                title="columnB"
-              >
-                columnB
-              </div>
+              columnB
             </div>
             <div
               class="euiDataGridHeaderCell__icon"

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -48,12 +48,15 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
                 columnA
               </div>
             </div>
-            <span
+            <div
               class="euiDataGridHeaderCell__icon"
-              color="text"
-              data-euiicon-type="boxesVertical"
-              data-test-subj="dataGridHeaderCellActionButton-columnA"
-            />
+            >
+              <span
+                color="text"
+                data-euiicon-type="boxesVertical"
+                data-test-subj="dataGridHeaderCellActionButton-columnA"
+              />
+            </div>
           </button>
         </div>
         <p
@@ -102,12 +105,15 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
                 columnB
               </div>
             </div>
-            <span
+            <div
               class="euiDataGridHeaderCell__icon"
-              color="text"
-              data-euiicon-type="boxesVertical"
-              data-test-subj="dataGridHeaderCellActionButton-columnB"
-            />
+            >
+              <span
+                color="text"
+                data-euiicon-type="boxesVertical"
+                data-test-subj="dataGridHeaderCellActionButton-columnB"
+              />
+            </div>
           </button>
         </div>
         <p

--- a/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
+++ b/src/components/datagrid/body/__snapshots__/data_grid_body_virtualized.test.tsx.snap
@@ -39,10 +39,10 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
             tabindex="-1"
           >
             <div
-              class="euiDataGridHeaderCell__content"
+              class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
             >
               <div
-                class="euiDataGridHeaderCell__title"
+                class="euiDataGridHeaderCell__innerTruncatedContent"
                 title="columnA"
               >
                 columnA
@@ -96,10 +96,10 @@ exports[`EuiDataGridBodyVirtualized renders 1`] = `
             tabindex="-1"
           >
             <div
-              class="euiDataGridHeaderCell__content"
+              class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
             >
               <div
-                class="euiDataGridHeaderCell__title"
+                class="euiDataGridHeaderCell__innerTruncatedContent"
                 title="columnB"
               >
                 columnB

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -27,14 +27,10 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
       tabindex="-1"
     >
       <div
-        class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
+        class="euiDataGridHeaderCell__content"
+        title="someColumn"
       >
-        <div
-          class="euiDataGridHeaderCell__innerTruncatedContent"
-          title="someColumn"
-        >
-          someColumn
-        </div>
+        someColumn
       </div>
       <div
         class="euiDataGridHeaderCell__icon"

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -27,10 +27,10 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
       tabindex="-1"
     >
       <div
-        class="euiDataGridHeaderCell__content"
+        class="euiDataGridHeaderCell__content euiDataGridHeaderCell__content--withInnerTruncation"
       >
         <div
-          class="euiDataGridHeaderCell__title"
+          class="euiDataGridHeaderCell__innerTruncatedContent"
           title="someColumn"
         >
           someColumn

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -36,12 +36,15 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
           someColumn
         </div>
       </div>
-      <span
+      <div
         class="euiDataGridHeaderCell__icon"
-        color="text"
-        data-euiicon-type="boxesVertical"
-        data-test-subj="dataGridHeaderCellActionButton-someColumn"
-      />
+      >
+        <span
+          color="text"
+          data-euiicon-type="boxesVertical"
+          data-test-subj="dataGridHeaderCellActionButton-someColumn"
+        />
+      </div>
     </button>
   </div>
   <p

--- a/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
+++ b/src/components/datagrid/body/header/__snapshots__/data_grid_header_cell.test.tsx.snap
@@ -28,14 +28,18 @@ exports[`EuiDataGridHeaderCell renders 1`] = `
     >
       <div
         class="euiDataGridHeaderCell__content"
-        title="someColumn"
       >
-        someColumn
+        <div
+          class="euiDataGridHeaderCell__title"
+          title="someColumn"
+        >
+          someColumn
+        </div>
       </div>
       <span
         class="euiDataGridHeaderCell__icon"
         color="text"
-        data-euiicon-type="arrowDown"
+        data-euiicon-type="boxesVertical"
         data-test-subj="dataGridHeaderCellActionButton-someColumn"
       />
     </button>

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -17,14 +17,6 @@
   align-items: center;
   display: flex;
 
-  &.euiDataGridHeaderCell--numeric {
-    text-align: right;
-  }
-
-  &.euiDataGridHeaderCell--currency {
-    text-align: right;
-  }
-
   &:focus {
     @include euiDataGridCellFocus;
     border-top: none;
@@ -45,16 +37,10 @@
       width: 100%;
       font-weight: $euiFontWeightBold;
       outline: none;
-
-      .euiDataGridHeaderCell--numeric &,
-      .euiDataGridHeaderCell--currency & {
-        justify-content: flex-end;
-      }
     }
 
     .euiDataGridHeaderCell__content {
       @include euiTextTruncate;
-      text-align: left;
     }
 
     .euiDataGridHeaderCell__sortingArrow {
@@ -77,6 +63,20 @@
         width: $euiSize;
         opacity: 1;
       }
+    }
+  }
+
+  // Align numeric and currency schemas to the right
+  &.euiDataGridHeaderCell--numeric,
+  &.euiDataGridHeaderCell--currency {
+    justify-content: flex-end; // Accounts for cells disabled actions (no popover)
+
+    .euiDataGridHeaderCell__button {
+      justify-content: flex-end; // Accounts for cells with a popover
+    }
+
+    .euiDataGridHeaderCell__icon {
+      margin-left: 0;
     }
   }
 }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -73,7 +73,7 @@
   // Align numeric and currency schemas to the right
   &.euiDataGridHeaderCell--numeric,
   &.euiDataGridHeaderCell--currency {
-    justify-content: flex-end; // Accounts for cells disabled actions (no popover)
+    justify-content: flex-end; // Accounts for columns with disabled actions (no popover)
 
     .euiDataGridHeaderCell__button {
       justify-content: flex-end; // Accounts for cells with a popover

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -50,6 +50,10 @@
     .euiDataGridHeaderCell__icon {
       flex: 0 0 auto; // Ensure icon doesn't shrink
       margin-left: auto; // Aligns the icon to the right
+      // Center the icon vertically
+      display: flex;
+      align-items: center;
+      height: $euiSize;
       overflow: hidden;
       width: 0;
       opacity: 0;

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -72,17 +72,26 @@
       white-space: nowrap;
     }
 
+    .euiDataGridHeaderCell__content,
+    .euiDataGridHeaderCell__title,
+    .euiPopover {
+      min-width: 0; // to make sure that title is truncated and all icons are still visible
+    }
+
     .euiDataGridHeaderCell__icon {
+      display: none;
       flex-grow: 0;
       flex-basis: auto;
       width: auto;
       padding-left: $euiSizeXS;
     }
 
-    .euiDataGridHeaderCell__content,
-    .euiDataGridHeaderCell__title,
-    .euiPopover {
-      min-width: 0; // to make sure that title is truncated and all icons are still visible
+    &:focus-within,
+    &:hover,
+    .euiDataGridHeaderCell__button--withOpenPopover {
+      .euiDataGridHeaderCell__icon {
+        display: inline-block;
+      }
     }
   }
 }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -38,30 +38,38 @@
     }
 
     .euiDataGridHeaderCell__sortingArrow {
-      margin-right: $euiSizeXS;
+      margin-left: $euiSizeXS;
+      flex-grow: 0;
+      flex-shrink: 0;
     }
 
     .euiDataGridHeaderCell__button {
-      flex: 0 0 auto;
       position: relative;
       align-items: center;
       display: flex;
       width: 100%;
       font-weight: $euiFontWeightBold;
       outline: none;
-
-      .euiDataGridHeaderCell__sortingArrow {
-        flex-grow: 0;
-      }
     }
 
     .euiDataGridHeaderCell__content {
+      display: flex;
+      align-items: center;
+      flex-grow: 1;
+      align-self: baseline;
+    }
+
+    &.euiDataGridHeaderCell--numeric,
+    &.euiDataGridHeaderCell--currency {
+      .euiDataGridHeaderCell__content {
+        justify-content: flex-end;
+      }
+    }
+
+    .euiDataGridHeaderCell__title {
       @include euiTextTruncate;
       overflow: hidden;
       white-space: nowrap;
-      text-align: left;
-      flex-grow: 1;
-      align-self: baseline;
     }
 
     .euiDataGridHeaderCell__icon {
@@ -69,6 +77,12 @@
       flex-basis: auto;
       width: auto;
       padding-left: $euiSizeXS;
+    }
+
+    .euiDataGridHeaderCell__contentContainer,
+    .euiDataGridHeaderCell__content,
+    .euiPopover {
+      min-width: 0; // to make sure that title is truncated and all icons are still visible
     }
   }
 }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -53,27 +53,33 @@
     }
 
     .euiDataGridHeaderCell__content {
-      display: flex;
-      align-items: center;
+      @include euiTextTruncate;
+      overflow: hidden;
+      white-space: nowrap;
+      text-align: left;
       flex-grow: 1;
       align-self: baseline;
+
+      // this modifier is introduced for backwards compatability of the existing `euiDataGridHeaderCell__content` class
+      &--withInnerTruncation {
+        display: flex;
+        align-items: center;
+      }
     }
 
     &.euiDataGridHeaderCell--numeric,
     &.euiDataGridHeaderCell--currency {
-      .euiDataGridHeaderCell__content {
+      .euiDataGridHeaderCell__content--withInnerTruncation {
         justify-content: flex-end;
       }
     }
 
-    .euiDataGridHeaderCell__title {
+    .euiDataGridHeaderCell__innerTruncatedContent {
       @include euiTextTruncate;
-      overflow: hidden;
-      white-space: nowrap;
     }
 
-    .euiDataGridHeaderCell__content,
-    .euiDataGridHeaderCell__title,
+    .euiDataGridHeaderCell__content--withInnerTruncation,
+    .euiDataGridHeaderCell__innerTruncatedContent,
     .euiPopover {
       min-width: 0; // to make sure that title is truncated and all icons are still visible
     }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -37,57 +37,33 @@
       border-top: none;
     }
 
-    .euiDataGridHeaderCell__sortingArrow {
-      margin-left: $euiSizeXS;
-      flex-grow: 0;
-      flex-shrink: 0;
-    }
-
     .euiDataGridHeaderCell__button {
       position: relative;
-      align-items: center;
       display: flex;
+      align-items: center;
+      gap: $euiSizeXS;
       width: 100%;
       font-weight: $euiFontWeightBold;
       outline: none;
-    }
 
-    .euiDataGridHeaderCell__content {
-      @include euiTextTruncate;
-      overflow: hidden;
-      white-space: nowrap;
-      text-align: left;
-      flex-grow: 1;
-      align-self: baseline;
-
-      // this modifier is introduced for backwards compatability of the existing `euiDataGridHeaderCell__content` class
-      &--withInnerTruncation {
-        display: flex;
-        align-items: center;
-      }
-    }
-
-    &.euiDataGridHeaderCell--numeric,
-    &.euiDataGridHeaderCell--currency {
-      .euiDataGridHeaderCell__content--withInnerTruncation {
+      .euiDataGridHeaderCell--numeric &,
+      .euiDataGridHeaderCell--currency & {
         justify-content: flex-end;
       }
     }
 
-    .euiDataGridHeaderCell__innerTruncatedContent {
+    .euiDataGridHeaderCell__content {
       @include euiTextTruncate;
+      text-align: left;
     }
 
-    .euiDataGridHeaderCell__content--withInnerTruncation,
-    .euiDataGridHeaderCell__innerTruncatedContent,
-    .euiPopover {
-      min-width: 0; // to make sure that title is truncated and all icons are still visible
+    .euiDataGridHeaderCell__sortingArrow {
+      flex: 0 0 auto; // Ensure icon doesn't shrink
     }
 
     .euiDataGridHeaderCell__icon {
-      flex-grow: 0;
-      flex-shrink: 0;
-      padding-left: $euiSizeXS;
+      flex: 0 0 auto; // Ensure icon doesn't shrink
+      margin-left: auto; // Aligns the icon to the right
       overflow: hidden;
       width: 0;
       opacity: 0;

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -79,8 +79,8 @@
       padding-left: $euiSizeXS;
     }
 
-    .euiDataGridHeaderCell__contentContainer,
     .euiDataGridHeaderCell__content,
+    .euiDataGridHeaderCell__title,
     .euiPopover {
       min-width: 0; // to make sure that title is truncated and all icons are still visible
     }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -80,7 +80,7 @@
 
     .euiDataGridHeaderCell__icon {
       flex-grow: 0;
-      flex-basis: auto;
+      flex-shrink: 0;
       padding-left: $euiSizeXS;
       overflow: hidden;
       width: 0;

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -79,18 +79,21 @@
     }
 
     .euiDataGridHeaderCell__icon {
-      display: none;
       flex-grow: 0;
       flex-basis: auto;
-      width: auto;
       padding-left: $euiSizeXS;
+      overflow: hidden;
+      width: 0;
+      opacity: 0;
+      transition: width $euiAnimSpeedFast ease-in, opacity $euiAnimSpeedSlow ease-in;
     }
 
     &:focus-within,
     &:hover,
     .euiDataGridHeaderCell__button--withOpenPopover {
       .euiDataGridHeaderCell__icon {
-        display: inline-block;
+        width: $euiSize;
+        opacity: 1;
       }
     }
   }

--- a/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -62,7 +62,7 @@
 
     &:focus-within,
     &:hover,
-    .euiDataGridHeaderCell__button--withOpenPopover {
+    .euiPopover-isOpen {
       .euiDataGridHeaderCell__icon {
         width: $euiSize;
         opacity: 1;

--- a/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
@@ -256,9 +256,19 @@ describe('EuiDataGridHeaderCell', () => {
       fireEvent.click(toggle);
       waitForEuiPopoverOpen();
       expect(mockFocusContext.setFocusedCell).toHaveBeenCalledWith([0, -1]);
+      expect(
+        container.querySelector(
+          '.euiDataGridHeaderCell__button--withOpenPopover'
+        )
+      ).toBeInTheDocument();
 
       fireEvent.click(toggle);
       waitForEuiPopoverClose();
+      expect(
+        container.querySelector(
+          '.euiDataGridHeaderCell__button--withOpenPopover'
+        )
+      ).not.toBeInTheDocument();
     });
 
     describe('keyboard arrow navigation', () => {

--- a/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.test.tsx
@@ -256,19 +256,9 @@ describe('EuiDataGridHeaderCell', () => {
       fireEvent.click(toggle);
       waitForEuiPopoverOpen();
       expect(mockFocusContext.setFocusedCell).toHaveBeenCalledWith([0, -1]);
-      expect(
-        container.querySelector(
-          '.euiDataGridHeaderCell__button--withOpenPopover'
-        )
-      ).toBeInTheDocument();
 
       fireEvent.click(toggle);
       waitForEuiPopoverClose();
-      expect(
-        container.querySelector(
-          '.euiDataGridHeaderCell__button--withOpenPopover'
-        )
-      ).not.toBeInTheDocument();
     });
 
     describe('keyboard arrow navigation', () => {

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -96,20 +96,15 @@ export const EuiDataGridHeaderCell: FunctionComponent<
   });
 
   const cellContent = (
-    <div
-      className={classnames(
-        'euiDataGridHeaderCell__content',
-        'euiDataGridHeaderCell__content--withInnerTruncation'
-      )}
-    >
+    <>
       <div
         title={displayAsText || id}
-        className="euiDataGridHeaderCell__innerTruncatedContent"
+        className="euiDataGridHeaderCell__content"
       >
         {display || displayAsText || id}
       </div>
       {sortingArrow}
-    </div>
+    </>
   );
 
   return (

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -156,13 +156,14 @@ export const EuiDataGridHeaderCell: FunctionComponent<
                   </div>
                   {sortingArrow}
                 </div>
-                <EuiIcon
-                  className="euiDataGridHeaderCell__icon"
-                  type="boxesVertical"
-                  size="s"
-                  color="text"
-                  data-test-subj={`dataGridHeaderCellActionButton-${id}`}
-                />
+                <div className="euiDataGridHeaderCell__icon">
+                  <EuiIcon
+                    type="boxesVertical"
+                    size="s"
+                    color="text"
+                    data-test-subj={`dataGridHeaderCellActionButton-${id}`}
+                  />
+                </div>
               </button>
             }
             isOpen={isPopoverOpen}

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -137,7 +137,10 @@ export const EuiDataGridHeaderCell: FunctionComponent<
             offset={7}
             button={
               <button
-                className="euiDataGridHeaderCell__button"
+                className={classnames('euiDataGridHeaderCell__button', {
+                  'euiDataGridHeaderCell__button--withOpenPopover':
+                    isPopoverOpen,
+                })}
                 onClick={() => {
                   setFocusedCell([index, -1]);
                   setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -144,16 +144,18 @@ export const EuiDataGridHeaderCell: FunctionComponent<
                 }}
                 aria-describedby={`${sortingAriaId} ${actionsAriaId}`}
               >
-                {sortingArrow}
-                <div
-                  className="euiDataGridHeaderCell__content"
-                  title={displayAsText || id}
-                >
-                  {display || displayAsText || id}
+                <div className="euiDataGridHeaderCell__content">
+                  <div
+                    title={displayAsText || id}
+                    className="euiDataGridHeaderCell__title"
+                  >
+                    {display || displayAsText || id}
+                  </div>
+                  {sortingArrow}
                 </div>
                 <EuiIcon
                   className="euiDataGridHeaderCell__icon"
-                  type="arrowDown"
+                  type="boxesVertical"
                   size="s"
                   color="text"
                   data-test-subj={`dataGridHeaderCellActionButton-${id}`}

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -143,10 +143,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<
             offset={7}
             button={
               <button
-                className={classnames('euiDataGridHeaderCell__button', {
-                  'euiDataGridHeaderCell__button--withOpenPopover':
-                    isPopoverOpen,
-                })}
+                className="euiDataGridHeaderCell__button"
                 onClick={() => {
                   setFocusedCell([index, -1]);
                   setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -95,6 +95,23 @@ export const EuiDataGridHeaderCell: FunctionComponent<
     suffix: 'actions',
   });
 
+  const cellContent = (
+    <div
+      className={classnames(
+        'euiDataGridHeaderCell__content',
+        'euiDataGridHeaderCell__content--withInnerTruncation'
+      )}
+    >
+      <div
+        title={displayAsText || id}
+        className="euiDataGridHeaderCell__innerTruncatedContent"
+      >
+        {display || displayAsText || id}
+      </div>
+      {sortingArrow}
+    </div>
+  );
+
   return (
     <EuiDataGridHeaderCellWrapper
       {...displayHeaderCellProps}
@@ -115,13 +132,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<
 
       {!showColumnActions ? (
         <>
-          {sortingArrow}
-          <div
-            className="euiDataGridHeaderCell__content"
-            title={displayAsText || id}
-          >
-            {display || displayAsText || id}
-          </div>
+          {cellContent}
           {sortingScreenReaderText && (
             <EuiScreenReaderOnly>
               <p>{sortingScreenReaderText}</p>
@@ -147,15 +158,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<
                 }}
                 aria-describedby={`${sortingAriaId} ${actionsAriaId}`}
               >
-                <div className="euiDataGridHeaderCell__content">
-                  <div
-                    title={displayAsText || id}
-                    className="euiDataGridHeaderCell__title"
-                  >
-                    {display || displayAsText || id}
-                  </div>
-                  {sortingArrow}
-                </div>
+                {cellContent}
                 <div className="euiDataGridHeaderCell__icon">
                   <EuiIcon
                     type="boxesVertical"


### PR DESCRIPTION
- Closes https://github.com/elastic/eui/issues/7137

## Summary

This PR updates styles of `EuiDataGrid` header cells:
- Action icon is changed to `boxesVertical` and it will appear on hover
- Sorting icon is moved to after the title
- Right-alignment of header cells content for numeric columns

Before:
<img width="400" alt="Screenshot 2023-11-16 at 13 57 44" src="https://github.com/elastic/eui/assets/1415710/aecdc13b-de4e-43ee-9b78-404599b0b5f6">

After:
<img width="400" alt="Screenshot 2023-11-16 at 13 58 17" src="https://github.com/elastic/eui/assets/1415710/2f9414d5-2e8f-403c-a718-f298fef3eaee">


## QA

- [x] QA truncation on small column widths, both with and without sorting

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist - N/A - snapshots only, since this is mostly just DOM/CSS changes
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
