### PR TITLE
[EuiSuperDatePicker] Allow passing `canRoundRelativeUnits={false}`, which turns off relative unit rounding

### DIFF
--- a/changelogs/upcoming/7502.md
+++ b/changelogs/upcoming/7502.md
@@ -1,0 +1,1 @@
+- Updated `EuiSuperDatePicker` with a new `preferLargerRelativeUnits` prop, which defaults to true (current behavior). To preserve displaying the unit that users select, set this to false.

--- a/changelogs/upcoming/7502.md
+++ b/changelogs/upcoming/7502.md
@@ -1,1 +1,1 @@
-- Updated `EuiSuperDatePicker` with a new `preferLargerRelativeUnits` prop, which defaults to true (current behavior). To preserve displaying the unit that users select, set this to false.
+- Updated `EuiSuperDatePicker` with a new `canRoundRelativeUnits` prop, which defaults to true (current behavior). To preserve displaying the unit that users select for relative time, set this to false.

--- a/src-docs/src/views/super_date_picker/playground.js
+++ b/src-docs/src/views/super_date_picker/playground.js
@@ -32,6 +32,13 @@ export const superDatePickerConfig = () => {
     value: true,
   };
 
+  propsToUse.preferLargerRelativeUnits = {
+    ...propsToUse.preferLargerRelativeUnits,
+    type: PropTypes.Boolean,
+    defaultValue: true,
+    value: true,
+  };
+
   propsToUse.locale = {
     ...propsToUse.locale,
     type: PropTypes.String,

--- a/src-docs/src/views/super_date_picker/playground.js
+++ b/src-docs/src/views/super_date_picker/playground.js
@@ -32,8 +32,8 @@ export const superDatePickerConfig = () => {
     value: true,
   };
 
-  propsToUse.preferLargerRelativeUnits = {
-    ...propsToUse.preferLargerRelativeUnits,
+  propsToUse.canRoundRelativeUnits = {
+    ...propsToUse.canRoundRelativeUnits,
     type: PropTypes.Boolean,
     defaultValue: true,
     value: true,

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
@@ -84,12 +84,11 @@ export const EuiDatePopoverButton: FunctionComponent<
     },
   ]);
 
