### PR TITLE
[DOCS]: EuiTable examples updated with unique checkbox labels.

### DIFF
--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -262,8 +262,10 @@ export default () => {
 
   const selection: EuiTableSelectionType<User> = {
     selectable: (user: User) => user.online,
-    selectableMessage: (selectable: boolean) =>
-      !selectable ? 'User is currently offline' : '',
+    selectableMessage: (selectable: boolean, user: User) =>
+      !selectable
+        ? `${user.firstName} ${user.lastName} is currently offline`
+        : `Select ${user.firstName} ${user.lastName}`,
     onSelectionChange,
   };
 

--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -187,8 +187,10 @@ export default () => {
 
   const selection: EuiTableSelectionType<User> = {
     selectable: (user: User) => user.online,
-    selectableMessage: (selectable: boolean) =>
-      !selectable ? 'User is currently offline' : '',
+    selectableMessage: (selectable: boolean, user: User) =>
+      !selectable
+        ? `${user.firstName} ${user.lastName} is currently offline`
+        : `Select ${user.firstName} ${user.lastName}`,
     onSelectionChange,
   };
 

--- a/src-docs/src/views/tables/footer/footer.tsx
+++ b/src-docs/src/views/tables/footer/footer.tsx
@@ -206,8 +206,10 @@ export default () => {
 
   const selection: EuiTableSelectionType<User> = {
     selectable: (user: User) => user.online,
-    selectableMessage: (selectable: boolean) =>
-      !selectable ? 'User is currently offline' : '',
+    selectableMessage: (selectable: boolean, user: User) =>
+      !selectable
+        ? `${user.firstName} ${user.lastName} is currently offline`
+        : `Select ${user.firstName} ${user.lastName}`,
     onSelectionChange,
   };
 

--- a/src-docs/src/views/tables/mobile/mobile.tsx
+++ b/src-docs/src/views/tables/mobile/mobile.tsx
@@ -182,8 +182,10 @@ export default () => {
 
   const selection: EuiTableSelectionType<User> = {
     selectable: (user: User) => user.online,
-    selectableMessage: (selectable: boolean) =>
-      !selectable ? 'User is currently offline' : '',
+    selectableMessage: (selectable: boolean, user: User) =>
+      !selectable
+        ? `${user.firstName} ${user.lastName} is currently offline`
+        : `Select ${user.firstName} ${user.lastName}`,
     onSelectionChange,
   };
 

--- a/src-docs/src/views/tables/selection/selection_controlled.tsx
+++ b/src-docs/src/views/tables/selection/selection_controlled.tsx
@@ -117,8 +117,10 @@ export default () => {
 
   const selection: EuiTableSelectionType<User> = {
     selectable: (user: User) => user.online,
-    selectableMessage: (selectable: boolean) =>
-      !selectable ? 'User is currently offline' : '',
+    selectableMessage: (selectable: boolean, user: User) =>
+      !selectable
+        ? `${user.firstName} ${user.lastName} is currently offline`
+        : `Select ${user.firstName} ${user.lastName}`,
     onSelectionChange,
     selected: selectedItems,
   };

--- a/src-docs/src/views/tables/selection/selection_uncontrolled.tsx
+++ b/src-docs/src/views/tables/selection/selection_uncontrolled.tsx
@@ -112,8 +112,10 @@ export default () => {
 
   const selection: EuiTableSelectionType<User> = {
     selectable: (user: User) => user.online,
-    selectableMessage: (selectable: boolean) =>
-      !selectable ? 'User is currently offline' : '',
+    selectableMessage: (selectable: boolean, user: User) =>
+      !selectable
+        ? `${user.firstName} ${user.lastName} is currently offline`
+        : `Select ${user.firstName} ${user.lastName}`,
     onSelectionChange,
     initialSelected: onlineUsers,
   };


### PR DESCRIPTION
## Summary

This PR came about from my investigation into #7542. That issue requested a way to add accessible `aria-labels` for `EuiDataGrid`. After confirming we could create unique labels in the data grid, I looked closer at `EuiBasicTable` to see if a similar mechanism was available.

The `selectableMessage()` callback accepts a second argument `item: User`, which was exactly the API I was looking for. Using that second argument, I refactored examples to concatenate accessible labels for the `EuiCheckbox` columns.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
