### PR TITLE
Fix #7412: Add missing closing quotes on line 110 of `src-docs\src\views\list_group\list_group_example.js`.

### DIFF
--- a/src-docs/src/views/list_group/list_group_example.js
+++ b/src-docs/src/views/list_group/list_group_example.js
@@ -107,7 +107,7 @@ export const ListGroupExample = {
     },
     {
       label: 'Second link',
-      href: '#,
+      href: '#',
       isActive: true,
       iconType: 'clock',
     }]


### PR DESCRIPTION
Fix #7412.