### PR TITLE
[CHORE] Update Tooltip and Popover callouts to info style.

### DIFF
--- a/src-docs/src/views/popover/popover_example.js
+++ b/src-docs/src/views/popover/popover_example.js
@@ -168,7 +168,6 @@ export const PopoverExample = {
 
       <EuiCallOut
         iconType="accessibility"
-        color="warning"
         title="Popovers have three accessibility requirements:"
       >
         <>

--- a/src-docs/src/views/tool_tip/tool_tip_example.js
+++ b/src-docs/src/views/tool_tip/tool_tip_example.js
@@ -65,7 +65,6 @@ export const ToolTipExample = {
 
       <EuiCallOut
         iconType="accessibility"
-        color="warning"
         title="Tooltips have three accessibilty requirements:"
       >
         <>


### PR DESCRIPTION
## Summary

Updated documentation for a11y callouts to use `info` styles in the `EuiTooltip` and `EuiPopover` components based on Cee's [suggestion from previous PR](https://github.com/elastic/eui/pull/7527#discussion_r1489782214). Screenshots attached at the bottom.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**

---
<img width="1245" alt="Screenshot 2024-02-14 at 11 53 50 AM" src="https://github.com/elastic/eui/assets/934879/fc6d2ee2-1041-4d49-b38e-d205200e7019">

---
<img width="1245" alt="Screenshot 2024-02-14 at 11 53 45 AM" src="https://github.com/elastic/eui/assets/934879/80048ed1-4521-43e4-b886-a286e49a6c52">

