### PR TITLE
[Storybook] Add Playground stories for components with letter H

### DIFF
--- a/src/components/header/header_breadcrumbs/header_breadcrumbs.stories.tsx
+++ b/src/components/header/header_breadcrumbs/header_breadcrumbs.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiBreadcrumbsProps } from '../../breadcrumbs';
+import { EuiHeaderBreadcrumbs } from './header_breadcrumbs';
+
+const meta: Meta<EuiBreadcrumbsProps> = {
+  title: 'EuiHeaderBreadcrumbs',
+  component: EuiHeaderBreadcrumbs,
+  args: {
+    // Component defaults
+    type: 'application',
+    max: 4,
+    truncate: true,
+    responsive: { xs: 1, s: 2, m: 4 },
+    lastBreadcrumbIsCurrentPage: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiBreadcrumbsProps>;
+
+export const Playground: Story = {
+  args: {
+    breadcrumbs: [
+      {
+        text: 'Breadcrumb 1',
+        href: '#',
+      },
+      {
+        text: 'Breadcrumb 2',
+        href: '#',
+      },
+      {
+        text: 'Current',
+        href: '#',
+      },
+    ],
+  },
+};

--- a/src/components/header/header_links/header_link.stories.tsx
+++ b/src/components/header/header_links/header_link.stories.tsx
@@ -23,6 +23,13 @@ const meta: Meta<EuiHeaderLinkProps> = {
   },
   // Component defaults
   args: {
+    type: 'button',
+    size: 'm',
+    iconSize: 'm',
+    iconSide: 'left',
+    isDisabled: false,
+    isLoading: false,
+    isSelected: false,
     isActive: false,
   },
 };

--- a/src/components/header/header_links/header_link.stories.tsx
+++ b/src/components/header/header_links/header_link.stories.tsx
@@ -14,22 +14,8 @@ import { EuiHeaderLink, EuiHeaderLinkProps } from './header_link';
 const meta: Meta<EuiHeaderLinkProps> = {
   title: 'EuiHeaderLink',
   component: EuiHeaderLink,
-  argTypes: {
-    flush: {
-      options: [undefined, 'left', 'right', 'both'],
-    },
-    iconType: { control: 'text' },
-    target: { control: 'text' },
-  },
   // Component defaults
   args: {
-    type: 'button',
-    size: 'm',
-    iconSize: 'm',
-    iconSide: 'left',
-    isDisabled: false,
-    isLoading: false,
-    isSelected: false,
     isActive: false,
   },
 };

--- a/src/components/header/header_links/header_link.stories.tsx
+++ b/src/components/header/header_links/header_link.stories.tsx
@@ -8,8 +8,8 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { EuiHeaderLink, EuiHeaderLinkProps } from './header_link';
 import { disableStorybookControls } from '../../../../.storybook/utils';
+import { EuiHeaderLink, EuiHeaderLinkProps } from './header_link';
 
 const meta: Meta<EuiHeaderLinkProps> = {
   title: 'EuiHeaderLink',

--- a/src/components/header/header_links/header_link.stories.tsx
+++ b/src/components/header/header_links/header_link.stories.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiHeaderLink, EuiHeaderLinkProps } from './header_link';
+import { disableStorybookControls } from '../../../../.storybook/utils';
+
+const meta: Meta<EuiHeaderLinkProps> = {
+  title: 'EuiHeaderLink',
+  component: EuiHeaderLink,
+  argTypes: {
+    flush: {
+      options: [undefined, 'left', 'right', 'both'],
+    },
+    iconType: { control: 'text' },
+    target: { control: 'text' },
+  },
+  // Component defaults
+  args: {
+    isActive: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiHeaderLinkProps>;
+
+export const Playground: Story = {
+  argTypes: disableStorybookControls(['buttonRef']),
+  args: {
+    children: 'Header link',
+  },
+};

--- a/src/components/health/health.stories.tsx
+++ b/src/components/health/health.stories.tsx
@@ -14,7 +14,9 @@ import { EuiHealth, EuiHealthProps } from './health';
 const meta: Meta<EuiHealthProps> = {
   title: 'EuiHealth',
   component: EuiHealth,
-  argTypes: {},
+  argTypes: {
+    color: { control: 'text' },
+  },
   // Component defaults
   args: {
     textSize: 's',
@@ -28,5 +30,6 @@ export const Playground: Story = {
   argTypes: hideStorybookControls(['aria-label']),
   args: {
     children: 'Status',
+    color: 'success',
   },
 };

--- a/src/components/health/health.stories.tsx
+++ b/src/components/health/health.stories.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { hideStorybookControls } from '../../../.storybook/utils';
+import { EuiHealth, EuiHealthProps } from './health';
+
+const meta: Meta<EuiHealthProps> = {
+  title: 'EuiHealth',
+  component: EuiHealth,
+  argTypes: {},
+  // Component defaults
+  args: {
+    textSize: 's',
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiHealthProps>;
+
+export const Playground: Story = {
+  argTypes: hideStorybookControls(['aria-label']),
+  args: {
+    children: 'Status',
+  },
+};

--- a/src/components/highlight/highlight.stories.tsx
+++ b/src/components/highlight/highlight.stories.tsx
@@ -16,7 +16,6 @@ const meta: Meta<EuiHighlightProps> = {
   argTypes: {},
   // Component defaults
   args: {
-    search: 'quick',
     strict: false,
     highlightAll: false,
     hasScreenReaderHelpText: true,
@@ -29,5 +28,14 @@ type Story = StoryObj<EuiHighlightProps>;
 export const Playground: Story = {
   args: {
     children: 'The quick brown fox jumped over the lazy dog.',
+    search: 'Quick',
+  },
+};
+
+export const MultipleSearchStrings: Story = {
+  args: {
+    children: 'The quick brown fox jumped over the lazy dog.',
+    search: ['Fox', 'Dog'],
+    highlightAll: true,
   },
 };

--- a/src/components/highlight/highlight.stories.tsx
+++ b/src/components/highlight/highlight.stories.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiHighlight, EuiHighlightProps } from './highlight';
+
+const meta: Meta<EuiHighlightProps> = {
+  title: 'EuiHighlight',
+  component: EuiHighlight,
+  argTypes: {},
+  // Component defaults
+  args: {
+    search: 'quick',
+    strict: false,
+    highlightAll: false,
+    hasScreenReaderHelpText: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiHighlightProps>;
+
+export const Playground: Story = {
+  args: {
+    children: 'The quick brown fox jumped over the lazy dog.',
+  },
+};

--- a/src/components/horizontal_rule/horizontal_rule.stories.tsx
+++ b/src/components/horizontal_rule/horizontal_rule.stories.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { hideStorybookControls } from '../../../.storybook/utils';
+import { EuiHorizontalRule, EuiHorizontalRuleProps } from './horizontal_rule';
+
+const meta: Meta<EuiHorizontalRuleProps> = {
+  title: 'EuiHorizontalRule',
+  component: EuiHorizontalRule,
+  argTypes: {},
+  // Component defaults
+  args: {
+    size: 'full',
+    margin: 'l',
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiHorizontalRuleProps>;
+
+export const Playground: Story = {
+  argTypes: hideStorybookControls(['aria-label']),
+};

--- a/src/components/responsive/hide_for.stories.tsx
+++ b/src/components/responsive/hide_for.stories.tsx
@@ -21,6 +21,7 @@ type Story = StoryObj<EuiHideForProps>;
 export const Playground: Story = {
   args: {
     sizes: ['xs'],
-    children: 'Hidden message: The quick brown fox jumped over the lazy dog.',
+    children:
+      'Try changing the Storybook viewport, or adding the `l` size, to see how it affects the visibility of this text.',
   },
 };

--- a/src/components/responsive/hide_for.stories.tsx
+++ b/src/components/responsive/hide_for.stories.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiHideFor, EuiHideForProps } from './hide_for';
+
+const meta: Meta<EuiHideForProps> = {
+  title: 'EuiHideFor',
+  component: EuiHideFor,
+};
+
+export default meta;
+type Story = StoryObj<EuiHideForProps>;
+
+export const Playground: Story = {
+  args: {
+    sizes: ['xs'],
+    children: 'Hidden message: The quick brown fox jumped over the lazy dog.',
+  },
+};


### PR DESCRIPTION
## Summary

closes #7478 

This PR adds "Playground" stories for the following components:

* EuiHeaderBreadcrumbs
* EuiHeaderLink
* EuiHealth
* EuiHighlight
* EuiHorizontalRule
* EuiHideFor

## QA

- [ ] Confirm that the prop controls for all the below storybooks work as expected:

- https://eui.elastic.co/pr_7553/storybook/index.html?path=/story/euiheaderbreadcrumbs--playground
- https://eui.elastic.co/pr_7553/storybook/index.html?path=/story/euiheaderlink--playground
- https://eui.elastic.co/pr_7553/storybook/index.html?path=/story/euihealth--playground
- https://eui.elastic.co/pr_7553/storybook/index.html?path=/story/euihighlight--playground
- https://eui.elastic.co/pr_7553/storybook/index.html?path=/story/euihorizontalrule--playground
- https://eui.elastic.co/pr_7553/storybook/index.html?path=/story/euihidefor--playground
