### PR TITLE
[EuiTextArea] Add `isClearable` and `icon` props

### DIFF
--- a/changelogs/upcoming/7449.md
+++ b/changelogs/upcoming/7449.md
@@ -1,1 +1,1 @@
-- Updated `EuiTextArea` to accept isClearable and icon as props
+- Updated `EuiTextArea` to accept `isClearable` and `icon` as props

--- a/changelogs/upcoming/7449.md
+++ b/changelogs/upcoming/7449.md
@@ -1,0 +1,1 @@
+- Updated `EuiTextArea` to accept isClearable and icon as props

--- a/src-docs/src/views/form_controls/text_area.js
+++ b/src-docs/src/views/form_controls/text_area.js
@@ -12,7 +12,7 @@ export default () => {
 
   return (
     /* DisplayToggles wrapper for Docs only */
-    <DisplayToggles>
+    <DisplayToggles canClear>
       <EuiTextArea
         placeholder="Placeholder text"
         aria-label="Use aria labels when no actual label is in use"

--- a/src/components/form/text_area/text_area.spec.tsx
+++ b/src/components/form/text_area/text_area.spec.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../../cypress/support" />
+
+import React, { useState } from 'react';
+import { EuiTextArea } from './text_area';
+
+describe('EuiTextArea', () => {
+  describe('isClearable', () => {
+    it('works for uncontrolled components', () => {
+      cy.realMount(<EuiTextArea isClearable />);
+
+      cy.get('textarea').type('hello world');
+      cy.get('textarea').should('have.value', 'hello world');
+
+      cy.get('[data-test-subj="clearTextAreaButton"]').click();
+      cy.get('textarea').should('have.value', '');
+    });
+
+    it('works for controlled components', () => {
+      const ControlledTextArea = ({}) => {
+        const [value, setValue] = useState('');
+        return (
+          <EuiTextArea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            isClearable
+          />
+        );
+      };
+      cy.realMount(<ControlledTextArea />);
+
+      cy.get('textarea').type('hello world');
+      cy.get('textarea').should('have.value', 'hello world');
+
+      cy.get('[data-test-subj="clearTextAreaButton"]').click();
+      cy.get('textarea').should('have.value', '');
+    });
+  });
+});

--- a/src/components/form/text_area/text_area.tsx
+++ b/src/components/form/text_area/text_area.tsx
@@ -17,8 +17,13 @@ import { EuiFormControlLayoutIconsProps } from '../form_control_layout/form_cont
 
 export type EuiTextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> &
   CommonProps & {
+    icon?: EuiFormControlLayoutIconsProps['icon'];
     isLoading?: boolean;
     isInvalid?: boolean;
+    /**
+     * Shows a button that allows users to quickly clear the textarea
+     */
+    isClearable?: boolean;
     /**
      * Expand to fill 100% of the parent.
      * Defaults to `fullWidth` prop of `<EuiForm>`.
@@ -26,11 +31,6 @@ export type EuiTextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> &
      */
     fullWidth?: boolean;
     compressed?: boolean;
-    /**
-     * Shows a button that quickly clears any input
-     */
-    isClearable?: boolean;
-    icon?: EuiFormControlLayoutIconsProps['icon'];
 
     /**
      * Which direction, if at all, should the textarea resize
@@ -58,15 +58,15 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
     compressed,
     fullWidth = defaultFullWidth,
     id,
+    icon,
     inputRef,
     isLoading,
     isInvalid,
+    isClearable,
     name,
     placeholder,
     resize = 'vertical',
     rows,
-    isClearable,
-    icon,
     ...rest
   } = props;
 

--- a/src/components/form/text_area/text_area.tsx
+++ b/src/components/form/text_area/text_area.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 import { EuiFormControlLayout } from '../form_control_layout';
 import { EuiValidatableControl } from '../validatable_control';
 import { useFormContext } from '../eui_form_context';
+import { EuiFormControlLayoutIconsProps } from '../form_control_layout/form_control_layout_icons';
 
 export type EuiTextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> &
   CommonProps & {
@@ -25,6 +26,11 @@ export type EuiTextAreaProps = TextareaHTMLAttributes<HTMLTextAreaElement> &
      */
     fullWidth?: boolean;
     compressed?: boolean;
+    /**
+     * Shows a button that quickly clears any input
+     */
+    isClearable?: boolean;
+    icon?: EuiFormControlLayoutIconsProps['icon'];
 
     /**
      * Which direction, if at all, should the textarea resize
@@ -59,6 +65,8 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
     placeholder,
     resize = 'vertical',
     rows,
+    isClearable,
+    icon,
     ...rest
   } = props;
 
@@ -82,11 +90,25 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
     definedRows = 6;
   }
 
+  const onClear = () => {
+    if (rest.onChange) {
+      rest.onChange({
+        target: { value: '' },
+      } as React.ChangeEvent<HTMLTextAreaElement>);
+    }
+  };
+
   return (
     <EuiFormControlLayout
       fullWidth={fullWidth}
       isLoading={isLoading}
       isInvalid={isInvalid}
+      clear={
+        isClearable
+          ? { onClick: onClear, 'data-test-subj': 'clearTextAreaButton' }
+          : undefined
+      }
+      icon={icon}
       className="euiFormControlLayout--euiTextArea"
     >
       <EuiValidatableControl isInvalid={isInvalid}>


### PR DESCRIPTION
## Summary

Added text area clearable and icon options , motivation is to replace this custom implementation in widely used kibana component https://github.com/elastic/kibana/blob/main/src/plugins/unified_search/public/query_string_input/query_string_input.tsx#L860

when `invalid` and `isClearable` both props are provided, both icons overlaps each other. 

## QA

<img width="489" alt="" src="https://github.com/elastic/eui/assets/549407/597cb530-c050-4a29-8ff9-777403d318fe">

![textarea_clear](https://github.com/elastic/eui/assets/549407/522a8b77-018c-4f85-8031-a540c97b7f58)

### General checklist

- Browser QA
    ~- [ ] Checked in **mobile**~
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ Looks like we can skip this, as the Figma designs for the Search field don't contain a clearable icon either
