### PR TITLE
test: fix validateDOMNesting warning 

### DIFF
--- a/src/components/table/__snapshots__/table_footer.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_footer.test.tsx.snap
@@ -1,15 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTableFooter is rendered 1`] = `
-<div>
+<table>
   <tfoot
     aria-label="aria-label"
     class="testClass1 testClass2 emotion-euiTestCss"
     data-test-subj="test subject string"
   >
     <tr>
-      children
+      <td>
+        children
+      </td>
     </tr>
   </tfoot>
-</div>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_footer_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_footer_cell.test.tsx.snap
@@ -1,129 +1,177 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTableFooterCell align defaults to left 1`] = `
-<td
-  class="euiTableFooterCell"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell align renders center when specified 1`] = `
-<td
-  class="euiTableFooterCell"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--alignCenter"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--alignCenter"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell align renders right when specified 1`] = `
-<td
-  class="euiTableFooterCell"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--alignRight"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--alignRight"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell is rendered 1`] = `
-<td
-  aria-label="aria-label"
-  class="euiTableFooterCell testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
->
-  <div
-    class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      children
-    </span>
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        aria-label="aria-label"
+        class="euiTableFooterCell testClass1 testClass2 emotion-euiTestCss"
+        data-test-subj="test subject string"
+      >
+        <div
+          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            children
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell width and style accepts style attribute 1`] = `
-<td
-  class="euiTableFooterCell"
-  style="width: 20%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+        style="width: 20%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell width and style accepts width attribute 1`] = `
-<td
-  class="euiTableFooterCell"
-  style="width: 10%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+        style="width: 10%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell width and style accepts width attribute as number 1`] = `
-<td
-  class="euiTableFooterCell"
-  style="width: 100px;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+        style="width: 100px;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;
 
 exports[`EuiTableFooterCell width and style resolves style and width attribute 1`] = `
-<td
-  class="euiTableFooterCell"
-  style="width: 10%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tfoot>
+    <tr>
+      <td
+        class="euiTableFooterCell"
+        style="width: 10%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tfoot>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_header.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header.test.tsx.snap
@@ -1,25 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTableHeader is rendered 1`] = `
-<thead
-  aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
->
-  <tr>
-    <td>
-      children
-    </td>
-  </tr>
-</thead>
+<table>
+  <thead
+    aria-label="aria-label"
+    class="testClass1 testClass2 emotion-euiTestCss"
+    data-test-subj="test subject string"
+  >
+    <tr>
+      <td>
+        children
+      </td>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`EuiTableHeader is rendered without <tr> 1`] = `
-<thead>
-  <tr>
-    <td>
-      children
-    </td>
-  </tr>
-</thead>
+<table>
+  <thead>
+    <tr>
+      <td>
+        children
+      </td>
+    </tr>
+  </thead>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -1,270 +1,348 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`align defaults to left 1`] = `
-<td
-  class="euiTableHeaderCell"
-  role="columnheader"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </span>
-</td>
+<table>
+  <thead>
+    <tr>
+      <td
+        class="euiTableHeaderCell"
+        role="columnheader"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </span>
+      </td>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`align renders center when specified 1`] = `
-<td
-  class="euiTableHeaderCell"
-  role="columnheader"
->
-  <span
-    class="euiTableCellContent euiTableCellContent--alignCenter"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </span>
-</td>
+<table>
+  <thead>
+    <tr>
+      <td
+        class="euiTableHeaderCell"
+        role="columnheader"
+      >
+        <span
+          class="euiTableCellContent euiTableCellContent--alignCenter"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </span>
+      </td>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`align renders right when specified 1`] = `
-<td
-  class="euiTableHeaderCell"
-  role="columnheader"
->
-  <span
-    class="euiTableCellContent euiTableCellContent--alignRight"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </span>
-</td>
+<table>
+  <thead>
+    <tr>
+      <td
+        class="euiTableHeaderCell"
+        role="columnheader"
+      >
+        <span
+          class="euiTableCellContent euiTableCellContent--alignRight"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </span>
+      </td>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`renders EuiTableHeaderCell 1`] = `
-<th
-  aria-label="aria-label"
-  class="euiTableHeaderCell testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
-  role="columnheader"
-  scope="col"
->
-  <span
-    class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="children"
-    >
-      children
-    </span>
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-label="aria-label"
+        class="euiTableHeaderCell testClass1 testClass2 emotion-euiTestCss"
+        data-test-subj="test subject string"
+        role="columnheader"
+        scope="col"
+      >
+        <span
+          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="children"
+          >
+            children
+          </span>
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`renders td when children is null/undefined 1`] = `
-<td
-  aria-label="aria-label"
-  class="euiTableHeaderCell testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
-  role="columnheader"
->
-  <span
-    class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </span>
-</td>
+<table>
+  <thead>
+    <tr>
+      <td
+        aria-label="aria-label"
+        class="euiTableHeaderCell testClass1 testClass2 emotion-euiTestCss"
+        data-test-subj="test subject string"
+        role="columnheader"
+      >
+        <span
+          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </span>
+      </td>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`sorting does not render a button with readOnly 1`] = `
-<th
-  aria-live="polite"
-  aria-sort="descending"
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-    <span
-      class="euiTableSortIcon"
-      data-euiicon-type="sortDown"
-    />
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-live="polite"
+        aria-sort="descending"
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+          <span
+            class="euiTableSortIcon"
+            data-euiicon-type="sortDown"
+          />
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`sorting is rendered with isSortAscending 1`] = `
-<th
-  aria-live="polite"
-  aria-sort="ascending"
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-    <span
-      class="euiTableSortIcon"
-      data-euiicon-type="sortUp"
-    />
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-live="polite"
+        aria-sort="ascending"
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+          <span
+            class="euiTableSortIcon"
+            data-euiicon-type="sortUp"
+          />
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`sorting is rendered with isSorted 1`] = `
-<th
-  aria-live="polite"
-  aria-sort="descending"
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-    <span
-      class="euiTableSortIcon"
-      data-euiicon-type="sortDown"
-    />
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-live="polite"
+        aria-sort="descending"
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+          <span
+            class="euiTableSortIcon"
+            data-euiicon-type="sortDown"
+          />
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`sorting renders a button with onSort 1`] = `
-<th
-  aria-live="polite"
-  aria-sort="descending"
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
->
-  <button
-    class="euiTableHeaderButton euiTableHeaderButton-isSorted"
-    data-test-subj="tableHeaderSortButton"
-    type="button"
-  >
-    <span
-      class="euiTableCellContent"
-    >
-      <span
-        class="euiTableCellContent__text"
-        title="Test"
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-live="polite"
+        aria-sort="descending"
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
       >
-        Test
-      </span>
-      <span
-        class="euiTableSortIcon"
-        data-euiicon-type="sortDown"
-      />
-    </span>
-  </button>
-</th>
+        <button
+          class="euiTableHeaderButton euiTableHeaderButton-isSorted"
+          data-test-subj="tableHeaderSortButton"
+          type="button"
+        >
+          <span
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
+              title="Test"
+            >
+              Test
+            </span>
+            <span
+              class="euiTableSortIcon"
+              data-euiicon-type="sortDown"
+            />
+          </span>
+        </button>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`width and style accepts style attribute 1`] = `
-<th
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
-  style="width: 20%;"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+        style="width: 20%;"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`width and style accepts width attribute 1`] = `
-<th
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
-  style="width: 10%;"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+        style="width: 10%;"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`width and style accepts width attribute as number 1`] = `
-<th
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
-  style="width: 100px;"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+        style="width: 100px;"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`width and style resolves style and width attribute 1`] = `
-<th
-  class="euiTableHeaderCell"
-  role="columnheader"
-  scope="col"
-  style="width: 10%;"
->
-  <span
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-      title="Test"
-    >
-      Test
-    </span>
-  </span>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+        style="width: 10%;"
+      >
+        <span
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+            title="Test"
+          >
+            Test
+          </span>
+        </span>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_header_cell_checkbox.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell_checkbox.test.tsx.snap
@@ -1,70 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTableHeaderCellCheckbox is rendered 1`] = `
-<th
-  aria-label="aria-label"
-  class="euiTableHeaderCellCheckbox testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
-  scope="col"
->
-  <div
-    class="euiTableCellContent"
-  />
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-label="aria-label"
+        class="euiTableHeaderCellCheckbox testClass1 testClass2 emotion-euiTestCss"
+        data-test-subj="test subject string"
+        scope="col"
+      >
+        <div
+          class="euiTableCellContent"
+        />
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`EuiTableHeaderCellCheckbox width and style accepts style attribute 1`] = `
-<th
-  class="euiTableHeaderCellCheckbox"
-  scope="col"
-  style="width: 20%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    Test
-  </div>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCellCheckbox"
+        scope="col"
+        style="width: 20%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          Test
+        </div>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`EuiTableHeaderCellCheckbox width and style accepts width attribute 1`] = `
-<th
-  class="euiTableHeaderCellCheckbox"
-  scope="col"
-  style="width: 10%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    Test
-  </div>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCellCheckbox"
+        scope="col"
+        style="width: 10%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          Test
+        </div>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`EuiTableHeaderCellCheckbox width and style accepts width attribute as number 1`] = `
-<th
-  class="euiTableHeaderCellCheckbox"
-  scope="col"
-  style="width: 100px;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    Test
-  </div>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCellCheckbox"
+        scope="col"
+        style="width: 100px;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          Test
+        </div>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;
 
 exports[`EuiTableHeaderCellCheckbox width and style resolves style and width attribute 1`] = `
-<th
-  class="euiTableHeaderCellCheckbox"
-  scope="col"
-  style="width: 10%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    Test
-  </div>
-</th>
+<table>
+  <thead>
+    <tr>
+      <th
+        class="euiTableHeaderCellCheckbox"
+        scope="col"
+        style="width: 10%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          Test
+        </div>
+      </th>
+    </tr>
+  </thead>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_row.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row.test.tsx.snap
@@ -1,41 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`isSelected renders true when specified 1`] = `
-<tr
-  class="euiTableRow euiTableRow-isSelected"
->
-  <td
-    class="euiTableRowCell euiTableRowCell--middle"
-  >
-    <div
-      class="euiTableCellContent"
+<table>
+  <tbody>
+    <tr
+      class="euiTableRow euiTableRow-isSelected"
     >
