### PR TITLE
[Storybook] Add playground stories for components beginning with the letter B 

### DIFF
--- a/src/components/badge/badge.stories.tsx
+++ b/src/components/badge/badge.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBadge, EuiBadgeProps } from './badge';
+
+const meta: Meta<EuiBadgeProps> = {
+  title: 'EuiBadge',
+  component: EuiBadge,
+  argTypes: {
+    iconType: { control: 'text' },
+  },
+  args: {
+    // Component defaults
+    iconSide: 'left',
+    isDisabled: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBadgeProps>;
+
+export const Playground: Story = {
+  args: {
+    children: 'Badge text',
+  },
+};

--- a/src/components/badge/badge_group/badge_group.stories.tsx
+++ b/src/components/badge/badge_group/badge_group.stories.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBadge } from '../badge';
+import { EuiBadgeGroup, EuiBadgeGroupProps } from './badge_group';
+
+const meta: Meta<EuiBadgeGroupProps> = {
+  title: 'EuiBadgeGroup',
+  component: EuiBadgeGroup,
+  args: {
+    // Component defaults
+    gutterSize: 'xs',
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBadgeGroupProps>;
+
+export const Playground: Story = {
+  args: {
+    children: (
+      <>
+        <EuiBadge>Badge</EuiBadge>
+        <EuiBadge>Badge</EuiBadge>
+        <EuiBadge>Badge</EuiBadge>
+      </>
+    ),
+  },
+};

--- a/src/components/badge/beta_badge/beta_badge.stories.tsx
+++ b/src/components/badge/beta_badge/beta_badge.stories.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBetaBadge, EuiBetaBadgeProps } from './beta_badge';
+
+const meta: Meta<EuiBetaBadgeProps> = {
+  title: 'EuiBetaBadge',
+  component: EuiBetaBadge,
+  argTypes: {
+    iconType: { control: 'text' },
+    tooltipContent: { control: 'text' },
+  },
+  args: {
+    // Component defaults
+    color: 'hollow',
+    size: 'm',
+    alignment: 'baseline',
+    tooltipPosition: 'top',
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBetaBadgeProps>;
+
+export const Playground: Story = {
+  args: {
+    label: 'Beta',
+  },
+};

--- a/src/components/badge/notification_badge/badge_notification.stories.tsx
+++ b/src/components/badge/notification_badge/badge_notification.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  EuiNotificationBadge,
+  EuiNotificationBadgeProps,
+} from './badge_notification';
+
+const meta: Meta<EuiNotificationBadgeProps> = {
+  title: 'EuiNotificationBadge',
+  component: EuiNotificationBadge,
+  args: {
+    // Component defaults
+    color: 'accent',
+    size: 's',
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiNotificationBadgeProps>;
+
+export const Playground: Story = {
+  args: {
+    children: '5',
+  },
+};

--- a/src/components/beacon/beacon.stories.tsx
+++ b/src/components/beacon/beacon.stories.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBeacon, EuiBeaconProps } from './beacon';
+
+const meta: Meta<EuiBeaconProps> = {
+  title: 'EuiBeacon',
+  component: EuiBeacon,
+  args: {
+    // Component defaults
+    color: 'success',
+    size: 12,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBeaconProps>;
+
+export const Playground: Story = {};

--- a/src/components/bottom_bar/bottom_bar.stories.tsx
+++ b/src/components/bottom_bar/bottom_bar.stories.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBottomBar, EuiBottomBarProps } from './bottom_bar';
+
+const meta: Meta<EuiBottomBarProps> = {
+  title: 'EuiBottomBar',
+  component: EuiBottomBar,
+  argTypes: {
+    top: { control: 'number' },
+  },
+  args: {
+    // Component defaults
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingSize: 'm',
+    position: 'fixed',
+    usePortal: true,
+    affordForDisplacement: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBottomBarProps>;
+
+export const Playground: Story = {
+  args: {
+    children: 'Bottom bar content',
+  },
+};

--- a/src/components/bottom_bar/bottom_bar.tsx
+++ b/src/components/bottom_bar/bottom_bar.tsx
@@ -71,7 +71,9 @@ export type EuiBottomBarProps = CommonProps &
      */
     bodyClassName?: string;
     /**
-     * Customize the screen reader heading that helps users find this control. Default is 'Page level controls'.
+     * Customize the screen reader heading that helps users find this control.
+     *
+     * @default Page level controls
      */
     landmarkHeading?: string;
     /**

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBreadcrumbs, EuiBreadcrumbsProps } from './breadcrumbs';
+
+const meta: Meta<EuiBreadcrumbsProps> = {
+  title: 'EuiBreadcrumbs',
+  component: EuiBreadcrumbs,
+  args: {
+    // Component defaults
+    type: 'page',
+    max: 5,
+    truncate: true,
+    responsive: { xs: 1, s: 2, m: 4 },
+    lastBreadcrumbIsCurrentPage: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBreadcrumbsProps>;
+
+export const Playground: Story = {
+  args: {
+    breadcrumbs: [
+      {
+        text: 'Breadcrumb 1',
+        href: '#',
+      },
+      {
+        text: 'Breadcrumb 2',
+        href: '#',
+      },
+      {
+        text: 'Current',
+        href: '#',
+      },
+    ],
+  },
+};

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -7,26 +7,28 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { disableStorybookControls } from '../../../../.storybook/utils';
+import { disableStorybookControls } from '../../../.storybook/utils';
 
-import { EuiButtonEmpty, EuiButtonEmptyProps } from './button_empty';
+import { EuiButton, Props as EuiButtonProps } from './button';
 
-const meta: Meta<EuiButtonEmptyProps> = {
-  title: 'EuiButtonEmpty',
-  component: EuiButtonEmpty,
+const meta: Meta<EuiButtonProps> = {
+  title: 'EuiButton',
+  component: EuiButton,
   argTypes: {
-    flush: {
-      options: [undefined, 'left', 'right', 'both'],
-    },
     iconType: { control: 'text' },
-    target: { control: 'text' },
+    // TODO: the `minWidth` prop takes many different types (bool, string, number)
+    // - we should consider adding our own custom control
   },
   args: {
     // Component defaults
+    element: 'button',
+    type: 'button',
     color: 'primary',
     size: 'm',
+    fill: false,
     iconSize: 'm',
     iconSide: 'left',
+    fullWidth: false,
     isDisabled: false,
     isLoading: false,
     isSelected: false,
@@ -34,11 +36,11 @@ const meta: Meta<EuiButtonEmptyProps> = {
 };
 
 export default meta;
-type Story = StoryObj<EuiButtonEmptyProps>;
+type Story = StoryObj<EuiButtonProps>;
 
 export const Playground: Story = {
   argTypes: disableStorybookControls(['buttonRef']),
   args: {
-    children: 'Tertiary action',
+    children: 'Button',
   },
 };

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -66,12 +66,14 @@ export type EuiButtonPropsForAnchor = PropsForAnchor<
   }
 >;
 
-export type EuiButtonPropsForButton = PropsForButton<
-  EuiButtonProps,
-  {
-    buttonRef?: Ref<HTMLButtonElement>;
-  }
->;
+// For some reason, Storybook doesn't parse `EuiButtonDisplayCommonProps` unless we include it here
+export type EuiButtonPropsForButton = EuiButtonDisplayCommonProps &
+  PropsForButton<
+    EuiButtonProps,
+    {
+      buttonRef?: Ref<HTMLButtonElement>;
+    }
+  >;
 
 export type Props = ExclusiveUnion<
   EuiButtonPropsForAnchor,

--- a/src/components/button/button_display/_button_display.tsx
+++ b/src/components/button/button_display/_button_display.tsx
@@ -68,6 +68,7 @@ export interface EuiButtonDisplayCommonProps
    */
   contentProps?: CommonProps & EuiButtonDisplayContentType;
   style?: CSSProperties;
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
 
 export type EuiButtonDisplayPropsForAnchor = PropsForAnchor<

--- a/src/components/button/button_empty/button_empty.stories.tsx
+++ b/src/components/button/button_empty/button_empty.stories.tsx
@@ -23,6 +23,7 @@ const meta: Meta<EuiButtonEmptyProps> = {
   },
   args: {
     // Component defaults
+    type: 'button',
     color: 'primary',
     size: 'm',
     iconSize: 'm',

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, Ref } from 'react';
+import React, { FunctionComponent, Ref, ButtonHTMLAttributes } from 'react';
 import classNames from 'classnames';
 
 import {
@@ -69,7 +69,7 @@ export interface CommonEuiButtonEmptyProps
   href?: string;
   target?: string;
   rel?: string;
-  type?: 'button' | 'submit';
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
   buttonRef?: Ref<HTMLButtonElement | HTMLAnchorElement>;
   /**
    * Object of props passed to the `<span>` wrapping the button's content

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -7,7 +7,12 @@
  */
 
 import classNames from 'classnames';
-import React, { FunctionComponent, HTMLAttributes, ReactNode } from 'react';
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactNode,
+} from 'react';
 
 import { useEuiTheme } from '../../../services';
 import { EuiScreenReaderOnly } from '../../accessibility';
@@ -40,7 +45,7 @@ export interface EuiButtonGroupOptionProps
   /**
    * The type of the underlying HTML button
    */
-  type?: 'button' | 'submit' | 'reset';
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
 
 export type EuiButtonGroupProps = CommonProps & {

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -78,7 +78,7 @@ export interface EuiButtonIconProps extends CommonProps {
 }
 
 export type EuiButtonIconPropsForAnchor = {
-  type?: string;
+  type?: AnchorHTMLAttributes<HTMLAnchorElement>['type'];
 } & PropsForAnchor<
   EuiButtonIconProps,
   {
@@ -87,7 +87,7 @@ export type EuiButtonIconPropsForAnchor = {
 >;
 
 export type EuiButtonIconPropsForButton = {
-  type?: 'submit' | 'reset' | 'button';
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
 } & PropsForButton<
   EuiButtonIconProps,
   {


### PR DESCRIPTION
## Summary

> ⚠️ I skipped `EuiBasicTable` for this PR, as our tabular content components are heckin' complex and probably deserve their own dedicated PR where we consider what exactly we want out of those stories/embeds

Note: `EuiButton` had some shenanigans that required a type workaround (shouldn't affect actual end-types, will verify with the docs props table) to get Storybook to read extended types as controls. Everything else was straightforward.

I also DRYed out the `type` type (ha) for our button components in https://github.com/elastic/eui/pull/7459/commits/0bc375da5c540430b44c082d5e2a1f5a363a6d71, which was somewhat all over the place.

<img src="https://media.giphy.com/media/26meIMecFffyD5BDzG/giphy.gif" alt="The letter B" width="300">

## QA

- [x] Confirm that the toggles & controls for all the below storybooks work as expected/reasonably
- https://eui.elastic.co/7459/storybook/?path=/story/euibadge--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibadgegroup--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibetabadge--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euinotificationbadge--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibeacon--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibottombar--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibreadcrumbs--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibutton--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibuttonempty--playground
- https://eui.elastic.co/7459/storybook/?path=/story/euibuttongroup--single-selection
- https://eui.elastic.co/7459/storybook/?path=/story/euibuttonicon--playground

Regression type check
- [x] https://eui.elastic.co/7459/#/navigation/button - make sure allowed size in prop table is still only `s` and `m` (no `xs`)

### General checklist

N/A, docs only