### PR TITLE
[EuiTextArea] Fix consumer `onChange`s not firing on `isClearable` button click

### DIFF
--- a/changelogs/upcoming/7473.md
+++ b/changelogs/upcoming/7473.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiTextArea` to correctly fire `onChange` callbacks on clear button click

--- a/src-docs/src/views/form_controls/text_area.js
+++ b/src-docs/src/views/form_controls/text_area.js
@@ -17,10 +17,7 @@ export default () => {
         placeholder="Placeholder text"
         aria-label="Use aria labels when no actual label is in use"
         value={value}
-        onChange={(e) => {
-          console.log('onChange fired');
-          onChange(e);
-        }}
+        onChange={(e) => onChange(e)}
       />
     </DisplayToggles>
   );

--- a/src-docs/src/views/form_controls/text_area.js
+++ b/src-docs/src/views/form_controls/text_area.js
@@ -17,7 +17,10 @@ export default () => {
         placeholder="Placeholder text"
         aria-label="Use aria labels when no actual label is in use"
         value={value}
-        onChange={(e) => onChange(e)}
+        onChange={(e) => {
+          console.log('onChange fired');
+          onChange(e);
+        }}
       />
     </DisplayToggles>
   );

--- a/src/components/form/text_area/text_area.spec.tsx
+++ b/src/components/form/text_area/text_area.spec.tsx
@@ -26,23 +26,46 @@ describe('EuiTextArea', () => {
     });
 
     it('works for controlled components', () => {
+      const onChange = cy.stub();
       const ControlledTextArea = ({}) => {
         const [value, setValue] = useState('');
-        return (
-          <EuiTextArea
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            isClearable
-          />
-        );
+        onChange.callsFake((e) => {
+          setValue(e.target.value);
+        });
+        return <EuiTextArea value={value} onChange={onChange} isClearable />;
       };
       cy.realMount(<ControlledTextArea />);
 
       cy.get('textarea').type('hello world');
-      cy.get('textarea').should('have.value', 'hello world');
+      cy.get('textarea')
+        .should('have.value', 'hello world')
+        .then(() => {
+          expect(onChange).to.have.callCount(11);
+        });
 
       cy.get('[data-test-subj="clearTextAreaButton"]').click();
-      cy.get('textarea').should('have.value', '');
+      cy.get('textarea')
+        .should('have.value', '')
+        .then(() => {
+          expect(onChange).to.have.callCount(12);
+        });
+    });
+
+    it('manually fires an onInput event', () => {
+      const onInput = cy.stub();
+      cy.realMount(<EuiTextArea isClearable onInput={onInput} />);
+
+      cy.get('textarea')
+        .type('1')
+        .then(() => {
+          expect(onInput).to.have.callCount(1);
+        });
+
+      cy.get('[data-test-subj="clearTextAreaButton"]')
+        .click()
+        .then(() => {
+          expect(onInput).to.have.callCount(2);
+        });
     });
   });
 });

--- a/src/components/form/text_area/text_area.tsx
+++ b/src/components/form/text_area/text_area.tsx
@@ -106,13 +106,22 @@ export const EuiTextArea: FunctionComponent<EuiTextAreaProps> = (props) => {
       return {
         onClick: () => {
           if (ref.current) {
-            ref.current.value = '';
+            // Updates the displayed value and fires `onChange` callbacks
+            // @see https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js
+            const nativeValueSetter = Object.getOwnPropertyDescriptor(
+              window.HTMLTextAreaElement.prototype,
+              'value'
+            )!.set!;
+            nativeValueSetter.call(ref.current, '');
+
             const event = new Event('input', {
               bubbles: true,
               cancelable: false,
             });
             ref.current.dispatchEvent(event);
-            ref.current.focus(); // set focus back to the textarea
+
+            // Set focus back to the textarea
+            ref.current.focus();
           }
         },
         'data-test-subj': 'clearTextAreaButton',


### PR DESCRIPTION
## Summary

@shahzad31 caught this when trying to implement the new `<EuiTextArea isClearable />` functionality in Kibana 🙏 I should have 1. written better tests and 2. followed the [existing **EuiFieldSearch** implementation](https://github.com/elastic/eui/blob/1e90096ea684223cbad134ba3fd250ba7960e7dc/src/components/form/field_search/field_search.tsx#L128-L154) more closely, as we need to call the prototype `.call()` after all (as opposed to setting `.value = ''`) in order for consumer `onChange` callbacks to correctly fire.

Both of the above are now fixed in this PR.

## QA

- Go to https://eui.elastic.co/pr_7473/#/forms/form-controls#textarea
- Click the `Display toggles` button, and toggle `clearable` to true
- Open your browser devtools to the console
- Type in a single character into the textarea, and confirm `onChange fired` logs out once
- [x] Click the `X` clear button in the bottom right hand corner and confirm `onChange fired` logs into the console for a second time

### General checklist

- [x] Revert [REVERT ME] commit
- Browser QA - N/A
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A