### PR TITLE
[EuiTable] New `responsiveBreakpoint` prop + initial setup for mobile vs desktop styles

### DIFF
--- a/changelogs/upcoming/7625.md
+++ b/changelogs/upcoming/7625.md
@@ -1,0 +1,7 @@
+- Updated `EuiTable`, `EuiBasicTable`, and `EuiInMemoryTable` with a new `responsiveBreakpoint` prop, which allows customizing the point at which the table collapses into a mobile-friendly view with cards
+- Updated `EuiProvider`'s `componentDefaults` prop to allow configuring `EuiTable.responsiveBreakpoint`
+
+**Deprecations**
+
+- Deprecated the `responsive` prop from `EuiTable`, `EuiBasicTable`, and `EuiInMemoryTable`. Use the new `responsiveBreakpoint` prop instead
+- `EuiTable` mobile headers no longer render in the DOM when not visible (previously rendered with `display: none`). This may affect DOM testing assertions.

--- a/src-docs/src/views/provider/provider_component_defaults.tsx
+++ b/src-docs/src/views/provider/provider_component_defaults.tsx
@@ -12,6 +12,7 @@ export const EuiComponentDefaultsProps: FunctionComponent<
 // Exported in one place for DRYness
 export const euiProviderComponentDefaultsSnippet = `<EuiProvider
   componentDefaults={{
+    EuiTable: { responsiveBreakpoint: 's', },
     EuiTablePagination: { itemsPerPage: 20, },
     EuiFocusTrap: { crossFrame: true },
     EuiPortal: { insert },

--- a/src-docs/src/views/tables/mobile/mobile.tsx
+++ b/src-docs/src/views/tables/mobile/mobile.tsx
@@ -302,7 +302,7 @@ export default () => {
         selection={selection}
         isSelectable={true}
         hasActions={true}
-        responsive={isResponsive}
+        responsiveBreakpoint={isResponsive}
         onChange={onTableChange}
       />
     </>

--- a/src-docs/src/views/tables/mobile/mobile_section.js
+++ b/src-docs/src/views/tables/mobile/mobile_section.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { GuideSectionTypes } from '../../../components';
 
 import Table from './mobile';
@@ -32,14 +33,26 @@ export const section = {
   text: (
     <>
       <p>
-        Allowing a table to be responsive means breaking each row down into its
-        own section and individually displaying each table header above the cell
-        contents. There are few times when you may want to exclude this behavior
-        from your table, for instance, when the table has very few columns or
-        the table does not break down easily into this format. For these use
-        cases, you may set <EuiCode language="js">responsive=false</EuiCode>.
+        Tables will be mobile-responsive by default, breaking down each row into
+        its own card section and individually displaying each table header above
+        the cell contents. The default breakpoint at which the table will
+        responsively shift into cards is the{' '}
+        <Link to="/theming/breakpoints/values">
+          <EuiCode>m</EuiCode> window size
+        </Link>
+        , which can be customized with the{' '}
+        <EuiCode>responsiveBreakpoint</EuiCode> prop (e.g.,{' '}
+        <EuiCode language="js">{'responsiveBreakpoint="s"'}</EuiCode>).
       </p>
       <p>
+        To never render your table responsively (e.g. for tables with very few
+        columns), you may set{' '}
+        <EuiCode language="js">{'responsiveBreakpoint={false}'}</EuiCode>.
+        Inversely, if you always want your table to render in a mobile-friendly
+        manner, pass <EuiCode>true</EuiCode>.
+      </p>
+      <p>
+        {/* TODO: This shouldn't be true by the end of the Emotion conversion */}
         To make your table work responsively, please make sure you add the
         following <EuiTextColor color="danger">additional</EuiTextColor> props
         to the top level table component (<strong>EuiBasicTable</strong> or{' '}

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
 >
   <div>
     <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
+      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
       id="__table_generated-id"
       tabindex="-1"
     >
@@ -122,7 +122,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
 >
   <div>
     <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
+      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
       id="__table_generated-id"
       tabindex="-1"
     >

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -6,113 +6,111 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
   class="euiBasicTable testClass1 testClass2 emotion-euiTestCss"
   data-test-subj="test subject string"
 >
-  <div>
-    <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
-      id="__table_generated-id"
-      tabindex="-1"
-    >
-      <caption
-        class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
-      />
-      <thead>
-        <tr>
-          <th
-            class="euiTableHeaderCell"
-            data-test-subj="tableHeaderCell_name_0"
-            role="columnheader"
-            scope="col"
+  <table
+    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    id="__table_generated-id"
+    tabindex="-1"
+  >
+    <caption
+      class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
+    />
+    <thead>
+      <tr>
+        <th
+          class="euiTableHeaderCell"
+          data-test-subj="tableHeaderCell_name_0"
+          role="columnheader"
+          scope="col"
+        >
+          <span
+            class="euiTableCellContent"
           >
             <span
-              class="euiTableCellContent"
+              class="euiTableCellContent__text"
+              title="Name; description"
             >
-              <span
-                class="euiTableCellContent__text"
-                title="Name; description"
-              >
-                Name
-              </span>
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                description
-              </span>
+              Name
             </span>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="css-0"
+            <span
+              class="emotion-euiScreenReaderOnly"
+            >
+              description
+            </span>
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="css-0"
+    >
+      <tr
+        class="euiTableRow"
       >
-        <tr
-          class="euiTableRow"
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                name1
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="euiTableRow"
+              name1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="euiTableRow"
+      >
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                name2
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="euiTableRow"
+              name2
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="euiTableRow"
+      >
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                name3
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+              name3
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -120,569 +118,567 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
 <div
   class="euiBasicTable"
 >
-  <div>
-    <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
-      id="__table_generated-id"
-      tabindex="-1"
+  <table
+    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    id="__table_generated-id"
+    tabindex="-1"
+  >
+    <caption
+      class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
+    />
+    <thead>
+      <tr>
+        <th
+          class="euiTableHeaderCellCheckbox"
+          scope="col"
+        >
+          <div
+            class="euiTableCellContent"
+          >
+            <div
+              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
+            >
+              <input
+                aria-label="Select all rows"
+                class="euiCheckbox__input"
+                data-test-subj="checkboxSelectAll"
+                id="_selection_column-checkbox_generated-id_desktop"
+                type="checkbox"
+              />
+              <div
+                class="euiCheckbox__square"
+              />
+            </div>
+          </div>
+        </th>
+        <th
+          aria-live="polite"
+          aria-sort="ascending"
+          class="euiTableHeaderCell"
+          data-test-subj="tableHeaderCell_name_0"
+          role="columnheader"
+          scope="col"
+        >
+          <button
+            class="euiTableHeaderButton euiTableHeaderButton-isSorted"
+            data-test-subj="tableHeaderSortButton"
+            type="button"
+          >
+            <span
+              class="euiTableCellContent"
+            >
+              <span
+                class="euiTableCellContent__text"
+                title="Name; your name"
+              >
+                Name
+              </span>
+              <span
+                class="emotion-euiScreenReaderOnly"
+              >
+                your name
+              </span>
+              <span
+                class="euiTableSortIcon"
+                data-euiicon-type="sortUp"
+              />
+            </span>
+          </button>
+        </th>
+        <th
+          class="euiTableHeaderCell"
+          data-test-subj="tableHeaderCell_id_1"
+          role="columnheader"
+          scope="col"
+        >
+          <span
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
+              title="ID; your id"
+            >
+              ID
+            </span>
+            <span
+              class="emotion-euiScreenReaderOnly"
+            >
+              your id
+            </span>
+          </span>
+        </th>
+        <th
+          class="euiTableHeaderCell"
+          data-test-subj="tableHeaderCell_age_2"
+          role="columnheader"
+          scope="col"
+        >
+          <span
+            class="euiTableCellContent euiTableCellContent--alignRight"
+          >
+            <span
+              class="euiTableCellContent__text"
+              title="Age; your age"
+            >
+              Age
+            </span>
+            <span
+              class="emotion-euiScreenReaderOnly"
+            >
+              your age
+            </span>
+          </span>
+        </th>
+        <th
+          class="euiTableHeaderCell"
+          role="columnheader"
+          scope="col"
+        >
+          <span
+            class="euiTableCellContent euiTableCellContent--alignRight"
+          >
+            <span
+              class="euiTableCellContent__text"
+              title="Actions"
+            >
+              Actions
+            </span>
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="css-0"
     >
-      <caption
-        class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
-      />
-      <thead>
-        <tr>
-          <th
-            class="euiTableHeaderCellCheckbox"
-            scope="col"
-          >
-            <div
-              class="euiTableCellContent"
-            >
-              <div
-                class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
-              >
-                <input
-                  aria-label="Select all rows"
-                  class="euiCheckbox__input"
-                  data-test-subj="checkboxSelectAll"
-                  id="_selection_column-checkbox_generated-id_desktop"
-                  type="checkbox"
-                />
-                <div
-                  class="euiCheckbox__square"
-                />
-              </div>
-            </div>
-          </th>
-          <th
-            aria-live="polite"
-            aria-sort="ascending"
-            class="euiTableHeaderCell"
-            data-test-subj="tableHeaderCell_name_0"
-            role="columnheader"
-            scope="col"
-          >
-            <button
-              class="euiTableHeaderButton euiTableHeaderButton-isSorted"
-              data-test-subj="tableHeaderSortButton"
-              type="button"
-            >
-              <span
-                class="euiTableCellContent"
-              >
-                <span
-                  class="euiTableCellContent__text"
-                  title="Name; your name"
-                >
-                  Name
-                </span>
-                <span
-                  class="emotion-euiScreenReaderOnly"
-                >
-                  your name
-                </span>
-                <span
-                  class="euiTableSortIcon"
-                  data-euiicon-type="sortUp"
-                />
-              </span>
-            </button>
-          </th>
-          <th
-            class="euiTableHeaderCell"
-            data-test-subj="tableHeaderCell_id_1"
-            role="columnheader"
-            scope="col"
-          >
-            <span
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-                title="ID; your id"
-              >
-                ID
-              </span>
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                your id
-              </span>
-            </span>
-          </th>
-          <th
-            class="euiTableHeaderCell"
-            data-test-subj="tableHeaderCell_age_2"
-            role="columnheader"
-            scope="col"
-          >
-            <span
-              class="euiTableCellContent euiTableCellContent--alignRight"
-            >
-              <span
-                class="euiTableCellContent__text"
-                title="Age; your age"
-              >
-                Age
-              </span>
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                your age
-              </span>
-            </span>
-          </th>
-          <th
-            class="euiTableHeaderCell"
-            role="columnheader"
-            scope="col"
-          >
-            <span
-              class="euiTableCellContent euiTableCellContent--alignRight"
-            >
-              <span
-                class="euiTableCellContent__text"
-                title="Actions"
-              >
-                Actions
-              </span>
-            </span>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="css-0"
+      <tr
+        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
       >
-        <tr
-          class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+        <td
+          class="euiTableRowCellCheckbox"
         >
-          <td
-            class="euiTableRowCellCheckbox"
+          <div
+            class="euiTableCellContent"
           >
             <div
-              class="euiTableCellContent"
+              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
             >
+              <input
+                aria-label="Select this row"
+                class="euiCheckbox__input"
+                data-test-subj="checkboxSelectRow-1"
+                id="__table_generated-id_selection_column_1-checkbox"
+                title="Select this row"
+                type="checkbox"
+              />
               <div
-                class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
-              >
-                <input
-                  aria-label="Select this row"
-                  class="euiCheckbox__input"
-                  data-test-subj="checkboxSelectRow-1"
-                  id="__table_generated-id_selection_column_1-checkbox"
-                  title="Select this row"
-                  type="checkbox"
-                />
-                <div
-                  class="euiCheckbox__square"
-                />
-              </div>
+                class="euiCheckbox__square"
+              />
             </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent euiTableCellContent--overflowingContent"
-            >
-              NAME1
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              ID
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                1
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              Age
-            </div>
-            <div
-              class="euiTableCellContent euiTableCellContent--alignRight"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                20
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableCellContent emotion-euiBasicTableActionsWrapper euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-            >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-              >
-                <button
-                  class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Edit
-                    </span>
-                  </span>
-                </button>
-              </span>
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-              >
-                <button
-                  class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Delete
-                    </span>
-                  </span>
-                </button>
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCellCheckbox"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableCellContent"
-            >
-              <div
-                class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
-              >
-                <input
-                  aria-label="Select this row"
-                  class="euiCheckbox__input"
-                  data-test-subj="checkboxSelectRow-2"
-                  id="__table_generated-id_selection_column_2-checkbox"
-                  title="Select this row"
-                  type="checkbox"
-                />
-                <div
-                  class="euiCheckbox__square"
-                />
-              </div>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent euiTableCellContent--overflowingContent"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent euiTableCellContent--overflowingContent"
-            >
-              NAME2
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              ID
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                2
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              Age
-            </div>
-            <div
-              class="euiTableCellContent euiTableCellContent--alignRight"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                21
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--middle"
-          >
-            <div
-              class="euiTableCellContent emotion-euiBasicTableActionsWrapper euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-            >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-              >
-                <button
-                  class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Edit
-                    </span>
-                  </span>
-                </button>
-              </span>
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
-              >
-                <button
-                  class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                  type="button"
-                >
-                  <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                  >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Delete
-                    </span>
-                  </span>
-                </button>
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+            NAME1
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCellCheckbox"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+          >
+            ID
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
+            >
+              1
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+          >
+            Age
+          </div>
+          <div
+            class="euiTableCellContent euiTableCellContent--alignRight"
+          >
+            <span
+              class="euiTableCellContent__text"
+            >
+              20
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableCellContent emotion-euiBasicTableActionsWrapper euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+          >
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            >
+              <button
+                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                type="button"
+              >
+                <span
+                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                >
+                  <span
+                    class="eui-textTruncate euiButtonEmpty__text"
+                  >
+                    Edit
+                  </span>
+                </span>
+              </button>
+            </span>
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            >
+              <button
+                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                type="button"
+              >
+                <span
+                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                >
+                  <span
+                    class="eui-textTruncate euiButtonEmpty__text"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </button>
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+      >
+        <td
+          class="euiTableRowCellCheckbox"
+        >
+          <div
+            class="euiTableCellContent"
           >
             <div
-              class="euiTableCellContent"
+              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
             >
+              <input
+                aria-label="Select this row"
+                class="euiCheckbox__input"
+                data-test-subj="checkboxSelectRow-2"
+                id="__table_generated-id_selection_column_2-checkbox"
+                title="Select this row"
+                type="checkbox"
+              />
               <div
-                class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
-              >
-                <input
-                  aria-label="Select this row"
-                  class="euiCheckbox__input"
-                  data-test-subj="checkboxSelectRow-3"
-                  id="__table_generated-id_selection_column_3-checkbox"
-                  title="Select this row"
-                  type="checkbox"
-                />
-                <div
-                  class="euiCheckbox__square"
-                />
-              </div>
+                class="euiCheckbox__square"
+              />
             </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent euiTableCellContent--overflowingContent"
-            >
-              NAME3
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent euiTableCellContent--overflowingContent"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              ID
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                3
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+            NAME2
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-            >
-              Age
-            </div>
-            <div
-              class="euiTableCellContent euiTableCellContent--alignRight"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                22
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--middle"
+            ID
+          </div>
+          <div
+            class="euiTableCellContent"
           >
-            <div
-              class="euiTableCellContent emotion-euiBasicTableActionsWrapper euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+            <span
+              class="euiTableCellContent__text"
             >
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+              2
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+          >
+            Age
+          </div>
+          <div
+            class="euiTableCellContent euiTableCellContent--alignRight"
+          >
+            <span
+              class="euiTableCellContent__text"
+            >
+              21
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableCellContent emotion-euiBasicTableActionsWrapper euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+          >
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            >
+              <button
+                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                type="button"
               >
-                <button
-                  class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                  type="button"
+                <span
+                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                 >
                   <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                    class="eui-textTruncate euiButtonEmpty__text"
                   >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Edit
-                    </span>
+                    Edit
                   </span>
-                </button>
-              </span>
-              <span
-                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                </span>
+              </button>
+            </span>
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            >
+              <button
+                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                type="button"
               >
-                <button
-                  class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                  type="button"
+                <span
+                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                 >
                   <span
-                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                    class="eui-textTruncate euiButtonEmpty__text"
                   >
-                    <span
-                      class="eui-textTruncate euiButtonEmpty__text"
-                    >
-                      Delete
-                    </span>
+                    Delete
                   </span>
-                </button>
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-      <tfoot>
-        <tr>
-          <td
-            class="euiTableFooterCell"
+                </span>
+              </button>
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+      >
+        <td
+          class="euiTableRowCellCheckbox"
+        >
+          <div
+            class="euiTableCellContent"
           >
             <div
-              class="euiTableCellContent"
+              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
             >
-              <span
-                class="euiTableCellContent__text"
+              <input
+                aria-label="Select this row"
+                class="euiCheckbox__input"
+                data-test-subj="checkboxSelectRow-3"
+                id="__table_generated-id_selection_column_3-checkbox"
+                title="Select this row"
+                type="checkbox"
+              />
+              <div
+                class="euiCheckbox__square"
               />
             </div>
-          </td>
-          <td
-            class="euiTableFooterCell"
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              />
-            </div>
-          </td>
-          <td
-            class="euiTableFooterCell"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent euiTableCellContent--overflowingContent"
           >
-            <div
-              class="euiTableCellContent"
+            NAME3
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+          >
+            ID
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              <span
-                class="euiTableCellContent__text"
+              3
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+          >
+            Age
+          </div>
+          <div
+            class="euiTableCellContent euiTableCellContent--alignRight"
+          >
+            <span
+              class="euiTableCellContent__text"
+            >
+              22
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableRowCell euiTableRowCell--hasActions euiTableRowCell--middle"
+        >
+          <div
+            class="euiTableCellContent emotion-euiBasicTableActionsWrapper euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+          >
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            >
+              <button
+                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                type="button"
               >
-                <strong>
-                  Total items: 
-                  5
-                </strong>
-              </span>
-            </div>
-          </td>
-          <td
-            class="euiTableFooterCell"
-          >
-            <div
-              class="euiTableCellContent"
+                <span
+                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                >
+                  <span
+                    class="eui-textTruncate euiButtonEmpty__text"
+                  >
+                    Edit
+                  </span>
+                </span>
+              </button>
+            </span>
+            <span
+              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
-              <span
-                class="euiTableCellContent__text"
-              />
-            </div>
-          </td>
-          <td
-            class="euiTableFooterCell"
+              <button
+                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                type="button"
+              >
+                <span
+                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                >
+                  <span
+                    class="eui-textTruncate euiButtonEmpty__text"
+                  >
+                    Delete
+                  </span>
+                </span>
+              </button>
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td
+          class="euiTableFooterCell"
+        >
+          <div
+            class="euiTableCellContent"
           >
-            <div
-              class="euiTableCellContent"
+            <span
+              class="euiTableCellContent__text"
+            />
+          </div>
+        </td>
+        <td
+          class="euiTableFooterCell"
+        >
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
+            />
+          </div>
+        </td>
+        <td
+          class="euiTableFooterCell"
+        >
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              <span
-                class="euiTableCellContent__text"
-              />
-            </div>
-          </td>
-        </tr>
-      </tfoot>
-    </table>
-  </div>
+              <strong>
+                Total items: 
+                5
+              </strong>
+            </span>
+          </div>
+        </td>
+        <td
+          class="euiTableFooterCell"
+        >
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
+            />
+          </div>
+        </td>
+        <td
+          class="euiTableFooterCell"
+        >
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
+            />
+          </div>
+        </td>
+      </tr>
+    </tfoot>
+  </table>
   <div>
     <div
       class="euiSpacer euiSpacer--m emotion-euiSpacer-m"

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -7,20 +7,6 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
   data-test-subj="test subject string"
 >
   <div>
-    <div
-      class="euiTableHeaderMobile"
-    >
-      <div
-        class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-baseline-row"
-      >
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        />
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        />
-      </div>
-    </div>
     <table
       class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
       id="__table_generated-id"
@@ -135,67 +121,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
   class="euiBasicTable"
 >
   <div>
-    <div
-      class="euiTableHeaderMobile"
-    >
-      <div
-        class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-baseline-row"
-      >
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        >
-          <div
-            class="euiCheckbox emotion-euiCheckbox"
-          >
-            <input
-              aria-label="Select all rows"
-              class="euiCheckbox__input"
-              id="_selection_column-checkbox_generated-id_mobile"
-              type="checkbox"
-            />
-            <div
-              class="euiCheckbox__square"
-            />
-            <label
-              class="euiCheckbox__label"
-              for="_selection_column-checkbox_generated-id_mobile"
-            >
-              Select all rows
-            </label>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        >
-          <div
-            class="euiTableSortMobile"
-          >
-            <div
-              class="euiPopover emotion-euiPopover-inline-block"
-            >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-primary-flush-right"
-                type="button"
-              >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-                >
-                  <span
-                    class="eui-textTruncate euiButtonEmpty__text"
-                  >
-                    Sorting
-                  </span>
-                  <span
-                    color="inherit"
-                    data-euiicon-type="arrowDown"
-                  />
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
     <table
       class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
       id="__table_generated-id"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiInMemoryTable behavior mobile header 1`] = `
+<div
+  class="euiTableHeaderMobile emotion-euiTableHeaderMobile"
+>
+  <div
+    class="euiCheckbox emotion-euiCheckbox"
+  >
+    <input
+      aria-label="Select all rows"
+      class="euiCheckbox__input"
+      id="_selection_column-checkbox_generated-id_mobile"
+      type="checkbox"
+    />
+    <div
+      class="euiCheckbox__square"
+    />
+    <label
+      class="euiCheckbox__label"
+      for="_selection_column-checkbox_generated-id_mobile"
+    >
+      Select all rows
+    </label>
+  </div>
+  <div
+    class="euiTableSortMobile"
+  >
+    <div
+      class="euiPopover emotion-euiPopover-inline-block"
+    >
+      <button
+        class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-xs-empty-primary-flush-right"
+        type="button"
+      >
+        <span
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+        >
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            Sorting
+          </span>
+          <span
+            color="inherit"
+            data-euiicon-type="arrowDown"
+          />
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EuiInMemoryTable behavior pagination 1`] = `
 <nav
   aria-label="Pagination for table: "
@@ -103,20 +155,6 @@ exports[`EuiInMemoryTable empty array 1`] = `
   data-test-subj="test subject string"
 >
   <div>
