### PR TITLE
[EuiTableRow] Convert to Emotion

### DIFF
--- a/changelogs/upcoming/TBD.md
+++ b/changelogs/upcoming/TBD.md
@@ -1,0 +1,11 @@
+**CSS-in-JS conversions**
+
+- Removed the following `EuiTable` Sass variables:
+  - `$euiTableHoverColor`
+  - `$euiTableSelectedColor`
+  - `$euiTableHoverSelectedColor`
+  - `$euiTableActionsBorderColor`
+  - `$euiTableHoverClickableColor`
+  - `$euiTableFocusClickableColor`
+- Removed the following `EuiTable` Sass mixins:
+  - `euiTableActionsBackgroundMobile`

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
       class="css-0"
     >
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"
@@ -66,7 +66,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"
@@ -88,7 +88,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"
@@ -251,7 +251,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
       class="css-0"
     >
       <tr
-        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCellCheckbox"
@@ -372,7 +372,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         </td>
       </tr>
       <tr
-        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCellCheckbox"
@@ -493,7 +493,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         </td>
       </tr>
       <tr
-        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+        class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCellCheckbox"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`EuiInMemoryTable empty array 1`] = `
       class="css-0"
     >
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"
@@ -285,7 +285,7 @@ exports[`EuiInMemoryTable with items 1`] = `
       class="css-0"
     >
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"
@@ -307,7 +307,7 @@ exports[`EuiInMemoryTable with items 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"
@@ -329,7 +329,7 @@ exports[`EuiInMemoryTable with items 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow"
+        class="euiTableRow emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell euiTableRowCell--middle"

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`EuiTable renders 1`] = `
   </thead>
   <tbody>
     <tr
-      class="euiTableRow"
+      class="euiTableRow emotion-euiTableRow-desktop"
     >
       <td
         class="euiTableRowCell euiTableRowCell--middle"
@@ -62,7 +62,7 @@ exports[`EuiTable renders 1`] = `
       </td>
     </tr>
     <tr
-      class="euiTableRow"
+      class="euiTableRow emotion-euiTableRow-desktop"
     >
       <td
         class="euiTableRowCell euiTableRowCell--middle"

--- a/src/components/table/__snapshots__/table_row.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`isSelected renders true when specified 1`] = `
 <table>
   <tbody>
     <tr
-      class="euiTableRow euiTableRow-isSelected emotion-euiTableRow-desktop"
+      class="euiTableRow euiTableRow-isSelected emotion-euiTableRow-desktop-selected"
     >
       <td
         class="euiTableRowCell euiTableRowCell--middle"

--- a/src/components/table/__snapshots__/table_row.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`isSelected renders true when specified 1`] = `
 <table>
   <tbody>
     <tr
-      class="euiTableRow euiTableRow-isSelected"
+      class="euiTableRow euiTableRow-isSelected emotion-euiTableRow-desktop"
     >
       <td
         class="euiTableRowCell euiTableRowCell--middle"
@@ -27,7 +27,7 @@ exports[`renders EuiTableRow 1`] = `
   <tbody>
     <tr
       aria-label="aria-label"
-      class="euiTableRow testClass1 testClass2 emotion-euiTestCss"
+      class="euiTableRow testClass1 testClass2 emotion-euiTableRow-desktop-euiTestCss"
       data-test-subj="test subject string"
     >
       <td

--- a/src/components/table/_mixins.scss
+++ b/src/components/table/_mixins.scss
@@ -11,10 +11,3 @@
   width: $euiTableCellCheckboxWidth;
   vertical-align: middle;
 }
-
-@mixin euiTableActionsBackgroundMobile {
-  background-image: linear-gradient(to right, $euiTableActionsBorderColor 0, $euiTableActionsBorderColor 1px, transparent 1px, transparent 100%);
-  background-size: $euiTableActionsAreaWidth 100%;
-  background-position-x: right;
-  background-repeat: no-repeat;
-}

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -81,17 +81,6 @@
         }
       }
 
