### PR TITLE
[EuiTourStep] `className` consistency with EuiPopover + performance/cleanups

### DIFF
--- a/changelogs/upcoming/7497.md
+++ b/changelogs/upcoming/7497.md
@@ -1,0 +1,4 @@
+**Breaking changes**
+
+- `EuiTourStep`'s `className` and `style` props now apply to the anchoring element instead of to the popover panel, to match `EuiPopover` behavior.
+  - Convert your existing usages to `panelClassName` and `panelStyle` respectively instead.

--- a/src/components/beacon/__snapshots__/beacon.test.tsx.snap
+++ b/src/components/beacon/__snapshots__/beacon.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`EuiBeacon is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-success-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -14,7 +14,7 @@ exports[`EuiBeacon props color accent is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-accent-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -23,7 +23,7 @@ exports[`EuiBeacon props color danger is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-danger-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -32,7 +32,7 @@ exports[`EuiBeacon props color primary is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-primary-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -41,7 +41,7 @@ exports[`EuiBeacon props color subdued is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-subdued-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -50,7 +50,7 @@ exports[`EuiBeacon props color success is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-success-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -59,7 +59,7 @@ exports[`EuiBeacon props color warning is rendered 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-warning-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 12px; width: 12px;"
+  style="block-size: 12px; inline-size: 12px;"
 />
 `;
 
@@ -68,6 +68,6 @@ exports[`EuiBeacon props size accepts size 1`] = `
   aria-label="aria-label"
   class="euiBeacon testClass1 testClass2 emotion-euiBeacon-success-euiTestCss"
   data-test-subj="test subject string"
-  style="height: 14px; width: 14px;"
+  style="block-size: 14px; inline-size: 14px;"
 />
 `;

--- a/src/components/beacon/beacon.tsx
+++ b/src/components/beacon/beacon.tsx
@@ -6,12 +6,14 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
 import { CommonProps } from '../common';
 import classNames from 'classnames';
 
-import { euiBeaconStyles } from './beacon.styles';
+import { logicalStyles } from '../../global_styling';
 import { useEuiTheme } from '../../services';
+
+import { euiBeaconStyles } from './beacon.styles';
 
 export const COLORS = [
   'subdued',
@@ -51,11 +53,15 @@ export const EuiBeacon: FunctionComponent<EuiBeaconProps> = ({
   const styles = euiBeaconStyles(euiTheme);
   const cssStyles = [styles.euiBeacon, styles[color]];
 
-  const beaconStyle = {
-    ...style,
-    height: size,
-    width: size,
-  };
+  const beaconStyle = useMemo(
+    () =>
+      logicalStyles({
+        ...style,
+        height: size,
+        width: size,
+      }),
+    [style, size]
+  );
 
   return (
     <div className={classes} css={cssStyles} style={beaconStyle} {...rest} />

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -1,565 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiTourStep accepts an array of buttons in the footerAction prop 1`] = `
-<div
-  class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    data-focus-lock-disabled="disabled"
-  >
+exports[`EuiTourStep renders 1`] = `
+<body>
+  <div>
     <div
-      aria-label="aria-label"
-      aria-labelledby="generated-id"
-      aria-live="assertive"
-      aria-modal="true"
-      class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour-euiTestCss"
-      data-popover-open="true"
-      data-popover-panel="true"
-      role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
+      class="euiPopover euiPopover-isOpen euiTourAnchor testClass1 testClass2 emotion-euiPopover-inline-block-euiTestCss"
+      data-test-subj="test subject string"
     >
+      <span>
+        Test
+      </span>
       <div
-        class="euiPopover__arrow emotion-euiPopoverArrow-left"
-        data-popover-arrow="left"
-        style="left: 0px; top: 10px;"
-      >
-        <div
-          class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
-          style="height: 12px; width: 12px;"
-        />
-      </div>
-      <div>
-        <div
-          style="min-width: 300px; max-width: 600px;"
-        >
-          <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
-            id="generated-id"
-          >
-            <h2
-              class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
-            >
-              A demo
-            </h2>
-          </div>
-          <div
-            class="euiTour__content"
-          >
-            You are here
-          </div>
-          <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
-          >
-            <div
-              class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
-            >
-              <div
-                class="euiFlexGroup emotion-euiFlexGroup-wrap-s-flexEnd-center-row"
-              >
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <button>
-                    Button 1
-                  </button>
-                </div>
-                <div
-                  class="euiFlexItem emotion-euiFlexItem-growZero"
-                >
-                  <button>
-                    Button 2
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-</div>
-`;
-
-exports[`EuiTourStep can be closed 1`] = `
-<div
-  class="euiPopover emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-</div>
-`;
-
-exports[`EuiTourStep can change the minWidth and maxWidth 1`] = `
-<div
-  class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    data-focus-lock-disabled="disabled"
-  >
-    <div
-      aria-label="aria-label"
-      aria-labelledby="generated-id"
-      aria-live="assertive"
-      aria-modal="true"
-      class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour-euiTestCss"
-      data-popover-open="true"
-      data-popover-panel="true"
-      role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
-    >
-      <div
-        class="euiPopover__arrow emotion-euiPopoverArrow-left"
-        data-popover-arrow="left"
-        style="left: 0px; top: 10px;"
-      >
-        <div
-          class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
-          style="height: 12px; width: 12px;"
-        />
-      </div>
-      <div>
-        <div
-          style="min-width: 240px; max-width: 420px;"
-        >
-          <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
-            id="generated-id"
-          >
-            <h2
-              class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
-            >
-              A demo
-            </h2>
-          </div>
-          <div
-            class="euiTour__content"
-          >
-            You are here
-          </div>
-          <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
-          >
-            <div
-              class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
-            >
-              <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button
-                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-text-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Close tour
-                    </span>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-</div>
-`;
-
-exports[`EuiTourStep can have subtitle 1`] = `
-<div
-  class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    data-focus-lock-disabled="disabled"
-  >
-    <div
-      aria-label="aria-label"
-      aria-labelledby="generated-id"
-      aria-live="assertive"
-      aria-modal="true"
-      class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour-euiTestCss"
-      data-popover-open="true"
-      data-popover-panel="true"
-      role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
-    >
-      <div
-        class="euiPopover__arrow emotion-euiPopoverArrow-left"
-        data-popover-arrow="left"
-        style="left: 0px; top: 10px;"
-      >
-        <div
-          class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
-          style="height: 12px; width: 12px;"
-        />
-      </div>
-      <div>
-        <div
-          style="min-width: 300px; max-width: 600px;"
-        >
-          <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
-            id="generated-id"
-          >
-            <h2
-              class="euiTitle emotion-euiTitle-xxxs-euiTourHeader__subtitle"
-            >
-              Subtitle
-            </h2>
-            <h3
-              class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
-            >
-              A demo
-            </h3>
-          </div>
-          <div
-            class="euiTour__content"
-          >
-            You are here
-          </div>
-          <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
-          >
-            <div
-              class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
-            >
-              <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button
-                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-text-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Close tour
-                    </span>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-</div>
-`;
-
-exports[`EuiTourStep can override the footer action 1`] = `
-<div
-  class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    data-focus-lock-disabled="disabled"
-  >
-    <div
-      aria-label="aria-label"
-      aria-labelledby="generated-id"
-      aria-live="assertive"
-      aria-modal="true"
-      class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour-euiTestCss"
-      data-popover-open="true"
-      data-popover-panel="true"
-      role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
-    >
-      <div
-        class="euiPopover__arrow emotion-euiPopoverArrow-left"
-        data-popover-arrow="left"
-        style="left: 0px; top: 10px;"
-      >
-        <div
-          class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
-          style="height: 12px; width: 12px;"
-        />
-      </div>
-      <div>
-        <div
-          style="min-width: 300px; max-width: 600px;"
-        >
-          <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
-            id="generated-id"
-          >
-            <h2
-              class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
-            >
-              A demo
-            </h2>
-          </div>
-          <div
-            class="euiTour__content"
-          >
-            You are here
-          </div>
-          <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
-          >
-            <div
-              class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
-            >
-              <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button>
-                  Test
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-</div>
-`;
-
-exports[`EuiTourStep can turn off the beacon 1`] = `
-<div
-  class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    data-focus-lock-disabled="disabled"
-  >
-    <div
-      aria-label="aria-label"
-      aria-labelledby="generated-id"
-      aria-live="assertive"
-      aria-modal="true"
-      class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour-euiTestCss"
-      data-popover-open="true"
-      data-popover-panel="true"
-      role="dialog"
-      style="top: -22px; left: -16px; will-change: transform, opacity; z-index: 2000;"
-    >
-      <div
-        class="euiPopover__arrow emotion-euiPopoverArrow-left"
-        data-popover-arrow="left"
-        style="left: 0px; top: 10px;"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
       />
-      <div>
-        <div
-          style="min-width: 300px; max-width: 600px;"
-        >
-          <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
-            id="generated-id"
-          >
-            <h2
-              class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
-            >
-              A demo
-            </h2>
-          </div>
-          <div
-            class="euiTour__content"
-          >
-            You are here
-          </div>
-          <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
-          >
-            <div
-              class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
-            >
-              <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
-              >
-                <button
-                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-text-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Close tour
-                    </span>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-</div>
-`;
-
-exports[`EuiTourStep is rendered 1`] = `
-<div
-  class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block"
-  data-test-subj="test subject string"
->
-  <span>
-    Test
-  </span>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-  <div
-    data-focus-lock-disabled="disabled"
-  >
-    <div
-      aria-label="aria-label"
-      aria-labelledby="generated-id"
-      aria-live="assertive"
-      aria-modal="true"
-      class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour-euiTestCss"
-      data-popover-open="true"
-      data-popover-panel="true"
-      role="dialog"
-      style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
-    >
       <div
-        class="euiPopover__arrow emotion-euiPopoverArrow-left"
-        data-popover-arrow="left"
-        style="left: 0px; top: 10px;"
+        data-focus-lock-disabled="disabled"
       >
         <div
-          class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
-          style="height: 12px; width: 12px;"
-        />
-      </div>
-      <div>
-        <div
-          style="min-width: 300px; max-width: 600px;"
+          aria-label="aria-label"
+          aria-labelledby="generated-id"
+          aria-live="assertive"
+          aria-modal="true"
+          class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel euiTour emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-left-euiTour"
+          data-popover-open="true"
+          data-popover-panel="true"
+          role="dialog"
+          style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
         >
           <div
-            class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
-            id="generated-id"
-          >
-            <h2
-              class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
-            >
-              A demo
-            </h2>
-          </div>
-          <div
-            class="euiTour__content"
-          >
-            You are here
-          </div>
-          <div
-            class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
+            class="euiPopover__arrow emotion-euiPopoverArrow-left"
+            data-popover-arrow="left"
+            style="left: 0px; top: 10px;"
           >
             <div
-              class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
+              class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
+              style="height: 12px; width: 12px;"
+            />
+          </div>
+          <div>
+            <div
+              style="min-width: 300px; max-width: 600px;"
             >
               <div
-                class="euiFlexItem emotion-euiFlexItem-growZero"
+                class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"
+                id="generated-id"
               >
-                <button
-                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-text-flush-right"
-                  type="button"
+                <h2
+                  class="euiTitle emotion-euiTitle-xxs-euiTourHeader__title"
                 >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                  A demo
+                </h2>
+              </div>
+              <div
+                class="euiTour__content"
+              >
+                You are here
+              </div>
+              <div
+                class="euiPopoverFooter euiTourFooter emotion-euiPopoverFooter-m-m-euiTourFooter"
+              >
+                <div
+                  class="euiFlexGroup emotion-euiFlexGroup-l-flexEnd-center-row"
+                >
+                  <div
+                    class="euiFlexItem emotion-euiFlexItem-growZero"
                   >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
+                    <button
+                      class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-text-flush-right"
+                      type="button"
                     >
-                      Close tour
-                    </span>
-                  </span>
-                </button>
+                      <span
+                        class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                      >
+                        <span
+                          class="eui-textTruncate euiButtonEmpty__text"
+                        >
+                          Close tour
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="-1"
+      />
     </div>
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="-1"
-  />
-</div>
+</body>
 `;

--- a/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -36,12 +36,12 @@ exports[`EuiTourStep renders 1`] = `
           >
             <div
               class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
-              style="height: 12px; width: 12px;"
+              style="block-size: 12px; inline-size: 12px;"
             />
           </div>
           <div>
             <div
-              style="min-width: 300px; max-width: 600px;"
+              style="min-inline-size: 300px; max-inline-size: 600px;"
             >
               <div
                 class="euiPopoverTitle euiTourHeader emotion-euiPopoverTitle-m-m-euiTourHeader"

--- a/src/components/tour/_tour_footer.styles.ts
+++ b/src/components/tour/_tour_footer.styles.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme, shade, tint } from '../../services';
+import { logicalCSS } from '../../global_styling';
+
+export const _tourFooterBgColor = ({ colorMode, euiTheme }: UseEuiTheme) =>
+  colorMode === 'DARK'
+    ? shade(euiTheme.colors.lightestShade, 0.45)
+    : tint(euiTheme.colors.lightestShade, 0.5);
+
+export const euiTourFooterStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+  return {
+    // Base
+    euiTourFooter: css`
+      background-color: ${_tourFooterBgColor(euiThemeContext)};
+      ${logicalCSS('border-bottom-left-radius', euiTheme.border.radius.medium)}
+      ${logicalCSS('border-bottom-right-radius', euiTheme.border.radius.medium)}
+    `,
+  };
+};

--- a/src/components/tour/_tour_footer.tsx
+++ b/src/components/tour/_tour_footer.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, useMemo, memo } from 'react';
+
+import { useEuiTheme } from '../../services';
+import { EuiI18n } from '../i18n';
+import { EuiPopoverFooter } from '../popover';
+import { EuiButtonEmpty } from '../button';
+import { EuiFlexGroup, EuiFlexItem } from '../flex';
+
+import {
+  EuiTourStepIndicator,
+  type EuiTourStepStatus,
+} from './tour_step_indicator';
+import type { EuiTourStepProps } from './tour_step';
+
+import { euiTourFooterStyles } from './_tour_footer.styles';
+
+type EuiTourFooterProps = Pick<
+  EuiTourStepProps,
+  'footerAction' | 'step' | 'stepsTotal' | 'onFinish'
+>;
+
+export const EuiTourFooter: FunctionComponent<EuiTourFooterProps> = memo(
+  ({ footerAction, step, stepsTotal, onFinish }) => {
+    const euiTheme = useEuiTheme();
+    const footerStyles = euiTourFooterStyles(euiTheme);
+
+    const customFooterAction = useMemo(() => {
+      if (!footerAction) return null;
+
+      return Array.isArray(footerAction) ? (
+        <EuiFlexGroup
+          gutterSize="s"
+          alignItems="center"
+          justifyContent="flexEnd"
+          responsive={false}
+          wrap
+        >
+          {footerAction.map((action, index) => (
+            <EuiFlexItem key={index} grow={false}>
+              {action}
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      ) : (
+        <EuiFlexItem grow={false}>{footerAction}</EuiFlexItem>
+      );
+    }, [footerAction]);
+
+    const indicators = useMemo(() => {
+      if (stepsTotal <= 1) return null;
+
+      return (
+        <EuiFlexItem grow={false}>
+          <ul className="euiTourFooter__stepList">
+            {[...Array(stepsTotal).keys()].map((_, i) => {
+              let status: EuiTourStepStatus = 'complete';
+              if (step === i + 1) {
+                status = 'active';
+              } else if (step <= i) {
+                status = 'incomplete';
+              }
+              return (
+                <EuiTourStepIndicator key={i} number={i + 1} status={status} />
+              );
+            })}
+          </ul>
+        </EuiFlexItem>
+      );
+    }, [step, stepsTotal]);
+
+    return (
+      <EuiPopoverFooter
+        css={footerStyles.euiTourFooter}
+        className="euiTourFooter"
+      >
+        <EuiFlexGroup
+          responsive={false}
+          justifyContent={stepsTotal > 1 ? 'spaceBetween' : 'flexEnd'}
+          alignItems="center"
+        >
+          {indicators}
+
+          {footerAction ? (
+            customFooterAction
+          ) : (
+            <EuiFlexItem grow={false}>
+              <EuiI18n
+                tokens={[
+                  'euiTourFooter.endTour',
+                  'euiTourFooter.skipTour',
+                  'euiTourFooter.closeTour',
+                ]}
+                defaults={['End tour', 'Skip tour', 'Close tour']}
+              >
+                {([endTour, skipTour, closeTour]: string[]) => (
+                  <EuiButtonEmpty
+                    onClick={onFinish}
+                    color="text"
+                    flush="right"
+                    size="xs"
+                  >
+                    {stepsTotal > 1
+                      ? stepsTotal === step
+                        ? endTour
+                        : skipTour
+                      : closeTour}
+                  </EuiButtonEmpty>
+                )}
+              </EuiI18n>
+            </EuiFlexItem>
+          )}
+        </EuiFlexGroup>
+      </EuiPopoverFooter>
+    );
+  }
+);
+EuiTourFooter.displayName = '_EuiTourFooter';

--- a/src/components/tour/_tour_header.styles.ts
+++ b/src/components/tour/_tour_header.styles.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+import { logicalCSS } from '../../global_styling';
+
+export const euiTourHeaderStyles = ({ euiTheme }: UseEuiTheme) => ({
+  // Base
+  euiTourHeader: css`
+    ${logicalCSS('border-bottom', 'none')}
+    /* Overriding default EuiPopoverTitle styles */
+    ${logicalCSS('margin-bottom', euiTheme.size.s)}
+  `,
+  // Elements
+  euiTourHeader__title: css`
+    /* Removes extra margin applied to sibling EuiTitle's */
+    ${logicalCSS('margin-top', 0)}
+  `,
+  euiTourHeader__subtitle: css`
+    color: ${euiTheme.colors.subduedText};
+    padding-block-end: ${euiTheme.size.xs};
+  `,
+});

--- a/src/components/tour/_tour_header.tsx
+++ b/src/components/tour/_tour_header.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, memo } from 'react';
+
+import { useEuiTheme } from '../../services';
+import { EuiPopoverTitle } from '../popover';
+import { EuiTitle } from '../title';
+
+import type { EuiTourStepProps } from './tour_step';
+
+import { euiTourHeaderStyles } from './_tour_header.styles';
+
+type EuiTourHeaderProps = { id: string } & Pick<
+  EuiTourStepProps,
+  'title' | 'subtitle'
+>;
+
+export const EuiTourHeader: FunctionComponent<EuiTourHeaderProps> = memo(
+  ({ id, title, subtitle }) => {
+    const euiTheme = useEuiTheme();
+    const headerStyles = euiTourHeaderStyles(euiTheme);
+
+    return (
+      <EuiPopoverTitle
+        css={headerStyles.euiTourHeader}
+        className="euiTourHeader"
+        id={id}
+      >
+        {subtitle && (
+          <EuiTitle css={headerStyles.euiTourHeader__subtitle} size="xxxs">
+            <h2>{subtitle}</h2>
+          </EuiTitle>
+        )}
+        <EuiTitle css={headerStyles.euiTourHeader__title} size="xxs">
+          {subtitle ? <h3>{title}</h3> : <h2>{title}</h2>}
+        </EuiTitle>
+      </EuiPopoverTitle>
+    );
+  }
+);
+EuiTourHeader.displayName = '_EuiTourHeader';

--- a/src/components/tour/tour.styles.ts
+++ b/src/components/tour/tour.styles.ts
@@ -7,30 +7,18 @@
  */
 
 import { css } from '@emotion/react';
-import {
-  UseEuiTheme,
-  shade,
-  tint,
-  COLOR_MODES_STANDARD,
-  EuiThemeColorModeStandard,
-} from '../../services';
+import { UseEuiTheme } from '../../services';
 import { logicalCSS, mathWithUnits, euiCanAnimate } from '../../global_styling';
 import { openAnimationTiming } from '../popover/popover_panel/_popover_panel.styles';
 import { popoverArrowSize } from '../popover/popover_arrow/_popover_arrow.styles';
 
-const backgroundColor = (color: string, colorMode: EuiThemeColorModeStandard) =>
-  colorMode === COLOR_MODES_STANDARD.dark
-    ? shade(color, 0.45)
-    : tint(color, 0.5);
+import { _tourFooterBgColor } from './_tour_footer.styles';
 
-export const euiTourStyles = ({ euiTheme, colorMode }: UseEuiTheme) => ({
+export const euiTourStyles = (euiThemeContext: UseEuiTheme) => ({
   // Targets EuiPopoverPanel
   euiTour: css`
     [data-popover-arrow='top']::before {
-      ${logicalCSS(
-        'border-top-color',
-        backgroundColor(euiTheme.colors.lightestShade, colorMode)
-      )}
+      ${logicalCSS('border-top-color', _tourFooterBgColor(euiThemeContext))}
     }
   `,
 });
@@ -74,33 +62,3 @@ export const euiTourBeaconStyles = ({ euiTheme }: UseEuiTheme) => {
     `,
   };
 };
-
-export const euiTourHeaderStyles = ({ euiTheme }: UseEuiTheme) => ({
-  // Base
-  euiTourHeader: css`
-    ${logicalCSS('border-bottom', 'none')}
-    /* Overriding default EuiPopoverTitle styles */
-    ${logicalCSS('margin-bottom', euiTheme.size.s)}
-  `,
-  // Elements
-  euiTourHeader__title: css`
-    /* Removes extra margin applied to sibling EuiTitle's */
-    ${logicalCSS('margin-top', 0)}
-  `,
-  euiTourHeader__subtitle: css`
-    color: ${euiTheme.colors.subduedText};
-    padding-block-end: ${euiTheme.size.xs};
-  `,
-});
-
-export const euiTourFooterStyles = ({ euiTheme, colorMode }: UseEuiTheme) => ({
-  // Base
-  euiTourFooter: css`
-    background-color: ${backgroundColor(
-      euiTheme.colors.lightestShade,
-      colorMode
-    )};
-    ${logicalCSS('border-bottom-left-radius', euiTheme.border.radius.medium)}
-    ${logicalCSS('border-bottom-right-radius', euiTheme.border.radius.medium)}
-  `,
-});

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -91,8 +91,8 @@ describe('EuiTourStep', () => {
     expect(
       container.querySelector('.euiTour__content')?.parentElement
     ).toHaveStyle({
-      'min-width': '240px',
-      'max-width': '420px',
+      'min-inline-size': '240px',
+      'max-inline-size': '420px',
     });
   });
 

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -7,7 +7,6 @@
  */
 
 import React from 'react';
-import { mount } from 'enzyme';
 import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
@@ -52,62 +51,74 @@ describe('EuiTourStep', () => {
     }
   );
 
-  test('is rendered', () => {
-    const component = mount(
+  it('renders', () => {
+    const { baseElement } = render(
       <EuiTourStep {...props} isStepOpen>
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component.render()).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
   });
 
-  test('can have subtitle', () => {
-    const component = mount(
+  it('can have subtitle', () => {
+    const { getByText } = render(
       <EuiTourStep {...props} isStepOpen subtitle="Subtitle">
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component.render()).toMatchSnapshot();
+    expect(getByText('Subtitle')).toBeInTheDocument();
   });
 
-  test('can be closed', () => {
-    const component = mount(
+  it('can be closed', () => {
+    const { container } = render(
       <EuiTourStep {...props} isStepOpen={false}>
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component.render()).toMatchSnapshot();
+    expect(container.querySelector('.euiTour')).not.toBeInTheDocument();
   });
 
-  test('can change the minWidth and maxWidth', () => {
-    const component = mount(
+  it('can change the minWidth and maxWidth', () => {
+    const { container } = render(
       <EuiTourStep {...props} minWidth={240} maxWidth={420} isStepOpen>
         <span>Test</span>
       </EuiTourStep>
     );
 
-    expect(component.render()).toMatchSnapshot();
+    expect(
+      container.querySelector('.euiTour__content')?.parentElement
+    ).toHaveStyle({
+      'min-width': '240px',
+      'max-width': '420px',
+    });
   });
 
-  test('can override the footer action', () => {
-    const component = mount(
+  it('can override the footer action', () => {
+    const { queryByText, rerender } = render(
+      <EuiTourStep {...props} isStepOpen>
+        <span>Test</span>
+      </EuiTourStep>
+    );
+    expect(queryByText('Close tour')).toBeInTheDocument();
+
+    rerender(
       <EuiTourStep
         {...props}
         isStepOpen
-        footerAction={<button onClick={() => {}}>Test</button>}
+        footerAction={<button onClick={() => {}}>Custom footer</button>}
       >
         <span>Test</span>
       </EuiTourStep>
     );
-
-    expect(component.render()).toMatchSnapshot();
+    expect(queryByText('Close tour')).not.toBeInTheDocument();
+    expect(queryByText('Custom footer')).toBeInTheDocument();
   });
 
-  test('accepts an array of buttons in the footerAction prop', () => {
-    const component = mount(
+  it('accepts an array of buttons in the footerAction prop', () => {
+    const { getByText } = render(
       <EuiTourStep
         {...props}
         isStepOpen
@@ -120,20 +131,27 @@ describe('EuiTourStep', () => {
       </EuiTourStep>
     );
 
-    expect(component.render()).toMatchSnapshot();
+    expect(getByText('Button 1')).toBeInTheDocument();
+    expect(getByText('Button 2')).toBeInTheDocument();
   });
 
-  test('can turn off the beacon', () => {
-    const component = mount(
+  it('can turn off the beacon', () => {
+    const { container, rerender } = render(
+      <EuiTourStep {...props} isStepOpen>
+        <span>Test</span>
+      </EuiTourStep>
+    );
+    expect(container.querySelector('.euiTour__beacon')).toBeInTheDocument();
+
+    rerender(
       <EuiTourStep {...props} isStepOpen decoration="none">
         <span>Test</span>
       </EuiTourStep>
     );
-
-    expect(component.render()).toMatchSnapshot();
+    expect(container.querySelector('.euiTour__beacon')).not.toBeInTheDocument();
   });
 
-  test('applies classNames and styles to the correct locations', () => {
+  it('applies classNames and styles to the correct locations', () => {
     const TestTour = ({ isStepOpen }: { isStepOpen?: boolean }) => (
       <EuiTourStep
         {...props}

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -133,12 +133,14 @@ describe('EuiTourStep', () => {
     expect(component.render()).toMatchSnapshot();
   });
 
-  test('applies classNames to the correct locations', () => {
+  test('applies classNames and styles to the correct locations', () => {
     const TestTour = ({ isStepOpen }: { isStepOpen?: boolean }) => (
       <EuiTourStep
         {...props}
         className="goesOnAnchor"
+        style={{ color: 'blue' }}
         panelClassName="goesOnPopover"
+        panelStyle={{ color: 'red' }}
         isStepOpen={isStepOpen}
       >
         <span>Test</span>
@@ -149,8 +151,14 @@ describe('EuiTourStep', () => {
 
     expect(container.querySelector('.goesOnPopover')).not.toBeInTheDocument();
     expect(container.querySelector('.goesOnAnchor')).toBeInTheDocument();
+    expect(container.querySelector('.goesOnAnchor')).toHaveStyle({
+      color: 'blue',
+    });
 
     rerender(<TestTour isStepOpen />);
     expect(container.querySelector('.goesOnPopover')).toBeInTheDocument();
+    expect(container.querySelector('.goesOnPopover')).toHaveStyle({
+      color: 'red',
+    });
   });
 });

--- a/src/components/tour/tour_step.test.tsx
+++ b/src/components/tour/tour_step.test.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -130,5 +131,26 @@ describe('EuiTourStep', () => {
     );
 
     expect(component.render()).toMatchSnapshot();
+  });
+
+  test('applies classNames to the correct locations', () => {
+    const TestTour = ({ isStepOpen }: { isStepOpen?: boolean }) => (
+      <EuiTourStep
+        {...props}
+        className="goesOnAnchor"
+        panelClassName="goesOnPopover"
+        isStepOpen={isStepOpen}
+      >
+        <span>Test</span>
+      </EuiTourStep>
+    );
+
+    const { container, rerender } = render(<TestTour />);
+
+    expect(container.querySelector('.goesOnPopover')).not.toBeInTheDocument();
+    expect(container.querySelector('.goesOnAnchor')).toBeInTheDocument();
+
+    rerender(<TestTour isStepOpen />);
+    expect(container.querySelector('.goesOnPopover')).toBeInTheDocument();
   });
 });

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -8,6 +8,7 @@
 
 import React, {
   CSSProperties,
+  HTMLAttributes,
   FunctionComponent,
   ReactElement,
   ReactNode,
@@ -47,9 +48,11 @@ import {
   euiTourHeaderStyles,
 } from './tour.styles';
 
-type PopoverOverrides = 'button' | 'closePopover';
-
-type EuiPopoverPartials = Partial<Pick<EuiPopoverProps, 'closePopover'>>;
+type _EuiPopoverProps = EuiPopoverProps & HTMLAttributes<HTMLDivElement>;
+type _PopoverOverrides = 'button' | 'closePopover';
+type _PopoverPartials = 'closePopover';
+type ExtendedEuiPopoverProps = Omit<_EuiPopoverProps, _PopoverOverrides> &
+  Partial<Pick<EuiPopoverProps, _PopoverPartials>>;
 
 export type EuiTourStepAnchorProps = ExclusiveUnion<
   {
@@ -69,8 +72,7 @@ export type EuiTourStepAnchorProps = ExclusiveUnion<
 >;
 
 export type EuiTourStepProps = CommonProps &
-  Omit<EuiPopoverProps, PopoverOverrides> &
-  EuiPopoverPartials &
+  ExtendedEuiPopoverProps &
   EuiTourStepAnchorProps & {
     /**
      * Contents of the tour step popover
@@ -108,11 +110,6 @@ export type EuiTourStepProps = CommonProps &
     stepsTotal: number;
 
     /**
-     * Optional, standard DOM `style` attribute. Passed to the EuiPopover panel.
-     */
-    style?: CSSProperties;
-
-    /**
      * Smaller title text that appears atop each step in the tour. The subtitle gets wrapped in the appropriate heading level.
      */
     subtitle?: ReactNode;
@@ -148,7 +145,6 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   onFinish,
   step = 1,
   stepsTotal,
-  style,
   subtitle,
   title,
   decoration = 'beacon',
@@ -289,7 +285,6 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     isOpen: isStepOpen,
     ownFocus: false,
     panelClassName: popoverClasses,
-    panelStyle: style,
     panelProps: {
       ...panelProps,
       css: [tourStyles.euiTour, css, panelProps?.css],

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -37,7 +37,8 @@ import { EuiTourHeader } from './_tour_header';
 import { EuiTourFooter } from './_tour_footer';
 import { euiTourStyles, euiTourBeaconStyles } from './tour.styles';
 
-type _EuiPopoverProps = EuiPopoverProps & HTMLAttributes<HTMLDivElement>;
+type _EuiPopoverProps = EuiPopoverProps &
+  Omit<HTMLAttributes<HTMLDivElement>, 'content' | 'title' | 'step'>;
 type _PopoverOverrides = 'button' | 'closePopover';
 type _PopoverPartials = 'closePopover';
 type ExtendedEuiPopoverProps = Omit<_EuiPopoverProps, _PopoverOverrides> &

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -14,9 +14,11 @@ import React, {
   ReactNode,
   useEffect,
   useState,
+  useMemo,
 } from 'react';
 import classNames from 'classnames';
 
+import { logicalStyles } from '../../global_styling';
 import { CommonProps, ExclusiveUnion, NoArgCallback } from '../common';
 
 import { EuiBeacon } from '../beacon';
@@ -298,8 +300,13 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     ...rest,
   };
 
+  const widthStyles = useMemo(
+    () => logicalStyles({ minWidth, maxWidth }),
+    [minWidth, maxWidth]
+  );
+
   const layout = (
-    <div style={{ minWidth, maxWidth }}>
+    <div style={widthStyles}>
       <EuiPopoverTitle
         css={headerStyles.euiTourHeader}
         className="euiTourHeader"

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -15,6 +15,7 @@ import React, {
   useEffect,
   useState,
   useMemo,
+  useCallback,
 } from 'react';
 import classNames from 'classnames';
 
@@ -22,19 +23,8 @@ import { logicalStyles } from '../../global_styling';
 import { CommonProps, ExclusiveUnion, NoArgCallback } from '../common';
 
 import { EuiBeacon } from '../beacon';
-import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button';
-import { EuiFlexGroup, EuiFlexItem } from '../flex';
-import { EuiI18n } from '../i18n';
-import {
-  EuiPopover,
-  EuiPopoverFooter,
-  EuiPopoverProps,
-  EuiPopoverTitle,
-  EuiWrappingPopover,
-} from '../popover';
-import { EuiTitle } from '../title';
+import { EuiPopover, EuiPopoverProps, EuiWrappingPopover } from '../popover';
 
-import { EuiTourStepIndicator, EuiTourStepStatus } from './tour_step_indicator';
 import {
   useGeneratedHtmlId,
   findElementBySelectorOrRef,
@@ -43,12 +33,9 @@ import {
 } from '../../services';
 import { EuiPopoverPosition } from '../../services/popover';
 
-import {
-  euiTourStyles,
-  euiTourBeaconStyles,
-  euiTourFooterStyles,
-  euiTourHeaderStyles,
-} from './tour.styles';
+import { EuiTourHeader } from './_tour_header';
+import { EuiTourFooter } from './_tour_footer';
+import { euiTourStyles, euiTourBeaconStyles } from './tour.styles';
 
 type _EuiPopoverProps = EuiPopoverProps & HTMLAttributes<HTMLDivElement>;
 type _PopoverOverrides = 'button' | 'closePopover';
@@ -158,19 +145,18 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   const titleId = useGeneratedHtmlId();
   if (step === 0) {
     console.warn(
-      'EuiTourStep `step` should 1-based indexing. Please update to eliminate 0 indexes.'
+      'EuiTourStep `step` should use 1-based indexing. Please update to eliminate 0 indexes.'
     );
   }
 
   const [anchorNode, setAnchorNode] = useState<HTMLElement | null>(null);
   const [popoverPosition, setPopoverPosition] = useState<EuiPopoverPosition>();
 
-  const onPositionChange = (position: EuiPopoverPosition) => {
+  const onPositionChange = useCallback((position: EuiPopoverPosition) => {
     setPopoverPosition(position);
-  };
+  }, []);
 
   useEffect(() => {
-    let timeout: number;
     if (anchor) {
       // Wait until next tick to find anchor node in case it's not already
       // in DOM requestAnimationFrame isn't used here because we don't need to
@@ -178,22 +164,18 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
       // needs to go through a react DOM rerender which may take more than
       // 1 frame (16ms) of time.
       // TODO: It would be ideal to have some kind of intersection observer here instead
-      timeout = window.setTimeout(() => {
+      const timeout = window.setTimeout(() => {
         setAnchorNode(findElementBySelectorOrRef(anchor));
       });
-    }
 
-    return () => {
-      timeout && window.clearTimeout(timeout);
-    };
+      return () => window.clearTimeout(timeout);
+    }
   }, [anchor]);
 
   const anchorClasses = classNames('euiTourAnchor', className);
   const popoverClasses = classNames('euiTour', panelClassName);
   const euiTheme = useEuiTheme();
   const tourStyles = euiTourStyles(euiTheme);
-  const headerStyles = euiTourHeaderStyles(euiTheme);
-  const footerStyles = euiTourFooterStyles(euiTheme);
   const beaconStyles = euiTourBeaconStyles(euiTheme);
   const beaconCss = [
     beaconStyles.euiTourBeacon,
@@ -201,147 +183,48 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     popoverPosition && beaconStyles[popoverPosition],
   ];
 
-  const finishButtonProps: EuiButtonEmptyProps = {
-    color: 'text',
-    flush: 'right',
-    size: 'xs',
-  };
-
-  const optionalFooterAction: JSX.Element = Array.isArray(footerAction) ? (
-    <EuiFlexGroup
-      gutterSize="s"
-      alignItems="center"
-      justifyContent="flexEnd"
-      responsive={false}
-      wrap
-    >
-      {footerAction.map((action, index) => (
-        <EuiFlexItem key={index} grow={false}>
-          {action}
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGroup>
-  ) : (
-    <EuiFlexItem grow={false}>{footerAction}</EuiFlexItem>
-  );
-
-  const footer = (
-    <EuiFlexGroup
-      responsive={false}
-      justifyContent={stepsTotal > 1 ? 'spaceBetween' : 'flexEnd'}
-      alignItems="center"
-    >
-      {stepsTotal > 1 && (
-        <EuiFlexItem grow={false}>
-          <ul className="euiTourFooter__stepList">
-            {[...Array(stepsTotal).keys()].map((_, i) => {
-              let status: EuiTourStepStatus = 'complete';
-              if (step === i + 1) {
-                status = 'active';
-              } else if (step <= i) {
-                status = 'incomplete';
-              }
-              return (
-                <EuiTourStepIndicator key={i} number={i + 1} status={status} />
-              );
-            })}
-          </ul>
-        </EuiFlexItem>
-      )}
-
-      {footerAction ? (
-        optionalFooterAction
-      ) : (
-        <EuiFlexItem grow={false}>
-          <EuiI18n
-            tokens={[
-              'euiTourStep.endTour',
-              'euiTourStep.skipTour',
-              'euiTourStep.closeTour',
-            ]}
-            defaults={['End tour', 'Skip tour', 'Close tour']}
-          >
-            {([endTour, skipTour, closeTour]: string[]) => {
-              let content = closeTour;
-              if (stepsTotal > 1) {
-                content = stepsTotal === step ? endTour : skipTour;
-              }
-              return (
-                <EuiButtonEmpty onClick={onFinish} {...finishButtonProps}>
-                  {content}
-                </EuiButtonEmpty>
-              );
-            }}
-          </EuiI18n>
-        </EuiFlexItem>
-      )}
-    </EuiFlexGroup>
-  );
-
   const hasBeacon = decoration === 'beacon';
-
-  const popoverProps = {
-    className: anchorClasses,
-    anchorPosition: anchorPosition,
-    closePopover: closePopover,
-    isOpen: isStepOpen,
-    ownFocus: false,
-    panelClassName: popoverClasses,
-    panelProps: {
-      ...panelProps,
-      css: [tourStyles.euiTour, css, panelProps?.css],
-    },
-    offset: hasBeacon ? 10 : 0,
-    'aria-labelledby': titleId,
-    arrowChildren: hasBeacon && (
-      <EuiBeacon css={beaconCss} className="euiTour__beacon" />
-    ),
-    onPositionChange,
-    ...rest,
-  };
 
   const widthStyles = useMemo(
     () => logicalStyles({ minWidth, maxWidth }),
     [minWidth, maxWidth]
   );
 
-  const layout = (
-    <div style={widthStyles}>
-      <EuiPopoverTitle
-        css={headerStyles.euiTourHeader}
-        className="euiTourHeader"
-        id={titleId}
-      >
-        {subtitle && (
-          <EuiTitle css={headerStyles.euiTourHeader__subtitle} size="xxxs">
-            <h2>{subtitle}</h2>
-          </EuiTitle>
-        )}
-        <EuiTitle css={headerStyles.euiTourHeader__title} size="xxs">
-          {subtitle ? <h3>{title}</h3> : <h2>{title}</h2>}
-        </EuiTitle>
-      </EuiPopoverTitle>
-      <div className="euiTour__content">{content}</div>
-      <EuiPopoverFooter
-        css={footerStyles.euiTourFooter}
-        className="euiTourFooter"
-      >
-        {footer}
-      </EuiPopoverFooter>
-    </div>
-  );
+  const noAnchor = !anchor && children;
+  const PopoverComponent = noAnchor ? EuiPopover : EuiWrappingPopover;
+  const button = noAnchor ? children : anchorNode;
 
-  if (!anchor && children) {
-    return (
-      <EuiPopover button={children} {...popoverProps}>
-        {layout}
-      </EuiPopover>
-    );
-  }
-
-  return anchorNode ? (
-    <EuiWrappingPopover button={anchorNode} {...popoverProps}>
-      {layout}
-    </EuiWrappingPopover>
+  return button ? (
+    <PopoverComponent
+      button={button as HTMLElement & ReactNode}
+      className={anchorClasses}
+      anchorPosition={anchorPosition}
+      closePopover={closePopover}
+      isOpen={isStepOpen}
+      ownFocus={false}
+      panelClassName={popoverClasses}
+      panelProps={{
+        ...panelProps,
+        css: [tourStyles.euiTour, css, panelProps?.css],
+      }}
+      offset={hasBeacon ? 10 : 0}
+      aria-labelledby={titleId}
+      arrowChildren={
+        hasBeacon && <EuiBeacon css={beaconCss} className="euiTour__beacon" />
+      }
+      onPositionChange={onPositionChange}
+      {...rest}
+    >
+      <div style={widthStyles}>
+        <EuiTourHeader id={titleId} title={title} subtitle={subtitle} />
+        <div className="euiTour__content">{content}</div>
+        <EuiTourFooter
+          footerAction={footerAction}
+          step={step}
+          stepsTotal={stepsTotal}
+          onFinish={onFinish}
+        />
+      </div>
+    </PopoverComponent>
   ) : null;
 };

--- a/src/components/tour/tour_step.tsx
+++ b/src/components/tour/tour_step.tsx
@@ -154,6 +154,7 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   decoration = 'beacon',
   footerAction,
   panelProps,
+  panelClassName,
   ...rest
 }) => {
   const titleId = useGeneratedHtmlId();
@@ -189,7 +190,8 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
     };
   }, [anchor]);
 
-  const classes = classNames('euiTour', className);
+  const anchorClasses = classNames('euiTourAnchor', className);
+  const popoverClasses = classNames('euiTour', panelClassName);
   const euiTheme = useEuiTheme();
   const tourStyles = euiTourStyles(euiTheme);
   const headerStyles = euiTourHeaderStyles(euiTheme);
@@ -281,11 +283,12 @@ export const EuiTourStep: FunctionComponent<EuiTourStepProps> = ({
   const hasBeacon = decoration === 'beacon';
 
   const popoverProps = {
+    className: anchorClasses,
     anchorPosition: anchorPosition,
     closePopover: closePopover,
     isOpen: isStepOpen,
     ownFocus: false,
-    panelClassName: classes,
+    panelClassName: popoverClasses,
     panelStyle: style,
     panelProps: {
       ...panelProps,


### PR DESCRIPTION
## Summary

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7497/commits)!

### Breaking prop<->DOM changes

- Applies EuiTourStep `className`s to the anchor element instead of to the popover panel
  - This change was made to be consistent with `EuiPopover` behavior (consumers cannot otherwise apply styles to the anchor since we deprecated the  `anchorClassName` prop).
  - Existing usages should be converted to `panelClassName` instead
- Applies EuiTourStep's `style` prop to the anchor element instead of to the popover panel
  - Also for popover consistency. Existing usages should be converted to `panelStyle` instead.
  - See also https://github.com/elastic/eui/pull/5897#discussion_r873837342 for previous discussion/confusion about this prop

### Tech debt

- Converts all Enzyme tests for EuiTourStep to RTL and switches snapshots to assertions
- Converts several inline CSS styles to their logical property equivalents
- Refactors code heavily for performance; adds missing memoization and breaks out several conditional inline JSX to `React.memo`'d subcomponents which optimizes/reduces rerenders.
  - Additionally, smaller subcomponents makes it easier to reason about individual bits of code/logic.

## QA

- [x] https://eui.elastic.co/pr_7497/#/display/tour - confirm **no** regressions in UI or UX compared to [production](https://eui.elastic.co/#/display/tour)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile** - _Note: appears to be somewhat buggy already in prod_
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes**~ - _EuiTour does not appear to be inherently accessible in production_
- Docs site QA - N/A - refactor
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A