-    <div
-      class="euiTableHeaderMobile"
-    >
-      <div
-        class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-baseline-row"
-      >
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        />
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        />
-      </div>
-    </div>
     <table
       class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
       id="__table_generated-id"
@@ -212,20 +250,6 @@ exports[`EuiInMemoryTable with items 1`] = `
   data-test-subj="test subject string"
 >
   <div>
-    <div
-      class="euiTableHeaderMobile"
-    >
-      <div
-        class="euiFlexGroup emotion-euiFlexGroup-l-spaceBetween-baseline-row"
-      >
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        />
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        />
-      </div>
-    </div>
     <table
       class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
       id="__table_generated-id"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`EuiInMemoryTable empty array 1`] = `
 >
   <div>
     <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
+      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
       id="__table_generated-id"
       tabindex="-1"
     >
@@ -251,7 +251,7 @@ exports[`EuiInMemoryTable with items 1`] = `
 >
   <div>
     <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed"
+      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
       id="__table_generated-id"
       tabindex="-1"
     >

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`EuiInMemoryTable behavior mobile header 1`] = `
     </label>
   </div>
   <div
-    class="euiTableSortMobile"
+    class="euiTableSortMobile emotion-euiTableSortMobile"
   >
     <div
       class="euiPopover emotion-euiPopover-inline-block"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -154,65 +154,63 @@ exports[`EuiInMemoryTable empty array 1`] = `
   class="euiBasicTable testClass1 testClass2 emotion-euiTestCss"
   data-test-subj="test subject string"
 >
-  <div>
-    <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
-      id="__table_generated-id"
-      tabindex="-1"
-    >
-      <caption
-        class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
-      />
-      <thead>
-        <tr>
-          <th
-            class="euiTableHeaderCell"
-            data-test-subj="tableHeaderCell_name_0"
-            role="columnheader"
-            scope="col"
+  <table
+    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    id="__table_generated-id"
+    tabindex="-1"
+  >
+    <caption
+      class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
+    />
+    <thead>
+      <tr>
+        <th
+          class="euiTableHeaderCell"
+          data-test-subj="tableHeaderCell_name_0"
+          role="columnheader"
+          scope="col"
+        >
+          <span
+            class="euiTableCellContent"
           >
             <span
-              class="euiTableCellContent"
+              class="euiTableCellContent__text"
+              title="Name; description"
             >
-              <span
-                class="euiTableCellContent__text"
-                title="Name; description"
-              >
-                Name
-              </span>
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                description
-              </span>
+              Name
             </span>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="css-0"
-      >
-        <tr
-          class="euiTableRow"
-        >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
-            colspan="1"
-          >
-            <div
-              class="euiTableCellContent euiTableCellContent--alignCenter"
+            <span
+              class="emotion-euiScreenReaderOnly"
             >
-              <span
-                class="euiTableCellContent__text"
-              >
-                No items found
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+              description
+            </span>
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="css-0"
+    >
+      <tr
+        class="euiTableRow"
+      >
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
+          colspan="1"
+        >
+          <div
+            class="euiTableCellContent euiTableCellContent--alignCenter"
+          >
+            <span
+              class="euiTableCellContent__text"
+            >
+              No items found
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
@@ -249,112 +247,110 @@ exports[`EuiInMemoryTable with items 1`] = `
   class="euiBasicTable testClass1 testClass2 emotion-euiTestCss"
   data-test-subj="test subject string"
 >