-      &.euiTableRow-isSelectable {
-        padding-left: $euiTableCellCheckboxWidth + ($euiTableCellContentPadding / 2);
-        position: relative;
-
-        .euiTableRowCellCheckbox {
-          position: absolute;
-          left: $euiTableCellContentPadding / 2;
-          top: $euiSizeS;
-        }
-      }
-
       &.euiTableRow-isExpandedRow {
         @include euiTableActionsBackgroundMobile;
         margin-top: -$euiTableCellContentPadding * 2;

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -43,28 +43,6 @@
           top: $euiSizeXS;
         }
       }
-
-      &.euiTableRow-isExpandedRow {
-        margin-top: -$euiTableCellContentPadding * 2;
-        position: relative;
-        z-index: 2; // on top of its parent/previous row
-        border-top: none;
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
-        padding-left: $euiSizeS; // override selectable as the padding is already applied via the contents
-
-        &:hover {
-          background-color: $euiColorEmptyShade; // keep white background to cover triggering row's border
-        }
-
-        .euiTableRowCell {
-          width: calc(100% - #{$euiSizeXXL});
-
-          &::before {
-            display: none;
-          }
-        }
-      }
     }
 
     .euiTableRowCell {

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -24,22 +24,7 @@
       @include euiFontSizeM;
     }
 
-    // Make each row a Panel
-    @include euiPanel($selector: '.euiTableRow');
-
     .euiTableRow {
-      @include euiBottomShadowSmall;
-      background-color: map-get($euiPanelBackgroundColorModifiers, 'plain');
-      border-radius: $euiBorderRadius;
-      display: flex;
-      flex-wrap: wrap;
-      padding: $euiTableCellContentPadding;
-      margin-bottom: $euiTableCellContentPadding;
-
-      &:hover {
-        background-color: map-get($euiPanelBackgroundColorModifiers, 'plain');
-      }
-
       &.euiTableRow-isExpandable,
       &.euiTableRow-hasActions {
         @include euiTableActionsBackgroundMobile;
@@ -109,7 +94,6 @@
 
       &.euiTableRow-isExpandedRow {
         @include euiTableActionsBackgroundMobile;
-        @include euiBottomShadowSmall;
         margin-top: -$euiTableCellContentPadding * 2;
         position: relative;
         z-index: 2; // on top of its parent/previous row

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -25,35 +25,6 @@
     }
 
     .euiTableRow {
-      &.euiTableRow-isExpandable,
-      &.euiTableRow-hasActions {
-        @include euiTableActionsBackgroundMobile;
-        padding-right: $euiSizeXXL;
-        position: relative;
-      }
-
-      &.euiTableRow-isExpandable .euiTableRowCell--isExpander,
-      &.euiTableRow-hasActions .euiTableRowCell--hasActions {
-        min-width: 0;
-        width: $euiSizeL;
-        position: absolute;
-        top: $euiTableCellContentPadding + (($euiTableCellContentPadding * $euiLineHeight) - $euiTableCellContentPadding) + $euiSizeXS; // same as row padding-top + cell padding + 1/2 line height
-        right: $euiTableCellContentPadding;
-
-        &::before {
-          display: none; // Don't display table headers
-        }
-
-        .euiTableCellContent {
-          flex-direction: column;
-          padding: 0;
-
-          .euiLink {
-            padding: $euiSizeXS;
-          }
-        }
-      }
-
       // Custom actions
       &:not(.euiTableRow-hasActions) .euiTableRowCell--hasActions:last-child {
         width: 100%;
@@ -64,7 +35,7 @@
           left: 0;
           right: 0;
           height: $euiBorderWidthThin;
-          background-color: $euiTableActionsBorderColor;
+          background-color: $euiBorderColor;
         }
 
         .euiTableCellContent {
@@ -73,16 +44,7 @@
         }
       }
 
-      &.euiTableRow-hasActions.euiTableRow-isExpandable {
-        .euiTableRowCell--isExpander {
-          top: auto;
-          bottom: $euiSize; // same as row padding-bottom
-          right: 0;
-        }
-      }
-
       &.euiTableRow-isExpandedRow {
-        @include euiTableActionsBackgroundMobile;
         margin-top: -$euiTableCellContentPadding * 2;
         position: relative;
         z-index: 2; // on top of its parent/previous row

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -107,16 +107,6 @@
         }
       }
 
-      // override hover & selected colors
-      &.euiTableRow-isSelected {
-        &,
-        &:hover,
-        + .euiTableRow.euiTableRow-isExpandedRow,
-        &:hover + .euiTableRow.euiTableRow-isExpandedRow .euiTableRowCell {
-          background-color: $euiTableSelectedColor;
-        }
-      }
-
       &.euiTableRow-isExpandedRow {
         @include euiTableActionsBackgroundMobile;
         @include euiBottomShadowSmall;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -152,22 +152,3 @@
     }
   }
 }
