### PR TITLE
[Emotion] Memoize `EuiSkeleton` components

### DIFF
--- a/src/components/skeleton/skeleton_circle.tsx
+++ b/src/components/skeleton/skeleton_circle.tsx
@@ -9,8 +9,8 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
-import { useEuiTheme } from '../../services';
 
 import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
 import { euiSkeletonCircleStyles } from './skeleton_circle.styles';
@@ -36,8 +36,7 @@ export const EuiSkeletonCircle: FunctionComponent<EuiSkeletonCircleProps> = ({
   children,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiSkeletonCircleStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiSkeletonCircleStyles);
   const cssStyles = [styles.euiSkeletonCircle, styles[size]];
 
   return (

--- a/src/components/skeleton/skeleton_rectangle.tsx
+++ b/src/components/skeleton/skeleton_rectangle.tsx
@@ -9,8 +9,8 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
-import { useEuiTheme } from '../../services';
 import { logicalStyles } from '../../global_styling';
 
 import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
@@ -44,8 +44,7 @@ export const EuiSkeletonRectangle: FunctionComponent<
   children,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiSkeletonRectangleStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiSkeletonRectangleStyles);
   const cssStyles = [styles.euiSkeletonRectangle, styles[borderRadius]];
 
   return (

--- a/src/components/skeleton/skeleton_text.tsx
+++ b/src/components/skeleton/skeleton_text.tsx
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
-import { useEuiTheme } from '../../services';
 import { TextSize } from '../text/text';
 
 import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
@@ -45,14 +45,19 @@ export const EuiSkeletonText: FunctionComponent<EuiSkeletonTextProps> = ({
   children,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiSkeletonTextStyles(euiTheme);
-  const lineCssStyles = [styles.euiSkeletonText, styles[size]];
+  const styles = useEuiMemoizedStyles(euiSkeletonTextStyles);
+  const cssStyles = useMemo(
+    () => [styles.euiSkeletonText, styles[size]],
+    [styles, size]
+  );
 
-  const lineElements = [];
-  for (let i = 0; i < lines; i++) {
-    lineElements.push(<span key={i} css={lineCssStyles} />);
-  }
+  const lineElements = useMemo(() => {
+    const lineElements = [];
+    for (let i = 0; i < lines; i++) {
+      lineElements.push(<span key={i} css={cssStyles} />);
+    }
+    return lineElements;
+  }, [lines, cssStyles]);
 
   return (
     <EuiSkeletonLoading

--- a/src/components/skeleton/skeleton_title.tsx
+++ b/src/components/skeleton/skeleton_title.tsx
@@ -9,8 +9,8 @@
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
-import { useEuiTheme } from '../../services';
 import { EuiTitleSize } from '../title';
 
 import { EuiSkeletonLoading, _EuiSkeletonAriaProps } from './skeleton_loading';
@@ -37,8 +37,7 @@ export const EuiSkeletonTitle: FunctionComponent<EuiSkeletonTitleProps> = ({
   children,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiSkeletonTitleStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiSkeletonTitleStyles);
   const cssStyles = [styles.euiSkeletonTitle, styles[size]];
 
   return (


### PR DESCRIPTION
## Summary

Pulled out the original work/impetus from Kevin's PR (#7374) for PR atomic-ness and also because it dovetails nicely into our existing Emotion perf/memoization work (see #7561)

## QA

- [x] [Staging](https://eui.elastic.co/pr_7562/#/display/skeleton) should look the same as [production](https://eui.elastic.co/#/display/skeleton)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist - N/A
- Release checklist - Skipping as this should not impact consumers or end users
- Designer checklist - N/A