-  <div>
-    <table
-      class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
-      id="__table_generated-id"
-      tabindex="-1"
-    >
-      <caption
-        class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
-      />
-      <thead>
-        <tr>
-          <th
-            class="euiTableHeaderCell"
-            data-test-subj="tableHeaderCell_name_0"
-            role="columnheader"
-            scope="col"
+  <table
+    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    id="__table_generated-id"
+    tabindex="-1"
+  >
+    <caption
+      class="euiTableCaption emotion-euiTableCaptionStyles-euiScreenReaderOnly"
+    />
+    <thead>
+      <tr>
+        <th
+          class="euiTableHeaderCell"
+          data-test-subj="tableHeaderCell_name_0"
+          role="columnheader"
+          scope="col"
+        >
+          <span
+            class="euiTableCellContent"
           >
             <span
-              class="euiTableCellContent"
+              class="euiTableCellContent__text"
+              title="Name; description"
             >
-              <span
-                class="euiTableCellContent__text"
-                title="Name; description"
-              >
-                Name
-              </span>
-              <span
-                class="emotion-euiScreenReaderOnly"
-              >
-                description
-              </span>
+              Name
             </span>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="css-0"
+            <span
+              class="emotion-euiScreenReaderOnly"
+            >
+              description
+            </span>
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class="css-0"
+    >
+      <tr
+        class="euiTableRow"
       >