-
-// Animate expanded row must be on the contents div inside
-// This adds a quick pop in animation, but does not attempt to animate to height auto
-// - down that road dragons lie. @see https://github.com/elastic/eui/issues/6770
-.euiTableRow-isExpandedRow .euiTableCellContent {
-  animation: $euiAnimSpeedFast $euiAnimSlightResistance 1 normal none growExpandedRow;
-}
-
-@keyframes growExpandedRow {
-  0% {
-    opacity: 0;
-    transform: translateY(-$euiSizeM);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -48,41 +48,9 @@
   border: none;
 }
 
-.euiTableRow {
-  &:hover {
-    background-color: $euiTableHoverColor;
-  }
-
-  &.euiTableRow-isClickable {
-    &:hover {
-      background-color: $euiTableHoverClickableColor;
-      cursor: pointer;
-    }
-
-    &:focus {
-      background-color: $euiTableFocusClickableColor;
-    }
-  }
-
-  &.euiTableRow-isExpandedRow {
-    background-color: $euiTableHoverColor;
-
-    &.euiTableRow-isSelectable .euiTableCellContent {
-      padding-left: $euiTableCellCheckboxWidth + $euiTableCellContentPadding;
-    }
-  }
-
-  &.euiTableRow-isSelected {
-    background-color: $euiTableSelectedColor;
-
-    + .euiTableRow.euiTableRow-isExpandedRow .euiTableRowCell {
-      background-color: $euiTableSelectedColor;
-    }
-
-    &:hover,
-    &:hover + .euiTableRow.euiTableRow-isExpandedRow .euiTableRowCell {
-      background-color: $euiTableHoverSelectedColor;
-    }
+.euiTableRow-isExpandedRow {
+  &.euiTableRow-isSelectable .euiTableCellContent {
+    padding-left: $euiTableCellCheckboxWidth + $euiTableCellContentPadding;
   }
 }
 

--- a/src/components/table/_variables.scss
+++ b/src/components/table/_variables.scss
@@ -7,11 +7,4 @@ $euiTableCellCheckboxWidth: $euiSizeXL;
 
 $euiTableActionsAreaWidth: $euiSizeXXL;
 
-// Colors
-
-$euiTableHoverColor: tintOrShade($euiColorLightestShade, 50%, 20%);
-$euiTableSelectedColor: tintOrShade($euiFocusBackgroundColor, 30%, 0%);
-$euiTableHoverSelectedColor: tintOrShade($euiFocusBackgroundColor, 0, 10%);
 $euiTableActionsBorderColor: transparentize($euiColorMediumShade, .9);
-$euiTableHoverClickableColor: transparentize($euiColorPrimary, .95);
-$euiTableFocusClickableColor: transparentize($euiColorPrimary, .9);

--- a/src/components/table/_variables.scss
+++ b/src/components/table/_variables.scss
@@ -4,7 +4,3 @@ $euiTableCellContentPadding: $euiSizeS;
 $euiTableCellContentPaddingCompressed: $euiSizeXS;
 
 $euiTableCellCheckboxWidth: $euiSizeXL;
-
-$euiTableActionsAreaWidth: $euiSizeXXL;
-
-$euiTableActionsBorderColor: transparentize($euiColorMediumShade, .9);

--- a/src/components/table/table.styles.ts
+++ b/src/components/table/table.styles.ts
@@ -9,13 +9,43 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import { euiFontSize, euiNumberFormat, logicalCSS } from '../../global_styling';
+import {
+  euiFontSize,
+  euiNumberFormat,
+  logicalCSS,
+  mathWithUnits,
+} from '../../global_styling';
+
+export const euiTableVariables = ({ euiTheme }: UseEuiTheme) => {
+  const cellContentPadding = euiTheme.size.s;
+  const compressedCellContentPadding = euiTheme.size.xs;
+
+  const mobileSizes = {
+    actions: {
+      width: euiTheme.size.xxl,
+      offset: mathWithUnits(cellContentPadding, (x) => x * 2),
+    },
+    checkbox: {
+      width: mathWithUnits(
+        [euiTheme.size.xl, euiTheme.size.xs],
+        (x, y) => x + y
+      ),
+      offset: mathWithUnits(cellContentPadding, (x) => x / 2),
+    },
+  };
+
+  return {
+    cellContentPadding,
+    compressedCellContentPadding,
+    mobileSizes,
+  };
+};
 
 export const euiTableStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
-  const cellContentPadding = euiTheme.size.s;
-  const compressedCellContentPadding = euiTheme.size.xs;
+  const { cellContentPadding, compressedCellContentPadding } =
+    euiTableVariables(euiThemeContext);
 
   return {
     euiTable: css`

--- a/src/components/table/table_row.stories.tsx
+++ b/src/components/table/table_row.stories.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { EuiButtonIcon } from '../button';
+import { EuiCheckbox } from '../form';
+import {
+  EuiTable,
+  EuiTableBody,
+  EuiTableRowCell,
+  EuiTableRowCellCheckbox,
+} from './index';
+
+import { EuiTableRow, EuiTableRowProps } from './table_row';
+
+const meta: Meta<EuiTableRowProps> = {
+  title: 'Tabular Content/EuiTable/EuiTableRow',
+  component: EuiTableRow,
+};
+
+export default meta;
+type Story = StoryObj<EuiTableRowProps>;
+
+export const Playground: Story = {
+  argTypes: {
+    // For quicker/easier testing
+    onClick: { control: 'boolean' },
+  },
+  args: {
+    // @ts-ignore - using a switch for easiser testing
+    onClick: false,
+    // Set default booleans for easier toggling/testing
+    hasActions: false,
+    isExpandable: false,
+    isExpandedRow: false,
+    isSelectable: false,
+    isSelected: false,
+  },
+  render: ({
+    onClick,
+    isSelectable,
+    hasActions,
+    isExpandable,
+    isExpandedRow,
+    ...args
+  }) => (
+    // Note: This is an approximate mock of what `EuiBasicTable` does for selection/actions/expansion
+    <EuiTable tableLayout="auto">
+      <EuiTableBody>
+        <EuiTableRow
+          onClick={!!onClick ? action('onClick') : undefined}
+          isSelectable={isSelectable}
+          hasActions={hasActions}
+          isExpandable={isExpandable}
+          {...args}
+        >
+          {isSelectable && (
+            <EuiTableRowCellCheckbox>
+              <EuiCheckbox
+                id="selectRow"
+                checked={args.isSelected}
+                onChange={() => {}}
+              />
+            </EuiTableRowCellCheckbox>
+          )}
+          <EuiTableRowCell>First name</EuiTableRowCell>
+          <EuiTableRowCell>Last name</EuiTableRowCell>
+          <EuiTableRowCell>Some other data</EuiTableRowCell>
+          {hasActions && (
+            <EuiTableRowCell width="1%" hasActions={true}>
+              <EuiButtonIcon iconType="copy" />
+            </EuiTableRowCell>
+          )}
+          {isExpandable && (
+            <EuiTableRowCell width="1%" isExpander={true}>
+              <EuiButtonIcon iconType="arrowDown" />
+            </EuiTableRowCell>
+          )}
+        </EuiTableRow>
+        {isExpandedRow && (
+          <EuiTableRow isExpandedRow={isExpandedRow}>
+            <EuiTableRowCell width="100%" colSpan={100}>
+              expanded content
+            </EuiTableRowCell>
+          </EuiTableRow>
+        )}
+      </EuiTableBody>
+    </EuiTable>
+  ),
+};

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -8,20 +8,77 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme } from '../../services';
+import { UseEuiTheme, tint, shade, transparentize } from '../../services';
 
 export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
+
+  const rowColors = _rowColorVariables(euiThemeContext);
 
   return {
     euiTableRow: css``,
 
     desktop: {
-      desktop: css``,
+      desktop: css`
+        &:hover {
+          background-color: ${rowColors.hover};
+        }
+      `,
+      expanded: css`
+        background-color: ${rowColors.hover};
+      `,
+      clickable: css`
+        &:hover {
+          background-color: ${rowColors.clickable.hover};
+          cursor: pointer;
+        }
+
+        &:focus {
+          background-color: ${rowColors.clickable.focus};
+        }
+      `,
+      selected: css`
+        &,
+        & + .euiTableRow-isExpandedRow {
+          background-color: ${rowColors.selected.color};
+        }
+
+        &:hover,
+        &:hover + .euiTableRow-isExpandedRow {
+          background-color: ${rowColors.selected.hover};
+        }
+      `,
     },
 
     mobile: {
       mobile: css``,
+      selected: css`
+        &,
+        & + .euiTableRow-isExpandedRow {
+          background-color: ${rowColors.selected.color};
+        }
+      `,
     },
   };
 };
+
+const _rowColorVariables = ({ euiTheme, colorMode }: UseEuiTheme) => ({
+  hover:
+    colorMode === 'DARK'
+      ? euiTheme.colors.lightestShade
+      : tint(euiTheme.colors.lightestShade, 0.5),
+  selected: {
+    color:
+      colorMode === 'DARK'
+        ? shade(euiTheme.colors.primary, 0.7)
+        : tint(euiTheme.colors.primary, 0.96),
+    hover:
+      colorMode === 'DARK'
+        ? shade(euiTheme.colors.primary, 0.75)
+        : tint(euiTheme.colors.primary, 0.9),
+  },
+  clickable: {
+    hover: transparentize(euiTheme.colors.primary, 0.05),
+    focus: transparentize(euiTheme.colors.primary, 0.1),
+  },
+});

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -124,7 +124,8 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
       rightColumnContent: `
         position: absolute;
         ${logicalCSS('right', 0)}
-        ${logicalCSS('min-width', 0)}
+        /* TODO: remove !important once euiTableRowCell is converted to Emotion */
+        ${logicalCSS('min-width', '0 !important')}
         ${logicalCSS('width', mobileColumns.actions.width)}
 
         .euiTableCellContent {

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -23,7 +23,10 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
 
   const cellContentPadding = euiTheme.size.s;
   const mobileColumns = {
-    actions: {}, // TODO
+    actions: {
+      width: euiTheme.size.xxl,
+      offset: mathWithUnits(cellContentPadding, (x) => x * 2),
+    },
     checkbox: {
       width: mathWithUnits(
         [euiTheme.size.xl, euiTheme.size.xs],
@@ -100,6 +103,56 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
           ${logicalCSS('left', mobileColumns.checkbox.offset)}
         }
       `,
+      /**
+       * Right column styles + border
+       * Used for cell actions and row expander arrow
+       */
+      hasRightColumn: css`
+        ${logicalCSS('padding-right', mobileColumns.actions.width)}
+
+        &::after {
+          content: '';
+          position: absolute;
+          ${logicalCSS('vertical', 0)}
+          ${logicalCSS('right', mobileColumns.actions.width)}
+          ${logicalCSS('width', euiTheme.border.width.thin)}
+          background-color: ${euiTheme.border.color};
+        }
+      `,
+      rightColumnContent: `
+        position: absolute;
+        ${logicalCSS('right', 0)}
+        ${logicalCSS('min-width', 0)}
+        ${logicalCSS('width', mobileColumns.actions.width)}
+
+        .euiTableCellContent {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: ${euiTheme.size.s};
+          padding: 0;
+        }
+      `,
+      get actions() {
+        return css`
+          .euiTableRowCell--hasActions {
+            ${this.rightColumnContent}
+            ${logicalCSS('top', mobileColumns.actions.offset)}
+          }
+        `;
+      },
+      get expandable() {
+        return css`
+          .euiTableRowCell--isExpander {
+            ${this.rightColumnContent}
+            ${logicalCSS('bottom', mobileColumns.actions.offset)}
+          }
+        `;
+      },
+      /**
+       * TODO: next
+       */
+      expanded: css``,
     },
   };
 };

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -9,12 +9,10 @@
 import { css, keyframes } from '@emotion/react';
 
 import { UseEuiTheme, tint, shade, transparentize } from '../../services';
-import {
-  euiBackgroundColor,
-  logicalCSS,
-  mathWithUnits,
-} from '../../global_styling';
+import { euiBackgroundColor, logicalCSS } from '../../global_styling';
 import { euiShadow } from '../../themes/amsterdam/global_styling/mixins';
+
+import { euiTableVariables } from './table.styles';
 
 export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
@@ -22,20 +20,8 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const rowColors = _rowColorVariables(euiThemeContext);
   const expandedAnimationCss = _expandedRowAnimation(euiThemeContext);
 
-  const cellContentPadding = euiTheme.size.s;
-  const mobileColumns = {
-    actions: {
-      width: euiTheme.size.xxl,
-      offset: mathWithUnits(cellContentPadding, (x) => x * 2),
-    },
-    checkbox: {
-      width: mathWithUnits(
-        [euiTheme.size.xl, euiTheme.size.xs],
-        (x, y) => x + y
-      ),
-      offset: mathWithUnits(cellContentPadding, (x) => x / 2),
-    },
-  };
+  const { cellContentPadding, mobileSizes } =
+    euiTableVariables(euiThemeContext);
 
   return {
     euiTableRow: css``,
@@ -97,12 +83,12 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
        * Used for selection checkbox
        */
       selectable: css`
-        ${logicalCSS('padding-left', mobileColumns.checkbox.width)}
+        ${logicalCSS('padding-left', mobileSizes.checkbox.width)}
 
         .euiTableRowCellCheckbox {
           position: absolute;
           ${logicalCSS('top', cellContentPadding)}
-          ${logicalCSS('left', mobileColumns.checkbox.offset)}
+          ${logicalCSS('left', mobileSizes.checkbox.offset)}
         }
       `,
       /**
@@ -110,13 +96,13 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
        * Used for cell actions and row expander arrow
        */
       hasRightColumn: css`
-        ${logicalCSS('padding-right', mobileColumns.actions.width)}
+        ${logicalCSS('padding-right', mobileSizes.actions.width)}
 
         &::after {
           content: '';
           position: absolute;
           ${logicalCSS('vertical', 0)}
-          ${logicalCSS('right', mobileColumns.actions.width)}
+          ${logicalCSS('right', mobileSizes.actions.width)}
           ${logicalCSS('width', euiTheme.border.width.thin)}
           background-color: ${euiTheme.border.color};
         }
@@ -126,7 +112,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('right', 0)}
         /* TODO: remove !important once euiTableRowCell is converted to Emotion */
         ${logicalCSS('min-width', '0 !important')}
-        ${logicalCSS('width', mobileColumns.actions.width)}
+        ${logicalCSS('width', mobileSizes.actions.width)}
 
         .euiTableCellContent {
           display: flex;
@@ -140,7 +126,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
         return css`
           .euiTableRowCell--hasActions {
             ${this.rightColumnContent}
-            ${logicalCSS('top', mobileColumns.actions.offset)}
+            ${logicalCSS('top', mobileSizes.actions.offset)}
           }
         `;
       },
@@ -148,7 +134,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
         return css`
           .euiTableRowCell--isExpander {
             ${this.rightColumnContent}
-            ${logicalCSS('bottom', mobileColumns.actions.offset)}
+            ${logicalCSS('bottom', mobileSizes.actions.offset)}
           }
         `;
       },
@@ -156,7 +142,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
        * Bottom of card - expanded rows
        */
       expanded: css`
-        ${logicalCSS('margin-top', `-${mobileColumns.actions.offset}`)}
+        ${logicalCSS('margin-top', `-${mobileSizes.actions.offset}`)}
         /* Padding accounting for the checkbox is already applied via the content */
         ${logicalCSS('padding-left', cellContentPadding)}
 

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 
 import { UseEuiTheme, tint, shade, transparentize } from '../../services';
 import {
@@ -20,6 +20,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
   const rowColors = _rowColorVariables(euiThemeContext);
+  const expandedAnimationCss = _expandedRowAnimation(euiThemeContext);
 
   const cellContentPadding = euiTheme.size.s;
   const mobileColumns = {
@@ -47,6 +48,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
       `,
       expanded: css`
         background-color: ${rowColors.hover};
+        ${expandedAnimationCss}
       `,
       clickable: css`
         &:hover {
@@ -150,11 +152,48 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
         `;
       },
       /**
-       * TODO: next
+       * Bottom of card - expanded rows
        */
-      expanded: css``,
+      expanded: css`
+        ${logicalCSS('margin-top', `-${mobileColumns.actions.offset}`)}
+        /* Padding accounting for the checkbox is already applied via the content */
+        ${logicalCSS('padding-left', cellContentPadding)}
+
+        ${logicalCSS('border-top', euiTheme.border.thin)}
+        ${logicalCSS('border-top-left-radius', 0)}
+        ${logicalCSS('border-top-right-radius', 0)}
+
+        .euiTableRowCell {
+          ${logicalCSS('width', '100%')}
+        }
+
+        ${expandedAnimationCss}
+      `,
     },
   };
+};
+
+const _expandedRowAnimation = ({ euiTheme }: UseEuiTheme) => {
+  // Do not attempt to animate to height auto - down that road dragons lie
+  // @see https://github.com/elastic/eui/pull/6826
+  const expandRow = keyframes`
+    0% {
+      opacity: 0;
+      transform: translateY(-${euiTheme.size.m});
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  `;
+
+  // Animation must be on the contents div inside, not the row itself
+  return css`
+    .euiTableCellContent {
+      animation: ${euiTheme.animation.fast} ${euiTheme.animation.resistance} 1
+        normal none ${expandRow};
+    }
+  `;
 };
 
 const _rowColorVariables = ({ euiTheme, colorMode }: UseEuiTheme) => ({

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../services';
+
+export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiTableRow: css``,
+
+    desktop: {
+      desktop: css``,
+    },
+
+    mobile: {
+      mobile: css``,
+    },
+  };
+};

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -9,11 +9,19 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme, tint, shade, transparentize } from '../../services';
+import {
+  euiBackgroundColor,
+  logicalCSS,
+  mathWithUnits,
+} from '../../global_styling';
+import { euiShadow } from '../../themes/amsterdam/global_styling/mixins';
 
 export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
   const rowColors = _rowColorVariables(euiThemeContext);
