### PR TITLE
[Emotion] Convert EuiTreeView

### DIFF
--- a/changelogs/upcoming/7513.md
+++ b/changelogs/upcoming/7513.md
@@ -1,3 +1,7 @@
+**Bug fixes**
+
+- Fixed an `EuiTreeView` bug where `aria-expanded` was being applied to items without expandable children
+
 **CSS-in-JS conversions**
 
 - Converted `EuiTreeView` to Emotion. Updates as part of the conversion:

--- a/changelogs/upcoming/7513.md
+++ b/changelogs/upcoming/7513.md
@@ -1,0 +1,5 @@
+**CSS-in-JS conversions**
+
+- Converted `EuiTreeView` to Emotion. Updates as part of the conversion:
+  - Removed `.euiTreeView__wrapper` div node
+  - Enforced consistent `icon` size based on `display` size

--- a/src-docs/src/views/tree_view/playground.js
+++ b/src-docs/src/views/tree_view/playground.js
@@ -1,14 +1,17 @@
 import { EuiTreeView, EuiIcon } from '../../../../src/components';
+import { EuiTreeViewClass } from '../../../../src/components/tree_view/tree_view';
 import {
   propUtilityForPlayground,
   generateCustomProps,
 } from '../../services/playground';
 
 export const TreeViewConfig = () => {
-  const docgenInfo = Array.isArray(EuiTreeView.__docgenInfo)
-    ? EuiTreeView.__docgenInfo[0]
-    : EuiTreeView.__docgenInfo;
+  const docgenInfo = Array.isArray(EuiTreeViewClass.__docgenInfo)
+    ? EuiTreeViewClass.__docgenInfo[0]
+    : EuiTreeViewClass.__docgenInfo;
   const propsToUse = propUtilityForPlayground(docgenInfo.props);
+
+  delete propsToUse.theme;
 
   propsToUse.display = {
     ...propsToUse.display,

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -6,7 +6,6 @@
 @import 'datagrid/index';
 @import 'form/index';
 @import 'markdown_editor/index';
-@import 'tree_view/index';
 @import 'side_nav/index';
 @import 'selectable/index';
 @import 'table/index';

--- a/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
+++ b/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`EuiTreeView is rendered 1`] = `
             class="euiTreeView__node emotion-euiTreeView__node-default"
           >
             <button
-              aria-expanded="false"
               class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
               data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
               id="item_a"
@@ -128,7 +127,6 @@ exports[`EuiTreeView is rendered 1`] = `
       class="euiTreeView__node emotion-euiTreeView__node-default"
     >
       <button
-        aria-expanded="false"
         class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
         data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
         id="item_two"

--- a/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
+++ b/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
@@ -11,29 +11,29 @@ exports[`EuiTreeView is rendered 1`] = `
   <ul
     aria-describedby="euiTreeView_generated-id--instruction"
     aria-label="aria-label"
-    class="euiTreeView testClass1 testClass2 emotion-euiTreeView-euiTestCss"
+    class="euiTreeView testClass1 testClass2 emotion-euiTreeView-default-euiTestCss"
     data-test-subj="test subject string"
     id="euiTreeView_generated-id"
   >
     <li
-      class="euiTreeView__node euiTreeView__node--expanded"
+      class="euiTreeView__node euiTreeView__node--expanded emotion-euiTreeView__node-default-expanded"
     >
       <button
         aria-controls="euiTreeView_generated-id_item_one"
         aria-expanded="true"
-        class="euiTreeView__nodeInner"
+        class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
         data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
         id="item_one"
       >
         <span
-          class="euiTreeView__iconWrapper"
+          class="euiTreeView__iconWrapper emotion-euiTreeView__iconWrapper-default"
         >
           <span
             data-euiicon-type="folderOpen"
           />
         </span>
         <span
-          class="euiTreeView__nodeLabel"
+          class="euiTreeView__nodeLabel eui-textTruncate"
         >
           Item One
         </span>
@@ -42,55 +42,50 @@ exports[`EuiTreeView is rendered 1`] = `
         id="euiTreeView_generated-id_item_one"
       >
         <ul
-          aria-label="Item One child of aria-label"
-          class="euiTreeView emotion-euiTreeView"
+          class="euiTreeView emotion-euiTreeView-default"
         >
           <li
-            class="euiTreeView__node"
+            class="euiTreeView__node emotion-euiTreeView__node-default"
           >
             <button
-              aria-controls="euiTreeView_generated-id_item_a"
               aria-expanded="false"
-              class="euiTreeView__nodeInner"
+              class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
               data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
               id="item_a"
             >
               <span
-                class="euiTreeView__iconWrapper"
+                class="euiTreeView__iconWrapper emotion-euiTreeView__iconWrapper-default"
               >
                 <span
                   data-euiicon-type="document"
                 />
               </span>
               <span
-                class="euiTreeView__nodeLabel"
+                class="euiTreeView__nodeLabel eui-textTruncate"
               >
                 Item A
               </span>
             </button>
-            <div
-              id="euiTreeView_generated-id_item_a"
-            />
           </li>
           <li
-            class="euiTreeView__node"
+            class="euiTreeView__node emotion-euiTreeView__node-default"
           >
             <button
               aria-controls="euiTreeView_generated-id_item_b"
               aria-expanded="false"
-              class="euiTreeView__nodeInner"
+              class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
               data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
               id="item_b"
             >
               <span
-                class="euiTreeView__iconWrapper"
+                class="euiTreeView__iconWrapper emotion-euiTreeView__iconWrapper-default"
               >
                 <span
                   data-euiicon-type="arrowRight"
                 />
               </span>
               <span
-                class="euiTreeView__nodeLabel"
+                class="euiTreeView__nodeLabel eui-textTruncate"
               >
                 Item B
               </span>
@@ -100,24 +95,24 @@ exports[`EuiTreeView is rendered 1`] = `
             />
           </li>
           <li
-            class="euiTreeView__node"
+            class="euiTreeView__node emotion-euiTreeView__node-default"
           >
             <button
               aria-controls="euiTreeView_generated-id_item_c"
               aria-expanded="false"
-              class="euiTreeView__nodeInner"
+              class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
               data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
               id="item_c"
             >
               <span
-                class="euiTreeView__iconWrapper"
+                class="euiTreeView__iconWrapper emotion-euiTreeView__iconWrapper-default"
               >
                 <span
                   data-euiicon-type="arrowRight"
                 />
               </span>
               <span
-                class="euiTreeView__nodeLabel"
+                class="euiTreeView__nodeLabel eui-textTruncate"
               >
                 Item C
               </span>
@@ -130,24 +125,20 @@ exports[`EuiTreeView is rendered 1`] = `
       </div>
     </li>
     <li
-      class="euiTreeView__node"
+      class="euiTreeView__node emotion-euiTreeView__node-default"
     >
       <button
-        aria-controls="euiTreeView_generated-id_item_two"
         aria-expanded="false"
-        class="euiTreeView__nodeInner"
+        class="euiTreeView__nodeInner emotion-euiTreeView__nodeInner-default"
         data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
         id="item_two"
       >
         <span
-          class="euiTreeView__nodeLabel"
+          class="euiTreeView__nodeLabel eui-textTruncate"
         >
           Item Two
         </span>
       </button>
-      <div
-        id="euiTreeView_generated-id_item_two"
-      />
     </li>
   </ul>
 </div>

--- a/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
+++ b/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`EuiTreeView is rendered 1`] = `
   <ul
     aria-describedby="euiTreeView_generated-id--instruction"
     aria-label="aria-label"
-    class="euiTreeView testClass1 testClass2 emotion-euiTestCss"
+    class="euiTreeView testClass1 testClass2 emotion-euiTreeView-euiTestCss"
     data-test-subj="test subject string"
     id="euiTreeView_generated-id"
   >
@@ -48,7 +48,7 @@ exports[`EuiTreeView is rendered 1`] = `
         >
           <ul
             aria-label="Item One child of aria-label"
