### PR TITLE
[Emotion] Add HOC util for memoized styles + memoize `EuiIcon` styles

### DIFF
--- a/src/components/icon/icon.styles.ts
+++ b/src/components/icon/icon.styles.ts
@@ -7,15 +7,8 @@
  */
 
 import { css, keyframes } from '@emotion/react';
-import { logicalCSS, euiCanAnimate } from '../../global_styling';
+import { logicalSizeCSS, euiCanAnimate } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
-
-const iconSize = (size: string) => {
-  return `
-    ${logicalCSS('width', size)};
-    ${logicalCSS('height', size)};
-  `;
-};
 
 export const iconLoadingOpacity = 0.05;
 
@@ -100,11 +93,11 @@ export const euiIconStyles = ({ euiTheme }: UseEuiTheme) => ({
   `,
   // Sizes
   original: css``,
-  s: css(iconSize(euiTheme.size.m)),
-  m: css(iconSize(euiTheme.size.base)),
-  l: css(iconSize(euiTheme.size.l)),
-  xl: css(iconSize(euiTheme.size.xl)),
-  xxl: css(iconSize(euiTheme.size.xxl)),
+  s: css(logicalSizeCSS(euiTheme.size.m)),
+  m: css(logicalSizeCSS(euiTheme.size.base)),
+  l: css(logicalSizeCSS(euiTheme.size.l)),
+  xl: css(logicalSizeCSS(euiTheme.size.xl)),
+  xxl: css(logicalSizeCSS(euiTheme.size.xxl)),
   // Variants
   // App icons are two-toned. This provides the base color.
   app: css`

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -304,20 +304,14 @@ export class EuiIconClass extends PureComponent<
           this.props['aria-labelledby'] ||
           this.props.title
         );
-      const hideIconEmpty = isAriaHidden && { 'aria-hidden': true };
-
-      let titleId: any;
 
       // If no aria-label or aria-labelledby is provided but there's a title, a titleId is generated
       //  The svg aria-labelledby attribute gets this titleId
       //  The svg title element gets this titleId as an id
-      if (
-        !this.props['aria-label'] &&
-        !this.props['aria-labelledby'] &&
-        title
-      ) {
-        titleId = { titleId: generateId() };
-      }
+      const titleId =
+        !this.props['aria-label'] && !this.props['aria-labelledby'] && title
+          ? { titleId: generateId() }
+          : undefined;
 
       return (
         <Svg
@@ -327,12 +321,12 @@ export class EuiIconClass extends PureComponent<
           tabIndex={tabIndex}
           role="img"
           title={title}
+          {...titleId}
           data-icon-type={iconTitle}
           data-is-loaded={isLoaded || undefined}
           data-is-loading={isLoading || undefined}
-          {...titleId}
           {...rest}
-          {...hideIconEmpty}
+          aria-hidden={isAriaHidden || undefined}
         />
       );
     }

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -23,8 +23,8 @@ import { enqueueStateChange } from '../../services/react';
 
 import {
   htmlIdGenerator,
-  withEuiTheme,
-  WithEuiThemeProps,
+  withEuiStylesMemoizer,
+  WithEuiStylesMemoizerProps,
 } from '../../services';
 export { COLORS } from './named_colors';
 import { isNamedColor, NamedColor } from './named_colors';
@@ -130,11 +130,11 @@ export const appendIconComponentCache = (iconTypeToIconComponentMap: {
 };
 
 export class EuiIconClass extends PureComponent<
-  EuiIconProps & WithEuiThemeProps,
+  EuiIconProps & WithEuiStylesMemoizerProps,
   State
 > {
   isMounted = false;
-  constructor(props: EuiIconProps & WithEuiThemeProps) {
+  constructor(props: EuiIconProps & WithEuiStylesMemoizerProps) {
     super(props);
 
     const { type } = props;
@@ -238,8 +238,8 @@ export class EuiIconClass extends PureComponent<
       tabIndex,
       title,
       onIconLoad,
-      theme,
       style,
+      stylesMemoizer,
       ...rest
     } = this.props;
 
@@ -267,7 +267,7 @@ export class EuiIconClass extends PureComponent<
     const classes = classNames('euiIcon', className);
 
     // Emotion styles
-    const styles = euiIconStyles(theme);
+    const styles = stylesMemoizer(euiIconStyles);
     const cssStyles = [
       styles.euiIcon,
       styles[size],
@@ -339,4 +339,4 @@ export class EuiIconClass extends PureComponent<
   }
 }
 
-export const EuiIcon = withEuiTheme<EuiIconProps>(EuiIconClass);
+export const EuiIcon = withEuiStylesMemoizer<EuiIconProps>(EuiIconClass);

--- a/src/services/theme/index.ts
+++ b/src/services/theme/index.ts
@@ -22,7 +22,11 @@ export {
 } from './hooks';
 export type { EuiThemeProviderProps } from './provider';
 export { EuiThemeProvider } from './provider';
-export { useEuiMemoizedStyles } from './style_memoization';
+export {
+  useEuiMemoizedStyles,
+  withEuiStylesMemoizer,
+  type WithEuiStylesMemoizerProps,
+} from './style_memoization';
 export { getEuiDevProviderWarning, setEuiDevProviderWarning } from './warning';
 export {
   buildTheme,


### PR DESCRIPTION
## Summary

This PR is a performance enhancement (+ minor code cleanup) on the `EuiIcon` component, and should not regress or change any output UI or generated classNames.

As always, I recommend [code reviewing by commit](https://github.com/elastic/eui/pull/7544/commits).

## QA

- https://eui.elastic.co/pr_7544/#/display/icons looks the same as [production](https://eui.elastic.co/#/display/icons)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist
    - ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ Should be fine if tests pass
- Release checklist - N/A
    - ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.~ - Skipping the changelog on these PRs as they shouldn't affect either end-users or consumers
- Designer checklist - N/A
