### PR TITLE
[Emotion][perf] Memoize `EuiButton` styles & mixins

### DIFF
--- a/src/components/button/button_display/_button_display.tsx
+++ b/src/components/button/button_display/_button_display.tsx
@@ -16,7 +16,7 @@ import React, {
 
 // @ts-ignore module doesn't export `createElement`
 import { createElement } from '@emotion/react';
-import { getSecureRelForTarget, useEuiTheme } from '../../../services';
+import { getSecureRelForTarget, useEuiMemoizedStyles } from '../../../services';
 
 import {
   CommonProps,
@@ -139,9 +139,7 @@ export const EuiButtonDisplay = forwardRef<HTMLElement, EuiButtonDisplayProps>(
       isLoading,
     });
 
-    const theme = useEuiTheme();
-
-    const styles = euiButtonDisplayStyles(theme);
+    const styles = useEuiMemoizedStyles(euiButtonDisplayStyles);
     const cssStyles = [
       styles.euiButtonDisplay,
       styles[size],

--- a/src/components/button/button_empty/button_empty.tsx
+++ b/src/components/button/button_empty/button_empty.tsx
@@ -15,7 +15,7 @@ import {
   PropsForAnchor,
   PropsForButton,
 } from '../../common';
-import { useEuiTheme, getSecureRelForTarget } from '../../../services';
+import { useEuiMemoizedStyles, getSecureRelForTarget } from '../../../services';
 
 import {
   EuiButtonDisplayContent,
@@ -119,8 +119,7 @@ export const EuiButtonEmpty: FunctionComponent<EuiButtonEmptyProps> = ({
     display: 'empty',
   });
 
-  const euiTheme = useEuiTheme();
-  const styles = euiButtonEmptyStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiButtonEmptyStyles);
   const cssStyles = [
     styles.euiButtonEmpty,
     styles[size],

--- a/src/components/button/button_group/button_group.styles.ts
+++ b/src/components/button/button_group/button_group.styles.ts
@@ -11,17 +11,15 @@ import { UseEuiTheme } from '../../../services';
 import { logicalCSS } from '../../../global_styling';
 import { euiFormVariables } from '../../form/form.styles';
 
-export const euiButtonGroupStyles = () => {
-  return {
-    euiButtonGroup: css`
-      display: inline-block;
-      ${logicalCSS('max-width', '100%')}
-      position: relative; /* Ensures the EuiScreenReaderOnly component is positioned relative to this component */
-    `,
-    fullWidth: css`
-      display: block;
-    `,
-  };
+export const euiButtonGroupStyles = {
+  euiButtonGroup: css`
+    display: inline-block;
+    ${logicalCSS('max-width', '100%')}
+    position: relative; /* Ensures the EuiScreenReaderOnly component is positioned relative to this component */
+  `,
+  fullWidth: css`
+    display: block;
+  `,
 };
 
 export const euiButtonGroupButtonsStyles = (euiThemeContext: UseEuiTheme) => {

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -14,7 +14,7 @@ import React, {
   ReactNode,
 } from 'react';
 
-import { useEuiTheme } from '../../../services';
+import { useEuiMemoizedStyles } from '../../../services';
 import { EuiScreenReaderOnly } from '../../accessibility';
 import { CommonProps } from '../../common';
 
@@ -142,10 +142,9 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
   type = 'single',
   ...rest
 }) => {
-  const wrapperStyles = euiButtonGroupStyles();
   const wrapperCssStyles = [
-    wrapperStyles.euiButtonGroup,
-    isFullWidth && wrapperStyles.fullWidth,
+    euiButtonGroupStyles.euiButtonGroup,
+    isFullWidth && euiButtonGroupStyles.fullWidth,
   ];
 
   const styles = useEuiMemoizedStyles(euiButtonGroupButtonsStyles);

--- a/src/components/button/button_group/button_group.tsx
+++ b/src/components/button/button_group/button_group.tsx
@@ -142,15 +142,13 @@ export const EuiButtonGroup: FunctionComponent<Props> = ({
   type = 'single',
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-
   const wrapperStyles = euiButtonGroupStyles();
   const wrapperCssStyles = [
     wrapperStyles.euiButtonGroup,
     isFullWidth && wrapperStyles.fullWidth,
   ];
 
-  const styles = euiButtonGroupButtonsStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiButtonGroupButtonsStyles);
   const cssStyles = [
     styles.euiButtonGroup__buttons,
     isFullWidth && styles.fullWidth,

--- a/src/components/button/button_icon/button_icon.styles.ts
+++ b/src/components/button/button_icon/button_icon.styles.ts
@@ -6,11 +6,12 @@
  * Side Public License, v 1.
  */
 
-import { css } from '@emotion/react';
+import { css, type SerializedStyles } from '@emotion/react';
 
 import { UseEuiTheme } from '../../../services';
 import { logicalSizeCSS } from '../../../global_styling';
 import {
+  BUTTON_COLORS,
   _EuiButtonColor,
   euiButtonEmptyColor,
   euiButtonSizeMap,
@@ -55,14 +56,16 @@ export const euiButtonIconStyles = (euiThemeContext: UseEuiTheme) => {
   };
 };
 
-export const _emptyHoverStyles = (
-  euiThemeContext: UseEuiTheme,
-  color: _EuiButtonColor
-) => {
-  return css`
-    &:hover {
-      background-color: ${euiButtonEmptyColor(euiThemeContext, color)
-        .backgroundColor};
-    }
-  `;
-};
+export const _emptyHoverStyles = (euiThemeContext: UseEuiTheme) =>
+  BUTTON_COLORS.reduce(
+    (styles, color) => ({
+      ...styles,
+      [color]: css`
+        &:hover {
+          background-color: ${euiButtonEmptyColor(euiThemeContext, color)
+            .backgroundColor};
+        }
+      `,
+    }),
+    {} as Record<_EuiButtonColor, SerializedStyles>
+  );

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -14,7 +14,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { getSecureRelForTarget, useEuiTheme } from '../../../services';
+import { getSecureRelForTarget, useEuiTheme, useEuiMemoizedStyles } from '../../../services';
 import {
   CommonProps,
   ExclusiveUnion,
@@ -142,7 +142,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
     !isDisabled &&
     _emptyHoverStyles(euiThemeContext, color);
 
-  const styles = euiButtonIconStyles(euiThemeContext);
+  const styles = useEuiMemoizedStyles(euiButtonIconStyles);
   const cssStyles = [
     styles.euiButtonIcon,
     styles[size],

--- a/src/components/button/button_icon/button_icon.tsx
+++ b/src/components/button/button_icon/button_icon.tsx
@@ -14,7 +14,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { getSecureRelForTarget, useEuiTheme, useEuiMemoizedStyles } from '../../../services';
+import { getSecureRelForTarget, useEuiMemoizedStyles } from '../../../services';
 import {
   CommonProps,
   ExclusiveUnion,
@@ -118,7 +118,6 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
   isLoading,
   ...rest
 }) => {
-  const euiThemeContext = useEuiTheme();
   const isDisabled = isButtonDisabled({
     isDisabled: _isDisabled || disabled,
     href,
@@ -137,10 +136,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
 
   const buttonColorStyles = useEuiButtonColorCSS({ display });
   const buttonFocusStyle = useEuiButtonFocusCSS();
-  const emptyHoverStyles =
-    display === 'empty' &&
-    !isDisabled &&
-    _emptyHoverStyles(euiThemeContext, color);
+  const emptyHoverStyles = useEuiMemoizedStyles(_emptyHoverStyles);
 
   const styles = useEuiMemoizedStyles(euiButtonIconStyles);
   const cssStyles = [
@@ -148,7 +144,7 @@ export const EuiButtonIcon: FunctionComponent<Props> = ({
     styles[size],
     buttonColorStyles[isDisabled ? 'disabled' : color],
     buttonFocusStyle,
-    emptyHoverStyles,
+    display === 'empty' && !isDisabled && emptyHoverStyles[color],
     isDisabled && styles.isDisabled,
   ];
 

--- a/src/themes/amsterdam/global_styling/mixins/__snapshots__/button.test.ts.snap
+++ b/src/themes/amsterdam/global_styling/mixins/__snapshots__/button.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useEuiButtonFocusCSS 1`] = `
+Object {
+  "map": undefined,
+  "name": "1s8jae7-focusCSS",
+  "next": Object {
+    "name": "animation-70pju1",
+    "next": undefined,
+    "styles": "@keyframes animation-70pju1{
+  50% {
+    transform: translateY(1px);
+  }
+}",
+  },
+  "styles": "@media screen and (prefers-reduced-motion: no-preference){transition:transform 250ms ease-in-out,background-color 250ms ease-in-out;&:hover:not(:disabled){transform:translateY(-1px);}&:focus{animation:animation-70pju1 250ms cubic-bezier(.34, 1.61, .7, 1);}&:active:not(:disabled){transform:translateY(1px);}};",
+  "toString": [Function],
+}
+`;

--- a/src/themes/amsterdam/global_styling/mixins/__snapshots__/button.test.ts.snap
+++ b/src/themes/amsterdam/global_styling/mixins/__snapshots__/button.test.ts.snap
@@ -1,5 +1,167 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`useEuiButtonColorCSS base 1`] = `
+Object {
+  "accent": Object {
+    "map": undefined,
+    "name": "1uoldaz-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#a03465;background-color:#fcdcea;;;label:base-accent;",
+    "toString": [Function],
+  },
+  "danger": Object {
+    "map": undefined,
+    "name": "1cquuvx-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#ab231c;background-color:#f2d4d2;;;label:base-danger;",
+    "toString": [Function],
+  },
+  "disabled": Object {
+    "map": undefined,
+    "name": "13xo60b-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#a2abba;background-color:rgba(211,218,230,0.15);;;label:base-disabled;",
+    "toString": [Function],
+  },
+  "primary": Object {
+    "map": undefined,
+    "name": "1thox14-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#0061a6;background-color:#cce4f5;;;label:base-primary;",
+    "toString": [Function],
+  },
+  "success": Object {
+    "map": undefined,
+    "name": "1j0clgi-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#006c66;background-color:#ccf2f0;;;label:base-success;",
+    "toString": [Function],
+  },
+  "text": Object {
+    "map": undefined,
+    "name": "40srs0-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#343741;background-color:#e9edf3;;;label:base-text;",
+    "toString": [Function],
+  },
+  "warning": Object {
+    "map": undefined,
+    "name": "19dh407-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#83650a;background-color:#fff3d0;;;label:base-warning;",
+    "toString": [Function],
+  },
+}
+`;
+
+exports[`useEuiButtonColorCSS empty 1`] = `
+Object {
+  "accent": Object {
+    "map": undefined,
+    "name": "cy4kjs-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#a03465;&:focus,&:active{background-color:rgba(240,78,152,0.1);};label:empty-accent;",
+    "toString": [Function],
+  },
+  "danger": Object {
+    "map": undefined,
+    "name": "j8xrk3-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#ab231c;&:focus,&:active{background-color:rgba(189,39,30,0.1);};label:empty-danger;",
+    "toString": [Function],
+  },
+  "disabled": Object {
+    "map": undefined,
+    "name": "2vymtv-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#a2abba;&:focus,&:active{background-color:transparent;};label:empty-disabled;",
+    "toString": [Function],
+  },
+  "primary": Object {
+    "map": undefined,
+    "name": "15isz8i-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#0061a6;&:focus,&:active{background-color:rgba(0,119,204,0.1);};label:empty-primary;",
+    "toString": [Function],
+  },
+  "success": Object {
+    "map": undefined,
+    "name": "h2w3e9-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#006c66;&:focus,&:active{background-color:rgba(0,191,179,0.1);};label:empty-success;",
+    "toString": [Function],
+  },
+  "text": Object {
+    "map": undefined,
+    "name": "1dqg6bz-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#343741;&:focus,&:active{background-color:rgba(211,218,230,0.2);};label:empty-text;",
+    "toString": [Function],
+  },
+  "warning": Object {
+    "map": undefined,
+    "name": "w61e3r-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#83650a;&:focus,&:active{background-color:rgba(254,197,20,0.1);};label:empty-warning;",
+    "toString": [Function],
+  },
+}
+`;
+
+exports[`useEuiButtonColorCSS fill 1`] = `
+Object {
+  "accent": Object {
+    "map": undefined,
+    "name": "vi45v3-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#000;background-color:#f583b7;outline-color:#000;;label:fill-accent;",
+    "toString": [Function],
+  },
+  "danger": Object {
+    "map": undefined,
+    "name": "1ge48z4-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#FFF;background-color:#BD271E;outline-color:#000;;label:fill-danger;",
+    "toString": [Function],
+  },
+  "disabled": Object {
+    "map": undefined,
+    "name": "xc42v8-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#a2abba;background-color:rgba(211,218,230,0.15);outline-color:#000;;label:fill-disabled;",
+    "toString": [Function],
+  },
+  "primary": Object {
+    "map": undefined,
+    "name": "btstjy-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#FFF;background-color:#07C;outline-color:#000;;label:fill-primary;",
+    "toString": [Function],
+  },
+  "success": Object {
+    "map": undefined,
+    "name": "p9aexd-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#000;background-color:#4dd2ca;outline-color:#000;;label:fill-success;",
+    "toString": [Function],
+  },
+  "text": Object {
+    "map": undefined,
+    "name": "5c80s5-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#FFF;background-color:#69707D;outline-color:#000;;label:fill-text;",
+    "toString": [Function],
+  },
+  "warning": Object {
+    "map": undefined,
+    "name": "17xxsr5-displaysColorsMap-display-color",
+    "next": undefined,
+    "styles": "color:#000;background-color:#FEC514;outline-color:#000;;label:fill-warning;",
+    "toString": [Function],
+  },
+}
+`;
+
 exports[`useEuiButtonFocusCSS 1`] = `
 Object {
   "map": undefined,

--- a/src/themes/amsterdam/global_styling/mixins/button.test.ts
+++ b/src/themes/amsterdam/global_styling/mixins/button.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import { useEuiButtonFocusCSS } from './button';
+
+test('useEuiButtonFocusCSS', () => {
+  const { result } = renderHook(() => useEuiButtonFocusCSS());
+  expect(result.current).toMatchSnapshot();
+});

--- a/src/themes/amsterdam/global_styling/mixins/button.test.ts
+++ b/src/themes/amsterdam/global_styling/mixins/button.test.ts
@@ -8,7 +8,20 @@
 
 import { renderHook } from '@testing-library/react';
 
-import { useEuiButtonFocusCSS } from './button';
+import {
+  useEuiButtonColorCSS,
+  BUTTON_DISPLAYS,
+  useEuiButtonFocusCSS,
+} from './button';
+
+describe('useEuiButtonColorCSS', () => {
+  BUTTON_DISPLAYS.forEach((display) => {
+    test(display, () => {
+      const { result } = renderHook(() => useEuiButtonColorCSS({ display }));
+      expect(result.current).toMatchSnapshot();
+    });
+  });
+});
 
 test('useEuiButtonFocusCSS', () => {
   const { result } = renderHook(() => useEuiButtonFocusCSS());

--- a/src/themes/amsterdam/global_styling/mixins/button.ts
+++ b/src/themes/amsterdam/global_styling/mixins/button.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import { euiBackgroundColor, euiCanAnimate } from '../../../../global_styling';
 import {
   hexToRgb,
@@ -17,6 +17,7 @@ import {
   transparentize,
   useEuiTheme,
   UseEuiTheme,
+  useEuiMemoizedStyles,
 } from '../../../../services';
 
 export const BUTTON_COLORS = [
@@ -219,10 +220,16 @@ export const useEuiButtonColorCSS = (options: _EuiButtonOptions = {}) => {
  * Creates the translate animation when button is in focus.
  * @returns string
  */
-export const useEuiButtonFocusCSS = () => {
-  const { euiTheme } = useEuiTheme();
+export const useEuiButtonFocusCSS = () =>
+  useEuiMemoizedStyles<any>(euiButtonFocusCSS);
 
-  return `
+const euiButtonFocusAnimation = keyframes`
+  50% {
+    transform: translateY(1px);
+  }
+`;
+const euiButtonFocusCSS = ({ euiTheme }: UseEuiTheme) => {
+  const focusCSS = css`
     ${euiCanAnimate} {
       transition: transform ${euiTheme.animation.normal} ease-in-out,
         background-color ${euiTheme.animation.normal} ease-in-out;
@@ -232,7 +239,7 @@ export const useEuiButtonFocusCSS = () => {
       }
 
       &:focus {
-        animation: euiButtonActive ${euiTheme.animation.normal}
+        animation: ${euiButtonFocusAnimation} ${euiTheme.animation.normal}
           ${euiTheme.animation.bounce};
       }
 
@@ -241,6 +248,11 @@ export const useEuiButtonFocusCSS = () => {
       }
     }
   `;
+  // Remove the auto-generated label.
+  // We could typically avoid a label by using a plain string `` instead of css``,
+  // but we need css`` for keyframes`` to work for the focus animation
+  focusCSS.styles = focusCSS.styles.replace('label:focusCSS;', '');
+  return focusCSS;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR is a performance enhancement (+ one missing Emotion animation conversion) on the `EuiButton` component(s) and should not regress or change any output UI or generated classNames.

As always, I recommend [code reviewing by commit](https://github.com/elastic/eui/pull/7541/commits).

## QA

- Go to https://eui.elastic.co/pr_7541/#/navigation/button
- [x] Confim all buttons look the same/have the same colors as [production](https://eui.elastic.co/#/navigation/button)
- [x] Confirm that keyboard tabbing to the first two buttons on the page plays a small transformY animation
- [x] Confirm that [hovering over empty EuiButtonIcons](https://eui.elastic.co/pr_7541/#/navigation/button#icon-buttons) renders the correct colored background

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.~ - Skipping the changelog on these PRs as they shouldn't affect either end-users or consumers
- Designer checklist - N/A