-      <span
-        class="euiTableCellContent__text"
-      />
-    </div>
-  </td>
-</tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`renders EuiTableRow 1`] = `
-<tr
-  aria-label="aria-label"
-  class="euiTableRow testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
->
-  <td
-    class="euiTableRowCell euiTableRowCell--middle"
-  >
-    <div
-      class="euiTableCellContent"
+<table>
+  <tbody>
+    <tr
+      aria-label="aria-label"
+      class="euiTableRow testClass1 testClass2 emotion-euiTestCss"
+      data-test-subj="test subject string"
     >
-      <span
-        class="euiTableCellContent__text"
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
       >
-        hi
-      </span>
-    </div>
-  </td>
-</tr>
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            hi
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
@@ -1,251 +1,353 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`align defaults to left 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`align renders center when specified 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--alignCenter"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--alignCenter"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`align renders right when specified 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--alignRight"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--alignRight"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`children's className merges new classnames into existing ones 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-  >
-    <div
-      class="testClass euiTableCellContent__hoverItem"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+        >
+          <div
+            class="testClass euiTableCellContent__hoverItem"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`renders EuiTableRowCell 1`] = `
-<td
-  aria-label="aria-label"
-  class="euiTableRowCell euiTableRowCell--middle"
-  data-test-subj="test subject string"
->
-  <div
-    class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      children
-    </span>
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        aria-label="aria-label"
+        class="euiTableRowCell euiTableRowCell--middle"
+        data-test-subj="test subject string"
+      >
+        <div
+          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            children
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`textOnly defaults to true 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`textOnly is rendered when specified 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--overflowingContent"
-  />
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--overflowingContent"
+        />
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`truncateText defaults to false 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`truncateText renders lines configuration 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text euiTextBlockTruncate emotion-euiTextBlockTruncate"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text euiTextBlockTruncate emotion-euiTextBlockTruncate"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`truncateText renders true 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent euiTableCellContent--truncateText"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent euiTableCellContent--truncateText"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`valign defaults to middle 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`valign renders bottom when specified 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--bottom"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--bottom"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`valign renders top when specified 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--top"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    />
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--top"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          />
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`width and style accepts style attribute 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
-  style="width: 20%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+        style="width: 20%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`width and style accepts width attribute 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
-  style="width: 10%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+        style="width: 10%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`width and style accepts width attribute as number 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
-  style="width: 100px;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+        style="width: 100px;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;
 
 exports[`width and style resolves style and width attribute 1`] = `
