### PR TITLE
[EuiCollapsibleNavFooter] Fix broken flex/overflow height

### DIFF
--- a/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_body_footer.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_body_footer.test.tsx.snap
@@ -22,5 +22,9 @@ exports[`EuiCollapsibleNavFooter renders 1`] = `
   aria-label="aria-label"
   class="euiFlyoutFooter euiCollapsibleNav__footer testClass1 testClass2 emotion-euiFlyoutFooter-euiCollapsibleNav__footer-euiTestCss"
   data-test-subj="test subject string"
-/>
+>
+  <div
+    class="emotion-euiFlyoutFooter__overflow"
+  />
+</div>
 `;

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
@@ -36,8 +36,11 @@ export const euiCollapsibleNavFooterStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
   return {
     euiCollapsibleNav__footer: css`
+      ${logicalCSS('max-height', '50%')}
       background-color: ${euiTheme.colors.emptyShade};
       ${logicalCSS('border-top', euiTheme.border.thin)}
+    `,
+    euiFlyoutFooter__overflow: css`
       ${euiYScrollWithShadows(euiThemeContext, { side: 'end' })}
     `,
     isPushCollapsed: css`

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.styles.ts
@@ -21,10 +21,7 @@ export const hideScrollbars = `
 `;
 
 export const euiCollapsibleNavBodyStyles = {
-  // In case things get really dire responsively, ensure the footer doesn't overtake the body
-  euiCollapsibleNav__body: css`
-    ${logicalCSS('min-height', '50%')}
-  `,
+  euiCollapsibleNav__body: css``,
   isPushCollapsed: css`
     .euiFlyoutBody__overflow {
       ${hideScrollbars}
@@ -36,6 +33,7 @@ export const euiCollapsibleNavFooterStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
   return {
     euiCollapsibleNav__footer: css`
+      /* In case things get really dire responsively, ensure the footer doesn't overtake the body */
       ${logicalCSS('max-height', '50%')}
       background-color: ${euiTheme.colors.emptyShade};
       ${logicalCSS('border-top', euiTheme.border.thin)}

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.tsx
@@ -65,7 +65,7 @@ export const EuiCollapsibleNavFooter: EuiFlyoutFooterProps = ({
   const { isCollapsed, isPush } = useContext(EuiCollapsibleNavContext);
   const euiTheme = useEuiTheme();
   const styles = euiCollapsibleNavFooterStyles(euiTheme);
-  const cssStyles = [styles.euiCollapsibleNav__footer];
+  const cssStyles = styles.euiCollapsibleNav__footer;
   const overflowWrapperStyles = [
     styles.euiFlyoutFooter__overflow,
     isCollapsed && isPush && styles.isPushCollapsed,

--- a/src/components/collapsible_nav_beta/collapsible_nav_body_footer.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_body_footer.tsx
@@ -57,6 +57,7 @@ export const EuiCollapsibleNavBody: EuiFlyoutBodyProps = ({
 
 export const EuiCollapsibleNavFooter: EuiFlyoutFooterProps = ({
   className,
+  children,
   ...props
 }) => {
   const classes = classNames('euiCollapsibleNav__footer', className);
@@ -64,10 +65,15 @@ export const EuiCollapsibleNavFooter: EuiFlyoutFooterProps = ({
   const { isCollapsed, isPush } = useContext(EuiCollapsibleNavContext);
   const euiTheme = useEuiTheme();
   const styles = euiCollapsibleNavFooterStyles(euiTheme);
-  const cssStyles = [
-    styles.euiCollapsibleNav__footer,
+  const cssStyles = [styles.euiCollapsibleNav__footer];
+  const overflowWrapperStyles = [
+    styles.euiFlyoutFooter__overflow,
     isCollapsed && isPush && styles.isPushCollapsed,
   ];
 
-  return <EuiFlyoutFooter className={classes} css={cssStyles} {...props} />;
+  return (
+    <EuiFlyoutFooter className={classes} css={cssStyles} {...props}>
+      <div css={overflowWrapperStyles}>{children}</div>
+    </EuiFlyoutFooter>
+  );
 };


### PR DESCRIPTION
## Summary

I swear I saw and fixed this at some point, but apparently that was a holiday fever dream 🤦 

| Before | After |
|--------|--------|
| <img width="297" alt="" src="https://github.com/elastic/eui/assets/549407/fc172969-17df-4bd4-92fb-f3f7211bd7ce"> | <img width="302" alt="" src="https://github.com/elastic/eui/assets/549407/02f58d74-7f7d-4a03-9dc5-06f2cd5a4c6f"> | 

This bug requires adding another div wrapper to work correctly (as `EuiFlyoutBody` currently does) because ✨ flex shenanigans ✨ 💀 

## QA

- https://eui.elastic.co/pr_7453/storybook/?path=/story/euicollapsiblenavbeta--kibana-example (compared against [production](https://eui.elastic.co/storybook/?path=/story/euicollapsiblenavbeta--kibana-example))

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist - N/A, snapshot update only
- Release checklist - N/A, **skipping changelog due to this being a beta component**
- Designer checklist - N/A