### PR TITLE
[EuiBreadcrumb] Fix styling on `application` types with popovers + perf improvements

### DIFF
--- a/changelogs/upcoming/7580.md
+++ b/changelogs/upcoming/7580.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a visual bug with `EuiHeadersBreadcrumbs` with popovers

--- a/changelogs/upcoming/7580.md
+++ b/changelogs/upcoming/7580.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed a visual bug with `EuiHeadersBreadcrumbs` with popovers
+- Fixed a visual bug with `EuiHeaderBreadcrumbs` with popovers

--- a/src/components/breadcrumbs/__snapshots__/_breadcrumb_content.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/_breadcrumb_content.test.tsx.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverContent\` 1`] = `
+<body>
+  <div>
+    <div
+      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
+      data-test-subj="popover"
+    >
+      <button
+        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
+        data-test-subj="popoverToggle"
+        title="Toggles a popover - Clicking this button will toggle a popover dialog."
+        type="button"
+      >
+        <span
+          class="emotion-euiBreadcrumb__popoverTruncation"
+        >
+          Toggles a popover
+        </span>
+        <span
+          data-euiicon-type="arrowDown"
+        >
+           - Clicking this button will toggle a popover dialog.
+        </span>
+      </button>
+    </div>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
+    >
+      <div
+        aria-describedby="generated-id"
+        aria-live="off"
+        aria-modal="true"
+        class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-bottom"
+        data-autofocus="true"
+        data-popover-open="true"
+        data-popover-panel="true"
+        role="dialog"
+        style="top: 16px; left: -22px; z-index: 2000;"
+        tabindex="0"
+      >
+        <div
+          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+          data-popover-arrow="bottom"
+          style="left: 10px; top: 0px;"
+        />
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a dialog. Press Escape, or tap/click outside the dialog to close.
+        </p>
+        <div>
+          Hello popover world
+        </div>
+      </div>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`EuiBreadcrumbContent renders interactive breadcrumbs with href or onClick 1`] = `
+<div>
+  <a
+    class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+    href="#"
+    rel="noreferrer"
+    title="Link"
+  >
+    Link
+  </a>
+  <button
+    class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
+    title="Button"
+    type="button"
+  >
+    Button
+  </button>
+</div>
+`;
+
+exports[`EuiBreadcrumbContent renders plain uninteractive breadcrumb text 1`] = `
+<span
+  class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-euiTextColor-subdued"
+  title="Text"
+>
+  Text
+</span>
+`;

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -4,17 +4,17 @@ exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverCo
 <body>
   <div>
     <div
-      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       data-test-subj="popover"
     >
       <button
-        class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
         data-test-subj="popoverToggle"
         title="Toggles a popover - Clicking this button will toggle a popover dialog."
         type="button"
       >
         <span
-          class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+          class="emotion-euiBreadcrumb__popoverTruncation"
         >
           Toggles a popover
         </span>

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -1,30 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverContent\` 1`] = `
+exports[`EuiBreadcrumb is a light <li> wrapper around the content 1`] = `
+<li
+  class="euiBreadcrumb emotion-euiBreadcrumb-page-isTruncated"
+  data-test-subj="euiBreadcrumb"
+>
+  Hello world
+</li>
+`;
+
+exports[`EuiBreadcrumbCollapsed renders a ... breadcrumb with collapsed content in a popover 1`] = `
 <body>
   <div>
-    <div
-      class="euiPopover euiPopover-isOpen emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
-      data-test-subj="popover"
+    <li
+      class="euiBreadcrumb emotion-euiBreadcrumb-application-isCollapsed"
+      data-test-subj="euiBreadcrumb"
     >
-      <button
-        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
-        data-test-subj="popoverToggle"
-        title="Toggles a popover - Clicking this button will toggle a popover dialog."
-        type="button"
+      <div
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
-        <span
-          class="emotion-euiBreadcrumb__popoverTruncation"
+        <button
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-application"
+          title="See collapsed breadcrumbs"
+          type="button"
         >
-          Toggles a popover
-        </span>
-        <span
-          data-euiicon-type="arrowDown"
-        >
-           - Clicking this button will toggle a popover dialog.
-        </span>
-      </button>
-    </div>
+          <span
+            class="emotion-euiBreadcrumb__popoverTruncation"
+          >
+            <span
+              aria-label="See collapsed breadcrumbs"
+            >
+              …
+            </span>
+          </span>
+          <span
+            data-euiicon-type="arrowDown"
+          >
+             - Clicking this button will toggle a popover dialog.
+          </span>
+        </button>
+      </div>
+    </li>
   </div>
   <div
     data-euiportal="true"
@@ -32,21 +48,20 @@ exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverCo
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
+      tabindex="-1"
     />
     <div
-      data-focus-lock-disabled="false"
+      data-focus-lock-disabled="disabled"
     >
       <div
         aria-describedby="generated-id"
         aria-live="off"
         aria-modal="true"
-        class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-isOpen-hasTransform-bottom"
+        class="euiPanel euiPanel--plain euiPanel--paddingMedium euiPopover__panel emotion-euiPanel-grow-m-m-plain-euiPopover__panel-light-hasTransform"
         data-autofocus="true"
-        data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
@@ -61,46 +76,15 @@ exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverCo
           You are in a dialog. Press Escape, or tap/click outside the dialog to close.
         </p>
         <div>
-          Hello popover world
+          I render inside the popover
         </div>
       </div>
     </div>
     <div
       data-focus-guard="true"
       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
-`;
-
-exports[`EuiBreadcrumbContent renders interactive breadcrumbs with href or onClick 1`] = `
-<div>
-  <a
-    class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
-    href="#"
-    rel="noreferrer"
-    title="Link"
-  >
-    Link
-  </a>
-  <button
-    class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-page"
-    title="Button"
-    type="button"
-  >
-    Button
-  </button>
-</div>
-`;
-
-exports[`EuiBreadcrumbContent renders plain uninteractive breadcrumb text 1`] = `
-<div>
-  <span
-    class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page-euiTextColor-subdued"
-    title="Text"
-  >
-    Text
-  </span>
-</div>
 `;

--- a/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -39,15 +39,15 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       >
         <button
-          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+            class="emotion-euiBreadcrumb__popoverTruncation"
           >
             <span
               aria-label="See collapsed breadcrumbs"
@@ -143,15 +143,15 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       >
         <button
-          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+            class="emotion-euiBreadcrumb__popoverTruncation"
           >
             <span
               aria-label="See collapsed breadcrumbs"
@@ -329,15 +329,15 @@ exports[`EuiBreadcrumbs props max renders 1 item 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       >
         <button
-          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+            class="emotion-euiBreadcrumb__popoverTruncation"
           >
             <span
               aria-label="See collapsed breadcrumbs"
@@ -514,15 +514,15 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       >
         <button
-          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+            class="emotion-euiBreadcrumb__popoverTruncation"
           >
             <span
               aria-label="See collapsed breadcrumbs"
@@ -617,15 +617,15 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       >
         <button
-          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+            class="emotion-euiBreadcrumb__popoverTruncation"
           >
             <span
               aria-label="See collapsed breadcrumbs"
@@ -695,15 +695,15 @@ exports[`EuiBreadcrumbs props responsive is rendered with custom breakpoints 1`]
       data-test-subj="euiBreadcrumb"
     >
       <div
-        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
+        class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper-page"
       >
         <button
-          class="euiLink emotion-euiLink-subdued-euiBreadcrumb__popoverButton"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-page"
           title="See collapsed breadcrumbs"
           type="button"
         >
           <span
