### PR TITLE
[EuiFlyoutResizable] Add optional `onResize` callback

### DIFF
--- a/changelogs/upcoming/7464.md
+++ b/changelogs/upcoming/7464.md
@@ -1,0 +1,1 @@
+- Updated `EuiFlyoutResizable` with new optional `onResize` callback

--- a/src-docs/src/views/flyout/flyout_resizable.tsx
+++ b/src-docs/src/views/flyout/flyout_resizable.tsx
@@ -32,7 +32,6 @@ export default () => {
         side={flyoutSide as EuiFlyoutProps['side']}
         onClose={() => setIsFlyoutVisible(false)}
         aria-labelledby={flyoutTitleId}
-        onResize={console.log}
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">

--- a/src-docs/src/views/flyout/flyout_resizable.tsx
+++ b/src-docs/src/views/flyout/flyout_resizable.tsx
@@ -32,6 +32,7 @@ export default () => {
         side={flyoutSide as EuiFlyoutProps['side']}
         onClose={() => setIsFlyoutVisible(false)}
         aria-labelledby={flyoutTitleId}
+        onResize={console.log}
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="m">

--- a/src/components/flyout/flyout_resizable.spec.tsx
+++ b/src/components/flyout/flyout_resizable.spec.tsx
@@ -166,6 +166,36 @@ describe('EuiFlyoutResizable', () => {
         cy.get('.euiFlyout').should('have.css', 'inline-size', '400px');
       };
     });
+
+    it('calls the optional onResize callback on mouseup and keyboard events only', () => {
+      const onResize = cy.stub();
+      cy.mount(
+        <EuiFlyoutResizable onClose={onClose} size={800} onResize={onResize} />
+      );
+
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mousedown', { clientX: 400 })
+        .trigger('mousemove', { clientX: 600 })
+        .then(() => {
+          expect(onResize).not.have.been.called;
+        });
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('mouseup')
+        .then(() => {
+          expect(onResize.callCount).to.eql(1);
+          expect(onResize).to.have.been.calledWith(600);
+        });
+
+      cy.get('[data-test-subj="euiResizableButton"]').focus();
+      cy.realPress('ArrowRight').then(() => {
+        expect(onResize.callCount).to.eql(2);
+        expect(onResize).to.have.been.calledWith(590);
+      });
+      cy.realPress('ArrowLeft').then(() => {
+        expect(onResize.callCount).to.eql(3);
+        expect(onResize.lastCall.args).to.eql([600]);
+      });
+    });
   });
 
   describe('push flyouts', () => {


### PR DESCRIPTION
## Summary

Per recent EUI feedback - adds an `onResize` callback where the latest flyout width is passed, which allows consumers to do things like, e.g. save user preference by storing the flyout width in `localStorage`

## QA

- Go to https://eui.elastic.co/pr_7464/#/layout/flyout#resizable-flyouts
- Open your browser devtools and go to the console
- [x] Confirm that the flyout with is only logged to the console once you **stop** dragging and the flyout width is settled, and not at the beginning or middle of a drag
- [x] Confirm that the flyout with is logged to the console on every left/right arrow keypress

### General checklist

- [x] Revert [REVERT ME] QA commit
- Browser QA - N/A
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A