### PR TITLE
[BUG] Fixed community GHA curl command.

### DIFF
--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -19,7 +19,7 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-writing-an-environment-variable-to-github_env
         run: |
           DATA=$(
-            curl -L -i -w "%{http_code}" \
+            curl -L -i -g -w "%{http_code}" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.EUI_COMMUNITY_PR }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
## Summary
We had an automated PR submitted earlier that didn't present the community contribution message. Looking through the logs I deduced it was related to the URL structure including a bracket. I updated the `curl` command to remediate the issue.

https://curl.se/docs/manpage.html#-g

PR closes #7573.

## QA
I recreated the `curl` command locally, created a single-use token, and hardcoded the URL we were looking to validate. The test returned the correct data after adding the `-g` flag. I tested for negative and affirmative org membership.

Will retest with my QA account after PR merges to confirm the community message has not had any regression.