-            class="euiTreeView"
+            class="euiTreeView emotion-euiTreeView"
           >
             <li
               class="euiTreeView__node"

--- a/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
+++ b/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EuiTreeView is rendered 1`] = `
-<div
-  class="euiText euiTreeView__wrapper emotion-euiText-m"
->
+<div>
   <p
     class="emotion-euiScreenReaderOnly"
     id="euiTreeView_generated-id--instruction"
@@ -43,96 +41,92 @@ exports[`EuiTreeView is rendered 1`] = `
       <div
         id="euiTreeView_generated-id_item_one"
       >
-        <div
-          class="euiText euiTreeView__wrapper emotion-euiText-m"
+        <ul
+          aria-label="Item One child of aria-label"
+          class="euiTreeView emotion-euiTreeView"
         >
-          <ul
-            aria-label="Item One child of aria-label"
-            class="euiTreeView emotion-euiTreeView"
+          <li
+            class="euiTreeView__node"
           >
-            <li
-              class="euiTreeView__node"
+            <button
+              aria-controls="euiTreeView_generated-id_item_a"
+              aria-expanded="false"
+              class="euiTreeView__nodeInner"
+              data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
+              id="item_a"
             >
-              <button
-                aria-controls="euiTreeView_generated-id_item_a"
-                aria-expanded="false"
-                class="euiTreeView__nodeInner"
-                data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
-                id="item_a"
+              <span
+                class="euiTreeView__iconWrapper"
               >
                 <span
-                  class="euiTreeView__iconWrapper"
-                >
-                  <span
-                    data-euiicon-type="document"
-                  />
-                </span>
-                <span
-                  class="euiTreeView__nodeLabel"
-                >
-                  Item A
-                </span>
-              </button>
-              <div
-                id="euiTreeView_generated-id_item_a"
-              />
-            </li>
-            <li
-              class="euiTreeView__node"
+                  data-euiicon-type="document"
+                />
+              </span>
+              <span
+                class="euiTreeView__nodeLabel"
+              >
+                Item A
+              </span>
+            </button>
+            <div
+              id="euiTreeView_generated-id_item_a"
+            />
+          </li>
+          <li
+            class="euiTreeView__node"
+          >
+            <button
+              aria-controls="euiTreeView_generated-id_item_b"
+              aria-expanded="false"
+              class="euiTreeView__nodeInner"
+              data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
+              id="item_b"
             >
-              <button
-                aria-controls="euiTreeView_generated-id_item_b"
-                aria-expanded="false"
-                class="euiTreeView__nodeInner"
-                data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
-                id="item_b"
+              <span
+                class="euiTreeView__iconWrapper"
               >
                 <span
-                  class="euiTreeView__iconWrapper"
-                >
-                  <span
-                    data-euiicon-type="arrowRight"
-                  />
-                </span>
-                <span
-                  class="euiTreeView__nodeLabel"
-                >
-                  Item B
-                </span>
-              </button>
-              <div
-                id="euiTreeView_generated-id_item_b"
-              />
-            </li>
-            <li
-              class="euiTreeView__node"
+                  data-euiicon-type="arrowRight"
+                />
+              </span>
+              <span
+                class="euiTreeView__nodeLabel"
+              >
+                Item B
+              </span>
+            </button>
+            <div
+              id="euiTreeView_generated-id_item_b"
+            />
+          </li>
+          <li
+            class="euiTreeView__node"
+          >
+            <button
+              aria-controls="euiTreeView_generated-id_item_c"
+              aria-expanded="false"
+              class="euiTreeView__nodeInner"
+              data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
+              id="item_c"
             >
-              <button
-                aria-controls="euiTreeView_generated-id_item_c"
-                aria-expanded="false"
-                class="euiTreeView__nodeInner"
-                data-test-subj="euiTreeViewButton-euiTreeView_generated-id"
-                id="item_c"
+              <span
+                class="euiTreeView__iconWrapper"
               >
                 <span
-                  class="euiTreeView__iconWrapper"
-                >
-                  <span
-                    data-euiicon-type="arrowRight"
-                  />
-                </span>
-                <span
-                  class="euiTreeView__nodeLabel"
-                >
-                  Item C
-                </span>
-              </button>
-              <div
-                id="euiTreeView_generated-id_item_c"
-              />
-            </li>
-          </ul>
-        </div>
+                  data-euiicon-type="arrowRight"
+                />
+              </span>
+              <span
+                class="euiTreeView__nodeLabel"
+              >
+                Item C
+              </span>
+            </button>
+            <div
+              id="euiTreeView_generated-id_item_c"
+            />
+          </li>
+        </ul>
       </div>
     </li>
     <li

--- a/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
+++ b/src/components/tree_view/__snapshots__/tree_view.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`EuiTreeView is rendered 1`] = `
     class="euiTreeView testClass1 testClass2 emotion-euiTreeView-default-euiTestCss"
     data-test-subj="test subject string"
     id="euiTreeView_generated-id"
+    role="list"
   >
     <li
       class="euiTreeView__node euiTreeView__node--expanded emotion-euiTreeView__node-default-expanded"
@@ -43,6 +44,7 @@ exports[`EuiTreeView is rendered 1`] = `
       >
         <ul
           class="euiTreeView emotion-euiTreeView-default"
+          role="list"
         >
           <li
             class="euiTreeView__node emotion-euiTreeView__node-default"

--- a/src/components/tree_view/_index.scss
+++ b/src/components/tree_view/_index.scss
@@ -1,1 +1,0 @@
-@import 'tree_view';

--- a/src/components/tree_view/_tree_view_item.styles.ts
+++ b/src/components/tree_view/_tree_view_item.styles.ts
@@ -67,11 +67,24 @@ export const euiTreeViewItemStyles = (euiThemeContext: UseEuiTheme) => {
     },
 
     icon: {
-      // Line height helps vertically center the icons
       euiTreeView__iconWrapper: css`
-        line-height: 0;
+        flex-shrink: 0;
+        line-height: 0; /* Vertically centers the icon */
+
+        /* Handle smaller icons in compressed mode */
+        & > * {
+          ${logicalCSS('max-width', '100%')}
+        }
+
+        & > .euiToken {
+          ${logicalCSS('max-height', '100%')}
+          ${logicalCSS('height', 'auto')}
+
+          svg {
+            ${logicalCSS('width', '100%')}
+          }
+        }
       `,
-      euiTreeView__placeholder: css``,
       default: css`
         ${logicalCSS(
           'width',

--- a/src/components/tree_view/_tree_view_item.styles.ts
+++ b/src/components/tree_view/_tree_view_item.styles.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme, transparentize } from '../../services';
+import { euiFocusRing, logicalCSS, mathWithUnits } from '../../global_styling';
+
+export const euiTreeViewItemStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  const defaultSize = euiTheme.size.xl;
+  const compressedSize = euiTheme.size.l;
+
+  return {
+    li: {
+      euiTreeView__node: css``,
+      default: css`
+        ${logicalCSS('max-height', defaultSize)}
+        line-height: ${defaultSize};
+      `,
+      compressed: css`
+        ${logicalCSS('max-height', compressedSize)}
+        line-height: ${compressedSize};
+      `,
+      expanded: css`
+        ${logicalCSS('max-height', '100vh')}
+      `,
+    },
+
+    button: {
+      euiTreeView__nodeInner: css`
+        ${logicalCSS('width', '100%')}
+        ${logicalCSS('padding-left', euiTheme.size.s)}
+        ${logicalCSS('padding-right', euiTheme.size.xxs)}
+        display: flex;
+        align-items: center;
+
+        &:focus {
+          ${euiFocusRing(euiThemeContext, 'inset')}
+        }
+
+        &:hover,
+        &:active,
+        &:focus {
+          background-color: ${transparentize(
+            euiTheme.colors.text,
+            euiTheme.focus.transparency
+          )};
+        }
+      `,
+      default: css`
+        ${logicalCSS('height', defaultSize)}
+        gap: ${euiTheme.size.s};
+        border-radius: ${euiTheme.border.radius.medium};
+      `,
+      compressed: css`
+        ${logicalCSS('height', compressedSize)}
+        gap: ${euiTheme.size.xs};
+        border-radius: ${euiTheme.border.radius.small};
+      `,
+    },
+
+    icon: {
+      // Line height helps vertically center the icons
+      euiTreeView__iconWrapper: css`
+        line-height: 0;
+      `,
+      euiTreeView__placeholder: css``,
+      default: css`
+        ${logicalCSS(
+          'width',
+          mathWithUnits(defaultSize, (x) => x / 2)
+        )}
+      `,
+      compressed: css`
+        ${logicalCSS(
+          'width',
+          mathWithUnits(compressedSize, (x) => x / 2)
+        )}
+      `,
+    },
+  };
+};

