### PR TITLE
[EuiTextArea] Fix extra 2-3px of height caused by `display: inline-block`

### DIFF
--- a/changelogs/upcoming/7607.md
+++ b/changelogs/upcoming/7607.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiTextArea`'s CSS box model to no longer render a few extra pixels of strut height

--- a/src/components/form/text_area/_text_area.scss
+++ b/src/components/form/text_area/_text_area.scss
@@ -2,6 +2,11 @@
   @include euiFormControlStyle;
   line-height: $euiLineHeight; // give more spacing between multiple lines
 
+  // <textarea>s default to `inline-block`, which causes an extra 2-3px of
+  // unnecessary height within its parent `block` form control wrapper.
+  // @see https://stackoverflow.com/a/27536461/4294462
+  display: block;
+
   // Textareas have their own sizing
   &,
   &--compressed {


### PR DESCRIPTION
## Summary

@yansavitski super awesomely pointed out to us in Slack that `inline-block` displays produce [struts](http://www.w3.org/TR/CSS2/visudet.html#strut), which make room for descenders, hence the extra 2-3px. [Another helpful comment from StackOverflow](https://stackoverflow.com/a/27536461/4294462):

> The default `vertical-align` is to have the bottom edge of the `inline-block` box lined up with the baseline of the surrounding text. Even if there is no surrounding text, the layout engine still has to make room for an entire line of text.

Setting `vertical-align: top` works for Chrome but not for Firefox. Since our textarea component doesn't need descender logic at all, or inline behavior (since it's already wrapped in a `<div>` form control wrapper), the easiest solution is to simply set `display: block` on `EuiTextArea` to eliminate the extra height.

| Before | After |
|--------|--------|
| <img width="482" alt="screenshot" src="https://github.com/elastic/eui/assets/549407/a7715308-bbc1-44de-a22a-a0590a3ffd11"> | <img width="484" alt="screenshot" src="https://github.com/elastic/eui/assets/549407/ae5b023d-5b5d-4504-84bc-fcbf5bb4c6fc"> | 

## QA

- Go to https://eui.elastic.co/pr_7607/#/forms/form-controls#textarea
- [x] Inspect the `<textarea>` element and the 2 div wrappers above it, and confirm all are the exact same pixel height

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist - N/A, CSS change only
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A