-        <tr
-          class="euiTableRow"
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                name1
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="euiTableRow"
+              name1
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="euiTableRow"
+      >
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                name2
-              </span>
-            </div>
-          </td>
-        </tr>
-        <tr
-          class="euiTableRow"
+              name2
+            </span>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="euiTableRow"
+      >
+        <td
+          class="euiTableRowCell euiTableRowCell--middle"
         >
-          <td
-            class="euiTableRowCell euiTableRowCell--middle"
+          <div
+            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
           >
-            <div
-              class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+            Name
+          </div>
+          <div
+            class="euiTableCellContent"
+          >
+            <span
+              class="euiTableCellContent__text"
             >
-              Name
-            </div>
-            <div
-              class="euiTableCellContent"
-            >
-              <span
-                class="euiTableCellContent__text"
-              >
-                name3
-              </span>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+              name3
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -30,7 +30,6 @@ import {
 import { CommonProps } from '../common';
 import { isFunction } from '../../services/predicate';
 import { get } from '../../services/objects';
-import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiCheckbox } from '../form';
 
 import { EuiComponentDefaultsContext } from '../provider/component_defaults';
@@ -564,15 +563,9 @@ export class EuiBasicTable<T extends object = any> extends Component<
     } = this.props;
 
     const mobileHeader = responsive ? (
-      <EuiTableHeaderMobile>
-        <EuiFlexGroup
-          responsive={false}
-          justifyContent="spaceBetween"
-          alignItems="baseline"
-        >
-          <EuiFlexItem grow={false}>{this.renderSelectAll(true)}</EuiFlexItem>
-          <EuiFlexItem grow={false}>{this.renderTableMobileSort()}</EuiFlexItem>
-        </EuiFlexGroup>
+      <EuiTableHeaderMobile responsiveBreakpoint={responsiveBreakpoint}>
+        {this.renderSelectAll(true)}
+        {this.renderTableMobileSort()}
       </EuiTableHeaderMobile>
     ) : undefined;
     const caption = this.renderTableCaption();

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -262,10 +262,6 @@ interface BasicTableProps<T extends object>
    */
   pagination?: undefined;
   /**
-   * If true, will convert table to cards in mobile view
-   */
-  responsive?: boolean;
-  /**
    * Applied to `EuiTableRow`
    */
   rowProps?: object | RowPropsCallback<T>;
@@ -529,6 +525,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
       compressed,
       itemIdToExpandedRowMap,
       responsive,
+      responsiveBreakpoint,
       isSelectable,
       isExpandable,
       hasActions,
