### PR TITLE
[EuiDataGrid] Sorting popover scrollbar CSS bug/workaround

### DIFF
--- a/src-docs/src/views/datagrid/basics/datagrid.js
+++ b/src-docs/src/views/datagrid/basics/datagrid.js
@@ -84,7 +84,7 @@ const RenderCellValue = ({ rowIndex, columnId, setCellProps }) => {
   }, [rowIndex, columnId, setCellProps, data]);
 
   function getFormatted() {
-    return data[rowIndex][columnId].formatted
+    return data[rowIndex][columnId]?.formatted
       ? data[rowIndex][columnId].formatted
       : data[rowIndex][columnId];
   }
@@ -209,6 +209,25 @@ const columns = [
     initialWidth: 70,
     isResizable: false,
     actions: false,
+  },
+  {
+    id: 'test',
+    displayAsText: 'Long long long field name',
+  },
+  {
+    id: 'test1',
+  },
+  {
+    id: 'test2',
+  },
+  {
+    id: 'test3',
+  },
+  {
+    id: 'test4',
+  },
+  {
+    id: 'test5',
   },
 ];
 

--- a/src/components/datagrid/controls/_data_grid_column_sorting.scss
+++ b/src/components/datagrid/controls/_data_grid_column_sorting.scss
@@ -23,7 +23,9 @@
 .euiDataGridColumnSorting__field {
   @include euiInteractiveStates;
   @include euiTextTruncate;
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: $euiSizeS;
   padding: $euiSizeXS $euiSizeS;
   width: 100%;
   outline-offset: -$euiFocusRingSize;

--- a/src/components/datagrid/controls/_data_grid_column_sorting.scss
+++ b/src/components/datagrid/controls/_data_grid_column_sorting.scss
@@ -10,14 +10,27 @@
   padding-top: $euiSizeXS;
   padding-bottom: $euiSizeXS;
   max-height: 300px;
+
+  // Workaround for scrollbar clipping into text longer than the popover min width
+  @supports (scrollbar-gutter: stable) {
+    scrollbar-gutter: stable;
+  }
+  @supports not (scrollbar-gutter: stable) {
+    padding-right: 10px; // Safari :|
+  }
 }
 
 .euiDataGridColumnSorting__field {
   @include euiInteractiveStates;
+  @include euiTextTruncate;
   display: block;
   padding: $euiSizeXS $euiSizeS;
   width: 100%;
   outline-offset: -$euiFocusRingSize;
+
+  @supports not (scrollbar-gutter: stable) {
+    min-width: fit-content;
+  }
 }
 
 .euiDataGridColumnSorting__name {

--- a/src/components/datagrid/controls/column_sorting.tsx
+++ b/src/components/datagrid/controls/column_sorting.tsx
@@ -236,38 +236,25 @@ export const useDataGridColumnSorting = (
                                   sorting.onSort(nextColumns);
                                 }}
                               >
-                                <EuiFlexGroup
-                                  alignItems="center"
-                                  gutterSize="s"
-                                  component="span"
-                                  responsive={false}
-                                >
-                                  <EuiFlexItem grow={false}>
-                                    <EuiToken
-                                      iconType={
-                                        schemaDetails(id) != null
-                                          ? getDetailsForSchema(
-                                              schemaDetectors,
-                                              schema[id].columnType
-                                            ).icon
-                                          : 'tokenString'
-                                      }
-                                      color={
-                                        schemaDetails(id) != null
-                                          ? getDetailsForSchema(
-                                              schemaDetectors,
-                                              schema[id].columnType
-                                            ).color
-                                          : undefined
-                                      }
-                                    />
-                                  </EuiFlexItem>
-                                  <EuiFlexItem grow={false}>
-                                    <EuiText size="xs">
-                                      {displayValues[id]}
-                                    </EuiText>
-                                  </EuiFlexItem>
-                                </EuiFlexGroup>
+                                <EuiToken
+                                  iconType={
+                                    schemaDetails(id) != null
+                                      ? getDetailsForSchema(
+                                          schemaDetectors,
+                                          schema[id].columnType
+                                        ).icon
+                                      : 'tokenString'
+                                  }
+                                  color={
+                                    schemaDetails(id) != null
+                                      ? getDetailsForSchema(
+                                          schemaDetectors,
+                                          schema[id].columnType
+                                        ).color
+                                      : undefined
+                                  }
+                                />
+                                <EuiText size="xs">{displayValues[id]}</EuiText>
                               </button>
                             );
                           }


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7551

With scrollbar:

| Browser | Before | After |
|--------|--------|--------|
| Firefox | <img width="217" alt="" src="https://github.com/elastic/eui/assets/549407/3e159d66-fbe0-4ae1-b33d-2e498879d385"> | <img width="228" alt="" src="https://github.com/elastic/eui/assets/549407/393f08b2-685d-4c30-9978-e12eee2aa074"> |
| Safari | <img width="187" alt="" src="https://github.com/elastic/eui/assets/549407/fdc3f9dd-28ee-4142-ba63-9258f5d5ecfb"> | <img width="205" alt="" src="https://github.com/elastic/eui/assets/549407/d30aaedd-1466-46e0-b540-2f812d8d51aa"> |
| Chrome | <img width="201" alt="" src="https://github.com/elastic/eui/assets/549407/0527b0ce-1921-4344-9dc8-41b06c9bff49"> | <img width="201" alt="" src="https://github.com/elastic/eui/assets/549407/48dd4ea2-b8dd-4115-a1eb-f1c54f979805"> |

Without scrollbar:

| Before | After |
|--------|--------|
| <img width="247" alt="" src="https://github.com/elastic/eui/assets/549407/f2d2282e-7b25-4e42-aa3b-2ae65cb6745c"> | <img width="244" alt="" src="https://github.com/elastic/eui/assets/549407/5ebe54cc-0db5-4e4c-b46c-2d31956ba225"> | 

## QA

- On your Mac, open your system settings and go to Appearance > Show Scrollbars
- Check `Always`
- In Safari: Go to https://eui.elastic.co/pr_7567/#/tabular-content/data-grid and click `Sort fields` in the toolbar and then click `Pick fields to sort by`
- [ ] Confirm `Long long long field name` is 1 line and is not cut off
- [ ] Confirm the above is also true for Firefox
- [ ] Confirm the above is also true for Chrome
- Regression testing:
- [ ] Go to any other datagrid example with fewer fields/no scrollbar and confirm it still works

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked in **mobile**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist - N/A, CSS-only change
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A