### PR TITLE
[EuiSuperDatePicker][EuiAutoRefresh][EuiRefreshInterval] Allow setting a minimum interval in milliseconds

### DIFF
--- a/changelogs/upcoming/7516.md
+++ b/changelogs/upcoming/7516.md
@@ -1,0 +1,2 @@
+- Updated `EuiSuperDatePicker` with a new `refreshMinInterval` prop, which accepts a minimum number in milliseconds
+- Updated `EuiAutoRefresh` and `EuiRefreshInterval` with a new `minInterval` prop, which accepts a minimum number in milliseconds

--- a/src/components/date_picker/auto_refresh/auto_refresh.test.tsx
+++ b/src/components/date_picker/auto_refresh/auto_refresh.test.tsx
@@ -43,12 +43,13 @@ describe('EuiAutoRefresh', () => {
   });
 
   test('minInterval renders an invalid warning on the number input', () => {
+    const onRefreshChange = jest.fn();
     const { getByRole, getByTestSubject } = render(
       <EuiAutoRefresh
         isPaused={false}
         refreshInterval={1000}
         minInterval={3000}
-        onRefreshChange={() => {}}
+        onRefreshChange={onRefreshChange}
       />
     );
     const getNumberInput = () =>
@@ -60,12 +61,27 @@ describe('EuiAutoRefresh', () => {
     expect(getNumberInput()).toBeInvalid();
 
     fireEvent.change(getUnitSelect(), { target: { value: 'm' } });
+    expect(onRefreshChange).toHaveBeenLastCalledWith({
+      refreshInterval: 60000,
+      intervalUnits: 'm',
+      isPaused: false,
+    });
     expect(getNumberInput()).toBeValid();
 
     fireEvent.change(getUnitSelect(), { target: { value: 's' } });
+    expect(onRefreshChange).toHaveBeenLastCalledWith({
+      refreshInterval: 3000, // Should pass back the minimum instead of the current 1000 value
+      intervalUnits: 's',
+      isPaused: false,
+    });
     expect(getNumberInput()).toBeInvalid();
 
     fireEvent.change(getNumberInput(), { target: { value: 5 } });
+    expect(onRefreshChange).toHaveBeenLastCalledWith({
+      refreshInterval: 5000,
+      intervalUnits: 's',
+      isPaused: false,
+    });
     expect(getNumberInput()).toBeValid();
   });
 

--- a/src/components/date_picker/auto_refresh/auto_refresh.test.tsx
+++ b/src/components/date_picker/auto_refresh/auto_refresh.test.tsx
@@ -42,6 +42,33 @@ describe('EuiAutoRefresh', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  test('minInterval renders an invalid warning on the number input', () => {
+    const { getByRole, getByTestSubject } = render(
+      <EuiAutoRefresh
+        isPaused={false}
+        refreshInterval={1000}
+        minInterval={3000}
+        onRefreshChange={() => {}}
+      />
+    );
+    const getNumberInput = () =>
+      getByTestSubject('superDatePickerRefreshIntervalInput');
+    const getUnitSelect = () =>
+      getByTestSubject('superDatePickerRefreshIntervalUnitsSelect');
+
+    fireEvent.click(getByRole('button'));
+    expect(getNumberInput()).toBeInvalid();
+
+    fireEvent.change(getUnitSelect(), { target: { value: 'm' } });
+    expect(getNumberInput()).toBeValid();
+
+    fireEvent.change(getUnitSelect(), { target: { value: 's' } });
+    expect(getNumberInput()).toBeInvalid();
+
+    fireEvent.change(getNumberInput(), { target: { value: 5 } });
+    expect(getNumberInput()).toBeValid();
+  });
+
   test('intervalUnits forces rendering in the provided units', () => {
     const { getByLabelText, getByRole, getByTestSubject } = render(
       <EuiAutoRefresh

--- a/src/components/date_picker/auto_refresh/auto_refresh.tsx
+++ b/src/components/date_picker/auto_refresh/auto_refresh.tsx
@@ -40,6 +40,7 @@ export const EuiAutoRefresh: FunctionComponent<EuiAutoRefreshProps> = ({
   isDisabled,
   isPaused = true,
   refreshInterval = 1000,
+  minInterval = 0,
   readOnly = true,
   ...rest
 }) => {
@@ -90,6 +91,7 @@ export const EuiAutoRefresh: FunctionComponent<EuiAutoRefreshProps> = ({
         onRefreshChange={onRefreshChange}
         isPaused={isPaused}
         refreshInterval={refreshInterval}
+        minInterval={minInterval}
         intervalUnits={intervalUnits}
       />
     </EuiInputPopover>
@@ -115,6 +117,7 @@ export const EuiAutoRefreshButton: FunctionComponent<
   isDisabled,
   isPaused = true,
   refreshInterval = 1000,
+  minInterval = 0,
   shortHand = false,
   size = 's',
   color = 'text',
@@ -168,6 +171,7 @@ export const EuiAutoRefreshButton: FunctionComponent<
         onRefreshChange={onRefreshChange}
         isPaused={isPaused}
         refreshInterval={refreshInterval}
+        minInterval={minInterval}
         intervalUnits={intervalUnits}
       />
     </EuiPopover>

--- a/src/components/date_picker/auto_refresh/refresh_interval.tsx
+++ b/src/components/date_picker/auto_refresh/refresh_interval.tsx
@@ -77,9 +77,9 @@ export type EuiRefreshIntervalProps = {
    */
   refreshInterval?: Milliseconds;
   /**
-   * Passes back the updated state of `isPaused` `refreshInterval`, and `intervalUnits`.
+   * Allows specifying a minimum interval in milliseconds
    */
-  onRefreshChange: ApplyRefreshInterval;
+  minInterval?: Milliseconds;
   /**
    * By default, refresh interval units will be rounded up to next largest unit of time
    * (for example, 90 seconds will become 2m).
@@ -87,6 +87,10 @@ export type EuiRefreshIntervalProps = {
    * If you do not want this behavior, you can manually control the rendered unit via this prop.
    */
   intervalUnits?: RefreshUnitsOptions;
+  /**
+   * Passes back the updated state of `isPaused`, `refreshInterval`, and `intervalUnits`.
+   */
+  onRefreshChange: ApplyRefreshInterval;
 };
 
 interface EuiRefreshIntervalState {
@@ -101,6 +105,7 @@ export class EuiRefreshInterval extends Component<
   static defaultProps = {
     isPaused: true,
     refreshInterval: 1000,
+    minInterval: 0,
   };
 
   state: EuiRefreshIntervalState = fromMilliseconds(

--- a/src/components/date_picker/auto_refresh/refresh_interval.tsx
+++ b/src/components/date_picker/auto_refresh/refresh_interval.tsx
@@ -171,7 +171,7 @@ export class EuiRefreshInterval extends Component<
   };
 
   applyRefreshInterval = () => {
-    const { onRefreshChange, isPaused } = this.props;
+    const { onRefreshChange, isPaused, minInterval } = this.props;
     const { units, value } = this.state;
     if (value === '') {
       return;
@@ -180,7 +180,10 @@ export class EuiRefreshInterval extends Component<
       return;
     }
 
-    const refreshInterval = toMilliseconds(units, value);
+    const refreshInterval = Math.max(
+      toMilliseconds(units, value),
+      minInterval || 0
+    );
 
     onRefreshChange({
       refreshInterval,

--- a/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -350,6 +350,7 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
               class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
               data-test-subj="superDatePickerRefreshIntervalInput"
               disabled=""
+              min="0"
               step="any"
               type="number"
               value="0"

--- a/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -149,6 +149,11 @@ export type EuiSuperDatePickerProps = CommonProps & {
    */
   refreshInterval?: Milliseconds;
   /**
+   * Minimum refresh interval in milliseconds
+   * @default 0
+   */
+  refreshMinInterval?: Milliseconds;
+  /**
    * By default, refresh interval units will be rounded up to next largest unit of time
    * (for example, 90 seconds will become 2m).
    *
@@ -497,6 +502,7 @@ export class EuiSuperDatePickerInternal extends Component<
       timeOptions,
       dateFormat,
       refreshInterval,
+      refreshMinInterval,
       refreshIntervalUnits,
       isPaused,
       isDisabled,
@@ -511,6 +517,7 @@ export class EuiSuperDatePickerInternal extends Component<
     const autoRefreshAppend: EuiFormControlLayoutProps['append'] = !isPaused ? (
       <EuiAutoRefreshButton
         refreshInterval={refreshInterval}
+        minInterval={refreshMinInterval}
         intervalUnits={refreshIntervalUnits}
         isDisabled={!!isDisabled}
         isPaused={isPaused}
@@ -671,6 +678,7 @@ export class EuiSuperDatePickerInternal extends Component<
       isPaused,
       onRefreshChange,
       refreshInterval,
+      refreshMinInterval,
       refreshIntervalUnits,
       showUpdateButton,
       'data-test-subj': dataTestSubj,
@@ -700,6 +708,7 @@ export class EuiSuperDatePickerInternal extends Component<
           <EuiAutoRefresh
             isPaused={isPaused}
             refreshInterval={refreshInterval}
+            minInterval={refreshMinInterval}
             intervalUnits={refreshIntervalUnits}
             onRefreshChange={this.onRefreshChange}
             fullWidth={width === 'full'}


### PR DESCRIPTION
## Summary

closes #7512

This PR adds a `refreshMinInterval` prop to **EuiSuperDatePicker** and an `minInterval` prop to **EuiAutoRefresh** and **EuiRefreshInterval**, which primarily does the following:

- Adds a browser `min` property to the number input, which affects the stepper and shows an invalid state/icon if the user types in a value below that min
- Updates the `onRefreshChange` callback to never send back a `refreshInterval` value lower than than the passed `minInterval` value

## QA

![min_interval](https://github.com/elastic/eui/assets/549407/b633e949-a593-4832-9bf1-97d769e27d9e)

- Go to https://eui.elastic.co/pr_7516/#/templates/super-date-picker
- Click the **Playground** button
- ctrl+f for and toggle the `isPaused` prop to false
- ctrl+f for and set the `refreshMinInterval` prop to, e.g. `20000`
- [x] Click the auto refresh button, and confirm that the popover has an invalid highlight/icon on open
- [x] Type in, e.g. `100` and confirm the invalid state goes away
- [x] Change the number back to 1 and then set the unit to `Minutes`. Confirm the invalid icon goes away when in a higher unit that passes the min threshold

### General checklist

- Browser QA - N/A
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A