### PR TITLE
[EuiResizableContainer] Mouse drags outside of the container no longer lose dragging state

### DIFF
--- a/changelogs/upcoming/7456.md
+++ b/changelogs/upcoming/7456.md
@@ -1,0 +1,1 @@
+- Enhanced `EuiResizableContainer` to preserve the drag/resize event when the user's mouse leaves the parent container and re-enters

--- a/src/components/flyout/flyout_resizable.spec.tsx
+++ b/src/components/flyout/flyout_resizable.spec.tsx
@@ -62,27 +62,33 @@ describe('EuiFlyoutResizable', () => {
     it('mouse drag', () => {
       cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('mousedown', { pageX: 400 })
-        .trigger('mousemove', { pageX: 600 });
+        .trigger('mousedown', { clientX: 400 })
+        .trigger('mousemove', { clientX: 600 });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '600px');
 
       cy.get('[data-test-subj="euiResizableButton"]').trigger('mousemove', {
-        pageX: 200,
+        clientX: 200,
       });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '1000px');
 
       // Should not change the flyout width if not dragging
       cy.get('[data-test-subj="euiResizableButton"]')
         .trigger('mouseup')
-        .trigger('mousemove', { pageX: 1000 });
+        .trigger('mousemove', { clientX: 1000 });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '1000px');
     });
 
     it('mobile touch drag', () => {
       cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('touchstart', { targetTouches: [{ pageX: 400 }], touches: [] })
-        .trigger('touchmove', { targetTouches: [{ pageX: 800 }], touches: [] })
+        .trigger('touchstart', {
+          targetTouches: [{ clientX: 400 }],
+          touches: [],
+        })
+        .trigger('touchmove', {
+          targetTouches: [{ clientX: 800 }],
+          touches: [],
+        })
         .trigger('touchend', { touches: [] });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '400px');
     });
@@ -101,8 +107,8 @@ describe('EuiFlyoutResizable', () => {
     it('does not allow the flyout to be resized past the window width', () => {
       cy.mount(<EuiFlyoutResizable onClose={onClose} size={800} />);
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('mousedown', { pageX: 400 })
-        .trigger('mousemove', { pageX: -100 });
+        .trigger('mousedown', { clientX: 400 })
+        .trigger('mousemove', { clientX: -100 });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '1180px');
     });
 
@@ -111,8 +117,8 @@ describe('EuiFlyoutResizable', () => {
         <EuiFlyoutResizable onClose={onClose} size={800} maxWidth={1000} />
       );
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('mousedown', { pageX: 400 })
-        .trigger('mousemove', { pageX: 100 });
+        .trigger('mousedown', { clientX: 400 })
+        .trigger('mousemove', { clientX: 100 });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '1000px');
     });
 
@@ -121,8 +127,8 @@ describe('EuiFlyoutResizable', () => {
         <EuiFlyoutResizable onClose={onClose} size={800} minWidth={100} />
       );
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('mousedown', { pageX: 400 })
-        .trigger('mousemove', { pageX: 2000 });
+        .trigger('mousedown', { clientX: 400 })
+        .trigger('mousemove', { clientX: 2000 });
       cy.get('.euiFlyout').should('have.css', 'inline-size', '100px');
     });
 
@@ -155,8 +161,8 @@ describe('EuiFlyoutResizable', () => {
         cy.get('.euiFlyout').should('have.css', 'inline-size', '850px');
 
         cy.get('[data-test-subj="euiResizableButton"]')
-          .trigger('mousedown', { pageX: 850, ...options })
-          .trigger('mousemove', { pageX: 400, ...options });
+          .trigger('mousedown', { clientX: 850, ...options })
+          .trigger('mousemove', { clientX: 400, ...options });
         cy.get('.euiFlyout').should('have.css', 'inline-size', '400px');
       };
     });