-<td
-  class="euiTableRowCell euiTableRowCell--middle"
-  style="width: 10%;"
->
-  <div
-    class="euiTableCellContent"
-  >
-    <span
-      class="euiTableCellContent__text"
-    >
-      Test
-    </span>
-  </div>
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        class="euiTableRowCell euiTableRowCell--middle"
+        style="width: 10%;"
+      >
+        <div
+          class="euiTableCellContent"
+        >
+          <span
+            class="euiTableCellContent__text"
+          >
+            Test
+          </span>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;

--- a/src/components/table/__snapshots__/table_row_cell_checkbox.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell_checkbox.test.tsx.snap
@@ -1,13 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTableRowCellCheckbox is rendered 1`] = `
-<td
-  aria-label="aria-label"
-  class="euiTableRowCellCheckbox testClass1 testClass2 emotion-euiTestCss"
-  data-test-subj="test subject string"
->
-  <div
-    class="euiTableCellContent"
-  />
-</td>
+<table>
+  <tbody>
+    <tr>
+      <td
+        aria-label="aria-label"
+        class="euiTableRowCellCheckbox testClass1 testClass2 emotion-euiTestCss"
+        data-test-subj="test subject string"
+      >
+        <div
+          class="euiTableCellContent"
+        />
+      </td>
+    </tr>
+  </tbody>
+</table>
 `;

--- a/src/components/table/table_footer.test.tsx
+++ b/src/components/table/table_footer.test.tsx
@@ -15,9 +15,13 @@ import { EuiTableFooter } from './table_footer';
 describe('EuiTableFooter', () => {
   test('is rendered', () => {
     const { container } = render(
-      <EuiTableFooter {...requiredProps}>children</EuiTableFooter>
+      <table>
+        <EuiTableFooter {...requiredProps}>
+          <td>children</td>
+        </EuiTableFooter>
+      </table>
     );
 
-    expect(container).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/table/table_footer_cell.test.tsx
+++ b/src/components/table/table_footer_cell.test.tsx
@@ -12,8 +12,18 @@ import { render } from '../../test/rtl';
 
 import { EuiTableFooterCell } from './table_footer_cell';
 
-import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
+import { CENTER_ALIGNMENT, RIGHT_ALIGNMENT } from '../../services';
 import { WARNING_MESSAGE } from './utils';
+
+function renderTable(ui: React.ReactElement) {
+  return render(
+    <table>
+      <tfoot>
+        <tr>{ui}</tr>
+      </tfoot>
+    </table>
+  );
+}
 
 describe('EuiTableFooterCell', () => {
   const _consoleWarn = console.warn;
@@ -29,7 +39,7 @@ describe('EuiTableFooterCell', () => {
   });
 
   test('is rendered', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableFooterCell {...requiredProps}>children</EuiTableFooterCell>
     );
 
@@ -38,13 +48,13 @@ describe('EuiTableFooterCell', () => {
 
   describe('align', () => {
     test('defaults to left', () => {
-      const { container } = render(<EuiTableFooterCell />);
+      const { container } = renderTable(<EuiTableFooterCell />);
 
       expect(container.firstChild).toMatchSnapshot();
     });
 
     test('renders right when specified', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableFooterCell align={RIGHT_ALIGNMENT} />
       );
 
@@ -52,7 +62,7 @@ describe('EuiTableFooterCell', () => {
     });
 
     test('renders center when specified', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableFooterCell align={CENTER_ALIGNMENT} />
       );
 
@@ -62,7 +72,7 @@ describe('EuiTableFooterCell', () => {
 
   describe('width and style', () => {
     test('accepts style attribute', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableFooterCell style={{ width: '20%' }}>Test</EuiTableFooterCell>
       );
 
@@ -70,7 +80,7 @@ describe('EuiTableFooterCell', () => {
     });
 
     test('accepts width attribute', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableFooterCell width="10%">Test</EuiTableFooterCell>
       );
 
@@ -78,7 +88,7 @@ describe('EuiTableFooterCell', () => {
     });
 
     test('accepts width attribute as number', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableFooterCell width={100}>Test</EuiTableFooterCell>
       );
 
@@ -86,7 +96,7 @@ describe('EuiTableFooterCell', () => {
     });
 
     test('resolves style and width attribute', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableFooterCell width="10%" style={{ width: '20%' }}>
           Test
         </EuiTableFooterCell>

--- a/src/components/table/table_header.test.tsx
+++ b/src/components/table/table_header.test.tsx
@@ -15,20 +15,24 @@ import { EuiTableHeader } from './table_header';
 describe('EuiTableHeader', () => {
   test('is rendered', () => {
     const { container } = render(
-      <EuiTableHeader {...requiredProps}>
-        <td>children</td>
-      </EuiTableHeader>
+      <table>
+        <EuiTableHeader {...requiredProps}>
+          <td>children</td>
+        </EuiTableHeader>
+      </table>
     );
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered without <tr>', () => {
     const { container } = render(
-      <EuiTableHeader wrapWithTableRow={false}>
-        <tr>
-          <td>children</td>
-        </tr>
-      </EuiTableHeader>
+      <table>
+        <EuiTableHeader wrapWithTableRow={false}>
+          <tr>
+            <td>children</td>
+          </tr>
+        </EuiTableHeader>
+      </table>
     );
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -15,8 +15,18 @@ import { EuiTableHeaderCell } from './table_header_cell';
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
 import { WARNING_MESSAGE } from './utils';
 
+function renderTable(ui: React.ReactElement) {
+  return render(
+    <table>
+      <thead>
+        <tr>{ui}</tr>
+      </thead>
+    </table>
+  );
+}
+
 test('renders EuiTableHeaderCell', () => {
-  const { container } = render(
+  const { container } = renderTable(
     <EuiTableHeaderCell {...requiredProps}>children</EuiTableHeaderCell>
   );
 
@@ -24,20 +34,20 @@ test('renders EuiTableHeaderCell', () => {
 });
 
 test('renders td when children is null/undefined', () => {
-  const { container } = render(<EuiTableHeaderCell {...requiredProps} />);
+  const { container } = renderTable(<EuiTableHeaderCell {...requiredProps} />);
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 describe('align', () => {
   test('defaults to left', () => {
-    const { container } = render(<EuiTableHeaderCell />);
+    const { container } = renderTable(<EuiTableHeaderCell />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders right when specified', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell align={RIGHT_ALIGNMENT} />
     );
 
@@ -45,7 +55,7 @@ describe('align', () => {
   });
 
   test('renders center when specified', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell align={CENTER_ALIGNMENT} />
     );
 
@@ -55,7 +65,7 @@ describe('align', () => {
 
 describe('sorting', () => {
   test('is rendered with isSorted', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell isSorted>Test</EuiTableHeaderCell>
     );
 
@@ -63,7 +73,7 @@ describe('sorting', () => {
   });
 
   test('is rendered with isSortAscending', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell isSorted isSortAscending>
         Test
       </EuiTableHeaderCell>
@@ -73,7 +83,7 @@ describe('sorting', () => {
   });
 
   test('renders a button with onSort', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell isSorted onSort={() => {}}>
         Test
       </EuiTableHeaderCell>
@@ -83,7 +93,7 @@ describe('sorting', () => {
   });
 
   test('does not render a button with readOnly', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell readOnly isSorted onSort={() => {}}>
         Test
       </EuiTableHeaderCell>
@@ -107,7 +117,7 @@ describe('width and style', () => {
   });
 
   test('accepts style attribute', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell style={{ width: '20%' }}>Test</EuiTableHeaderCell>
     );
 
@@ -115,7 +125,7 @@ describe('width and style', () => {
   });
 
   test('accepts width attribute', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell width="10%">Test</EuiTableHeaderCell>
     );
 
@@ -123,7 +133,7 @@ describe('width and style', () => {
   });
 
   test('accepts width attribute as number', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell width={100}>Test</EuiTableHeaderCell>
     );
 
@@ -131,7 +141,7 @@ describe('width and style', () => {
   });
 
   test('resolves style and width attribute', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCell width="10%" style={{ width: '20%' }}>
         Test
       </EuiTableHeaderCell>

--- a/src/components/table/table_header_cell_checkbox.test.tsx
+++ b/src/components/table/table_header_cell_checkbox.test.tsx
@@ -13,6 +13,16 @@ import { render } from '../../test/rtl';
 import { EuiTableHeaderCellCheckbox } from './table_header_cell_checkbox';
 import { WARNING_MESSAGE } from './utils';
 
+function renderTable(ui: React.ReactElement) {
+  return render(
+    <table>
+      <thead>
+        <tr>{ui}</tr>
+      </thead>
+    </table>
+  );
+}
+
 describe('EuiTableHeaderCellCheckbox', () => {
   const _consoleWarn = console.warn;
   beforeAll(() => {
@@ -27,7 +37,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
   });
 
   test('is rendered', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableHeaderCellCheckbox {...requiredProps} />
     );
 
@@ -36,7 +46,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
 
   describe('width and style', () => {
     test('accepts style attribute', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableHeaderCellCheckbox style={{ width: '20%' }}>
           Test
         </EuiTableHeaderCellCheckbox>
@@ -46,7 +56,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
     });
 
     test('accepts width attribute', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableHeaderCellCheckbox width="10%">
           Test
         </EuiTableHeaderCellCheckbox>
@@ -56,7 +66,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
     });
 
     test('accepts width attribute as number', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableHeaderCellCheckbox width={100}>
           Test
         </EuiTableHeaderCellCheckbox>
@@ -66,7 +76,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
     });
 
     test('resolves style and width attribute', () => {
-      const { container } = render(
+      const { container } = renderTable(
         <EuiTableHeaderCellCheckbox width="10%" style={{ width: '20%' }}>
           Test
         </EuiTableHeaderCellCheckbox>

--- a/src/components/table/table_row.test.tsx
+++ b/src/components/table/table_row.test.tsx
@@ -14,8 +14,16 @@ import { EuiTableRow } from './table_row';
 
 import { EuiTableRowCell } from './table_row_cell';
 
+function renderTable(ui: React.ReactElement) {
+  return render(
+    <table>
+      <tbody>{ui}</tbody>
+    </table>
+  );
+}
+
 test('renders EuiTableRow', () => {
-  const { container } = render(
+  const { container } = renderTable(
     <EuiTableRow {...requiredProps}>
       <EuiTableRowCell>hi</EuiTableRowCell>
     </EuiTableRow>
@@ -26,7 +34,7 @@ test('renders EuiTableRow', () => {
 
 describe('isSelected', () => {
   test('renders true when specified', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRow isSelected={true}>
         <EuiTableRowCell />
       </EuiTableRow>

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -12,11 +12,21 @@ import { render } from '../../test/rtl';
 
 import { EuiTableRowCell } from './table_row_cell';
 
-import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services/alignment';
+import { CENTER_ALIGNMENT, RIGHT_ALIGNMENT } from '../../services/alignment';
 import { WARNING_MESSAGE } from './utils';
 
+function renderTable(ui: React.ReactElement) {
+  return render(
+    <table>
+      <tbody>
+        <tr>{ui}</tr>
+      </tbody>
+    </table>
+  );
+}
+
 test('renders EuiTableRowCell', () => {
-  const { container } = render(
+  const { container } = renderTable(
     <EuiTableRowCell {...requiredProps}>children</EuiTableRowCell>
   );
 
@@ -25,19 +35,23 @@ test('renders EuiTableRowCell', () => {
 
 describe('align', () => {
   test('defaults to left', () => {
-    const { container } = render(<EuiTableRowCell />);
+    const { container } = renderTable(<EuiTableRowCell />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders right when specified', () => {
-    const { container } = render(<EuiTableRowCell align={RIGHT_ALIGNMENT} />);
+    const { container } = renderTable(
+      <EuiTableRowCell align={RIGHT_ALIGNMENT} />
+    );
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders center when specified', () => {
-    const { container } = render(<EuiTableRowCell align={CENTER_ALIGNMENT} />);
+    const { container } = renderTable(
+      <EuiTableRowCell align={CENTER_ALIGNMENT} />
+    );
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -45,19 +59,19 @@ describe('align', () => {
 
 describe('valign', () => {
   test('defaults to middle', () => {
-    const { container } = render(<EuiTableRowCell />);
+    const { container } = renderTable(<EuiTableRowCell />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders top when specified', () => {
-    const { container } = render(<EuiTableRowCell valign="top" />);
+    const { container } = renderTable(<EuiTableRowCell valign="top" />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('renders bottom when specified', () => {
-    const { container } = render(<EuiTableRowCell valign="bottom" />);
+    const { container } = renderTable(<EuiTableRowCell valign="bottom" />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -65,13 +79,13 @@ describe('valign', () => {
 
 describe('textOnly', () => {
   test('defaults to true', () => {
-    const { container } = render(<EuiTableRowCell />);
+    const { container } = renderTable(<EuiTableRowCell />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   test('is rendered when specified', () => {
-    const { container } = render(<EuiTableRowCell textOnly={false} />);
+    const { container } = renderTable(<EuiTableRowCell textOnly={false} />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -79,13 +93,13 @@ describe('textOnly', () => {
 
 describe('truncateText', () => {
   it('defaults to false', () => {
-    const { container } = render(<EuiTableRowCell />);
+    const { container } = renderTable(<EuiTableRowCell />);
 
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('renders true', () => {
-    const { container } = render(<EuiTableRowCell truncateText={true} />);
+    const { container } = renderTable(<EuiTableRowCell truncateText={true} />);
 
     expect(
       container.querySelector('.euiTableCellContent--truncateText')
@@ -94,7 +108,7 @@ describe('truncateText', () => {
   });
 
   test('renders lines configuration', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRowCell truncateText={{ lines: 2 }} />
     );
 
@@ -110,7 +124,7 @@ describe('truncateText', () => {
 
 describe("children's className", () => {
   test('merges new classnames into existing ones', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRowCell textOnly={false} showOnHover={true}>
         <div className="testClass" />
       </EuiTableRowCell>
@@ -134,7 +148,7 @@ describe('width and style', () => {
   });
 
   test('accepts style attribute', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRowCell style={{ width: '20%' }}>Test</EuiTableRowCell>
     );
 
@@ -142,7 +156,7 @@ describe('width and style', () => {
   });
 
   test('accepts width attribute', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRowCell width="10%">Test</EuiTableRowCell>
     );
 
@@ -150,7 +164,7 @@ describe('width and style', () => {
   });
 
   test('accepts width attribute as number', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRowCell width={100}>Test</EuiTableRowCell>
     );
 
@@ -158,7 +172,7 @@ describe('width and style', () => {
   });
 
   test('resolves style and width attribute', () => {
-    const { container } = render(
+    const { container } = renderTable(
       <EuiTableRowCell width="10%" style={{ width: '20%' }}>
         Test
       </EuiTableRowCell>

--- a/src/components/table/table_row_cell_checkbox.test.tsx
+++ b/src/components/table/table_row_cell_checkbox.test.tsx
@@ -15,7 +15,13 @@ import { EuiTableRowCellCheckbox } from './table_row_cell_checkbox';
 describe('EuiTableRowCellCheckbox', () => {
   test('is rendered', () => {
     const { container } = render(
-      <EuiTableRowCellCheckbox {...requiredProps} />
+      <table>
+        <tbody>
+          <tr>
+            <EuiTableRowCellCheckbox {...requiredProps} />
+          </tr>
+        </tbody>
+      </table>
     );
 
     expect(container.firstChild).toMatchSnapshot();


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/eui/issues/6979.

Table elements (`<thead>`, `<tfoot>`, `<tr>`, `<td>`, etc.) have their own set of permitted parents. This PR updates the Jest unit tests for table components to fix the `validateDOMNesting` warnings.

## QA

### General checklist

- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
