### PR TITLE
build: deploy new docs site when available

### DIFF
--- a/scripts/deploy/build_docs
+++ b/scripts/deploy/build_docs
@@ -4,14 +4,23 @@ set -e
 
 NODE_IMG="docker.elastic.co/eui/ci:6.0"
 
+# Docusaurus must know the base URL to work properly
+DOCS_BASE_URL="/new-docs/"
+if [ -n "${GIT_PULL_REQUEST_ID}" ] && [ "${GIT_PULL_REQUEST_ID}" != "false" ]; then
+  DOCS_BASE_URL="/pr_${GIT_PULL_REQUEST_ID}/new-docs/"
+fi
+
+echo "Docusaurus base URL set to: ${DOCS_BASE_URL}"
+
 # Compile using node image
 echo "Building docs using ${NODE_IMG} Docker image"
 docker pull $NODE_IMG
 docker run \
     --rm -i \
     --env HOME=/tmp \
+    --env DOCS_BASE_URL="$DOCS_BASE_URL" \
     --"user=$(id -u)":"$(id -g)" \
     --volume "$PWD":/app \
     --workdir /app \
     $NODE_IMG \
-    bash -c 'yarn && yarn build && yarn build-docs && yarn build-storybook'
+    bash -c 'yarn && yarn build && yarn build-docs && yarn build-storybook && if [[ -d website ]]; then yarn --cwd website && yarn --cwd website build; fi'

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -55,7 +55,8 @@ post_comment_to_gh()
     printf '\nAdding comment to GitHub Pull Request: %i\n' "${GIT_PULL_REQUEST_ID}"
     comment="Preview staging links for this PR:
 - Docs site: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/
-- Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook"
+- Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook
+- New docs site (in development): https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/new-docs"
 
     curl \
       --silent \
@@ -78,11 +79,19 @@ publish_to_bucket()
     -z js,css,html # enable gzip encoding for these extensions
   )
 
+  # Current docs
   echo "Copying ${PWD}/docs/* to ${full_bucket_path}"
   gsutil "${copy_options[@]}" "${PWD}/docs/*" "${full_bucket_path}"
 
+  # Storybook
   echo "Copying ${PWD}/storybook-static/* to ${full_bucket_path}storybook/"
   gsutil "${copy_options[@]}" "${PWD}/storybook-static/*" "${full_bucket_path}storybook/"
+
+  # New docs
+  if [[ -d "${PWD}/website/build" ]]; then
+    echo "Copying ${PWD}/website/build/* to ${full_bucket_path}new-docs/"
+    gsutil "${copy_options[@]}" "${PWD}/website/build/*" "${full_bucket_path}new-docs/"
+  fi
 }
 
 if [[ "$1" != "nodocker" ]]; then


### PR DESCRIPTION
## Summary

This adds the ability to build the new docs site when the `website` directory is available on a branch. It must be merged to `main` to get Buildkite to run the updated code on our `feat/new-docs` feature branch.

## QA

- [ ] Code changes look valid

QA will be done manually by checking Buildkite behavior after merging this PR to `main`.