### PR TITLE
[EuiDataGrid] Fix cell popovers not closing on outside grid click

### DIFF
--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -57,7 +57,9 @@
   &:focus,
   &:focus-within,
   // Always make the cell actions visible when the cell popover is open
-  &.euiDataGridRowCell--open {
+  &.euiDataGridRowCell--open,
+  // Prevents the animation from replaying when keyboard focus is moved from the popover back to the cell
+  &[data-keyboard-closing] {
     .euiDataGridRowCell__actions {
       animation-duration: $euiAnimSpeedExtraFast;
       animation-name: euiDataGridCellActionsSlideIn;
@@ -67,7 +69,7 @@
   }
 
   // if a cell is not hovered nor focused nor open via popover, don't show buttons in general
-  &:not(:hover):not(:focus):not(.euiDataGridRowCell--open) {
+  &:not(:hover):not(:focus):not(.euiDataGridRowCell--open):not([data-keyboard-closing]) {
     .euiDataGridRowCell__actions {
       display: none;
     }

--- a/src/components/datagrid/body/data_grid_cell.tsx
+++ b/src/components/datagrid/body/data_grid_cell.tsx
@@ -457,10 +457,6 @@ export class EuiDataGridCell extends Component<
             this.setState({ disableCellTabIndex: true });
           }
         }, 0);
-      // Close the cell popover if the popover was open and the user clicked the cell
-      if (this.props.popoverContext.popoverIsOpen) {
-        this.props.popoverContext.closeCellPopover();
-      }
     }
   };
 

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -155,6 +155,18 @@ describe('EuiDataGridCellPopover', () => {
 
     cy.get('[data-test-subj="cellActionB"]').first().realClick();
     cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
+
+    // Clicking the cell actions outside the popover should not have disabled the focus trap
+    cy.repeatRealPress('Tab', 3);
+    cy.focused().should(
+      'have.attr',
+      'data-test-subj',
+      'euiDataGridExpansionPopover'
+    );
+    cy.get('body').realClick({ position: 'bottomRight' });
+    cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+      'not.exist'
+    );
   });
 
   it('allows consumers to use setCellPopoverProps, passed from renderCellPopover, to customize popover props', () => {

--- a/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.spec.tsx
@@ -87,21 +87,74 @@ describe('EuiDataGridCellPopover', () => {
     });
   });
 
