### PR TITLE
Relax href-or-on-click rule to warning

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -25,7 +25,7 @@ module.exports = {
     recommended: {
       plugins: ['@elastic/eslint-plugin-eui'],
       rules: {
-        '@elastic/eui/href-or-on-click': 'error',
+        '@elastic/eui/href-or-on-click': 'warn',
       },
     },
   },

--- a/packages/eslint-plugin/rules/href_or_on_click.js
+++ b/packages/eslint-plugin/rules/href_or_on_click.js
@@ -24,7 +24,7 @@ module.exports = {
         if (hasHref && hasOnClick) {
           context.report(
             node,
-            `<${node.name.name}> accepts either \`href\` or \`onClick\`, not both.`
+            `<${node.name.name}> supplied with both \`href\` and \`onClick\`; is this intentional? (Valid use cases include programmatic navigation via \`onClick\` while preserving "Open in new tab" style functionality via \`href\`.)`
           );
         }
       },


### PR DESCRIPTION
## Summary

Relax the eslint rule `href-or-on-click` from `error` to `warn` because there are valid use cases for supplying both properties to navigation components.