@@ -558,7 +555,13 @@ export class EuiBasicTable<T extends object = any> extends Component<
   }
 
   renderTable() {
-    const { compressed, responsive, tableLayout, loading } = this.props;
+    const {
+      compressed,
+      responsive,
+      responsiveBreakpoint,
+      tableLayout,
+      loading,
+    } = this.props;
 
     const mobileHeader = responsive ? (
       <EuiTableHeaderMobile>
@@ -582,6 +585,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
         <EuiTable
           id={this.tableId}
           tableLayout={tableLayout}
+          responsiveBreakpoint={responsiveBreakpoint}
           responsive={responsive}
           compressed={compressed}
           css={loading && safariLoadingWorkaround}

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -562,19 +562,15 @@ export class EuiBasicTable<T extends object = any> extends Component<
       loading,
     } = this.props;
 
-    const mobileHeader = responsive ? (
-      <EuiTableHeaderMobile responsiveBreakpoint={responsiveBreakpoint}>
-        {this.renderSelectAll(true)}
-        {this.renderTableMobileSort()}
-      </EuiTableHeaderMobile>
-    ) : undefined;
-    const caption = this.renderTableCaption();
-    const head = this.renderTableHead();
-    const body = this.renderTableBody();
-    const footer = this.renderTableFooter();
     return (
-      <div>
-        {mobileHeader}
+      <>
+        {/* TODO: Remove conditional once `responsive` prop is deprecated */}
+        {responsive && (
+          <EuiTableHeaderMobile responsiveBreakpoint={responsiveBreakpoint}>
+            {this.renderSelectAll(true)}
+            {this.renderTableMobileSort()}
+          </EuiTableHeaderMobile>
+        )}
         <EuiTable
           id={this.tableId}
           tableLayout={tableLayout}
@@ -583,12 +579,12 @@ export class EuiBasicTable<T extends object = any> extends Component<
           compressed={compressed}
           css={loading && safariLoadingWorkaround}
         >
-          {caption}
-          {head}
-          {body}
-          {footer}
+          {this.renderTableCaption()}
+          {this.renderTableHead()}
+          {this.renderTableBody()}
+          {this.renderTableFooter()}
         </EuiTable>
-      </div>
+      </>
     );
   }
 

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -638,7 +638,9 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const { getByText } = render(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(
+      <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
+    );
 
     expect(getByText('Page 1 of 1')).toBeTruthy();
     expect(getByText('Select all rows')).toBeTruthy();
@@ -667,7 +669,9 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const { getByText } = render(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(
+      <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
+    );
 
     expect(getByText('Page 1 of 1')).toBeTruthy();
     expect(getByText('Select all rows')).toBeTruthy();
@@ -700,7 +704,9 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const { getByText } = render(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(
+      <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
+    );
 
     expect(getByText('Page 1 of 2')).toBeTruthy();
     expect(getByText('Select all rows')).toBeTruthy();
@@ -741,7 +747,9 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const { getByText } = render(<EuiInMemoryTable {...props} />);
+    const { getByText } = render(
+      <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
+    );
 
     expect(getByText('Page 1 of 1')).toBeTruthy();
     expect(getByText('Select all rows')).toBeTruthy();
@@ -784,7 +792,7 @@ describe('EuiInMemoryTable', () => {
       },
     };
     const { getByText, getByPlaceholderText } = render(
-      <EuiInMemoryTable {...props} />
+      <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
     );
 
     expect(getByText('Page 1 of 1')).toBeTruthy();
@@ -881,7 +889,9 @@ describe('EuiInMemoryTable', () => {
         onSelectionChange: () => undefined,
       },
     };
-    const { container, queryByText } = render(<EuiInMemoryTable {...props} />);
+    const { container, queryByText } = render(
+      <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
+    );
 
     expect(queryByText('Page 1 of 1')).toBeTruthy();
     expect(queryByText('Select all rows')).toBeTruthy();
@@ -1088,6 +1098,38 @@ describe('EuiInMemoryTable', () => {
   });
 
   describe('behavior', () => {
+    test('mobile header', () => {
+      const props: EuiInMemoryTableProps<BasicItem> = {
+        ...requiredProps,
+        items: [
+          { id: '1', name: 'name1' },
+          { id: '2', name: 'name2' },
+          { id: '3', name: 'name3' },
+        ],
+        itemId: 'id',
+        columns: [
+          {
+            field: 'name',
+            name: 'Name',
+            description: 'description',
+            sortable: true,
+          },
+        ],
+        pagination: true,
+        sorting: true,
+        selection: {
+          onSelectionChange: () => undefined,
+        },
+      };
+      const { container } = render(
+        <EuiInMemoryTable responsiveBreakpoint={true} {...props} />
+      );
+
+      expect(
+        container.querySelector('.euiTableHeaderMobile')
+      ).toMatchSnapshot();
+    });
+
     test('pagination', async () => {
       const props: EuiInMemoryTableProps<BasicItem> = {
         ...requiredProps,

--- a/src/components/provider/component_defaults/component_defaults.tsx
+++ b/src/components/provider/component_defaults/component_defaults.tsx
@@ -16,7 +16,7 @@ import React, {
 
 import type { EuiPortalProps } from '../../portal';
 import type { EuiFocusTrapProps } from '../../focus_trap';
-import type { EuiTablePaginationProps } from '../../table';
+import type { EuiTablePaginationProps, EuiTableProps } from '../../table';
 
 export type EuiComponentDefaults = {
   /**
@@ -37,6 +37,12 @@ export type EuiComponentDefaults = {
     EuiTablePaginationProps,
     'itemsPerPage' | 'itemsPerPageOptions' | 'showPerPageOptions'
   >;
+  /**
+   * Provide a global configuration for EuiTable's `responsiveBreakpoint` prop. Defaults to `'s'`.
+   *
+   * Defaults will be inherited all `EuiBasicTable`s and `EuiInMemoryTable`s.
+   */
+  EuiTable?: Pick<EuiTableProps, 'responsiveBreakpoint'>;
 };
 
 // Declaring as a static const for reference integrity/reducing rerenders

--- a/src/components/provider/component_defaults/component_defaults.tsx
+++ b/src/components/provider/component_defaults/component_defaults.tsx
@@ -40,7 +40,7 @@ export type EuiComponentDefaults = {
   /**
    * Provide a global configuration for EuiTable's `responsiveBreakpoint` prop. Defaults to `'s'`.
    *
-   * Defaults will be inherited all `EuiBasicTable`s and `EuiInMemoryTable`s.
+   * Defaults will be inherited by all `EuiBasicTable`s and `EuiInMemoryTable`s.
    */
   EuiTable?: Pick<EuiTableProps, 'responsiveBreakpoint'>;
 };

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders EuiTable 1`] = `
+exports[`EuiTable renders 1`] = `
 <table
   aria-label="aria-label"
   class="euiTable testClass1 testClass2 euiTable--responsive emotion-euiTable-fixed-uncompressed-euiTestCss"

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiTable renders 1`] = `
 <table
   aria-label="aria-label"
-  class="euiTable testClass1 testClass2 euiTable--responsive emotion-euiTable-fixed-uncompressed-euiTestCss"
+  class="euiTable testClass1 testClass2 euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop-euiTestCss"
   data-test-subj="test subject string"
   tabindex="-1"
 >

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -3,5 +3,3 @@
 
 @import 'table';
 @import 'responsive';
-
-@import 'mobile/index';

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -1,41 +1,13 @@
 // TODO: Address nesting during Emotion conversion, if possible
 // stylelint-disable max-nesting-depth
 
-.euiTableRowCell__mobileHeader {
-  // Don't display by default unless table is responsive
-  display: none;
-}
-
-@include euiBreakpoint('xs', 's') {
-  .euiTableRowCell--hideForMobile { // must come last to override any special cases
-    // stylelint-disable-next-line declaration-no-important
-    display: none !important;
-  }
-}
-
-@include euiBreakpoint('m', 'l', 'xl') {
-  .euiTableRowCell--hideForDesktop { // must come last to override any special cases
-    // stylelint-disable-next-line declaration-no-important
-    display: none !important;
-  }
-}
-
 @include euiBreakpoint('xs', 's') {
   .euiTable.euiTable--responsive {
-    thead {
-      display: none; // Use mobile versions of selecting and filtering instead
-    }
-
-    tfoot {
-      display: none; // Not supporting responsive footer content
-    }
-
     .euiTableRowCell__mobileHeader {
       // Always truncate
       @include euiTextTruncate;
       @include fontSize($euiFontSize * .6875);
 
-      display: block;
       color: $euiColorDarkShade;
       padding: $euiSizeS;
       padding-bottom: 0;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -101,10 +101,6 @@
   &--baseline {
     vertical-align: baseline;
   }
-
-  &.euiTableRowCell--isMobileHeader {
-    display: none; // Hide if not mobile breakpoint
-  }
 }
 
 .euiTableRowCellCheckbox {

--- a/src/components/table/mobile/__snapshots__/table_header_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_header_mobile.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EuiTableHeaderMobile is rendered 1`] = `
+exports[`EuiTableHeaderMobile renders when below the responsive breakpoint 1`] = `
 <div
   aria-label="aria-label"
-  class="euiTableHeaderMobile testClass1 testClass2 emotion-euiTestCss"
+  class="euiTableHeaderMobile testClass1 testClass2 emotion-euiTableHeaderMobile-euiTestCss"
   data-test-subj="test subject string"
 />
 `;

--- a/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
+++ b/src/components/table/mobile/__snapshots__/table_sort_mobile.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EuiTableSortMobile is rendered 1`] = `
 <div
-  class="euiTableSortMobile testClass1 testClass2 emotion-euiTestCss"
+  class="euiTableSortMobile testClass1 testClass2 emotion-euiTableSortMobile-euiTestCss"
 >
   <div
     class="euiPopover emotion-euiPopover-inline-block"

--- a/src/components/table/mobile/_index.scss
+++ b/src/components/table/mobile/_index.scss
@@ -1,1 +1,0 @@
-@import 'mobile';

--- a/src/components/table/mobile/_mobile.scss
+++ b/src/components/table/mobile/_mobile.scss
@@ -1,4 +1,0 @@
-// Hide mobile-only elements by default
-.euiTableHeaderCell--hideForDesktop {
-  display: none;
-}

--- a/src/components/table/mobile/_mobile.scss
+++ b/src/components/table/mobile/_mobile.scss
@@ -1,17 +1,4 @@
 // Hide mobile-only elements by default
-.euiTableHeaderMobile,
 .euiTableHeaderCell--hideForDesktop {
   display: none;
-}
-
-@include euiBreakpoint('xs', 's') {
-  .euiTableHeaderMobile {
-    display: flex;
-    justify-content: flex-end;
-    padding: $euiTableCellContentPadding 0;
-  }
-
-  .euiTableSortMobile {
-    display: block;
-  }
 }

--- a/src/components/table/mobile/responsive_context.ts
+++ b/src/components/table/mobile/responsive_context.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { createContext, useContext } from 'react';
 import {
   useIsWithinMinBreakpoint,
   type EuiBreakpointSize,
@@ -32,3 +33,12 @@ export const useIsEuiTableResponsive = (
   const isResponsive = !useIsWithinMinBreakpoint(isBoolean ? '' : breakpoint);
   return isBoolean ? breakpoint : isResponsive;
 };
+
+/**
+ * Context set by parent table components
+ * Hook used by cells to fetch parent isResponsive state
+ */
+export const EuiTableIsResponsiveContext = createContext<boolean>(false);
+
+export const useEuiTableIsResponsive = () =>
+  useContext(EuiTableIsResponsiveContext);

--- a/src/components/table/mobile/responsive_context.ts
+++ b/src/components/table/mobile/responsive_context.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  useIsWithinMinBreakpoint,
+  type EuiBreakpointSize,
+} from '../../../services';
+import { useComponentDefaults } from '../../provider/component_defaults';
+
+export const DEFAULT_TABLE_BREAKPOINT: EuiBreakpointSize = 'm';
+
+/**
+ * Used by parent/top-level table components to determine isResponsive state
+ * based on the passed breakpoint
+ */
+export const useIsEuiTableResponsive = (
+  componentProp?: EuiBreakpointSize | boolean
+): boolean => {
+  const componentDefault =
+    useComponentDefaults().EuiTable?.responsiveBreakpoint;
+  const breakpoint =
+    componentProp ?? componentDefault ?? DEFAULT_TABLE_BREAKPOINT;
+
+  const isBoolean = typeof breakpoint === 'boolean';
+
+  // We use ! and minBreakpoint to more accurately reflect the single point at which tables collapse
+  const isResponsive = !useIsWithinMinBreakpoint(isBoolean ? '' : breakpoint);
+  return isBoolean ? breakpoint : isResponsive;
+};

--- a/src/components/table/mobile/responsive_context.ts
+++ b/src/components/table/mobile/responsive_context.ts
@@ -29,7 +29,8 @@ export const useIsEuiTableResponsive = (
 
   const isBoolean = typeof breakpoint === 'boolean';
 
-  // We use ! and minBreakpoint to more accurately reflect the single point at which tables collapse
+  // Note: we're using `!useIsWithinMinBreakpoint` here instead of `useIsWithinMaxBreakpoint`
+  // because it more accurately reflects the single breakpoint at which tables collapse
   const isResponsive = !useIsWithinMinBreakpoint(isBoolean ? '' : breakpoint);
   return isBoolean ? breakpoint : isResponsive;
 };

--- a/src/components/table/mobile/table_header_mobile.styles.ts
+++ b/src/components/table/mobile/table_header_mobile.styles.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../../services';
+
+export const euiTableHeaderMobileStyles = ({ euiTheme }: UseEuiTheme) => ({
+  euiTableHeaderMobile: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding-block: ${euiTheme.size.s};
+  `,
+});

--- a/src/components/table/mobile/table_header_mobile.test.tsx
+++ b/src/components/table/mobile/table_header_mobile.test.tsx
@@ -9,13 +9,38 @@
 import React from 'react';
 import { requiredProps } from '../../../test';
 import { render } from '../../../test/rtl';
+import { EuiProvider } from '../../provider';
 
 import { EuiTableHeaderMobile } from './table_header_mobile';
 
 describe('EuiTableHeaderMobile', () => {
-  test('is rendered', () => {
-    const { container } = render(<EuiTableHeaderMobile {...requiredProps} />);
+  it('does not render if window size is above the default m breakpoint', () => {
+    const { container } = render(<EuiTableHeaderMobile />);
 
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders when below the responsive breakpoint', () => {
+    const { container } = render(
+      <EuiTableHeaderMobile responsiveBreakpoint="xl" {...requiredProps} />
+    );
+
+    expect(container).not.toBeEmptyDOMElement();
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('respects EuiProvider.componentDefaults', () => {
+    const { container } = render(
+      <EuiProvider
+        componentDefaults={{
+          EuiTable: { responsiveBreakpoint: 'xl' },
+        }}
+      >
+        <EuiTableHeaderMobile />
+      </EuiProvider>,
+      { wrapper: undefined }
+    );
+
+    expect(container).not.toBeEmptyDOMElement();
   });
 });

--- a/src/components/table/mobile/table_header_mobile.tsx
+++ b/src/components/table/mobile/table_header_mobile.tsx
@@ -8,16 +8,26 @@
 
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
+
+import { useEuiMemoizedStyles } from '../../../services';
 import { CommonProps } from '../../common';
 
+import type { EuiTableProps } from '../table';
+import { useIsEuiTableResponsive } from './responsive_context';
+import { euiTableHeaderMobileStyles } from './table_header_mobile.styles';
+
 export const EuiTableHeaderMobile: FunctionComponent<
-  CommonProps & HTMLAttributes<HTMLDivElement>
-> = ({ children, className, ...rest }) => {
+  CommonProps &
+    HTMLAttributes<HTMLDivElement> &
+    Pick<EuiTableProps, 'responsiveBreakpoint'>
+> = ({ children, className, responsiveBreakpoint, ...rest }) => {
+  const isResponsive = useIsEuiTableResponsive(responsiveBreakpoint);
+  const styles = useEuiMemoizedStyles(euiTableHeaderMobileStyles);
   const classes = classNames('euiTableHeaderMobile', className);
 
-  return (
-    <div className={classes} {...rest}>
+  return isResponsive ? (
+    <div className={classes} css={styles.euiTableHeaderMobile} {...rest}>
       {children}
     </div>
-  );
+  ) : null;
 };

--- a/src/components/table/mobile/table_sort_mobile.tsx
+++ b/src/components/table/mobile/table_sort_mobile.tsx
@@ -9,10 +9,12 @@
 import React, { Component, ReactNode, Key } from 'react';
 import classNames from 'classnames';
 
+import { CommonProps } from '../../common';
 import { EuiButtonEmpty } from '../../button/button_empty';
 import { EuiPopover, PopoverAnchorPosition } from '../../popover';
 import { EuiContextMenuPanel } from '../../context_menu';
 import { EuiI18n } from '../../i18n';
+
 import { EuiTableSortMobileItem } from './table_sort_mobile_item';
 
 interface ItemProps {
@@ -23,8 +25,7 @@ interface ItemProps {
   isSortAscending?: boolean;
 }
 
-export interface EuiTableSortMobileProps {
-  className?: string;
+export interface EuiTableSortMobileProps extends CommonProps {
   anchorPosition?: PopoverAnchorPosition;
   items?: ItemProps[];
 }
@@ -51,6 +52,12 @@ export class EuiTableSortMobile extends Component<
     this.setState({
       isPopoverOpen: false,
     });
+  };
+
+  // Aligns the button to the right even when it's the only element present
+  euiTableSortMobileStyles = {
+    marginInlineStart: 'auto',
+    label: 'euiTableSortMobile',
   };
 
   render() {
@@ -101,6 +108,10 @@ export class EuiTableSortMobile extends Component<
       </EuiPopover>
     );
 
-    return <div className={classes}>{mobileSortPopover}</div>;
+    return (
+      <div className={classes} css={this.euiTableSortMobileStyles}>
+        {mobileSortPopover}
+      </div>
+    );
   }
 }

--- a/src/components/table/table.styles.ts
+++ b/src/components/table/table.styles.ts
@@ -56,6 +56,29 @@ export const euiTableStyles = (euiThemeContext: UseEuiTheme) => {
         padding: ${compressedCellContentPadding};
       }
     `,
+    /**
+     * Responsive/mobile vs desktop styles
+     */
+    desktop: css`
+      .euiTableHeaderCell--hideForDesktop,
+      .euiTableRowCell--hideForDesktop,
+      .euiTableRowCell__mobileHeader {
+        display: none;
+      }
+    `,
+    mobile: css`
+      .euiTableRowCell--hideForMobile {
+        display: none;
+      }
+
+      thead {
+        display: none; /* Use mobile versions of selecting and filtering instead */
+      }
+
+      tfoot {
+        display: none; /* Not supporting responsive footer content */
+      }
+    `,
   };
 };
 

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { requiredProps } from '../../test/required_props';
 import { render } from '../../test/rtl';
+import { EuiProvider } from '../provider';
 
 import { EuiTable } from './table';
 import { EuiTableRow } from './table_row';
@@ -17,22 +18,68 @@ import { EuiTableBody } from './table_body';
 import { EuiTableHeader } from './table_header';
 import { EuiTableHeaderCell } from './table_header_cell';
 
-test('renders EuiTable', () => {
-  const { container } = render(
-    <EuiTable {...requiredProps}>
-      <EuiTableHeader>
-        <EuiTableHeaderCell>Hi Title</EuiTableHeaderCell>
-        <EuiTableHeaderCell>Bye Title</EuiTableHeaderCell>
-      </EuiTableHeader>
-      <EuiTableBody>
-        <EuiTableRow>
-          <EuiTableRowCell>Hi</EuiTableRowCell>
-        </EuiTableRow>
-        <EuiTableRow>
-          <EuiTableRowCell>Bye</EuiTableRowCell>
-        </EuiTableRow>
-      </EuiTableBody>
-    </EuiTable>
-  );
-  expect(container.firstChild).toMatchSnapshot();
+describe('EuiTable', () => {
+  it('renders', () => {
+    const { container } = render(
+      <EuiTable {...requiredProps}>
+        <EuiTableHeader>
+          <EuiTableHeaderCell>Hi Title</EuiTableHeaderCell>
+          <EuiTableHeaderCell>Bye Title</EuiTableHeaderCell>
+        </EuiTableHeader>
+        <EuiTableBody>
+          <EuiTableRow>
+            <EuiTableRowCell>Hi</EuiTableRowCell>
+          </EuiTableRow>
+          <EuiTableRow>
+            <EuiTableRowCell>Bye</EuiTableRowCell>
+          </EuiTableRow>
+        </EuiTableBody>
+      </EuiTable>
+    );
+    expect(container.firstChild).toMatchSnapshot();
+    expect(container.firstChild).not.toHaveClass('euiTable--responsive');
+  });
+
+  describe('responsive/mobile context', () => {
+    it('renders responsive styles if below the default m breakpoint', () => {
+      window.innerWidth = 767;
+      const { container } = render(<EuiTable />);
+      expect(container.firstChild).toHaveClass('euiTable--responsive');
+    });
+
+    it('allows customizing responsiveBreakpoint', () => {
+      const { container } = render(<EuiTable responsiveBreakpoint="xl" />);
+
+      expect(container.firstChild).toHaveClass('euiTable--responsive');
+    });
+
+    it('allows customizing responsiveBreakpoint via EuiProvider.componentDefaults', () => {
+      const { container } = render(
+        <EuiProvider
+          componentDefaults={{
+            EuiTable: { responsiveBreakpoint: 'xl' },
+          }}
+        >
+          <EuiTable />
+        </EuiProvider>,
+        { wrapper: undefined }
+      );
+
+      expect(container.firstChild).toHaveClass('euiTable--responsive');
+    });
+  });
+
+  it('always renders responsive tables styles if set to `true`', () => {
+    window.innerWidth = 2000;
+    const { container } = render(<EuiTable responsiveBreakpoint={true} />);
+
+    expect(container.firstElementChild!.className).toContain('-mobile');
+  });
+
+  it('allows never rendering responsive tables if set to `false`', () => {
+    window.innerWidth = 320;
+    const { container } = render(<EuiTable responsiveBreakpoint={false} />);
+
+    expect(container.firstChild).not.toHaveClass('euiTable--responsive');
+  });
 });

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -76,7 +76,7 @@ describe('EuiTable', () => {
     expect(container.firstElementChild!.className).toContain('-mobile');
   });
 
-  it('allows never rendering responsive tables if set to `false`', () => {
+  it('never renders responsive tables if set to `false`', () => {
     window.innerWidth = 320;
     const { container } = render(<EuiTable responsiveBreakpoint={false} />);
 

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -73,7 +73,7 @@ describe('EuiTable', () => {
     window.innerWidth = 2000;
     const { container } = render(<EuiTable responsiveBreakpoint={true} />);
 
-    expect(container.firstElementChild!.className).toContain('-mobile');
+    expect(container.firstChild).toHaveClass('euiTable--responsive');
   });
 
   it('allows never rendering responsive tables if set to `false`', () => {

--- a/src/components/table/table.test.tsx
+++ b/src/components/table/table.test.tsx
@@ -37,20 +37,20 @@ describe('EuiTable', () => {
       </EuiTable>
     );
     expect(container.firstChild).toMatchSnapshot();
-    expect(container.firstChild).not.toHaveClass('euiTable--responsive');
   });
 
   describe('responsive/mobile context', () => {
     it('renders responsive styles if below the default m breakpoint', () => {
       window.innerWidth = 767;
       const { container } = render(<EuiTable />);
-      expect(container.firstChild).toHaveClass('euiTable--responsive');
+
+      expect(container.firstElementChild!.className).toContain('-mobile');
     });
 
     it('allows customizing responsiveBreakpoint', () => {
       const { container } = render(<EuiTable responsiveBreakpoint="xl" />);
 
-      expect(container.firstChild).toHaveClass('euiTable--responsive');
+      expect(container.firstElementChild!.className).toContain('-mobile');
     });
 
     it('allows customizing responsiveBreakpoint via EuiProvider.componentDefaults', () => {
@@ -65,7 +65,7 @@ describe('EuiTable', () => {
         { wrapper: undefined }
       );
 
-      expect(container.firstChild).toHaveClass('euiTable--responsive');
+      expect(container.firstElementChild!.className).toContain('-mobile');
     });
   });
 
@@ -73,13 +73,13 @@ describe('EuiTable', () => {
     window.innerWidth = 2000;
     const { container } = render(<EuiTable responsiveBreakpoint={true} />);
 
-    expect(container.firstChild).toHaveClass('euiTable--responsive');
+    expect(container.firstElementChild!.className).toContain('-mobile');
   });
 
   it('allows never rendering responsive tables if set to `false`', () => {
     window.innerWidth = 320;
     const { container } = render(<EuiTable responsiveBreakpoint={false} />);
 
-    expect(container.firstChild).not.toHaveClass('euiTable--responsive');
+    expect(container.firstElementChild!.className).toContain('-desktop');
   });
 });

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -52,7 +52,7 @@ export const EuiTable: FunctionComponent<EuiTableProps> = ({
     useIsEuiTableResponsive(responsiveBreakpoint) && responsive;
 
   const classes = classNames('euiTable', className, {
-    'euiTable--responsive': isResponsive,
+    'euiTable--responsive': responsive,
   });
 
   const styles = useEuiMemoizedStyles(euiTableStyles);
@@ -61,6 +61,7 @@ export const EuiTable: FunctionComponent<EuiTableProps> = ({
     styles.layout[tableLayout],
     (!compressed || isResponsive) && styles.uncompressed,
     compressed && !isResponsive && styles.compressed,
+    isResponsive ? styles.mobile : styles.desktop,
   ];
 
   return (

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -12,7 +12,10 @@ import classNames from 'classnames';
 import { useEuiMemoizedStyles, type EuiBreakpointSize } from '../../services';
 import { CommonProps } from '../common';
 
-import { useIsEuiTableResponsive } from './mobile/responsive_context';
+import {
+  useIsEuiTableResponsive,
+  EuiTableIsResponsiveContext,
+} from './mobile/responsive_context';
 import { euiTableStyles } from './table.styles';
 
 export interface EuiTableProps
@@ -66,7 +69,9 @@ export const EuiTable: FunctionComponent<EuiTableProps> = ({
 
   return (
     <table tabIndex={-1} css={cssStyles} className={classes} {...rest}>
-      {children}
+      <EuiTableIsResponsiveContext.Provider value={isResponsive}>
+        {children}
+      </EuiTableIsResponsiveContext.Provider>
     </table>
   );
 };

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -9,16 +9,30 @@
 import React, { FunctionComponent, TableHTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-import { useEuiMemoizedStyles, useIsWithinMaxBreakpoint } from '../../services';
+import { useEuiMemoizedStyles, type EuiBreakpointSize } from '../../services';
 import { CommonProps } from '../common';
 
+import { useIsEuiTableResponsive } from './mobile/responsive_context';
 import { euiTableStyles } from './table.styles';
 
 export interface EuiTableProps
   extends CommonProps,
     TableHTMLAttributes<HTMLTableElement> {
   compressed?: boolean;
+  /**
+   * @deprecated - use `responsiveBreakpoint` instead
+   */
   responsive?: boolean;
+  /**
+   * Named breakpoint. Below this size, the table will collapse
+   * into responsive cards.
+   *
+   * Pass `false` to never collapse to a mobile view, or inversely,
+   * `true` to always render mobile-friendly cards.
+   *
+   * @default m
+   */
+  responsiveBreakpoint?: EuiBreakpointSize | boolean;
   /**
    * Sets the table-layout CSS property
    */
@@ -30,14 +44,15 @@ export const EuiTable: FunctionComponent<EuiTableProps> = ({
   className,
   compressed,
   tableLayout = 'fixed',
+  responsiveBreakpoint, // Default handled by `useIsEuiTableResponsive`
   responsive = true,
   ...rest
 }) => {
-  // TODO: Make the table responsive breakpoint customizable via prop
-  const isResponsive = useIsWithinMaxBreakpoint('s') && responsive;
+  const isResponsive =
+    useIsEuiTableResponsive(responsiveBreakpoint) && responsive;
 
   const classes = classNames('euiTable', className, {
-    'euiTable--responsive': responsive,
+    'euiTable--responsive': isResponsive,
   });
 
   const styles = useEuiMemoizedStyles(euiTableStyles);

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -22,11 +22,11 @@ import {
   LEFT_ALIGNMENT,
   RIGHT_ALIGNMENT,
   CENTER_ALIGNMENT,
-  useIsWithinBreakpoints,
 } from '../../services';
 import { isObject } from '../../services/predicate';
 import { EuiTextBlockTruncate } from '../text_truncate';
 
+import { useEuiTableIsResponsive } from './mobile/responsive_context';
 import { resolveWidthAsStyle } from './utils';
 
 interface EuiTableRowCellSharedPropsShape {
@@ -170,7 +170,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   });
 
   const widthValue =
-    useIsWithinBreakpoints(['xs', 's']) && mobileOptions.width
+    useEuiTableIsResponsive() && mobileOptions.width
       ? mobileOptions.width
       : width;
 


### PR DESCRIPTION
## Summary

> NOTE: This is going into the EuiTable Emotion conversion/cleanup feature branch.

This PR sets up a new `responsiveBreakpoint` prop for all table components (`EuiTable`, `EuiBasicTable`, and `EuiInMemoryTable` that allows consumers to customize the breakpoint at which tables collapse, and also cascades the dynamic responsive/mobile state down to all child cells/rows via context.

This PR only **very minimally** converts Sass responsive styles to Emotion - it's primarily just set up and JS proof-of-concept for now to help make PR review more bite-sized.

ℹ️ The line diff #s look, scary but it's 80% indentation from snapshots - make sure you [view with whitespace changes off](https://github.com/elastic/eui/pull/7625/files?diff=split&w=1). As always, I also strongly recommend [reviewing by commit](https://github.com/elastic/eui/pull/7625/commits).

## QA

PLEASE NOTE that staging / responsive tables will look broken until **all responsive EuiTable styles** have been converted.

As such, this is mostly code review / it's probably not worth deeply QAing other than confirming the new docs [responsive table true/false toggle](https://eui.elastic.co/pr_7625/#/tabular-content/tables#responsive-tables) works at all window sizes.

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A