### PR TITLE
[Emotion] Allow configuring style memoization error/warning level

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -40,6 +40,12 @@ import { writingModeStyles } from './writing_mode.styles';
 import '../dist/eui_theme_light.css';
 
 /**
+ * Ensure that any provider errors throw & warn us early
+ */
+import { setEuiDevProviderWarning } from '../src/services';
+setEuiDevProviderWarning('error');
+
+/**
  * Prop controls
  */
 
@@ -51,7 +57,7 @@ const preview: Preview = {
     (Story, context) => (
       <EuiProvider
         colorMode={context.globals.colorMode}
-        {...(context.componentId === 'euiprovider' && context.args)}
+        {...(context.componentId === 'theming-euiprovider' && context.args)}
       >
         <div
           css={[

--- a/changelogs/upcoming/7626.md
+++ b/changelogs/upcoming/7626.md
@@ -1,0 +1,3 @@
+**CSS-in-JS conversions**
+
+- Updated EUI's internal style memoization/performance utility to have configurable error/warning levels via `setEuiDevProviderWarning`

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -47,7 +47,7 @@ export const AppContext = ({ children }) => {
   };
 
   const isLocalDev = window.location.host.includes('803');
-  setEuiDevProviderWarning(isLocalDev ? 'error' : 'warning'); // Note: this can't be in a useEffect, otherwise it fires too late for style memoization warnings to error on page reload
+  setEuiDevProviderWarning(isLocalDev ? 'error' : 'warn'); // Note: this can't be in a useEffect, otherwise it fires too late for style memoization warnings to error on page reload
 
   return (
     <EuiProvider

--- a/src-docs/src/views/app_context.js
+++ b/src-docs/src/views/app_context.js
@@ -7,7 +7,10 @@ import { translateUsingPseudoLocale } from '../services';
 import { getLocale } from '../store';
 
 import { EuiContext, EuiProvider } from '../../../src/components';
-import { euiStylisPrefixer } from '../../../src/services';
+import {
+  setEuiDevProviderWarning,
+  euiStylisPrefixer,
+} from '../../../src/services';
 import { EUI_THEMES } from '../../../src/themes';
 
 import favicon16Prod from '../images/favicon/prod/favicon-16x16.png';
@@ -44,6 +47,7 @@ export const AppContext = ({ children }) => {
   };
 
   const isLocalDev = window.location.host.includes('803');
+  setEuiDevProviderWarning(isLocalDev ? 'error' : 'warning'); // Note: this can't be in a useEffect, otherwise it fires too late for style memoization warnings to error on page reload
 
   return (
     <EuiProvider

--- a/src/services/theme/style_memoization.test.tsx
+++ b/src/services/theme/style_memoization.test.tsx
@@ -14,6 +14,7 @@ import { testOnReactVersion } from '../../test/internal';
 
 import type { UseEuiTheme } from './hooks';
 import { EuiThemeProvider } from './provider';
+import { setEuiDevProviderWarning } from './warning';
 
 import {
   useEuiMemoizedStyles,
@@ -79,11 +80,15 @@ describe('useEuiMemoizedStyles', () => {
   testOnReactVersion(['18'])(
     'throws an error if passed anonymous functions',
     () => {
+      setEuiDevProviderWarning('error');
       expect(() =>
-        renderHook(() => useEuiMemoizedStyles(() => ({})))
+        renderHook(() => useEuiMemoizedStyles(() => ({})), {
+          wrapper: EuiThemeProvider,
+        })
       ).toThrowError(
         'Styles are memoized per function. Your style functions must be statically defined in order to not create a new map entry every rerender.'
       );
+      setEuiDevProviderWarning(undefined);
     }
   );
 });

--- a/src/services/theme/style_memoization.tsx
+++ b/src/services/theme/style_memoization.tsx
@@ -19,6 +19,7 @@ import React, {
 
 import { useUpdateEffect } from '../hooks';
 import { useEuiTheme, UseEuiTheme } from './hooks';
+import { emitEuiProviderWarning } from './warning';
 
 type StylesMap = Record<string, any>; // Typically an object of serialized css`` styles, but can have any amount of nesting, so it's not worth it to try and strictly type this
 type MemoizedStylesMap = WeakMap<Function, StylesMap>;
@@ -60,7 +61,7 @@ const getMemoizedStyles = (
   euiThemeContext: UseEuiTheme
 ) => {
   if (!stylesGenerator.name) {
-    throw new Error(
+    emitEuiProviderWarning(
       'Styles are memoized per function. Your style functions must be statically defined in order to not create a new map entry every rerender.'
     );
   }


### PR DESCRIPTION
## Summary

The catch I added in https://github.com/elastic/eui/pull/7529#discussion_r1489868842 has backfired, in that it's producing a false negative on staging (but not local??) in https://github.com/elastic/eui/pull/7625#pullrequestreview-1962844728.

To work around prod false negatives but preserve the intended goal of catching anonymous style functions in development, I'm tweaking the thrown error to use our internal EUI provider warning utility, which allows us (and consumers) to configure the warning level used. In this case, I'm setting it to `error` for local docs dev and for storybook, but to just `warn` for staging/prod.

As always, I recommend [following along by commit](https://github.com/elastic/eui/pull/7626/commits).

## QA

I think QA is already pretty well covered by our tests, so IMO a brief smoke check of [staging](https://eui.elastic.co/pr_7626/#/) to ensure no errors is sufficient. Here are the extra QA steps I took locally:

- [x] Removed `EuiProvider` in app_context.js to confirm the expected error threw
- [x] Nested/duplicated `EuiProvider`s to confirm the expected error threw
- [x] Changed an arbitrary style function to an anonymous fn to confirm the expected error threw

### General checklist

- Browser QA - N/A
- Docs site QA - N/A
- Code quality checklist
    - [x] ~Added or~ updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A