### PR TITLE
fix(EuiPageTemplate): replace `CSS.escape` usage with string replace to fix SSR support

### DIFF
--- a/changelogs/upcoming/7525.md
+++ b/changelogs/upcoming/7525.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed the `CSS is not defined` bug in `EuiPageTemplate` when rendering in some SSR environments, particularly Next.js v13 and up

--- a/src/components/page_template/page_template.tsx
+++ b/src/components/page_template/page_template.tsx
@@ -141,7 +141,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
     restrictWidth,
     paddingSize,
     // pageInnerId may contain colons that are parsed as pseudo-elements if not escaped
-    parent: `#${CSS.escape(pageInnerId)}`,
+    parent: `#${pageInnerId.replaceAll(':', '\\:')}`,
   });
 
   const innerPanelled = () => panelled ?? Boolean(sidebar.length > 0);


### PR DESCRIPTION
## Summary

Some SSR environments (e.g., Next.js) don't provide the `CSS` utilities object, and the currently used `CSS.escape` static function is undefined.

This PR replaces the `CSS.escape` usage with a regular string replace. The `useGeneratedHtmlId` uses `React.useId` that may return a string containing colons, and these will now be escaped with the `\` character.

## QA

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