-  const formattedValue = useFormatTimeString(
-    value,
-    dateFormat,
+  const formattedValue = useFormatTimeString(value, dateFormat, {
     roundUp,
-    locale
-  );
+    locale,
+    preferLargerRelativeUnits,
+  });
   let title = formattedValue;
 
   const invalidTitle = useEuiI18n(

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
@@ -38,7 +38,7 @@ export interface EuiDatePopoverButtonProps {
   onPopoverClose: EuiPopoverProps['closePopover'];
   onPopoverToggle: MouseEventHandler<HTMLButtonElement>;
   position: 'start' | 'end';
-  preferLargerRelativeUnits?: boolean;
+  canRoundRelativeUnits?: boolean;
   roundUp?: boolean;
   timeFormat: string;
   value: string;
@@ -57,7 +57,7 @@ export const EuiDatePopoverButton: FunctionComponent<
     needsUpdating,
     value,
     buttonProps,
-    preferLargerRelativeUnits,
+    canRoundRelativeUnits,
     roundUp,
     onChange,
     locale,
@@ -87,7 +87,7 @@ export const EuiDatePopoverButton: FunctionComponent<
   const formattedValue = useFormatTimeString(value, dateFormat, {
     roundUp,
     locale,
-    preferLargerRelativeUnits,
+    canRoundRelativeUnits,
   });
   let title = formattedValue;
 
@@ -134,7 +134,7 @@ export const EuiDatePopoverButton: FunctionComponent<
       <EuiDatePopoverContent
         value={value}
         roundUp={roundUp}
-        preferLargerRelativeUnits={preferLargerRelativeUnits}
+        canRoundRelativeUnits={canRoundRelativeUnits}
         onChange={onChange}
         dateFormat={dateFormat}
         timeFormat={timeFormat}

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_button.tsx
@@ -38,6 +38,7 @@ export interface EuiDatePopoverButtonProps {
   onPopoverClose: EuiPopoverProps['closePopover'];
   onPopoverToggle: MouseEventHandler<HTMLButtonElement>;
   position: 'start' | 'end';
+  preferLargerRelativeUnits?: boolean;
   roundUp?: boolean;
   timeFormat: string;
   value: string;
@@ -56,6 +57,7 @@ export const EuiDatePopoverButton: FunctionComponent<
     needsUpdating,
     value,
     buttonProps,
+    preferLargerRelativeUnits,
     roundUp,
     onChange,
     locale,
@@ -133,6 +135,7 @@ export const EuiDatePopoverButton: FunctionComponent<
       <EuiDatePopoverContent
         value={value}
         roundUp={roundUp}
+        preferLargerRelativeUnits={preferLargerRelativeUnits}
         onChange={onChange}
         dateFormat={dateFormat}
         timeFormat={timeFormat}

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.tsx
@@ -28,6 +28,7 @@ import { LocaleSpecifier } from 'moment'; // eslint-disable-line import/named
 export interface EuiDatePopoverContentProps {
   value: string;
   onChange: (date: string) => void;
+  preferLargerRelativeUnits?: boolean;
   roundUp?: boolean;
   dateFormat: string;
   timeFormat: string;
@@ -41,6 +42,7 @@ export const EuiDatePopoverContent: FunctionComponent<
   EuiDatePopoverContentProps
 > = ({
   value,
+  preferLargerRelativeUnits = true,
   roundUp = false,
   onChange,
   dateFormat,
@@ -108,7 +110,9 @@ export const EuiDatePopoverContent: FunctionComponent<
         <EuiRelativeTab
           dateFormat={dateFormat}
           locale={locale}
-          value={toAbsoluteString(value, roundUp)}
+          value={
+            preferLargerRelativeUnits ? toAbsoluteString(value, roundUp) : value
+          }
           onChange={onChange}
           roundUp={roundUp}
           position={position}

--- a/src/components/date_picker/super_date_picker/date_popover/date_popover_content.tsx
+++ b/src/components/date_picker/super_date_picker/date_popover/date_popover_content.tsx
@@ -28,7 +28,7 @@ import { LocaleSpecifier } from 'moment'; // eslint-disable-line import/named
 export interface EuiDatePopoverContentProps {
   value: string;
   onChange: (date: string) => void;
-  preferLargerRelativeUnits?: boolean;
+  canRoundRelativeUnits?: boolean;
   roundUp?: boolean;
   dateFormat: string;
   timeFormat: string;
@@ -42,7 +42,7 @@ export const EuiDatePopoverContent: FunctionComponent<
   EuiDatePopoverContentProps
 > = ({
   value,
-  preferLargerRelativeUnits = true,
+  canRoundRelativeUnits = true,
   roundUp = false,
   onChange,
   dateFormat,
@@ -111,7 +111,7 @@ export const EuiDatePopoverContent: FunctionComponent<
           dateFormat={dateFormat}
           locale={locale}
           value={
-            preferLargerRelativeUnits ? toAbsoluteString(value, roundUp) : value
+            canRoundRelativeUnits ? toAbsoluteString(value, roundUp) : value
           }
           onChange={onChange}
           roundUp={roundUp}

--- a/src/components/date_picker/super_date_picker/pretty_duration.test.tsx
+++ b/src/components/date_picker/super_date_picker/pretty_duration.test.tsx
@@ -154,8 +154,8 @@ describe('useFormatTimeString', () => {
       ).toBe('~ 15分後');
     });
 
-    describe('preferLargerRelativeUnits', () => {
-      const option = { preferLargerRelativeUnits: false };
+    describe('canRoundRelativeUnits', () => {
+      const option = { canRoundRelativeUnits: false };
 
       it("allows skipping moment.fromNow()'s default rounding", () => {
         expect(

--- a/src/components/date_picker/super_date_picker/pretty_duration.test.tsx
+++ b/src/components/date_picker/super_date_picker/pretty_duration.test.tsx
@@ -13,6 +13,7 @@ import {
   usePrettyDuration,
   PrettyDuration,
   showPrettyDuration,
+  useFormatTimeString,
 } from './pretty_duration';
 
 const dateFormat = 'MMMM Do YYYY, HH:mm:ss.SSS';
@@ -121,5 +122,55 @@ describe('showPrettyDuration', () => {
     expect(
       showPrettyDuration('2018-01-17T18:57:57.149Z', 'now', quickRanges)
     ).toBe(false);
+  });
+});
+
+describe('useFormatTimeString', () => {
+  it('it takes a time string and formats it into a humanized date', () => {
+    expect(
+      renderHook(() => useFormatTimeString('now-3s', dateFormat)).result.current
+    ).toEqual('~ a few seconds ago');
+    expect(
+      renderHook(() => useFormatTimeString('now+1m', dateFormat)).result.current
+    ).toEqual('~ in a minute');
+    expect(
+      renderHook(() => useFormatTimeString('now+100w', dateFormat)).result
+        .current
+    ).toEqual('~ in 2 years');
+  });
+
+  it("always parses the 'now' string as-is", () => {
+    expect(
+      renderHook(() => useFormatTimeString('now', dateFormat)).result.current
+    ).toEqual('now');
+  });
+
+  describe('options', () => {
+    test('locale', () => {
+      expect(
+        renderHook(() =>
+          useFormatTimeString('now+15m', dateFormat, { locale: 'ja' })
+        ).result.current
+      ).toBe('~ 15分後');
+    });
+
+    describe('preferLargerRelativeUnits', () => {
+      const option = { preferLargerRelativeUnits: false };
+
+      it("allows skipping moment.fromNow()'s default rounding", () => {
+        expect(
+          renderHook(() => useFormatTimeString('now-3s', dateFormat, option))
+            .result.current
+        ).toEqual('3 seconds ago');
+        expect(
+          renderHook(() => useFormatTimeString('now+1m', dateFormat, option))
+            .result.current
+        ).toEqual('in a minute');
+        expect(
+          renderHook(() => useFormatTimeString('now+100w', dateFormat, option))
+            .result.current
+        ).toEqual('in 100 weeks');
+      });
+    });
   });
 });

--- a/src/components/date_picker/super_date_picker/pretty_duration.tsx
+++ b/src/components/date_picker/super_date_picker/pretty_duration.tsx
@@ -149,13 +149,13 @@ export const useFormatTimeString = (
   options?: {
     locale?: LocaleSpecifier;
     roundUp?: boolean;
-    preferLargerRelativeUnits?: boolean;
+    canRoundRelativeUnits?: boolean;
   }
 ): string => {
   const {
     locale = 'en',
     roundUp = false,
-    preferLargerRelativeUnits = true,
+    canRoundRelativeUnits = true,
   } = options || {};
 
   // i18n'd strings
@@ -180,7 +180,7 @@ export const useFormatTimeString = (
   }
 
   if (moment.isMoment(tryParse)) {
-    if (preferLargerRelativeUnits) {
+    if (canRoundRelativeUnits) {
       return `~ ${tryParse.locale(locale).fromNow()}`;
     } else {
       // To force a specific unit to be used, we need to skip moment.fromNow()

--- a/src/components/date_picker/super_date_picker/pretty_duration.tsx
+++ b/src/components/date_picker/super_date_picker/pretty_duration.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import dateMath from '@elastic/datemath';
-import moment, { LocaleSpecifier } from 'moment'; // eslint-disable-line import/named
+import moment, { LocaleSpecifier, RelativeTimeKey } from 'moment'; // eslint-disable-line import/named
 import { useEuiI18n } from '../../i18n';
 import { getDateMode, DATE_MODES } from './date_modes';
 import { parseRelativeParts } from './relative_utils';
@@ -146,9 +146,18 @@ const ISO_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 export const useFormatTimeString = (
   timeString: string,
   dateFormat: string,
-  roundUp = false,
-  locale: LocaleSpecifier = 'en'
+  options?: {
+    locale?: LocaleSpecifier;
+    roundUp?: boolean;
+    preferLargerRelativeUnits?: boolean;
+  }
 ): string => {
+  const {
+    locale = 'en',
+    roundUp = false,
+    preferLargerRelativeUnits = true,
+  } = options || {};
+
   // i18n'd strings
   const nowDisplay = useEuiI18n('euiPrettyDuration.now', 'now');
   const invalidDateDisplay = useEuiI18n(
@@ -171,7 +180,27 @@ export const useFormatTimeString = (
   }
 
   if (moment.isMoment(tryParse)) {
-    return `~ ${tryParse.locale(locale).fromNow()}`;
+    if (preferLargerRelativeUnits) {
+      return `~ ${tryParse.locale(locale).fromNow()}`;
+    } else {
+      // To force a specific unit to be used, we need to skip moment.fromNow()
+      // entirely and write our own custom moment formatted output.
+      const { count, unit: _unit } = parseRelativeParts(timeString);
+      const isFuture = _unit.endsWith('+');
+      const unit = isFuture ? _unit.slice(0, -1) : _unit; // We want just the unit letter without the trailing +
+
+      // @see https://momentjs.com/docs/#/customization/relative-time/
+      const relativeUnitKey = (
+        count === 1 ? unit : unit + unit
+      ) as RelativeTimeKey;
+
+      // @see https://momentjs.com/docs/#/i18n/locale-data/
+      return moment.localeData().pastFuture(
+        isFuture ? count : count * -1,
+        moment.localeData().relativeTime(count, false, relativeUnitKey, false)
+        // Booleans don't seem to actually matter for output, .pastFuture() handles that
+      );
+    }
   }
 
   return timeString;
@@ -246,7 +275,7 @@ export const usePrettyDuration = ({
    * If it's none of the above, display basic fallback copy
    */
   const displayFrom = useFormatTimeString(timeFrom, dateFormat);
-  const displayTo = useFormatTimeString(timeTo, dateFormat, true);
+  const displayTo = useFormatTimeString(timeTo, dateFormat, { roundUp: true });
   const fallbackDuration = useEuiI18n(
     'euiPrettyDuration.fallbackDuration',
     '{displayFrom} to {displayTo}',

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -32,6 +32,12 @@ const findInternalInstance = (
 };
 
 describe('EuiSuperDatePicker', () => {
+  // RTL doesn't automatically clean up portals/datepicker popovers between tests
+  afterEach(() => {
+    const portals = document.querySelectorAll('[data-euiportal]');
+    portals.forEach((portal) => portal.parentNode?.removeChild(portal));
+  });
+
   shouldRenderCustomStyles(<EuiSuperDatePicker onTimeChange={noop} />, {
     skip: { style: true },
   });
@@ -311,6 +317,60 @@ describe('EuiSuperDatePicker', () => {
           />
         );
         expect(container.firstChild).toMatchSnapshot();
+      });
+    });
+
+    describe('preferLargerRelativeUnits', () => {
+      const props = {
+        onTimeChange: noop,
+        start: 'now-300m',
+        end: 'now',
+      };
+
+      it('defaults to true, which will round relative units up to the next largest unit', () => {
+        const { getByTestSubject } = render(
+          <EuiSuperDatePicker {...props} preferLargerRelativeUnits={true} />
+        );
+        fireEvent.click(getByTestSubject('superDatePickerShowDatesButton'));
+
+        const startButton = getByTestSubject(
+          'superDatePickerstartDatePopoverButton'
+        );
+        expect(startButton).toHaveTextContent('~ 5 hours ago');
+
+        const countInput = getByTestSubject(
+          'superDatePickerRelativeDateInputNumber'
+        );
+        expect(countInput).toHaveValue(5);
+
+        const unitSelect = getByTestSubject(
+          'superDatePickerRelativeDateInputUnitSelector'
+        );
+        expect(unitSelect).toHaveValue('h');
+
+        fireEvent.change(countInput, { target: { value: 300 } });
+        fireEvent.change(unitSelect, { target: { value: 'd' } });
+        expect(startButton).toHaveTextContent('~ 10 months ago');
+      });
+
+      it('when false, allows preserving the unit set in the start/end time timestamp', () => {
+        const { getByTestSubject } = render(
+          <EuiSuperDatePicker {...props} preferLargerRelativeUnits={false} />
+        );
+        fireEvent.click(getByTestSubject('superDatePickerShowDatesButton'));
+
+        const startButton = getByTestSubject(
+          'superDatePickerstartDatePopoverButton'
+        );
+        expect(startButton).toHaveTextContent('300 minutes ago');
+
+        const unitSelect = getByTestSubject(
+          'superDatePickerRelativeDateInputUnitSelector'
+        );
+        expect(unitSelect).toHaveValue('m');
+
+        fireEvent.change(unitSelect, { target: { value: 'd' } });
+        expect(startButton).toHaveTextContent('300 days ago');
       });
     });
   });

--- a/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -320,7 +320,7 @@ describe('EuiSuperDatePicker', () => {
       });
     });
 
-    describe('preferLargerRelativeUnits', () => {
+    describe('canRoundRelativeUnits', () => {
       const props = {
         onTimeChange: noop,
         start: 'now-300m',
@@ -329,7 +329,7 @@ describe('EuiSuperDatePicker', () => {
 
       it('defaults to true, which will round relative units up to the next largest unit', () => {
         const { getByTestSubject } = render(
-          <EuiSuperDatePicker {...props} preferLargerRelativeUnits={true} />
+          <EuiSuperDatePicker {...props} canRoundRelativeUnits={true} />
         );
         fireEvent.click(getByTestSubject('superDatePickerShowDatesButton'));
 
@@ -355,7 +355,7 @@ describe('EuiSuperDatePicker', () => {
 
       it('when false, allows preserving the unit set in the start/end time timestamp', () => {
         const { getByTestSubject } = render(
-          <EuiSuperDatePicker {...props} preferLargerRelativeUnits={false} />
+          <EuiSuperDatePicker {...props} canRoundRelativeUnits={false} />
         );
         fireEvent.click(getByTestSubject('superDatePickerShowDatesButton'));
 

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -187,7 +187,7 @@ export type EuiSuperDatePickerProps = CommonProps & {
    * If you do not want this behavior and instead wish to keep the exact units
    * input by the user, set this flag to `false`.
    */
-  preferLargerRelativeUnits?: boolean;
+  canRoundRelativeUnits?: boolean;
 };
 
 type EuiSuperDatePickerInternalProps = EuiSuperDatePickerProps & {
@@ -250,7 +250,7 @@ export class EuiSuperDatePickerInternal extends Component<
     recentlyUsedRanges: [],
     refreshInterval: 1000,
     showUpdateButton: true,
-    preferLargerRelativeUnits: true,
+    canRoundRelativeUnits: true,
     start: 'now-15m',
     timeFormat: 'HH:mm',
     width: 'restricted',
@@ -478,7 +478,7 @@ export class EuiSuperDatePickerInternal extends Component<
       isQuickSelectOnly,
       showUpdateButton,
       commonlyUsedRanges,
-      preferLargerRelativeUnits,
+      canRoundRelativeUnits,
       timeOptions,
       dateFormat,
       refreshInterval,
@@ -573,7 +573,7 @@ export class EuiSuperDatePickerInternal extends Component<
                 utcOffset={utcOffset}
                 timeFormat={timeFormat}
                 locale={locale || contextLocale}
-                preferLargerRelativeUnits={preferLargerRelativeUnits}
+                canRoundRelativeUnits={canRoundRelativeUnits}
                 isOpen={this.state.isStartDatePopoverOpen}
                 onPopoverToggle={this.onStartDatePopoverToggle}
                 onPopoverClose={this.onStartDatePopoverClose}
@@ -594,7 +594,7 @@ export class EuiSuperDatePickerInternal extends Component<
                 utcOffset={utcOffset}
                 timeFormat={timeFormat}
                 locale={locale || contextLocale}
-                preferLargerRelativeUnits={preferLargerRelativeUnits}
+                canRoundRelativeUnits={canRoundRelativeUnits}
                 roundUp
                 isOpen={this.state.isEndDatePopoverOpen}
                 onPopoverToggle={this.onEndDatePopoverToggle}

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -179,6 +179,15 @@ export type EuiSuperDatePickerProps = CommonProps & {
    * Props passed to the update button #EuiSuperUpdateButtonProps
    */
   updateButtonProps?: EuiSuperUpdateButtonProps;
+
+  /**
+   * By default, relative units will be rounded up to next largest unit of time
+   * (for example, 90 minutes will become ~ 2 hours).
+   *
+   * If you do not want this behavior and instead wish to keep the exact units
+   * input by the user, set this flag to `false`.
+   */
+  preferLargerRelativeUnits?: boolean;
 };
 
 type EuiSuperDatePickerInternalProps = EuiSuperDatePickerProps & {
@@ -241,6 +250,7 @@ export class EuiSuperDatePickerInternal extends Component<
     recentlyUsedRanges: [],
     refreshInterval: 1000,
     showUpdateButton: true,
+    preferLargerRelativeUnits: true,
     start: 'now-15m',
     timeFormat: 'HH:mm',
     width: 'restricted',
@@ -468,6 +478,7 @@ export class EuiSuperDatePickerInternal extends Component<
       isQuickSelectOnly,
       showUpdateButton,
       commonlyUsedRanges,
+      preferLargerRelativeUnits,
       timeOptions,
       dateFormat,
       refreshInterval,
@@ -562,6 +573,7 @@ export class EuiSuperDatePickerInternal extends Component<
                 utcOffset={utcOffset}
                 timeFormat={timeFormat}
                 locale={locale || contextLocale}
+                preferLargerRelativeUnits={preferLargerRelativeUnits}
                 isOpen={this.state.isStartDatePopoverOpen}
                 onPopoverToggle={this.onStartDatePopoverToggle}
                 onPopoverClose={this.onStartDatePopoverClose}
@@ -582,6 +594,7 @@ export class EuiSuperDatePickerInternal extends Component<
                 utcOffset={utcOffset}
                 timeFormat={timeFormat}
                 locale={locale || contextLocale}
+                preferLargerRelativeUnits={preferLargerRelativeUnits}
                 roundUp
                 isOpen={this.state.isEndDatePopoverOpen}
                 onPopoverToggle={this.onEndDatePopoverToggle}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/4026, addresses https://github.com/elastic/kibana/issues/143157

👋 I'm bad at naming things, please feel free to suggest a less wordy name for this prop if you can think of one!

💭 NOTE: If we find that users prefer this behavior as a default, we should potentially consider turning this flag on to default to `true` in the future. This will require us to track usage and user feedback over time.

### Screencaps 

| Before | After |
|--------|--------|
| <img width="568" alt="before" src="https://github.com/elastic/eui/assets/549407/15a98ff9-e1d9-4bcf-b91a-8e3122145164"> | <img width="573" alt="after" src="https://github.com/elastic/eui/assets/549407/f090dabb-de74-4ce2-8e46-a371a905216e"> |

![relative_interval](https://github.com/elastic/eui/assets/549407/b8adddec-2e09-4f2d-9a8d-a13e7ec345bb)

## QA

- Go to https://eui.elastic.co/pr_7502/#/templates/super-date-picker
- Click the `Playground` link on the page
- Find the `canRoundRelativeUnits` control and toggle it to false
- Click the playground input
- [x] Change the numeric value from `15` to `1500` and confirm that the rendered output shows `1500 minutes ago` (instead of rounding up to a day)
- [x] Change the unit to hours and confirm the rendered output shows `1500 hours ago` (instead of rounding up to months etc)
- [x] Confirm that changing to future times still renders the correct humanized phrase, e.g. "in x years"
- Find the `locale` playground toggle and change it to, e.g. `fr` or `ja`
- [x] Confirm the in the input correctly renders in the expected language

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked in multiple i18n locales
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - I don't consider this important enough to add an entire section for (vs. just testing in the playground), please LMK if you disagree!
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A