### PR TITLE
[EuiFilterButton] DOM text wrapper cleanup

### DIFF
--- a/changelogs/upcoming/7444.md
+++ b/changelogs/upcoming/7444.md
@@ -1,0 +1,3 @@
+**Deprecations**
+
+- Updated `EuiFilterButton` to remove the second `.euiFilterButton__textShift` span wrapper. Target `.euiFilterButton__text` instead

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`EuiFilterButton props numActiveFilters and hasActiveFilters renders 1`]
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text"
+      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text-hasNotification"
     />
     <span
       aria-label="5 active filters"
@@ -128,7 +128,7 @@ exports[`EuiFilterButton props numFilters renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text"
+      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text-hasNotification"
     />
     <span
       aria-label="5 available filters"
@@ -199,7 +199,7 @@ exports[`EuiFilterButton renders zero properly 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text"
+      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text-hasNotification"
     />
     <span
       aria-label="0 available filters"

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -11,12 +11,8 @@ exports[`EuiFilterButton does not render a badge or count if numFilters is not p
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -30,12 +26,8 @@ exports[`EuiFilterButton props badgeColor renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -49,12 +41,8 @@ exports[`EuiFilterButton props grow can be turned off 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -68,12 +56,8 @@ exports[`EuiFilterButton props iconType and iconSide renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content-hasIcon"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
     <span
       color="inherit"
       data-euiicon-type="user"
@@ -92,12 +76,8 @@ exports[`EuiFilterButton props isDisabled renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -111,12 +91,8 @@ exports[`EuiFilterButton props isSelected renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -130,18 +106,14 @@ exports[`EuiFilterButton props numActiveFilters and hasActiveFilters renders 1`]
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text-hasNotification"
+      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text"
+    />
+    <span
+      aria-label="5 active filters"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-accent-euiFilterButton__notification-badgeContent"
+      role="marquee"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-      <span
-        aria-label="5 active filters"
-        class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-accent-euiFilterButton__notification-badgeContent"
-        role="marquee"
-      >
-        5
-      </span>
+      5
     </span>
   </span>
 </button>
@@ -156,18 +128,14 @@ exports[`EuiFilterButton props numFilters renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text-hasNotification"
+      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text"
+    />
+    <span
+      aria-label="5 available filters"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
+      role="marquee"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-      <span
-        aria-label="5 available filters"
-        class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
-        role="marquee"
-      >
-        5
-      </span>
+      5
     </span>
   </span>
 </button>
@@ -182,12 +150,8 @@ exports[`EuiFilterButton props type renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -201,12 +165,8 @@ exports[`EuiFilterButton props withNext renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -222,12 +182,8 @@ exports[`EuiFilterButton renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
-    >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-    </span>
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+    />
   </span>
 </button>
 `;
@@ -243,18 +199,14 @@ exports[`EuiFilterButton renders zero properly 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text-hasNotification"
+      class="euiFilterButton__text euiFilterButton__text-hasNotification emotion-euiFilterButton__text"
+    />
+    <span
+      aria-label="0 available filters"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
+      role="marquee"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-      />
-      <span
-        aria-label="0 available filters"
-        class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
-        role="marquee"
-      >
-        0
-      </span>
+      0
     </span>
   </span>
 </button>

--- a/src/components/filter_group/filter_button.styles.ts
+++ b/src/components/filter_group/filter_button.styles.ts
@@ -46,7 +46,7 @@ export const euiFilterButtonStyles = (euiThemeContext: UseEuiTheme) => {
         /* Remove underline from whole button so notifications don't get the underline */
         text-decoration: none;
 
-        .euiFilterButton__textShift {
+        .euiFilterButton__text {
           /* And put it only on the actual text part */
           text-decoration: underline;
         }
@@ -83,17 +83,14 @@ export const euiFilterButtonChildStyles = ({ euiTheme }: UseEuiTheme) => {
     content: {
       euiFilterButton__content: css``,
       hasIcon: css`
-        justify-content: space-between;
+        /* Align the dropdown arrow/caret to the right */
+        & > .euiIcon:last-child {
+          ${logicalCSS('margin-left', 'auto')}
+        }
       `,
     },
     text: {
-      euiFilterButton__text: css``,
-      hasNotification: css`
-        display: flex;
-        align-items: center;
-        gap: ${euiTheme.size.s};
-      `,
-      euiFilterButton__textShift: css`
+      euiFilterButton__text: css`
         ${euiTextShift('bold', 'data-text', euiTheme)}
         ${euiTextTruncate()}
         ${logicalCSS(

--- a/src/components/filter_group/filter_button.styles.ts
+++ b/src/components/filter_group/filter_button.styles.ts
@@ -93,6 +93,8 @@ export const euiFilterButtonChildStyles = ({ euiTheme }: UseEuiTheme) => {
       euiFilterButton__text: css`
         ${euiTextShift('bold', 'data-text', euiTheme)}
         ${euiTextTruncate()}
+      `,
+      hasNotification: css`
         ${logicalCSS(
           'min-width',
           mathWithUnits(euiTheme.size.base, (x) => x * 3)

--- a/src/components/filter_group/filter_button.test.tsx
+++ b/src/components/filter_group/filter_button.test.tsx
@@ -116,5 +116,21 @@ describe('EuiFilterButton', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
     });
+
+    it('allows customizing the inner filter button text via textProps', () => {
+      const { getByTestSubject } = render(
+        <EuiFilterButton textProps={{ 'data-test-subj': 'test' }} />
+      );
+
+      expect(getByTestSubject('test')).toBeInTheDocument();
+    });
+
+    it('allows passing other EuiButtonEmpty props', () => {
+      const { getByTestSubject } = render(
+        <EuiFilterButton contentProps={{ 'data-test-subj': 'test' }} />
+      );
+
+      expect(getByTestSubject('test')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -144,6 +144,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   );
   const textCssStyles = [
     textStyles.euiFilterButton__text,
+    showBadge && textStyles.hasNotification,
     textProps && textProps.css,
   ];
 

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -103,6 +103,9 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     className
   );
 
+  /**
+   * Badge
+   */
   const showBadge = numFiltersDefined || numActiveFiltersDefined;
   const badgeCount = numActiveFilters || numFilters;
   const activeBadgeLabel = useEuiI18n(
@@ -114,12 +117,6 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     'euiFilterButton.filterBadgeAvailableAriaLabel',
     '{count} available filters',
     { count: badgeCount }
-  );
-
-  const buttonTextClassNames = classNames(
-    'euiFilterButton__text',
-    { 'euiFilterButton__text-hasNotification': showBadge },
-    textProps && textProps.className
   );
 
   const badgeContent = showBadge && (
@@ -137,23 +134,34 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     </EuiNotificationBadge>
   );
 
+  /**
+   * Text
+   */
+  const buttonTextClassNames = classNames(
+    'euiFilterButton__text',
+    { 'euiFilterButton__text-hasNotification': showBadge },
+    textProps && textProps.className
+  );
+  const textCssStyles = [
+    textStyles.euiFilterButton__text,
+    textProps && textProps.css,
+  ];
+
   const [ref, innerText] = useInnerText();
   const dataText =
     children && typeof children === 'string' ? children : innerText;
-  const buttonContents = (
-    <>
-      <span
-        ref={ref}
-        className="euiFilterButton__textShift"
-        css={textStyles.euiFilterButton__textShift}
-        data-text={dataText}
-        title={dataText}
-      >
-        {children}
-      </span>
 
-      {badgeContent}
-    </>
+  const textContent = (
+    <span
+      ref={ref}
+      data-text={dataText}
+      title={dataText}
+      {...textProps}
+      className={buttonTextClassNames}
+      css={textCssStyles}
+    >
+      {children}
+    </span>
   );
 
   return (
@@ -165,15 +173,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
       iconSide={iconSide}
       iconType={iconType}
       type={type}
-      textProps={{
-        ...textProps,
-        className: buttonTextClassNames,
-        css: [
-          textStyles.euiFilterButton__text,
-          showBadge && textStyles.hasNotification,
-          textProps && textProps.css,
-        ],
-      }}
+      textProps={false}
       contentProps={{
         ...contentProps,
         css: [
@@ -184,7 +184,8 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
       }}
       {...rest}
     >
-      {buttonContents}
+      {textContent}
+      {badgeContent}
     </EuiButtonEmpty>
   );
 };

--- a/src/components/search_bar/__snapshots__/search_bar.test.tsx.snap
+++ b/src/components/search_bar/__snapshots__/search_bar.test.tsx.snap
@@ -145,15 +145,11 @@ exports[`SearchBar render - provided query, filters 1`] = `
           class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
         >
           <span
-            class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+            class="euiFilterButton__text emotion-euiFilterButton__text"
+            data-text="Open"
+            title="Open"
           >
-            <span
-              class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-              data-text="Open"
-              title="Open"
-            >
-              Open
-            </span>
+            Open
           </span>
         </span>
       </button>
@@ -168,15 +164,11 @@ exports[`SearchBar render - provided query, filters 1`] = `
             class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content-hasIcon"
           >
             <span
-              class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+              class="euiFilterButton__text emotion-euiFilterButton__text"
+              data-text="Tag"
+              title="Tag"
             >
-              <span
-                class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-                data-text="Tag"
-                title="Tag"
-              >
-                Tag
-              </span>
+              Tag
             </span>
             <span
               color="inherit"

--- a/src/components/search_bar/__snapshots__/search_filters.test.tsx.snap
+++ b/src/components/search_bar/__snapshots__/search_filters.test.tsx.snap
@@ -19,15 +19,11 @@ exports[`EuiSearchBarFilters render - with filters 1`] = `
       class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
     >
       <span
-        class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+        class="euiFilterButton__text emotion-euiFilterButton__text"
+        data-text="Open"
+        title="Open"
       >
-        <span
-          class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-          data-text="Open"
-          title="Open"
-        >
-          Open
-        </span>
+        Open
       </span>
     </span>
   </button>
@@ -42,15 +38,11 @@ exports[`EuiSearchBarFilters render - with filters 1`] = `
         class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content-hasIcon"
       >
         <span
-          class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+          class="euiFilterButton__text emotion-euiFilterButton__text"
+          data-text="Tag"
+          title="Tag"
         >
-          <span
-            class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-            data-text="Tag"
-            title="Tag"
-          >
-            Tag
-          </span>
+          Tag
         </span>
         <span
           color="inherit"

--- a/src/components/search_bar/filters/__snapshots__/field_value_toggle_filter.test.tsx.snap
+++ b/src/components/search_bar/filters/__snapshots__/field_value_toggle_filter.test.tsx.snap
@@ -10,15 +10,11 @@ exports[`FieldValueToggleFilter render - active 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Kibana"
+      title="Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Kibana"
-        title="Kibana"
-      >
-        Kibana
-      </span>
+      Kibana
     </span>
   </span>
 </button>
@@ -34,15 +30,11 @@ exports[`FieldValueToggleFilter render - active negated - custom negated name 1`
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Others"
+      title="Others"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Others"
-        title="Others"
-      >
-        Others
-      </span>
+      Others
     </span>
   </span>
 </button>
@@ -58,15 +50,11 @@ exports[`FieldValueToggleFilter render - active negated 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Not Kibana"
+      title="Not Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Not Kibana"
-        title="Not Kibana"
-      >
-        Not Kibana
-      </span>
+      Not Kibana
     </span>
   </span>
 </button>
@@ -82,15 +70,11 @@ exports[`FieldValueToggleFilter renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Kibana"
+      title="Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Kibana"
-        title="Kibana"
-      >
-        Kibana
-      </span>
+      Kibana
     </span>
   </span>
 </button>

--- a/src/components/search_bar/filters/__snapshots__/field_value_toggle_group_filter.test.tsx.snap
+++ b/src/components/search_bar/filters/__snapshots__/field_value_toggle_group_filter.test.tsx.snap
@@ -10,15 +10,11 @@ exports[`TermToggleGroupFilter render - active 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Kibana"
+      title="Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Kibana"
-        title="Kibana"
-      >
-        Kibana
-      </span>
+      Kibana
     </span>
   </span>
 </button>
@@ -34,15 +30,11 @@ exports[`TermToggleGroupFilter render - active negated - custom negated name 1`]
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="-Kibana"
+      title="-Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="-Kibana"
-        title="-Kibana"
-      >
-        -Kibana
-      </span>
+      -Kibana
     </span>
   </span>
 </button>
@@ -58,15 +50,11 @@ exports[`TermToggleGroupFilter render - active negated 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Not Kibana"
+      title="Not Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Not Kibana"
-        title="Not Kibana"
-      >
-        Not Kibana
-      </span>
+      Not Kibana
     </span>
   </span>
 </button>
@@ -82,15 +70,11 @@ exports[`TermToggleGroupFilter renders 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Kibana"
+      title="Kibana"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Kibana"
-        title="Kibana"
-      >
-        Kibana
-      </span>
+      Kibana
     </span>
   </span>
 </button>

--- a/src/components/search_bar/filters/__snapshots__/is_filter.test.tsx.snap
+++ b/src/components/search_bar/filters/__snapshots__/is_filter.test.tsx.snap
@@ -10,15 +10,11 @@ exports[`IsFilter render 1`] = `
     class="euiButtonEmpty__content emotion-euiButtonDisplayContent-euiFilterButton__content"
   >
     <span
-      class="eui-textTruncate euiButtonEmpty__text euiFilterButton__text emotion-euiFilterButton__text"
+      class="euiFilterButton__text emotion-euiFilterButton__text"
+      data-text="Open"
+      title="Open"
     >
-      <span
-        class="euiFilterButton__textShift emotion-euiFilterButton__textShift"
-        data-text="Open"
-        title="Open"
-      >
-        Open
-      </span>
+      Open
     </span>
   </span>
 </button>


### PR DESCRIPTION
## Summary

In https://github.com/elastic/eui/pull/7369 / https://github.com/elastic/eui/pull/7369/commits/bb8cca07db55025c8076fbfc3127d09469ab8f14, I added the ability to disable `EuiButtonEmpty`'s text wrapper DOM node via `textProps={false}`.

Since `EuiFilterButton` already adds its own custom text wrapper `<span>` element, we can clean up/go down from two `<span>` text wrappers to just one, by using the above API.

## QA

- Go to https://eui.elastic.co/pr_7444/#/forms/filter-group
- [x] Confirm that there are no visual regressions in any UI/UX (including clicking buttons, etc) compared to [production](https://eui.elastic.co/#/forms/filter-group)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A, tech debt
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A