### PR TITLE
[EuiSelectable] Support scrolling in non-virtualized lists

### DIFF
--- a/changelogs/upcoming/7609.md
+++ b/changelogs/upcoming/7609.md
@@ -1,0 +1,1 @@
+- Updated `EuiSelectable` to support scrolling list containers when `listProps.isVirtualization` is set to `false`

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -479,11 +479,14 @@ export const SelectableExample = {
           </p>
           <p>
             If <EuiCode>listProps.isVirtualized</EuiCode> is set to{' '}
-            <EuiCode>false</EuiCode>, each row will fit its contents and removes
-            all scrolling. Therefore, we recommend having a large enough
-            container to accommodate all options. You can also remove truncation
-            by setting <EuiCode>{'textWrap="wrap"'}</EuiCode> when
-            virtualization is off.
+            <EuiCode>false</EuiCode>, each row will fit its content. You can
+            also remove truncation by setting{' '}
+            <EuiCode>{'textWrap="wrap"'}</EuiCode> when virtualization is off.
+            Note that while this is useful for dynamic options, it can also be
+            computationally expensive as <em>all</em> off-screen options will be
+            rendered to the DOM. We do not recommend turning off virtualization
+            for high numbers of options, but if you absolutely must do so, we
+            suggest using methods such as async loading more options.
           </p>
           <h3>Custom content</h3>
           <p>

--- a/src/components/selectable/selectable.spec.tsx
+++ b/src/components/selectable/selectable.spec.tsx
@@ -253,6 +253,22 @@ describe('EuiSelectable', () => {
     });
   });
 
