### PR TITLE
[Emotion] Create hook utility for memoizing component styles per-theme

### DIFF
--- a/changelogs/upcoming/7529.md
+++ b/changelogs/upcoming/7529.md
@@ -1,0 +1,3 @@
+**CSS-in-JS conversions**
+
+- Added a new memoization/performance optimization utility for CSS-in-JS styles

--- a/src/components/beacon/beacon.tsx
+++ b/src/components/beacon/beacon.tsx
@@ -11,7 +11,7 @@ import { CommonProps } from '../common';
 import classNames from 'classnames';
 
 import { logicalStyles } from '../../global_styling';
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 
 import { euiBeaconStyles } from './beacon.styles';
 
@@ -48,9 +48,8 @@ export const EuiBeacon: FunctionComponent<EuiBeaconProps> = ({
   style,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
+  const styles = useEuiMemoizedStyles(euiBeaconStyles);
   const classes = classNames('euiBeacon', className);
-  const styles = euiBeaconStyles(euiTheme);
   const cssStyles = [styles.euiBeacon, styles[color]];
 
   const beaconStyle = useMemo(

--- a/src/components/code/code.styles.ts
+++ b/src/components/code/code.styles.ts
@@ -9,12 +9,10 @@
 import { css } from '@emotion/react';
 import { logicalShorthandCSS } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
-import { UseEuiCodeSyntaxVariables } from './code_syntax.styles';
+import { euiCodeSyntaxVariables } from './code_syntax.styles';
 
-export const euiCodeStyles = (
-  euiThemeContext: UseEuiTheme,
-  euiCodeSyntaxVariables: UseEuiCodeSyntaxVariables
-) => {
+export const euiCodeStyles = (euiThemeContext: UseEuiTheme) => {
+  const codeSyntaxVariables = euiCodeSyntaxVariables(euiThemeContext);
   const { euiTheme } = euiThemeContext;
 
   return {
@@ -25,12 +23,12 @@ export const euiCodeStyles = (
       font-family: ${euiTheme.font.familyCode};
       font-size: 0.9em; /* 1 */
       ${logicalShorthandCSS('padding', '0.2em 0.5em')} /* 1 */
-      background: ${euiCodeSyntaxVariables.backgroundColor};
+      background: ${codeSyntaxVariables.backgroundColor};
       border-radius: ${euiTheme.border.radius.small};
       font-weight: ${euiTheme.font.weight.bold};
-      color: ${euiCodeSyntaxVariables.inlineCodeColor};
+      color: ${codeSyntaxVariables.inlineCodeColor};
 
-      ${euiCodeSyntaxVariables.tokensCss}
+      ${codeSyntaxVariables.tokensCss}
     `,
     transparentBackground: css`
       background: transparent;

--- a/src/components/code/code.tsx
+++ b/src/components/code/code.tsx
@@ -15,8 +15,7 @@ import {
   checkSupportedLanguage,
   getHtmlContent,
 } from './utils';
-import { useEuiTheme } from '../../services';
-import { useEuiCodeSyntaxVariables } from './code_syntax.styles';
+import { useEuiMemoizedStyles } from '../../services';
 import { euiCodeStyles } from './code.styles';
 
 export type EuiCodeProps = EuiCodeSharedProps;
@@ -47,7 +46,7 @@ export const EuiCode: FunctionComponent<EuiCodeProps> = ({
 
   const classes = classNames('euiCode', className);
 
-  const styles = euiCodeStyles(useEuiTheme(), useEuiCodeSyntaxVariables());
+  const styles = useEuiMemoizedStyles(euiCodeStyles);
   const cssStyles = [
     styles.euiCode,
     transparentBackground && styles.transparentBackground,

--- a/src/components/code/code_block.styles.ts
+++ b/src/components/code/code_block.styles.ts
@@ -22,12 +22,10 @@ import {
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
-import { UseEuiCodeSyntaxVariables } from './code_syntax.styles';
+import { euiCodeSyntaxVariables } from './code_syntax.styles';
 
-export const euiCodeBlockStyles = (
-  euiThemeContext: UseEuiTheme,
-  euiCodeSyntaxVariables: UseEuiCodeSyntaxVariables
-) => {
+export const euiCodeBlockStyles = (euiThemeContext: UseEuiTheme) => {
+  const codeSyntaxVariables = euiCodeSyntaxVariables(euiThemeContext);
   const { euiTheme } = euiThemeContext;
 
   return {
@@ -35,9 +33,9 @@ export const euiCodeBlockStyles = (
       max-inline-size: 100%;
       display: block;
       position: relative;
-      background: ${euiCodeSyntaxVariables.backgroundColor};
+      background: ${codeSyntaxVariables.backgroundColor};
 
-      ${euiCodeSyntaxVariables.tokensCss}
+      ${codeSyntaxVariables.tokensCss}
     `,
     // Font size
     s: css`
@@ -134,17 +132,14 @@ export const euiCodeBlockPreStyles = (euiThemeContext: UseEuiTheme) => {
   };
 };
 
-export const euiCodeBlockCodeStyles = (
-  euiThemeContext: UseEuiTheme,
-  euiCodeSyntaxVariables: UseEuiCodeSyntaxVariables
-) => {
+export const euiCodeBlockCodeStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
   return {
     euiCodeBlock__code: css`
       font-family: ${euiTheme.font.familyCode};
       font-size: inherit;
-      color: ${euiCodeSyntaxVariables.color};
+      color: ${euiTheme.colors.text};
       display: block;
     `,
     isVirtualized: css`

--- a/src/components/code/code_block.tsx
+++ b/src/components/code/code_block.tsx
@@ -9,7 +9,12 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { RefractorNode } from 'refractor';
 import classNames from 'classnames';
-import { useCombinedRefs, useEuiTheme } from '../../services';
+
+import {
+  useCombinedRefs,
+  useEuiTheme,
+  useEuiMemoizedStyles,
+} from '../../services';
 import { ExclusiveUnion } from '../common';
 import {
   EuiCodeSharedProps,
@@ -32,7 +37,6 @@ import {
   euiCodeBlockPreStyles,
   euiCodeBlockCodeStyles,
 } from './code_block.styles';
-import { useEuiCodeSyntaxVariables } from './code_syntax.styles';
 
 // Based on observed line height for non-virtualized code blocks
 const fontSizeToRowHeightMap = {
@@ -123,7 +127,6 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
-  const euiCodeSyntaxVariables = useEuiCodeSyntaxVariables();
   const language = useMemo(
     () => checkSupportedLanguage(_language),
     [_language]
@@ -177,7 +180,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   const hasControls = !!(copyButton || fullScreenButton);
   const hasBothControls = !!(copyButton && fullScreenButton);
 
-  const styles = euiCodeBlockStyles(euiTheme, euiCodeSyntaxVariables);
+  const styles = useEuiMemoizedStyles(euiCodeBlockStyles);
   const cssStyles = [
     styles.euiCodeBlock,
     styles[fontSize],
@@ -188,26 +191,26 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
         : styles.hasControls[paddingSize]),
   ];
 
+  const preStyles = useEuiMemoizedStyles(euiCodeBlockPreStyles);
   const [preProps, preFullscreenProps] = useMemo(() => {
     const isWhiteSpacePre = whiteSpace === 'pre' || isVirtualized;
 
-    const styles = euiCodeBlockPreStyles(euiTheme);
     const cssStyles = [
-      styles.euiCodeBlock__pre,
+      preStyles.euiCodeBlock__pre,
       isWhiteSpacePre
-        ? styles.whiteSpace.pre.pre
-        : styles.whiteSpace.preWrap.preWrap,
+        ? preStyles.whiteSpace.pre.pre
+        : preStyles.whiteSpace.preWrap.preWrap,
     ];
 
     const preProps = {
       className: 'euiCodeBlock__pre',
       css: [
         ...cssStyles,
-        styles.padding[paddingSize],
+        preStyles.padding[paddingSize],
         hasControls &&
           (isWhiteSpacePre
-            ? styles.whiteSpace.pre.controlsOffset[paddingSize]
-            : styles.whiteSpace.preWrap.controlsOffset[paddingSize]),
+            ? preStyles.whiteSpace.pre.controlsOffset[paddingSize]
+            : preStyles.whiteSpace.preWrap.controlsOffset[paddingSize]),
       ],
       tabIndex: isVirtualized ? 0 : tabIndex,
     };
@@ -216,11 +219,11 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
       css: [
         ...cssStyles,
         // Force fullscreen to use xl padding
-        styles.padding.xl,
+        preStyles.padding.xl,
         hasControls &&
           (isWhiteSpacePre
-            ? styles.whiteSpace.pre.controlsOffset.xl
-            : styles.whiteSpace.preWrap.controlsOffset.xl),
+            ? preStyles.whiteSpace.pre.controlsOffset.xl
+            : preStyles.whiteSpace.preWrap.controlsOffset.xl),
       ],
       tabIndex: 0,
       onKeyDown,
@@ -228,7 +231,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
 
     return [preProps, preFullscreenProps];
   }, [
-    euiTheme,
+    preStyles,
     whiteSpace,
     isVirtualized,
     hasControls,
@@ -237,11 +240,11 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
     tabIndex,
   ]);
 
+  const codeStyles = useEuiMemoizedStyles(euiCodeBlockCodeStyles);
   const codeProps = useMemo(() => {
-    const styles = euiCodeBlockCodeStyles(euiTheme, euiCodeSyntaxVariables);
     const cssStyles = [
-      styles.euiCodeBlock__code,
-      isVirtualized && styles.isVirtualized,
+      codeStyles.euiCodeBlock__code,
+      isVirtualized && codeStyles.isVirtualized,
     ];
 
     return {
@@ -250,7 +253,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
       'data-code-language': language,
       ...rest,
     };
-  }, [language, euiTheme, euiCodeSyntaxVariables, isVirtualized, rest]);
+  }, [codeStyles, language, isVirtualized, rest]);
 
   return (
     <div

--- a/src/components/code/code_block_controls.styles.ts
+++ b/src/components/code/code_block_controls.styles.ts
@@ -16,13 +16,11 @@
 import { css } from '@emotion/react';
 import { euiPaddingSize } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
-import { UseEuiCodeSyntaxVariables } from './code_syntax.styles';
+import { euiCodeSyntaxVariables } from './code_syntax.styles';
 
-export const euiCodeBlockControlsStyles = (
-  euiThemeContext: UseEuiTheme,
-  euiCodeSyntaxVariables: UseEuiCodeSyntaxVariables
-) => {
+export const euiCodeBlockControlsStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
+  const codeSyntaxVariables = euiCodeSyntaxVariables(euiThemeContext);
 
   return {
     euiCodeBlock__controls: css`
@@ -30,7 +28,7 @@ export const euiCodeBlockControlsStyles = (
       display: flex;
       flex-direction: column;
       gap: ${euiTheme.size.xs};
-      background: ${euiCodeSyntaxVariables.backgroundColor};
+      background: ${codeSyntaxVariables.backgroundColor};
     `,
     offset: {
       none: css`

--- a/src/components/code/code_block_controls.tsx
+++ b/src/components/code/code_block_controls.tsx
@@ -7,19 +7,15 @@
  */
 
 import React, { FC, Fragment, ReactNode } from 'react';
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import type { EuiCodeBlockPaddingSize } from './code_block';
-import { useEuiCodeSyntaxVariables } from './code_syntax.styles';
 import { euiCodeBlockControlsStyles } from './code_block_controls.styles';
 
 export const EuiCodeBlockControls: FC<{
   controls: ReactNode[];
   paddingSize: EuiCodeBlockPaddingSize;
 }> = ({ paddingSize, controls }) => {
-  const styles = euiCodeBlockControlsStyles(
-    useEuiTheme(),
-    useEuiCodeSyntaxVariables()
-  );
+  const styles = useEuiMemoizedStyles(euiCodeBlockControlsStyles);
   const cssStyles = [styles.euiCodeBlock__controls, styles.offset[paddingSize]];
 
   const hasControls = controls.some((control) => !!control);

--- a/src/components/code/code_block_full_screen.tsx
+++ b/src/components/code/code_block_full_screen.tsx
@@ -14,12 +14,11 @@ import React, {
   useMemo,
   PropsWithChildren,
 } from 'react';
-import { keys, useEuiTheme } from '../../services';
+import { keys, useEuiMemoizedStyles } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { EuiButtonIcon } from '../button';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiOverlayMask } from '../overlay_mask';
-import { useEuiCodeSyntaxVariables } from './code_syntax.styles';
 import { euiCodeBlockStyles } from './code_block.styles';
 
 /**
@@ -92,7 +91,7 @@ export const useFullScreen = ({
 export const EuiCodeBlockFullScreenWrapper: FunctionComponent<
   PropsWithChildren
 > = ({ children }) => {
-  const styles = euiCodeBlockStyles(useEuiTheme(), useEuiCodeSyntaxVariables());
+  const styles = useEuiMemoizedStyles(euiCodeBlockStyles);
   const cssStyles = [
     styles.euiCodeBlock,
     styles.l, // Force fullscreen to use large font

--- a/src/components/code/code_syntax.styles.ts
+++ b/src/components/code/code_syntax.styles.ts
@@ -16,6 +16,8 @@ const visColors = euiPaletteColorBlind();
 
 // These variables are computationally expensive - do not call them outside `useEuiMemoizedStyles`
 export const euiCodeSyntaxVariables = ({ euiTheme }: UseEuiTheme) => {
+  console.log('euiCodeSyntaxVariables() fired'); // REVERT ME
+
   const backgroundColor = euiTheme.colors.lightestShade;
 
   return {

--- a/src/components/code/code_syntax.styles.ts
+++ b/src/components/code/code_syntax.styles.ts
@@ -6,56 +6,51 @@
  * Side Public License, v 1.
  */
 
-import { useMemo } from 'react';
 import {
-  useEuiTheme,
+  UseEuiTheme,
   makeHighContrastColor,
   euiPaletteColorBlind,
 } from '../../services';
 
 const visColors = euiPaletteColorBlind();
 
-// These variables are computationally expensive, so it needs
-// to be a hook in order to memoize it per theme
-export const useEuiCodeSyntaxVariables = () => {
-  const { euiTheme } = useEuiTheme();
+// These variables are computationally expensive - do not call them outside `useEuiMemoizedStyles`
+export const euiCodeSyntaxVariables = ({ euiTheme }: UseEuiTheme) => {
+  const backgroundColor = euiTheme.colors.lightestShade;
 
-  return useMemo(() => {
-    const backgroundColor = euiTheme.colors.lightestShade;
+  return {
+    backgroundColor: backgroundColor,
+    color: makeHighContrastColor(euiTheme.colors.text)(backgroundColor),
+    inlineCodeColor: makeHighContrastColor(visColors[3])(backgroundColor),
+    selectedBackgroundColor: 'inherit',
+    commentColor: makeHighContrastColor(euiTheme.colors.subduedText)(
+      backgroundColor
+    ),
+    selectorTagColor: 'inherit',
+    stringColor: makeHighContrastColor(visColors[2])(backgroundColor),
+    tagColor: makeHighContrastColor(visColors[1])(backgroundColor),
+    nameColor: makeHighContrastColor(visColors[1])(backgroundColor),
+    numberColor: makeHighContrastColor(visColors[0])(backgroundColor),
+    keywordColor: makeHighContrastColor(visColors[3])(backgroundColor),
+    functionTitleColor: 'inherit',
+    typeColor: makeHighContrastColor(visColors[1])(backgroundColor),
+    attributeColor: 'inherit',
+    symbolColor: makeHighContrastColor(visColors[9])(backgroundColor),
+    paramsColor: 'inherit',
+    metaColor: makeHighContrastColor(euiTheme.colors.subduedText)(
+      backgroundColor
+    ),
+    titleColor: makeHighContrastColor(visColors[7])(backgroundColor),
+    sectionColor: makeHighContrastColor(visColors[9])(backgroundColor),
+    additionColor: makeHighContrastColor(visColors[0])(backgroundColor),
+    deletionColor: makeHighContrastColor(euiTheme.colors.danger)(
+      backgroundColor
+    ),
+    selectorClassColor: 'inherit',
+    selectorIdColor: 'inherit',
 
-    return {
-      backgroundColor: backgroundColor,
-      color: makeHighContrastColor(euiTheme.colors.text)(backgroundColor),
-      inlineCodeColor: makeHighContrastColor(visColors[3])(backgroundColor),
-      selectedBackgroundColor: 'inherit',
-      commentColor: makeHighContrastColor(euiTheme.colors.subduedText)(
-        backgroundColor
-      ),
-      selectorTagColor: 'inherit',
-      stringColor: makeHighContrastColor(visColors[2])(backgroundColor),
-      tagColor: makeHighContrastColor(visColors[1])(backgroundColor),
-      nameColor: makeHighContrastColor(visColors[1])(backgroundColor),
-      numberColor: makeHighContrastColor(visColors[0])(backgroundColor),
-      keywordColor: makeHighContrastColor(visColors[3])(backgroundColor),
-      functionTitleColor: 'inherit',
-      typeColor: makeHighContrastColor(visColors[1])(backgroundColor),
-      attributeColor: 'inherit',
-      symbolColor: makeHighContrastColor(visColors[9])(backgroundColor),
-      paramsColor: 'inherit',
-      metaColor: makeHighContrastColor(euiTheme.colors.subduedText)(
-        backgroundColor
-      ),
-      titleColor: makeHighContrastColor(visColors[7])(backgroundColor),
-      sectionColor: makeHighContrastColor(visColors[9])(backgroundColor),
-      additionColor: makeHighContrastColor(visColors[0])(backgroundColor),
-      deletionColor: makeHighContrastColor(euiTheme.colors.danger)(
-        backgroundColor
-      ),
-      selectorClassColor: 'inherit',
-      selectorIdColor: 'inherit',
-
-      get tokensCss() {
-        return `
+    get tokensCss() {
+      return `
   .token.punctuation:not(.interpolation-punctuation):not([class*='attr-']) {
     opacity: .7;
   }
@@ -181,11 +176,6 @@ export const useEuiCodeSyntaxVariables = () => {
   .token.entity {
     cursor: help;
   }`;
-      },
-    };
-  }, [euiTheme]);
+    },
+  };
 };
-
-export type UseEuiCodeSyntaxVariables = ReturnType<
-  typeof useEuiCodeSyntaxVariables
->;

--- a/src/components/code/code_syntax.styles.ts
+++ b/src/components/code/code_syntax.styles.ts
@@ -16,8 +16,6 @@ const visColors = euiPaletteColorBlind();
 
 // These variables are computationally expensive - do not call them outside `useEuiMemoizedStyles`
 export const euiCodeSyntaxVariables = ({ euiTheme }: UseEuiTheme) => {
-  console.log('euiCodeSyntaxVariables() fired'); // REVERT ME
-
   const backgroundColor = euiTheme.colors.lightestShade;
 
   return {

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -22,6 +22,7 @@ export {
 } from './hooks';
 export type { EuiThemeProviderProps } from './provider';
 export { EuiThemeProvider } from './provider';
+export { useEuiMemoizedStyles } from './style_memoization';
 export { getEuiDevProviderWarning, setEuiDevProviderWarning } from './warning';
 export {
   buildTheme,

--- a/src/services/theme/provider.tsx
+++ b/src/services/theme/provider.tsx
@@ -31,6 +31,7 @@ import {
   EuiColorModeContext,
 } from './context';
 import { EuiEmotionThemeProvider } from './emotion';
+import { EuiMemoizedStylesProvider } from './style_memoization';
 import { buildTheme, getColorMode, getComputed, mergeDeep } from './utils';
 import {
   EuiThemeColorMode,
@@ -229,9 +230,11 @@ export const EuiThemeProvider = <T extends {} = {}>({
           <EuiModificationsContext.Provider value={modifications}>
             <EuiThemeContext.Provider value={theme}>
               <EuiNestedThemeContext.Provider value={nestedThemeContext}>
-                <EuiEmotionThemeProvider>
-                  {renderedChildren}
-                </EuiEmotionThemeProvider>
+                <EuiMemoizedStylesProvider>
+                  <EuiEmotionThemeProvider>
+                    {renderedChildren}
+                  </EuiEmotionThemeProvider>
+                </EuiMemoizedStylesProvider>
               </EuiNestedThemeContext.Provider>
             </EuiThemeContext.Provider>
           </EuiModificationsContext.Provider>

--- a/src/services/theme/provider.tsx
+++ b/src/services/theme/provider.tsx
@@ -31,7 +31,7 @@ import {
   EuiColorModeContext,
 } from './context';
 import { EuiEmotionThemeProvider } from './emotion';
-import { EuiMemoizedStylesProvider } from './style_memoization';
+import { EuiThemeMemoizedStylesProvider } from './style_memoization';
 import { buildTheme, getColorMode, getComputed, mergeDeep } from './utils';
 import {
   EuiThemeColorMode,
@@ -230,11 +230,11 @@ export const EuiThemeProvider = <T extends {} = {}>({
           <EuiModificationsContext.Provider value={modifications}>
             <EuiThemeContext.Provider value={theme}>
               <EuiNestedThemeContext.Provider value={nestedThemeContext}>
-                <EuiMemoizedStylesProvider>
+                <EuiThemeMemoizedStylesProvider>
                   <EuiEmotionThemeProvider>
                     {renderedChildren}
                   </EuiEmotionThemeProvider>
-                </EuiMemoizedStylesProvider>
+                </EuiThemeMemoizedStylesProvider>
               </EuiNestedThemeContext.Provider>
             </EuiThemeContext.Provider>
           </EuiModificationsContext.Provider>

--- a/src/services/theme/style_memoization.test.tsx
+++ b/src/services/theme/style_memoization.test.tsx
@@ -9,7 +9,8 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 import { fireEvent } from '@testing-library/react';
-import { render } from '../../test/rtl';
+import { render, renderHook } from '../../test/rtl';
+import { testOnReactVersion } from '../../test/internal';
 
 import type { UseEuiTheme } from './hooks';
 import { EuiThemeProvider } from './provider';
@@ -70,4 +71,15 @@ describe('useEuiMemoizedStyles', () => {
     );
     expect(componentStyles).toHaveBeenCalledTimes(2);
   });
+
+  testOnReactVersion(['18'])(
+    'throws an error if passed anonymous functions',
+    () => {
+      expect(() =>
+        renderHook(() => useEuiMemoizedStyles(() => ({})))
+      ).toThrowError(
+        'Styles are memoized per function. Your style functions must be statically defined in order to not create a new map entry every rerender.'
+      );
+    }
+  );
 });

--- a/src/services/theme/style_memoization.test.tsx
+++ b/src/services/theme/style_memoization.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import { fireEvent } from '@testing-library/react';
+import { render } from '../../test/rtl';
+
+import type { UseEuiTheme } from './hooks';
+import { EuiThemeProvider } from './provider';
+
+import { useEuiMemoizedStyles } from './style_memoization';
+
+describe('useEuiMemoizedStyles', () => {
+  beforeEach(jest.clearAllMocks);
+
+  const componentStyles = jest.fn(({ euiTheme }: UseEuiTheme) => ({
+    someComponent: css`
+      color: ${euiTheme.colors.primaryText};
+    `,
+  }));
+  const Component = () => {
+    const [rerender, setRerender] = useState(false);
+    const styles = useEuiMemoizedStyles(componentStyles);
+    return (
+      <button
+        css={styles.someComponent}
+        onClick={() => setRerender(!rerender)}
+      />
+    );
+  };
+
+  it('memoizes the passed fn, only computing the styles once regardless of other rerenders', () => {
+    const { getByRole } = render(<Component />);
+
+    expect(componentStyles).toHaveBeenCalledTimes(1);
+    expect(getByRole('button')).toHaveStyleRule('color', '#006bb8');
+
+    fireEvent.click(getByRole('button'));
+    expect(componentStyles).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes styles if the upstream theme changes', () => {
+    const { rerender, getByRole } = render(
+      <EuiThemeProvider colorMode="light">
+        <Component />
+      </EuiThemeProvider>
+    );
+    expect(componentStyles).toHaveBeenCalledTimes(1);
+    expect(getByRole('button')).toHaveStyleRule('color', '#006bb8');
+
+    rerender(
+      <EuiThemeProvider colorMode="dark">
+        <Component />
+      </EuiThemeProvider>
+    );
+    expect(componentStyles).toHaveBeenCalledTimes(2);
+    expect(getByRole('button')).toHaveStyleRule('color', '#36a2ef');
+
+    // Should not recompute styles if no theme changes
+    rerender(
+      <EuiThemeProvider colorMode="dark">
+        <Component />
+      </EuiThemeProvider>
+    );
+    expect(componentStyles).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/theme/style_memoization.tsx
+++ b/src/services/theme/style_memoization.tsx
@@ -62,6 +62,11 @@ export const useEuiMemoizedStyles = <
   const euiThemeContext = useEuiTheme();
 
   const memoizedComponentStyles = useMemo(() => {
+    if (!styleGenerator.name) {
+      throw new Error(
+        'Styles are memoized per function. Your style functions must be statically defined in order to not create a new map entry every rerender.'
+      );
+    }
     const existingStyles = memoizedStyles.get(styleGenerator);
     if (existingStyles) {
       return existingStyles;

--- a/src/services/theme/style_memoization.tsx
+++ b/src/services/theme/style_memoization.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+} from 'react';
+import type { SerializedStyles, CSSObject } from '@emotion/react';
+
+import { useUpdateEffect } from '../hooks';
+import { useEuiTheme, UseEuiTheme } from './hooks';
+
+type Styles = SerializedStyles | CSSObject | string | null; // Is this too restrictive?
+type StylesMaps = Record<string, Styles | Record<string, Styles>>;
+type MemoizedStylesMap = Map<Function, StylesMaps>;
+
+export const EuiThemeMemoizedStylesContext = createContext<MemoizedStylesMap>(
+  new Map()
+);
+
+export const EuiMemoizedStylesProvider: FunctionComponent<
+  PropsWithChildren
+> = ({ children }) => {
+  // Note: we *should not* use `useMemo` instead of `useState` here, as useMemo is not guaranteed
+  // and its cache can get thrown away by React (https://react.dev/reference/react/useMemo#caveats)
+  const [componentStyles, rerenderStyles] = useState<MemoizedStylesMap>(
+    new Map()
+  );
+
+  // On theme update, wipe the map, which causes the below hook to recompute all styles
+  const { euiTheme } = useEuiTheme();
+  useUpdateEffect(() => {
+    rerenderStyles(new Map());
+  }, [euiTheme]);
+
+  return (
+    <EuiThemeMemoizedStylesContext.Provider value={componentStyles}>
+      {children}
+    </EuiThemeMemoizedStylesContext.Provider>
+  );
+};
+
+/**
+ * Hook that memoizes the returned values of components style fns/generators
+ * per-theme
+ */
+export const useEuiMemoizedStyles = <
+  T extends (theme: UseEuiTheme) => StylesMaps
+>(
+  styleGenerator: T
+): ReturnType<T> => {
+  const memoizedStyles = useContext(EuiThemeMemoizedStylesContext);
+  const euiThemeContext = useEuiTheme();
+
+  const memoizedComponentStyles = useMemo(() => {
+    const existingStyles = memoizedStyles.get(styleGenerator);
+    if (existingStyles) {
+      return existingStyles;
+    } else {
+      const generatedStyles = styleGenerator(euiThemeContext);
+      memoizedStyles.set(styleGenerator, generatedStyles);
+
+      return generatedStyles;
+    }
+  }, [styleGenerator, memoizedStyles, euiThemeContext]);
+
+  return memoizedComponentStyles as ReturnType<T>;
+};

--- a/src/services/theme/style_memoization.tsx
+++ b/src/services/theme/style_memoization.tsx
@@ -30,7 +30,7 @@ export const EuiThemeMemoizedStylesContext = createContext<MemoizedStylesMap>(
   new WeakMap()
 );
 
-export const EuiMemoizedStylesProvider: FunctionComponent<
+export const EuiThemeMemoizedStylesProvider: FunctionComponent<
   PropsWithChildren
 > = ({ children }) => {
   // Note: we *should not* use `useMemo` instead of `useState` here, as useMemo is not guaranteed


### PR DESCRIPTION
## Summary

> ⚠️ As always, I strongly recommend [reviewing by commit](https://github.com/elastic/eui/pull/7529/commits).

This PR is an initial setup PR for memoizing a component's Emotion styles **per theme** (instead of **per component**). This should (hopefully) greatly improve the performance of our Emotion styles/object generation, especially for components used repeatedly in many places, e.g. EuiCode, EuiButton, etc.

I replaced the memoization used in #7486 with this new architecture as a proof of concept; this PR should maintain the performance improvements of the linked PR while being easy to swap in and replace across all of EUI's existing components, e.g.

```ts
const euiTheme = useEuiTheme();
const styles = euiComponentStyles(euiTheme);

// becomes

const styles = useEuiMemoizedStyles(euiComponentStyles);
```

### What this PR _does not_ do

- Handle class components - I have a spike for this in a separate branch, but would prefer to keep this PR small for now to focus on the overlying idea/concept

- Memoize dark vs. light themes - I played around with trying to memoize both light and dark themes separately, to make swapping back and forth faster/more performant, but eventually gave up on the idea as the full theme reference re-instantiates every time `colorMode` changes (which makes sense as theme tokens are also changing). TBH I also anticipate this as not being necessary as most end-users will not be swapping back and forth frequently between light/dark modes

- Convert all components to use this util - this is a very basic setup and proof of concept of 2 components. If it passes muster, I'll open more follow-up PRs in batches later.

## QA

- [x] [EuiBeacon CSS](https://eui.elastic.co/pr_7529/#/utilities/beacon) rendered/looks the same as before as before
- [x] [EuiCode CSS](https://eui.elastic.co/pr_7529/#/editors-syntax/code) renders the same as before
- EuiCode Performance
  - Open your devtools console
  - [x] `euiCodeSyntaxVariables()` only fires **3 times** on page load
  - [x] `euiCodeSyntaxVariables()` **does not** fire on fullscreen mode state change nor on page navigation
  - [x] `euiCodeSyntaxVariables()` **does** fire again on dark/light screen mode change (because the theme variables have changed)

### General checklist

- [x] Revert [REVERT ME] commit
- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A, this is mostly an internal EUI utility
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A