### PR TITLE
[EuiDataGrid] Fix timeout clean-up when component unmounts

### DIFF
--- a/changelogs/upcoming/7534.md
+++ b/changelogs/upcoming/7534.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid` component to clean up timer from side effect on unmount

--- a/src/components/datagrid/utils/grid_height_width.ts
+++ b/src/components/datagrid/utils/grid_height_width.ts
@@ -183,12 +183,14 @@ export const useVirtualizeContainerWidth = (
 
   useEffect(() => {
     // wait for layout to settle, then measure virtualize container
-    setTimeout(() => {
+    const timerId = setTimeout(() => {
       if (virtualizeContainer?.clientWidth) {
         const containerWidth = virtualizeContainer.clientWidth;
         setVirtualizeContainerWidth(containerWidth);
       }
     }, 100);
+
+    return () => clearTimeout(timerId);
   }, [pageSize, virtualizeContainer]);
 
   // Use clientWidth of the virtualization container to take scroll bar into account


### PR DESCRIPTION
## Summary

The component could unmount before the timeout to set the virtualized `clientWidth` update the state.

React has a specific error for this scenario, which is occurring in one of the consuming apps:

**Console screen**

<img width="1656" alt="Screenshot 2024-02-19 at 11 04 36" src="https://github.com/elastic/eui/assets/34506779/3b9b0780-9d83-41a9-b2ec-fc022ae810b0"> 

**Reproduction**

https://github.com/elastic/eui/assets/34506779/b3cac963-ca90-40ae-84fd-4eadaebae483

A defensive timer clean-up on the side effect removes the error and cleans the memory the timer uses.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - ~[ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A