+  describe('isVirtualization={false}', () => {
+    it('correctly scrolls keyboard navigated elements into view', () => {
+      cy.realMount(
+        <EuiSelectableListboxOnly
+          listProps={{ isVirtualized: false }}
+          height={50}
+        />
+      );
+      cy.get('.euiSelectableList__list').invoke('scrollTop').should('eq', 0);
+
+      cy.realPress('Tab');
+      cy.realPress('ArrowUp');
+      cy.get('.euiSelectableList__list').invoke('scrollTop').should('eq', 48);
+    });
+  });
+
   describe('truncation', () => {
     const sharedProps = {
       style: { width: 240 },

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`EuiSelectableListItem group labels handles updating aria attrs correctl
     tabindex="-1"
   >
     <ul
-      aria-activedescendant="option_undefined"
       aria-label="aria-label"
       aria-multiselectable="true"
       id="list"

--- a/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -1456,7 +1456,7 @@ exports[`EuiSelectableListItem props height is full 1`] = `
 </div>
 `;
 
-exports[`EuiSelectableListItem props isVirtualized can be false 1`] = `
+exports[`EuiSelectableListItem props isVirtualized={false} renders 1`] = `
 <div
   class="euiSelectableList testClass1 testClass2 emotion-euiTestCss"
   data-test-subj="test subject string"

--- a/src/components/selectable/selectable_list/_selectable_list.scss
+++ b/src/components/selectable/selectable_list/_selectable_list.scss
@@ -21,6 +21,7 @@
   @include euiOverflowShadow;
   @include euiScrollBar;
   overflow: auto;
+  position: relative; // Chrome/Edge loses its mind without this and doesn't render `mask-image` correctly
 
   &:focus,
   & > ul:focus {

--- a/src/components/selectable/selectable_list/_selectable_list.scss
+++ b/src/components/selectable/selectable_list/_selectable_list.scss
@@ -20,6 +20,7 @@
 .euiSelectableList__list {
   @include euiOverflowShadow;
   @include euiScrollBar;
+  overflow: auto;
 
   &:focus,
   & > ul:focus {

--- a/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -227,16 +227,33 @@ describe('EuiSelectableListItem', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    test('isVirtualized can be false', () => {
-      const { container } = render(
-        <EuiSelectableList
-          options={options}
-          isVirtualized={false}
-          {...selectableListRequiredProps}
-        />
-      );
+    describe('isVirtualized={false}', () => {
+      it('renders', () => {
+        const { container } = render(
+          <EuiSelectableList
+            options={options}
+            {...selectableListRequiredProps}
+            isVirtualized={false}
+          />
+        );
 
-      expect(container.firstChild).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
+      });
+
+      it('maintains the passed height when false', () => {
+        const { container } = render(
+          <EuiSelectableList
+            options={options}
+            {...selectableListRequiredProps}
+            isVirtualized={false}
+            height={300}
+          />
+        );
+
+        expect(container.querySelector('.euiSelectableList__list')).toHaveStyle(
+          'block-size: 300px'
+        );
+      });
     });
 
     test('searchable enables correct screen reader instructions', () => {

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -609,10 +609,12 @@ export class EuiSelectableList<T> extends Component<
       ...rest
     } = this.props;
 
+    const heightIsFull = forcedHeight === 'full';
+
     const classes = classNames(
       'euiSelectableList',
       {
-        'euiSelectableList-fullHeight': forcedHeight === 'full',
+        'euiSelectableList-fullHeight': heightIsFull,
         'euiSelectableList-bordered': bordered,
       },
       className
@@ -625,6 +627,7 @@ export class EuiSelectableList<T> extends Component<
         ) : (
           <div
             className="euiSelectableList__list"
+            style={!heightIsFull ? { blockSize: forcedHeight } : undefined}
             ref={this.removeScrollableTabStop}
           >
             <ul ref={this.setListBoxRef}>

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -247,21 +247,25 @@ export class EuiSelectableList<T> extends Component<
     const { isVirtualized, activeOptionIndex, visibleOptions, options } =
       this.props;
 
-    if (this.listBoxRef && this.props.searchable !== true) {
-      this.listBoxRef.setAttribute(
-        'aria-activedescendant',
-        `${this.props.makeOptionId(activeOptionIndex)}`
-      );
-    }
+    if (prevProps.activeOptionIndex !== activeOptionIndex) {
+      const { makeOptionId } = this.props;
 
-    if (typeof activeOptionIndex !== 'undefined') {
-      if (isVirtualized) {
-        this.listRef?.scrollToItem(activeOptionIndex, 'auto');
-      } else {
-        const activeOptionId = `#${this.props.makeOptionId(activeOptionIndex)}`;
-        const activeOptionEl = this.listBoxRef?.querySelector(activeOptionId);
-        if (activeOptionEl) {
-          activeOptionEl.scrollIntoView({ block: 'nearest' });
+      if (this.listBoxRef && this.props.searchable !== true) {
+        this.listBoxRef.setAttribute(
+          'aria-activedescendant',
+          makeOptionId(activeOptionIndex)
+        );
+      }
+
+      if (typeof activeOptionIndex !== 'undefined') {
+        if (isVirtualized) {
+          this.listRef?.scrollToItem(activeOptionIndex, 'auto');
+        } else {
+          const activeOptionId = `#${makeOptionId(activeOptionIndex)}`;
+          const activeOptionEl = this.listBoxRef?.querySelector(activeOptionId);
+          if (activeOptionEl) {
+            activeOptionEl.scrollIntoView({ block: 'nearest' });
+          }
         }
       }
     }

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -244,7 +244,8 @@ export class EuiSelectableList<T> extends Component<
   };
 
   componentDidUpdate(prevProps: EuiSelectableListProps<T>) {
-    const { activeOptionIndex, visibleOptions, options } = this.props;
+    const { isVirtualized, activeOptionIndex, visibleOptions, options } =
+      this.props;
 
     if (this.listBoxRef && this.props.searchable !== true) {
       this.listBoxRef.setAttribute(
@@ -253,8 +254,16 @@ export class EuiSelectableList<T> extends Component<
       );
     }
 
-    if (this.listRef && typeof activeOptionIndex !== 'undefined') {
-      this.listRef.scrollToItem(activeOptionIndex, 'auto');
+    if (typeof activeOptionIndex !== 'undefined') {
+      if (isVirtualized) {
+        this.listRef?.scrollToItem(activeOptionIndex, 'auto');
+      } else {
+        const activeOptionId = `#${this.props.makeOptionId(activeOptionIndex)}`;
+        const activeOptionEl = this.listBoxRef?.querySelector(activeOptionId);
+        if (activeOptionEl) {
+          activeOptionEl.scrollIntoView({ block: 'nearest' });
+        }
+      }
     }
 
     if (


### PR DESCRIPTION
## Summary

@jeramysoucy pointed out this missing functionality/feature request in the ability to turn off virtualization in `EuiSelectable` - it should continue to support scrolling as necessary. This is fairly trivial for EUI to do and it's not totally clear to me why it wasn't implemented in the first place when `isVirtualized={false}` was added as a prop, so I've gone ahead and added support for that in this PR.

| Before | After |
|--------|--------|
| <img width="423" alt="screenshot" src="https://github.com/elastic/eui/assets/549407/b11e6cae-8193-44fb-8696-1b8b760f74fc"> | <img width="427" alt="screenshot" src="https://github.com/elastic/eui/assets/549407/d36aa018-9306-4b6d-a119-14363c91d48d"> | 

## QA

- Go to https://eui.elastic.co/pr_7609/#/forms/selectable#rendering-the-options
- Switch the `Virtualized` toggle to off
- [x] Confirm that list height/scrolling is maintained
- [x] Confirm that using the up/down arrow keys to navigate through options works as expected/the same as for virtualized lists

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    -~ [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A