### PR TITLE
[EuiIcon] Remove logic that applies `aria-hidden` to empty/loading icons; [EuiIconTip] Fix non-i18n'd default `aria-label`

### DIFF
--- a/changelogs/upcoming/7606.md
+++ b/changelogs/upcoming/7606.md
@@ -1,3 +1,7 @@
+**Bug fixes**
+
+- Fixed `EuiIconTip`'s default `aria-label` text to be i18n tokenizable
+
 **Accessibility**
 
 - `EuiIcons` no longer apply `aria-hidden` to empty icons, as long as a valid title or label is provided to the icon. In particular, this is intended to improve the accessibility of loading `EuiIconTip`s.

--- a/changelogs/upcoming/7606.md
+++ b/changelogs/upcoming/7606.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- `EuiIcons` no longer apply `aria-hidden` to empty icons, as long as a valid title or label is provided to the icon. In particular, this is intended to improve the accessibility of loading `EuiIconTip`s.

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -296,14 +296,12 @@ export class EuiIconClass extends PureComponent<
     } else {
       const Svg = icon;
 
-      // If it's an empty icon, or if there is no aria-label, aria-labelledby, or title it gets aria-hidden true
-      const isAriaHidden =
-        icon === empty ||
-        !(
-          this.props['aria-label'] ||
-          this.props['aria-labelledby'] ||
-          this.props.title
-        );
+      // If there is no aria-label, aria-labelledby, or title it gets aria-hidden true
+      const isAriaHidden = !(
+        this.props['aria-label'] ||
+        this.props['aria-labelledby'] ||
+        this.props.title
+      );
 
       // If no aria-label or aria-labelledby is provided but there's a title, a titleId is generated
       //  The svg aria-labelledby attribute gets this titleId
@@ -326,7 +324,7 @@ export class EuiIconClass extends PureComponent<
           data-is-loaded={isLoaded || undefined}
           data-is-loading={isLoading || undefined}
           {...rest}
-          aria-hidden={isAriaHidden || undefined}
+          aria-hidden={isAriaHidden || rest['aria-hidden']}
         />
       );
     }

--- a/src/components/tool_tip/icon_tip.tsx
+++ b/src/components/tool_tip/icon_tip.tsx
@@ -9,6 +9,7 @@
 import React, { FunctionComponent } from 'react';
 
 import { PropsOf } from '../common';
+import { useEuiI18n } from '../i18n';
 import { EuiIcon, IconSize, IconType } from '../icon';
 import { EuiToolTip, EuiToolTipProps } from './tool_tip';
 
@@ -53,22 +54,26 @@ type Props = Omit<EuiToolTipProps, 'children' | 'delay' | 'position'> &
 
 export const EuiIconTip: FunctionComponent<Props> = ({
   type = 'questionInCircle',
-  'aria-label': ariaLabel = 'Info',
+  'aria-label': ariaLabel,
   color,
   size,
   iconProps,
   position = 'top',
   delay = 'regular',
   ...rest
-}) => (
-  <EuiToolTip position={position} delay={delay} {...rest}>
-    <EuiIcon
-      tabIndex={0}
-      type={type}
-      color={color}
-      size={size}
-      aria-label={ariaLabel}
-      {...iconProps}
-    />
-  </EuiToolTip>
-);
+}) => {
+  const defaultAriaLabel = useEuiI18n('euiIconTip.defaultAriaLabel', 'Info');
+
+  return (
+    <EuiToolTip position={position} delay={delay} {...rest}>
+      <EuiIcon
+        tabIndex={0}
+        type={type}
+        color={color}
+        size={size}
+        aria-label={ariaLabel || defaultAriaLabel}
+        {...iconProps}
+      />
+    </EuiToolTip>
+  );
+};


### PR DESCRIPTION
## Summary

closes #7400

Empty and loading icons can still have perfectly valid `aria-label` attributes that should be made available to screen reader users and not hidden - we should not apply `aria-hidden` unless there is no meaningful text to read out.

| Before | After |
|--------|--------|
| <img width="612" alt="" src="https://github.com/elastic/eui/assets/549407/c9162a21-8ee4-455e-878f-a7a0b86d88d6"> | <img width="624" alt="" src="https://github.com/elastic/eui/assets/549407/70b0ef27-8ffd-45a9-9e9e-db647bbaef7d"> | 

I also noticed while here that `EuiIconTip`'s default aria-label isn't correctly `i18n`ed, and can be bypassed by consumers passing an empty string, so I tweaked both of those things while here.

## QA

To QA `EuiIconTip` specifically:
- `gh pr checkout 7606`
- Open `src/components/icon/icon.tsx`
- Comment out lines 210 - 221 (`enqueueStateChange` invocation)
- Go to http://localhost:8030/#/display/tooltip#icontip
- [x] Run axe devtools and confirm no errors

Regression testing:
- Go to https://eui.elastic.co/pr_7606/#/display/icons
- [x] Confirm that icons on the page with no title/label (e.g. first example) still have `aria-hidden="true"`

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A