### PR TITLE
[EuIContextMenuItem] Remove deprecated `toolTipTitle` and `toolTipPosition` props

### DIFF
--- a/changelogs/upcoming/7489.md
+++ b/changelogs/upcoming/7489.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- Removed deprecated `toolTipTitle` and `toolTipPosition` props from `EuiContextMenuItem`. Use `toolTipProps.title` and `toolTilProps.position` instead

--- a/src-docs/src/views/context_menu/context_menu.js
+++ b/src-docs/src/views/context_menu/context_menu.js
@@ -59,9 +59,11 @@ export default () => {
         {
           name: 'Add a tooltip',
           icon: 'document',
-          toolTipTitle: 'Optional tooltip',
           toolTipContent: 'Optional content for a tooltip',
-          toolTipPosition: 'right',
+          toolTipProps: {
+            title: 'Optional tooltip title',
+            position: 'right',
+          },
           onClick: closePopover,
         },
         {
@@ -78,7 +80,7 @@ export default () => {
           name: 'Disabled option',
           icon: 'user',
           toolTipContent: 'For reasons, this item is disabled',
-          toolTipPosition: 'right',
+          toolTipProps: { position: 'right' },
           disabled: true,
           onClick: closePopover,
         },

--- a/src/components/context_menu/context_menu.stories.tsx
+++ b/src/components/context_menu/context_menu.stories.tsx
@@ -53,9 +53,11 @@ const panels: EuiContextMenuProps['panels'] = [
       {
         name: 'Add a tooltip',
         icon: 'document',
-        toolTipTitle: 'Optional tooltip',
         toolTipContent: 'Optional content for a tooltip',
-        toolTipPosition: 'right',
+        toolTipProps: {
+          title: 'Optional tooltip title',
+          position: 'right',
+        },
         onClick: noop,
       },
       {
@@ -72,7 +74,7 @@ const panels: EuiContextMenuProps['panels'] = [
         name: 'Disabled option',
         icon: 'user',
         toolTipContent: 'For reasons, this item is disabled',
-        toolTipPosition: 'right',
+        toolTipProps: { position: 'right' },
         disabled: true,
         onClick: noop,
       },

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -318,16 +318,7 @@ export class EuiContextMenuClass extends Component<
         return <EuiHorizontalRule key={key} margin="none" {...rest} />;
       }
 
-      const {
-        panel,
-        name,
-        key,
-        icon,
-        onClick,
-        toolTipTitle,
-        toolTipContent,
-        ...rest
-      } = item;
+      const { panel, name, key, icon, onClick, ...rest } = item;
 
       const onClickHandler = panel
         ? (event: React.MouseEvent) => {
@@ -351,8 +342,6 @@ export class EuiContextMenuClass extends Component<
           icon={icon}
           onClick={onClickHandler}
           hasPanel={Boolean(panel)}
-          toolTipTitle={toolTipTitle}
-          toolTipContent={toolTipContent}
           {...rest}
         >
           {name}

--- a/src/components/context_menu/context_menu_item.test.tsx
+++ b/src/components/context_menu/context_menu_item.test.tsx
@@ -138,8 +138,6 @@ describe('EuiContextMenuItem', () => {
     const { getByRole, baseElement } = render(
       <EuiContextMenuItem
         toolTipContent="tooltip content"
-        toolTipTitle="overridden"
-        // Should override the deprecated props
         toolTipProps={{ title: 'Test', position: 'top', delay: 'long' }}
       >
         Hello

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -26,7 +26,7 @@ import {
 import { validateHref } from '../../services/security/href_validator';
 import { CommonProps, keysOf } from '../common';
 import { EuiIcon } from '../icon';
-import { EuiToolTip, EuiToolTipProps, ToolTipPositions } from '../tool_tip';
+import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 
 import { euiContextMenuItemStyles } from './context_menu_item.styles';
 
@@ -53,14 +53,6 @@ export interface EuiContextMenuItemProps
    * Accepts any prop that EuiToolTip does, except for `content` and `children`.
    */
   toolTipProps?: Partial<Omit<EuiToolTipProps, 'content' | 'children'>>;
-  /**
-   * @deprecated Use toolTipProps.title instead
-   */
-  toolTipTitle?: ReactNode;
-  /**
-   * @deprecated Use tooltipProps.position instead
-   */
-  toolTipPosition?: ToolTipPositions;
   href?: string;
   target?: string;
   rel?: string;
@@ -99,9 +91,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
   buttonRef,
   disabled: _disabled,
   layoutAlign = 'center',
-  toolTipTitle,
   toolTipContent,
-  toolTipPosition = 'right',
   toolTipProps,
   href,
   target,
@@ -215,8 +205,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
     );
     return (
       <EuiToolTip
-        title={toolTipTitle ? toolTipTitle : null}
-        position={toolTipPosition}
+        position="right"
         {...toolTipProps}
         anchorClassName={anchorClasses}
         content={toolTipContent}


### PR DESCRIPTION
## Summary

See https://github.com/elastic/eui/pull/7373 and our [deprecation schedule](https://github.com/elastic/eui/issues/1469).

Consumers should use `toolTipProps.title` and `toolTipProps.position` instead.

## QA

### General checklist

- Browser QA - N/A
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A