### PR TITLE
[EuiProgress] Fix broken transition CSS

### DIFF
--- a/changelogs/upcoming/7538.md
+++ b/changelogs/upcoming/7538.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed missing animation on native `EuiProgress` bar update

--- a/src/components/progress/progress.styles.ts
+++ b/src/components/progress/progress.styles.ts
@@ -10,6 +10,7 @@ import { css, keyframes } from '@emotion/react';
 import {
   logicalCSS,
   logicalTextAlignCSS,
+  euiCanAnimate,
   euiCantAnimate,
   euiFontSize,
   euiTextTruncate,
@@ -105,11 +106,13 @@ export const euiProgressStyles = (
       background-color: ${euiTheme.colors.lightShade};
     }
 
-    /* Note: FF/Mozilla doesn't actually support animating the native progress bar
-       @see https://bugzilla.mozilla.org/show_bug.cgi?id=662351 */
-    ${crossBrowserProgressValue(
-      `transition: width ${euiTheme.animation.normal} linear`
-    )}
+    ${euiCanAnimate} {
+      /* Note: FF/Mozilla doesn't actually support animating the native progress bar
+        @see https://bugzilla.mozilla.org/show_bug.cgi?id=662351 */
+      ${crossBrowserProgressValue(
+        `transition: width ${euiTheme.animation.normal} linear`
+      )}
+    }
   `,
   // An indeterminate bar has an unreliable end time. Because of a Firefox animation issue,
   // we apply this style to a <div> instead of a <progress> element.

--- a/src/components/progress/progress.styles.ts
+++ b/src/components/progress/progress.styles.ts
@@ -108,7 +108,7 @@ export const euiProgressStyles = (
     /* Note: FF/Mozilla doesn't actually support animating the native progress bar
        @see https://bugzilla.mozilla.org/show_bug.cgi?id=662351 */
     ${crossBrowserProgressValue(
-      `transition: width ${euiTheme.animation.normal} linear;`
+      `transition: width ${euiTheme.animation.normal} linear`
     )}
   `,
   // An indeterminate bar has an unreliable end time. Because of a Firefox animation issue,

--- a/src/components/progress/progress.styles.ts
+++ b/src/components/progress/progress.styles.ts
@@ -105,6 +105,8 @@ export const euiProgressStyles = (
       background-color: ${euiTheme.colors.lightShade};
     }
 
+    /* Note: FF/Mozilla doesn't actually support animating the native progress bar
+       @see https://bugzilla.mozilla.org/show_bug.cgi?id=662351 */
     ${crossBrowserProgressValue(
       `transition: width ${euiTheme.animation.normal} linear;`
     )}

--- a/src/components/progress/progress.styles.ts
+++ b/src/components/progress/progress.styles.ts
@@ -106,7 +106,7 @@ export const euiProgressStyles = (
     }
 
     ${crossBrowserProgressValue(
-      'transition: width ${euiTheme.animation.normal} linear;'
+      `transition: width ${euiTheme.animation.normal} linear;`
     )}
   `,
   // An indeterminate bar has an unreliable end time. Because of a Firefox animation issue,


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7523

I missed a template literal while converting the component from Sass to Emotion (#5986) 🤦 Also I never noticed this because I work primarily in Firefox and apparently [progress animations have never worked in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=662351) 😭 

## QA

In a webkit browser:
- [On production](https://eui.elastic.co/v93.1.0/#/display/progress#progress-with-values), and click `Toggle Progress` - it should not animate smoothly (compared to [pre-Emotion conversion](https://eui.elastic.co/v37.0.0/#/display/progress#progress-with-values))
- [Go to staging](https://eui.elastic.co/pr_7538/#/display/progress#progress-with-values) and click `Toggle Progress`
- [x] Confirm the progress bar smoothly animates/transitions
- Open your System settings and check the `Reduce motion` option under `Accessibility`
- [x] Refresh/re-click the button and confirm progress no longer smoothly animates

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** ~including keyboard-only and screenreader modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist - N/A, CSS only change
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A
