### PR TITLE
[EuiRange][EuiDualRange] Respond to resizing/layout changes

### DIFF
--- a/changelogs/upcoming/7442.md
+++ b/changelogs/upcoming/7442.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- `EuiRange`/`EuiDualRange`'s track ticks & highlights now update their positions on resize

--- a/src-docs/src/views/range/range.tsx
+++ b/src-docs/src/views/range/range.tsx
@@ -1,48 +1,64 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 
-import { EuiRange, EuiAccordion } from '../../../../src/components';
+import { EuiRange, EuiRangeProps, EuiSpacer } from '../../../../src/components';
 
-// import { useGeneratedHtmlId } from '../../../../src/services';
+import { useGeneratedHtmlId } from '../../../../src/services';
 
 export default () => {
-  const [value, setValue] = useState(21);
-  const [active, setActive] = useState(false);
+  const [value, setValue] = useState('120');
 
-  const range = useMemo(
-    () => (
-      <>
-        <div
-          style={{
-            display: active ? undefined : 'none',
-          }}
-        >
-          <EuiRange
-            value={value}
-            onChange={(e) => {
-              const range = e.currentTarget.value;
-              setValue(Number(range.trim()));
-            }}
-            max={100}
-            min={0}
-            showRange
-            showInput
-            fullWidth={false}
-            showTicks
-            tickInterval={25}
-          />
-        </div>
-      </>
-    ),
-    [active, value]
-  );
+  const basicRangeId = useGeneratedHtmlId({ prefix: 'basicRange' });
+  const rangeWithShowValueId = useGeneratedHtmlId({
+    prefix: 'rangeWithShowValue',
+  });
+  const rangeWithValuePrependId = useGeneratedHtmlId({
+    prefix: 'rangeWithValuePrepend',
+  });
+
+  const onChange: EuiRangeProps['onChange'] = (e) => {
+    setValue(e.currentTarget.value);
+  };
 
   return (
-    <EuiAccordion
-      id="rangeTest"
-      buttonContent="Toggle accordion"
-      onToggle={() => setActive(!active)}
-    >
-      {range}
-    </EuiAccordion>
+    <>
+      <EuiRange
+        id={basicRangeId}
+        min={100}
+        max={200}
+        step={0.05}
+        value={value}
+        onChange={onChange}
+        showLabels
+        aria-label="An example of EuiRange with showLabels prop"
+      />
+
+      <EuiSpacer size="xl" />
+
+      <EuiRange
+        id={rangeWithShowValueId}
+        min={100}
+        max={200}
+        value={value}
+        onChange={onChange}
+        showLabels
+        showValue
+        aria-label="An example of EuiRange with showValue prop"
+      />
+
+      <EuiSpacer size="xl" />
+
+      <EuiRange
+        id={rangeWithValuePrependId}
+        min={100}
+        max={200}
+        value={value}
+        onChange={onChange}
+        showLabels
+        showRange
+        showValue
+        valuePrepend="100 - "
+        aria-label="An example of EuiRange with valuePrepend prop"
+      />
+    </>
   );
 };

--- a/src-docs/src/views/range/range.tsx
+++ b/src-docs/src/views/range/range.tsx
@@ -1,64 +1,48 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 
-import { EuiRange, EuiRangeProps, EuiSpacer } from '../../../../src/components';
+import { EuiRange, EuiAccordion } from '../../../../src/components';
 
