### PR TITLE
[Docs] Remove tour beacon/notification notifcation about Amsterdam theme

### DIFF
--- a/src-docs/src/components/guide_theme_selector/guide_theme_selector.tsx
+++ b/src-docs/src/components/guide_theme_selector/guide_theme_selector.tsx
@@ -11,15 +11,11 @@ import { ThemeContext } from '../with_theme';
 // @ts-ignore Not TS
 import { GuideLocaleSelector } from '../guide_locale_selector';
 import {
-  EuiText,
-  EuiTourStep,
   EuiPopover,
   EuiHorizontalRule,
   EuiButton,
   EuiContextMenuPanel,
   EuiContextMenuItem,
-  EuiLink,
-  EuiIcon,
 } from '../../../../src/components';
 
 type GuideThemeSelectorProps = {
@@ -45,18 +41,9 @@ const GuideThemeSelectorComponent: React.FunctionComponent<
 > = ({ context, onToggleLocale, selectedLocale }) => {
   const isMobileSize = useIsWithinBreakpoints(['xs', 's']);
   const [isPopoverOpen, setPopover] = useState(false);
-  const [isOpen, setIsOpen] = useState(
-    localStorage.getItem(STORAGE_KEY) !== 'dismissed'
-  );
-
-  const onTourDismiss = () => {
-    setIsOpen(false);
-    localStorage.setItem(STORAGE_KEY, 'dismissed');
-  };
 
   const onButtonClick = () => {
     setPopover(!isPopoverOpen);
-    setIsOpen(false);
     localStorage.setItem(STORAGE_KEY, 'dismissed');
   };
 
@@ -102,49 +89,27 @@ const GuideThemeSelectorComponent: React.FunctionComponent<
   );
 
   return (
-    <EuiTourStep
-      content={
-        <EuiText style={{ maxWidth: 320 }}>
-          <p>
-            Amsterdam is now the only theme and the legacy theme has been
-            removed.
-          </p>
-        </EuiText>
-      }
-      isStepOpen={isOpen}
-      onFinish={onTourDismiss}
-      step={1}
-      stepsTotal={1}
-      title={
-        <>
-          <EuiIcon type="bell" size="s" /> &nbsp; Theming update
-        </>
-      }
-      footerAction={<EuiLink onClick={onTourDismiss}>Got it!</EuiLink>}
+    <EuiPopover
+      id="docsThemeSelector"
       repositionOnScroll
+      button={button}
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      anchorPosition="downRight"
     >
-      <EuiPopover
-        id="docsThemeSelector"
-        repositionOnScroll
-        button={button}
-        isOpen={isPopoverOpen}
-        closePopover={closePopover}
-        panelPaddingSize="none"
-        anchorPosition="downRight"
-      >
-        <EuiContextMenuPanel size="s" items={items} />
-        {location.host.includes('803') && (
-          <>
-            <EuiHorizontalRule margin="none" />
-            <div style={{ padding: 8 }}>
-              <GuideLocaleSelector
-                onToggleLocale={onToggleLocale}
-                selectedLocale={selectedLocale}
-              />
-            </div>
-          </>
-        )}
-      </EuiPopover>
-    </EuiTourStep>
+      <EuiContextMenuPanel size="s" items={items} />
+      {location.host.includes('803') && (
+        <>
+          <EuiHorizontalRule margin="none" />
+          <div style={{ padding: 8 }}>
+            <GuideLocaleSelector
+              onToggleLocale={onToggleLocale}
+              selectedLocale={selectedLocale}
+            />
+          </div>
+        </>
+      )}
+    </EuiPopover>
   );
 };


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7588

Removes this popover/beacon:

<img width="438" alt="" src="https://github.com/elastic/eui/assets/549407/e7652827-a0b4-4e20-a8e6-a7748c4a1235">


## QA

- Go to https://eui.elastic.co/pr_7595/
- Clear your site cookies/local storage data
- [x] Refresh and confirm no popup/tour notification appears over the light/dark mode switcher

### General checklist

N/A, docs only