### PR TITLE
[EuiBasicTable][EuiInMemoryTable] Enable more action props to accept an optional callback + fix missing tooltips on collapsed actions

### DIFF
--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -1,1 +1,5 @@
 - Updated the actions column in `EuiBasicTable` and `EuiInMemoryTable`s. Alongside `name`, the `description`, `href`, and `data-test-subj` properties now also accept an optional callback that the current `item` will be passed to
+
+**Bug fixes**
+
+- Fixed `EuiBasicTable` and `EuiInMemoryTable` actions not showing tooltip descriptions when rendered in the all actions popover menu

--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -1,5 +1,11 @@
 - Updated the actions column in `EuiBasicTable` and `EuiInMemoryTable`s. Alongside `name`, the `description`, `href`, and `data-test-subj` properties now also accept an optional callback that the current `item` will be passed to
+- Updated `EuiContextMenuItem` with a new `toolTipProps` prop
 
 **Bug fixes**
 
 - Fixed `EuiBasicTable` and `EuiInMemoryTable` actions not showing tooltip descriptions when rendered in the all actions popover menu
+
+**Deprecations**
+
+- Deprecated `EuiContextMenuItem`'s `toolTipTitle` prop. Use `toolTipProps.title` instead
+- Deprecated `EuiContextMenuItem`'s `toolTipPosition` prop. Use `toolTipProps.position` instead

--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -1,1 +1,1 @@
-- Updated the actions column in `EuiBasicTable` and `EuiInMemoryTable`s. Alongside `name`, the `description` property now also accepts an optional callback that the current `item` will be passed to
+- Updated the actions column in `EuiBasicTable` and `EuiInMemoryTable`s. Alongside `name`, the `description`, `href`, and `data-test-subj` properties now also accept an optional callback that the current `item` will be passed to

--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -9,3 +9,7 @@
 
 - Deprecated `EuiContextMenuItem`'s `toolTipTitle` prop. Use `toolTipProps.title` instead
 - Deprecated `EuiContextMenuItem`'s `toolTipPosition` prop. Use `toolTipProps.position` instead
+
+**Accessibility**
+
+- Fixed `EuiBasicTable` and `EuiInMemoryTable` actions not correctly reading out action descriptions to screen readers

--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -4,6 +4,7 @@
 **Bug fixes**
 
 - Fixed `EuiBasicTable` and `EuiInMemoryTable` actions not showing tooltip descriptions when rendered in the all actions popover menu
+- Fixed missing underlines on `EuiContextMenu` link hover
 
 **Deprecations**
 

--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -13,3 +13,4 @@
 **Accessibility**
 
 - Fixed `EuiBasicTable` and `EuiInMemoryTable` actions not correctly reading out action descriptions to screen readers
+- Fixed `EuiBasicTable` and `EuiInMemoryTable` primary actions not visibly appearing on keyboard focus

--- a/changelogs/upcoming/7373.md
+++ b/changelogs/upcoming/7373.md
@@ -1,0 +1,1 @@
+- Updated the actions column in `EuiBasicTable` and `EuiInMemoryTable`s. Alongside `name`, the `description` property now also accepts an optional callback that the current `item` will be passed to

--- a/scripts/jest/setup/throw_on_console_error.js
+++ b/scripts/jest/setup/throw_on_console_error.js
@@ -26,6 +26,17 @@ console.error = (message, ...rest) => {
     return;
   }
 