-            class="euiBreadcrumb__content emotion-euiBreadcrumb__content-page"
+            class="emotion-euiBreadcrumb__popoverTruncation"
           >
             <span
               aria-label="See collapsed breadcrumbs"

--- a/src/components/breadcrumbs/_breadcrumb_content.styles.ts
+++ b/src/components/breadcrumbs/_breadcrumb_content.styles.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+import { transparentize } from '../../services/color';
+import {
+  euiFontSize,
+  euiTextTruncate,
+  euiFocusRing,
+  logicalCSS,
+  logicalBorderRadiusCSS,
+  mathWithUnits,
+} from '../../global_styling';
+
+/**
+ * Styles cast to inner <a>, <button>, <span> elements
+ */
+export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+  return {
+    euiBreadcrumb__content: css`
+      font-weight: ${euiTheme.font.weight.medium};
+      text-align: center;
+      vertical-align: baseline;
+    `,
+
+    // Truncation styles
+    isTruncated: css`
+      ${euiTextTruncate(mathWithUnits(euiTheme.size.base, (x) => x * 10))}
+    `,
+    isTruncatedLast: css`
+      /* This removes the default breadcrumb max-width while ensuring that the last breadcrumb
+         still cuts off with a '...' if it's overflowing outside the parent breadcrumbs container */
+      ${euiTextTruncate('none')}
+    `,
+
+    // Types
+    page: css`
+      &:is(a):focus {
+        ${euiFocusRing(euiThemeContext, 'inset')}
+      }
+
+      &:is(button):focus {
+        ${euiFocusRing(euiThemeContext, 'center')}
+      }
+    `,
+    application: css`
+      ${euiFontSize(euiThemeContext, 'xs')}
+      background-color: ${transparentize(euiTheme.colors.darkestShade, 0.2)};
+      clip-path: polygon(
+        0 0,
+        calc(100% - ${euiTheme.size.s}) 0,
+        100% 50%,
+        calc(100% - ${euiTheme.size.s}) 100%,
+        0 100%,
+        ${euiTheme.size.s} 50%
+      );
+      color: ${euiTheme.colors.darkestShade};
+      line-height: ${euiTheme.size.base};
+      ${logicalCSS('padding-vertical', euiTheme.size.xs)}
+      ${logicalCSS('padding-horizontal', euiTheme.size.base)}
+
+      &:is(a),
+      &:is(button) {
+        background-color: ${transparentize(euiTheme.colors.primary, 0.2)};
+        color: ${euiTheme.colors.link};
+
+        :focus {
+          ${euiFocusRing(euiThemeContext, 'inset')}
+
+          :focus-visible {
+            border-radius: ${euiTheme.border.radius.medium};
+            clip-path: none;
+          }
+        }
+      }
+    `,
+    applicationStyles: {
+      onlyChild: css`
+        border-radius: ${euiTheme.border.radius.medium};
+        clip-path: none;
+        ${logicalCSS('padding-horizontal', euiTheme.size.m)}
+      `,
+      firstChild: css`
+        ${logicalBorderRadiusCSS(
+          `${euiTheme.border.radius.medium} 0 0 ${euiTheme.border.radius.medium}`,
+          true
+        )}
+        clip-path: polygon(
+          0 0,
+          calc(100% - ${euiTheme.size.s}) 0,
+          100% 50%,
+          calc(100% - ${euiTheme.size.s}) 100%,
+          0 100%
+        );
+        ${logicalCSS('padding-left', euiTheme.size.m)}
+      `,
+      lastChild: css`
+        ${logicalBorderRadiusCSS(
+          `0 ${euiTheme.border.radius.medium} ${euiTheme.border.radius.medium} 0`,
+          true
+        )}
+        clip-path: polygon(
+          0 0,
+          100% 0,
+          100% 100%,
+          0 100%,
+          ${euiTheme.size.s} 50%
+        );
+        ${logicalCSS('padding-right', euiTheme.size.m)}
+      `,
+    },
+  };
+};
+
+export const euiBreadcrumbPopoverStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    euiBreadcrumb__popoverButton: css`
+      max-inline-size: 100%;
+      display: inline-flex;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+    `,
+    euiBreadcrumb__popoverTruncation: css``,
+    popoverWrapper: {
+      euiBreadcrumb__popoverWrapper: css``,
+      page: css`
+        /* At small container widths, the popover anchor needs to leave room for the breadcrumb separator,
+         which is weird to get an exact width for because it's transformed at an angle */
+        max-inline-size: calc(
+          100% - ${mathWithUnits(euiTheme.size.base, (x) => x + 1)}
+        );
+      `,
+      application: null,
+    },
+  };
+};

