### PR TITLE
[EuiSelectable] Fix non-virtualized lists causing Jest errors

### DIFF
--- a/changelogs/upcoming/7618.md
+++ b/changelogs/upcoming/7618.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed unvirtualized `EuiSelectable`s to not cause Jest/jsdom errors on active option change

--- a/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/src/components/selectable/selectable_list/selectable_list.tsx
@@ -264,7 +264,9 @@ export class EuiSelectableList<T> extends Component<
           const activeOptionId = `#${makeOptionId(activeOptionIndex)}`;
           const activeOptionEl = this.listBoxRef?.querySelector(activeOptionId);
           if (activeOptionEl) {
-            activeOptionEl.scrollIntoView({ block: 'nearest' });
+            // TODO: we can remove scrollIntoView's conditional chaining once jsdom stubs it
+            // @see https://github.com/jsdom/jsdom/issues/1695
+            activeOptionEl.scrollIntoView?.({ block: 'nearest' });
           }
         }
       }


### PR DESCRIPTION
## Summary

This is happening on `activeOptionIndex` change only. jsdom doesn't support or stub `scrollIntoView` (and we don't need it to be called in Jest tests) so adding a conditional check for it fixes several Kibana Jest failures:

- https://github.com/elastic/kibana/pull/179363#issuecomment-2018584834
- https://github.com/jsdom/jsdom/issues/1695

## QA

N/A, tests only

### General checklist

- Browser QA - N/A
- Docs site QA - N/A
- Code quality checklist
    - ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ Skipping this to speed up the patch/upgrade process, unless someone thinks it's really important to do
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A