### PR TITLE
[EuiResizableButton] Add new `indicator` style prop

### DIFF
--- a/changelogs/upcoming/7455.md
+++ b/changelogs/upcoming/7455.md
@@ -1,0 +1,1 @@
+- Updated `EuiResizableButton` with a new `showIndicator` prop, which allows replacing the default grab handle with a plain border

--- a/changelogs/upcoming/7455.md
+++ b/changelogs/upcoming/7455.md
@@ -1,1 +1,1 @@
-- Updated `EuiResizableButton` with a new `showIndicator` prop, which allows replacing the default grab handle with a plain border
+- Updated `EuiResizableButton` to allow customizing the `indicator` style with either `handle` (default) or `border`

--- a/src-docs/src/views/resizable_container/resizable_button_indicator.tsx
+++ b/src-docs/src/views/resizable_container/resizable_button_indicator.tsx
@@ -18,7 +18,7 @@ export default () => (
           <EuiText>{text}</EuiText>
         </EuiResizablePanel>
 
-        <EuiResizableButton showIndicator={false} />
+        <EuiResizableButton indicator="border" />
 
         <EuiResizablePanel
           initialSize={50}
@@ -36,7 +36,7 @@ export default () => (
                   <EuiText>{text}</EuiText>
                 </EuiResizablePanel>
 
-                <EuiResizableButton showIndicator={false} />
+                <EuiResizableButton indicator="border" />
 
                 <EuiResizablePanel initialSize={50} minSize="50px" tabIndex={0}>
                   <EuiText>{text}</EuiText>

--- a/src-docs/src/views/resizable_container/resizable_button_indicator.tsx
+++ b/src-docs/src/views/resizable_container/resizable_button_indicator.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { EuiText, EuiResizableContainer } from '../../../../src/components';
+import { faker } from '@faker-js/faker';
+
+const text = (
+  <>
+    <p>{faker.lorem.paragraphs()}</p>
+    <p>{faker.lorem.paragraphs()}</p>
+    <p>{faker.lorem.paragraphs()}</p>
+  </>
+);
+
+export default () => (
+  <EuiResizableContainer style={{ height: '300px' }}>
+    {(EuiResizablePanel, EuiResizableButton) => (
+      <>
+        <EuiResizablePanel initialSize={50} minSize="50px" tabIndex={0}>
+          <EuiText>{text}</EuiText>
+        </EuiResizablePanel>
+
+        <EuiResizableButton showIndicator={false} />
+
+        <EuiResizablePanel
+          initialSize={50}
+          minSize="50px"
+          tabIndex={0}
+          paddingSize="none"
+        >
+          <EuiResizableContainer
+            direction="vertical"
+            style={{ height: '100%', overflow: 'hidden' }}
+          >
+            {(EuiResizablePanel, EuiResizableButton) => (
+              <>
+                <EuiResizablePanel initialSize={50} minSize="50px" tabIndex={0}>
+                  <EuiText>{text}</EuiText>
+                </EuiResizablePanel>
+
+                <EuiResizableButton showIndicator={false} />
+
+                <EuiResizablePanel initialSize={50} minSize="50px" tabIndex={0}>
+                  <EuiText>{text}</EuiText>
+                </EuiResizablePanel>
+              </>
+            )}
+          </EuiResizableContainer>
+        </EuiResizablePanel>
+      </>
+    )}
+  </EuiResizableContainer>
+);

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -521,9 +521,9 @@ export const ResizableContainerExample = {
             indicator as a UI hint. For use cases where the resize behavior is
             "nice to have" but not a primary UX focus, or where there are many
             other busy UI elements on the page, you can set{' '}
-            <EuiCode>{'showIndicator={false}'}</EuiCode> to display a subdued
-            border element instead, which only provides resize affordance on
-            hover or focus.
+            <EuiCode>indicator="border"</EuiCode> to display a subdued border
+            element instead, which only provides resize affordance on hover or
+            focus.
           </p>
         </>
       ),
@@ -532,7 +532,7 @@ export const ResizableContainerExample = {
       props: { EuiResizableButton },
       snippet: `<EuiResizableButton
   isHorizontal
-  showIndicator={false}
+  indicator="border"
 />`,
     },
     {

--- a/src-docs/src/views/resizable_container/resizable_container_example.js
+++ b/src-docs/src/views/resizable_container/resizable_container_example.js
@@ -29,6 +29,7 @@ import ResizablePanelCollapsible from './resizable_panel_collapsible';
 import ResizablePanelCollapsibleResponsive from './resizable_panel_collapsible_responsive';
 import ResizablePanelCollapsibleOpts from './resizable_panel_collapsible_options';
 import ResizablePanelCollapsibleExt from './resizable_panel_collapsible_external';
+import ResizableButtonIndicator from './resizable_button_indicator';
 import ResizableButton from './resizable_button';
 
 const ResizableContainerSource = require('!!raw-loader!./resizable_container_basic');
@@ -40,6 +41,7 @@ const ResizablePanelCollapsibleSource = require('!!raw-loader!./resizable_panel_
 const ResizablePanelCollapsibleResponsiveSource = require('!!raw-loader!./resizable_panel_collapsible_responsive');
 const ResizablePanelCollapsibleOptsSource = require('!!raw-loader!./resizable_panel_collapsible_options');
 const ResizablePanelCollapsibleExtSource = require('!!raw-loader!./resizable_panel_collapsible_external');
+const ResizableButtonIndicatorSource = require('!!raw-loader!./resizable_button_indicator');
 const ResizableButtonSource = require('!!raw-loader!./resizable_button');
 
 const basicSnippet = `<EuiResizableContainer>
@@ -508,10 +510,39 @@ export const ResizableContainerExample = {
       source: [
         {
           type: GuideSectionTypes.TSX,
+          code: ResizableButtonIndicatorSource,
+        },
+      ],
+      title: 'Resizable button indicator',
+      text: (
+        <>
+          <p>
+            By default, <strong>EuiResizableButton</strong> shows a grab handle
+            indicator as a UI hint. For use cases where the resize behavior is
+            "nice to have" but not a primary UX focus, or where there are many
+            other busy UI elements on the page, you can set{' '}
+            <EuiCode>{'showIndicator={false}'}</EuiCode> to display a subdued
+            border element instead, which only provides resize affordance on
+            hover or focus.
+          </p>
+        </>
+      ),
+      demo: <ResizableButtonIndicator />,
+      demoPanelProps: { paddingSize: 'none' },
+      props: { EuiResizableButton },
+      snippet: `<EuiResizableButton
+  isHorizontal
+  showIndicator={false}
+/>`,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
           code: ResizableButtonSource,
         },
       ],
-      title: 'Custom resizable button',
+      title: 'Custom resize logic',
       text: (
         <>
           <p>

--- a/src/components/flyout/flyout_resizable.styles.ts
+++ b/src/components/flyout/flyout_resizable.styles.ts
@@ -14,17 +14,21 @@ import { logicalCSS } from '../../global_styling';
 export const euiFlyoutResizableButtonStyles = ({ euiTheme }: UseEuiTheme) => ({
   euiFlyoutResizableButton: css`
     position: absolute;
-
-    /* Hide the default grab icon (although the hover/focus states should remain) */
-    &::before,
-    &::after {
-      background-color: transparent;
-    }
   `,
-  left: css`
-    ${logicalCSS('right', `-${euiTheme.border.width.thin}`)}
-  `,
-  right: css`
-    ${logicalCSS('left', `-${euiTheme.border.width.thin}`)}
-  `,
+  overlay: {
+    left: css`
+      ${logicalCSS('right', 0)}
+    `,
+    right: css`
+      ${logicalCSS('left', 0)}
+    `,
+  },
+  push: {
+    left: css`
+      ${logicalCSS('right', `-${euiTheme.border.width.thin}`)}
+    `,
+    right: css`
+      ${logicalCSS('left', `-${euiTheme.border.width.thin}`)}
+    `,
+  },
 });

--- a/src/components/flyout/flyout_resizable.tsx
+++ b/src/components/flyout/flyout_resizable.tsx
@@ -33,6 +33,7 @@ export const EuiFlyoutResizable = forwardRef(
       maxWidth,
       minWidth = 200,
       side = 'right',
+      type = 'overlay',
       children,
       ...rest
     }: EuiFlyoutResizableProps,
@@ -40,7 +41,7 @@ export const EuiFlyoutResizable = forwardRef(
   ) => {
     const euiTheme = useEuiTheme();
     const styles = euiFlyoutResizableButtonStyles(euiTheme);
-    const cssStyles = [styles.euiFlyoutResizableButton, styles[side]];
+    const cssStyles = [styles.euiFlyoutResizableButton, styles[type][side]];
 
     const getFlyoutMinMaxWidth = useCallback(
       (width: number) => {
@@ -140,10 +141,12 @@ export const EuiFlyoutResizable = forwardRef(
         size={flyoutWidth || size}
         maxWidth={maxWidth}
         side={side}
+        type={type}
         ref={setRefs}
       >
         <EuiResizableButton
           isHorizontal
+          showIndicator={false}
           css={cssStyles}
           onMouseDown={onMouseDown}
           onTouchStart={onMouseDown}

--- a/src/components/flyout/flyout_resizable.tsx
+++ b/src/components/flyout/flyout_resizable.tsx
@@ -147,7 +147,7 @@ export const EuiFlyoutResizable = forwardRef(
       >
         <EuiResizableButton
           isHorizontal
-          showIndicator={false}
+          indicator="border"
           css={cssStyles}
           onMouseDown={onMouseDown}
           onTouchStart={onMouseDown}

--- a/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiResizableButton renders 1`] = `
 <div>
   <button
     aria-label="aria-label"
-    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-vertical-center-euiTestCss"
+    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-grabHandle-vertical-vertical-center-euiTestCss"
     data-test-subj="test subject string"
     type="button"
   />

--- a/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_button.test.tsx.snap
@@ -4,8 +4,19 @@ exports[`EuiResizableButton renders 1`] = `
 <div>
   <button
     aria-label="aria-label"
-    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-grabHandle-vertical-vertical-center-euiTestCss"
+    class="euiResizableButton testClass1 testClass2 emotion-euiResizableButton-handle-vertical-vertical-center-euiTestCss"
     data-test-subj="test subject string"
+    type="button"
+  />
+</div>
+`;
+
+exports[`EuiResizableButton renders different indicator styles and directions 1`] = `
+<div>
+  <button
+    aria-label="Press the left or right arrow keys to adjust panels size"
+    class="euiResizableButton emotion-euiResizableButton-border-horizontal-horizontal"
+    data-test-subj="euiResizableButton"
     type="button"
   />
 </div>

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -60,7 +60,7 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiResizableContainer can be vertical 1`] = `
   </div>
   <button
     aria-label="Press the up or down arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-vertical-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-vertical-vertical-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -140,7 +140,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -159,7 +159,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -199,7 +199,7 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -251,7 +251,7 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -291,7 +291,7 @@ exports[`EuiResizableContainer is rendered 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -344,7 +344,7 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"

--- a/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
+++ b/src/components/resizable_container/__snapshots__/resizable_container.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`EuiResizableContainer can adjust panel props 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -60,7 +60,7 @@ exports[`EuiResizableContainer can be controlled externally 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -100,7 +100,7 @@ exports[`EuiResizableContainer can be vertical 1`] = `
   </div>
   <button
     aria-label="Press the up or down arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-vertical-vertical-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-vertical-vertical-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -140,7 +140,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -159,7 +159,7 @@ exports[`EuiResizableContainer can have more than two panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -199,7 +199,7 @@ exports[`EuiResizableContainer can have scrollable panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -251,7 +251,7 @@ exports[`EuiResizableContainer can have toggleable panels 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -291,7 +291,7 @@ exports[`EuiResizableContainer is rendered 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"
@@ -344,7 +344,7 @@ exports[`EuiResizableContainer toggleable panels can be configurable 1`] = `
   </div>
   <button
     aria-label="Press the left or right arrow keys to adjust panels size"
-    class="euiResizableButton emotion-euiResizableButton-grabHandle-horizontal-horizontal-center"
+    class="euiResizableButton emotion-euiResizableButton-handle-horizontal-horizontal-center"
     data-test-subj="euiResizableButton"
     id="resizable-button_generated-id"
     type="button"

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -33,8 +33,14 @@ type Story = StoryObj<EuiResizableButtonProps>;
 
 export const Playground: Story = {
   render: (args) => (
-    <EuiPanel style={{ blockSize: 200, inlineSize: 200 }}>
-      <EuiResizableButton {...args} />
+    <EuiPanel
+      style={{ blockSize: 200, inlineSize: 200, position: 'relative' }}
+      borderRadius="none"
+    >
+      <EuiResizableButton
+        style={{ position: 'absolute', top: 0, left: 0 }}
+        {...args}
+      />
     </EuiPanel>
   ),
 };

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta<EuiResizableButtonProps> = {
   component: EuiResizableButton,
   args: {
     // Component defaults
+    showIndicator: true,
     alignIndicator: 'center',
     disabled: false,
     isHorizontal: false,

--- a/src/components/resizable_container/resizable_button.stories.tsx
+++ b/src/components/resizable_container/resizable_button.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<EuiResizableButtonProps> = {
   component: EuiResizableButton,
   args: {
     // Component defaults
-    showIndicator: true,
+    indicator: 'handle',
     alignIndicator: 'center',
     disabled: false,
     isHorizontal: false,

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -22,9 +22,9 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
   const transition = `${transitionSpeed} ease`;
 
   return {
-    // Mimics the "grab" icon with CSS psuedo-elements.
-    // 1. The "grab" icon transforms into a thicker straight line on :hover and :focus
-    // 2. Start/end aligned handles should have a slight margin offset that disappears on hover/focus
+    // Creates a resizable indicator (either a grab handle or a plain border) with CSS psuedo-elements.
+    // 1. The "grab" handle transforms into a thicker straight line on :hover and :focus
+    // 2. Start/end aligned grab handles should have a slight margin offset that disappears on hover/focus
     // 3. CSS hack to smooth out/anti-alias the 1px wide handles at various zoom levels
     euiResizableButton: css`
       z-index: 1;
@@ -47,7 +47,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
 
-      /* Lighten the "grab" icon on :hover */
+      /* Lighten color on :hover */
       &:hover {
         &::before,
         &::after {
@@ -55,7 +55,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
 
-      /* Add a transparent background to the container and emphasize the "grab" icon
+      /* Add a transparent background to the container and color the border primary
          with primary color on :focus (NOTE - :active is needed for Safari) */
       &:focus,
       &:active {
@@ -65,7 +65,7 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::after {
           background-color: ${euiTheme.colors.primary};
 
-          /* Overrides default transition so that "grab" icon background-color doesn't animate */
+          /* Overrides default transition so that "grab" background-color doesn't animate */
           ${euiCanAnimate} {
             transition: width ${transition}, height ${transition};
             transition-delay: ${mathWithUnits(transitionSpeed, (x) => x / 2)};

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -86,13 +86,14 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('height', buttonSize)}
       margin-block: ${mathWithUnits(buttonSize, (x) => x / -2)};
     `,
-    border: {
-      border: css`
-        &::before,
-        &::after {
-          background-color: ${euiTheme.border.color};
-        }
-      `,
+
+    border: css`
+      &::before,
+      &::after {
+        background-color: ${euiTheme.border.color};
+      }
+    `,
+    borderDirection: {
       horizontal: css`
         &::before {
           ${logicalCSS('width', euiTheme.border.width.thin)}
@@ -124,38 +125,39 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         }
       `,
     },
-    grabHandle: {
-      grabHandle: css`
-        gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
 
-        /* 1 */
-        &:hover,
-        &:focus,
-        &:active {
-          gap: 0;
-        }
+    handle: css`
+      gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
 
-        ${euiCanAnimate} {
-          transition: gap ${transition};
-        }
+      /* 1 */
+      &:hover,
+      &:focus,
+      &:active {
+        gap: 0;
+      }
 
+      ${euiCanAnimate} {
+        transition: gap ${transition};
+      }
+
+      &::before,
+      &::after {
+        background-color: ${euiTheme.colors.darkestShade};
+        transform: translateZ(0); /* 3 */
+      }
+
+      /* Lighten color on :hover */
+      &:hover {
         &::before,
         &::after {
-          background-color: ${euiTheme.colors.darkestShade};
-          transform: translateZ(0); /* 3 */
-        }
-
-        /* Lighten color on :hover */
-        &:hover {
-          &::before,
-          &::after {
-            /* Delay transition on hover so animation is not accidentally triggered on mouse over */
-            ${euiCanAnimate} {
-              transition-delay: ${transitionSpeed};
-            }
+          /* Delay transition on hover so animation is not accidentally triggered on mouse over */
+          ${euiCanAnimate} {
+            transition-delay: ${transitionSpeed};
           }
         }
-      `,
+      }
+    `,
+    handleDirection: {
       horizontal: css`
         &::before,
         &::after {

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -130,7 +130,8 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
 
         /* 1 */
         &:hover,
-        &:focus {
+        &:focus,
+        &:active {
           gap: 0;
         }
 

--- a/src/components/resizable_container/resizable_button.styles.ts
+++ b/src/components/resizable_container/resizable_button.styles.ts
@@ -31,29 +31,15 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       flex-shrink: 0;
       display: flex;
       justify-content: center;
-      gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
 
       &:disabled {
         display: none;
-      }
-
-      /* 1 */
-      &:hover,
-      &:focus {
-        gap: 0;
-        justify-content: center;
-      }
-
-      ${euiCanAnimate} {
-        transition: gap ${transition}, justify-content ${transition};
       }
 
       &::before,
       &::after {
         content: '';
         display: block;
-        background-color: ${euiTheme.colors.darkestShade};
-        transform: translateZ(0); /* 3 */
 
         ${euiCanAnimate} {
           transition: width ${transition}, height ${transition},
@@ -66,11 +52,6 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
         &::before,
         &::after {
           background-color: ${euiTheme.colors.mediumShade};
-
-          /* Delay transition on hover so animation is not accidentally triggered on mouse over */
-          ${euiCanAnimate} {
-            transition-delay: ${transitionSpeed};
-          }
         }
       }
 
@@ -97,25 +78,6 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('height', '100%')}
       ${logicalCSS('width', buttonSize)}
       margin-inline: ${mathWithUnits(buttonSize, (x) => x / -2)};
-
-      &::before,
-      &::after {
-        ${logicalCSS('width', grabHandleHeight)}
-        ${logicalCSS('height', grabHandleWidth)}
-        margin-block: ${euiTheme.size.base}; /* 2 */
-      }
-
-      /* 1 */
-      &:hover,
-      &:focus,
-      &:active {
-        &::before,
-        &::after {
-          ${logicalCSS('height', '100%')}
-          margin-block: 0; /* 2 */
-          transform: none; /* 3 */
-        }
-      }
     `,
     vertical: css`
       flex-direction: column;
@@ -123,26 +85,117 @@ export const euiResizableButtonStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('width', '100%')}
       ${logicalCSS('height', buttonSize)}
       margin-block: ${mathWithUnits(buttonSize, (x) => x / -2)};
-
-      &::before,
-      &::after {
-        ${logicalCSS('height', grabHandleHeight)}
-        ${logicalCSS('width', grabHandleWidth)}
-        margin-inline: ${euiTheme.size.base}; /* 2 */
-      }
-
-      /* 1 */
-      &:hover,
-      &:focus,
-      &:active {
+    `,
+    border: {
+      border: css`
         &::before,
         &::after {
-          ${logicalCSS('width', '100%')}
-          margin-inline: 0; /* 2 */
-          transform: none; /* 3 */
+          background-color: ${euiTheme.border.color};
         }
-      }
-    `,
+      `,
+      horizontal: css`
+        &::before {
+          ${logicalCSS('width', euiTheme.border.width.thin)}
+          ${logicalCSS('height', '100%')}
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+          &::after {
+            ${logicalCSS('width', euiTheme.border.width.thin)}
+            ${logicalCSS('height', '100%')}
+          }
+        }
+      `,
+      vertical: css`
+        &::before {
+          ${logicalCSS('height', euiTheme.border.width.thin)}
+          ${logicalCSS('width', '100%')}
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+          &::after {
+            ${logicalCSS('height', euiTheme.border.width.thin)}
+            ${logicalCSS('width', '100%')}
+          }
+        }
+      `,
+    },
+    grabHandle: {
+      grabHandle: css`
+        gap: ${mathWithUnits(grabHandleHeight, (x) => x * 2)};
+
+        /* 1 */
+        &:hover,
+        &:focus {
+          gap: 0;
+        }
+
+        ${euiCanAnimate} {
+          transition: gap ${transition};
+        }
+
+        &::before,
+        &::after {
+          background-color: ${euiTheme.colors.darkestShade};
+          transform: translateZ(0); /* 3 */
+        }
+
+        /* Lighten color on :hover */
+        &:hover {
+          &::before,
+          &::after {
+            /* Delay transition on hover so animation is not accidentally triggered on mouse over */
+            ${euiCanAnimate} {
+              transition-delay: ${transitionSpeed};
+            }
+          }
+        }
+      `,
+      horizontal: css`
+        &::before,
+        &::after {
+          ${logicalCSS('width', grabHandleHeight)}
+          ${logicalCSS('height', grabHandleWidth)}
+          margin-block: ${euiTheme.size.base}; /* 2 */
+        }
+
+        /* 1 */
+        &:hover,
+        &:focus,
+        &:active {
+          &::before,
+          &::after {
+            ${logicalCSS('height', '100%')}
+            margin-block: 0; /* 2 */
+            transform: none; /* 3 */
+          }
+        }
+      `,
+      vertical: css`
+        &::before,
+        &::after {
+          ${logicalCSS('height', grabHandleHeight)}
+          ${logicalCSS('width', grabHandleWidth)}
+          margin-inline: ${euiTheme.size.base}; /* 2 */
+        }
+
+        /* 1 */
+        &:hover,
+        &:focus,
+        &:active {
+          &::before,
+          &::after {
+            ${logicalCSS('width', '100%')}
+            margin-inline: 0; /* 2 */
+            transform: none; /* 3 */
+          }
+        }
+      `,
+    },
     alignIndicator: {
       center: css`
         align-items: center;

--- a/src/components/resizable_container/resizable_button.test.tsx
+++ b/src/components/resizable_container/resizable_button.test.tsx
@@ -28,6 +28,14 @@ describe('EuiResizableButton', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('renders different indicator styles and directions', () => {
+    const { container } = render(
+      <EuiResizableButton isHorizontal={true} indicator="border" />
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('renders as hidden if disabled', () => {
     const { container } = render(<EuiResizableButton disabled />);
 

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -37,6 +37,13 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
      */
     isHorizontal?: boolean;
     /**
+     * By default, EuiResizableButton will show a grab handle to indicate resizability.
+     * This indicator can be optionally hidden to show a plain border instead.
+     *
+     * @default true
+     */
+    showIndicator?: boolean;
+    /**
      * Specify the alignment of the initial resize indicator. Defaults to `center`,
      * but consider using `start` for extremely tall content that scrolls off-screen
      */
@@ -54,44 +61,57 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
 export const EuiResizableButton = forwardRef<
   HTMLButtonElement,
   EuiResizableButtonProps
->(({ isHorizontal, alignIndicator = 'center', className, ...rest }, ref) => {
-  const classes = classNames('euiResizableButton', className);
+>(
+  (
+    {
+      isHorizontal,
+      showIndicator = true,
+      alignIndicator = 'center',
+      className,
+      ...rest
+    },
+    ref
+  ) => {
+    const classes = classNames('euiResizableButton', className);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiResizableButtonStyles(euiTheme);
-  const cssStyles = [
-    styles.euiResizableButton,
-    isHorizontal ? styles.horizontal : styles.vertical,
-    styles.alignIndicator[alignIndicator],
-  ];
+    const euiTheme = useEuiTheme();
+    const styles = euiResizableButtonStyles(euiTheme);
+    const cssStyles = [
+      styles.euiResizableButton,
+      isHorizontal ? styles.horizontal : styles.vertical,
+      styles.alignIndicator[alignIndicator],
+    ];
 
-  return (
-    <EuiI18n
-      tokens={[
-        'euiResizableButton.horizontalResizerAriaLabel',
-        'euiResizableButton.verticalResizerAriaLabel',
-      ]}
-      defaults={[
-        'Press the left or right arrow keys to adjust panels size',
-        'Press the up or down arrow keys to adjust panels size',
-      ]}
-    >
-      {([horizontalResizerAriaLabel, verticalResizerAriaLabel]: string[]) => (
-        <button
-          ref={ref}
-          aria-label={
-            isHorizontal ? horizontalResizerAriaLabel : verticalResizerAriaLabel
-          }
-          className={classes}
-          css={cssStyles}
-          data-test-subj="euiResizableButton"
-          type="button"
-          {...rest}
-        />
-      )}
-    </EuiI18n>
-  );
-});
+    return (
+      <EuiI18n
+        tokens={[
+          'euiResizableButton.horizontalResizerAriaLabel',
+          'euiResizableButton.verticalResizerAriaLabel',
+        ]}
+        defaults={[
+          'Press the left or right arrow keys to adjust panels size',
+          'Press the up or down arrow keys to adjust panels size',
+        ]}
+      >
+        {([horizontalResizerAriaLabel, verticalResizerAriaLabel]: string[]) => (
+          <button
+            ref={ref}
+            aria-label={
+              isHorizontal
+                ? horizontalResizerAriaLabel
+                : verticalResizerAriaLabel
+            }
+            className={classes}
+            css={cssStyles}
+            data-test-subj="euiResizableButton"
+            type="button"
+            {...rest}
+          />
+        )}
+      </EuiI18n>
+    );
+  }
+);
 EuiResizableButton.displayName = 'EuiResizableButton';
 
 /**

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -44,7 +44,7 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
      */
     showIndicator?: boolean;
     /**
-     * Specify the alignment of the initial resize indicator. Defaults to `center`,
+     * Specify the alignment of the initial grab handle indicator. Defaults to `center`,
      * but consider using `start` for extremely tall content that scrolls off-screen
      */
     alignIndicator?: 'center' | 'start' | 'end';

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -74,12 +74,17 @@ export const EuiResizableButton = forwardRef<
   ) => {
     const classes = classNames('euiResizableButton', className);
 
+    const resizeDirection = isHorizontal ? 'horizontal' : 'vertical';
+    const indicatorType = showIndicator ? 'grabHandle' : 'border';
+
     const euiTheme = useEuiTheme();
     const styles = euiResizableButtonStyles(euiTheme);
     const cssStyles = [
       styles.euiResizableButton,
-      isHorizontal ? styles.horizontal : styles.vertical,
-      styles.alignIndicator[alignIndicator],
+      showIndicator ? styles.grabHandle.grabHandle : styles.border.border,
+      styles[indicatorType][resizeDirection],
+      styles[resizeDirection],
+      showIndicator && styles.alignIndicator[alignIndicator],
     ];
 
     return (

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -39,13 +39,12 @@ export type EuiResizableButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
     /**
      * By default, EuiResizableButton will show a grab handle to indicate resizability.
      * This indicator can be optionally hidden to show a plain border instead.
-     *
-     * @default true
      */
-    showIndicator?: boolean;
+    indicator?: 'handle' | 'border';
     /**
-     * Specify the alignment of the initial grab handle indicator. Defaults to `center`,
-     * but consider using `start` for extremely tall content that scrolls off-screen
+     * Allows customizing the alignment of grab `handle` indicators (does nothing for
+     * border indicators). Defaults to `center`, but consider using `start` for extremely
+     * tall content that scrolls off-screen
      */
     alignIndicator?: 'center' | 'start' | 'end';
     /**
@@ -65,7 +64,7 @@ export const EuiResizableButton = forwardRef<
   (
     {
       isHorizontal,
-      showIndicator = true,
+      indicator = 'handle',
       alignIndicator = 'center',
       className,
       ...rest
@@ -75,16 +74,15 @@ export const EuiResizableButton = forwardRef<
     const classes = classNames('euiResizableButton', className);
 
     const resizeDirection = isHorizontal ? 'horizontal' : 'vertical';
-    const indicatorType = showIndicator ? 'grabHandle' : 'border';
 
     const euiTheme = useEuiTheme();
     const styles = euiResizableButtonStyles(euiTheme);
     const cssStyles = [
       styles.euiResizableButton,
-      showIndicator ? styles.grabHandle.grabHandle : styles.border.border,
-      styles[indicatorType][resizeDirection],
+      styles[indicator],
+      styles[`${indicator}Direction`][resizeDirection],
       styles[resizeDirection],
-      showIndicator && styles.alignIndicator[alignIndicator],
+      indicator === 'handle' && styles.alignIndicator[alignIndicator],
     ];
 
     return (


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7447

This PR updates `<EuiResizableButton />` to accept a `indicator={handle|border}` prop, which allows rendering either the default grab handle or a thin subdued border. It also updates `<EuiFlyoutResizable />` to use this new prop.

## Screencaps

![resizable_indicator_storybook](https://github.com/elastic/eui/assets/549407/4ca44963-0366-4e2c-bf0c-68044e18055e)

![resizable_indicator](https://github.com/elastic/eui/assets/549407/af22152f-1def-4033-9606-d7514c96f0fb)

## QA

- https://eui.elastic.co/pr_7455/#/layout/resizable-container#resizable-button-indicator
  - [x] Confirm the new border appearance looks works as expected in all states (hover, active, etc)
  - [x] Confirm that all other drag handle indicators on the page behave as before/on production in all states, with no visual regressions
- https://eui.elastic.co/pr_7455/storybook/?path=/story/euiresizablebutton--playground
  - [x] Confirm that changing `alignIndicator` when `indicator` is set to `border` does nothing
  - [x] Confirm that switching between `indicator` border/handle works as expected

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Tested Storybook
    ~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    ~- [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~ - Resizable container doesn't appear to be in our Figma library