### PR TITLE
[EuiDataGrid] Fix "Grid row classes" docs example

### DIFF
--- a/changelogs/upcoming/7549.md
+++ b/changelogs/upcoming/7549.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiDataGrid` bug with `gridStyle.rowClasses`, where custom consumer classes that began with `euiDataGridRow` would not be correctly removed/reapplied

--- a/changelogs/upcoming/7549.md
+++ b/changelogs/upcoming/7549.md
@@ -1,3 +1,4 @@
 **Bug fixes**
 
 - Fixed an `EuiDataGrid` bug with `gridStyle.rowClasses`, where custom consumer classes that began with `euiDataGridRow` would not be correctly removed/reapplied
+- Fixed a visual `EuiDataGrid` bug where `EuiCheckbox`es within control columns were not vertically centered within single height rows

--- a/src-docs/src/views/datagrid/styling/row_classes.js
+++ b/src-docs/src/views/datagrid/styling/row_classes.js
@@ -90,7 +90,7 @@ const SelectionRowCell = ({ rowIndex }) => {
   const [selectedRows, updateSelectedRows] = useContext(SelectionContext);
   const isChecked = selectedRows.has(rowIndex);
   return (
-    <div>
+    <>
       <EuiCheckbox
         id={`${rowIndex}`}
         aria-label={`Select row ${rowIndex}, ${data[rowIndex].name}`}
@@ -103,7 +103,7 @@ const SelectionRowCell = ({ rowIndex }) => {
           }
         }}
       />
-    </div>
+    </>
   );
 };
 
@@ -153,20 +153,18 @@ export default () => {
 
   return (
     <SelectionContext.Provider value={rowSelection}>
-      <div>
-        <EuiDataGrid
-          aria-label="Top EUI contributors"
-          columns={columns}
-          columnVisibility={{ visibleColumns, setVisibleColumns }}
-          rowCount={data.length}
-          renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
-          leadingControlColumns={leadingControlColumns}
-          toolbarVisibility={{
-            additionalControls: <SelectionButton />,
-          }}
-          gridStyle={{ rowClasses, rowHover: 'none' }}
-        />
-      </div>
+      <EuiDataGrid
+        aria-label="Top EUI contributors"
+        columns={columns}
+        columnVisibility={{ visibleColumns, setVisibleColumns }}
+        rowCount={data.length}
+        renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+        leadingControlColumns={leadingControlColumns}
+        toolbarVisibility={{
+          additionalControls: <SelectionButton />,
+        }}
+        gridStyle={{ rowClasses, rowHover: 'none' }}
+      />
     </SelectionContext.Provider>
   );
 };

--- a/src/components/datagrid/_data_grid_data_row.scss
+++ b/src/components/datagrid/_data_grid_data_row.scss
@@ -119,6 +119,10 @@
   height: auto;
   display: flex;
   align-items: center;
+
+  &.euiDataGridRowCell__content--defaultHeight {
+    height: 100%;
+  }
 }
 
 // Positioning for cell actions & the cell expansion popover

--- a/src/components/datagrid/body/data_grid_row_manager.ts
+++ b/src/components/datagrid/body/data_grid_row_manager.ts
@@ -82,7 +82,9 @@ export const useRowManager = ({
     if (rowClasses) {
       rowIdToElements.current.forEach((rowElement, rowIndex) => {
         const euiClasses = Array.from(rowElement.classList)
-          .filter((className) => className.startsWith('euiDataGridRow'))
+          .filter((className) =>
+            ['euiDataGridRow', 'euiDataGridRow--striped'].includes(className)
+          )
           .join(' ');
 
         if (rowClasses[rowIndex]) {


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7548 (fix is in first commit, other commits are bonus/cleanup)

This bug primarily affects our docs example, and likely has very minimal impact on consumers (given that it's unlikely that they're naming their own custom `className`s with `.euiDataGridRow`).

## QA

**Reproducing the bug**
  - Go to https://eui.elastic.co/pr_/#/tabular-content/data-grid-style-display#grid-row-classes
  - Select any row, and then unselect it
  - The highlight CSS is not removed when it should be

**QAing the fix** 
- Go to https://eui.elastic.co/pr_7549/#/tabular-content/data-grid-style-display#grid-row-classes
- Select any row and then unselect it
- [x] The highlight CSS should be removed on checkbox uncheck, and the striped CSS should be restored for the 3rd row

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist
    - ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ Opted to skip this as the bug is so incredibly specific to our docs example, LMK if you disagree
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A