--- a/src/components/breadcrumbs/_breadcrumb_content.test.tsx
+++ b/src/components/breadcrumbs/_breadcrumb_content.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import {
+  render,
+  waitForEuiPopoverOpen,
+  waitForEuiPopoverClose,
+} from '../../test/rtl';
+
+import { EuiBreadcrumbContent } from './_breadcrumb_content';
+
+describe('EuiBreadcrumbContent', () => {
+  it('renders plain uninteractive breadcrumb text', () => {
+    const { container, getByText } = render(
+      <EuiBreadcrumbContent type="page" text="Text" />
+    );
+    expect(getByText('Text').nodeName).toEqual('SPAN');
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders interactive breadcrumbs with href or onClick', () => {
+    const { container, getByText } = render(
+      <>
+        <EuiBreadcrumbContent type="page" text="Link" href="#" />
+        <EuiBreadcrumbContent type="page" text="Button" onClick={() => {}} />
+      </>
+    );
+    expect(getByText('Link').nodeName).toEqual('A');
+    expect(getByText('Button').nodeName).toEqual('BUTTON');
+    expect(container).toMatchSnapshot();
+  });
+
+  describe('breadcrumbs with popovers', () => {
+    it('renders with `popoverContent`', async () => {
+      const { baseElement, getByTestSubject } = render(
+        <EuiBreadcrumbContent
+          type="page"
+          text="Toggles a popover"
+          data-test-subj="popoverToggle"
+          popoverContent="Hello popover world"
+          popoverProps={{ 'data-test-subj': 'popover' }}
+        />
+      );
+      fireEvent.click(getByTestSubject('popoverToggle'));
+      await waitForEuiPopoverOpen();
+
+      expect(getByTestSubject('popover')).toBeInTheDocument();
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('passes a popover close callback to `popoverContent` render functions', async () => {
+      const { getByTestSubject } = render(
+        <EuiBreadcrumbContent
+          type="page"
+          text="Controlled breadcrumb popover"
+          data-test-subj="popoverToggle"
+          popoverContent={(closePopover) => (
+            <button onClick={closePopover} data-test-subj="popoverClose">
+              Close popover
+            </button>
+          )}
+        />
+      );
+
+      fireEvent.click(getByTestSubject('popoverToggle'));
+      await waitForEuiPopoverOpen();
+
+      fireEvent.click(getByTestSubject('popoverClose'));
+      await waitForEuiPopoverClose();
+    });
+  });
+
+  describe('highlightLastBreadcrumb', () => {
+    it('adds an aria-current attr', () => {
+      const { getByText } = render(
+        <EuiBreadcrumbContent type="page" text="Home" highlightLastBreadcrumb />
+      );
+      expect(getByText('Home')).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('colors both interactive and non-interactive breadcrumbs text-colored', () => {
+      const { getByTestSubject } = render(
+        <>
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="control" // Not the last breadcrumb / not highlighted
+          />
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="text"
+            highlightLastBreadcrumb
+          />
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="link"
+            href="#"
+            highlightLastBreadcrumb
+          />
+          <EuiBreadcrumbContent
+            type="page"
+            text="Home"
+            data-test-subj="popover"
+            popoverContent="popover"
+            highlightLastBreadcrumb
+          />
+        </>
+      );
+      expect(getByTestSubject('control')).toHaveStyleRule('color', '#646a77');
+      expect(getByTestSubject('text')).toHaveStyleRule('color', '#343741');
+      expect(getByTestSubject('link')).toHaveStyleRule('color', '#343741');
+      expect(getByTestSubject('popover')).toHaveStyleRule('color', '#343741');
+    });
+  });
+});

--- a/src/components/breadcrumbs/_breadcrumb_content.tsx
+++ b/src/components/breadcrumbs/_breadcrumb_content.tsx
@@ -1,0 +1,222 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  useState,
+  useCallback,
+  forwardRef,
+} from 'react';
+import { ArrayCSSInterpolation } from '@emotion/css';
+import classNames from 'classnames';
+
+import { useEuiMemoizedStyles } from '../../services';
+import { EuiInnerText } from '../inner_text';
+import { EuiTextColor } from '../text';
+import { EuiLink } from '../link';
+import { EuiPopover } from '../popover';
+import { EuiIcon } from '../icon';
+import { useEuiI18n } from '../i18n';
+
+import type { EuiBreadcrumbProps, _EuiBreadcrumbProps } from './types';
+import {
+  euiBreadcrumbContentStyles,
+  euiBreadcrumbPopoverStyles,
+} from './_breadcrumb_content.styles';
+
+export const EuiBreadcrumbContent: FunctionComponent<
+  EuiBreadcrumbProps & _EuiBreadcrumbProps
+> = ({
+  text,
+  truncate,
+  type,
+  href,
+  rel, // required by our local href-with-rel eslint rule
+  onClick,
+  popoverContent,
+  popoverProps,
+  className,
+  color,
+  isFirstBreadcrumb,
+  isLastBreadcrumb,
+  isOnlyBreadcrumb,
+  highlightLastBreadcrumb,
+  truncateLastBreadcrumb,
+  ...rest
+}) => {
+  const classes = classNames('euiBreadcrumb__content', className);
+
+  const styles = useEuiMemoizedStyles(euiBreadcrumbContentStyles);
+  const cssStyles = [styles.euiBreadcrumb__content, styles[type]];
+  if (type === 'application') {
+    if (isOnlyBreadcrumb) {
+      cssStyles.push(styles.applicationStyles.onlyChild);
+    } else if (isFirstBreadcrumb) {
+      cssStyles.push(styles.applicationStyles.firstChild);
+    } else if (isLastBreadcrumb) {
+      cssStyles.push(styles.applicationStyles.lastChild);
+    }
+  }
+  const truncationStyles = [
+    truncate && !truncateLastBreadcrumb && styles.isTruncated,
+    truncateLastBreadcrumb && styles.isTruncatedLast,
+  ];
+
+  const isBreadcrumbWithPopover = !!popoverContent;
+  const isInteractiveBreadcrumb = href || onClick;
+  const linkColor = color || (highlightLastBreadcrumb ? 'text' : 'subdued');
+  const plainTextColor = highlightLastBreadcrumb ? 'default' : 'subdued'; // Does not inherit `color` prop
+  const ariaCurrent = highlightLastBreadcrumb ? ('page' as const) : undefined;
+
+  return (
+    <EuiInnerText>
+      {(ref, innerText) => {
+        const title = innerText === '' ? undefined : innerText;
+        const baseProps = {
+          ref,
+          title,
+          'aria-current': ariaCurrent,
+          className: classes,
+          css: [...cssStyles, ...truncationStyles],
+        };
+
+        if (isBreadcrumbWithPopover) {
+          const { css: _, ...popoverButtonProps } = baseProps;
+          return (
+            <EuiBreadcrumbPopover
+              {...popoverButtonProps}
+              breadcrumbCss={cssStyles}
+              truncationCss={truncationStyles}
+              isLastBreadcrumb={isLastBreadcrumb}
+              type={type}
+              color={linkColor}
+              popoverContent={popoverContent}
+              popoverProps={popoverProps}
+              {...rest}
+            >
+              {text}
+            </EuiBreadcrumbPopover>
+          );
+        } else if (isInteractiveBreadcrumb) {
+          return (
+            <EuiLink
+              {...baseProps}
+              color={linkColor}
+              onClick={onClick}
+              href={href}
+              rel={rel}
+              {...rest}
+            >
+              {text}
+            </EuiLink>
+          );
+        } else {
+          return (
+            <EuiTextColor color={plainTextColor} cloneElement>
+              <span {...baseProps} {...rest}>
+                {text}
+              </span>
+            </EuiTextColor>
+          );
+        }
+      }}
+    </EuiInnerText>
+  );
+};
+
+type EuiBreadcrumbPopoverProps = HTMLAttributes<HTMLElement> &
+  Pick<EuiBreadcrumbProps, 'popoverProps' | 'popoverContent' | 'color'> &
+  Pick<_EuiBreadcrumbProps, 'type' | 'isLastBreadcrumb'> & {
+    breadcrumbCss: ArrayCSSInterpolation;
+    truncationCss: ArrayCSSInterpolation;
+  };
+const EuiBreadcrumbPopover = forwardRef<
+  HTMLButtonElement,
+  EuiBreadcrumbPopoverProps
+>(
+  (
+    {
+      popoverContent,
+      popoverProps,
+      color,
+      type,
+      title,
+      'aria-current': ariaCurrent,
+      className,
+      isLastBreadcrumb,
+      breadcrumbCss,
+      truncationCss,
+      children,
+      ...rest
+    },
+    ref
+  ) => {
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+    const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+    const togglePopover = useCallback(
+      () => setIsPopoverOpen((isOpen) => !isOpen),
+      []
+    );
+
+    const popoverAriaLabel = useEuiI18n(
+      // This component was moved into another file for organization/dev readability,
+      // but we're keeping the i18n token the same as before for consumer consistency
+      // eslint-disable-next-line local/i18n
+      'euiBreadcrumb.popoverAriaLabel',
+      'Clicking this button will toggle a popover dialog.'
+    );
+
+    const styles = useEuiMemoizedStyles(euiBreadcrumbPopoverStyles);
+    const wrapperStyles = [
+      styles.popoverWrapper.euiBreadcrumb__popoverWrapper,
+      !isLastBreadcrumb && styles.popoverWrapper[type],
+    ];
+    const buttonStyles = [
+      styles.euiBreadcrumb__popoverButton,
+      ...breadcrumbCss,
+    ];
+    const truncationStyles = [
+      styles.euiBreadcrumb__popoverTruncation,
+      ...truncationCss,
+    ];
+
+    return (
+      <EuiPopover
+        {...popoverProps}
+        isOpen={isPopoverOpen}
+        closePopover={closePopover}
+        css={wrapperStyles}
+        button={
+          <EuiLink
+            ref={ref}
+            title={title}
+            aria-current={ariaCurrent}
+            className={className}
+            css={buttonStyles}
+            color={color}
+            onClick={togglePopover}
+            {...rest}
+          >
+            <span css={truncationStyles}>{children}</span>
+            <EuiIcon
+              type="arrowDown"
+              size="s"
+              aria-label={` - ${popoverAriaLabel}`}
+            />
+          </EuiLink>
+        }
+      >
+        {typeof popoverContent === 'function'
+          ? popoverContent(closePopover)
+          : popoverContent}
+      </EuiPopover>
+    );
+  }
+);
+EuiBreadcrumbPopover.displayName = 'EuiBreadcrumbPopover';

--- a/src/components/breadcrumbs/breadcrumb.styles.ts
+++ b/src/components/breadcrumbs/breadcrumb.styles.ts
@@ -71,6 +71,8 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
       text-align: center;
       vertical-align: baseline;
     `,
+
+    // Truncation styles
     isTruncated: css`
       ${euiTextTruncate(mathWithUnits(euiTheme.size.base, (x) => x * 10))}
     `,
@@ -78,21 +80,6 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
       /* This removes the default breadcrumb max-width while ensuring that the last breadcrumb
          still cuts off with a '...' if it's overflowing outside the parent breadcrumbs container */
       ${euiTextTruncate('none')}
-    `,
-
-    // Popover styles
-    euiBreadcrumb__popoverButton: css`
-      max-inline-size: 100%;
-      display: inline-flex;
-      align-items: center;
-      gap: ${euiTheme.size.xs};
-    `,
-    euiBreadcrumb__popoverWrapper: css`
-      /* At small container widths, the popover anchor needs to leave room for the breadcrumb separator,
-         which is weird to get an exact width for because it's transformed at an angle */
-      max-inline-size: calc(
-        100% - ${mathWithUnits(euiTheme.size.base, (x) => x + 1)}
-      );
     `,
 
     // Types
@@ -170,6 +157,29 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
         );
         ${logicalCSS('padding-right', euiTheme.size.m)}
       `,
+    },
+  };
+};
+
+export const euiBreadcrumbPopoverStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    euiBreadcrumb__popoverButton: css`
+      max-inline-size: 100%;
+      display: inline-flex;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+    `,
+    euiBreadcrumb__popoverTruncation: css``,
+    popoverWrapper: {
+      euiBreadcrumb__popoverWrapper: css``,
+      page: css`
+        /* At small container widths, the popover anchor needs to leave room for the breadcrumb separator,
+         which is weird to get an exact width for because it's transformed at an angle */
+        max-inline-size: calc(
+          100% - ${mathWithUnits(euiTheme.size.base, (x) => x + 1)}
+        );
+      `,
+      application: null,
     },
   };
 };

--- a/src/components/breadcrumbs/breadcrumb.styles.ts
+++ b/src/components/breadcrumbs/breadcrumb.styles.ts
@@ -8,18 +8,12 @@
 
 import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
-import { transparentize } from '../../services/color';
-import {
-  euiFontSize,
-  euiTextTruncate,
-  euiFocusRing,
-  logicalCSS,
-  logicalBorderRadiusCSS,
-  mathWithUnits,
-} from '../../global_styling';
+import { logicalCSS } from '../../global_styling';
 
+/**
+ * Styles cast to <li> element
+ */
 export const euiBreadcrumbStyles = (euiThemeContext: UseEuiTheme) => {
-  // Styles cast to <li> element
   const { euiTheme } = euiThemeContext;
   return {
     euiBreadcrumb: css`
@@ -59,127 +53,5 @@ export const euiBreadcrumbStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('margin-right', `-${euiTheme.size.xs}`)}
       }
     `,
-  };
-};
-
-export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
-  // Styles cast to <a>, <span>, or collapsed <button> elements
-  const { euiTheme } = euiThemeContext;
-  return {
-    euiBreadcrumb__content: css`
-      font-weight: ${euiTheme.font.weight.medium};
-      text-align: center;
-      vertical-align: baseline;
-    `,
-
-    // Truncation styles
-    isTruncated: css`
-      ${euiTextTruncate(mathWithUnits(euiTheme.size.base, (x) => x * 10))}
-    `,
-    isTruncatedLast: css`
-      /* This removes the default breadcrumb max-width while ensuring that the last breadcrumb
-         still cuts off with a '...' if it's overflowing outside the parent breadcrumbs container */
-      ${euiTextTruncate('none')}
-    `,
-
-    // Types
-    page: css`
-      &:is(a):focus {
-        ${euiFocusRing(euiThemeContext, 'inset')}
-      }
-
-      &:is(button):focus {
-        ${euiFocusRing(euiThemeContext, 'center')}
-      }
-    `,
-    application: css`
-      ${euiFontSize(euiThemeContext, 'xs')}
-      background-color: ${transparentize(euiTheme.colors.darkestShade, 0.2)};
-      clip-path: polygon(
-        0 0,
-        calc(100% - ${euiTheme.size.s}) 0,
-        100% 50%,
-        calc(100% - ${euiTheme.size.s}) 100%,
-        0 100%,
-        ${euiTheme.size.s} 50%
-      );
-      color: ${euiTheme.colors.darkestShade};
-      line-height: ${euiTheme.size.base};
-      ${logicalCSS('padding-vertical', euiTheme.size.xs)}
-      ${logicalCSS('padding-horizontal', euiTheme.size.base)}
-
-      &:is(a),
-      &:is(button) {
-        background-color: ${transparentize(euiTheme.colors.primary, 0.2)};
-        color: ${euiTheme.colors.link};
-
-        :focus {
-          ${euiFocusRing(euiThemeContext, 'inset')}
-
-          :focus-visible {
-            border-radius: ${euiTheme.border.radius.medium};
-            clip-path: none;
-          }
-        }
-      }
-    `,
-    applicationStyles: {
-      onlyChild: css`
-        border-radius: ${euiTheme.border.radius.medium};
-        clip-path: none;
-        ${logicalCSS('padding-horizontal', euiTheme.size.m)}
-      `,
-      firstChild: css`
-        ${logicalBorderRadiusCSS(
-          `${euiTheme.border.radius.medium} 0 0 ${euiTheme.border.radius.medium}`,
-          true
-        )}
-        clip-path: polygon(
-          0 0,
-          calc(100% - ${euiTheme.size.s}) 0,
-          100% 50%,
-          calc(100% - ${euiTheme.size.s}) 100%,
-          0 100%
-        );
-        ${logicalCSS('padding-left', euiTheme.size.m)}
-      `,
-      lastChild: css`
-        ${logicalBorderRadiusCSS(
-          `0 ${euiTheme.border.radius.medium} ${euiTheme.border.radius.medium} 0`,
-          true
-        )}
-        clip-path: polygon(
-          0 0,
-          100% 0,
-          100% 100%,
-          0 100%,
-          ${euiTheme.size.s} 50%
-        );
-        ${logicalCSS('padding-right', euiTheme.size.m)}
-      `,
-    },
-  };
-};
-
-export const euiBreadcrumbPopoverStyles = ({ euiTheme }: UseEuiTheme) => {
-  return {
-    euiBreadcrumb__popoverButton: css`
-      max-inline-size: 100%;
-      display: inline-flex;
-      align-items: center;
-      gap: ${euiTheme.size.xs};
-    `,
-    euiBreadcrumb__popoverTruncation: css``,
-    popoverWrapper: {
-      euiBreadcrumb__popoverWrapper: css``,
-      page: css`
-        /* At small container widths, the popover anchor needs to leave room for the breadcrumb separator,
-         which is weird to get an exact width for because it's transformed at an angle */
-        max-inline-size: calc(
-          100% - ${mathWithUnits(euiTheme.size.base, (x) => x + 1)}
-        );
-      `,
-      application: null,
-    },
   };
 };

--- a/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -8,119 +8,31 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import {
-  render,
-  waitForEuiPopoverOpen,
-  waitForEuiPopoverClose,
-} from '../../test/rtl';
+import { render, waitForEuiPopoverOpen } from '../../test/rtl';
 
-import { EuiBreadcrumbContent } from './breadcrumb';
+import { EuiBreadcrumb, EuiBreadcrumbCollapsed } from './breadcrumb';
 
-describe('EuiBreadcrumbContent', () => {
-  it('renders plain uninteractive breadcrumb text', () => {
-    const { container, getByText } = render(
-      <>
-        <EuiBreadcrumbContent type="page" text="Text" />
-      </>
+describe('EuiBreadcrumb', () => {
+  it('is a light <li> wrapper around the content', () => {
+    const { container } = render(
+      <EuiBreadcrumb type="page" truncate={true}>
+        Hello world
+      </EuiBreadcrumb>
     );
-    expect(getByText('Text').nodeName).toEqual('SPAN');
-    expect(container).toMatchSnapshot();
+    expect(container.firstChild).toMatchSnapshot();
   });
+});
 
-  it('renders interactive breadcrumbs with href or onClick', () => {
-    const { container, getByText } = render(
-      <>
-        <EuiBreadcrumbContent type="page" text="Link" href="#" />
-        <EuiBreadcrumbContent type="page" text="Button" onClick={() => {}} />
-      </>
+describe('EuiBreadcrumbCollapsed', () => {
+  it('renders a ... breadcrumb with collapsed content in a popover', () => {
+    const { getByRole, getByText, baseElement } = render(
+      <EuiBreadcrumbCollapsed type="application">
+        I render inside the popover
+      </EuiBreadcrumbCollapsed>
     );
-    expect(getByText('Link').nodeName).toEqual('A');
-    expect(getByText('Button').nodeName).toEqual('BUTTON');
-    expect(container).toMatchSnapshot();
-  });
-
-  describe('breadcrumbs with popovers', () => {
-    it('renders with `popoverContent`', async () => {
-      const { baseElement, getByTestSubject } = render(
-        <EuiBreadcrumbContent
-          type="page"
-          text="Toggles a popover"
-          data-test-subj="popoverToggle"
-          popoverContent="Hello popover world"
-          popoverProps={{ 'data-test-subj': 'popover' }}
-        />
-      );
-      fireEvent.click(getByTestSubject('popoverToggle'));
-      await waitForEuiPopoverOpen();
-
-      expect(getByTestSubject('popover')).toBeInTheDocument();
-      expect(baseElement).toMatchSnapshot();
-    });
-
-    it('passes a popover close callback to `popoverContent` render functions', async () => {
-      const { getByTestSubject } = render(
-        <EuiBreadcrumbContent
-          type="page"
-          text="Controlled breadcrumb popover"
-          data-test-subj="popoverToggle"
-          popoverContent={(closePopover) => (
-            <button onClick={closePopover} data-test-subj="popoverClose">
-              Close popover
-            </button>
-          )}
-        />
-      );
-
-      fireEvent.click(getByTestSubject('popoverToggle'));
-      await waitForEuiPopoverOpen();
-
-      fireEvent.click(getByTestSubject('popoverClose'));
-      await waitForEuiPopoverClose();
-    });
-  });
-
-  describe('highlightLastBreadcrumb', () => {
-    it('adds an aria-current attr', () => {
-      const { getByText } = render(
-        <EuiBreadcrumbContent type="page" text="Home" highlightLastBreadcrumb />
-      );
-      expect(getByText('Home')).toHaveAttribute('aria-current', 'page');
-    });
-
-    it('colors both interactive and non-interactive breadcrumbs text-colored', () => {
-      const { getByTestSubject } = render(
-        <>
-          <EuiBreadcrumbContent
-            type="page"
-            text="Home"
-            data-test-subj="control" // Not the last breadcrumb / not highlighted
-          />
-          <EuiBreadcrumbContent
-            type="page"
-            text="Home"
-            data-test-subj="text"
-            highlightLastBreadcrumb
-          />
-          <EuiBreadcrumbContent
-            type="page"
-            text="Home"
-            data-test-subj="link"
-            href="#"
-            highlightLastBreadcrumb
-          />
-          <EuiBreadcrumbContent
-            type="page"
-            text="Home"
-            data-test-subj="popover"
-            popoverContent="popover"
-            highlightLastBreadcrumb
-          />
-        </>
-      );
-      expect(getByTestSubject('control')).toHaveStyleRule('color', '#646a77');
-      expect(getByTestSubject('text')).toHaveStyleRule('color', '#343741');
-      expect(getByTestSubject('link')).toHaveStyleRule('color', '#343741');
-      expect(getByTestSubject('popover')).toHaveStyleRule('color', '#343741');
-    });
+    fireEvent.click(getByRole('button'));
+    waitForEuiPopoverOpen();
+    expect(getByText('I render inside the popover')).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot();
   });
 });

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -17,7 +17,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
 import { EuiInnerText } from '../inner_text';
 import { EuiTextColor } from '../text';
@@ -87,8 +87,7 @@ export const EuiBreadcrumb: FunctionComponent<
 > = ({ children, className, type, truncate, ...rest }) => {
   const classes = classNames('euiBreadcrumb', className);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiBreadcrumbStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiBreadcrumbStyles);
   const cssStyles = [
     styles.euiBreadcrumb,
     styles[type],
@@ -129,8 +128,7 @@ export const EuiBreadcrumbContent: FunctionComponent<
 }) => {
   const classes = classNames('euiBreadcrumb__content', className);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiBreadcrumbContentStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiBreadcrumbContentStyles);
   const cssStyles = [
     styles.euiBreadcrumb__content,
     styles[type],
@@ -231,8 +229,7 @@ export const EuiBreadcrumbCollapsed: FunctionComponent<_EuiBreadcrumbProps> = ({
   isFirstBreadcrumb,
   type,
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiBreadcrumbStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiBreadcrumbStyles);
   const cssStyles = [styles.isCollapsed];
 
   const ariaLabel = useEuiI18n(

--- a/src/components/breadcrumbs/breadcrumb.tsx
+++ b/src/components/breadcrumbs/breadcrumb.tsx
@@ -7,87 +7,24 @@
  */
 
 import React, {
-  PropsWithChildren,
   FunctionComponent,
   HTMLAttributes,
-  AriaAttributes,
-  MouseEventHandler,
-  ReactNode,
-  useState,
-  useCallback,
-  forwardRef,
+  PropsWithChildren,
 } from 'react';
-import { ArrayCSSInterpolation } from '@emotion/css';
 import classNames from 'classnames';
 
 import { useEuiMemoizedStyles } from '../../services';
-import { CommonProps } from '../common';
-import { EuiInnerText } from '../inner_text';
-import { EuiTextColor } from '../text';
-import { EuiLink, EuiLinkColor } from '../link';
-import { EuiPopover, EuiPopoverProps } from '../popover';
-import { EuiIcon } from '../icon';
 import { useEuiI18n } from '../i18n';
 
-import {
-  euiBreadcrumbStyles,
-  euiBreadcrumbContentStyles,
-  euiBreadcrumbPopoverStyles,
-} from './breadcrumb.styles';
+import type { EuiBreadcrumbProps, _EuiBreadcrumbProps } from './types';
+import { EuiBreadcrumbContent } from './_breadcrumb_content';
 
-export type EuiBreadcrumbProps = Omit<
-  HTMLAttributes<HTMLElement>,
-  'color' | 'aria-current'
-> &
-  CommonProps & {
-    href?: string;
-    rel?: string;
-    onClick?: MouseEventHandler<HTMLAnchorElement>;
-    /**
-     * Visible label of the breadcrumb
-     */
-    text: ReactNode;
-    /**
-     * Force a max-width on the breadcrumb text
-     */
-    truncate?: boolean;
-    /**
-     * Accepts any EuiLink `color` when rendered as one (has `href`, `onClick`, or `popoverContent`)
-     */
-    color?: EuiLinkColor;
-    /**
-     * Override the existing `aria-current` which defaults to `page` for the last breadcrumb
-     */
-    'aria-current'?: AriaAttributes['aria-current'];
-    /**
-     * Creates a breadcrumb that toggles a popover dialog. Takes any rendered node(s),
-     * or a render function that will pass callback allowing you to close the
-     * breadcrumb popover from within your popover content.
-     *
-     * If passed, both `href` and `onClick` will be ignored - the breadcrumb's
-     * click behavior should only trigger a popover.
-     */
-    popoverContent?: ReactNode | ((closePopover: () => void) => ReactNode);
-    /**
-     * Allows customizing the popover if necessary. Accepts any props that
-     * [EuiPopover](/#/layout/popover) accepts, except for props that control state.
-     */
-    popoverProps?: Omit<EuiPopoverProps, 'button' | 'closePopover' | 'isOpen'>;
-  };
-
-// Used internally only by the parent EuiBreadcrumbs
-type _EuiBreadcrumbProps = PropsWithChildren &
-  Pick<EuiBreadcrumbProps, 'truncate'> & {
-    type: 'page' | 'application';
-    isFirstBreadcrumb?: boolean;
-    isLastBreadcrumb?: boolean;
-    isOnlyBreadcrumb?: boolean;
-    highlightLastBreadcrumb?: boolean;
-    truncateLastBreadcrumb?: boolean;
-  };
+import { euiBreadcrumbStyles } from './breadcrumb.styles';
 
 export const EuiBreadcrumb: FunctionComponent<
-  HTMLAttributes<HTMLLIElement> & _EuiBreadcrumbProps
+  HTMLAttributes<HTMLLIElement> &
+    Pick<_EuiBreadcrumbProps, 'type'> &
+    Pick<EuiBreadcrumbProps, 'truncate'>
 > = ({ children, className, type, truncate, ...rest }) => {
   const classes = classNames('euiBreadcrumb', className);
 
@@ -110,199 +47,9 @@ export const EuiBreadcrumb: FunctionComponent<
   );
 };
 
-export const EuiBreadcrumbContent: FunctionComponent<
-  EuiBreadcrumbProps & _EuiBreadcrumbProps
-> = ({
-  text,
-  truncate,
-  type,
-  href,
-  rel, // required by our local href-with-rel eslint rule
-  onClick,
-  popoverContent,
-  popoverProps,
-  className,
-  color,
-  isFirstBreadcrumb,
-  isLastBreadcrumb,
-  isOnlyBreadcrumb,
-  highlightLastBreadcrumb,
-  truncateLastBreadcrumb,
-  ...rest
-}) => {
-  const classes = classNames('euiBreadcrumb__content', className);
-
-  const styles = useEuiMemoizedStyles(euiBreadcrumbContentStyles);
-  const cssStyles = [styles.euiBreadcrumb__content, styles[type]];
-  if (type === 'application') {
-    if (isOnlyBreadcrumb) {
-      cssStyles.push(styles.applicationStyles.onlyChild);
-    } else if (isFirstBreadcrumb) {
-      cssStyles.push(styles.applicationStyles.firstChild);
-    } else if (isLastBreadcrumb) {
-      cssStyles.push(styles.applicationStyles.lastChild);
-    }
-  }
-  const truncationStyles = [
-    truncate && !truncateLastBreadcrumb && styles.isTruncated,
-    truncateLastBreadcrumb && styles.isTruncatedLast,
-  ];
-
-  const isBreadcrumbWithPopover = !!popoverContent;
-  const isInteractiveBreadcrumb = href || onClick;
-  const linkColor = color || (highlightLastBreadcrumb ? 'text' : 'subdued');
-  const plainTextColor = highlightLastBreadcrumb ? 'default' : 'subdued'; // Does not inherit `color` prop
-  const ariaCurrent = highlightLastBreadcrumb ? ('page' as const) : undefined;
-
-  return (
-    <EuiInnerText>
-      {(ref, innerText) => {
-        const title = innerText === '' ? undefined : innerText;
-        const baseProps = {
-          ref,
-          title,
-          'aria-current': ariaCurrent,
-          className: classes,
-          css: [...cssStyles, ...truncationStyles],
-        };
-
-        if (isBreadcrumbWithPopover) {
-          const { css: _, ...popoverButtonProps } = baseProps;
-          return (
-            <EuiBreadcrumbPopover
-              {...popoverButtonProps}
-              breadcrumbCss={cssStyles}
-              truncationCss={truncationStyles}
-              isLastBreadcrumb={isLastBreadcrumb}
-              type={type}
-              color={linkColor}
-              popoverContent={popoverContent}
-              popoverProps={popoverProps}
-              {...rest}
-            >
-              {text}
-            </EuiBreadcrumbPopover>
-          );
-        } else if (isInteractiveBreadcrumb) {
-          return (
-            <EuiLink
-              {...baseProps}
-              color={linkColor}
-              onClick={onClick}
-              href={href}
-              rel={rel}
-              {...rest}
-            >
-              {text}
-            </EuiLink>
-          );
-        } else {
-          return (
-            <EuiTextColor color={plainTextColor} cloneElement>
-              <span {...baseProps} {...rest}>
-                {text}
-              </span>
-            </EuiTextColor>
-          );
-        }
-      }}
-    </EuiInnerText>
-  );
-};
-
-type EuiBreadcrumbPopoverProps = HTMLAttributes<HTMLElement> &
-  Pick<EuiBreadcrumbProps, 'popoverProps' | 'popoverContent' | 'color'> &
-  Pick<_EuiBreadcrumbProps, 'type' | 'isLastBreadcrumb'> & {
-    breadcrumbCss: ArrayCSSInterpolation;
-    truncationCss: ArrayCSSInterpolation;
-  };
-const EuiBreadcrumbPopover = forwardRef<
-  HTMLButtonElement,
-  EuiBreadcrumbPopoverProps
->(
-  (
-    {
-      popoverContent,
-      popoverProps,
-      color,
-      type,
-      title,
-      'aria-current': ariaCurrent,
-      className,
-      isLastBreadcrumb,
-      breadcrumbCss,
-      truncationCss,
-      children,
-      ...rest
-    },
-    ref
-  ) => {
-    const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-    const closePopover = useCallback(() => setIsPopoverOpen(false), []);
-    const togglePopover = useCallback(
-      () => setIsPopoverOpen((isOpen) => !isOpen),
-      []
-    );
-
-    const popoverAriaLabel = useEuiI18n(
-      'euiBreadcrumb.popoverAriaLabel',
-      'Clicking this button will toggle a popover dialog.'
-    );
-
-    const styles = useEuiMemoizedStyles(euiBreadcrumbPopoverStyles);
-    const wrapperStyles = [
-      styles.popoverWrapper.euiBreadcrumb__popoverWrapper,
-      !isLastBreadcrumb && styles.popoverWrapper[type],
-    ];
-    const buttonStyles = [
-      styles.euiBreadcrumb__popoverButton,
-      ...breadcrumbCss,
-    ];
-    const truncationStyles = [
-      styles.euiBreadcrumb__popoverTruncation,
-      ...truncationCss,
-    ];
-
-    return (
-      <EuiPopover
-        {...popoverProps}
-        isOpen={isPopoverOpen}
-        closePopover={closePopover}
-        css={wrapperStyles}
-        button={
-          <EuiLink
-            ref={ref}
-            title={title}
-            aria-current={ariaCurrent}
-            className={className}
-            css={buttonStyles}
-            color={color}
-            onClick={togglePopover}
-            {...rest}
-          >
-            <span css={truncationStyles}>{children}</span>
-            <EuiIcon
-              type="arrowDown"
-              size="s"
-              aria-label={` - ${popoverAriaLabel}`}
-            />
-          </EuiLink>
-        }
-      >
-        {typeof popoverContent === 'function'
-          ? popoverContent(closePopover)
-          : popoverContent}
-      </EuiPopover>
-    );
-  }
-);
-EuiBreadcrumbPopover.displayName = 'EuiBreadcrumbPopover';
-
-export const EuiBreadcrumbCollapsed: FunctionComponent<_EuiBreadcrumbProps> = ({
-  children,
-  isFirstBreadcrumb,
-  type,
-}) => {
+export const EuiBreadcrumbCollapsed: FunctionComponent<
+  PropsWithChildren & Pick<_EuiBreadcrumbProps, 'type' | 'isFirstBreadcrumb'>
+> = ({ children, isFirstBreadcrumb, type }) => {
   const styles = useEuiMemoizedStyles(euiBreadcrumbStyles);
   const cssStyles = [styles.isCollapsed];
 

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -8,7 +8,8 @@
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { EuiBreadcrumbs, EuiBreadcrumbsProps } from './breadcrumbs';
+import type { EuiBreadcrumbsProps } from './types';
+import { EuiBreadcrumbs } from './breadcrumbs';
 
 const meta: Meta<EuiBreadcrumbsProps> = {
   title: 'Navigation/EuiBreadcrumbs',

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { useEuiI18n } from '../i18n';
 import {
-  useEuiTheme,
+  useEuiMemoizedStyles,
   EuiBreakpointSize,
   useCurrentEuiBreakpoint,
 } from '../../services';
@@ -95,8 +95,7 @@ export const EuiBreadcrumbs: FunctionComponent<EuiBreadcrumbsProps> = ({
 }) => {
   const ariaLabel = useEuiI18n('euiBreadcrumbs.nav.ariaLabel', 'Breadcrumbs');
 
-  const euiTheme = useEuiTheme();
-  const breadcrumbsListStyles = euiBreadcrumbsListStyles(euiTheme);
+  const breadcrumbsListStyles = useEuiMemoizedStyles(euiBreadcrumbsListStyles);
   const cssBreadcrumbsListStyles = [
     breadcrumbsListStyles.euiBreadcrumbs__list,
     truncate && breadcrumbsListStyles.isTruncated,

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -9,73 +9,19 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import classNames from 'classnames';
 
-import { CommonProps, ExclusiveUnion } from '../common';
+import { ExclusiveUnion } from '../common';
 import { useEuiI18n } from '../i18n';
-import {
-  useEuiMemoizedStyles,
-  EuiBreakpointSize,
-  useCurrentEuiBreakpoint,
-} from '../../services';
+import { useEuiMemoizedStyles, useCurrentEuiBreakpoint } from '../../services';
 
-import {
-  EuiBreadcrumb,
-  EuiBreadcrumbContent,
-  EuiBreadcrumbCollapsed,
+import type {
+  EuiBreadcrumbResponsiveMaxCount,
+  EuiBreadcrumbsProps,
   EuiBreadcrumbProps,
-} from './breadcrumb';
+} from './types';
+import { EuiBreadcrumb, EuiBreadcrumbCollapsed } from './breadcrumb';
+import { EuiBreadcrumbContent } from './_breadcrumb_content';
 
 import { euiBreadcrumbsListStyles } from './breadcrumbs.styles';
-
-export type EuiBreadcrumbResponsiveMaxCount = {
-  /**
-   * Any of the following keys are allowed: `'xs' | 's' | 'm' | 'l' | 'xl'`
-   * Omitting a key will display all breadcrumbs at that breakpoint
-   */
-  [key in EuiBreakpointSize]?: number;
-};
-
-export type EuiBreadcrumbsProps = CommonProps & {
-  /**
-   * Hides extra (above the max) breadcrumbs under a collapsed item as the window gets smaller.
-   * Pass a custom #EuiBreadcrumbResponsiveMaxCount object to change the number of breadcrumbs to show at the particular breakpoints.
-   *
-   * Pass `false` to turn this behavior off.
-   *
-   * Default: `{ xs: 1, s: 2, m: 4 }`
-   */
-  responsive?: boolean | EuiBreadcrumbResponsiveMaxCount;
-
-  /**
-   * Forces all breadcrumbs to single line and
-   * truncates each breadcrumb to a particular width,
-   * except for the last item
-   */
-  truncate?: boolean;
-
-  /**
-   * Collapses the inner items past the maximum set here
-   * into a single ellipses item.
-   * Omitting or passing a `0` value will show all breadcrumbs.
-   */
-  max?: number | null;
-
-  /**
-   * The array of individual #EuiBreadcrumb items
-   */
-  breadcrumbs: EuiBreadcrumbProps[];
-
-  /**
-   * Determines breadcrumbs appearance, with `page` being the default styling.
-   * Application breadcrumbs should only be once per page, in (e.g.) EuiHeader
-   */
-  type?: 'page' | 'application';
-
-  /**
-   * Whether the last breadcrumb should visually (and accessibly, to screen readers)
-   * be highlighted as the current page. Defaults to true.
-   */
-  lastBreadcrumbIsCurrentPage?: boolean;
-};
 
 const responsiveDefault: EuiBreadcrumbResponsiveMaxCount = {
   xs: 1,

--- a/src/components/breadcrumbs/index.ts
+++ b/src/components/breadcrumbs/index.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-export type { EuiBreadcrumbProps as EuiBreadcrumb } from './breadcrumb';
 export type {
+  EuiBreadcrumbProps as EuiBreadcrumb,
   EuiBreadcrumbsProps,
   EuiBreadcrumbResponsiveMaxCount,
-} from './breadcrumbs';
+} from './types';
 export { EuiBreadcrumbs } from './breadcrumbs';

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type {
+  ReactNode,
+  HTMLAttributes,
+  AriaAttributes,
+  MouseEventHandler,
+} from 'react';
+import type { EuiBreakpointSize } from '../../services';
+import type { CommonProps } from '../common';
+import type { EuiLinkColor } from '../link';
+import type { EuiPopoverProps } from '../popover';
+
+/**
+ * Consumer facing type exports
+ */
+
+export type EuiBreadcrumbResponsiveMaxCount = {
+  /**
+   * Any of the following keys are allowed: `'xs' | 's' | 'm' | 'l' | 'xl'`
+   * Omitting a key will display all breadcrumbs at that breakpoint
+   */
+  [key in EuiBreakpointSize]?: number;
+};
+
+export type EuiBreadcrumbsProps = CommonProps & {
+  /**
+   * Hides extra (above the max) breadcrumbs under a collapsed item as the window gets smaller.
+   * Pass a custom #EuiBreadcrumbResponsiveMaxCount object to change the number of breadcrumbs to show at the particular breakpoints.
+   *
+   * Pass `false` to turn this behavior off.
+   *
+   * Default: `{ xs: 1, s: 2, m: 4 }`
+   */
+  responsive?: boolean | EuiBreadcrumbResponsiveMaxCount;
+
+  /**
+   * Forces all breadcrumbs to single line and
+   * truncates each breadcrumb to a particular width,
+   * except for the last item
+   */
+  truncate?: boolean;
+
+  /**
+   * Collapses the inner items past the maximum set here
+   * into a single ellipses item.
+   * Omitting or passing a `0` value will show all breadcrumbs.
+   */
+  max?: number | null;
+
+  /**
+   * The array of individual #EuiBreadcrumb items
+   */
+  breadcrumbs: EuiBreadcrumbProps[];
+
+  /**
+   * Determines breadcrumbs appearance, with `page` being the default styling.
+   * Application breadcrumbs should only be once per page, in (e.g.) EuiHeader
+   */
+  type?: 'page' | 'application';
+
+  /**
+   * Whether the last breadcrumb should visually (and accessibly, to screen readers)
+   * be highlighted as the current page. Defaults to true.
+   */
+  lastBreadcrumbIsCurrentPage?: boolean;
+};
+
+export type EuiBreadcrumbProps = Omit<
+  HTMLAttributes<HTMLElement>,
+  'color' | 'aria-current'
+> &
+  CommonProps & {
+    href?: string;
+    rel?: string;
+    onClick?: MouseEventHandler<HTMLAnchorElement>;
+    /**
+     * Visible label of the breadcrumb
+     */
+    text: ReactNode;
+    /**
+     * Force a max-width on the breadcrumb text
+     */
+    truncate?: boolean;
+    /**
+     * Accepts any EuiLink `color` when rendered as one (has `href`, `onClick`, or `popoverContent`)
+     */
+    color?: EuiLinkColor;
+    /**
+     * Override the existing `aria-current` which defaults to `page` for the last breadcrumb
+     */
+    'aria-current'?: AriaAttributes['aria-current'];
+    /**
+     * Creates a breadcrumb that toggles a popover dialog. Takes any rendered node(s),
+     * or a render function that will pass callback allowing you to close the
+     * breadcrumb popover from within your popover content.
+     *
+     * If passed, both `href` and `onClick` will be ignored - the breadcrumb's
+     * click behavior should only trigger a popover.
+     */
+    popoverContent?: ReactNode | ((closePopover: () => void) => ReactNode);
+    /**
+     * Allows customizing the popover if necessary. Accepts any props that
+     * [EuiPopover](/#/layout/popover) accepts, except for props that control state.
+     */
+    popoverProps?: Omit<EuiPopoverProps, 'button' | 'closePopover' | 'isOpen'>;
+  };
+
+/**
+ * Internal props set by parent EuiBreadcrumbs only
+ */
+
+export type _EuiBreadcrumbProps = {
+  type: NonNullable<EuiBreadcrumbsProps['type']>;
+  isFirstBreadcrumb?: boolean;
+  isLastBreadcrumb?: boolean;
+  isOnlyBreadcrumb?: boolean;
+  highlightLastBreadcrumb?: boolean;
+  truncateLastBreadcrumb?: boolean;
+};

--- a/src/components/header/__snapshots__/header.test.tsx.snap
+++ b/src/components/header/__snapshots__/header.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`EuiHeader sections render breadcrumbs and props 1`] = `
       >
         <span
           aria-current="page"
