### PR TITLE
[DOCS] Add guidance for `EuiTabs` around higher-order navigation

### DIFF
--- a/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
@@ -57,6 +57,13 @@ export const BreadcrumbsExample = {
         </Link>{' '}
         should be used for application-wide navigation.
       </p>
+      <p>
+        See{' '}
+        <Link to="/navigation/tabs/guidelines">
+          <strong>EuiTabs guidelines</strong>
+        </Link>{' '}
+        if your application requires breadcrumbs and tabs on the same view.
+      </p>
     </EuiText>
   ),
   sections: [

--- a/src-docs/src/views/tabs/tabs_example.js
+++ b/src-docs/src/views/tabs/tabs_example.js
@@ -9,9 +9,9 @@ import {
   EuiTab,
   EuiTabbedContent,
   EuiText,
-  EuiLink,
 } from '../../../../src/components';
 
+import TabsGuidance from './tabs_guidance';
 import { tabsConfig } from './playground';
 
 import Tabs from './tabs';
@@ -31,16 +31,13 @@ const controlledSource = require('!!raw-loader!./controlled');
 
 export const TabsExample = {
   title: 'Tabs',
+  guidelines: <TabsGuidance />,
   intro: (
     <EuiText>
       <p>
-        Use tabs to organize <strong>in-page</strong> navigation, segmenting
-        mutually-exclusive content under a single organizational principle. For
-        more guideline usage see{' '}
-        <EuiLink href="https://www.nngroup.com/articles/tabs-used-right/">
-          NNG&apos;s article &quot;Tabs, Used Right&quot;
-        </EuiLink>
-        .
+        Use tabs to organize related but unique content for a single idea or
+        subject. Tabs show and hide content using <strong>in-page</strong>{' '}
+        navigation UI.
       </p>
     </EuiText>
   ),

--- a/src-docs/src/views/tabs/tabs_guidance.js
+++ b/src-docs/src/views/tabs/tabs_guidance.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import {
   EuiCode,
@@ -42,8 +43,13 @@ export default () => (
       <h3>Tabs must not update higher-level navigation</h3>
       <p>
         Do not update navigation such as{' '}
-        <EuiLink href="/#/navigation/breadcrumbs">breadcrumbs</EuiLink> or{' '}
-        <EuiLink href="/#/navigation/collapsible-nav">navigation menus</EuiLink>{' '}
+        <Link to="/navigation/breadcrumbs">
+          <strong>breadcrumbs</strong>
+        </Link>{' '}
+        or{' '}
+        <Link to="/navigation/collapsible-nav">
+          <strong>navigation menus</strong>
+        </Link>{' '}
         when users click on tabs. Tabs show localized information and it is not
         always clear what changed if tabs are below the fold or navigation does
         not match the route.

--- a/src-docs/src/views/tabs/tabs_guidance.js
+++ b/src-docs/src/views/tabs/tabs_guidance.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import {
+  EuiCode,
+  EuiText,
+  EuiLink,
+  EuiSpacer,
+} from '../../../../src/components';
+
+export default () => (
+  <>
+    <EuiText grow={false}>
+      <h2>Follow best practices for tabbed interfaces</h2>
+      <p>
+        Use tabs to organize in-page content. Each tab should contain a segment
+        of information relevant to the current subject. For more best practices
+        see{' '}
+        <EuiLink href="https://www.nngroup.com/articles/tabs-used-right/">
+          NNG&apos;s article &quot;Tabs, Used Right&quot;
+        </EuiLink>
+        .
+      </p>
+      <EuiSpacer size="xs" />
+      <h3>Use props to tailor the user experience</h3>
+      <p>
+        Tab props allow consumers to set the selected tab on first render, and
+        add custom behavior on tab click. For instance, you could use the{' '}
+        <EuiCode>selectedTab</EuiCode> prop to show a second or third tab on
+        page load. You could also use the <EuiCode>onTabClick</EuiCode> prop to
+        add custom click behavior.
+      </p>
+      <EuiSpacer size="xs" />
+      <h3>Manage the user experience if you change routes or URLs</h3>
+      <p>
+        Be sure the correct tab is selected if you use the{' '}
+        <EuiCode>href</EuiCode> prop to append a hash to the current route. If
+        your tab adds a <EuiCode>#tabbedHash</EuiCode> to the URL, the matching
+        tab should be selected when users refresh the page. It can be confusing
+        to users when hash routes do not match a selected tab.
+      </p>
+      <EuiSpacer size="xs" />
+      <h3>Tabs must not update higher-level navigation</h3>
+      <p>
+        Do not update navigation such as{' '}
+        <EuiLink href="/#/navigation/breadcrumbs">breadcrumbs</EuiLink> or{' '}
+        <EuiLink href="/#/navigation/collapsible-nav">navigation menus</EuiLink>{' '}
+        when users click on tabs. Tabs show localized information and it is not
+        always clear what changed if tabs are below the fold or navigation does
+        not match the route.
+      </p>
+    </EuiText>
+  </>
+);

--- a/src-docs/src/views/tabs/tabs_guidance.js
+++ b/src-docs/src/views/tabs/tabs_guidance.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import {
   EuiCode,
@@ -11,48 +10,43 @@ import {
 export default () => (
   <>
     <EuiText grow={false}>
-      <h2>Follow best practices for tabbed interfaces</h2>
+      <h2>Do</h2>
       <p>
-        Use tabs to organize in-page content. Each tab should contain a segment
-        of information relevant to the current subject. For more best practices
-        see{' '}
+        Follow best practices. Use tabs to organize in-page content. Each tab
+        should contain a segment of information relevant to the current subject.
+        For more UX tips see{' '}
         <EuiLink href="https://www.nngroup.com/articles/tabs-used-right/">
           NNG&apos;s article &quot;Tabs, Used Right&quot;
         </EuiLink>
         .
       </p>
-      <EuiSpacer size="xs" />
-      <h3>Use props to tailor the user experience</h3>
+      <h2>Do</h2>
       <p>
-        Tab props allow consumers to set the selected tab on first render, and
-        add custom behavior on tab click. For instance, you could use the{' '}
-        <EuiCode>selectedTab</EuiCode> prop to show a second or third tab on
-        page load. You could also use the <EuiCode>onTabClick</EuiCode> prop to
-        add custom click behavior.
+        For tabs showing primary page content, use the <EuiCode>href</EuiCode>{' '}
+        prop to change the current URL hash. Ensure the tab selection is
+        persisted in the user's navigation history and works with the browser's
+        back button.
       </p>
       <EuiSpacer size="xs" />
-      <h3>Manage the user experience if you change routes or URLs</h3>
+      <h2>Do</h2>
       <p>
-        Be sure the correct tab is selected if you use the{' '}
-        <EuiCode>href</EuiCode> prop to append a hash to the current route. If
-        your tab adds a <EuiCode>#tabbedHash</EuiCode> to the URL, the matching
-        tab should be selected when users refresh the page. It can be confusing
-        to users when hash routes do not match a selected tab.
+        Ensure when a page is loaded with a URL hash representing a selected tab
+        (as applied by the <EuiCode>href</EuiCode> prop), that the corresponding
+        tab is shown using the <EuiCode>selectedTab</EuiCode> prop.
       </p>
       <EuiSpacer size="xs" />
-      <h3>Tabs must not update higher-level navigation</h3>
+      <h2>Don't</h2>
       <p>
-        Do not update navigation such as{' '}
-        <Link to="/navigation/breadcrumbs">
-          <strong>breadcrumbs</strong>
-        </Link>{' '}
-        or{' '}
-        <Link to="/navigation/collapsible-nav">
-          <strong>navigation menus</strong>
-        </Link>{' '}
-        when users click on tabs. Tabs show localized information and it is not
-        always clear what changed if tabs are below the fold or navigation does
-        not match the route.
+        Apply the <EuiCode>href</EuiCode> prop to change the current page URL
+        hash on more than one set of tabs per page, or non-primary content.
+      </p>
+      <EuiSpacer size="xs" />
+      <h2>Don't</h2>
+      <p>
+        Keep users on the same page visually, but change the higher-level
+        navigation logically. Tabs should keep users at the same place within an
+        application. Breadcrumbs and main navigation should not change. The URL
+        hash is the only thing that should change.
       </p>
     </EuiText>
   </>


### PR DESCRIPTION
## Summary

We made some decisions about the `EuiBreadcrumbs` component in a [design discussion](https://github.com/elastic/eui/discussions/7345) in before UX Summit. One of the recommended actions was to document best practices for using tabs, based on my [comment about tabs updating breadcrumb links](https://github.com/elastic/eui/discussions/7345#discussioncomment-7567709).

This PR adds a `Guidelines` tab to `EuiTabs` and cross-links the new guidance from our `EuiBreadcrumbs` page. Screenshots attached below QA criteria. PR closes #7367.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**

<img width="1071" alt="Screenshot 2023-12-08 at 4 42 24 PM" src="https://github.com/elastic/eui/assets/934879/ca5f7844-17e9-4554-a0a8-572c5d63b28d">


<img width="1255" alt="Screenshot 2023-12-07 at 1 44 29 PM" src="https://github.com/elastic/eui/assets/934879/4c21dcf6-3566-4fdc-b0cd-5668ca0225ad">

