### PR TITLE
[Emotion] Memoize `EuiPanel` + color/padding hook utilities + `EuiResizableContainer/Panel`

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -154,6 +154,9 @@ module.exports = {
         // This is set to deprecate after stylelint v16, but in the meanwhile, is helpful
         // for finding extraneous semicolons after utils that already output semicolons (e.g. logicalCSS())
         'no-extra-semicolons': true,
+
+        // Emotion uses the `label` property to generate the output className string
+        'property-no-unknown': [true, { ignoreProperties: 'label' }],
       },
     },
   ],

--- a/src/components/panel/panel.tsx
+++ b/src/components/panel/panel.tsx
@@ -13,7 +13,7 @@ import React, {
   Ref,
 } from 'react';
 import classNames from 'classnames';
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import {
   useEuiBackgroundColorCSS,
   useEuiPaddingCSS,
@@ -107,12 +107,11 @@ export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
   element,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
   // Shadows are only allowed when there's a white background (plain)
   const canHaveShadow = !hasBorder && color === 'plain';
   const canHaveBorder = color === 'plain' || color === 'transparent';
 
-  const styles = euiPanelStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiPanelStyles);
   const cssStyles = [
     styles.euiPanel,
     grow && styles.grow,

--- a/src/components/resizable_container/resizable_button.tsx
+++ b/src/components/resizable_container/resizable_button.tsx
@@ -18,7 +18,7 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../common';
 import { EuiI18n } from '../i18n';
-import { useEuiTheme, useGeneratedHtmlId } from '../../services';
+import { useEuiMemoizedStyles, useGeneratedHtmlId } from '../../services';
 
 import { useEuiResizableContainerContext } from './context';
 import {
@@ -75,8 +75,7 @@ export const EuiResizableButton = forwardRef<
 
     const resizeDirection = isHorizontal ? 'horizontal' : 'vertical';
 
-    const euiTheme = useEuiTheme();
-    const styles = euiResizableButtonStyles(euiTheme);
+    const styles = useEuiMemoizedStyles(euiResizableButtonStyles);
     const cssStyles = [
       styles.euiResizableButton,
       styles[indicator],

--- a/src/components/resizable_container/resizable_collapse_button.tsx
+++ b/src/components/resizable_container/resizable_collapse_button.tsx
@@ -9,7 +9,7 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { EuiButtonIcon, EuiButtonIconPropsForButton } from '../button';
 import { euiScreenReaderOnlyStyles } from '../accessibility/screen_reader_only/screen_reader_only.styles';
 
@@ -56,8 +56,7 @@ export const EuiResizableCollapseButton: FunctionComponent<
   const screenReaderOnlyStyles =
     euiScreenReaderOnlyStyles(showOnFocus).euiScreenReaderOnly;
 
-  const euiTheme = useEuiTheme();
-  const styles = euiResizableCollapseButtonStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiResizableCollapseButtonStyles);
 
   const collapsedStyles = [
     styles.collapsed.collapsed,

--- a/src/components/resizable_container/resizable_container.styles.ts
+++ b/src/components/resizable_container/resizable_container.styles.ts
@@ -9,15 +9,13 @@
 import { css } from '@emotion/react';
 import { logicalCSS } from '../../global_styling';
 
-export const euiResizableContainerStyles = () => {
-  return {
-    euiResizableContainer: css`
-      display: flex;
-      ${logicalCSS('width', '100%')}
-    `,
-    horizontal: css``,
-    vertical: css`
-      flex-direction: column;
-    `,
-  };
+export const euiResizableContainerStyles = {
+  euiResizableContainer: css`
+    display: flex;
+    ${logicalCSS('width', '100%')}
+  `,
+  horizontal: css``,
+  vertical: css`
+    flex-direction: column;
+  `,
 };

--- a/src/components/resizable_container/resizable_container.tsx
+++ b/src/components/resizable_container/resizable_container.tsx
@@ -43,7 +43,7 @@ import {
   ResizeTrigger,
 } from './types';
 
-import { euiResizableContainerStyles } from './resizable_container.styles';
+import { euiResizableContainerStyles as styles } from './resizable_container.styles';
 
 export interface EuiResizableContainerProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'children'>,
@@ -108,8 +108,6 @@ export const EuiResizableContainer: FunctionComponent<
   const isHorizontal = direction === 'horizontal';
 
   const classes = classNames('euiResizableContainer', className);
-
-  const styles = euiResizableContainerStyles();
   const cssStyles = [styles.euiResizableContainer, styles[direction]];
 
   const [actions, reducerState] = useContainerCallbacks({

--- a/src/components/resizable_container/resizable_panel.styles.ts
+++ b/src/components/resizable_container/resizable_panel.styles.ts
@@ -11,19 +11,16 @@ import {
   logicalCSS,
   logicalCSSWithFallback,
   euiScrollBarStyles,
-  euiPaddingSizeCSS,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
-export const euiResizablePanelStyles = (euiThemeContext: UseEuiTheme) => {
-  return {
-    euiResizablePanel: css`
-      position: relative;
-    `,
-    collapsed: css`
-      overflow: hidden;
-    `,
-  };
+export const euiResizablePanelStyles = {
+  euiResizablePanel: css`
+    position: relative;
+  `,
+  collapsed: css`
+    overflow: hidden;
+  `,
 };
 
 export const euiResizablePanelContentStyles = (

--- a/src/components/resizable_container/resizable_panel.styles.ts
+++ b/src/components/resizable_container/resizable_panel.styles.ts
@@ -23,9 +23,6 @@ export const euiResizablePanelStyles = (euiThemeContext: UseEuiTheme) => {
     collapsed: css`
       overflow: hidden;
     `,
-    paddingSizes: {
-      ...euiPaddingSizeCSS(euiThemeContext),
-    },
   };
 };
 

--- a/src/components/resizable_container/resizable_panel.tsx
+++ b/src/components/resizable_container/resizable_panel.tsx
@@ -18,7 +18,11 @@ import React, {
 import classNames from 'classnames';
 
 import { useGeneratedHtmlId, useEuiTheme } from '../../services';
-import { logicalSizeStyle, euiPaddingSize } from '../../global_styling';
+import {
+  logicalSizeStyle,
+  useEuiPaddingSize,
+  useEuiPaddingCSS,
+} from '../../global_styling';
 import { CommonProps } from '../common';
 
 import { useEuiResizableContainerContext } from './context';
@@ -239,7 +243,7 @@ export const EuiResizablePanel: FunctionComponent<EuiResizablePanelProps> = ({
   const cssStyles = [
     styles.euiResizablePanel,
     isCollapsed && styles.collapsed,
-    styles.paddingSizes[wrapperPadding],
+    useEuiPaddingCSS()[wrapperPadding],
     wrapperProps?.css,
   ];
   const contentStyles = euiResizablePanelContentStyles(euiTheme);
@@ -261,7 +265,7 @@ export const EuiResizablePanel: FunctionComponent<EuiResizablePanelProps> = ({
       : logicalSizeStyle('100%', `${size || innerSize}%`)),
   };
 
-  const padding = euiPaddingSize(euiTheme, paddingSize) || '0px';
+  const padding = useEuiPaddingSize(paddingSize) || '0px';
 
   useEffect(() => {
     if (!registration) return;

--- a/src/components/resizable_container/resizable_panel.tsx
+++ b/src/components/resizable_container/resizable_panel.tsx
@@ -17,7 +17,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useGeneratedHtmlId, useEuiTheme } from '../../services';
+import { useGeneratedHtmlId, useEuiMemoizedStyles } from '../../services';
 import {
   logicalSizeStyle,
   useEuiPaddingSize,
@@ -37,7 +37,7 @@ import {
 } from './types';
 import { EuiResizableCollapseButton } from './resizable_collapse_button';
 import {
-  euiResizablePanelStyles,
+  euiResizablePanelStyles as styles,
   euiResizablePanelContentStyles,
 } from './resizable_panel.styles';
 
@@ -237,16 +237,13 @@ export const EuiResizablePanel: FunctionComponent<EuiResizablePanelProps> = ({
 
   const axis = isHorizontal ? 'horizontal' : 'vertical';
 
-  const euiTheme = useEuiTheme();
-
-  const styles = euiResizablePanelStyles(euiTheme);
   const cssStyles = [
     styles.euiResizablePanel,
     isCollapsed && styles.collapsed,
     useEuiPaddingCSS()[wrapperPadding],
     wrapperProps?.css,
   ];
-  const contentStyles = euiResizablePanelContentStyles(euiTheme);
+  const contentStyles = useEuiMemoizedStyles(euiResizablePanelContentStyles);
   const contentCssStyles = [
     contentStyles.euiResizablePanel__content,
     scrollable && contentStyles.scrollable,

--- a/src/global_styling/mixins/__snapshots__/_color.test.ts.snap
+++ b/src/global_styling/mixins/__snapshots__/_color.test.ts.snap
@@ -32,34 +32,34 @@ exports[`useEuiBackgroundColor mixin returns a calculated background version for
 
 exports[`useEuiBackgroundColor mixin returns a calculated background version for each color: warning 1`] = `"#fff9e8"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: accent 1`] = `"background-color:#feedf5;;label:accent;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: accent 1`] = `"background-color:#feedf5;label:accent;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: danger 1`] = `"background-color:#f8e9e9;;label:danger;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: danger 1`] = `"background-color:#f8e9e9;label:danger;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: plain 1`] = `"background-color:#FFF;;label:plain;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: plain 1`] = `"background-color:#FFF;label:plain;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: primary 1`] = `"background-color:#e6f1fa;;label:primary;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: primary 1`] = `"background-color:#e6f1fa;label:primary;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: subdued 1`] = `"background-color:#f7f8fc;;label:subdued;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: subdued 1`] = `"background-color:#f7f8fc;label:subdued;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: success 1`] = `"background-color:#e6f9f7;;label:success;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: success 1`] = `"background-color:#e6f9f7;label:success;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: transparent 1`] = `"background-color:transparent;;label:transparent;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: transparent 1`] = `"background-color:transparent;label:transparent;"`;
 
-exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: warning 1`] = `"background-color:#fff9e8;;label:warning;"`;
+exports[`useEuiBackgroundColorCSS hook returns an object of Emotion background-color properties for each color: warning 1`] = `"background-color:#fff9e8;label:warning;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: accent 1`] = `"border-color:#f9b8d6;;label:accent;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: accent 1`] = `"border-color:#f9b8d6;label:accent;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: danger 1`] = `"border-color:#e5a9a5;;label:danger;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: danger 1`] = `"border-color:#e5a9a5;label:danger;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: plain 1`] = `"border-color:#D3DAE6;;label:plain;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: plain 1`] = `"border-color:#D3DAE6;label:plain;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: primary 1`] = `"border-color:#99c9eb;;label:primary;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: primary 1`] = `"border-color:#99c9eb;label:primary;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: subdued 1`] = `"border-color:#D3DAE6;;label:subdued;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: subdued 1`] = `"border-color:#D3DAE6;label:subdued;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: success 1`] = `"border-color:#99e5e1;;label:success;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: success 1`] = `"border-color:#99e5e1;label:success;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: transparent 1`] = `"border-color:#D3DAE6;;label:transparent;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: transparent 1`] = `"border-color:#D3DAE6;label:transparent;"`;
 
-exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: warning 1`] = `"border-color:#fedc72;;label:warning;"`;
+exports[`useEuiBorderColorCSS hook returns an object of Emotion border-color properties for each color: warning 1`] = `"border-color:#fedc72;label:warning;"`;

--- a/src/global_styling/mixins/__snapshots__/_padding.test.ts.snap
+++ b/src/global_styling/mixins/__snapshots__/_padding.test.ts.snap
@@ -1,76 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: l 1`] = `"padding-block-end:24px;;label:l;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for all sides, for each size: l 1`] = `"padding:24px;label:l;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: m 1`] = `"padding-block-end:16px;;label:m;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for all sides, for each size: m 1`] = `"padding:16px;label:m;"`;
+
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for all sides, for each size: none 1`] = `null`;
+
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for all sides, for each size: s 1`] = `"padding:8px;label:s;"`;
+
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for all sides, for each size: xl 1`] = `"padding:32px;label:xl;"`;
+
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for all sides, for each size: xs 1`] = `"padding:4px;label:xs;"`;
+
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: l 1`] = `"padding-block-end:24px;label:l;"`;
+
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: m 1`] = `"padding-block-end:16px;label:m;"`;
 
 exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: none 1`] = `null`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: s 1`] = `"padding-block-end:8px;;label:s;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: s 1`] = `"padding-block-end:8px;label:s;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: xl 1`] = `"padding-block-end:32px;;label:xl;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: xl 1`] = `"padding-block-end:32px;label:xl;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: xs 1`] = `"padding-block-end:4px;;label:xs;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: bottom, for each size: xs 1`] = `"padding-block-end:4px;label:xs;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: l 1`] = `"padding-inline:24px;;label:l;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: l 1`] = `"padding-inline:24px;label:l;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: m 1`] = `"padding-inline:16px;;label:m;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: m 1`] = `"padding-inline:16px;label:m;"`;
 
 exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: none 1`] = `null`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: s 1`] = `"padding-inline:8px;;label:s;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: s 1`] = `"padding-inline:8px;label:s;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: xl 1`] = `"padding-inline:32px;;label:xl;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: xl 1`] = `"padding-inline:32px;label:xl;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: xs 1`] = `"padding-inline:4px;;label:xs;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: horizontal, for each size: xs 1`] = `"padding-inline:4px;label:xs;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: l 1`] = `"padding-inline-start:24px;;label:l;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: l 1`] = `"padding-inline-start:24px;label:l;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: m 1`] = `"padding-inline-start:16px;;label:m;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: m 1`] = `"padding-inline-start:16px;label:m;"`;
 
 exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: none 1`] = `null`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: s 1`] = `"padding-inline-start:8px;;label:s;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: s 1`] = `"padding-inline-start:8px;label:s;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: xl 1`] = `"padding-inline-start:32px;;label:xl;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: xl 1`] = `"padding-inline-start:32px;label:xl;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: xs 1`] = `"padding-inline-start:4px;;label:xs;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: left, for each size: xs 1`] = `"padding-inline-start:4px;label:xs;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: l 1`] = `"padding-inline-end:24px;;label:l;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: l 1`] = `"padding-inline-end:24px;label:l;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: m 1`] = `"padding-inline-end:16px;;label:m;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: m 1`] = `"padding-inline-end:16px;label:m;"`;
 
 exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: none 1`] = `null`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: s 1`] = `"padding-inline-end:8px;;label:s;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: s 1`] = `"padding-inline-end:8px;label:s;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: xl 1`] = `"padding-inline-end:32px;;label:xl;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: xl 1`] = `"padding-inline-end:32px;label:xl;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: xs 1`] = `"padding-inline-end:4px;;label:xs;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: right, for each size: xs 1`] = `"padding-inline-end:4px;label:xs;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: l 1`] = `"padding-block-start:24px;;label:l;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: l 1`] = `"padding-block-start:24px;label:l;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: m 1`] = `"padding-block-start:16px;;label:m;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: m 1`] = `"padding-block-start:16px;label:m;"`;
 
 exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: none 1`] = `null`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: s 1`] = `"padding-block-start:8px;;label:s;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: s 1`] = `"padding-block-start:8px;label:s;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: xl 1`] = `"padding-block-start:32px;;label:xl;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: xl 1`] = `"padding-block-start:32px;label:xl;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: xs 1`] = `"padding-block-start:4px;;label:xs;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: top, for each size: xs 1`] = `"padding-block-start:4px;label:xs;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: l 1`] = `"padding-block:24px;;label:l;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: l 1`] = `"padding-block:24px;label:l;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: m 1`] = `"padding-block:16px;;label:m;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: m 1`] = `"padding-block:16px;label:m;"`;
 
 exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: none 1`] = `null`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: s 1`] = `"padding-block:8px;;label:s;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: s 1`] = `"padding-block:8px;label:s;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: xl 1`] = `"padding-block:32px;;label:xl;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: xl 1`] = `"padding-block:32px;label:xl;"`;
 
-exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: xs 1`] = `"padding-block:4px;;label:xs;"`;
+exports[`useEuiPaddingCSS hook returns an object of Emotion padding properties for side: vertical, for each size: xs 1`] = `"padding-block:4px;label:xs;"`;
 
 exports[`useEuiPaddingSize returns a static padding value for each size l 1`] = `"24px"`;
 

--- a/src/global_styling/mixins/_color.ts
+++ b/src/global_styling/mixins/_color.ts
@@ -6,8 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { useMemo } from 'react';
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import {
   shade,
   tint,
@@ -15,6 +14,7 @@ import {
   transparentize,
   useEuiTheme,
   UseEuiTheme,
+  useEuiMemoizedStyles,
 } from '../../services';
 
 export const BACKGROUND_COLORS = [
@@ -36,6 +36,10 @@ export interface _EuiBackgroundColorOptions {
    */
   method?: 'opaque' | 'transparent';
 }
+
+/**
+ * Get a single background color with optional alpha transparency
+ */
 
 export const euiBackgroundColor = (
   { euiTheme, colorMode }: UseEuiTheme,
@@ -70,6 +74,7 @@ export const euiBackgroundColor = (
   }
 };
 
+// TODO: This isn't actually used anywhere in EUI and is hard to memoize. Should we deprecate it?
 export const useEuiBackgroundColor = (
   color: _EuiBackgroundColor,
   { method }: _EuiBackgroundColorOptions = {}
@@ -78,39 +83,28 @@ export const useEuiBackgroundColor = (
   return euiBackgroundColor(euiTheme, color, { method });
 };
 
-export const useEuiBackgroundColorCSS = () => {
-  const euiThemeContext = useEuiTheme();
+/**
+ * Get a memoized object of non-alpha background colors
+ */
 
-  return useMemo(
-    () => ({
-      transparent: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'transparent')};
-      `,
-      plain: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'plain')};
-      `,
-      subdued: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'subdued')};
-      `,
-      accent: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'accent')};
-      `,
-      primary: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'primary')};
-      `,
-      success: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'success')};
-      `,
-      warning: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'warning')};
-      `,
-      danger: css`
-        background-color: ${euiBackgroundColor(euiThemeContext, 'danger')};
+const _euiBackgroundColors = (euiThemeContext: UseEuiTheme) =>
+  BACKGROUND_COLORS.reduce(
+    (acc, color) => ({
+      ...acc,
+      [color]: css`
+        background-color: ${euiBackgroundColor(euiThemeContext, color)};
+        label: ${color};
       `,
     }),
-    [euiThemeContext]
+    {} as Record<_EuiBackgroundColor, SerializedStyles>
   );
-};
+
+export const useEuiBackgroundColorCSS = () =>
+  useEuiMemoizedStyles(_euiBackgroundColors);
+
+/**
+ * Border colors
+ */
 
 export const euiBorderColor = (
   { euiTheme, colorMode }: UseEuiTheme,
@@ -128,36 +122,17 @@ export const euiBorderColor = (
   }
 };
 
-export const useEuiBorderColorCSS = () => {
-  const euiThemeContext = useEuiTheme();
-
-  return useMemo(
-    () => ({
-      transparent: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'transparent')};
-      `,
-      plain: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'plain')};
-      `,
-      subdued: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'subdued')};
-      `,
-      accent: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'accent')};
-      `,
-      primary: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'primary')};
-      `,
-      success: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'success')};
-      `,
-      warning: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'warning')};
-      `,
-      danger: css`
-        border-color: ${euiBorderColor(euiThemeContext, 'danger')};
+const _euiBorderColors = (euiThemeContext: UseEuiTheme) =>
+  BACKGROUND_COLORS.reduce(
+    (acc, color) => ({
+      ...acc,
+      [color]: css`
+        border-color: ${euiBorderColor(euiThemeContext, color)};
+        label: ${color};
       `,
     }),
-    [euiThemeContext]
+    {} as Record<_EuiBackgroundColor, SerializedStyles>
   );
-};
+
+export const useEuiBorderColorCSS = () =>
+  useEuiMemoizedStyles(_euiBorderColors);

--- a/src/global_styling/mixins/_padding.test.ts
+++ b/src/global_styling/mixins/_padding.test.ts
@@ -23,8 +23,8 @@ describe('useEuiPaddingSize returns a static padding value', () => {
 });
 
 describe('useEuiPaddingCSS hook returns an object of Emotion padding properties', () => {
-  LOGICAL_SIDES.forEach((side) => {
-    describe(`for side: ${side},`, () => {
+  [...LOGICAL_SIDES, undefined].forEach((side) => {
+    describe(side ? `for side: ${side},` : 'for all sides,', () => {
       const sizes = renderHook(() => useEuiPaddingCSS(side)).result.current;
 
       describe('for each size:', () => {

--- a/src/services/theme/style_memoization.tsx
+++ b/src/services/theme/style_memoization.tsx
@@ -16,17 +16,12 @@ import React, {
   useCallback,
   forwardRef,
 } from 'react';
-import type { SerializedStyles, CSSObject } from '@emotion/react';
 
 import { useUpdateEffect } from '../hooks';
 import { useEuiTheme, UseEuiTheme } from './hooks';
 
-type Styles = SerializedStyles | CSSObject | string | null;
-type StylesMaps = Record<string, Styles | Record<string, Styles>>;
-// NOTE: We're specifically using a WeakMap instead of a Map in order to allow
-// unmounted components to have their styles garbage-collected by the browser
-// @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
-type MemoizedStylesMap = WeakMap<Function, StylesMaps>;
+type StylesMap = unknown; // Typically an object of serialized css`` styles, but can have any amount of nesting, so it's not worth it to try and strictly type this
+type MemoizedStylesMap = WeakMap<Function, StylesMap>;
 
 export const EuiThemeMemoizedStylesContext = createContext<MemoizedStylesMap>(
   new WeakMap()
@@ -85,7 +80,7 @@ const getMemoizedStyles = (
  * per-theme
  */
 export const useEuiMemoizedStyles = <
-  T extends (theme: UseEuiTheme) => StylesMaps
+  T extends (theme: UseEuiTheme) => StylesMap
 >(
   stylesGenerator: T
 ): ReturnType<T> => {
@@ -97,7 +92,7 @@ export const useEuiMemoizedStyles = <
     [stylesGenerator, memoizedStyles, euiThemeContext]
   );
 
-  return memoizedComponentStyles as ReturnType<T>;
+  return memoizedComponentStyles;
 };
 
 /**

--- a/src/themes/amsterdam/global_styling/mixins/button.ts
+++ b/src/themes/amsterdam/global_styling/mixins/button.ts
@@ -242,7 +242,7 @@ const euiButtonDisplaysColors = (euiThemeContext: UseEuiTheme) => {
  * @returns string
  */
 export const useEuiButtonFocusCSS = () =>
-  useEuiMemoizedStyles<any>(euiButtonFocusCSS);
+  useEuiMemoizedStyles(euiButtonFocusCSS);
 
 const euiButtonFocusAnimation = keyframes`
   50% {


### PR DESCRIPTION
## Summary

This PR is an Emotion performance pass of the following components/utilities:

- `EuiPanel`
- `EuiResizablePanel` (+ all other `EuiResizableContainer` components while here)
- Padding utilties (`useEuiPaddingCSS`)
- Color utilities (`useEuiBackgroundColorCSS` & `useEuiBorderColorCSS`)

As always, I recommend following along by commit.

## QA

- [ ] Confirm the EuiPanel docs render/look the same as production
- [ ] Confirm the EuiResizablecontainer docs render/look the same as production

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist - N/A, tech debt
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist - N/A, tech debt and shouldn't affect consumers or end-users
- Designer checklist - N/A