-          class="euiBreadcrumb__content emotion-euiBreadcrumb__content-application-isTruncatedLast-onlyChild-euiTextColor-default"
+          class="euiBreadcrumb__content emotion-euiBreadcrumb__content-application-onlyChild-isTruncatedLast-euiTextColor-default"
           title="Breadcrumb"
         >
           Breadcrumb

--- a/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EuiHeaderBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-subdued-euiBreadcrumb__content-application-isTruncated-firstChild"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-subdued-euiBreadcrumb__content-application-firstChild-isTruncated"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -54,7 +54,7 @@ exports[`EuiHeaderBreadcrumbs is rendered 1`] = `
     >
       <span
         aria-current="page"
-        class="euiBreadcrumb__content emotion-euiBreadcrumb__content-application-isTruncatedLast-lastChild-euiTextColor-default"
+        class="euiBreadcrumb__content emotion-euiBreadcrumb__content-application-lastChild-isTruncatedLast-euiTextColor-default"
         title="Edit"
       >
         Edit
@@ -79,7 +79,7 @@ exports[`EuiHeaderBreadcrumbs renders only one breadcrumb with all rounded corne
     >
       <span
         aria-current="page"
-        class="euiBreadcrumb__content emotion-euiBreadcrumb__content-application-isTruncatedLast-onlyChild-euiTextColor-default"
+        class="euiBreadcrumb__content emotion-euiBreadcrumb__content-application-onlyChild-isTruncatedLast-euiTextColor-default"
         title="Home"
       >
         Home

