### PR TITLE
build: deploy new docs

### DIFF
--- a/scripts/deploy/build_docs
+++ b/scripts/deploy/build_docs
@@ -4,14 +4,23 @@ set -e
 
 NODE_IMG="docker.elastic.co/eui/ci:6.0"
 
+# Docusaurus must know the base URL to work properly
+DOCS_BASE_URL="/new-docs/"
+if [ -n "${GIT_PULL_REQUEST_ID}" ] && [ "${GIT_PULL_REQUEST_ID}" != "false" ]; then
+  DOCS_BASE_URL="/pr_${GIT_PULL_REQUEST_ID}/new-docs/"
+fi
+
+echo "Docusaurus base URL set to: ${DOCS_BASE_URL}"
+
 # Compile using node image
 echo "Building docs using ${NODE_IMG} Docker image"
 docker pull $NODE_IMG
 docker run \
     --rm -i \
     --env HOME=/tmp \
+    --env DOCS_BASE_URL="$DOCS_BASE_URL" \
     --"user=$(id -u)":"$(id -g)" \
     --volume "$PWD":/app \
     --workdir /app \
     $NODE_IMG \
-    bash -c 'yarn && yarn build && yarn build-docs && yarn build-storybook'
+    bash -c 'yarn && yarn build && yarn build-docs && yarn build-storybook && yarn --cwd website && yarn --cwd website build'

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -55,7 +55,8 @@ post_comment_to_gh()
     printf '\nAdding comment to GitHub Pull Request: %i\n' "${GIT_PULL_REQUEST_ID}"
     comment="Preview staging links for this PR:
 - Docs site: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/
-- Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook"
+- Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook
+- New docs site (in development): https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/new-docs"
 
     curl \
       --silent \
@@ -78,11 +79,17 @@ publish_to_bucket()
     -z js,css,html # enable gzip encoding for these extensions
   )
 
+  # Current docs
   echo "Copying ${PWD}/docs/* to ${full_bucket_path}"
   gsutil "${copy_options[@]}" "${PWD}/docs/*" "${full_bucket_path}"
 
+  # Storybook
   echo "Copying ${PWD}/storybook-static/* to ${full_bucket_path}storybook/"
   gsutil "${copy_options[@]}" "${PWD}/storybook-static/*" "${full_bucket_path}storybook/"
+
+  # New docs
+  echo "Copying ${PWD}/website/build/* to ${full_bucket_path}new-docs/"
+  gsutil "${copy_options[@]}" "${PWD}/website/build/*" "${full_bucket_path}new-docs/"
 }
 
 if [[ "$1" != "nodocker" ]]; then

--- a/scripts/deploy/deploy_docs
+++ b/scripts/deploy/deploy_docs
@@ -56,7 +56,7 @@ post_comment_to_gh()
     comment="Preview staging links for this PR:
 - Docs site: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/
 - Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook
-- New docs site (in development): https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/new-docs"
+- New docs site (in development): https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/new-docs/"
 
     curl \
       --silent \

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -2,6 +2,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
+const baseUrl = process.env.DOCS_BASE_URL || '/';
+
 const config: Config = {
   title: 'Elastic UI Framework',
   tagline: 'The framework powering the Elastic Stack',
@@ -11,7 +13,7 @@ const config: Config = {
   url: 'https://eui.elastic.co',
 
   // Set the /<baseUrl>/ pathname under which your site is served
-  baseUrl: '/',
+  baseUrl,
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   title: 'Elastic UI Framework',
   tagline: 'The framework powering the Elastic Stack',
   favicon: 'favicon.ico',
+  trailingSlash: true,
 
   // Set the production url of your site here
   url: 'https://eui.elastic.co',


### PR DESCRIPTION
## Summary

This PR resolves #7402 by updating `build_docs` and `deploy_docs` to build the new docs site and deploy it under `new-docs` directory.

## QA

- [ ] Code changes look valid
- [x] docusaurus site PR preview is deployed and accessible
