### PR TITLE
build: add prerelease resource

### DIFF
--- a/.buildkite/pipelines/pipeline_release.yml
+++ b/.buildkite/pipelines/pipeline_release.yml
@@ -1,0 +1,7 @@
+steps:
+  - command: "echo 'This pipeline is currently a no-op'"
+    label: ':shrug: noop'
+    agents:
+      provider: gcp
+    # TODO: remove the test-automatic-releases condition when the pipeline is production-ready
+    if: build.branch == "main" || build.branch == "build/test-automatic-releases"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -30,6 +30,7 @@ spec:
 ---
 ##
 # Example pipeline
+# TODO: Remove this resource and related pipeline if they're not needed anymore
 ##
 
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,12 @@
-################################################################################
-###################### catalog-info for EUI ######################
-# Declare a Backstage Component that represents your application.
+# EUI Catalog info for Backstage
+# Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/
+# DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU'RE DOING!
+
 ---
+##
+# EUI component
+##
+
 # yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
 apiVersion: backstage.io/v1alpha1
 kind: Component
@@ -22,11 +27,11 @@ spec:
   system: ci-systems
   lifecycle: production
 
-###############################################################################
-############################# Buildkite pipelines ##############################
-# Declare your Buildkite pipeline.
-# This declaration creates the Backstage entity and the pipeline in Buildkite.
 ---
+##
+# Example pipeline
+##
+
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
@@ -39,7 +44,7 @@ metadata:
       url: "https://buildkite.com/elastic/eui",
     }
   ]
-      
+
 spec:
   type: buildkite-pipeline
   owner: group:eui-team
@@ -65,9 +70,12 @@ spec:
         everyone:
           access_level: READ_ONLY
 
-############################ Pull request test #############################
-# Run all unit and functional tests on PR
 ---
+##
+# buildkite-pipeline-eui-pull-request-test
+# Pull request - run all unit and functional tests
+##
+
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
@@ -80,7 +88,7 @@ metadata:
       url: "https://buildkite.com/elastic/eui-pull-request-test",
     }
   ]
-      
+
 spec:
   type: buildkite-pipeline
   owner: group:eui-team
@@ -106,9 +114,12 @@ spec:
         everyone:
           access_level: BUILD_AND_READ
 
-############################ Pull request deploy docs #############################
-# Deploy docs to cloud on PR
 ---
+##
+# buildkite-pipeline-eui-pull-request-deploy-docs
+# Pull request - deploy docs website PR preview
+##
+
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
@@ -121,7 +132,7 @@ metadata:
       url: "https://buildkite.com/elastic/eui-pull-request-deploy-docs",
     }
   ]
-      
+
 spec:
   type: buildkite-pipeline
   owner: group:eui-team
@@ -148,9 +159,12 @@ spec:
           access_level: BUILD_AND_READ
 
 
-############################ Pull request combined job #############################
-# Orchestrate tests and deploying docs to cloud on branch PR
 ---
+##
+# buildkite-pipeline-eui-pull-request-test-and-deploy
+# Pull request - run tests and deploy docs website PR preview
+##
+
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
@@ -163,7 +177,7 @@ metadata:
       url: "https://buildkite.com/elastic/eui-pull-request-test-and-deploy",
     }
   ]
-      
+
 spec:
   type: buildkite-pipeline
   owner: group:eui-team
@@ -194,10 +208,12 @@ spec:
         everyone:
           access_level: BUILD_AND_READ
 
-
-############################ Release deploy docs #############################
-# Publish docs to EUI subdomain when we tag a new release
 ---
+##
+# buildkite-pipeline-eui-release-deploy-docs
+# EUI Release - publish docs to eui.elastic.co when we tag a new release
+##
+
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -252,3 +252,47 @@ spec:
          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+##
+# buildkite-pipeline-eui-release
+# EUI Release - handle (pre)release process on merge to main
+##
+
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-eui-release
+  description: EUI pipeline to release the latest version of @elastic/eui
+  links: [
+    {
+      title: "EUI - release",
+      url: "https://buildkite.com/elastic/eui-release",
+    }
+  ]
+
+spec:
+  type: buildkite-pipeline
+  owner: group:eui-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: eui-release
+    spec:
+      repository: elastic/eui
+      pipeline_file: ".buildkite/pipelines/pipeline_release.yml"
+      provider_settings:
+        build_branches: true
+        build_tags: false
+        build_pull_requests: false
+        filter_enabled: true
+        # TODO: remove the test-automatic-releases condition when the pipeline is production-ready
+        filter_condition: build.branch == "main" || build.branch == "build/test-automatic-releases"
+      teams:
+        eui-team:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,8 @@
+# This file is meant to be edited by EUI core contributors and Elastic
+# employees only. We *won't* accept any changes from external contributors
+# and will close any pull requests that modify this file,
+# even if the changes seem safe.
+
 # EUI Catalog info for Backstage
 # Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/
 # DO NOT MODIFY THIS FILE UNLESS YOU KNOW WHAT YOU'RE DOING!


### PR DESCRIPTION
## Summary

This PR adds a new Backstage resource to handle the automatic EUI (pre)release process on merges to `main` and a placeholder Buildkite pipeline setup so that it can be tested safely using the `build/test-automatic-releases` branch.

## QA

- [ ] Validate the `catalog-info.yaml` syntax using the Backstage config validator (ask @tkajtoch for a link to the internal tool if needed)

Additional QA will be done manually by @tkajtoch after merging this PR to `main` and letting the changes propagate to Backstage and Buildkite.