### PR TITLE
[EuiResizeObserver] Remove reflow/`getBoundingClientRect()` usage on resize

### DIFF
--- a/changelogs/upcoming/7575.md
+++ b/changelogs/upcoming/7575.md
@@ -1,0 +1,1 @@
+- Enhanced `EuiResizeObserver` and `useResizeObserver`'s performance to not trigger page reflows on resize event

--- a/src/components/observer/resize_observer/resize_observer.tsx
+++ b/src/components/observer/resize_observer/resize_observer.tsx
@@ -28,12 +28,9 @@ export class EuiResizeObserver extends EuiObserver<EuiResizeObserverProps> {
     width: 0,
   };
 
-  onResize: ResizeObserverCallback = () => {
-    // `entry.contentRect` provides incomplete `height` and `width` data.
-    // Use `getBoundingClientRect` to account for padding and border.
-    // https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly
-    if (!this.childNode) return;
-    const { height, width } = this.childNode.getBoundingClientRect();
+  onResize: ResizeObserverCallback = ([entry]) => {
+    const { inlineSize: width, blockSize: height } = entry.borderBoxSize[0];
+
     // Check for actual resize event
     if (this.state.height === height && this.state.width === width) {
       return;
@@ -102,14 +99,11 @@ export const useResizeObserver = (
         height: boundingRect.height,
       });
 
-      const observer = makeResizeObserver(container, () => {
-        // `entry.contentRect` provides incomplete `height` and `width` data.
-        // Use `getBoundingClientRect` to account for padding and border.
-        // https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly
-        const { height, width } = container.getBoundingClientRect();
+      const observer = makeResizeObserver(container, ([entry]) => {
+        const { inlineSize, blockSize } = entry.borderBoxSize[0];
         setSize({
-          width,
-          height,
+          width: inlineSize,
+          height: blockSize,
         });
       });
 

--- a/src/components/observer/resize_observer/resize_observer.tsx
+++ b/src/components/observer/resize_observer/resize_observer.tsx
@@ -91,14 +91,6 @@ export const useResizeObserver = (
 
   useEffect(() => {
     if (container != null) {
-      // ResizeObserver's first call to the observation callback is scheduled in the future
-      // so find the container's initial dimensions now
-      const boundingRect = container.getBoundingClientRect();
-      setSize({
-        width: boundingRect.width,
-        height: boundingRect.height,
-      });
-
       const observer = makeResizeObserver(container, ([entry]) => {
         const { inlineSize, blockSize } = entry.borderBoxSize[0];
         setSize({


### PR DESCRIPTION
## Summary

See @davismcphee's comment in https://github.com/elastic/eui/pull/7462#issuecomment-1977616140:

> It looks like `useResizeObserver` relies on `getBoundingClientRect` because `contentRect` only provides the content sizing for elements instead of box sizing:
https://github.com/elastic/eui/blob/635f860520e8cd981175438748705f27a51eb0ac/src/components/observer/resize_observer/resize_observer.tsx#L106-L109
> But I assume this code is old and isn't actually needed anymore since [`ResizeObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry) now supports [`borderBoxSize`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/borderBoxSize) to access box sizing.

This is definitely a refactor/perf improvement we want across the board in our resize observer (both component and hook), hence me opening this PR.

## QA

- Go to https://eui.elastic.co/pr_7575/#/utilities/resize-observer
- [ ] Confirm both examples print the correct dimensions on page load (compare against [production](https://eui.elastic.co/#/utilities/resize-observer))
  - Note: It looks like subpixel rounding is slightly different on Chrome/FF than on Safari. IMO, this is fine and well worth the perf tradeoff
- [ ] Add items and padding and confirm the measurements update as expected (also compared against production)

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist - Skipped as there are no jsdom/unit tests for the resize observer API. Manual QA for now
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A