### PR TITLE
[EuiTreeView] JSX Typescript error

### DIFF
--- a/changelogs/upcoming/7452.md
+++ b/changelogs/upcoming/7452.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiTreeView` JSX Typescript error

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -31,7 +31,7 @@ function hasAriaLabel(
 
 function getTreeId(
   propId: string | undefined,
-  contextId: string,
+  contextId: string = '',
   idGenerator: Function
 ) {
   return propId ?? (contextId === '' ? idGenerator() : contextId);
@@ -123,8 +123,12 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
 
   constructor(
     props: EuiTreeViewProps,
-    context: ContextType<typeof EuiTreeViewContext>
+    // Without the optional ? typing, TS will throw errors on JSX component errors
+    // @see https://github.com/facebook/react/issues/13944#issuecomment-1183693239
+    context?: ContextType<typeof EuiTreeViewContext>
   ) {
+    // TODO: context in constructor has been deprecated.
+    // We should likely convert this to a function component
     super(props, context);
 
     this.isNested = !!this.context;


### PR DESCRIPTION
## Problem

#7340 made some type changes to EuiTreeView (adding `context` to the `constructor()` - [link](https://github.com/elastic/eui/pull/7340/files#diff-091725c0c3c4b9e1f82f2b5ae31d04ab61cf5be90f2404a86da17e6d90230d55)) that unfortunately broke the typing for the component in Kibana (https://github.com/elastic/kibana/pull/174487/commits/621cb79f45db71d17a0b1caf3d76b4e3b30239d3).

The error is also visible in EUI when viewing `tree_view.tsx` in VSCode, but doesn't come up in CLI linting for some reason:
<img width="1022" alt="" src="https://github.com/elastic/eui/assets/549407/6ffc2620-347c-4cef-a962-57a2a1f989ef">

## Solution

Adding a `?` optional type to the `context` usage in `constructor()` appears to appease the JSX component instantiation error.

https://github.com/facebook/react/issues/13944#issuecomment-1183693239 implies that there is no production React 'fix' for this, since usage is deprecated, so this PR is more of a temporary bandaid for now.

A more long-term fix would be to convert the class component to a function component instead.

## QA

### General checklist

- Browser QA - N/A
- Docs site QA - NA
- Code quality checklist
    ~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A