### PR TITLE
[docs][EuiFlexGroup] Fix example order/organization

### DIFF
--- a/src-docs/src/views/flex/flex_example.js
+++ b/src-docs/src/views/flex/flex_example.js
@@ -363,28 +363,6 @@ export const FlexExample = {
       ),
     },
     {
-      title: 'Allowing flex items to wrap',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: flexGroupWrapSource,
-        },
-      ],
-      text: (
-        <p>
-          You can set <EuiCode>wrap</EuiCode> on <strong>EuiFlexGroup</strong>{' '}
-          if it contains <strong>EuiFlexItems</strong> with minimum widths,
-          which you want to wrap as the container becomes narrower.
-        </p>
-      ),
-      snippet: flexGroupWrap,
-      demo: (
-        <FlexItemHighlightWrapper>
-          <FlexGroupWrap />
-        </FlexItemHighlightWrapper>
-      ),
-    },
-    {
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -452,6 +430,28 @@ export const FlexExample = {
       demo: (
         <FlexItemHighlightWrapper>
           <Direction />
+        </FlexItemHighlightWrapper>
+      ),
+    },
+    {
+      title: 'Allowing flex items to wrap',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: flexGroupWrapSource,
+        },
+      ],
+      text: (
+        <p>
+          You can set <EuiCode>wrap</EuiCode> on <strong>EuiFlexGroup</strong>{' '}
+          if it contains <strong>EuiFlexItems</strong> with minimum widths,
+          which you want to wrap as the container becomes narrower.
+        </p>
+      ),
+      snippet: flexGroupWrap,
+      demo: (
+        <FlexItemHighlightWrapper>
+          <FlexGroupWrap />
         </FlexItemHighlightWrapper>
       ),
     },


### PR DESCRIPTION
## Summary

Thanks to @julianrosado for pointing out that our flex documentation randomly had the `wrap` example in the middle of the justify/align examples! 

## QA

- https://eui.elastic.co/pr_7414/#/layout/flex#justify-and-align

### General checklist

N/A, docs only