--- a/src/components/tree_view/_tree_view_item.tsx
+++ b/src/components/tree_view/_tree_view_item.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  PropsWithChildren,
+  HTMLAttributes,
+  ReactNode,
+  Ref,
+  memo,
+} from 'react';
+import classNames from 'classnames';
+
+import { useEuiTheme } from '../../services';
+import { CommonProps } from '../common';
+import { EuiIcon } from '../icon';
+
+import { EuiTreeViewProps } from './tree_view';
+import { euiTreeViewItemStyles } from './_tree_view_item.styles';
+
+type EuiTreeViewItemProps = HTMLAttributes<HTMLButtonElement> &
+  CommonProps &
+  PropsWithChildren & {
+    id: string;
+    label: ReactNode;
+    icon?: ReactNode;
+    hasArrow?: boolean;
+    isActive?: boolean;
+    isExpanded?: boolean;
+    display?: EuiTreeViewProps['display'];
+    buttonRef?: Ref<HTMLButtonElement>;
+    wrapperProps?: HTMLAttributes<HTMLLIElement>;
+  };
+
+export const EuiTreeViewItem: FunctionComponent<EuiTreeViewItemProps> = memo(
+  ({
+    id,
+    label,
+    className,
+    children,
+    display = 'default',
+    icon,
+    hasArrow,
+    isActive,
+    isExpanded,
+    buttonRef,
+    wrapperProps,
+    ...rest
+  }) => {
+    const euiTheme = useEuiTheme();
+    const styles = euiTreeViewItemStyles(euiTheme);
+
+    const wrapperClasses = classNames(
+      'euiTreeView__node',
+      { 'euiTreeView__node--expanded': isExpanded },
+      wrapperProps?.className
+    );
+    const wrapperStyles = [
+      styles.li.euiTreeView__node,
+      styles.li[display],
+      isExpanded && styles.li.expanded,
+    ];
+
+    const buttonClasses = classNames('euiTreeView__nodeInner', className, {
+      'euiTreeView__node--active': isActive,
+    });
+    const buttonStyles = [
+      styles.button.euiTreeView__nodeInner,
+      styles.button[display],
+    ];
+
+    const iconStyles = [
+      styles.icon.euiTreeView__iconWrapper,
+      styles.icon[display],
+    ];
+
+    return (
+      <li {...wrapperProps} css={wrapperStyles} className={wrapperClasses}>
+        <button
+          id={id}
+          css={buttonStyles}
+          className={buttonClasses}
+          aria-expanded={isExpanded}
+          ref={buttonRef}
+          {...rest}
+        >
+          {hasArrow &&
+            (!!children ? (
+              <EuiIcon
+                className="euiTreeView__expansionArrow"
+                size={display === 'compressed' ? 's' : 'm'}
+                type={isExpanded ? 'arrowDown' : 'arrowRight'}
+              />
+            ) : (
+              <span
+                css={iconStyles}
+                className="euiTreeView__arrowPlaceholder"
+              />
+            ))}
+          {icon && (
+            <span css={iconStyles} className="euiTreeView__iconWrapper">
+              {icon}
+            </span>
+          )}
+          <span className="euiTreeView__nodeLabel eui-textTruncate">
+            {label}
+          </span>
+        </button>
+        {children}
+      </li>
+    );
+  }
+);
+EuiTreeViewItem.displayName = 'EuiTreeViewItem';