-import { useGeneratedHtmlId } from '../../../../src/services';
+// import { useGeneratedHtmlId } from '../../../../src/services';
 
 export default () => {
-  const [value, setValue] = useState('120');
+  const [value, setValue] = useState(21);
+  const [active, setActive] = useState(false);
 
-  const basicRangeId = useGeneratedHtmlId({ prefix: 'basicRange' });
-  const rangeWithShowValueId = useGeneratedHtmlId({
-    prefix: 'rangeWithShowValue',
-  });
-  const rangeWithValuePrependId = useGeneratedHtmlId({
-    prefix: 'rangeWithValuePrepend',
-  });
-
-  const onChange: EuiRangeProps['onChange'] = (e) => {
-    setValue(e.currentTarget.value);
-  };
+  const range = useMemo(
+    () => (
+      <>
+        <div
+          style={{
+            display: active ? undefined : 'none',
+          }}
+        >
+          <EuiRange
+            value={value}
+            onChange={(e) => {
+              const range = e.currentTarget.value;
+              setValue(Number(range.trim()));
+            }}
+            max={100}
+            min={0}
+            showRange
+            showInput
+            fullWidth={false}
+            showTicks
+            tickInterval={25}
+          />
+        </div>
+      </>
+    ),
+    [active, value]
+  );
 
   return (
-    <>
-      <EuiRange
-        id={basicRangeId}
-        min={100}
-        max={200}
-        step={0.05}
-        value={value}
-        onChange={onChange}
-        showLabels
-        aria-label="An example of EuiRange with showLabels prop"
-      />
-
-      <EuiSpacer size="xl" />
-
-      <EuiRange
-        id={rangeWithShowValueId}
-        min={100}
-        max={200}
-        value={value}
-        onChange={onChange}
-        showLabels
-        showValue
-        aria-label="An example of EuiRange with showValue prop"
-      />
-
-      <EuiSpacer size="xl" />
-
-      <EuiRange
-        id={rangeWithValuePrependId}
-        min={100}
-        max={200}
-        value={value}
-        onChange={onChange}
-        showLabels
-        showRange
-        showValue
-        valuePrepend="100 - "
-        aria-label="An example of EuiRange with valuePrepend prop"
-      />
-    </>
+    <EuiAccordion
+      id="rangeTest"
+      buttonContent="Toggle accordion"
+      onToggle={() => setActive(!active)}
+    >
+      {range}
+    </EuiAccordion>
   );
 };

