### PR TITLE
[CHORE] Adding env var to trigger docs deploy manually from Buildkite UI

### DIFF
--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -45,7 +45,7 @@ post_comment_to_gh()
       curl -s -L "https://api.github.com/repos/elastic/eui/issues/${GIT_PULL_REQUEST_ID}/comments" \
       | jq -c '.[] | select(.user.login == "kibanamachine") | .id' \
     )
-    for comment_id in ${kibanamachine_comment_ids[@]}; do
+    for comment_id in "${kibanamachine_comment_ids[@]}"; do
       curl -L \
         -X DELETE \
         -H "Authorization: token ${GITHUB_TOKEN}" \
@@ -150,7 +150,13 @@ else
       publish_to_bucket
     fi
 
-  # Let users know neither job ran
+  # Manually deploy latest docs via Buildkite UI
+  elif [[ "${DEPLOY_ROOT}" == "true" ]]; then
+    echo "Maually deploying latest release. Deploying to root eui.elastic.co"
+    full_bucket_path="gs://${BUCKET}/"
+    publish_to_bucket
+
+  # Let users know none of the three jobs ran
   else
     echo "This is neither a pull request nor a tag release. No docs were deployed."
   fi

--- a/wiki/eui-team-processes/releasing-versions.md
+++ b/wiki/eui-team-processes/releasing-versions.md
@@ -40,7 +40,7 @@ npm whoami # Should return an error about not being logged in
 
 Buildkite automatically deploys our docs to the EUI `Bekitzur` environment. The Buildkite job is started when a new tag is pushed to the `main` branch.
 
-To view the progress of your job or check for errors:
+**To view the progress of your job or check for errors:**
 
 * Log in to Buildkite using Elastic SSO
 * Filter jobs by `eui-team`
@@ -49,6 +49,16 @@ To view the progress of your job or check for errors:
 * From the build detail view:
   * Click the `Rebuild` button if your job needs to be restarted **or**
   * Click the `.buildkite/scripts/pipelines/pipeline_deploy_docs.sh` row to view logs and environment details
+
+**To deploy release docs manually:**
+
+* Log in to Buildkite using Elastic SSO
+* Filter jobs by `eui-team`
+* Click on `eui-release-deploy-docs`
+* Click the green `New Build` button on the top right
+* Click the `Options` accordion to show the Environment Variables textbox
+* Add `DEPLOY_ROOT=true` to the Environment Variables textbox
+* Click `Create Build` to start the job manually
 
 ### Tag the release in GitHub
 


### PR DESCRIPTION
## Summary

PR adds conditional logic to our `deploy_docs` shell script to listen for `DEPLOY_ROOT` env variable. If this variable is added to the release deploy docs job, it will trigger the build without pushing a new tag / release. PR closes #7396.

## QA

Manually triggering the job assumes two key pieces of information:
1. The job will be run against the `main` branch. Selected by default in Buildkite UI.
2. The job will be run against the `HEAD` commit on main. Selected by default in Buildkite UI.

QA will be done in two parts, all in Buildkite:

- [x] Jobs must run correctly in PR
- [ ]  After PR is merged, I will trigger the job using Buildkite UI to pass in the new env variable and verify it runs correctly