### PR TITLE
[docs] Fix Colors > Contrast docs page

### DIFF
--- a/src-docs/src/views/theme/color/_contrast_js.tsx
+++ b/src-docs/src/views/theme/color/_contrast_js.tsx
@@ -56,7 +56,12 @@ export const ColorSectionJS: FunctionComponent<ColorSection> = ({
       }}
     >
       <EuiText size="xs">
-        <EuiFlexGrid columns={2} direction="column" gutterSize="s">
+        <EuiFlexGrid
+          css={{ gridTemplateRows: 'auto', gridAutoFlow: 'row' }}
+          columns={2}
+          direction="column"
+          gutterSize="s"
+        >
           {showTextVariants && colorIsCore(colorValue) && (
             <ColorsContrastItem
               foreground={`${color}Text`}

--- a/src-docs/src/views/theme/color/_contrast_js.tsx
+++ b/src-docs/src/views/theme/color/_contrast_js.tsx
@@ -166,6 +166,8 @@ color: $\{euiTheme.colors.${foreground}};`;
               color: foregroundColor,
               borderRadius: euiTheme.border.radius.medium,
             }}
+            // @ts-expect-error - this isn't a valid color type, we mostly just want to disable the default EuiListGroupItem button color from being rendered since we're setting our own via `style`
+            color="inherit"
             label={sanitizeColorName(foreground)}
           />
         )}

--- a/src-docs/src/views/theme/color/_contrast_sass.tsx
+++ b/src-docs/src/views/theme/color/_contrast_sass.tsx
@@ -184,6 +184,8 @@ color: $${foreground};`;
               color: foregroundColor,
               borderRadius: euiTheme.border.radius.medium,
             }}
+            // @ts-expect-error - this isn't a valid color type, we mostly just want to disable the default EuiListGroupItem button color from being rendered since we're setting our own via `style`
+            color="inherit"
             label={sanitizeColorName(foreground)}
           />
         )}

