### PR TITLE
[EuiTextTruncate] Fix timeout clean-up when component unmounts

### DIFF
--- a/changelogs/upcoming/7495.md
+++ b/changelogs/upcoming/7495.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiTextTruncate` component to clean up timer from side effect on unmount

--- a/src/components/text_truncate/text_truncate.test.tsx
+++ b/src/components/text_truncate/text_truncate.test.tsx
@@ -38,18 +38,38 @@ describe('EuiTextTruncate', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('allows delaying truncation calculation by `calculationDelayMs`', () => {
-    jest.useFakeTimers();
+  describe('calculationDelayMs', () => {
+    beforeAll(jest.useFakeTimers);
+    afterAll(jest.useRealTimers);
 
-    const { queryByTestSubject } = render(
-      <EuiTextTruncate {...props} width={0} calculationDelayMs={50} />
-    );
-    expect(queryByTestSubject('truncatedText')).not.toBeInTheDocument();
+    it('allows delaying truncation calculation by the specified duration', () => {
+      const { queryByTestSubject } = render(
+        <EuiTextTruncate {...props} width={0} calculationDelayMs={50} />
+      );
+      expect(queryByTestSubject('truncatedText')).not.toBeInTheDocument();
 
-    act(() => jest.advanceTimersByTime(50));
-    expect(queryByTestSubject('truncatedText')).toBeInTheDocument();
+      act(() => jest.advanceTimersByTime(50));
+      expect(queryByTestSubject('truncatedText')).toBeInTheDocument();
+    });
 
-    jest.useRealTimers();
+    it('sets and clears the timeout on update or unmount', () => {
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      const { unmount, rerender } = render(
+        <EuiTextTruncate {...props} width={0} calculationDelayMs={50} />
+      );
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(0);
+
+      rerender(
+        <EuiTextTruncate {...props} width={0} calculationDelayMs={100} />
+      );
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Number));
+
+      unmount();
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(2);
+      expect(clearTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Number));
+    });
   });
 
   describe('resize observer', () => {

--- a/src/components/text_truncate/text_truncate.test.tsx
+++ b/src/components/text_truncate/text_truncate.test.tsx
@@ -70,6 +70,19 @@ describe('EuiTextTruncate', () => {
       expect(clearTimeoutSpy).toHaveBeenCalledTimes(2);
       expect(clearTimeoutSpy).toHaveBeenLastCalledWith(expect.any(Number));
     });
+
+    it('does not set or clear a timeout if a duration is not passed', () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+
+      const { unmount } = render(
+        <EuiTextTruncate {...props} width={0} calculationDelayMs={0} />
+      );
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      unmount();
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('resize observer', () => {

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -138,9 +138,14 @@ const EuiTextTruncateWithWidth: FunctionComponent<
   // If necessary, wait a tick on mount before truncating
   const [ready, setReady] = useState(!calculationDelayMs);
   useEffect(() => {
+    let timerId: NodeJS.Timeout;
     if (calculationDelayMs) {
-      setTimeout(() => setReady(true), calculationDelayMs);
+      timerId = setTimeout(() => setReady(true), calculationDelayMs);
     }
+
+    return () => {
+      clearTimeout(timerId);
+    };
   }, [calculationDelayMs]);
 
   // Handle exceptions where we need to override the passed props

--- a/src/components/text_truncate/text_truncate.tsx
+++ b/src/components/text_truncate/text_truncate.tsx
@@ -138,14 +138,10 @@ const EuiTextTruncateWithWidth: FunctionComponent<
   // If necessary, wait a tick on mount before truncating
   const [ready, setReady] = useState(!calculationDelayMs);
   useEffect(() => {
-    let timerId: NodeJS.Timeout;
     if (calculationDelayMs) {
-      timerId = setTimeout(() => setReady(true), calculationDelayMs);
+      const timerId = setTimeout(() => setReady(true), calculationDelayMs);
+      return () => clearTimeout(timerId);
     }
-
-    return () => {
-      clearTimeout(timerId);
-    };
   }, [calculationDelayMs]);
 
   // Handle exceptions where we need to override the passed props


### PR DESCRIPTION
## Summary

The component could unmount before the timeout to mark the component as `ready` is resolved and update the state.

React has a specific error for this scenario, which is occurring in one of the consuming apps:

<img width="1837" alt="unmount-error" src="https://github.com/elastic/eui/assets/34506779/a69cb336-7115-4da5-9c4b-755451aeed32">

A defensive timer clean-up on the side effect removes the error and cleans the memory the timer uses.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - ~[ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A