+  // Silence RTL act() errors, that appear to primarily come from the fact
+  // that we have multiple versions of `@testing-library/dom` installed
+  if (
+    typeof message === 'string' &&
+    message.startsWith(
+      'Warning: The current testing environment is not configured to support act(...)'
+    )
+  ) {
+    return;
+  }
+
   // Print React validateDOMNesting warning as a console.warn instead
   // of throwing an error.
   // TODO: Remove when edge-case DOM nesting is fixed in all components

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -189,6 +189,7 @@ export default () => {
           icon: 'editorLink',
           color: 'primary',
           type: 'icon',
+          enabled: ({ online }) => !!online,
           href: ({ id }) => `${window.location.href}?id=${id}`,
           target: '_self',
           'data-test-subj': 'action-outboundlink',
@@ -218,7 +219,8 @@ export default () => {
           {
             name: 'Edit',
             isPrimary: true,
-            available: ({ online }: { online: boolean }) => !online,
+            available: ({ online }) => !online,
+            enabled: ({ online }) => !!online,
             description: 'Edit this user',
             icon: 'pencil',
             type: 'icon',

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -183,13 +183,14 @@ export default () => {
     } else {
       let actions: Array<DefaultItemAction<User>> = [
         {
-          name: 'Elastic.co',
-          description: 'Go to elastic.co',
+          name: 'User profile',
+          description: ({ firstName, lastName }) =>
+            `Visit ${firstName} ${lastName}'s profile`,
           icon: 'editorLink',
           color: 'primary',
           type: 'icon',
-          href: 'https://elastic.co',
-          target: '_blank',
+          href: ({ id }) => `${window.location.href}?id=${id}`,
+          target: '_self',
           'data-test-subj': 'action-outboundlink',
         },
       ];
@@ -205,13 +206,14 @@ export default () => {
           },
           {
             name: (user: User) => (user.id ? 'Delete' : 'Remove'),
-            description: 'Delete this user',
+            description: ({ firstName, lastName }) =>
+              `Delete ${firstName} ${lastName}`,
             icon: 'trash',
             color: 'danger',
             type: 'icon',
             onClick: deleteUser,
             isPrimary: true,
-            'data-test-subj': 'action-delete',
+            'data-test-subj': ({ id }) => `action-delete-${id}`,
           },
           {
             name: 'Edit',

--- a/src-docs/src/views/tables/actions/actions_section.js
+++ b/src-docs/src/views/tables/actions/actions_section.js
@@ -1,9 +1,14 @@
 import React from 'react';
-import { EuiBasicTable } from '../../../../../src/components';
+
+import { EuiBasicTable, EuiCode } from '../../../../../src/components';
+
 import { GuideSectionTypes } from '../../../components';
 
+import { EuiTableActionsColumnType } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
+import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
+import { DefaultItemActionProps as DefaultItemAction } from '../props/props';
+
 import Table from './actions';
-import { EuiCode } from '../../../../../src/components/code';
 const source = require('!!raw-loader!./actions');
 
 export const section = {
@@ -40,5 +45,6 @@ export const section = {
     </>
   ),
   components: { EuiBasicTable },
+  props: { EuiTableActionsColumnType, DefaultItemAction, CustomItemAction },
   demo: <Table />,
 };

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CollapsedItemActions custom actions 1`] = `
-<body>
+<body
+  class=""
+>
   <div>
     <div
       class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
@@ -176,30 +178,38 @@ exports[`CollapsedItemActions default actions 1`] = `
             tabindex="-1"
           >
             <div>
-              <button
-                class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
-                data-test-subj="defaultAction"
-                type="button"
+              <span
+                class="euiToolTipAnchor eui-displayBlock emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                <button
+                  class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
+                  data-test-subj="defaultAction"
+                  type="button"
                 >
-                  default1
-                </span>
-              </button>
-              <a
-                class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
-                data-test-subj="xyz-link"
-                href="#/xyz"
-                rel="noopener noreferrer"
-                target="_blank"
+                  <span
+                    class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                  >
+                    default1
+                  </span>
+                </button>
+              </span>
+              <span
+                class="euiToolTipAnchor eui-displayBlock emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                <a
+                  class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
+                  data-test-subj="xyz-link"
+                  href="#/xyz"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  name xyz
-                </span>
-              </a>
+                  <span
+                    class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+                  >
+                    name xyz
+                  </span>
+                </a>
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -189,14 +189,15 @@ exports[`CollapsedItemActions default actions 1`] = `
               </button>
               <a
                 class="euiContextMenuItem euiBasicTable__collapsedAction emotion-euiContextMenuItem-m-center"
-                href="https://www.elastic.co/"
+                data-test-subj="xyz-link"
+                href="#/xyz"
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 <span
                   class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
                 >
-                  default2
+                  name xyz
                 </span>
               </a>
             </div>

--- a/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
@@ -1,86 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DefaultItemAction render - button 1`] = `
-<EuiToolTip
-  content="action 1"
-  delay="long"
-  display="inlineBlock"
-  position="top"
+exports[`DefaultItemAction renders an EuiButtonEmpty when \`type="button" 1`] = `
+<span
+  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
 >
-  <EuiButtonEmpty
-    color="primary"
-    flush="right"
-    isDisabled={false}
-    onClick={[Function]}
-    size="s"
+  <button
+    class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+    type="button"
   >
-    action1
-  </EuiButtonEmpty>
-</EuiToolTip>
-`;
-
-exports[`DefaultItemAction render - default button 1`] = `
-<EuiToolTip
-  content="action 1"
-  delay="long"
-  display="inlineBlock"
-  position="top"
->
-  <EuiButtonEmpty
-    color="primary"
-    flush="right"
-    isDisabled={false}
-    onClick={[Function]}
-    size="s"
-  >
-    action1
-  </EuiButtonEmpty>
-</EuiToolTip>
-`;
-
-exports[`DefaultItemAction render - icon 1`] = `
-<EuiToolTip
-  content="action 1"
-  delay="long"
-  display="inlineBlock"
-  position="top"
->
-  <EuiButtonIcon
-    aria-labelledby="generated-id"
-    color="primary"
-    iconType="trash"
-    isDisabled={false}
-    onClick={[Function]}
-  />
-  <EuiScreenReaderOnly>
     <span
-      id="generated-id"
+      class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
     >
-      <span>
+      <span
+        class="eui-textTruncate euiButtonEmpty__text"
+      >
         action1
       </span>
     </span>
-  </EuiScreenReaderOnly>
-</EuiToolTip>
+  </button>
+</span>
 `;
 
-exports[`DefaultItemAction render - name 1`] = `
-<EuiToolTip
-  content="action 1"
-  delay="long"
-  display="inlineBlock"
-  position="top"
+exports[`DefaultItemAction renders an EuiButtonIcon when \`type="icon"\` 1`] = `
+<span
+  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
 >
-  <EuiButtonEmpty
-    color="primary"
-    flush="right"
-    isDisabled={false}
-    onClick={[Function]}
-    size="s"
+  <button
+    aria-labelledby="generated-id"
+    class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="euiButtonIcon__icon"
+      color="inherit"
+      data-euiicon-type="trash"
+    />
+  </button>
+  <span
+    class="emotion-euiScreenReaderOnly"
+    id="generated-id"
   >
     <span>
-      xyz
+      action1
     </span>
-  </EuiButtonEmpty>
-</EuiToolTip>
+  </span>
+</span>
 `;

--- a/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
@@ -21,22 +21,24 @@ exports[`DefaultItemAction renders an EuiButtonEmpty when \`type="button" 1`] = 
 </span>
 `;
 
-exports[`DefaultItemAction renders an EuiButtonIcon when \`type="icon"\` 1`] = `
-<span
-  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
->
-  <button
-    aria-labelledby="generated-id"
-    class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
-    type="button"
+exports[`DefaultItemAction renders an EuiButtonIcon with screen reader text when \`type="icon"\` 1`] = `
+<div>
+  <span
+    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
   >
-    <span
-      aria-hidden="true"
-      class="euiButtonIcon__icon"
-      color="inherit"
-      data-euiicon-type="trash"
-    />
-  </button>
+    <button
+      aria-labelledby="generated-id"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="trash"
+      />
+    </button>
+  </span>
   <span
     class="emotion-euiScreenReaderOnly"
     id="generated-id"
@@ -45,5 +47,5 @@ exports[`DefaultItemAction renders an EuiButtonIcon when \`type="icon"\` 1`] = `
       action1
     </span>
   </span>
-</span>
+</div>
 `;

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -18,13 +18,13 @@ type EuiButtonIconColorFunction<T> = (item: T) => ButtonColor;
 
 export interface DefaultItemActionBase<T> {
   /**
-   * The display name of the action (will be the button caption)
+   * The display name of the action (will render as visible text if rendered within a collapsed menu)
    */
   name: ReactNode | ((item: T) => ReactNode);
   /**
-   * Describes the action (will be the button title)
+   * Describes the action (will render as tooltip content)
    */
-  description: string;
+  description: string | ((item: T) => string);
   /**
    * A handler function to execute the action
    */

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -88,8 +88,13 @@ export interface CustomItemAction<T> {
 
 export type Action<T> = DefaultItemAction<T> | CustomItemAction<T>;
 
-export const isCustomItemAction = (
-  action: DefaultItemAction<any> | CustomItemAction<any>
-): action is CustomItemAction<any> => {
+export const isCustomItemAction = <T>(
+  action: DefaultItemAction<T> | CustomItemAction<T>
+): action is CustomItemAction<T> => {
   return action.hasOwnProperty('render');
 };
+
+export const callWithItemIfFunction =
+  <T>(item: T) =>
+  <U>(prop: U | ((item: T) => U)): U =>
+    typeof prop === 'function' ? (prop as Function)(item) : prop;

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -29,7 +29,7 @@ export interface DefaultItemActionBase<T> {
    * A handler function to execute the action
    */
   onClick?: (item: T) => void;
-  href?: string;
+  href?: string | ((item: T) => string);
   target?: string;
   /**
    * A callback function that determines whether the action is available
@@ -40,7 +40,7 @@ export interface DefaultItemActionBase<T> {
    */
   enabled?: (item: T) => boolean;
   isPrimary?: boolean;
-  'data-test-subj'?: string;
+  'data-test-subj'?: string | ((item: T) => string);
 }
 
 export interface DefaultItemEmptyButtonAction<T>

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -12,6 +12,7 @@ import {
   render,
   waitForEuiPopoverOpen,
   waitForEuiPopoverClose,
+  waitForEuiToolTipVisible,
 } from '../../test/rtl';
 
 import { CollapsedItemActions } from './collapsed_item_actions';
@@ -65,7 +66,7 @@ describe('CollapsedItemActions', () => {
       actionEnabled: () => true,
     };
 
-    const { getByTestSubject, baseElement } = render(
+    const { getByTestSubject, getByText, baseElement } = render(
       <CollapsedItemActions {...props} />
     );
     fireEvent.click(getByTestSubject('euiCollapsedItemActionsButton'));
@@ -73,8 +74,11 @@ describe('CollapsedItemActions', () => {
 
     expect(baseElement).toMatchSnapshot();
 
-    expect(getByTestSubject('link-xyz')).toHaveAttribute('href', '#/xyz');
-    expect(getByTestSubject('link-xyz')).toHaveTextContent('name xyz');
+    expect(getByTestSubject('xyz-link')).toHaveAttribute('href', '#/xyz');
+    expect(getByTestSubject('xyz-link')).toHaveTextContent('name xyz');
+    fireEvent.mouseEnter(getByTestSubject('xyz-link'));
+    await waitForEuiToolTipVisible();
+    expect(getByText('description xyz')).toBeInTheDocument();
 
     fireEvent.click(getByTestSubject('defaultAction'));
     await waitForEuiPopoverClose();

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -16,12 +16,14 @@ import {
 
 import { CollapsedItemActions } from './collapsed_item_actions';
 
+type Item = { id: string };
+
 describe('CollapsedItemActions', () => {
   it('renders', () => {
     const props = {
       actions: [
         {
-          name: (item: { id: string }) => `default${item.id}`,
+          name: (item: Item) => `default${item.id}`,
           description: 'default 1',
           onClick: () => {},
         },
@@ -51,10 +53,11 @@ describe('CollapsedItemActions', () => {
           'data-test-subj': 'defaultAction',
         },
         {
-          name: 'default2',
-          description: 'default 2',
-          href: 'https://www.elastic.co/',
+          name: ({ id }: Item) => `name ${id}`,
+          description: ({ id }: Item) => `description ${id}`,
+          href: ({ id }: Item) => `#/${id}`,
           target: '_blank',
+          'data-test-subj': ({ id }: Item) => `${id}-link`,
         },
       ],
       itemId: 'id',
@@ -69,6 +72,9 @@ describe('CollapsedItemActions', () => {
     await waitForEuiPopoverOpen();
 
     expect(baseElement).toMatchSnapshot();
+
+    expect(getByTestSubject('link-xyz')).toHaveAttribute('href', '#/xyz');
+    expect(getByTestSubject('link-xyz')).toHaveTextContent('name xyz');
 
     fireEvent.click(getByTestSubject('defaultAction'));
     await waitForEuiPopoverClose();

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -21,7 +21,12 @@ import { EuiButtonIcon } from '../button';
 import { EuiToolTip } from '../tool_tip';
 import { EuiI18n } from '../i18n';
 
-import { Action, CustomItemAction } from './action_types';
+import {
+  Action,
+  CustomItemAction,
+  isCustomItemAction,
+  callWithItemIfFunction,
+} from './action_types';
 import { ItemIdResolved } from './table_types';
 
 export interface CollapsedItemActionsProps<T extends {}> {
@@ -31,10 +36,6 @@ export interface CollapsedItemActionsProps<T extends {}> {
   actionEnabled: (action: Action<T>) => boolean;
   className?: string;
 }
-
-const actionIsCustomItemAction = <T extends {}>(
-  action: Action<T>
-): action is CustomItemAction<T> => action.hasOwnProperty('render');
 
 export const CollapsedItemActions = <T extends {}>({
   actions,
@@ -59,7 +60,7 @@ export const CollapsedItemActions = <T extends {}>({
       const enabled = actionEnabled(action);
       if (enabled) setAllDisabled(false);
 
-      if (actionIsCustomItemAction(action)) {
+      if (isCustomItemAction<T>(action)) {
         const customAction = action as CustomItemAction<T>;
         const actionControl = customAction.render(item, enabled);
         controls.push(

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -75,20 +75,19 @@ export const CollapsedItemActions = <T extends {}>({
           </EuiContextMenuItem>
         );
       } else {
-        const {
-          onClick,
-          name,
-          href,
-          target,
-          'data-test-subj': dataTestSubj,
-        } = action;
-
         const buttonIcon = action.icon;
         let icon;
         if (buttonIcon) {
           icon = isString(buttonIcon) ? buttonIcon : buttonIcon(item);
         }
-        const buttonContent = typeof name === 'function' ? name(item) : name;
+
+        const buttonContent = callWithItemIfFunction(item)(action.name);
+        const href = callWithItemIfFunction(item)(action.href);
+        const dataTestSubj = callWithItemIfFunction(item)(
+          action['data-test-subj']
+        );
+
+        const { onClick, target } = action;
 
         controls.push(
           <EuiContextMenuItem

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -82,6 +82,7 @@ export const CollapsedItemActions = <T extends {}>({
         }
 
         const buttonContent = callWithItemIfFunction(item)(action.name);
+        const toolTipContent = callWithItemIfFunction(item)(action.description);
         const href = callWithItemIfFunction(item)(action.href);
         const dataTestSubj = callWithItemIfFunction(item)(
           action['data-test-subj']
@@ -101,6 +102,7 @@ export const CollapsedItemActions = <T extends {}>({
             onClick={() =>
               onClickItem(onClick ? () => onClick(item) : undefined)
             }
+            toolTipContent={toolTipContent}
           >
             {buttonContent}
           </EuiContextMenuItem>

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -103,6 +103,7 @@ export const CollapsedItemActions = <T extends {}>({
               onClickItem(onClick ? () => onClick(item) : undefined)
             }
             toolTipContent={toolTipContent}
+            toolTipProps={{ delay: 'long' }}
           >
             {buttonContent}
           </EuiContextMenuItem>

--- a/src/components/basic_table/default_item_action.test.tsx
+++ b/src/components/basic_table/default_item_action.test.tsx
@@ -43,7 +43,7 @@ describe('DefaultItemAction', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders an EuiButtonIcon when `type="icon"`', () => {
+  it('renders an EuiButtonIcon with screen reader text when `type="icon"`', () => {
     const action: IconButtonAction<Item> = {
       name: <span>action1</span>,
       description: 'action 1',
@@ -59,7 +59,7 @@ describe('DefaultItemAction', () => {
 
     const { container } = render(<DefaultItemAction {...props} />);
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('renders an EuiButtonEmpty if no type is specified', () => {

--- a/src/components/basic_table/default_item_action.test.tsx
+++ b/src/components/basic_table/default_item_action.test.tsx
@@ -7,6 +7,12 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import {
+  render,
+  waitForEuiToolTipVisible,
+  waitForEuiToolTipHidden,
+} from '../../test/rtl';
 import { shallow } from 'enzyme';
 import { DefaultItemAction } from './default_item_action';
 import {
@@ -89,5 +95,49 @@ describe('DefaultItemAction', () => {
     const component = shallow(<DefaultItemAction {...props} />);
 
     expect(component).toMatchSnapshot();
+  });
+
+  test('props that can be functions', async () => {
+    const action: EmptyButtonAction<Item> = {
+      name: ({ id }) =>
+        id === 'hello' ? <span>Hello</span> : <span>world</span>,
+      description: ({ id }) =>
+        id === 'hello' ? 'hello tooltip' : 'goodbye tooltip',
+      href: ({ id }) => `#/${id}`,
+      'data-test-subj': ({ id }) => `action-${id}`,
+    };
+
+    const { getByTestSubject, getByText } = render(
+      <>
+        <DefaultItemAction
+          action={action}
+          enabled={true}
+          item={{ id: 'hello' }}
+        />
+        <DefaultItemAction
+          action={action}
+          enabled={true}
+          item={{ id: 'world' }}
+        />
+      </>
+    );
+
+    const firstAction = getByTestSubject('action-hello');
+    expect(firstAction).toHaveTextContent('Hello');
+    expect(firstAction).toHaveAttribute('href', '#/hello');
+
+    const secondAction = getByTestSubject('action-world');
+    expect(secondAction).toHaveTextContent('world');
+    expect(secondAction).toHaveAttribute('href', '#/world');
+
+    fireEvent.mouseOver(firstAction);
+    await waitForEuiToolTipVisible();
+    expect(getByText('hello tooltip')).toBeInTheDocument();
+    fireEvent.mouseOut(firstAction);
+    await waitForEuiToolTipHidden();
+
+    fireEvent.mouseOver(secondAction);
+    await waitForEuiToolTipVisible();
+    expect(getByText('goodbye tooltip')).toBeInTheDocument();
   });
 });

--- a/src/components/basic_table/default_item_action.test.tsx
+++ b/src/components/basic_table/default_item_action.test.tsx
@@ -13,7 +13,7 @@ import {
   waitForEuiToolTipVisible,
   waitForEuiToolTipHidden,
 } from '../../test/rtl';
-import { shallow } from 'enzyme';
+
 import { DefaultItemAction } from './default_item_action';
 import {
   DefaultItemEmptyButtonAction as EmptyButtonAction,
@@ -25,24 +25,7 @@ interface Item {
 }
 
 describe('DefaultItemAction', () => {
-  test('render - default button', () => {
-    const action: EmptyButtonAction<Item> = {
-      name: 'action1',
-      description: 'action 1',
-      onClick: () => {},
-    };
-    const props = {
-      action,
-      enabled: true,
-      item: { id: 'xyz' },
-    };
-
-    const component = shallow(<DefaultItemAction {...props} />);
-
-    expect(component).toMatchSnapshot();
-  });
-
-  test('render - button', () => {
+  it('renders an EuiButtonEmpty when `type="button"', () => {
     const action: EmptyButtonAction<Item> = {
       name: 'action1',
       description: 'action 1',
@@ -55,30 +38,12 @@ describe('DefaultItemAction', () => {
       item: { id: 'xyz' },
     };
 
-    const component = shallow(<DefaultItemAction {...props} />);
+    const { container } = render(<DefaultItemAction {...props} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('render - name', () => {
-    const action: EmptyButtonAction<Item> = {
-      name: (item) => <span>{item.id}</span>,
-      description: 'action 1',
-      type: 'button',
-      onClick: () => {},
-    };
-    const props = {
-      action,
-      enabled: true,
-      item: { id: 'xyz' },
-    };
-
-    const component = shallow(<DefaultItemAction {...props} />);
-
-    expect(component).toMatchSnapshot();
-  });
-
-  test('render - icon', () => {
+  it('renders an EuiButtonIcon when `type="icon"`', () => {
     const action: IconButtonAction<Item> = {
       name: <span>action1</span>,
       description: 'action 1',
@@ -92,9 +57,26 @@ describe('DefaultItemAction', () => {
       item: { id: 'xyz' },
     };
 
-    const component = shallow(<DefaultItemAction {...props} />);
+    const { container } = render(<DefaultItemAction {...props} />);
 
-    expect(component).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders an EuiButtonEmpty if no type is specified', () => {
+    const action: EmptyButtonAction<Item> = {
+      name: 'action1',
+      description: 'action 1',
+      onClick: () => {},
+    };
+    const props = {
+      action,
+      enabled: true,
+      item: { id: 'xyz' },
+    };
+
+    const { container } = render(<DefaultItemAction {...props} />);
+
+    expect(container.querySelector('.euiButtonEmpty')).toBeInTheDocument();
   });
 
   test('props that can be functions', async () => {

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -55,12 +55,10 @@ export const DefaultItemAction = <T extends {}>({
   }
 
   let button;
-  const actionContent =
-    typeof action.name === 'function' ? action.name(item) : action.name;
-  const tooltipContent =
-    typeof action.description === 'function'
-      ? action.description(item)
-      : action.description;
+  const actionContent = callWithItemIfFunction(item)(action.name);
+  const tooltipContent = callWithItemIfFunction(item)(action.description);
+  const href = callWithItemIfFunction(item)(action.href);
+  const dataTestSubj = callWithItemIfFunction(item)(action['data-test-subj']);
 
   const ariaLabelId = useGeneratedHtmlId();
   if (action.type === 'icon') {
@@ -77,9 +75,9 @@ export const DefaultItemAction = <T extends {}>({
           color={color}
           iconType={icon}
           onClick={onClick}
-          href={action.href}
+          href={href}
           target={action.target}
-          data-test-subj={action['data-test-subj']}
+          data-test-subj={dataTestSubj}
         />
         {/* actionContent (action.name) is a ReactNode and must be rendered to an element and referenced by ID for screen readers */}
         <EuiScreenReaderOnly>
@@ -96,9 +94,9 @@ export const DefaultItemAction = <T extends {}>({
         color={color as EuiButtonEmptyProps['color']}
         iconType={icon}
         onClick={onClick}
-        href={action.href}
+        href={href}
         target={action.target}
-        data-test-subj={action['data-test-subj']}
+        data-test-subj={dataTestSubj}
         flush="right"
       >
         {actionContent}
@@ -114,3 +112,8 @@ export const DefaultItemAction = <T extends {}>({
     button
   );
 };
+
+const callWithItemIfFunction =
+  <T,>(item: T) =>
+  <U,>(prop: U | ((item: T) => U)): U =>
+    typeof prop === 'function' ? (prop as Function)(item) : prop;

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -81,6 +81,9 @@ export const DefaultItemAction = <T,>({
         href={href}
         target={action.target}
         data-test-subj={dataTestSubj}
+        // If action is disabled, the normal tooltip can't show - attempt to
+        // provide some amount of affordance with a browser title tooltip
+        title={!enabled ? tooltipContent : undefined}
       />
     );
     // actionContent (action.name) is a ReactNode and must be rendered

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 import { isString } from '../../services/predicate';
 import {
@@ -63,29 +63,32 @@ export const DefaultItemAction = <T,>({
   const dataTestSubj = callWithItemIfFunction(item)(action['data-test-subj']);
 
   const ariaLabelId = useGeneratedHtmlId();
+  let ariaLabelledBy: ReactNode;
+
   if (action.type === 'icon') {
     if (!icon) {
       throw new Error(`Cannot render item action [${action.name}]. It is configured to render as an icon but no
       icon is provided. Make sure to set the 'icon' property of the action`);
     }
     button = (
-      <>
-        <EuiButtonIcon
-          className={className}
-          aria-labelledby={ariaLabelId}
-          isDisabled={!enabled}
-          color={color}
-          iconType={icon}
-          onClick={onClick}
-          href={href}
-          target={action.target}
-          data-test-subj={dataTestSubj}
-        />
-        {/* actionContent (action.name) is a ReactNode and must be rendered to an element and referenced by ID for screen readers */}
-        <EuiScreenReaderOnly>
-          <span id={ariaLabelId}>{actionContent}</span>
-        </EuiScreenReaderOnly>
-      </>
+      <EuiButtonIcon
+        className={className}
+        aria-labelledby={ariaLabelId}
+        isDisabled={!enabled}
+        color={color}
+        iconType={icon}
+        onClick={onClick}
+        href={href}
+        target={action.target}
+        data-test-subj={dataTestSubj}
+      />
+    );
+    // actionContent (action.name) is a ReactNode and must be rendered
+    // to an element and referenced by ID for screen readers
+    ariaLabelledBy = (
+      <EuiScreenReaderOnly>
+        <span id={ariaLabelId}>{actionContent}</span>
+      </EuiScreenReaderOnly>
     );
   } else {
     button = (
@@ -106,11 +109,19 @@ export const DefaultItemAction = <T,>({
     );
   }
 
-  return enabled && tooltipContent ? (
-    <EuiToolTip content={tooltipContent} delay="long">
-      {button}
-    </EuiToolTip>
+  return enabled ? (
+    <>
+      <EuiToolTip content={tooltipContent} delay="long">
+        {button}
+      </EuiToolTip>
+      {/* SR text has to be rendered outside the tooltip,
+      otherwise EuiToolTip's own aria-labelledby won't properly clone */}
+      {ariaLabelledBy}
+    </>
   ) : (
-    button
+    <>
+      {button}
+      {ariaLabelledBy}
+    </>
   );
 };

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -26,10 +26,7 @@ export interface DefaultItemActionProps<T> {
   className?: string;
 }
 
-// In order to use generics with an arrow function inside a .tsx file, it's necessary to use
-// this `extends` hack and declare the types as shown, instead of declaring the const as a
-// FunctionComponent
-export const DefaultItemAction = <T extends {}>({
+export const DefaultItemAction = <T,>({
   action,
   enabled,
   item,

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -57,6 +57,11 @@ export const DefaultItemAction = <T extends {}>({
   let button;
   const actionContent =
     typeof action.name === 'function' ? action.name(item) : action.name;
+  const tooltipContent =
+    typeof action.description === 'function'
+      ? action.description(item)
+      : action.description;
+
   const ariaLabelId = useGeneratedHtmlId();
   if (action.type === 'icon') {
     if (!icon) {
@@ -101,8 +106,8 @@ export const DefaultItemAction = <T extends {}>({
     );
   }
 
-  return enabled && action.description ? (
-    <EuiToolTip content={action.description} delay="long">
+  return enabled && tooltipContent ? (
+    <EuiToolTip content={tooltipContent} delay="long">
       {button}
     </EuiToolTip>
   ) : (

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { ReactElement } from 'react';
+
 import { isString } from '../../services/predicate';
 import {
   EuiButtonEmpty,
@@ -15,9 +16,13 @@ import {
   EuiButtonIconProps,
 } from '../button';
 import { EuiToolTip } from '../tool_tip';
-import { DefaultItemAction as Action } from './action_types';
 import { useGeneratedHtmlId } from '../../services/accessibility';
 import { EuiScreenReaderOnly } from '../accessibility';
+
+import {
+  DefaultItemAction as Action,
+  callWithItemIfFunction,
+} from './action_types';
 
 export interface DefaultItemActionProps<T> {
   action: Action<T>;
@@ -109,8 +114,3 @@ export const DefaultItemAction = <T,>({
     button
   );
 };
-
-const callWithItemIfFunction =
-  <T,>(item: T) =>
-  <U,>(prop: U | ((item: T) => U)): U =>
-    typeof prop === 'function' ? (prop as Function)(item) : prop;

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -51,7 +51,7 @@ export const ExpandedItemActions = <T extends {}>({
           expandedItemActions__completelyHide: moreThanThree && index < 2,
         });
 
-        if (isCustomItemAction(action)) {
+        if (isCustomItemAction<T>(action)) {
           // custom action has a render function
           tools.push(
             <CustomItemAction

--- a/src/components/context_menu/__snapshots__/context_menu_item.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_item.test.tsx.snap
@@ -60,3 +60,52 @@ exports[`EuiContextMenuItem renders 1`] = `
   </span>
 </a>
 `;
+
+exports[`EuiContextMenuItem tooltip behavior 1`] = `
+<body
+  class="euiBody-hasPortalContent"
+>
+  <div>
+    <span
+      class="euiToolTipAnchor eui-displayBlock emotion-euiToolTipAnchor-inlineBlock"
+    >
+      <button
+        aria-describedby="generated-id"
+        class="euiContextMenuItem emotion-euiContextMenuItem-m-center"
+        type="button"
+      >
+        <span
+          class="euiContextMenuItem__text emotion-euiContextMenuItem__text"
+        >
+          Hello
+        </span>
+      </button>
+    </span>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      class="euiToolTipPopover euiToolTip emotion-euiToolTip-top"
+      data-position="top"
+      id="generated-id"
+      position="top"
+      role="tooltip"
+      style="top: -16px; left: -10px;"
+    >
+      <div
+        class="euiToolTip__title emotion-euiToolTip__title"
+      >
+        Test
+      </div>
+      <div
+        class="euiToolTip__arrow emotion-euiToolTip__arrow-top"
+        style="left: 4px; top: 0px;"
+      />
+      <div>
+        tooltip content
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/components/context_menu/context_menu_item.styles.ts
+++ b/src/components/context_menu/context_menu_item.styles.ts
@@ -27,13 +27,15 @@ export const euiContextMenuItemStyles = (euiThemeContext: UseEuiTheme) => {
       color: ${euiTheme.colors.text};
       outline-offset: -${euiTheme.focus.width};
 
-      &:enabled:hover,
-      &:enabled:focus {
-        text-decoration: underline;
-      }
+      &:not(:disabled) {
+        &:hover,
+        &:focus {
+          text-decoration: underline;
+        }
 
-      &:enabled:focus {
-        background-color: ${euiTheme.focus.backgroundColor};
+        &:focus {
+          background-color: ${euiTheme.focus.backgroundColor};
+        }
       }
     `,
     disabled: css`

--- a/src/components/context_menu/context_menu_item.test.tsx
+++ b/src/components/context_menu/context_menu_item.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { render } from '../../test/rtl';
+import { render, waitForEuiToolTipVisible } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
 
@@ -16,6 +16,18 @@ import { EuiContextMenuItem, SIZES } from './context_menu_item';
 
 describe('EuiContextMenuItem', () => {
   shouldRenderCustomStyles(<EuiContextMenuItem />);
+
+  shouldRenderCustomStyles(
+    <EuiContextMenuItem toolTipContent="test" data-test-subj="trigger" />,
+    {
+      childProps: ['toolTipProps', 'toolTipProps.anchorProps'],
+      skip: { parentTest: true },
+      renderCallback: async ({ getByTestSubject }) => {
+        fireEvent.mouseOver(getByTestSubject('trigger'));
+        await waitForEuiToolTipVisible();
+      },
+    }
+  );
 
   it('renders', () => {
     const { container } = render(
@@ -120,5 +132,23 @@ describe('EuiContextMenuItem', () => {
         container.querySelector('.euiContextMenu__arrow')
       ).toBeInTheDocument();
     });
+  });
+
+  test('tooltip behavior', async () => {
+    const { getByRole, baseElement } = render(
+      <EuiContextMenuItem
+        toolTipContent="tooltip content"
+        toolTipTitle="overridden"
+        // Should override the deprecated props
+        toolTipProps={{ title: 'Test', position: 'top', delay: 'long' }}
+      >
+        Hello
+      </EuiContextMenuItem>
+    );
+
+    fireEvent.mouseOver(getByRole('button'));
+    await waitForEuiToolTipVisible();
+
+    expect(baseElement).toMatchSnapshot();
   });
 });

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -25,7 +25,7 @@ import {
 import { validateHref } from '../../services/security/href_validator';
 import { CommonProps, keysOf } from '../common';
 import { EuiIcon } from '../icon';
-import { EuiToolTip, ToolTipPositions } from '../tool_tip';
+import { EuiToolTip, EuiToolTipProps, ToolTipPositions } from '../tool_tip';
 
 import { euiContextMenuItemStyles } from './context_menu_item.styles';
 
@@ -46,11 +46,16 @@ export interface EuiContextMenuItemProps extends CommonProps {
    */
   toolTipContent?: ReactNode;
   /**
-   * Optional title for the tooltip
+   * Optional configuration to pass to the underlying [EuiToolTip](/#/display/tooltip).
+   * Accepts any prop that EuiToolTip does, except for `content` and `children`.
+   */
+  toolTipProps?: Partial<Omit<EuiToolTipProps, 'content' | 'children'>>;
+  /**
+   * @deprecated Use toolTipProps.title instead
    */
   toolTipTitle?: ReactNode;
   /**
-   * Dictates the position of the tooltip.
+   * @deprecated Use tooltipProps.position instead
    */
   toolTipPosition?: ToolTipPositions;
   href?: string;
@@ -94,6 +99,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
   toolTipTitle,
   toolTipContent,
   toolTipPosition = 'right',
+  toolTipProps,
   href,
   target,
   rel,
@@ -173,7 +179,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
         {buttonContent}
       </a>
     );
-  } else if (href || rest.onClick) {
+  } else if (href || rest.onClick || toolTipContent) {
     button = (
       <button
         disabled={disabled}
@@ -200,12 +206,17 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
   }
 
   if (toolTipContent) {
+    const anchorClasses = classNames(
+      'eui-displayBlock',
+      toolTipProps?.anchorClassName
+    );
     return (
       <EuiToolTip
         title={toolTipTitle ? toolTipTitle : null}
-        content={toolTipContent}
-        anchorClassName="eui-displayBlock"
         position={toolTipPosition}
+        {...toolTipProps}
+        anchorClassName={anchorClasses}
+        content={toolTipContent}
       >
         {button}
       </EuiToolTip>

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -206,20 +206,15 @@
       transition: opacity $euiAnimSpeedNormal $euiAnimSlightResistance, filter $euiAnimSpeedNormal $euiAnimSlightResistance;
     }
 
-    .expandedItemActions__completelyHide,
-    .expandedItemActions__completelyHide:disabled,
-    .expandedItemActions__completelyHide:disabled:hover,
-    .expandedItemActions__completelyHide:disabled:focus,
-    .euiTableRow:hover & .expandedItemActions__completelyHide:disabled {
+    .expandedItemActions__completelyHide {
       filter: grayscale(0%);
       opacity: 0;
     }
   }
 
-  &:hover .euiTableCellContent--showOnHover .euiTableCellContent__hoverItem:not(:disabled) {
-    &,
-    &:hover,
-    &:focus {
+  &:hover .euiTableCellContent--showOnHover,
+  .euiTableCellContent--showOnHover:focus-within {
+    .euiTableCellContent__hoverItem {
       opacity: 1;
       filter: grayscale(0%);
     }


### PR DESCRIPTION
## Summary

@alvarezmelissa87 is working on a table that needs conditional action descriptions. She was previously attempting to use custom `render`ed actions to achieve this, but it would be much cleaner all around for their use case for EUI to simply allow `actions.description` to be a callback which we pass the current `item` to.

I also added this functionality to the `href` and `data-test-subj` keys while here, because why not/it seems useful! Example usage:

```tsx
<EuiBasicTable
  columns={[
    // ... columns
   {
      name: 'Actions',
      actions: [{
        name: (item) => `Delete ${item.name}`,
        description: (item) => item.someCondition ? 'This does X' : 'This does Y',
        href: (item) => `/delete/${item.id}`,
        'data-test-subj': (item) => `delete-${item.id}`,
      }],
    },
  ]}
/>
```

### Actions tooltip bugfix

While here, I noticed that the action descriptions (which normally renders as a delayed tooltip) was not correctly showing in the collapsed popover menu when they should be, so I added that in https://github.com/elastic/eui/pull/7373/commits/d29b623839b7501fb2256bfd0a5b87ca3e126e3d:

<img width="361" alt="" src="https://github.com/elastic/eui/assets/549407/c55ef212-af1d-43bb-a1ec-7dc0b63a8167">

![actions](https://github.com/elastic/eui/assets/549407/851e9656-8009-4fcb-9df8-dfd5aff7444f)

Doing this required adding a new `toolTipsProps` prop to `EuiContextMenu` so we could pass `delay="long"` to match the other actions tooltips (https://github.com/elastic/eui/pull/7373/commits/ba28dc07eb1381c0cc716100697ddd096ff8e47c)

As always, please [review by commit](https://github.com/elastic/eui/pull/7373/commits) (because I found a few more bugs even more bugs after that 🙈)

## QA

- Go to https://eui.elastic.co/pr_7373/#/tabular-content/tables#adding-actions-to-table
- Hover or focus on a non-disabled link action (online rows are enabled, offline rows are disabled)
- [x] Confirm the action description tooltip shows the row name
- Toggle the "Multiple Actions" switch in the top left corner
- [x] Confirm that keyboard tabbing into the actions column correctly makes the action buttons visible, unlike production
- [x] When clicking the "All actions" button, confirm that actions in the popover menu have tooltips, unlike production  

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
