### PR TITLE
[EuiFormRow] Fix `hasEmptyLabelSpace` being off by 2px

### DIFF
--- a/changelogs/upcoming/7380.md
+++ b/changelogs/upcoming/7380.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFormRow`s with `hasEmptyLabelSpace` being very slightly off in vertical alignment

--- a/src/components/form/form_row/_form_row.scss
+++ b/src/components/form/form_row/_form_row.scss
@@ -18,7 +18,7 @@
 }
 
 .euiFormRow--hasEmptyLabelSpace {
-  margin-top: floor($euiFontSize * $euiBodyLineHeight) + $euiSizeXS; /* 2 */
+  margin-top: $euiSize + $euiSizeXS; /* 2 */
   // the following ensure that contents that aren't inherently the same height
   // as inputs will align to the vertical center
   min-height: $euiFormControlHeight;


### PR DESCRIPTION
## Summary

Thank you to @zinckiwi for pointing this out! 🏅 

| Before | After |
|--------|--------|
| <img width="733" alt="before" src="https://github.com/elastic/eui/assets/549407/e434f85d-86a7-4f30-9fe3-b8f75b182769"> | <img width="730" alt="after" src="https://github.com/elastic/eui/assets/549407/16ec1d51-6844-4fbf-99b4-4d50e3d633fb"> | 

## QA

- [x] Go to https://eui.elastic.co/pr_7380/#/forms/form-layouts#inline, confirm the form row wrapper around the button has `margin-top: 20px` now instead of `18px`

### General checklist

- Browser QA
    - [x] Checked in **mobile** - not sure this is totally meaningful though as the flex container collapses on mobile
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A, bugfix
- Code quality checklist - N/A, CSS only change
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ - Presumably Figma is correct 😅 
