### PR TITLE
[EuiBasicTable] Fix regressed disabled actions UX when selecting rows

### DIFF
--- a/changelogs/upcoming/7428.md
+++ b/changelogs/upcoming/7428.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiBasicTable`/`EuiInMemoryTable` actions to correctly show as disabled when rows are being selected

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -362,7 +362,10 @@ export default () => {
 
   return (
     <>
-      <EuiFlexGroup alignItems="center">
+      <EuiFlexGroup
+        alignItems="center"
+        css={({ euiTheme }) => ({ minHeight: euiTheme.size.xxl })}
+      >
         <EuiFlexItem grow={false}>
           <EuiSwitch
             label="Multiple Actions"

--- a/src-docs/src/views/tables/actions/actions_section.js
+++ b/src-docs/src/views/tables/actions/actions_section.js
@@ -42,7 +42,7 @@ export const section = {
           stays visible at all times.
         </li>
         <li>
-          When any table row(s) are being selected, all item actions are
+          When one or more table row(s) are selected, all item actions are
           disabled. Users should be expected to use some bulk action outside the
           individual table rows instead.
         </li>

--- a/src-docs/src/views/tables/actions/actions_section.js
+++ b/src-docs/src/views/tables/actions/actions_section.js
@@ -41,6 +41,11 @@ export const section = {
           When more than 2 actions are supplied, only the ellipses icon button
           stays visible at all times.
         </li>
+        <li>
+          When any table row(s) are being selected, all item actions are
+          disabled. Users should be expected to use some bulk action outside the
+          individual table rows instead.
+        </li>
       </ul>
     </>
   ),

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -20,7 +20,10 @@ import {
 } from './basic_table';
 
 import { SortDirection } from '../../services';
-import { EuiTableFieldDataColumnType } from './table_types';
+import {
+  EuiTableFieldDataColumnType,
+  EuiTableActionsColumnType,
+} from './table_types';
 
 describe('getItemId', () => {
   it('returns undefined if no itemId prop is given', () => {
@@ -635,6 +638,51 @@ describe('EuiBasicTable', () => {
   });
 
   describe('actions', () => {
+    const actions: EuiTableActionsColumnType<{ id: string }>['actions'] = [
+      {
+        type: 'icon',
+        name: 'Edit',
+        isPrimary: true,
+        icon: 'pencil',
+        available: ({ id }) => !(Number(id) % 2),
+        description: 'edit',
+        'data-test-subj': 'editAction',
+        onClick: () => {},
+      },
+      {
+        type: 'icon',
+        name: 'Share',
+        icon: 'share',
+        isPrimary: true,
+        available: ({ id }) => id !== '3',
+        description: 'share',
+        onClick: () => {},
+      },
+      // Below actions are not primary and should be hidden behind collapse button
+      {
+        type: 'icon',
+        name: 'Copy',
+        icon: 'copy',
+        description: 'copy',
+        onClick: () => {},
+      },
+      {
+        type: 'icon',
+        name: 'Delete',
+        icon: 'trash',
+        description: 'delete',
+        'data-test-subj': ({ id }) => `deleteAction-${id}`,
+        onClick: () => {},
+      },
+      {
+        type: 'icon',
+        name: 'elastic.co',
+        icon: 'link',
+        description: 'Go to link',
+        onClick: () => {},
+      },
+    ];
+
     test('single action', () => {
       const props: EuiBasicTableProps<BasicItem> = {
         items: basicItems,
@@ -642,20 +690,13 @@ describe('EuiBasicTable', () => {
           ...basicColumns,
           {
             name: 'Actions',
-            actions: [
-              {
-                type: 'button',
-                name: 'Edit',
-                description: 'edit',
-                onClick: () => {},
-              },
-            ],
+            actions: [actions[3]],
           },
         ],
       };
       const { getAllByText } = render(<EuiBasicTable {...props} />);
 
-      expect(getAllByText('Edit')).toHaveLength(basicItems.length);
+      expect(getAllByText('Delete')).toHaveLength(basicItems.length);
     });
 
     test('multiple actions with custom availability', () => {
@@ -665,48 +706,7 @@ describe('EuiBasicTable', () => {
           ...basicColumns,
           {
             name: 'Actions',
-            actions: [
-              {
-                type: 'icon',
-                name: 'Edit',
-                isPrimary: true,
-                icon: 'pencil',
-                available: ({ id }) => !(Number(id) % 2),
-                description: 'edit',
-                onClick: () => {},
-              },
-              {
-                type: 'icon',
-                name: 'Share',
-                icon: 'share',
-                isPrimary: true,
-                available: ({ id }) => id !== '3',
-                description: 'share',
-                onClick: () => {},
-              },
-              // Below actions are not primary and should be hidden behind collapse button
-              {
-                type: 'icon',
-                name: 'Copy',
-                icon: 'copy',
-                description: 'copy',
-                onClick: () => {},
-              },
-              {
-                type: 'icon',
-                name: 'Delete',
-                icon: 'trash',
-                description: 'delete',
-                onClick: () => {},
-              },
-              {
-                type: 'icon',
-                name: 'elastic.co',
-                icon: 'link',
-                description: 'Go to link',
-                onClick: () => {},
-              },
-            ],
+            actions: actions,
           },
         ],
       };
@@ -719,6 +719,54 @@ describe('EuiBasicTable', () => {
       expect(getAllByTestSubject('euiCollapsedItemActionsButton')).toHaveLength(
         4
       );
+    });
+
+    describe('are disabled on selection', () => {
+      test('single action', () => {
+        const props: EuiBasicTableProps<BasicItem> = {
+          items: basicItems,
+          selection: {
+            onSelectionChange: () => {},
+            selected: [basicItems[0]],
+          },
+          columns: [
+            ...basicColumns,
+            {
+              name: 'Actions',
+              actions: [actions[3]],
+            },
+          ],
+        };
+        const { getByTestSubject } = render(<EuiBasicTable {...props} />);
+
+        expect(getByTestSubject('deleteAction-1')).toBeDisabled();
+        expect(getByTestSubject('deleteAction-2')).toBeDisabled();
+        expect(getByTestSubject('deleteAction-3')).toBeDisabled();
+      });
+
+      test('multiple actions', () => {
+        const props: EuiBasicTableProps<BasicItem> = {
+          items: basicItems,
+          selection: {
+            onSelectionChange: () => {},
+            selected: [basicItems[0]],
+          },
+          columns: [
+            ...basicColumns,
+            {
+              name: 'Actions',
+              actions: actions,
+            },
+          ],
+        };
+        const { getAllByTestSubject } = render(<EuiBasicTable {...props} />);
+
+        getAllByTestSubject('euiCollapsedItemActionsButton').forEach(
+          (button) => {
+            expect(button).toBeDisabled();
+          }
+        );
+      });
     });
   });
 

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -1153,17 +1153,21 @@ export class EuiBasicTable<T = any> extends Component<
     column: EuiTableActionsColumnType<T>,
     columnIndex: number
   ) {
-    const actionEnabled = (action: Action<T>) =>
-      this.state.selection.length === 0 &&
-      (!action.enabled || action.enabled(item));
+    // Disable all actions if any row(s) are selected
+    const allDisabled = this.state.selection.length > 0;
 
     let actualActions = column.actions.filter(
       (action: Action<T>) => !action.available || action.available(item)
     );
     if (actualActions.length > 2) {
-      // if any of the actions `isPrimary`, add them inline as well, but only the first 2
-      const primaryActions = actualActions.filter((o) => o.isPrimary);
-      actualActions = primaryActions.slice(0, 2);
+      if (allDisabled) {
+        // If all actions are disabled, do not show any actions but the popover toggle
+        actualActions = [];
+      } else {
+        // if any of the actions `isPrimary`, add them inline as well, but only the first 2
+        const primaryActions = actualActions.filter((o) => o.isPrimary);
+        actualActions = primaryActions.slice(0, 2);
+      }
 
       // if we have more than 1 action, we don't show them all in the cell, instead we
       // put them all in a popover tool. This effectively means we can only have a maximum
@@ -1177,9 +1181,9 @@ export class EuiBasicTable<T = any> extends Component<
           return (
             <CollapsedItemActions
               actions={column.actions}
+              actionsDisabled={allDisabled}
               itemId={itemId}
               item={item}
-              actionEnabled={actionEnabled}
             />
           );
         },
@@ -1189,9 +1193,9 @@ export class EuiBasicTable<T = any> extends Component<
     const tools = (
       <ExpandedItemActions
         actions={actualActions}
+        actionsDisabled={allDisabled}
         itemId={itemId}
         item={item}
-        actionEnabled={actionEnabled}
       />
     );
 

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -36,7 +36,7 @@ describe('CollapsedItemActions', () => {
       ],
       itemId: 'id',
       item: { id: '1' },
-      actionEnabled: () => true,
+      actionsDisabled: false,
     };
 
     const { container } = render(<CollapsedItemActions {...props} />);
@@ -63,7 +63,7 @@ describe('CollapsedItemActions', () => {
       ],
       itemId: 'id',
       item: { id: 'xyz' },
-      actionEnabled: () => true,
+      actionsDisabled: false,
     };
 
     const { getByTestSubject, getByText, baseElement } = render(
@@ -92,7 +92,7 @@ describe('CollapsedItemActions', () => {
       ],
       itemId: 'id',
       item: { id: 'xyz' },
-      actionEnabled: () => true,
+      actionsDisabled: false,
     };
 
     const { getByTestSubject, baseElement } = render(

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -33,7 +33,7 @@ export interface CollapsedItemActionsProps<T extends {}> {
   actions: Array<Action<T>>;
   item: T;
   itemId: ItemIdResolved;
-  actionEnabled: (action: Action<T>) => boolean;
+  actionsDisabled: boolean;
   className?: string;
 }
 
@@ -41,11 +41,10 @@ export const CollapsedItemActions = <T extends {}>({
   actions,
   itemId,
   item,
-  actionEnabled,
+  actionsDisabled,
   className,
 }: CollapsedItemActionsProps<T>) => {
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const [allDisabled, setAllDisabled] = useState(true);
 
   const onClickItem = useCallback((onClickAction?: () => void) => {
     setPopoverOpen(false);
@@ -57,8 +56,7 @@ export const CollapsedItemActions = <T extends {}>({
       const available = action.available?.(item) ?? true;
       if (!available) return controls;
 
-      const enabled = actionEnabled(action);
-      if (enabled) setAllDisabled(false);
+      const enabled = action.enabled == null || action.enabled(item);
 
       if (isCustomItemAction<T>(action)) {
         const customAction = action as CustomItemAction<T>;
@@ -94,7 +92,7 @@ export const CollapsedItemActions = <T extends {}>({
           <EuiContextMenuItem
             key={index}
             className="euiBasicTable__collapsedAction"
-            disabled={!enabled}
+            disabled={!enabled && !actionsDisabled}
             href={href}
             target={target}
             icon={icon}
@@ -111,7 +109,7 @@ export const CollapsedItemActions = <T extends {}>({
       }
       return controls;
     }, []);
-  }, [actions, actionEnabled, item, onClickItem]);
+  }, [actions, actionsDisabled, item, onClickItem]);
 
   const popoverButton = (
     <EuiI18n token="euiCollapsedItemActions.allActions" default="All actions">
@@ -121,7 +119,7 @@ export const CollapsedItemActions = <T extends {}>({
           aria-label={allActions}
           iconType="boxesHorizontal"
           color="text"
-          isDisabled={allDisabled}
+          isDisabled={actionsDisabled}
           onClick={() => setPopoverOpen((isOpen) => !isOpen)}
           data-test-subj="euiCollapsedItemActionsButton"
         />
@@ -129,7 +127,7 @@ export const CollapsedItemActions = <T extends {}>({
     </EuiI18n>
   );
 
-  const withTooltip = !allDisabled && (
+  const withTooltip = !actionsDisabled && (
     <EuiI18n token="euiCollapsedItemActions.allActions" default="All actions">
       {(allActions: ReactNode) => (
         <EuiToolTip content={allActions} delay="long">

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -112,11 +112,21 @@ export const CollapsedItemActions = <T extends {}>({
   }, [actions, actionsDisabled, item, onClickItem]);
 
   const popoverButton = (
-    <EuiI18n token="euiCollapsedItemActions.allActions" default="All actions">
-      {(allActions: string) => (
+    <EuiI18n
+      tokens={[
+        'euiCollapsedItemActions.allActions',
+        'euiCollapsedItemActions.allActionsDisabled',
+      ]}
+      defaults={[
+        'All actions',
+        'Individual item actions are disabled when rows are being selected.',
+      ]}
+    >
+      {([allActions, allActionsDisabled]: string[]) => (
         <EuiButtonIcon
           className={className}
-          aria-label={allActions}
+          aria-label={actionsDisabled ? allActionsDisabled : allActions}
+          title={actionsDisabled ? allActionsDisabled : undefined}
           iconType="boxesHorizontal"
           color="text"
           isDisabled={actionsDisabled}

--- a/src/components/basic_table/expanded_item_actions.test.tsx
+++ b/src/components/basic_table/expanded_item_actions.test.tsx
@@ -30,7 +30,7 @@ describe('ExpandedItemActions', () => {
       ],
       itemId: 'xyz',
       item: { id: 'xyz' },
-      actionEnabled: () => true,
+      actionsDisabled: false,
     };
 
     const component = shallow(<ExpandedItemActions {...props} />);

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -22,7 +22,7 @@ export interface ExpandedItemActionsProps<T> {
   actions: Array<Action<T>>;
   itemId: ItemIdResolved;
   item: T;
-  actionEnabled: (action: Action<T>) => boolean;
+  actionsDisabled: boolean;
   className?: string;
 }
 
@@ -30,7 +30,7 @@ export const ExpandedItemActions = <T extends {}>({
   actions,
   itemId,
   item,
-  actionEnabled,
+  actionsDisabled,
   className,
 }: ExpandedItemActionsProps<T>): ReactElement => {
   const moreThanThree = actions.length > 2;
@@ -43,7 +43,7 @@ export const ExpandedItemActions = <T extends {}>({
           return tools;
         }
 
-        const enabled = actionEnabled(action);
+        const enabled = action.enabled == null || action.enabled(item);
 
         const key = `item_action_${itemId}_${index}`;
 
@@ -59,7 +59,7 @@ export const ExpandedItemActions = <T extends {}>({
               className={classes}
               index={index}
               action={action as CustomAction<T>}
-              enabled={enabled}
+              enabled={enabled && !actionsDisabled}
               item={item}
             />
           );
@@ -69,7 +69,7 @@ export const ExpandedItemActions = <T extends {}>({
               key={key}
               className={classes}
               action={action as DefaultAction<T>}
-              enabled={enabled}
+              enabled={enabled && !actionsDisabled}
               item={item}
             />
           );


### PR DESCRIPTION
## Summary

#7361 / #7373 regressed this UX (I think either during the conversion from a class to a function component, or when I was fixing the broken keyboard/hover visibility), and wasn't caught during QA mostly because the intended UX was both completely undocumented and untested 🥲 which should have been fixed in this PR.

| Before | After |
|--------|--------|
| ![before](https://github.com/elastic/eui/assets/549407/e3fb827c-c502-4d20-9486-c35990eaa1e7) | ![after](https://github.com/elastic/eui/assets/549407/2b25aa39-6b3b-40dd-956e-5aef0894cb80) | 
| See https://eui.elastic.co/v91.2.0/#/tabular-content/tables#adding-actions-to-table for the regressed UX | See https://eui.elastic.co/v90.0.0/#/tabular-content/tables#adding-actions-to-table for the previous non-regressed UX |
 
## QA

- Go to https://eui.elastic.co/pr_7428/#/tabular-content/tables#adding-actions-to-table
- [x] Select all or any rows in the table, and confirm the link action becomes disabled
- [x] Unselect all rows in the table, and confirm the link action (for rows that were selectable) becomes enabled again
- Click the "Multiple actions" toggle in the top left corner of the demo
- [x] Select any row in the table, and confirm that all the `...` action toggles are disabled, and no other actions show on row hover
- [x] Unselect all rows in the table, and confirm that actions re-enable

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    ~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