--- a/src/components/header/header_breadcrumbs/header_breadcrumbs.tsx
+++ b/src/components/header/header_breadcrumbs/header_breadcrumbs.tsx
@@ -9,9 +9,9 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles } from '../../../services';
 import { EuiBreadcrumbs, EuiBreadcrumbsProps } from '../../breadcrumbs';
 import { euiHeaderBreadcrumbsStyles } from './header_breadcrumbs.styles';
-import { useEuiTheme } from '../../../services';
 
 export const EuiHeaderBreadcrumbs: FunctionComponent<EuiBreadcrumbsProps> = ({
   className,
@@ -20,9 +20,7 @@ export const EuiHeaderBreadcrumbs: FunctionComponent<EuiBreadcrumbsProps> = ({
 }) => {
   const classes = classNames('euiHeaderBreadcrumbs', className);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiHeaderBreadcrumbsStyles(euiTheme);
-  const cssHeaderBreadcrumbStyles = [styles.euiHeaderBreadcrumbs];
+  const styles = useEuiMemoizedStyles(euiHeaderBreadcrumbsStyles);
 
   return (
     <EuiBreadcrumbs
@@ -30,7 +28,7 @@ export const EuiHeaderBreadcrumbs: FunctionComponent<EuiBreadcrumbsProps> = ({
       truncate
       breadcrumbs={breadcrumbs}
       className={classes}
-      css={cssHeaderBreadcrumbStyles}
+      css={styles.euiHeaderBreadcrumbs}
       type="application"
       {...rest}
     />


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7577

| Before | After |
|--------|--------|
| <img width="323" alt="" src="https://github.com/elastic/eui/assets/549407/453c9855-67bd-4e9d-a7da-ee5d7c0f43e6"> | <img width="328" alt="" src="https://github.com/elastic/eui/assets/549407/e39eeb75-197f-4a2f-a862-a23334cf0239"> |

The underlying fix is to separate out the breadcrumb CSS from the truncation CSS and passing them to separate DOM elements for breadcrumbs with popovers. The final diff is a bit hard to follow because I ended up just pulling out breadcrumbs with popovers to a separate subcomponent, apologies for that 😬 

## QA

- Go to https://eui.elastic.co/pr_7580/storybook/?path=/story/navigation-euibreadcrumbs--playground&args=type:application
- Change the `max` control to `2`
- [x] Confirm the `...` collapsed button does not look broken
- Expand the `breadcrumbs` array and toggle the last breadcrumb. Click the `+` button and add a field: `popoverContent: 'anything'`
- [x] Confirm the popover toggle does not look broken

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist - N/A, primarily a visual/CSS bug - snapshots should be mostly the same as before
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A