### PR TITLE
[EuiBreadcrumb] Allow popover content to close the breadcrumb popover

### DIFF
--- a/changelogs/upcoming/7555.md
+++ b/changelogs/upcoming/7555.md
@@ -1,0 +1,1 @@
+- `EuiBreadcrumbs`'s `popoverContent` API now accepts a render function that will be passed a `closePopover` callback, allowing consumers to close the breadcrumb popover from their popover content

--- a/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
+++ b/src-docs/src/views/breadcrumbs/breadcrumbs_example.js
@@ -294,6 +294,14 @@ export const BreadcrumbsExample = {
             accepted as they are controlled automatically by{' '}
             <strong>EuiBreadcrumbs</strong>.
           </p>
+          <p>
+            If you need the ability to close the breadcrumb popover from within
+            your popover content, <EuiCode>popoverContent</EuiCode> accepts a
+            render function that will be passed a{' '}
+            <EuiCode>closePopover</EuiCode> callback, which you can invoke to
+            close the popover. See the Deployment breadcrumb below for example
+            usage.
+          </p>
           <EuiCallOut
             color="warning"
             iconType="accessibility"

--- a/src-docs/src/views/breadcrumbs/popover_content.tsx
+++ b/src-docs/src/views/breadcrumbs/popover_content.tsx
@@ -41,37 +41,34 @@ export default () => {
   const breadcrumbs: EuiBreadcrumb[] = [
     {
       text: 'My deployment',
-      popoverContent: (
-        <>
-          <EuiPopoverTitle paddingSize="s">Select a deployment</EuiPopoverTitle>
-          <EuiContextMenuPanel
-            size="s"
-            items={[
-              <EuiContextMenuItem
-                key="A"
-                href="#"
-                onClick={(e) => e.preventDefault()}
-              >
-                Go to Deployment A
-              </EuiContextMenuItem>,
-              <EuiContextMenuItem
-                key="B"
-                href="#"
-                onClick={(e) => e.preventDefault()}
-              >
-                Go to Deployment B
-              </EuiContextMenuItem>,
-              <EuiContextMenuItem
-                key="C"
-                href="#"
-                onClick={(e) => e.preventDefault()}
-              >
-                Go to all deployments
-              </EuiContextMenuItem>,
-            ]}
-          />
-        </>
-      ),
+      // Passing a render function allows closing the breadcrumb popover from within your content
+      popoverContent: (closePopover) => {
+        const onClick = (e: React.MouseEvent) => {
+          e.preventDefault();
+          closePopover();
+        };
+        return (
+          <>
+            <EuiPopoverTitle paddingSize="s">
+              Select a deployment
+            </EuiPopoverTitle>
+            <EuiContextMenuPanel
+              size="s"
+              items={[
+                <EuiContextMenuItem key="A" href="#" onClick={onClick}>
+                  Go to Deployment A
+                </EuiContextMenuItem>,
+                <EuiContextMenuItem key="B" href="#" onClick={onClick}>
+                  Go to Deployment B
+                </EuiContextMenuItem>,
+                <EuiContextMenuItem key="C" href="#" onClick={onClick}>
+                  Go to all deployments
+                </EuiContextMenuItem>,
+              ]}
+            />
+          </>
+        );
+      },
       popoverProps: { panelPaddingSize: 'none' },
     },
     {

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiBreadcrumbContent renders breadcrumbs with \`popoverContent\` with popovers 1`] = `
+exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverContent\` 1`] = `
 <body>
   <div>
     <div

--- a/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -8,7 +8,11 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { render, waitForEuiPopoverOpen } from '../../test/rtl';
+import {
+  render,
+  waitForEuiPopoverOpen,
+  waitForEuiPopoverClose,
+} from '../../test/rtl';
 
 import { EuiBreadcrumbContent } from './breadcrumb';
 
@@ -35,21 +39,44 @@ describe('EuiBreadcrumbContent', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('renders breadcrumbs with `popoverContent` with popovers', async () => {
-    const { baseElement, getByTestSubject } = render(
-      <EuiBreadcrumbContent
-        type="page"
-        text="Toggles a popover"
-        data-test-subj="popoverToggle"
-        popoverContent="Hello popover world"
-        popoverProps={{ 'data-test-subj': 'popover' }}
-      />
-    );
-    fireEvent.click(getByTestSubject('popoverToggle'));
-    await waitForEuiPopoverOpen();
+  describe('breadcrumbs with popovers', () => {
+    it('renders with `popoverContent`', async () => {
+      const { baseElement, getByTestSubject } = render(
+        <EuiBreadcrumbContent
+          type="page"
+          text="Toggles a popover"
+          data-test-subj="popoverToggle"
+          popoverContent="Hello popover world"
+          popoverProps={{ 'data-test-subj': 'popover' }}
+        />
+      );
+      fireEvent.click(getByTestSubject('popoverToggle'));
+      await waitForEuiPopoverOpen();
 
-    expect(getByTestSubject('popover')).toBeInTheDocument();
-    expect(baseElement).toMatchSnapshot();
+      expect(getByTestSubject('popover')).toBeInTheDocument();
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('passes a popover close callback to `popoverContent` render functions', async () => {
+      const { getByTestSubject } = render(
+        <EuiBreadcrumbContent
+          type="page"
+          text="Controlled breadcrumb popover"
+          data-test-subj="popoverToggle"
+          popoverContent={(closePopover) => (
+            <button onClick={closePopover} data-test-subj="popoverClose">
+              Close popover
+            </button>
+          )}
+        />
+      );
+
+      fireEvent.click(getByTestSubject('popoverToggle'));
+      await waitForEuiPopoverOpen();
+
+      fireEvent.click(getByTestSubject('popoverClose'));
+      await waitForEuiPopoverClose();
+    });
   });
 
   describe('highlightLastBreadcrumb', () => {

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -56,12 +56,14 @@ export type EuiBreadcrumbProps = Omit<
      */
     'aria-current'?: AriaAttributes['aria-current'];
     /**
-     * Creates a breadcrumb that toggles a popover dialog
+     * Creates a breadcrumb that toggles a popover dialog. Takes any rendered node(s),
+     * or a render function that will pass callback allowing you to close the
+     * breadcrumb popover from within your popover content.
      *
      * If passed, both `href` and `onClick` will be ignored - the breadcrumb's
      * click behavior should only trigger a popover.
      */
-    popoverContent?: ReactNode;
+    popoverContent?: ReactNode | ((closePopover: () => void) => ReactNode);
     /**
      * Allows customizing the popover if necessary. Accepts any props that
      * [EuiPopover](/#/layout/popover) accepts, except for props that control state.
@@ -166,11 +168,12 @@ export const EuiBreadcrumbContent: FunctionComponent<
         const styleProps = { className: classes, css: cssStyles };
 
         if (isPopoverBreadcrumb) {
+          const closePopover = () => setIsPopoverOpen(false);
           return (
             <EuiPopover
               {...popoverProps}
               isOpen={isPopoverOpen}
-              closePopover={() => setIsPopoverOpen(false)}
+              closePopover={closePopover}
               css={!isLastBreadcrumb && styles.euiBreadcrumb__popoverWrapper}
               button={
                 <EuiLink
@@ -190,7 +193,9 @@ export const EuiBreadcrumbContent: FunctionComponent<
                 </EuiLink>
               }
             >
-              {popoverContent}
+              {typeof popoverContent === 'function'
+                ? popoverContent(closePopover)
+                : popoverContent}
             </EuiPopover>
           );
         } else if (isInteractiveBreadcrumb) {


### PR DESCRIPTION
## Summary

@sebelga pinged me with the request for serverless nav work to be given the ability to optionally control EUI's breadcrumb popover state. His use case is for consumer popover content that does something/takes the user somewhere and then closes the popover, e.g.

<img src="https://github.com/elastic/eui/assets/549407/b885bb98-f35b-4d57-9926-03e1ed93f05b" alt="" width="350">

The approach I decided to take here was to allow `popoverContent` to be a render function that passes the `closePopover` callback to consumers. Example usage:

```tsx
<EuiBreadcrumbs
  breadcrumbs={[
    {
      text: 'My deployment',
      popoverContent: (closePopover) => (
        <EuiButtonEmpty
          onClick={() => {
            goSomewhere();
            closePopover();
          }}
        >
          Go to some deployment
        </EuiButtonEmpty>
      ),
    },
    { text: 'Another breadcrumb' },
  ]}
/>
```

I'm open to feedback as to whether we think this is the best approach in terms of giving consumers more flexibility vs handling internals for consumers so they don't have to. 

## QA

- Go to https://eui.elastic.co/pr_7555/#/navigation/breadcrumbs#popover-content
- [x] Confirm that clicking any of the links in the `My deployment` breadcrumb closes the breadcrumb popover

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A