--- a/src/components/tree_view/tree_view.a11y.tsx
+++ b/src/components/tree_view/tree_view.a11y.tsx
@@ -77,13 +77,13 @@ describe('EuiTreeView', () => {
   describe('Automated accessibility check', () => {
     it('has zero violations on first render', () => {
       cy.mount(<TreeView />);
-      cy.get('div.euiTreeView__wrapper').should('exist');
+      cy.get('ul.euiTreeView').should('exist');
       cy.checkAxe();
     });
 
     it('has zero violations with a nested child expanded', () => {
       cy.mount(<TreeView />);
-      cy.get('div.euiTreeView__wrapper').should('exist');
+      cy.get('ul.euiTreeView').should('exist');
       cy.get('button#item_b').realClick();
       cy.get('button#item_b').should('have.attr', 'aria-expanded', 'true');
       cy.get('li.euiTreeView__node').contains('A Cloud').should('exist');

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -1,9 +1,0 @@
-.euiTreeView__iconPlaceholder {
-  width: $euiSizeXL;
-}
-
-.euiTreeView--compressed {
-  .euiTreeView__iconPlaceholder {
-    width: $euiSizeL;
-  }
-}

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -2,46 +2,8 @@
   width: $euiSizeXL;
 }
 
-.euiTreeView__iconWrapper {
-  margin-right: $euiSizeS;
-}
-
 .euiTreeView--compressed {
-  .euiTreeView__iconWrapper {
-    margin: 0 ($euiSizeS * .75) 0 0;
-  }
-
   .euiTreeView__iconPlaceholder {
     width: $euiSizeL;
-  }
-}
-
-.euiTreeView--withArrows {
-  .euiTreeView__expansionArrow {
-    margin-right: $euiSizeXS;
-  }
-
-  &.euiTreeView {
-    .euiTreeView__nodeInner--withArrows {
-      .euiTreeView__iconWrapper {
-        margin-left: 0;
-      }
-    }
-
-    .euiTreeView__iconWrapper {
-      margin-left: $euiSize + $euiSizeXS;
-    }
-  }
-
-  &.euiTreeView--compressed {
-    .euiTreeView__nodeInner--withArrows {
-      .euiTreeView__iconWrapper {
-        margin-left: 0;
-      }
-    }
-
-    .euiTreeView__iconWrapper {
-      margin-left: $euiSize;
-    }
   }
 }

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -1,8 +1,3 @@
-.euiTreeView__wrapper .euiTreeView {
-  margin: 0;
-  list-style-type: none;
-}
-
 .euiTreeView__node {
   max-height: $euiSizeXL;
   line-height: $euiSizeXL;

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -25,10 +25,6 @@
   }
 }
 
-.euiTreeView__nodeLabel {
-  @include euiTextTruncate;
-}
-
 .euiTreeView__iconWrapper {
   margin-top: -($euiSizeXS / 2);
   margin-right: $euiSizeS;
@@ -46,10 +42,6 @@
 
   .euiTreeView__iconWrapper {
     margin: 0 ($euiSizeS * .75) 0 0;
-  }
-
-  .euiTreeView__nodeLabel {
-    margin-top: -1px;
   }
 
   .euiTreeView__iconPlaceholder {

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -3,13 +3,7 @@
 }
 
 .euiTreeView__iconWrapper {
-  margin-top: -($euiSizeXS / 2);
   margin-right: $euiSizeS;
-
-  // This helps tokens appear vertically centered
-  .euiToken {
-    margin-top: $euiSizeXS / 2;
-  }
 }
 
 .euiTreeView--compressed {

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -3,10 +3,6 @@
   list-style-type: none;
 }
 
-.euiTreeView .euiTreeView {
-  padding-left: $euiSizeL;
-}
-
 .euiTreeView__node {
   max-height: $euiSizeXL;
   line-height: $euiSizeXL;

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -1,28 +1,5 @@
-.euiTreeView__nodeInner {
-  @include euiTextTruncate;
-
-  padding-left: $euiSizeS;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  height: $euiSizeXL;
-  border-radius: $euiBorderRadius;
-  width: 100%;
-  text-align-last: left;
-
-  &:focus {
-    @include euiFocusRing('small', 'inner');
-  }
-
-  &:hover,
-  &:active,
-  &:focus {
-    @include euiFocusBackground($euiTextColor);
-  }
-
-  .euiTreeView__iconPlaceholder {
-    width: $euiSizeXL;
-  }
+.euiTreeView__iconPlaceholder {
+  width: $euiSizeXL;
 }
 
 .euiTreeView__iconWrapper {
@@ -36,10 +13,6 @@
 }
 
 .euiTreeView--compressed {
-  .euiTreeView__nodeInner {
-    height: $euiSizeL;
-  }
-
   .euiTreeView__iconWrapper {
     margin: 0 ($euiSizeS * .75) 0 0;
   }

--- a/src/components/tree_view/tree_view.scss
+++ b/src/components/tree_view/tree_view.scss
@@ -1,12 +1,3 @@
-.euiTreeView__node {
-  max-height: $euiSizeXL;
-  line-height: $euiSizeXL;
-}
-
-.euiTreeView__node--expanded {
-  max-height: 100vh;
-}
-
 .euiTreeView__nodeInner {
   @include euiTextTruncate;
 
@@ -48,32 +39,21 @@
   }
 }
 
-// TODO: Address nesting during Emotion conversion, if possible
-// stylelint-disable max-nesting-depth
 .euiTreeView--compressed {
-  .euiTreeView__node {
-    max-height: $euiSizeL;
-    line-height: $euiSizeL;
-
-    .euiTreeView__nodeInner {
-      height: $euiSizeL;
-    }
-
-    .euiTreeView__iconWrapper {
-      margin: 0 ($euiSizeS * .75) 0 0;
-    }
-
-    .euiTreeView__nodeLabel {
-      margin-top: -1px;
-    }
-
-    .euiTreeView__iconPlaceholder {
-      width: $euiSizeL;
-    }
+  .euiTreeView__nodeInner {
+    height: $euiSizeL;
   }
 
-  .euiTreeView__node--expanded {
-    max-height: 100vh;
+  .euiTreeView__iconWrapper {
+    margin: 0 ($euiSizeS * .75) 0 0;
+  }
+
+  .euiTreeView__nodeLabel {
+    margin-top: -1px;
+  }
+
+  .euiTreeView__iconPlaceholder {
+    width: $euiSizeL;
   }
 }
 

--- a/src/components/tree_view/tree_view.spec.tsx
+++ b/src/components/tree_view/tree_view.spec.tsx
@@ -77,7 +77,7 @@ describe('EuiTreeView', () => {
   describe('Keyboard functionality', () => {
     it('Expands and collapses children correctly', () => {
       cy.realMount(<TreeView />);
-      cy.get('div.euiTreeView__wrapper').should('exist');
+      cy.get('ul.euiTreeView').should('exist');
       cy.repeatRealPress('Tab', 3);
       cy.focused().contains('Item B');
       cy.realPress('Enter');

--- a/src/components/tree_view/tree_view.stories.tsx
+++ b/src/components/tree_view/tree_view.stories.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiIcon } from '../icon';
+import { EuiToken } from '../token';
+
+import { EuiTreeView, EuiTreeViewProps } from './tree_view';
+
+const meta: Meta<EuiTreeViewProps> = {
+  title: 'EuiTreeView',
+  component: EuiTreeView,
+  argTypes: {
+    'aria-label': {
+      type: {
+        name: 'string',
+        required: true,
+      },
+      description:
+        'Passing either an `aria-label` or an `aria-labelledby` is required for accessibility.',
+    },
+    'aria-labelledby': {
+      type: { name: 'string', required: true },
+      description:
+        'Passing either an `aria-label` or an `aria-labelledby` is required for accessibility.',
+    },
+  },
+  args: {
+    // Component defaults
+    display: 'default',
+    expandByDefault: false,
+    showExpansionArrows: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiTreeViewProps>;
+
+export const Playground: Story = {
+  args: {
+    'aria-label': 'Directory of items',
+    items: [
+      {
+        label: 'Item One',
+        id: 'item_one',
+        icon: <EuiIcon type="folderClosed" />,
+        iconWhenExpanded: <EuiIcon type="folderOpen" />,
+        isExpanded: true,
+        children: [
+          {
+            label: 'Item A',
+            id: 'item_a',
+            icon: <EuiIcon type="document" />,
+          },
+          {
+            label: 'Item B',
+            id: 'item_b',
+            useEmptyIcon: true,
+            children: [
+              {
+                label: 'A Cloud',
+                id: 'item_cloud',
+                icon: <EuiToken iconType="tokenConstant" />,
+              },
+              {
+                label: "I'm a Bug",
+                id: 'item_bug',
+                icon: <EuiToken iconType="tokenEnum" />,
+              },
+            ],
+          },
+          {
+            label: 'Item C',
+            id: 'item_c',
+            children: [
+              {
+                label: 'Another Cloud',
+                id: 'item_cloud2',
+                icon: <EuiToken iconType="tokenConstant" />,
+              },
+              {
+                label:
+                  'This one is a really long string that we will check truncates correctly',
+                id: 'item_bug2',
+                useEmptyIcon: true,
+                callback: () => '',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        label: 'Item Two',
+        id: 'item_two',
+      },
+    ],
+  },
+};

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -13,6 +13,7 @@ import {
   euiFontSize,
   euiFocusRing,
   logicalCSS,
+  mathWithUnits,
 } from '../../global_styling';
 
 export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
@@ -75,10 +76,12 @@ export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
       `,
       default: css`
         ${logicalCSS('height', defaultSize)}
+        gap: ${euiTheme.size.s};
         border-radius: ${euiTheme.border.radius.medium};
       `,
       compressed: css`
         ${logicalCSS('height', compressedSize)}
+        gap: ${euiTheme.size.xs};
         border-radius: ${euiTheme.border.radius.small};
       `,
     },

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -8,8 +8,12 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme } from '../../services';
-import { euiFontSize, logicalCSS } from '../../global_styling';
+import { UseEuiTheme, transparentize } from '../../services';
+import {
+  euiFontSize,
+  euiFocusRing,
+  logicalCSS,
+} from '../../global_styling';
 
 export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
@@ -45,6 +49,37 @@ export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
       `,
       expanded: css`
         ${logicalCSS('max-height', '100vh')}
+      `,
+    },
+
+    button: {
+      euiTreeView__nodeInner: css`
+        ${logicalCSS('width', '100%')}
+        ${logicalCSS('padding-left', euiTheme.size.s)}
+        ${logicalCSS('padding-right', euiTheme.size.xxs)}
+        display: flex;
+        align-items: center;
+
+        &:focus {
+          ${euiFocusRing(euiThemeContext, 'inset')}
+        }
+
+        &:hover,
+        &:active,
+        &:focus {
+          background-color: ${transparentize(
+            euiTheme.colors.text,
+            euiTheme.focus.transparency
+          )};
+        }
+      `,
+      default: css`
+        ${logicalCSS('height', defaultSize)}
+        border-radius: ${euiTheme.border.radius.medium};
+      `,
+      compressed: css`
+        ${logicalCSS('height', compressedSize)}
+        border-radius: ${euiTheme.border.radius.small};
       `,
     },
   };

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+import { logicalCSS } from '../../global_styling';
+
+export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiTreeView: css`
+      & & {
+        ${logicalCSS('padding-left', euiTheme.size.l)}
+      }
+    `,
+  };
+};

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -82,5 +82,10 @@ export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
         border-radius: ${euiTheme.border.radius.small};
       `,
     },
+
+    // Line height helps vertically center the icons
+    euiTreeView__iconWrapper: css`
+      line-height: 0;
+    `,
   };
 };

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -8,19 +8,11 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme, transparentize } from '../../services';
-import {
-  euiFontSize,
-  euiFocusRing,
-  logicalCSS,
-  mathWithUnits,
-} from '../../global_styling';
+import { UseEuiTheme } from '../../services';
+import { euiFontSize, logicalCSS } from '../../global_styling';
 
 export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
-
-  const defaultSize = euiTheme.size.xl;
-  const compressedSize = euiTheme.size.l;
 
   return {
     euiTreeView: css`
@@ -37,73 +29,5 @@ export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
     compressed: css`
       font-size: ${euiFontSize(euiThemeContext, 's').fontSize};
     `,
-
-    li: {
-      euiTreeView__node: css``,
-      default: css`
-        ${logicalCSS('max-height', defaultSize)}
-        line-height: ${defaultSize};
-      `,
-      compressed: css`
-        ${logicalCSS('max-height', compressedSize)}
-        line-height: ${compressedSize};
-      `,
-      expanded: css`
-        ${logicalCSS('max-height', '100vh')}
-      `,
-    },
-
-    button: {
-      euiTreeView__nodeInner: css`
-        ${logicalCSS('width', '100%')}
-        ${logicalCSS('padding-left', euiTheme.size.s)}
-        ${logicalCSS('padding-right', euiTheme.size.xxs)}
-        display: flex;
-        align-items: center;
-
-        &:focus {
-          ${euiFocusRing(euiThemeContext, 'inset')}
-        }
-
-        &:hover,
-        &:active,
-        &:focus {
-          background-color: ${transparentize(
-            euiTheme.colors.text,
-            euiTheme.focus.transparency
-          )};
-        }
-      `,
-      default: css`
-        ${logicalCSS('height', defaultSize)}
-        gap: ${euiTheme.size.s};
-        border-radius: ${euiTheme.border.radius.medium};
-      `,
-      compressed: css`
-        ${logicalCSS('height', compressedSize)}
-        gap: ${euiTheme.size.xs};
-        border-radius: ${euiTheme.border.radius.small};
-      `,
-    },
-
-    icon: {
-      // Line height helps vertically center the icons
-      euiTreeView__iconWrapper: css`
-        line-height: 0;
-      `,
-      euiTreeView__placeholder: css``,
-      default: css`
-        ${logicalCSS(
-          'width',
-          mathWithUnits(defaultSize, (x) => x / 2)
-        )}
-      `,
-      compressed: css`
-        ${logicalCSS(
-          'width',
-          mathWithUnits(compressedSize, (x) => x / 2)
-        )}
-      `,
-    },
   };
 };

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -14,6 +14,9 @@ import { euiFontSize, logicalCSS } from '../../global_styling';
 export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
+  const defaultSize = euiTheme.size.xl;
+  const compressedSize = euiTheme.size.l;
+
   return {
     euiTreeView: css`
       margin: 0;
@@ -29,5 +32,20 @@ export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
     compressed: css`
       font-size: ${euiFontSize(euiThemeContext, 's').fontSize};
     `,
+
+    li: {
+      euiTreeView__node: css``,
+      default: css`
+        ${logicalCSS('max-height', defaultSize)}
+        line-height: ${defaultSize};
+      `,
+      compressed: css`
+        ${logicalCSS('max-height', compressedSize)}
+        line-height: ${compressedSize};
+      `,
+      expanded: css`
+        ${logicalCSS('max-height', '100vh')}
+      `,
+    },
   };
 };

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -9,16 +9,25 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import { logicalCSS } from '../../global_styling';
+import { euiFontSize, logicalCSS } from '../../global_styling';
 
 export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
   return {
     euiTreeView: css`
+      margin: 0;
+      list-style-type: none;
+
       & & {
         ${logicalCSS('padding-left', euiTheme.size.l)}
       }
+    `,
+    default: css`
+      font-size: ${euiFontSize(euiThemeContext, 'm').fontSize};
+    `,
+    compressed: css`
+      font-size: ${euiFontSize(euiThemeContext, 's').fontSize};
     `,
   };
 };

--- a/src/components/tree_view/tree_view.styles.ts
+++ b/src/components/tree_view/tree_view.styles.ts
@@ -86,9 +86,24 @@ export const euiTreeViewStyles = (euiThemeContext: UseEuiTheme) => {
       `,
     },
 
-    // Line height helps vertically center the icons
-    euiTreeView__iconWrapper: css`
-      line-height: 0;
-    `,
+    icon: {
+      // Line height helps vertically center the icons
+      euiTreeView__iconWrapper: css`
+        line-height: 0;
+      `,
+      euiTreeView__placeholder: css``,
+      default: css`
+        ${logicalCSS(
+          'width',
+          mathWithUnits(defaultSize, (x) => x / 2)
+        )}
+      `,
+      compressed: css`
+        ${logicalCSS(
+          'width',
+          mathWithUnits(compressedSize, (x) => x / 2)
+        )}
+      `,
+    },
   };
 };

--- a/src/components/tree_view/tree_view.test.tsx
+++ b/src/components/tree_view/tree_view.test.tsx
@@ -79,7 +79,7 @@ describe('EuiTreeView', () => {
       <EuiTreeView items={items} {...requiredProps} />
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   test('length of open items', () => {

--- a/src/components/tree_view/tree_view.test.tsx
+++ b/src/components/tree_view/tree_view.test.tsx
@@ -7,11 +7,13 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { render } from '../../test/rtl';
+import { shouldRenderCustomStyles } from '../../test/internal';
+import { requiredProps } from '../../test/required_props';
+
 import { EuiIcon } from '../icon';
 import { EuiToken } from '../token';
-import { shallow } from 'enzyme';
-import { requiredProps } from '../../test/required_props';
-import { render } from '../../test/rtl';
 
 import { EuiTreeView } from './tree_view';
 
@@ -74,6 +76,8 @@ const items = [
 ];
 
 describe('EuiTreeView', () => {
+  shouldRenderCustomStyles(<EuiTreeView items={items} />);
+
   test('is rendered', () => {
     const { container } = render(
       <EuiTreeView items={items} {...requiredProps} />
@@ -82,44 +86,42 @@ describe('EuiTreeView', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('length of open items', () => {
-    const component = shallow<EuiTreeView>(
+  test('item expansion', () => {
+    const { container, getByText } = render(
       <EuiTreeView items={items} aria-label="Tree" />
     );
-    const instance = component.instance();
+    const getExpandedItems = () =>
+      container.querySelectorAll('[aria-expanded="true"]');
+    expect(getExpandedItems()).toHaveLength(1);
 
-    expect(component.state('openItems')).toHaveLength(1);
-
-    instance.handleNodeClick(items[1]);
-    expect(component.state('openItems')).toHaveLength(2);
+    fireEvent.click(getByText('Item B'));
+    expect(getExpandedItems()).toHaveLength(2);
   });
 
-  test('activeItem changes', () => {
-    const component = shallow<EuiTreeView>(
+  test('active item', () => {
+    const { container, getByText } = render(
       <EuiTreeView items={items} aria-label="Tree" />
     );
-    const instance = component.instance();
+    const getActiveItem = () =>
+      container.querySelector('.euiTreeView__node--active');
+    expect(getActiveItem()).not.toBeInTheDocument();
 
-    expect(component.state('activeItem')).toBe('');
-
-    instance.handleNodeClick(items[1]);
-    expect(component.state('activeItem')).toBe('item_two');
+    fireEvent.click(getByText('Item Two')!);
+    expect(getActiveItem()).toBeInTheDocument();
   });
 
   test('open node changes', () => {
-    const component = shallow<EuiTreeView>(
+    const { queryByText, getByText } = render(
       <EuiTreeView items={items} aria-label="Tree" />
     );
-    const instance = component.instance();
+    expect(queryByText('Item C')).toBeInTheDocument();
+    expect(queryByText('Another Bug')).not.toBeInTheDocument();
 
-    expect(instance.isNodeOpen(items[1])).toBe(false);
+    fireEvent.click(getByText('Item C'));
+    expect(queryByText('Another Bug')).toBeInTheDocument();
 
-    instance.handleNodeClick(items[1]);
-    expect(instance.isNodeOpen(items[1])).toBe(true);
-
-    expect(instance.isNodeOpen(items[0])).toBe(true);
-
-    instance.handleNodeClick(items[0]);
-    expect(instance.isNodeOpen(items[0])).toBe(false);
+    fireEvent.click(getByText('Item One'));
+    expect(queryByText('Item C')).not.toBeInTheDocument();
+    expect(queryByText('Another Bug')).not.toBeInTheDocument();
   });
 });

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -399,7 +399,10 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                 />
                               ) : null}
                               {node.icon && !node.useEmptyIcon ? (
-                                <span className="euiTreeView__iconWrapper">
+                                <span
+                                  css={styles.euiTreeView__iconWrapper}
+                                  className="euiTreeView__iconWrapper"
+                                >
                                   {this.isNodeOpen(node) &&
                                   node.iconWhenExpanded
                                     ? node.iconWhenExpanded

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -79,13 +79,6 @@ export interface Node {
 
 export type EuiTreeViewDisplayOptions = 'default' | 'compressed';
 
-const displayToClassNameMap: {
-  [option in EuiTreeViewDisplayOptions]: string | null;
-} = {
-  default: null,
-  compressed: 'euiTreeView--compressed',
-};
-
 interface EuiTreeViewState {
   openItems: string[];
   activeItem: string;
@@ -287,12 +280,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
     const cssStyles = [styles.euiTreeView, styles[display]];
 
     // Computed classNames
-    const classes = classNames(
-      'euiTreeView',
-      display ? displayToClassNameMap[display] : null,
-      { 'euiTreeView--withArrows': showExpansionArrows },
-      className
-    );
+    const classes = classNames('euiTreeView', className);
 
     const instructionsId = `${this.state.treeID}--instruction`;
 
@@ -358,13 +346,11 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
 
                       const nodeButtonClasses = classNames(
                         'euiTreeView__nodeInner',
-                        showExpansionArrows && node.children
-                          ? 'euiTreeView__nodeInner--withArrows'
-                          : null,
-                        this.state.activeItem === node.id
-                          ? 'euiTreeView__node--active'
-                          : null,
-                        node.className ? node.className : null
+                        node.className,
+                        {
+                          'euiTreeView__node--active':
+                            this.state.activeItem === node.id,
+                        }
                       );
                       const buttonStyles = [
                         styles.button.euiTreeView__nodeInner,

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -284,7 +284,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
     } = this.props;
 
     const styles = euiTreeViewStyles(theme);
-    const cssStyles = [styles.euiTreeView];
+    const cssStyles = [styles.euiTreeView, styles[display]];
 
     // Computed classNames
     const classes = classNames(
@@ -298,151 +298,144 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
 
     return (
       <EuiTreeViewContext.Provider value={this.state.treeID}>
-        <EuiText
-          size={display === 'compressed' ? 's' : 'm'}
-          className="euiTreeView__wrapper"
-        >
-          {!this.isNested && (
-            <EuiI18n
-              token="euiTreeView.listNavigationInstructions"
-              default="You can quickly navigate this list using arrow keys."
-            >
-              {(listNavigationInstructions: string) => (
-                <EuiScreenReaderOnly>
-                  <p id={instructionsId}>{listNavigationInstructions}</p>
-                </EuiScreenReaderOnly>
-              )}
-            </EuiI18n>
-          )}
-          <ul
-            className={classes}
-            id={!this.isNested ? this.state.treeID : undefined}
-            aria-describedby={!this.isNested ? instructionsId : undefined}
-            {...rest}
+        {!this.isNested && (
+          <EuiI18n
+            token="euiTreeView.listNavigationInstructions"
+            default="You can quickly navigate this list using arrow keys."
           >
-            {items.map((node, index) => {
-              const buttonId = node.id;
-              const wrappingId = this.treeIdGenerator(buttonId);
+            {(listNavigationInstructions: string) => (
+              <EuiScreenReaderOnly>
+                <p id={instructionsId}>{listNavigationInstructions}</p>
+              </EuiScreenReaderOnly>
+            )}
+          </EuiI18n>
+        )}
+        <ul
+          css={cssStyles}
+          className={classes}
+          id={!this.isNested ? this.state.treeID : undefined}
+          aria-describedby={!this.isNested ? instructionsId : undefined}
+          {...rest}
+        >
+          {items.map((node, index) => {
+            const buttonId = node.id;
+            const wrappingId = this.treeIdGenerator(buttonId);
 
-              return (
-                <EuiInnerText
-                  key={node.id + index}
-                  fallback={typeof node.label === 'string' ? node.label : ''}
-                >
-                  {(ref, innerText) => (
-                    <EuiI18n
-                      key={node.id + index}
-                      token="euiTreeView.ariaLabel"
-                      default="{nodeLabel} child of {ariaLabel}"
-                      values={{
-                        nodeLabel: innerText,
-                        ariaLabel: hasAriaLabel(rest) ? rest['aria-label'] : '',
-                      }}
-                    >
-                      {(ariaLabel: string) => {
-                        const label:
-                          | { 'aria-label': string }
-                          | { 'aria-labelledby': string } = hasAriaLabel(rest)
-                          ? {
-                              'aria-label': ariaLabel,
-                            }
-                          : {
-                              'aria-labelledby': `${buttonId} ${rest['aria-labelledby']}`,
-                            };
-
-                        const nodeClasses = classNames(
-                          'euiTreeView__node',
-                          display ? displayToClassNameMap[display] : null,
-                          {
-                            'euiTreeView__node--expanded':
-                              this.isNodeOpen(node),
+            return (
+              <EuiInnerText
+                key={node.id + index}
+                fallback={typeof node.label === 'string' ? node.label : ''}
+              >
+                {(ref, innerText) => (
+                  <EuiI18n
+                    key={node.id + index}
+                    token="euiTreeView.ariaLabel"
+                    default="{nodeLabel} child of {ariaLabel}"
+                    values={{
+                      nodeLabel: innerText,
+                      ariaLabel: hasAriaLabel(rest) ? rest['aria-label'] : '',
+                    }}
+                  >
+                    {(ariaLabel: string) => {
+                      const label:
+                        | { 'aria-label': string }
+                        | { 'aria-labelledby': string } = hasAriaLabel(rest)
+                        ? {
+                            'aria-label': ariaLabel,
                           }
-                        );
+                        : {
+                            'aria-labelledby': `${buttonId} ${rest['aria-labelledby']}`,
+                          };
 
-                        const nodeButtonClasses = classNames(
-                          'euiTreeView__nodeInner',
-                          showExpansionArrows && node.children
-                            ? 'euiTreeView__nodeInner--withArrows'
-                            : null,
-                          this.state.activeItem === node.id
-                            ? 'euiTreeView__node--active'
-                            : null,
-                          node.className ? node.className : null
-                        );
+                      const nodeClasses = classNames(
+                        'euiTreeView__node',
+                        display ? displayToClassNameMap[display] : null,
+                        {
+                          'euiTreeView__node--expanded': this.isNodeOpen(node),
+                        }
+                      );
 
-                        return (
-                          <React.Fragment>
-                            <li className={nodeClasses}>
-                              <button
-                                id={buttonId}
-                                aria-controls={wrappingId}
-                                aria-expanded={this.isNodeOpen(node)}
-                                ref={(ref) => this.setButtonRef(ref, index)}
-                                data-test-subj={`euiTreeViewButton-${this.state.treeID}`}
-                                onKeyDown={(event: React.KeyboardEvent) =>
-                                  this.onKeyDown(event, node)
-                                }
-                                onClick={() => this.handleNodeClick(node)}
-                                className={nodeButtonClasses}
-                              >
-                                {showExpansionArrows && node.children ? (
-                                  <EuiIcon
-                                    className="euiTreeView__expansionArrow"
-                                    size={display === 'compressed' ? 's' : 'm'}
-                                    type={
-                                      this.isNodeOpen(node)
-                                        ? 'arrowDown'
-                                        : 'arrowRight'
-                                    }
-                                  />
-                                ) : null}
-                                {node.icon && !node.useEmptyIcon ? (
-                                  <span className="euiTreeView__iconWrapper">
-                                    {this.isNodeOpen(node) &&
-                                    node.iconWhenExpanded
-                                      ? node.iconWhenExpanded
-                                      : node.icon}
-                                  </span>
-                                ) : null}
-                                {node.useEmptyIcon && !node.icon ? (
-                                  <span className="euiTreeView__iconPlaceholder" />
-                                ) : null}
-                                <span
-                                  ref={ref}
-                                  className="euiTreeView__nodeLabel"
-                                >
-                                  {node.label}
+                      const nodeButtonClasses = classNames(
+                        'euiTreeView__nodeInner',
+                        showExpansionArrows && node.children
+                          ? 'euiTreeView__nodeInner--withArrows'
+                          : null,
+                        this.state.activeItem === node.id
+                          ? 'euiTreeView__node--active'
+                          : null,
+                        node.className ? node.className : null
+                      );
+
+                      return (
+                        <React.Fragment>
+                          <li className={nodeClasses}>
+                            <button
+                              id={buttonId}
+                              aria-controls={wrappingId}
+                              aria-expanded={this.isNodeOpen(node)}
+                              ref={(ref) => this.setButtonRef(ref, index)}
+                              data-test-subj={`euiTreeViewButton-${this.state.treeID}`}
+                              onKeyDown={(event: React.KeyboardEvent) =>
+                                this.onKeyDown(event, node)
+                              }
+                              onClick={() => this.handleNodeClick(node)}
+                              className={nodeButtonClasses}
+                            >
+                              {showExpansionArrows && node.children ? (
+                                <EuiIcon
+                                  className="euiTreeView__expansionArrow"
+                                  size={display === 'compressed' ? 's' : 'm'}
+                                  type={
+                                    this.isNodeOpen(node)
+                                      ? 'arrowDown'
+                                      : 'arrowRight'
+                                  }
+                                />
+                              ) : null}
+                              {node.icon && !node.useEmptyIcon ? (
+                                <span className="euiTreeView__iconWrapper">
+                                  {this.isNodeOpen(node) &&
+                                  node.iconWhenExpanded
+                                    ? node.iconWhenExpanded
+                                    : node.icon}
                                 </span>
-                              </button>
-                              <div
-                                id={wrappingId}
-                                onKeyDown={(event: React.KeyboardEvent) =>
-                                  this.onChildrenKeydown(event, index)
-                                }
+                              ) : null}
+                              {node.useEmptyIcon && !node.icon ? (
+                                <span className="euiTreeView__iconPlaceholder" />
+                              ) : null}
+                              <span
+                                ref={ref}
+                                className="euiTreeView__nodeLabel"
                               >
-                                {node.children && this.isNodeOpen(node) ? (
-                                  <EuiTreeView
-                                    items={node.children}
-                                    display={display}
-                                    showExpansionArrows={showExpansionArrows}
-                                    expandByDefault={
-                                      this.state.expandChildNodes
-                                    }
-                                    {...label}
-                                  />
-                                ) : null}
-                              </div>
-                            </li>
-                          </React.Fragment>
-                        );
-                      }}
-                    </EuiI18n>
-                  )}
-                </EuiInnerText>
-              );
-            })}
-          </ul>
-        </EuiText>
+                                {node.label}
+                              </span>
+                            </button>
+                            <div
+                              id={wrappingId}
+                              onKeyDown={(event: React.KeyboardEvent) =>
+                                this.onChildrenKeydown(event, index)
+                              }
+                            >
+                              {node.children && this.isNodeOpen(node) ? (
+                                <EuiTreeView
+                                  items={node.children}
+                                  display={display}
+                                  showExpansionArrows={showExpansionArrows}
+                                  expandByDefault={this.state.expandChildNodes}
+                                  {...label}
+                                />
+                              ) : null}
+                            </div>
+                          </li>
+                        </React.Fragment>
+                      );
+                    }}
+                  </EuiI18n>
+                )}
+              </EuiInnerText>
+            );
+          })}
+        </ul>
       </EuiTreeViewContext.Provider>
     );
   }

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -309,7 +309,9 @@ export class EuiTreeViewClass extends Component<
           {items.map((node, index) => {
             const buttonId = node.id;
             const wrappingId = this.treeIdGenerator(buttonId);
-            const isNodeExpanded = this.isNodeOpen(node);
+            const isNodeExpanded = node.children
+              ? this.isNodeOpen(node)
+              : undefined; // Determines the `aria-expanded` attribute
 
             let icon = node.icon;
             if (node.iconWhenExpanded && isNodeExpanded) {

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -347,13 +347,14 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                             'aria-labelledby': `${buttonId} ${rest['aria-labelledby']}`,
                           };
 
-                      const nodeClasses = classNames(
-                        'euiTreeView__node',
-                        display ? displayToClassNameMap[display] : null,
-                        {
-                          'euiTreeView__node--expanded': this.isNodeOpen(node),
-                        }
-                      );
+                      const nodeClasses = classNames('euiTreeView__node', {
+                        'euiTreeView__node--expanded': this.isNodeOpen(node),
+                      });
+                      const liStyles = [
+                        styles.li.euiTreeView__node,
+                        styles.li[display],
+                        this.isNodeOpen(node) && styles.li.expanded,
+                      ];
 
                       const nodeButtonClasses = classNames(
                         'euiTreeView__nodeInner',
@@ -368,7 +369,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
 
                       return (
                         <React.Fragment>
-                          <li className={nodeClasses}>
+                          <li css={liStyles} className={nodeClasses}>
                             <button
                               id={buttonId}
                               aria-controls={wrappingId}

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -91,7 +91,7 @@ export type CommonTreeProps = CommonProps &
     items: Node[];
     /**
      * Optionally use a variation with smaller text and icon sizes
-     * @default 'default'
+     * @default default
      */
     display?: EuiTreeViewDisplayOptions;
     /**

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -371,6 +371,15 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                         styles.button[display],
                       ];
 
+                      const iconStyles = [
+                        styles.icon.euiTreeView__iconWrapper,
+                        styles.icon[display],
+                      ];
+                      const placeholderStyles = [
+                        styles.icon.euiTreeView__placeholder,
+                        styles.icon[display],
+                      ];
+
                       return (
                         <React.Fragment>
                           <li css={liStyles} className={nodeClasses}>
@@ -387,20 +396,26 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                               css={buttonStyles}
                               className={nodeButtonClasses}
                             >
-                              {showExpansionArrows && node.children ? (
-                                <EuiIcon
-                                  className="euiTreeView__expansionArrow"
-                                  size={display === 'compressed' ? 's' : 'm'}
-                                  type={
-                                    this.isNodeOpen(node)
-                                      ? 'arrowDown'
-                                      : 'arrowRight'
-                                  }
-                                />
-                              ) : null}
+                              {showExpansionArrows &&
+                                (node.children ? (
+                                  <EuiIcon
+                                    className="euiTreeView__expansionArrow"
+                                    size={display === 'compressed' ? 's' : 'm'}
+                                    type={
+                                      this.isNodeOpen(node)
+                                        ? 'arrowDown'
+                                        : 'arrowRight'
+                                    }
+                                  />
+                                ) : (
+                                  <span
+                                    css={placeholderStyles}
+                                    className="euiTreeView__arrowPlaceholder"
+                                  />
+                                ))}
                               {node.icon && !node.useEmptyIcon ? (
                                 <span
-                                  css={styles.euiTreeView__iconWrapper}
+                                  css={iconStyles}
                                   className="euiTreeView__iconWrapper"
                                 >
                                   {this.isNodeOpen(node) &&
@@ -410,7 +425,10 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                 </span>
                               ) : null}
                               {node.useEmptyIcon && !node.icon ? (
-                                <span className="euiTreeView__iconPlaceholder" />
+                                <span
+                                  css={placeholderStyles}
+                                  className="euiTreeView__iconPlaceholder"
+                                />
                               ) : null}
                               <span
                                 ref={ref}

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -366,6 +366,10 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                           : null,
                         node.className ? node.className : null
                       );
+                      const buttonStyles = [
+                        styles.button.euiTreeView__nodeInner,
+                        styles.button[display],
+                      ];
 
                       return (
                         <React.Fragment>
@@ -380,6 +384,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                 this.onKeyDown(event, node)
                               }
                               onClick={() => this.handleNodeClick(node)}
+                              css={buttonStyles}
                               className={nodeButtonClasses}
                             >
                               {showExpansionArrows && node.children ? (

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -13,13 +13,20 @@ import React, {
   ContextType,
 } from 'react';
 import classNames from 'classnames';
+
+import {
+  withEuiTheme,
+  WithEuiThemeProps,
+  keys,
+  htmlIdGenerator,
+} from '../../services';
 import { CommonProps } from '../common';
 import { EuiI18n } from '../i18n';
 import { EuiIcon } from '../icon';
 import { EuiScreenReaderOnly } from '../accessibility';
-import { EuiText } from '../text';
-import { keys, htmlIdGenerator } from '../../services';
 import { EuiInnerText } from '../inner_text';
+
+import { euiTreeViewStyles } from './tree_view.styles';
 
 const EuiTreeViewContext = createContext<string>('');
 
@@ -272,8 +279,12 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
       display = 'default',
       expandByDefault,
       showExpansionArrows,
+      theme,
       ...rest
     } = this.props;
+
+    const styles = euiTreeViewStyles(theme);
+    const cssStyles = [styles.euiTreeView];
 
     // Computed classNames
     const classes = classNames(
@@ -436,3 +447,5 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
     );
   }
 }
+
+export const EuiTreeView = withEuiTheme<EuiTreeViewProps>(EuiTreeViewClass);

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -92,16 +92,21 @@ export type CommonTreeProps = CommonProps &
      * Never accepts children directly, only through the `items` prop
      */
     children?: never;
-    /** An array of EuiTreeViewNodes
+    /**
+     * An array of EuiTreeViewNodes
      */
     items: Node[];
-    /** Optionally use a variation with smaller text and icon sizes
+    /**
+     * Optionally use a variation with smaller text and icon sizes
+     * @default 'default'
      */
     display?: EuiTreeViewDisplayOptions;
-    /** Set all items to open on initial load
+    /**
+     * Set all items to open on initial load
      */
     expandByDefault?: boolean;
-    /** Display expansion arrows next to all items
+    /**
+     * Display expansion arrows next to all items
      * that contain children
      */
     showExpansionArrows?: boolean;
@@ -113,7 +118,10 @@ export type EuiTreeViewProps = Omit<
 > &
   ({ 'aria-label': string } | { 'aria-labelledby': string });
 
-export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
+export class EuiTreeViewClass extends Component<
+  EuiTreeViewProps & WithEuiThemeProps,
+  EuiTreeViewState
+> {
   treeIdGenerator = htmlIdGenerator('euiTreeView');
 
   static contextType = EuiTreeViewContext;
@@ -122,7 +130,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
   isNested: boolean;
 
   constructor(
-    props: EuiTreeViewProps,
+    props: EuiTreeViewProps & WithEuiThemeProps,
     // Without the optional ? typing, TS will throw errors on JSX component errors
     // @see https://github.com/facebook/react/issues/13944#issuecomment-1183693239
     context?: ContextType<typeof EuiTreeViewContext>
@@ -367,7 +375,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                       ];
 
                       return (
-                        <React.Fragment>
+                        <>
                           <li css={liStyles} className={nodeClasses}>
                             <button
                               id={buttonId}
@@ -399,7 +407,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                     className="euiTreeView__arrowPlaceholder"
                                   />
                                 ))}
-                              {node.icon && !node.useEmptyIcon ? (
+                              {node.icon && !node.useEmptyIcon && (
                                 <span
                                   css={iconStyles}
                                   className="euiTreeView__iconWrapper"
@@ -409,13 +417,13 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                     ? node.iconWhenExpanded
                                     : node.icon}
                                 </span>
-                              ) : null}
-                              {node.useEmptyIcon && !node.icon ? (
+                              )}
+                              {node.useEmptyIcon && !node.icon && (
                                 <span
                                   css={placeholderStyles}
                                   className="euiTreeView__iconPlaceholder"
                                 />
-                              ) : null}
+                              )}
                               <span
                                 ref={ref}
                                 className="euiTreeView__nodeLabel eui-textTruncate"
@@ -429,7 +437,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                 this.onChildrenKeydown(event, index)
                               }
                             >
-                              {node.children && this.isNodeOpen(node) ? (
+                              {node.children && this.isNodeOpen(node) && (
                                 <EuiTreeView
                                   items={node.children}
                                   display={display}
@@ -437,10 +445,10 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                                   expandByDefault={this.state.expandChildNodes}
                                   {...label}
                                 />
-                              ) : null}
+                              )}
                             </div>
                           </li>
-                        </React.Fragment>
+                        </>
                       );
                     }}
                   </EuiI18n>

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -299,11 +299,13 @@ export class EuiTreeViewClass extends Component<
             )}
           </EuiI18n>
         )}
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
         <ul
           css={cssStyles}
           className={classes}
           id={!this.isNested ? this.state.treeID : undefined}
           aria-describedby={!this.isNested ? instructionsId : undefined}
+          role="list" // VoiceOver doesn't parse lists with `list-style: none` as the correct role - @see https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
           {...rest}
         >
           {items.map((node, index) => {

--- a/src/components/tree_view/tree_view.tsx
+++ b/src/components/tree_view/tree_view.tsx
@@ -406,7 +406,7 @@ export class EuiTreeView extends Component<EuiTreeViewProps, EuiTreeViewState> {
                               ) : null}
                               <span
                                 ref={ref}
-                                className="euiTreeView__nodeLabel"
+                                className="euiTreeView__nodeLabel eui-textTruncate"
                               >
                                 {node.label}
                               </span>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6416

Opinionated changes as part of this conversion:
- Removes `.euiTreeView__wrapper` (unnecessary extra div wrapper)
- Icons are now better vertically aligned/centered with text, and a consistent `icon` width/height is now enforced based on `display`/compressed sizing

As always, I recommend [reviewing by commit](https://github.com/elastic/eui/pull/7513/commits).

### ⚠️ Kibana usages that will need updating

https://github.com/elastic/kibana/blob/432a5d7734f127c321f75679be913a87bc3c71a6/x-pack/plugins/kubernetes_security/public/components/tree_view_container/dynamic_tree_view/index.tsx

The above is the highest-lift impact in Kibana that will need updating once this upgrade lands. They're apparently using the styles of EuiTreeView but not the actual component, which is partially why I split out a fairly stateless `EuiTreeViewItem` component for them to pull from and use directly.

## QA

- [x] Confirm [staging](https://eui.elastic.co/pr_7513/#/navigation/tree-view) looks the same as [production](https://eui.elastic.co/#/navigation/tree-view) (aside from some minor tweaks to icon vertical alignment/spacing)
- [x] Confirm that the [storybook toggles](https://eui.elastic.co/pr_7513/storybook/?path=/story/euitreeview--playground) work as expected (particularly `display` and `showExpansionArrows`)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist
    - ~[ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
- [x] [Emotion checklist](https://github.com/elastic/eui/issues/6416)