### PR TITLE
[EuiBreadcrumbs] Fix broken truncation for breadcrumbs that toggle popovers

### DIFF
--- a/changelogs/upcoming/7375.md
+++ b/changelogs/upcoming/7375.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed visual text truncation of `EuiBreadcrumb`s with `popoverContent`

--- a/src-docs/src/views/breadcrumbs/popover_content.tsx
+++ b/src-docs/src/views/breadcrumbs/popover_content.tsx
@@ -33,7 +33,7 @@ export default () => {
       prepend: <EuiAvatar type="space" size="s" name="Michael" />,
     },
     {
-      label: "Dwight's space",
+      label: "Assistant Manager Dwight's space",
       prepend: <EuiAvatar type="space" size="s" name="Dwight" />,
     },
   ]);
@@ -75,10 +75,10 @@ export default () => {
       popoverProps: { panelPaddingSize: 'none' },
     },
     {
-      text: 'My space',
+      text: spaces.find((space) => space.checked === 'on')!.label,
       popoverContent: (
         <EuiSelectable
-          singleSelection
+          singleSelection="always"
           options={spaces}
           onChange={(newOptions) => setSpaces(newOptions)}
           searchable

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiBreadcrumbContent renders breadcrumbs with \`popoverContent\` with p
 <body>
   <div>
     <div
-      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
+      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       data-test-subj="popover"
     >
       <button

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -8,13 +8,16 @@ exports[`EuiBreadcrumbContent renders breadcrumbs with \`popoverContent\` with p
       data-test-subj="popover"
     >
       <button
-        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+        class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
         data-test-subj="popoverToggle"
-        title="Toggles a popover  - Clicking this button will toggle a popover dialog."
+        title="Toggles a popover - Clicking this button will toggle a popover dialog."
         type="button"
       >
-        Toggles a popover
-         
+        <span
+          class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+        >
+          Toggles a popover
+        </span>
         <span
           data-euiicon-type="arrowDown"
         >

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -42,16 +42,19 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
         class="euiPopover emotion-euiPopover-inline-block"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            aria-label="See collapsed breadcrumbs"
+            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
           </span>
-           
           <span
             data-euiicon-type="arrowDown"
           >
@@ -143,16 +146,19 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
         class="euiPopover emotion-euiPopover-inline-block"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            aria-label="See collapsed breadcrumbs"
+            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
           </span>
-           
           <span
             data-euiicon-type="arrowDown"
           >
@@ -326,16 +332,19 @@ exports[`EuiBreadcrumbs props max renders 1 item 1`] = `
         class="euiPopover emotion-euiPopover-inline-block"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            aria-label="See collapsed breadcrumbs"
+            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
           </span>
-           
           <span
             data-euiicon-type="arrowDown"
           >
@@ -508,16 +517,19 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
         class="euiPopover emotion-euiPopover-inline-block"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            aria-label="See collapsed breadcrumbs"
+            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
           </span>
-           
           <span
             data-euiicon-type="arrowDown"
           >
@@ -608,16 +620,19 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
         class="euiPopover emotion-euiPopover-inline-block"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            aria-label="See collapsed breadcrumbs"
+            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
           </span>
-           
           <span
             data-euiicon-type="arrowDown"
           >
@@ -683,16 +698,19 @@ exports[`EuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
         class="euiPopover emotion-euiPopover-inline-block"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            aria-label="See collapsed breadcrumbs"
+            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
           >
-            …
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
           </span>
-           
           <span
             data-euiicon-type="arrowDown"
           >

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
           class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
@@ -143,7 +143,7 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
           class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
@@ -329,7 +329,7 @@ exports[`EuiBreadcrumbs props max renders 1 item 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
           class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
@@ -514,7 +514,7 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
           class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
@@ -617,7 +617,7 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
           class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
@@ -695,7 +695,7 @@ exports[`EuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
           class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"

--- a/src/components/breadcrumbs/breadcrumb.styles.ts
+++ b/src/components/breadcrumbs/breadcrumb.styles.ts
@@ -80,6 +80,14 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
       ${euiTextTruncate('none')}
     `,
 
+    // Popover styles
+    euiBreadcrumb__popoverButton: css`
+      max-inline-size: 100%;
+      display: inline-flex;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+    `,
+
     // Types
     page: css`
       &:is(a):focus {

--- a/src/components/breadcrumbs/breadcrumb.styles.ts
+++ b/src/components/breadcrumbs/breadcrumb.styles.ts
@@ -87,6 +87,13 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
       align-items: center;
       gap: ${euiTheme.size.xs};
     `,
+    euiBreadcrumb__popoverWrapper: css`
+      /* At small container widths, the popover anchor needs to leave room for the breadcrumb separator,
+         which is weird to get an exact width for because it's transformed at an angle */
+      max-inline-size: calc(
+        100% - ${mathWithUnits(euiTheme.size.base, (x) => x + 1)}
+      );
+    `,
 
     // Types
     page: css`

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -171,6 +171,7 @@ export const EuiBreadcrumbContent: FunctionComponent<
               {...popoverProps}
               isOpen={isPopoverOpen}
               closePopover={() => setIsPopoverOpen(false)}
+              css={!isLastBreadcrumb && styles.euiBreadcrumb__popoverWrapper}
               button={
                 <EuiLink
                   {...baseProps}

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -162,13 +162,8 @@ export const EuiBreadcrumbContent: FunctionComponent<
       {(ref, innerText) => {
         const title = innerText === '' ? undefined : innerText;
 
-        const sharedProps = {
-          ref,
-          title,
-          'aria-current': ariaCurrent,
-          className: classes,
-          css: cssStyles,
-        };
+        const baseProps = { ref, title, 'aria-current': ariaCurrent };
+        const styleProps = { className: classes, css: cssStyles };
 
         if (isPopoverBreadcrumb) {
           return (
@@ -178,13 +173,14 @@ export const EuiBreadcrumbContent: FunctionComponent<
               closePopover={() => setIsPopoverOpen(false)}
               button={
                 <EuiLink
-                  {...sharedProps}
+                  {...baseProps}
                   color={linkColor}
+                  css={styles.euiBreadcrumb__popoverButton}
                   // Avoid passing href and onClick - should only toggle the popover
                   onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
                   {...rest}
                 >
-                  {text}{' '}
+                  <span {...styleProps}>{text}</span>
                   <EuiIcon
                     type="arrowDown"
                     size="s"
@@ -199,7 +195,8 @@ export const EuiBreadcrumbContent: FunctionComponent<
         } else if (isInteractiveBreadcrumb) {
           return (
             <EuiLink
-              {...sharedProps}
+              {...baseProps}
+              {...styleProps}
               color={linkColor}
               onClick={onClick}
               href={href}
@@ -212,7 +209,7 @@ export const EuiBreadcrumbContent: FunctionComponent<
         } else {
           return (
             <EuiTextColor color={plainTextColor} cloneElement>
-              <span {...sharedProps} {...rest}>
+              <span {...baseProps} {...styleProps} {...rest}>
                 {text}
               </span>
             </EuiTextColor>


### PR DESCRIPTION
## Summary

I noticed this visual bug while suggesting a workaround to Anton for serverless breadcrumbs 😬 (https://github.com/elastic/eui/issues/7349#issuecomment-1818267121)

| Before | After |
|--------|--------|
| <img width="429" alt="" src="https://github.com/elastic/eui/assets/549407/6f67362d-6c8f-48a2-9d3d-a05ee935ae6f"><br>missing arrow on truncated text | <img width="450" alt="" src="https://github.com/elastic/eui/assets/549407/4907e25c-40f2-46d8-bd93-3c74bb263677"> |
| <img width="368" alt="" src="https://github.com/elastic/eui/assets/549407/8e14a8a2-4b59-4f35-9c81-c9b82ec66055"><br>broken truncation at small container widths | <img width="367" alt="" src="https://github.com/elastic/eui/assets/549407/4674fbc6-6638-4de3-965c-fef613a940e2"> | 

## QA

- Go to http://localhost:8030/#/navigation/breadcrumbs#popover-content
- Click "My space"
- Switch to "Assistant Manager Dwight's space"
- [x] Confirm that the long truncated text still show the dropdown arrow as expected

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A, bugfix (although
- Code quality checklist - N/A, CSS-only bugfix
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~