+
+  const cellContentPadding = euiTheme.size.s;
 
   return {
     euiTableRow: css``,
@@ -51,7 +59,18 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
     },
 
     mobile: {
-      mobile: css``,
+      mobile: css`
+        position: relative;
+        display: flex;
+        flex-wrap: wrap;
+        padding: ${cellContentPadding};
+        ${logicalCSS('margin-bottom', cellContentPadding)}
+
+        /* EuiPanel styling */
+        ${euiShadow(euiThemeContext, 's')}
+        background-color: ${euiBackgroundColor(euiThemeContext, 'plain')};
+        border-radius: ${euiTheme.border.radius.medium};
+      `,
       selected: css`
         &,
         & + .euiTableRow-isExpandedRow {

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -22,6 +22,16 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const rowColors = _rowColorVariables(euiThemeContext);
 
   const cellContentPadding = euiTheme.size.s;
+  const mobileColumns = {
+    actions: {}, // TODO
+    checkbox: {
+      width: mathWithUnits(
+        [euiTheme.size.xl, euiTheme.size.xs],
+        (x, y) => x + y
+      ),
+      offset: mathWithUnits(cellContentPadding, (x) => x / 2),
+    },
+  };
 
   return {
     euiTableRow: css``,
@@ -75,6 +85,19 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
         &,
         & + .euiTableRow-isExpandedRow {
           background-color: ${rowColors.selected.color};
+        }
+      `,
+      /**
+       * Left column offset (no border)
+       * Used for selection checkbox
+       */
+      selectable: css`
+        ${logicalCSS('padding-left', mobileColumns.checkbox.width)}
+
+        .euiTableRowCellCheckbox {
+          position: absolute;
+          ${logicalCSS('top', cellContentPadding)}
+          ${logicalCSS('left', mobileColumns.checkbox.offset)}
         }
       `,
     },

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -15,7 +15,10 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
-import { keys } from '../../services';
+import { keys, useEuiMemoizedStyles } from '../../services';
+
+import { useEuiTableIsResponsive } from './mobile/responsive_context';
+import { euiTableRowStyles } from './table_row.styles';
 
 export interface EuiTableRowProps {
   /**
@@ -59,6 +62,18 @@ export const EuiTableRow: FunctionComponent<Props> = ({
   onClick,
   ...rest
 }) => {
+  const isResponsive = useEuiTableIsResponsive();
+  const styles = useEuiMemoizedStyles(euiTableRowStyles);
+  const cssStyles = isResponsive
+    ? [
+        styles.euiTableRow,
+        styles.mobile.mobile,
+      ]
+    : [
+        styles.euiTableRow,
+        styles.desktop.desktop,
+      ];
+
   const classes = classNames('euiTableRow', className, {
     'euiTableRow-isSelectable': isSelectable,
     'euiTableRow-isSelected': isSelected,
@@ -70,7 +85,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
 
   if (!onClick) {
     return (
-      <tr className={classes} {...rest}>
+      <tr css={cssStyles} className={classes} {...rest}>
         {children}
       </tr>
     );
@@ -90,6 +105,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
 
   return (
     <tr
+      css={cssStyles}
       className={classes}
       onClick={onClick}
       onKeyDown={onKeyDown}

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -69,6 +69,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         styles.euiTableRow,
         styles.mobile.mobile,
         isSelected && styles.mobile.selected,
+        isSelectable && styles.mobile.selectable,
       ]
     : [
         styles.euiTableRow,

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -70,6 +70,11 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         styles.mobile.mobile,
         isSelected && styles.mobile.selected,
         isSelectable && styles.mobile.selectable,
+        hasActions && styles.mobile.actions,
+        isExpandable && styles.mobile.expandable,
+        isExpandedRow && styles.mobile.expanded,
+        (hasActions || isExpandable || isExpandedRow) &&
+          styles.mobile.hasRightColumn,
       ]
     : [
         styles.euiTableRow,

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -68,10 +68,14 @@ export const EuiTableRow: FunctionComponent<Props> = ({
     ? [
         styles.euiTableRow,
         styles.mobile.mobile,
+        isSelected && styles.mobile.selected,
       ]
     : [
         styles.euiTableRow,
         styles.desktop.desktop,
+        isSelected && styles.desktop.selected,
+        isExpandedRow && styles.desktop.expanded,
+        onClick && styles.desktop.clickable,
       ];
 
   const classes = classNames('euiTableRow', className, {

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -131,6 +131,8 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   },
   ...rest
 }) => {
+  const isResponsive = useEuiTableIsResponsive();
+
   const cellClasses = classNames('euiTableRowCell', {
     'euiTableRowCell--hasActions': hasActions,
     'euiTableRowCell--isExpander': isExpander,
@@ -169,10 +171,11 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     euiTableCellContent__hoverItem: showOnHover,
   });
 
-  const widthValue =
-    useEuiTableIsResponsive() && mobileOptions.width
-      ? mobileOptions.width
-      : width;
+  const widthValue = isResponsive
+    ? hasActions || isExpander
+      ? undefined // On mobile, actions are shifted to a right column via CSS
+      : mobileOptions.width
+    : width;
 
   const styleObj = resolveWidthAsStyle(style, widthValue);
 


### PR DESCRIPTION
## Summary

This doesn't convert _all_ table row styles to Emotion, but it converts (what I consider) to be the majority of row-related CSS (enough to get a mostly functional Storybook up). There are still some styles that I consider belong to cells, rather than rows, which I will target in the next cell-focused PR.

As mentioned in #7625, staging itself will still look broken until _all_ CSS is converted over (at which point I'll do another prod vs staging QA pass and also hopefully have more Storybooks written by then for easier QA).

⚠️ Removals/changes that will affect consumers (checked for zero usages in Kibana):
-  Removed Sass `@euiTableActionsBackgroundMobile` mixin
-  Removed Sass `$euiTableActionsBorderColor` variable (+ updated mobile usages to use the theme-wide border color token, matching desktop border colors)
-  Removed Sass `$euiTableHoverColor` variable
-  Removed Sass `$euiTableSelectedColor` variable
-  Removed Sass `$euiTableHoverSelectedColor` variable
-  Removed Sass `$euiTableHoverClickableColor` variable
-  Removed Sass `$euiTableFocusClickableColor` variable

## QA

- Go to https://eui.elastic.co/pr_7628/storybook/?path=/story/tabular-content-euitable-euitablerow--playground
- Toggle the various row props and confirm they work as you would expect (compared to production) on:
  - [x] Desktop
  - [x] Small mobile

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes _(Note that Storybook on dark mode will look semi broken due to cell styles not yet being converted to Emotion)_
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated a component Story
    ~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A - mobile tables aren't a thing in Figma