--- a/src-docs/src/views/theme/color/_contrast_sass.tsx
+++ b/src-docs/src/views/theme/color/_contrast_sass.tsx
@@ -83,7 +83,12 @@ export const ColorSectionSass: FunctionComponent<ColorSection> = ({
       style={{ background: matchPanelColor ? palette[color] : undefined }}
     >
       <EuiText size="xs">
-        <EuiFlexGrid columns={2} direction="column" gutterSize="s">
+        <EuiFlexGrid
+          css={{ gridTemplateRows: 'auto', gridAutoFlow: 'row' }}
+          columns={2}
+          direction="column"
+          gutterSize="s"
+        >
           {showTextVariants && colorIsCore(color) && (
             <ColorsContrastItem
               foreground={`${color}Text`}

--- a/src-docs/src/views/theme/color/_contrast_slider.tsx
+++ b/src-docs/src/views/theme/color/_contrast_slider.tsx
@@ -21,7 +21,7 @@ import {
   ratingAll,
 } from './_contrast_utilities';
 
-type ContrastSlider = EuiFlexGroupProps & {
+type ContrastSlider = Omit<EuiFlexGroupProps, 'onChange'> & {
   contrastValue: EuiRangeProps['value'];
   showTextVariants: boolean;
   onChange?: (value: number | string, checked: boolean) => void;

--- a/src-docs/src/views/theme/color/contrast.tsx
+++ b/src-docs/src/views/theme/color/contrast.tsx
@@ -28,7 +28,7 @@ import { _EuiThemeColorsMode } from '../../../../../src/global_styling/variables
 import {
   BACKGROUND_COLORS,
   _EuiBackgroundColor,
-  useEuiBackgroundColor,
+  euiBackgroundColor,
 } from '../../../../../src/global_styling';
 import {
   BUTTON_COLORS,
@@ -297,7 +297,9 @@ export default () => {
                         <ColorSectionJS
                           key={color}
                           color={color as keyof _EuiThemeColorsMode}
-                          colorValue={useEuiBackgroundColor(
+                          // Can't use hooks in a conditional switch, so use the non-hook version
+                          colorValue={euiBackgroundColor(
+                            euiTheme,
                             color as _EuiBackgroundColor
                           )}
                           hookName="useEuiBackgroundColor"
@@ -314,7 +316,9 @@ export default () => {
                         <ColorSectionJS
                           key={color}
                           color={color as keyof _EuiThemeColorsMode}
-                          colorValue={useEuiBackgroundColor(
+                          // Can't use hooks in a conditional switch
+                          colorValue={euiBackgroundColor(
+                            euiTheme,
                             color as _EuiBackgroundColor,
                             { method: 'transparent' }
                           )}

--- a/src-docs/src/views/theme/color/contrast.tsx
+++ b/src-docs/src/views/theme/color/contrast.tsx
@@ -127,12 +127,8 @@ export default () => {
           <ContrastSlider
             contrastValue={contrastValue}
             showTextVariants={showTextVariants}
-            // @ts-ignore Help
-            onChange={(
-              sliderValue: React.SetStateAction<number>,
-              toggleChecked: React.SetStateAction<boolean>
-            ) => {
-              setContrastValue(sliderValue);
+            onChange={(sliderValue, toggleChecked) => {
+              setContrastValue(Number(sliderValue));
               setShowTextVariants(toggleChecked);
             }}
           />

--- a/src-docs/src/views/theme/color/contrast.tsx
+++ b/src-docs/src/views/theme/color/contrast.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useCallback } from 'react';
 import { ThemeContext } from '../../../components/with_theme';
 
 import {
@@ -48,22 +48,21 @@ export const contrastSections = [
 const background_colors = BACKGROUND_COLORS.filter(
   (color) => color !== 'transparent'
 );
+const backgroundButtons = [
+  'container',
+  // 'hover', Commenting out for now since contrast can't be calculated on transparent values
+  'button',
+].map((m) => {
+  return {
+    id: m,
+    label: m,
+  };
+});
 
 export default () => {
   const euiTheme = useEuiTheme();
   const [showTextVariants, setShowTextVariants] = useState(true);
   const [contrastValue, setContrastValue] = useState(4.5);
-
-  const backgroundButtons = [
-    'container',
-    // 'hover', Commenting out for now since contrast can't be calculated on transparent values
-    'button',
-  ].map((m) => {
-    return {
-      id: m,
-      label: m,
-    };
-  });
 
   const [backgroundColors, setBackgroundColors] =
     useState<any>(background_colors);
@@ -74,7 +73,7 @@ export default () => {
     backgroundButtons[0].id
   );
 
-  const switchBackgroundColors = (id: string) => {
+  const switchBackgroundColors = useCallback((id: string) => {
     switch (id) {
       case 'container':
         setBackgroundSelected(id);
@@ -92,7 +91,7 @@ export default () => {
         setBackgroundFunction('euiButtonColor(color)');
         break;
     }
-  };
+  }, []);
 
   const showSass = useContext(ThemeContext).themeLanguage.includes('sass');
 

--- a/src-docs/src/views/theme/color/tokens.tsx
+++ b/src-docs/src/views/theme/color/tokens.tsx
@@ -32,8 +32,8 @@ export const colorsInfo = {
   title: 'Colors',
   notice: <ThemeNotice />,
   showThemeLanguageToggle: true,
-  description: (
-    <>
+  intro: (
+    <EuiText grow={false}>
       <p>
         Elastic UI builds with a very limited palette. It uses a core set of
         three colors with a green / orange / red qualitative set and combined
@@ -46,7 +46,7 @@ export const colorsInfo = {
         their <strong>evaluated</strong> value but by their{' '}
         <strong>purpose</strong>.
       </p>
-    </>
+    </EuiText>
   ),
 };
 


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7500

The text color broke in #7298, as part of this changelog item:

> - Fixed `EuiListGroupItem` to pass `style` props to the wrapping `<li>` element alongside `className` and `css`. All other props will be passed to the underlying content.

The contrast page was passing `style` to EuiListGroupItem and relying it to go onto the `<button>` element instead of the `<li>`. This broken the inherited color styling of the various button(s).

While here I also noticed a whole lot of other things going wrong with this page (😅) and pushed up several fixes - see the [commit history](https://github.com/elastic/eui/pull/7506/commits).

## QA

- https://eui.elastic.co/pr_7506/#/theming/colors/contrast looks correct/non-broken compared to [production](https://eui.elastic.co/v90.0.0/#/theming/colors/contrast)

### General checklist

- Browser QA
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - See QA steps
- Code quality checklist - N/A
- Release checklist - N/A, docs only
- Designer checklist - N/A