-  it('closes the cell popover when the originating cell is clicked', () => {
-    cy.realMount(<EuiDataGrid {...baseProps} />);
-    cy.get(
-      '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
-    ).realClick();
+  describe('closes the cell popover', () => {
+    // Mount and open the first cell popover
+    beforeEach(() => {
+      cy.realMount(<EuiDataGrid {...baseProps} />);
+      cy.get(
+        '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+      ).click();
+      cy.realPress('Enter');
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
+    });
 
-    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
+    it('when the originating cell is clicked', () => {
+      cy.get(
+        '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
+      ).realClick({ position: 'right' });
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+        'not.exist'
+      );
+    });
+
+    it('when the cell expand action button is clicked', () => {
+      cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+        'not.exist'
+      );
+    });
+
+    it('when anywhere outside the grid is clicked', () => {
+      cy.get('body').realClick({ position: 'bottomRight' });
+      cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
+        'not.exist'
+      );
+    });
+  });
+
+  it('does not close the cell popover when other cell actions are clicked', () => {
+    const cellActions = [
+      ({ Component }) => (
+        <Component
+          iconType="plusInCircle"
+          aria-label="A"
+          data-test-subj="cellActionA"
+        />
+      ),
+      ({ Component }) => (
+        <Component
+          iconType="minusInCircle"
+          aria-label="B"
+          data-test-subj="cellActionB"
+        />
+      ),
+    ];
+    cy.realMount(
+      <EuiDataGrid {...baseProps} columns={[{ id: 'A', cellActions }]} />
+    );
+    cy.get('[data-test-subj="dataGridRowCell"]').first().click();
+    cy.realPress('Enter');
     cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
 
-    cy.get(
-      '[data-gridcell-row-index="0"][data-gridcell-column-index="0"]'
-    ).realClick({ position: 'right' });
-    cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should(
-      'not.exist'
-    );
+    cy.get('[data-test-subj="cellActionA"]').first().realClick();
+    cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
+
+    // Close and re-open the cell popover by clicking
+    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
+    cy.get('[data-test-subj="euiDataGridCellExpandButton"]').click();
+
+    cy.get('[data-test-subj="cellActionB"]').first().realClick();
+    cy.get('[data-test-subj="euiDataGridExpansionPopover"]').should('exist');
   });
 
   it('allows consumers to use setCellPopoverProps, passed from renderCellPopover, to customize popover props', () => {

--- a/src/components/datagrid/body/data_grid_cell_popover.test.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.test.tsx
@@ -101,6 +101,7 @@ describe('useCellPopover', () => {
           display="block"
           focusTrapProps={
             Object {
+              "clickOutsideDisables": false,
               "onClickOutside": [Function],
             }
           }

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -107,7 +107,7 @@ export const useCellPopover = (): {
       anchorPosition={popoverAnchorPosition}
       repositionToCrossAxis={false}
       {...cellPopoverProps}
-      focusTrapProps={{ onClickOutside }}
+      focusTrapProps={{ onClickOutside, clickOutsideDisables: false }}
       panelProps={{
         'data-test-subj': 'euiDataGridExpansionPopover',
         ...(cellPopoverProps.panelProps || {}),

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -88,9 +88,9 @@ export const useCellPopover = (): {
   // clicking the expansion cell action triggers an outside click
   const onClickOutside = useCallback(
     (event: Event) => {
-      if (!popoverAnchor) return;
-      const cellActions = popoverAnchor.previousElementSibling;
-      if (cellActions?.contains(event.target as Node) === false) {
+      const cellActions =
+        popoverAnchor?.parentElement?.parentElement?.previousElementSibling;
+      if (!cellActions?.contains(event.target as Node)) {
         closeCellPopover();
       }
     },

--- a/src/components/datagrid/body/data_grid_cell_popover.tsx
+++ b/src/components/datagrid/body/data_grid_cell_popover.tsx
@@ -128,8 +128,16 @@ export const useCellPopover = (): {
           event.preventDefault();
           event.stopPropagation();
           closeCellPopover();
-          // Ensure focus is returned to the parent cell
-          requestAnimationFrame(() => popoverAnchor.parentElement!.focus());
+          const cell =
+            popoverAnchor.parentElement?.parentElement?.parentElement;
+
+          // Prevent cell animation flash while focus is being shifted between popover and cell
+          cell?.setAttribute('data-keyboard-closing', 'true');
+          // Ensure focus is returned to the parent cell, and remove animation stopgap
+          requestAnimationFrame(() => {
+            popoverAnchor.parentElement!.focus();
+            cell?.removeAttribute('data-keyboard-closing');
+          });
         }
       }}
       button={popoverAnchor}


### PR DESCRIPTION
## Summary

I noticed this bug while working on another (already in production) datagrid focus bug. Clicking anywhere outside the cell popover should auto close the popover; but right now in latest main it does not. This bug was introduced by #7343, so I want to get the fix in before the next release. I've added several E2E tests for it as well so it doesn't regress again.

| Before | After |
|--------|--------|
| ![before](https://github.com/elastic/eui/assets/549407/a02a4917-4586-4932-a1c9-0f2faa09d930) | ![after](https://github.com/elastic/eui/assets/549407/dfc9bc32-b823-4af9-b06d-23bb01fa5fc1) | 

## QA

- Go to https://eui.elastic.co/pr_7387/#/tabular-content/data-grid
- Click on any cell, then click the expand cell action icon
- [x] Click anywhere outside the grid and confirm the popover closes
- Go to https://eui.elastic.co/pr_7387/#/tabular-content/data-grid-cells-popovers#visible-cell-actions-and-cell-popovers
- Click on the first data cell, then press enter to open the cell popover
- [x] Click on the non-expand cell action icon and confirm it does not close the popover
- [x] Click outside the grid and confirm the popover closes 

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    ~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.~ - I'm skipping the changelog on this since it's a bugfix for something that's still in main / hasn't yet been released
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A