### PR TITLE
[docs][EuiCode] Fix moved Kibana repo link

### DIFF
--- a/src-docs/src/views/code/code_example.js
+++ b/src-docs/src/views/code/code_example.js
@@ -91,7 +91,7 @@ export const CodeExample = {
           or want to print long code (e.g., printing JSON from an API), we
           recommend installing a version of Monaco. If you are building within
           the Kibana platform, you can use their{' '}
-          <EuiLink href="https://github.com/elastic/kibana/tree/main/src/plugins/kibana_react/public/code_editor">
+          <EuiLink href="https://github.com/elastic/kibana/tree/main/packages/shared-ux/code_editor/impl">
             <strong>CodeEditor</strong>
           </EuiLink>
           .


### PR DESCRIPTION
## Summary

Thanks to @julianrosado for pointing this out!

## QA

- Go to https://eui.elastic.co/pr_7608/#/editors-syntax/code
- [x] Confirm the `CodeEditor` link in the callout does not 404

### General checklist

N/A, docs only