@@ -168,8 +174,8 @@ describe('EuiFlyoutResizable', () => {
       cy.get('body').should('have.css', 'padding-inline-end', '800px');
 
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('mousedown', { pageX: 400 })
-        .trigger('mousemove', { pageX: 1000 });
+        .trigger('mousedown', { clientX: 400 })
+        .trigger('mousemove', { clientX: 1000 });
 
       cy.get('.euiFlyout').should('have.css', 'inline-size', '200px');
       cy.get('body').should('have.css', 'padding-inline-end', '200px');
@@ -187,8 +193,8 @@ describe('EuiFlyoutResizable', () => {
       cy.get('body').should('have.css', 'padding-inline-start', '800px');
 
       cy.get('[data-test-subj="euiResizableButton"]')
-        .trigger('mousedown', { pageX: 800 })
-        .trigger('mousemove', { pageX: 200 });
+        .trigger('mousedown', { clientX: 800 })
+        .trigger('mousemove', { clientX: 200 });
 
       cy.get('.euiFlyout').should('have.css', 'inline-size', '200px');
       cy.get('body').should('have.css', 'padding-inline-start', '200px');

--- a/src/components/flyout/flyout_resizable.tsx
+++ b/src/components/flyout/flyout_resizable.tsx
@@ -17,6 +17,7 @@ import React, {
 
 import { keys, useCombinedRefs, useEuiTheme } from '../../services';
 import { EuiResizableButton } from '../resizable_container';
+import { getPosition } from '../resizable_container/helpers';
 
 import { EuiFlyout, EuiFlyoutProps } from './flyout';
 import { euiFlyoutResizableButtonStyles } from './flyout_resizable.styles';
@@ -80,7 +81,7 @@ export const EuiFlyoutResizable = forwardRef(
 
     const onMouseMove = useCallback(
       (e: MouseEvent | TouchEvent) => {
-        const mouseOffset = getMouseOrTouchX(e) - initialMouseX.current;
+        const mouseOffset = getPosition(e, true) - initialMouseX.current;
         const changedFlyoutWidth =
           initialWidth.current + mouseOffset * direction;
 
@@ -100,7 +101,7 @@ export const EuiFlyoutResizable = forwardRef(
 
     const onMouseDown = useCallback(
       (e: React.MouseEvent | React.TouchEvent) => {
-        initialMouseX.current = getMouseOrTouchX(e);
+        initialMouseX.current = getPosition(e, true);
         initialWidth.current = flyoutRef?.offsetWidth ?? 0;
 
         // Window event listeners instead of React events are used
@@ -155,13 +156,3 @@ export const EuiFlyoutResizable = forwardRef(
   }
 );
 EuiFlyoutResizable.displayName = 'EuiFlyoutResizable';
-
-const getMouseOrTouchX = (
-  e: TouchEvent | MouseEvent | React.MouseEvent | React.TouchEvent
-): number => {
-  // Some Typescript fooling is needed here
-  const x = (e as TouchEvent).targetTouches
-    ? (e as TouchEvent).targetTouches[0].pageX
-    : (e as MouseEvent).pageX;
-  return x;
-};

--- a/src/components/resizable_container/helpers.ts
+++ b/src/components/resizable_container/helpers.ts
@@ -34,11 +34,10 @@ interface Params {
   onPanelWidthChange?: ({}: { [key: string]: number }) => any;
 }
 
-function isMouseEvent(
-  event: ReactMouseEvent | ReactTouchEvent
-): event is ReactMouseEvent {
-  return typeof event === 'object' && 'pageX' in event && 'pageY' in event;
-}
+export const isTouchEvent = (
+  event: MouseEvent | ReactMouseEvent | TouchEvent | ReactTouchEvent
+): event is TouchEvent | ReactTouchEvent =>
+  typeof event === 'object' && 'targetTouches' in event;
 
 export const pxToPercent = (proportion: number, whole: number) => {
   if (whole < 1 || proportion < 0) return 0;
@@ -81,16 +80,13 @@ export const getPanelMinSize = (
 };
 
 export const getPosition = (
-  event: ReactMouseEvent | ReactTouchEvent,
+  event: ReactMouseEvent | MouseEvent | ReactTouchEvent | TouchEvent,
   isHorizontal: boolean
-) => {
-  const clientX = isMouseEvent(event)
-    ? event.clientX
-    : event.touches[0].clientX;
-  const clientY = isMouseEvent(event)
-    ? event.clientY
-    : event.touches[0].clientY;
-  return isHorizontal ? clientX : clientY;
+): number => {
+  const direction = isHorizontal ? 'clientX' : 'clientY';
+  return isTouchEvent(event)
+    ? event.targetTouches[0][direction]
+    : event[direction];
 };
 
 const getSiblingPanel = (

--- a/src/components/resizable_container/resizable_container.test.tsx
+++ b/src/components/resizable_container/resizable_container.test.tsx
@@ -7,7 +7,9 @@
  */
 
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
+
 import { findTestSubject, requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { render } from '../../test/rtl';
@@ -217,8 +219,7 @@ describe('EuiResizableContainer', () => {
     };
 
     test('onResizeStart and onResizeEnd are called for pointer events', () => {
-      const { container, button, onResizeStart, onResizeEnd } =
-        mountWithCallbacks();
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
       button.simulate('mousedown', {
         pageX: 0,
         pageY: 0,
@@ -227,7 +228,9 @@ describe('EuiResizableContainer', () => {
       });
       expect(onResizeStart).toHaveBeenCalledTimes(1);
       expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-      container.simulate('mouseup');
+      act(() => {
+        window.dispatchEvent(new Event('mouseup'));
+      });
       expect(onResizeEnd).toHaveBeenCalledTimes(1);
       button.simulate('mousedown', {
         pageX: 0,
@@ -237,7 +240,9 @@ describe('EuiResizableContainer', () => {
       });
       expect(onResizeStart).toHaveBeenCalledTimes(2);
       expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-      container.simulate('mouseleave');
+      act(() => {
+        window.dispatchEvent(new Event('mouseup'));
+      });
       expect(onResizeEnd).toHaveBeenCalledTimes(2);
       button.simulate('touchstart', {
         touches: [
@@ -249,7 +254,9 @@ describe('EuiResizableContainer', () => {
       });
       expect(onResizeStart).toHaveBeenCalledTimes(3);
       expect(onResizeStart).toHaveBeenLastCalledWith('pointer');
-      container.simulate('touchend');
+      act(() => {
+        window.dispatchEvent(new Event('touchend'));
+      });
       expect(onResizeEnd).toHaveBeenCalledTimes(3);
     });
 
@@ -312,8 +319,7 @@ describe('EuiResizableContainer', () => {
     });
 
     test('onResizeEnd is called before starting a new resize if a keyboard resize is triggered while a pointer resize is in progress', () => {
-      const { container, button, onResizeStart, onResizeEnd } =
-        mountWithCallbacks();
+      const { button, onResizeStart, onResizeEnd } = mountWithCallbacks();
       button.simulate('mousedown', {
         pageX: 0,
         pageY: 0,
@@ -326,7 +332,9 @@ describe('EuiResizableContainer', () => {
       expect(onResizeEnd).toHaveBeenCalledTimes(1);
       expect(onResizeStart).toHaveBeenCalledTimes(2);
       expect(onResizeStart).toHaveBeenLastCalledWith('key');
-      container.simulate('mouseup');
+      act(() => {
+        window.dispatchEvent(new Event('mouseup'));
+      });
       expect(onResizeEnd).toHaveBeenCalledTimes(1);
       button.simulate('keyup', { key: keys.ARROW_RIGHT });
       expect(onResizeEnd).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/4931

This PR updates `EuiResizableContainer` to use window event listeners for `mouseup`/`mousemove`, which is also how **EuiFlyoutResizable** works (#7439). Event listeners are created on mousedown and removed on mouseup.

The net result is that users can now drag outside resizable containers and not have their drag event abruptly ended. IMO, this provides a user experience with less friction and matches many other drag/resize experiences around the web.

| Before | After |
|--------|--------|
| ![resizable_container_drag_before](https://github.com/elastic/eui/assets/549407/6d6f5786-a0dc-4314-a0ed-ea4811ba9aef) [Production UX](https://eui.elastic.co/v92.0.0/#/layout/resizable-container) | ![resizable_container_drag](https://github.com/elastic/eui/assets/549407/8f843637-e5ea-4ba3-8269-56f64ca659b2) [New UX](https://eui.elastic.co/pr_7456/#/layout/resizable-container) | 

## QA

- Go to https://eui.elastic.co/pr_7456/#/layout/resizable-container
- [x] Confirm that clicking and dragging any panel outside its container/demo does not stop dragging (before the mouse button is released) if the mouse is moved back into the panel

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - N/A, no existing documentation around this behavior
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A