--- a/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
+++ b/src/components/form/range/__snapshots__/dual_range.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`EuiDualRange props isDraggable renders draggable track when isDraggable
       aria-valuetext="1, 8"
       class="euiRangeDraggable emotion-euiRangeDraggable"
       role="slider"
-      style="inset-inline-start: -Infinity%; inset-inline-end: calc(100% - -Infinity% - 16px);"
+      style="inset-inline-start: 0; inset-inline-end: calc(100% - 0 - 16px);"
       tabindex="0"
     >
       <div
@@ -41,7 +41,7 @@ exports[`EuiDualRange props isDraggable renders draggable track when isDraggable
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -51,7 +51,7 @@ exports[`EuiDualRange props isDraggable renders draggable track when isDraggable
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -105,7 +105,7 @@ exports[`EuiDualRange props levels renders levels when levels prop is set 1`] = 
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%; background-color: rgb(189, 39, 30);"
+      style="inset-inline-start: 0; background-color: rgb(189, 39, 30);"
       tabindex="0"
     />
     <div
@@ -115,7 +115,7 @@ exports[`EuiDualRange props levels renders levels when levels prop is set 1`] = 
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%; background-color: rgb(189, 39, 30);"
+      style="inset-inline-start: 0; background-color: rgb(189, 39, 30);"
       tabindex="0"
     />
     <div
@@ -191,7 +191,7 @@ exports[`EuiDualRange props maxInputProps allows overriding default props 1`] = 
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -201,7 +201,7 @@ exports[`EuiDualRange props maxInputProps allows overriding default props 1`] = 
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -294,7 +294,7 @@ exports[`EuiDualRange props maxInputProps applies passed props to max input 1`] 
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -304,7 +304,7 @@ exports[`EuiDualRange props maxInputProps applies passed props to max input 1`] 
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -407,7 +407,7 @@ exports[`EuiDualRange props minInputProps allows overriding default props 1`] = 
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -417,7 +417,7 @@ exports[`EuiDualRange props minInputProps allows overriding default props 1`] = 
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -511,7 +511,7 @@ exports[`EuiDualRange props minInputProps applies passed props to min input 1`] 
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -521,7 +521,7 @@ exports[`EuiDualRange props minInputProps applies passed props to min input 1`] 
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="-1"
     />
     <div
@@ -598,7 +598,7 @@ exports[`EuiDualRange props showLabels renders labels when showLabels=true 1`] =
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -608,7 +608,7 @@ exports[`EuiDualRange props showLabels renders labels when showLabels=true 1`] =
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -655,7 +655,7 @@ exports[`EuiDualRange props showRange hides range when showRange=false 1`] = `
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -665,7 +665,7 @@ exports[`EuiDualRange props showRange hides range when showRange=false 1`] = `
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
   </div>
@@ -698,7 +698,7 @@ exports[`EuiDualRange props showRange renders range when showRange=true 1`] = `
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -708,7 +708,7 @@ exports[`EuiDualRange props showRange renders range when showRange=true 1`] = `
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -750,7 +750,7 @@ exports[`EuiDualRange props value accepts empty strings 1`] = `
       aria-valuenow="0"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: NaN%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -760,7 +760,7 @@ exports[`EuiDualRange props value accepts empty strings 1`] = `
       aria-valuenow="0"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
   </div>
@@ -793,7 +793,7 @@ exports[`EuiDualRange props value accepts numbers 1`] = `
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -803,7 +803,7 @@ exports[`EuiDualRange props value accepts numbers 1`] = `
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -849,7 +849,7 @@ exports[`EuiDualRange renders 1`] = `
       aria-valuenow="1"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div
@@ -860,7 +860,7 @@ exports[`EuiDualRange renders 1`] = `
       aria-valuenow="8"
       class="euiRangeThumb emotion-euiRangeThumb"
       role="slider"
-      style="inset-inline-start: -Infinity%;"
+      style="inset-inline-start: 0;"
       tabindex="0"
     />
     <div

--- a/src/components/form/range/dual_range.test.tsx
+++ b/src/components/form/range/dual_range.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
@@ -14,7 +14,7 @@ import { render, screen } from '../../../test/rtl';
 
 import { EuiForm } from '../form';
 import type { EuiDualRangeProps } from './types';
-import { EuiDualRange, EuiDualRangeClass } from './dual_range';
+import { EuiDualRange } from './dual_range';
 
 const props = {
   min: 0,
@@ -327,33 +327,6 @@ describe('EuiDualRange', () => {
 
         expect(container.firstChild).toMatchSnapshot();
       });
-    });
-  });
-
-  describe('ref methods', () => {
-    // Whether we like it or not, at least 2 Kibana instances are using EuiDualRange
-    // `ref`s to access the `onResize` instance method (search for `rangeRef.current?.onResize`)
-    // If we switch EuiDualRange to a function component, we'll need to use `useImperativeHandle`
-    // to allow Kibana to continue calling `onResize`
-    it('allows calling the internal onResize method', () => {
-      // This super annoying type is now required to pass both the `ref` typing and account for instance methods
-      type EuiDualRangeRef = React.ComponentProps<typeof EuiDualRange> &
-        EuiDualRangeClass;
-
-      const ConsumerDualRange = () => {
-        const rangeRef = useRef<EuiDualRangeRef>(null);
-
-        useEffect(() => {
-          rangeRef.current?.onResize(500);
-        }, []);
-
-        return <EuiDualRange {...props} ref={rangeRef} />;
-      };
-
-      render(<ConsumerDualRange />);
-
-      // There isn't anything we can assert on here that isn't a huge headache,
-      // but the test should fail if `ref.current.onResize` is no longer available
     });
   });
 });

--- a/src/components/form/range/dual_range.tsx
+++ b/src/components/form/range/dual_range.tsx
@@ -59,10 +59,8 @@ export class EuiDualRangeClass extends Component<
 
   state = {
     id: this.props.id || htmlIdGenerator()(),
-    rangeSliderRefAvailable: false,
     isPopoverOpen: false,
     rangeWidth: 0,
-    isVisible: true, // used to trigger a rerender if initial element width is 0
   };
 
   get isInPopover() {
@@ -70,32 +68,6 @@ export class EuiDualRangeClass extends Component<
   }
   preventPopoverClose = false;
 
-  rangeSliderRef: HTMLInputElement | null = null;
-  handleRangeSliderRefUpdate = (ref: HTMLInputElement | null) => {
-    this.rangeSliderRef = ref;
-    if (ref) {
-      if (this.isInPopover) {
-        // Wait a tick for popover rendering to settle
-        requestAnimationFrame(() => {
-          this.setState({
-            rangeSliderRefAvailable: true,
-            rangeWidth: ref.clientWidth,
-          });
-        });
-      } else {
-        // If not in a popover, no need to wait
-        this.setState({
-          rangeSliderRefAvailable: true,
-          rangeWidth: ref.clientWidth,
-        });
-      }
-    } else {
-      this.setState({
-        rangeSliderRefAvailable: false,
-        rangeWidth: 0,
-      });
-    }
-  };
   private leftPosition = 0;
   private dragAcc = 0;
 
@@ -113,18 +85,6 @@ export class EuiDualRangeClass extends Component<
   }
   get isValid() {
     return this.lowerValueIsValid && this.upperValueIsValid;
-  }
-
-  componentDidMount() {
-    if (this.rangeSliderRef?.clientWidth === 0) {
-      this.setState({ isVisible: false });
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.rangeSliderRef?.clientWidth && !this.state.isVisible) {
-      this.setState({ isVisible: true });
-    }
   }
 
   _determineInvalidThumbMovement = (
@@ -397,15 +357,6 @@ export class EuiDualRangeClass extends Component<
     });
   };
 
-  onResize = (width: number) => {
-    if (this.rangeSliderRef) {
-      this.setState({
-        rangeWidth: this.rangeSliderRef.clientWidth,
-      });
-    }
-    this.props.inputPopoverProps?.onPanelResize?.(width);
-  };
-
   setRangeWidth = ({ width }: { width: number }) => {
     this.setState({ rangeWidth: width });
   };
@@ -432,7 +383,7 @@ export class EuiDualRangeClass extends Component<
     const delta = this.leftPosition - x;
     this.leftPosition = x;
     this.dragAcc = this.dragAcc + delta;
-    const percentageOfArea = this.dragAcc / this.rangeSliderRef!.clientWidth;
+    const percentageOfArea = this.dragAcc / this.state.rangeWidth;
     const percentageOfRange = percentageOfArea * (max - min);
     const newLower = this.getNearestStep(lowerValue - percentageOfRange);
     const newUpper = this.getNearestStep(upperValue - percentageOfRange);
@@ -609,13 +560,13 @@ export class EuiDualRangeClass extends Component<
     const dualRangeStyles = euiDualRangeStyles();
     const cssStyles = [dualRangeStyles.euiDualRange, customCss];
 
-    const leftThumbPosition = this.state.rangeSliderRefAvailable
+    const leftThumbPosition = this.state.rangeWidth
       ? this.calculateThumbPositionStyle(
           Number(this.lowerValue) || min,
           this.state.rangeWidth
         )
       : { left: '0' };
-    const rightThumbPosition = this.state.rangeSliderRefAvailable
+    const rightThumbPosition = this.state.rangeWidth
       ? this.calculateThumbPositionStyle(
           Number(this.upperValue) || max,
           this.state.rangeWidth
@@ -710,69 +661,59 @@ export class EuiDualRangeClass extends Component<
             onResize={this.setRangeWidth}
           />
 
-          {this.state.rangeSliderRefAvailable && (
-            <>
-              {isDraggable && this.isValid && (
-                <EuiRangeDraggable
-                  min={min}
-                  max={max}
-                  value={[this.lowerValue, this.upperValue]}
-                  disabled={disabled}
-                  lowerPosition={leftThumbPosition.left}
-                  upperPosition={rightThumbPosition.left}
-                  showTicks={showTicks}
-                  onChange={this.handleDrag}
-                  onFocus={this.onThumbFocus}
-                  onBlur={this.onThumbBlur}
-                  onKeyDown={this.handleDraggableKeyDown}
-                  aria-describedby={
-                    showInputOnly ? undefined : this.props['aria-describedby']
-                  }
-                  aria-label={
-                    showInputOnly ? undefined : this.props['aria-label']
-                  }
-                />
-              )}
-
-              <EuiRangeThumb
-                min={min}
-                max={Number(this.upperValue)}
-                value={this.lowerValue}
-                disabled={disabled}
-                showTicks={showTicks}
-                showInput={!!showInput}
-                onKeyDown={this.handleLowerKeyDown}
-                onFocus={this.onThumbFocus}
-                onBlur={this.onThumbBlur}
-                style={logicalStyles(leftThumbStyles)}
-                aria-describedby={
-                  showInputOnly ? undefined : this.props['aria-describedby']
-                }
-                aria-label={
-                  showInputOnly ? undefined : this.props['aria-label']
-                }
-              />
-
-              <EuiRangeThumb
-                min={Number(this.lowerValue)}
-                max={max}
-                value={this.upperValue}
-                disabled={disabled}
-                showTicks={showTicks}
-                showInput={!!showInput}
-                onKeyDown={this.handleUpperKeyDown}
-                onFocus={this.onThumbFocus}
-                onBlur={this.onThumbBlur}
-                style={logicalStyles(rightThumbStyles)}
-                aria-describedby={
-                  showInputOnly ? undefined : this.props['aria-describedby']
-                }
-                aria-label={
-                  showInputOnly ? undefined : this.props['aria-label']
-                }
-              />
-            </>
+          {isDraggable && this.isValid && (
+            <EuiRangeDraggable
+              min={min}
+              max={max}
+              value={[this.lowerValue, this.upperValue]}
+              disabled={disabled}
+              lowerPosition={leftThumbPosition.left}
+              upperPosition={rightThumbPosition.left}
+              showTicks={showTicks}
+              onChange={this.handleDrag}
+              onFocus={this.onThumbFocus}
+              onBlur={this.onThumbBlur}
+              onKeyDown={this.handleDraggableKeyDown}
+              aria-describedby={
+                showInputOnly ? undefined : this.props['aria-describedby']
+              }
+              aria-label={showInputOnly ? undefined : this.props['aria-label']}
+            />
           )}
+
+          <EuiRangeThumb
+            min={min}
+            max={Number(this.upperValue)}
+            value={this.lowerValue}
+            disabled={disabled}
+            showTicks={showTicks}
+            showInput={!!showInput}
+            onKeyDown={this.handleLowerKeyDown}
+            onFocus={this.onThumbFocus}
+            onBlur={this.onThumbBlur}
+            style={logicalStyles(leftThumbStyles)}
+            aria-describedby={
+              showInputOnly ? undefined : this.props['aria-describedby']
+            }
+            aria-label={showInputOnly ? undefined : this.props['aria-label']}
+          />
+
+          <EuiRangeThumb
+            min={Number(this.lowerValue)}
+            max={max}
+            value={this.upperValue}
+            disabled={disabled}
+            showTicks={showTicks}
+            showInput={!!showInput}
+            onKeyDown={this.handleUpperKeyDown}
+            onFocus={this.onThumbFocus}
+            onBlur={this.onThumbBlur}
+            style={logicalStyles(rightThumbStyles)}
+            aria-describedby={
+              showInputOnly ? undefined : this.props['aria-describedby']
+            }
+            aria-label={showInputOnly ? undefined : this.props['aria-label']}
+          />
 
           {showRange && this.isValid && (
             <EuiRangeHighlight
@@ -832,7 +773,6 @@ export class EuiDualRangeClass extends Component<
         isOpen={this.state.isPopoverOpen}
         closePopover={this.closePopover}
         disableFocusTrap={true}
-        onPanelResize={this.onResize}
         popoverScreenReaderText={dualSliderScreenReaderInstructions}
       >
         {theRange}

--- a/src/components/form/range/dual_range.tsx
+++ b/src/components/form/range/dual_range.tsx
@@ -406,6 +406,10 @@ export class EuiDualRangeClass extends Component<
     this.props.inputPopoverProps?.onPanelResize?.(width);
   };
 
+  setRangeWidth = ({ width }: { width: number }) => {
+    this.setState({ rangeWidth: width });
+  };
+
   getNearestStep = (value: number) => {
     const min = this.props.min;
     const max = this.props.max;
@@ -689,7 +693,6 @@ export class EuiDualRangeClass extends Component<
           <EuiRangeSlider
             className="euiDualRange__slider"
             css={dualRangeStyles.euiDualRange__slider}
-            ref={this.handleRangeSliderRefUpdate}
             id={id}
             name={name}
             min={min}
@@ -704,6 +707,7 @@ export class EuiDualRangeClass extends Component<
             onFocus={onFocus}
             onBlur={onBlur}
             {...rest}
+            onResize={this.setRangeWidth}
           />
 
           {this.state.rangeSliderRefAvailable && (

--- a/src/components/form/range/range.spec.tsx
+++ b/src/components/form/range/range.spec.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../../cypress/support" />
+
+import React from 'react';
+
+import { EuiRange } from './range';
+import { EuiDualRange } from './dual_range';
+
+const sharedProps = {
+  min: 0,
+  max: 100,
+  onChange: () => {},
+  showTicks: true,
+  showLabels: true,
+  levels: [
+    {
+      min: 0,
+      max: 20,
+      color: 'danger',
+    },
+    {
+      min: 20,
+      max: 100,
+      color: 'success',
+    },
+  ],
+};
+const firstExpectedLevel = /^0px 255[.0-9]+px$/;
+const secondExpectedLevel = /^71[.0-9]+px 0px$/;
+
+describe('EuiRange', () => {
+  const props = {
+    ...sharedProps,
+    value: 50,
+    showValue: true,
+    showRange: true,
+    tickInterval: 20,
+  };
+
+  // TODO: These should likely be visual snapshot regression tests instead
+  const assertRangePositions = () => {
+    // Ticks
+    cy.get('.euiRangeTick')
+      .first()
+      .should('have.css', 'inset-inline-start', '8px');
+    cy.get('.euiRangeTick')
+      .eq(3)
+      .should('have.css', 'inset-inline-start')
+      .and('match', /^195[.0-9]+px$/);
+    cy.get('.euiRangeTick')
+      .last()
+      .should('have.css', 'inset-inline-start')
+      .and('match', /^319[.0-9]+px$/);
+
+    // Levels - present in both EuiRangeLevels and EuiHighlight
+    cy.get('.euiRangeLevel')
+      .eq(0)
+      .should('have.css', 'inset-inline')
+      .and('match', firstExpectedLevel);
+    cy.get('.euiRangeLevel')
+      .eq(2)
+      .should('have.css', 'inset-inline')
+      .and('match', firstExpectedLevel);
+
+    cy.get('.euiRangeLevel')
+      .eq(1)
+      .should('have.css', 'inset-inline')
+      .and('match', secondExpectedLevel);
+    cy.get('.euiRangeLevel')
+      .eq(3)
+      .should('have.css', 'inset-inline')
+      .and('match', secondExpectedLevel);
+
+    // Highlight
+    cy.get('.euiRangeHighlight > div')
+      .should('have.css', 'margin-inline-start', '0px')
+      .should('have.css', 'inline-size')
+      .and('match', /^163[.0-9]+px$/);
+
+    // Tooltip
+    cy.get('.euiRangeTooltip > output')
+      .should('have.css', 'inset-inline-start')
+      .and('match', /^155[.0-9]+px$/);
+  };
+
+  it('renders ticks, levels, highlights, and tooltips in their correct positions', () => {
+    cy.mount(<EuiRange {...props} />);
+    assertRangePositions();
+  });
+
+  it('inputWithPopover', () => {
+    cy.realMount(
+      <EuiRange
+        {...props}
+        showInput="inputWithPopover"
+        inputPopoverProps={{ panelPaddingSize: 'none' }} // Makes the asserted/computed widths equivalent
+      />
+    );
+    cy.realPress('Tab');
+    assertRangePositions();
+  });
+});
+
+describe('EuiDualRange', () => {
+  const props = {
+    ...sharedProps,
+    value: [10, 80] as [number, number],
+    ticks: [
+      { label: '20kb', value: 20 },
+      { label: '100kb', value: 100 },
+    ],
+  };
+
+  // TODO: These should likely be visual snapshot regression tests instead
+  const assertRangePositions = () => {
+    // Ticks
+    cy.get('.euiRangeTick')
+      .first()
+      .should('have.css', 'inset-inline-start')
+      .and('match', /^69[.0-9]+px$/);
+    cy.get('.euiRangeTick')
+      .last()
+      .should('have.css', 'inset-inline-end', '0px');
+
+    // Levels - present in both EuiRangeLevels and EuiHighlight
+    cy.get('.euiRangeLevel')
+      .eq(0)
+      .should('have.css', 'inset-inline')
+      .and('match', firstExpectedLevel);
+    cy.get('.euiRangeLevel')
+      .eq(2)
+      .should('have.css', 'inset-inline')
+      .and('match', firstExpectedLevel);
+
+    cy.get('.euiRangeLevel')
+      .eq(1)
+      .should('have.css', 'inset-inline')
+      .and('match', secondExpectedLevel);
+    cy.get('.euiRangeLevel')
+      .eq(3)
+      .should('have.css', 'inset-inline')
+      .and('match', secondExpectedLevel);
+
+    // Highlight
+    cy.get('.euiRangeHighlight > div')
+      .should('have.css', 'margin-inline-start')
+      .and('match', /^32[.0-9]+px$/);
+    cy.get('.euiRangeHighlight > div')
+      .should('have.css', 'inline-size')
+      .and('match', /^229[.0-9]+px$/);
+
+    // Thumbs
+    cy.get('.euiRangeThumb')
+      .first()
+      .should('have.css', 'inset-inline-start')
+      .and('match', /^31[.0-9]+px$/);
+    cy.get('.euiRangeThumb')
+      .last()
+      .should('have.css', 'inset-inline-start')
+      .and('match', /^249[.0-9]+px$/);
+  };
+
+  it('renders ticks, levels, highlights, and thumbs in their correct positions', () => {
+    cy.mount(<EuiDualRange {...props} />);
+    assertRangePositions();
+  });
+
+  it('inputWithPopover', () => {
+    cy.realMount(
+      <EuiDualRange
+        {...props}
+        showInput="inputWithPopover"
+        inputPopoverProps={{ panelPaddingSize: 'none' }} // Makes the asserted/computed widths equivalent
+      />
+    );
+    cy.realPress('Tab');
+    assertRangePositions();
+  });
+});

--- a/src/components/form/range/range.tsx
+++ b/src/components/form/range/range.tsx
@@ -80,8 +80,8 @@ export class EuiRangeClass extends Component<
     );
   }
 
-  rangeSliderRef = (ref: HTMLInputElement | null) => {
-    this.setState({ trackWidth: ref?.clientWidth || 0 });
+  setTrackWidth = ({ width }: { width: number }) => {
+    this.setState({ trackWidth: width });
   };
 
   onInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
@@ -241,7 +241,7 @@ export class EuiRangeClass extends Component<
             aria-hidden={!!showInput}
             thumbColor={thumbColor}
             {...rest}
-            ref={this.rangeSliderRef}
+            onResize={this.setTrackWidth}
           />
 
           {showRange && this.isValid && (

--- a/src/components/form/range/range_slider.tsx
+++ b/src/components/form/range/range_slider.tsx
@@ -9,7 +9,7 @@
 import React, {
   ChangeEventHandler,
   InputHTMLAttributes,
-  forwardRef,
+  FunctionComponent,
   useMemo,
 } from 'react';
 import classNames from 'classnames';
@@ -17,6 +17,10 @@ import classNames from 'classnames';
 import { CommonProps } from '../../common';
 import { useEuiTheme } from '../../../services';
 import { logicalStyles } from '../../../global_styling';
+import {
+  EuiResizeObserver,
+  EuiResizeObserverProps,
+} from '../../observer/resize_observer';
 
 import type { EuiRangeProps, EuiRangeLevel } from './types';
 import { euiRangeLevelColor } from './range_levels_colors';
@@ -26,7 +30,10 @@ import {
 } from './range_slider.styles';
 
 export interface EuiRangeSliderProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'min' | 'max' | 'step'>,
+  extends Omit<
+      InputHTMLAttributes<HTMLInputElement>,
+      'min' | 'max' | 'step' | 'onResize'
+    >,
     CommonProps,
     Pick<
       EuiRangeProps,
@@ -43,68 +50,67 @@ export interface EuiRangeSliderProps
     > {
   onChange?: ChangeEventHandler<HTMLInputElement>;
   thumbColor?: EuiRangeLevel['color'];
+  onResize: EuiResizeObserverProps['onResize'];
 }
 
-export const EuiRangeSlider = forwardRef<HTMLInputElement, EuiRangeSliderProps>(
-  (
-    {
-      className,
-      disabled,
-      id,
-      max,
-      min,
-      name,
-      step,
-      onChange,
-      tabIndex,
-      value,
-      style,
-      showTicks,
-      showRange,
-      thumbColor,
-      ...rest
-    },
-    ref
-  ) => {
-    const classes = classNames('euiRangeSlider', className);
+export const EuiRangeSlider: FunctionComponent<EuiRangeSliderProps> = ({
+  className,
+  disabled,
+  id,
+  max,
+  min,
+  name,
+  step,
+  onChange,
+  tabIndex,
+  value,
+  style,
+  showTicks,
+  showRange,
+  thumbColor,
+  onResize,
+  ...rest
+}) => {
+  const classes = classNames('euiRangeSlider', className);
 
-    const euiTheme = useEuiTheme();
-    const styles = euiRangeSliderStyles(euiTheme);
-    const thumbStyles = euiRangeSliderThumbStyles(euiTheme);
-    const cssStyles = [
-      styles.euiRangeSlider,
-      showTicks && styles.hasTicks,
-      showRange && styles.hasRange,
-      thumbColor && thumbStyles.thumb,
-    ];
+  const euiTheme = useEuiTheme();
+  const styles = euiRangeSliderStyles(euiTheme);
+  const thumbStyles = euiRangeSliderThumbStyles(euiTheme);
+  const cssStyles = [
+    styles.euiRangeSlider,
+    showTicks && styles.hasTicks,
+    showRange && styles.hasRange,
+    thumbColor && thumbStyles.thumb,
+  ];
 
-    const sliderStyle = useMemo(() => {
-      return logicalStyles({
-        color: thumbColor && euiRangeLevelColor(thumbColor, euiTheme.euiTheme),
-        ...style,
-      });
-    }, [thumbColor, euiTheme, style]);
+  const sliderStyle = useMemo(() => {
+    return logicalStyles({
+      color: thumbColor && euiRangeLevelColor(thumbColor, euiTheme.euiTheme),
+      ...style,
+    });
+  }, [thumbColor, euiTheme, style]);
 
-    return (
-      <input
-        ref={ref}
-        type="range"
-        id={id}
-        name={name}
-        className={classes}
-        css={cssStyles}
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        disabled={disabled}
-        onChange={onChange}
-        style={sliderStyle}
-        tabIndex={tabIndex}
-        {...rest}
-      />
-    );
-  }
-);
-
-EuiRangeSlider.displayName = 'EuiRangeSlider';
+  return (
+    <EuiResizeObserver onResize={onResize}>
+      {(resizeRef) => (
+        <input
+          ref={resizeRef}
+          type="range"
+          id={id}
+          name={name}
+          className={classes}
+          css={cssStyles}
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          disabled={disabled}
+          onChange={onChange}
+          style={sliderStyle}
+          tabIndex={tabIndex}
+          {...rest}
+        />
+      )}
+    </EuiResizeObserver>
+  );
+};


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6846

This PR adds a resize observer to both **EuiRange** and **EuiDualRange** components, instead of only obtaining the `trackWidth`/`rangeWidth` on ref mount. TBH, I probably should have taken this approach in #7305 in the first place, as it allows us to simplify a good chunk of logic in **EuiDualRange**

| Before | After |
|--------|--------|
| ![before_accordion](https://github.com/elastic/eui/assets/549407/75e8eed3-4ac5-4387-a8b6-154af9f44991) | ![after_accordion](https://github.com/elastic/eui/assets/549407/a8cd95be-f3f2-4bee-99ed-6e7b7b4d9d35) |
| ![before_fullwidth](https://github.com/elastic/eui/assets/549407/3fdbc27d-c8b4-4574-8000-25a766f1d748) | ![after_fullwidth](https://github.com/elastic/eui/assets/549407/fe3b1a7c-ca0a-40dd-9589-6db8c823d81c) | 

## QA

- Go to https://eui.elastic.co/pr_7442/#/forms/range-sliders
- Scroll down to the first demo on the page
- [x] Confirm that the range ticks are correctly positioned on accordion option
- Scroll down to the last demo on the page (kitchen sink)
- Click the `Display toggles` buttons and toggle both to `fullWidth`
- [x] Confirm that both range ticks, highlights, and thumbnails update correctly on width change

### General checklist

- [x] Revert [REVERT ME] commit
- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A