### PR TITLE
[EuiFlyoutResizable] Add resizable flyout

### DIFF
--- a/changelogs/upcoming/7439.md
+++ b/changelogs/upcoming/7439.md
@@ -1,0 +1,1 @@
+- Added a new `EuiFlyoutResizable` component

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -402,6 +402,7 @@ export const FlyoutExample = {
     },
     {
       title: 'Resizable flyouts',
+      isBeta: true,
       source: [
         {
           type: GuideSectionTypes.JS,

--- a/src-docs/src/views/flyout/flyout_example.js
+++ b/src-docs/src/views/flyout/flyout_example.js
@@ -9,6 +9,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiFlyoutFooter,
+  EuiFlyoutResizable,
   EuiCallOut,
   EuiLink,
 } from '../../../../src/components';
@@ -36,6 +37,9 @@ const flyoutWithBannerSource = require('!!raw-loader!./flyout_banner');
 
 import FlyoutPush from './flyout_push';
 const flyoutPushSource = require('!!raw-loader!./flyout_push');
+
+import FlyoutResizable from './flyout_resizable';
+const flyoutResizableSource = require('!!raw-loader!./flyout_resizable');
 
 const flyOutSnippet = `<EuiFlyout onClose={closeFlyout}>
   <EuiFlyoutHeader hasBorder aria-labelledby={flyoutHeadingId}>
@@ -141,6 +145,18 @@ const flyoutPushedSnippet = `<EuiFlyout type="push" onClose={closeFlyout}>
   <EuiFlyoutFooter>
     <EuiButton onClose={closeFlyout}>Close</EuiButton>
   </EuiFlyoutFooter>
+</EuiFlyout>
+`;
+
+const flyoutResizableSnippet = `<EuiFlyoutResizable onClose={closeFlyout} maxWidth={1000} minWidth={300}>
+  <EuiFlyoutHeader hasBorder aria-labelledby={flyoutHeadingId}>
+    <EuiTitle>
+      <h2 id={flyoutHeadingId}>Flyout title</h2>
+    </EuiTitle>
+  </EuiFlyoutHeader>
+  <EuiFlyoutBody>
+    <!-- Flyout content -->
+  </EuiFlyoutBody>
 </EuiFlyout>
 `;
 
@@ -383,6 +399,36 @@ export const FlyoutExample = {
       snippet: flyoutMaxWidthSnippet,
       demo: <FlyoutMaxWidth />,
       props: { EuiFlyout },
+    },
+    {
+      title: 'Resizable flyouts',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: flyoutResizableSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            You can use <strong>EuiFlyoutResizable</strong> to render a flyout
+            that users can drag with their mouse or use arrow keys to resize.
+            This may be useful for scenarios where the space the user needs can
+            be unpredictable, if content is dynamic. Resizable flyouts allow
+            users to adjust content to better fit their individual screens and
+            workflows.
+          </p>
+          <p>
+            We strongly recommend setting reasonable numerical{' '}
+            <EuiCode>minWidth</EuiCode> and <EuiCode>maxWidth</EuiCode> props
+            based on the flyout content and page content that you <em>can</em>{' '}
+            predict.
+          </p>
+        </>
+      ),
+      snippet: flyoutResizableSnippet,
+      demo: <FlyoutResizable />,
+      props: { EuiFlyoutResizable },
     },
   ],
 };

--- a/src-docs/src/views/flyout/flyout_resizable.tsx
+++ b/src-docs/src/views/flyout/flyout_resizable.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+
+import {
+  EuiFlyoutResizable,
+  EuiFlyoutProps,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiButton,
+  EuiButtonGroup,
+  EuiText,
+  EuiTitle,
+  EuiSpacer,
+} from '../../../../src/components';
+
+import { useGeneratedHtmlId } from '../../../../src/services';
+
+export default () => {
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+  const [flyoutType, setFlyoutType] = useState('overlay');
+  const [flyoutSide, setFlyoutSide] = useState('right');
+
+  const flyoutTitleId = useGeneratedHtmlId({
+    prefix: 'simpleFlyoutTitle',
+  });
+
+  let flyout;
+
+  if (isFlyoutVisible) {
+    flyout = (
+      <EuiFlyoutResizable
+        type={flyoutType as EuiFlyoutProps['type']}
+        side={flyoutSide as EuiFlyoutProps['side']}
+        onClose={() => setIsFlyoutVisible(false)}
+        aria-labelledby={flyoutTitleId}
+      >
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2 id={flyoutTitleId}>A resizable flyout</h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiText>
+            <p>
+              This flyout is resizable by both mouse drag and arrow keys (when
+              the resizable edge is focused). Both push and overlay flyouts can
+              be resizable, on either side.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <EuiTitle size="xxs">
+            <h3>Flyout type</h3>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+          <EuiButtonGroup
+            legend="Flyout type"
+            options={[
+              { id: 'overlay', label: 'Overlay' },
+              { id: 'push', label: 'Push' },
+            ]}
+            idSelected={flyoutType}
+            onChange={(id) => setFlyoutType(id)}
+          />
+          <EuiSpacer />
+          <EuiTitle size="xxs">
+            <h3>Flyout side</h3>
+          </EuiTitle>
+          <EuiButtonGroup
+            legend="Flyout side"
+            options={[
+              { id: 'right', label: 'Right' },
+              { id: 'left', label: 'Left' },
+            ]}
+            idSelected={flyoutSide}
+            onChange={(id) => setFlyoutSide(id)}
+          />
+        </EuiFlyoutBody>
+      </EuiFlyoutResizable>
+    );
+  }
+
+  return (
+    <>
+      <EuiButton onClick={() => setIsFlyoutVisible(true)}>
+        Show resizable flyout
+      </EuiButton>
+      {flyout}
+    </>
+  );
+};

--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiCollapsibleNavBeta renders 1`] = `
 <body
   class="euiBody--hasFlyout"
-  style="padding-left: 0px;"
+  style="padding-inline-start: 0px;"
 >
   <div>
     <div
@@ -56,7 +56,7 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
 exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
 <body
   class="euiBody--hasFlyout"
-  style="padding-left: 0px;"
+  style="padding-inline-start: 0px;"
 >
   <div>
     <div

--- a/src/components/flyout/flyout.tsx
+++ b/src/components/flyout/flyout.tsx
@@ -226,9 +226,9 @@ export const EuiFlyout = forwardRef(
        */
       if (isPushed) {
         if (side === 'right') {
-          document.body.style.paddingRight = `${dimensions.width}px`;
+          document.body.style.paddingInlineEnd = `${dimensions.width}px`;
         } else if (side === 'left') {
-          document.body.style.paddingLeft = `${dimensions.width}px`;
+          document.body.style.paddingInlineStart = `${dimensions.width}px`;
         }
       }
 
@@ -237,9 +237,9 @@ export const EuiFlyout = forwardRef(
 
         if (isPushed) {
           if (side === 'right') {
-            document.body.style.paddingRight = '';
+            document.body.style.paddingInlineEnd = '';
           } else if (side === 'left') {
-            document.body.style.paddingLeft = '';
+            document.body.style.paddingInlineStart = '';
           }
         }
       };

--- a/src/components/flyout/flyout_resizable.spec.tsx
+++ b/src/components/flyout/flyout_resizable.spec.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../cypress/support" />
+
+import React from 'react';
+
+import { EuiFlyoutResizable } from './flyout_resizable';
+
+const onClose = () => {};
+
+describe('EuiFlyoutResizable', () => {
+  beforeEach(() => {
+    cy.viewport(1200, 500);
+  });
+
+  describe('sets the flyout size after initial load to a static number', () => {
+    it('default size', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} />);
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '600px');
+    });
+
+    it('size enum', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size="s" />);
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '384px');
+    });
+
+    it('number', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size={300} />);
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '300px');
+    });
+
+    it('CSS width', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size="80%" />);
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '960px');
+    });
+
+    it('with max width', () => {
+      cy.mount(
+        <EuiFlyoutResizable onClose={onClose} size="100%" maxWidth={400} />
+      );
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '400px');
+    });
+
+    it('with min width', () => {
+      cy.mount(
+        <EuiFlyoutResizable onClose={onClose} size={100} minWidth={200} />
+      );
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '200px');
+    });
+  });
+
+  describe('resizing', () => {
+    // There isn't a way to actually drag & drop in Cypress, so we're mocking it via triggers
+    it('mouse drag', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { pageX: 400 })
+        .trigger('mousemove', { pageX: 600 });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '600px');
+
+      cy.get('[data-test-subj="euiResizableButton"]').trigger('mousemove', {
+        pageX: 200,
+      });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '1000px');
+
+      // Should not change the flyout width if not dragging
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mouseup')
+        .trigger('mousemove', { pageX: 1000 });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '1000px');
+    });
+
+    it('mobile touch drag', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('touchstart', { targetTouches: [{ pageX: 400 }], touches: [] })
+        .trigger('touchmove', { targetTouches: [{ pageX: 800 }], touches: [] })
+        .trigger('touchend', { touches: [] });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '400px');
+    });
+
+    it('keyboard tabbing', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
+      cy.get('[data-test-subj="euiResizableButton"]').focus();
+
+      cy.repeatRealPress('ArrowRight', 10);
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '700px');
+
+      cy.repeatRealPress('ArrowLeft', 5);
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '750px');
+    });
+
+    it('does not allow the flyout to be resized past the window width', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { pageX: 400 })
+        .trigger('mousemove', { pageX: -100 });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '1180px');
+    });
+
+    it('does not allow the flyout to be resized past the max width', () => {
+      cy.mount(
+        <EuiFlyoutResizable onClose={onClose} size={800} maxWidth={1000} />
+      );
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { pageX: 400 })
+        .trigger('mousemove', { pageX: 100 });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '1000px');
+    });
+
+    it('does not allow the flyout to be resized past the min width', () => {
+      cy.mount(
+        <EuiFlyoutResizable onClose={onClose} size={800} minWidth={100} />
+      );
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { pageX: 400 })
+        .trigger('mousemove', { pageX: 2000 });
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '100px');
+    });
+  });
+});

--- a/src/components/flyout/flyout_resizable.spec.tsx
+++ b/src/components/flyout/flyout_resizable.spec.tsx
@@ -125,5 +125,40 @@ describe('EuiFlyoutResizable', () => {
         .trigger('mousemove', { pageX: 2000 });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '100px');
     });
+
+    describe('direction', () => {
+      it('reverses the calculations for left side flyouts', () => {
+        cy.mount(
+          <EuiFlyoutResizable onClose={onClose} size={800} side="left" />
+        );
+        assertReversedDirections();
+      });
+
+      it('reverses again for RTL logical property directions', () => {
+        cy.mount(
+          <EuiFlyoutResizable
+            onClose={onClose}
+            size={800}
+            style={{ direction: 'rtl' }}
+          />
+        );
+        assertReversedDirections({ force: true });
+      });
+
+      const assertReversedDirections = (options?: { force: boolean }) => {
+        cy.get('[data-test-subj="euiResizableButton"]').focus();
+
+        cy.repeatRealPress('ArrowRight', 10);
+        cy.get('.euiFlyout').should('have.css', 'inline-size', '900px');
+
+        cy.repeatRealPress('ArrowLeft', 5);
+        cy.get('.euiFlyout').should('have.css', 'inline-size', '850px');
+
+        cy.get('[data-test-subj="euiResizableButton"]')
+          .trigger('mousedown', { pageX: 850, ...options })
+          .trigger('mousemove', { pageX: 400, ...options });
+        cy.get('.euiFlyout').should('have.css', 'inline-size', '400px');
+      };
+    });
   });
 });

--- a/src/components/flyout/flyout_resizable.spec.tsx
+++ b/src/components/flyout/flyout_resizable.spec.tsx
@@ -161,4 +161,37 @@ describe('EuiFlyoutResizable', () => {
       };
     });
   });
+
+  describe('push flyouts', () => {
+    it('correctly updates the body padding offset on resize', () => {
+      cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} type="push" />);
+      cy.get('body').should('have.css', 'padding-inline-end', '800px');
+
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { pageX: 400 })
+        .trigger('mousemove', { pageX: 1000 });
+
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '200px');
+      cy.get('body').should('have.css', 'padding-inline-end', '200px');
+    });
+
+    it('handles left side push flyouts', () => {
+      cy.mount(
+        <EuiFlyoutResizable
+          onClose={onClose}
+          size={800}
+          type="push"
+          side="left"
+        />
+      );
+      cy.get('body').should('have.css', 'padding-inline-start', '800px');
+
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { pageX: 800 })
+        .trigger('mousemove', { pageX: 200 });
+
+      cy.get('.euiFlyout').should('have.css', 'inline-size', '200px');
+      cy.get('body').should('have.css', 'padding-inline-start', '200px');
+    });
+  });
 });

--- a/src/components/flyout/flyout_resizable.styles.ts
+++ b/src/components/flyout/flyout_resizable.styles.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+
+export const euiFlyoutResizableButtonStyles = ({ euiTheme }: UseEuiTheme) => ({
+  euiFlyoutResizableButton: css`
+    position: absolute;
+    inset-inline-start: -${euiTheme.border.width.thin};
+
+    /* Hide the default grab icon (although the hover/focus states should remain) */
+    &::before,
+    &::after {
+      background-color: transparent;
+    }
+  `,
+});

--- a/src/components/flyout/flyout_resizable.styles.ts
+++ b/src/components/flyout/flyout_resizable.styles.ts
@@ -9,16 +9,22 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
+import { logicalCSS } from '../../global_styling';
 
 export const euiFlyoutResizableButtonStyles = ({ euiTheme }: UseEuiTheme) => ({
   euiFlyoutResizableButton: css`
     position: absolute;
-    inset-inline-start: -${euiTheme.border.width.thin};
 
     /* Hide the default grab icon (although the hover/focus states should remain) */
     &::before,
     &::after {
       background-color: transparent;
     }
+  `,
+  left: css`
+    ${logicalCSS('right', `-${euiTheme.border.width.thin}`)}
+  `,
+  right: css`
+    ${logicalCSS('left', `-${euiTheme.border.width.thin}`)}
   `,
 });

--- a/src/components/flyout/flyout_resizable.tsx
+++ b/src/components/flyout/flyout_resizable.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  forwardRef,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
+
+import { keys, useCombinedRefs, useEuiTheme } from '../../services';
+import { EuiResizableButton } from '../resizable_container';
+
+import { EuiFlyout, EuiFlyoutProps } from './flyout';
+import { euiFlyoutResizableButtonStyles } from './flyout_resizable.styles';
+
+export type EuiFlyoutResizableProps = Omit<EuiFlyoutProps, 'maxWidth'> & {
+  maxWidth?: number;
+  minWidth?: number;
+};
+
+export const EuiFlyoutResizable = forwardRef(
+  (
+    {
+      size,
+      maxWidth,
+      minWidth = 200,
+      children,
+      ...rest
+    }: EuiFlyoutResizableProps,
+    ref
+  ) => {
+    const euiTheme = useEuiTheme();
+    const styles = euiFlyoutResizableButtonStyles(euiTheme);
+    const cssStyles = [styles.euiFlyoutResizableButton];
+
+    const getFlyoutMinMaxWidth = useCallback(
+      (width: number) => {
+        return Math.min(
+          Math.max(width, minWidth),
+          maxWidth || Infinity,
+          window.innerWidth - 20 // Leave some offset
+        );
+      },
+      [minWidth, maxWidth]
+    );
+
+    const [flyoutWidth, setFlyoutWidth] = useState(0);
+
+    // Must use state for the flyout ref in order for the useEffect to be correctly called after render
+    const [flyoutRef, setFlyoutRef] = useState<HTMLElement | null>(null);
+    const setRefs = useCombinedRefs([setFlyoutRef, ref]);
+    useEffect(() => {
+      setFlyoutWidth(flyoutRef?.offsetWidth ?? 0);
+    }, [flyoutRef, size]);
+
+    // Initial numbers to calculate from, on resize drag start
+    const initialWidth = useRef(0);
+    const initialMouseX = useRef(0);
+
+    const onMouseMove = useCallback(
+      (e: MouseEvent | TouchEvent) => {
+        const mouseOffset = getMouseOrTouchX(e) - initialMouseX.current;
+        const changedFlyoutWidth = initialWidth.current - mouseOffset;
+
+        setFlyoutWidth(getFlyoutMinMaxWidth(changedFlyoutWidth));
+      },
+      [getFlyoutMinMaxWidth]
+    );
+
+    const onMouseUp = useCallback(() => {
+      initialMouseX.current = 0;
+
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('touchmove', onMouseMove);
+      window.removeEventListener('touchend', onMouseUp);
+    }, [onMouseMove]);
+
+    const onMouseDown = useCallback(
+      (e: React.MouseEvent | React.TouchEvent) => {
+        initialMouseX.current = getMouseOrTouchX(e);
+        initialWidth.current = flyoutRef?.offsetWidth ?? 0;
+
+        // Window event listeners instead of React events are used
+        // in case the user's mouse leaves the component
+        window.addEventListener('mousemove', onMouseMove);
+        window.addEventListener('mouseup', onMouseUp);
+        window.addEventListener('touchmove', onMouseMove);
+        window.addEventListener('touchend', onMouseUp);
+      },
+      [flyoutRef, onMouseMove, onMouseUp]
+    );
+
+    const onKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        const KEYBOARD_OFFSET = 10;
+
+        switch (e.key) {
+          case keys.ARROW_RIGHT:
+            e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
+            setFlyoutWidth((flyoutWidth) =>
+              getFlyoutMinMaxWidth(flyoutWidth - KEYBOARD_OFFSET)
+            );
+            break;
+          case keys.ARROW_LEFT:
+            e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
+            setFlyoutWidth((flyoutWidth) =>
+              getFlyoutMinMaxWidth(flyoutWidth + KEYBOARD_OFFSET)
+            );
+        }
+      },
+      [getFlyoutMinMaxWidth]
+    );
+
+    return (
+      <EuiFlyout
+        {...rest}
+        size={flyoutWidth || size}
+        maxWidth={maxWidth}
+        ref={setRefs}
+      >
+        <EuiResizableButton
+          isHorizontal
+          css={cssStyles}
+          onMouseDown={onMouseDown}
+          onTouchStart={onMouseDown}
+          onKeyDown={onKeyDown}
+        />
+        {children}
+      </EuiFlyout>
+    );
+  }
+);
+EuiFlyoutResizable.displayName = 'EuiFlyoutResizable';
+
+const getMouseOrTouchX = (
+  e: TouchEvent | MouseEvent | React.MouseEvent | React.TouchEvent
+): number => {
+  // Some Typescript fooling is needed here
+  const x = (e as TouchEvent).targetTouches
+    ? (e as TouchEvent).targetTouches[0].pageX
+    : (e as MouseEvent).pageX;
+  return x;
+};

--- a/src/components/flyout/flyout_resizable.tsx
+++ b/src/components/flyout/flyout_resizable.tsx
@@ -57,8 +57,10 @@ export const EuiFlyoutResizable = forwardRef(
     const [flyoutRef, setFlyoutRef] = useState<HTMLElement | null>(null);
     const setRefs = useCombinedRefs([setFlyoutRef, ref]);
     useEffect(() => {
-      setFlyoutWidth(flyoutRef?.offsetWidth ?? 0);
-    }, [flyoutRef, size]);
+      setFlyoutWidth(
+        flyoutRef ? getFlyoutMinMaxWidth(flyoutRef.offsetWidth) : 0
+      );
+    }, [flyoutRef, getFlyoutMinMaxWidth, size]);
 
     // Initial numbers to calculate from, on resize drag start
     const initialWidth = useRef(0);

--- a/src/components/flyout/index.ts
+++ b/src/components/flyout/index.ts
@@ -19,3 +19,6 @@ export type { EuiFlyoutHeaderProps } from './flyout_header';
 export { EuiFlyoutHeader } from './flyout_header';
 
 export { euiFlyoutSlideInRight, euiFlyoutSlideInLeft } from './flyout.styles';
+
+export type { EuiFlyoutResizableProps } from './flyout_resizable';
+export { EuiFlyoutResizable } from './flyout_resizable';


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/287

<img src="https://github.com/elastic/eui/assets/549407/c8083bb0-c55c-49b1-bfc6-72be9f23c90e" alt="" width="500">

### Areas I'm looking for feedback on:

- **API** - does adding a new `<EuiFlyoutResizable />` component (as opposed to, e.g. `<EuiFlyout resizable={true} />`) make sense? I leaned this way because it felt the cleanest in terms of implementation (as opposed to adding Yet More Code to the existing logic-heavy flyout file), but definitely would like to hear feedback on this.

- **UI/UX** - do we need more visual indicators or UI hints that the edge is resizable? Or does the existing appearance feel sufficient?

- **Documentation** - especially with our new focus on patterns, I would really like feedback on the copy I wrote. I cribbed text from the above issue on _why_ using resizable flyouts might be a good idea, but I think we should also consider adding some copy on when _not_ to use resizable flyouts.

## QA

- https://eui.elastic.co/pr_7439/#/layout/flyout#resizable-flyouts

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
      - Jest tests skipped as this functionality requires a lot more mocking in jsdom (widths etc), and is significantly less painful in Cypress/E2E. Code coverage is at 100% with Cypress tests <img width="1168" alt="" src="https://github.com/elastic/eui/assets/549407/de904a76-54b6-4127-a158-7bf256e41f4c">
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
      - Not sure if this should be added. Will check at the next Figma meeting
