### PR TITLE
[EuiBasicTable][EuiInMemoryTable] Remove need for `isSelectable`, `isExpandable`, and `hasActions` props

### DIFF
--- a/changelogs/upcoming/7632.md
+++ b/changelogs/upcoming/7632.md
@@ -1,0 +1,10 @@
+**Breaking changes**
+
+- The following props are no longer needed by `EuiBasicTable` or `EuiInMemoryTable` for responsive table behavior to work correctly, and can be removed:
+  - `isSelectable`
+  - `isExpandable`
+  - `hasActions`
+
+**DOM changes**
+
+- `EuiTableRow`s rendered by basic and memory tables now only render a `.euiTableRow-isSelectable` className if the selection checkbox is not disabled

--- a/changelogs/upcoming/TBD.md
+++ b/changelogs/upcoming/TBD.md
@@ -1,6 +1,9 @@
 **CSS-in-JS conversions**
 
 - Removed the following `EuiTable` Sass variables:
+  - `$euiTableCellContentPadding`
+  - `$euiTableCellContentPaddingCompressed`
+  - `$euiTableCellCheckboxWidth`
   - `$euiTableHoverColor`
   - `$euiTableSelectedColor`
   - `$euiTableHoverSelectedColor`

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -396,7 +396,6 @@ export default () => {
         pagination={pagination}
         sorting={sorting}
         selection={selection}
-        hasActions={customAction ? false : true}
         onChange={onTableChange}
       />
     </>

--- a/src-docs/src/views/tables/custom/custom.tsx
+++ b/src-docs/src/views/tables/custom/custom.tsx
@@ -686,7 +686,7 @@ export default class extends Component<{}, State> {
         <EuiTableRow
           key={item.id}
           isSelected={this.isItemSelected(item.id)}
-          isSelectable={true}
+          hasSelection={true}
           hasActions={true}
         >
           {cells}

--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -261,7 +261,6 @@ export default () => {
       itemId="id"
       itemIdToExpandedRowMap={itemIdToExpandedRowMap}
       isExpandable={true}
-      hasActions={true}
       columns={columnsWithExpandingRowToggle}
       pagination={pagination}
       sorting={sorting}

--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -265,7 +265,6 @@ export default () => {
       columns={columnsWithExpandingRowToggle}
       pagination={pagination}
       sorting={sorting}
-      isSelectable={true}
       selection={selection}
       onChange={onTableChange}
     />

--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -260,7 +260,6 @@ export default () => {
       items={pageOfItems}
       itemId="id"
       itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-      isExpandable={true}
       columns={columnsWithExpandingRowToggle}
       pagination={pagination}
       sorting={sorting}

--- a/src-docs/src/views/tables/footer/footer.tsx
+++ b/src-docs/src/views/tables/footer/footer.tsx
@@ -221,7 +221,6 @@ export default () => {
       columns={columns}
       pagination={pagination}
       sorting={sorting}
-      isSelectable={true}
       selection={selection}
       onChange={onTableChange}
     />

--- a/src-docs/src/views/tables/in_memory/in_memory_selection_controlled.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection_controlled.tsx
@@ -258,7 +258,6 @@ export default () => {
         pagination={pagination}
         sorting={true}
         selection={selectionValue}
-        isSelectable={true}
       />
     </>
   );

--- a/src-docs/src/views/tables/in_memory/in_memory_selection_uncontrolled.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection_uncontrolled.tsx
@@ -250,7 +250,6 @@ export default () => {
       pagination={pagination}
       sorting={true}
       selection={selectionValue}
-      isSelectable={true}
     />
   );
 };

--- a/src-docs/src/views/tables/mobile/mobile.tsx
+++ b/src-docs/src/views/tables/mobile/mobile.tsx
@@ -300,7 +300,6 @@ export default () => {
         pagination={pagination}
         sorting={sorting}
         selection={selection}
-        isSelectable={true}
         hasActions={true}
         responsiveBreakpoint={isResponsive}
         onChange={onTableChange}

--- a/src-docs/src/views/tables/mobile/mobile.tsx
+++ b/src-docs/src/views/tables/mobile/mobile.tsx
@@ -300,7 +300,6 @@ export default () => {
         pagination={pagination}
         sorting={sorting}
         selection={selection}
-        hasActions={true}
         responsiveBreakpoint={isResponsive}
         onChange={onTableChange}
       />

--- a/src-docs/src/views/tables/mobile/mobile_section.js
+++ b/src-docs/src/views/tables/mobile/mobile_section.js
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { GuideSectionTypes } from '../../../components';
 
 import Table from './mobile';
-import { EuiTextColor } from '../../../../../src/components/text';
 import { EuiCode, EuiCodeBlock } from '../../../../../src/components/code';
 const source = require('!!raw-loader!./mobile');
 import { EuiTableRowCellMobileOptionsShape } from '../props/props';
@@ -51,26 +50,6 @@ export const section = {
         Inversely, if you always want your table to render in a mobile-friendly
         manner, pass <EuiCode>true</EuiCode>.
       </p>
-      <p>
-        {/* TODO: This shouldn't be true by the end of the Emotion conversion */}
-        To make your table work responsively, please make sure you add the
-        following <EuiTextColor color="danger">additional</EuiTextColor> props
-        to the top level table component (<strong>EuiBasicTable</strong> or{' '}
-        <strong>EuiInMemoryTable</strong>):
-      </p>
-      <ul>
-        <li>
-          <EuiCode>isSelectable</EuiCode>: if the table has a single column of
-          checkboxes for selecting rows
-        </li>
-        <li>
-          <EuiCode>isExpandable</EuiCode>: if the table has rows that can expand
-        </li>
-        <li>
-          <EuiCode>hasActions</EuiCode>: if the table has a column for actions
-          which may/may not be hidden in hover
-        </li>
-      </ul>
       <p>
         The <EuiCode>mobileOptions</EuiCode> object can be passed to the{' '}
         <strong>EuiTableRowCell</strong> directly or with each column item

--- a/src-docs/src/views/tables/selection/selection_controlled.tsx
+++ b/src-docs/src/views/tables/selection/selection_controlled.tsx
@@ -236,7 +236,6 @@ export default () => {
         columns={columns}
         pagination={pagination}
         sorting={sorting}
-        isSelectable={true}
         selection={selection}
         onChange={onTableChange}
         rowHeader="firstName"

--- a/src-docs/src/views/tables/selection/selection_uncontrolled.tsx
+++ b/src-docs/src/views/tables/selection/selection_uncontrolled.tsx
@@ -226,7 +226,6 @@ export default () => {
         columns={columns}
         pagination={pagination}
         sorting={sorting}
-        isSelectable={true}
         selection={selection}
         onChange={onTableChange}
         rowHeader="firstName"

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
       class="css-0"
     >
       <tr
-        class="euiTableRow emotion-euiTableRow-desktop"
+        class="euiTableRow euiTableRow-isSelectable emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
@@ -66,7 +66,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow emotion-euiTableRow-desktop"
+        class="euiTableRow euiTableRow-isSelectable emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
@@ -88,7 +88,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow emotion-euiTableRow-desktop"
+        class="euiTableRow euiTableRow-isSelectable emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -284,7 +284,7 @@ exports[`EuiInMemoryTable with items 1`] = `
       class="css-0"
     >
       <tr
-        class="euiTableRow emotion-euiTableRow-desktop"
+        class="euiTableRow euiTableRow-isSelectable emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
@@ -306,7 +306,7 @@ exports[`EuiInMemoryTable with items 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow emotion-euiTableRow-desktop"
+        class="euiTableRow euiTableRow-isSelectable emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
@@ -328,7 +328,7 @@ exports[`EuiInMemoryTable with items 1`] = `
         </td>
       </tr>
       <tr
-        class="euiTableRow emotion-euiTableRow-desktop"
+        class="euiTableRow euiTableRow-isSelectable emotion-euiTableRow-desktop"
       >
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -224,7 +224,6 @@ describe('EuiBasicTable', () => {
       itemIdToExpandedRowMap: {
         '1': <div>Expanded row</div>,
       },
-      isExpandable: true,
     };
     const { getByText } = render(<EuiBasicTable {...props} />);
 

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -241,7 +241,6 @@ interface BasicTableProps<T extends object>
    * Indicates which column should be used as the identifying cell in each row. Should match a "field" prop in FieldDataColumn
    */
   rowHeader?: string;
-  hasActions?: boolean;
   isExpandable?: boolean;
   /**
    * Provides an infinite loading indicator
@@ -523,7 +522,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
       itemIdToExpandedRowMap,
       responsiveBreakpoint,
       isExpandable,
-      hasActions,
       rowProps,
       cellProps,
       tableCaption,
@@ -966,7 +964,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
     const {
       columns,
       selection,
-      hasActions,
       rowHeader,
       itemIdToExpandedRowMap = {},
       isExpandable,
@@ -998,7 +995,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
       rowSelectionDisabled = !!isDisabled;
     }
 
-    let calculatedHasActions;
+    let hasActions;
     columns.forEach((column: EuiBasicTableColumn<T>, columnIndex: number) => {
       if ((column as EuiTableActionsColumnType<T>).actions) {
         cells.push(
@@ -1009,7 +1006,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
             columnIndex
           )
         );
-        calculatedHasActions = true;
+        hasActions = true;
       } else if ((column as EuiTableFieldDataColumnType<T>).field) {
         const fieldDataColumn = column as EuiTableFieldDataColumnType<T>;
         cells.push(
@@ -1069,7 +1066,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
         hasSelection={!!selection}
         isSelectable={!rowSelectionDisabled}
         isSelected={selected}
-        hasActions={hasActions == null ? calculatedHasActions : hasActions}
+        hasActions={hasActions}
         isExpandable={isExpandable}
         {...rowProps}
       >

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -243,7 +243,6 @@ interface BasicTableProps<T extends object>
   rowHeader?: string;
   hasActions?: boolean;
   isExpandable?: boolean;
-  isSelectable?: boolean;
   /**
    * Provides an infinite loading indicator
    */
@@ -523,7 +522,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
       compressed,
       itemIdToExpandedRowMap,
       responsiveBreakpoint,
-      isSelectable,
       isExpandable,
       hasActions,
       rowProps,
@@ -968,7 +966,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
     const {
       columns,
       selection,
-      isSelectable,
       hasActions,
       rowHeader,
       itemIdToExpandedRowMap = {},
@@ -990,10 +987,15 @@ export class EuiBasicTable<T extends object = any> extends Component<
             getItemId(selectedItem, itemIdCallback) === itemId
         );
 
-    let calculatedHasSelection;
+    let rowSelectionDisabled = false;
     if (selection) {
-      cells.push(this.renderItemSelectionCell(itemId, item, selected));
-      calculatedHasSelection = true;
+      const [checkboxCell, isDisabled] = this.renderItemSelectionCell(
+        itemId,
+        item,
+        selected
+      );
+      cells.push(checkboxCell);
+      rowSelectionDisabled = !!isDisabled;
     }
 
     let calculatedHasActions;
@@ -1051,7 +1053,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
       <EuiTableRow
         id={expandedRowId}
         isExpandedRow={true}
-        isSelectable={isSelectable}
+        hasSelection={!!selection}
       >
         <EuiTableRowCell colSpan={expandedRowColSpan} textOnly={false}>
           {itemIdToExpandedRowMap[itemId]}
@@ -1064,9 +1066,8 @@ export class EuiBasicTable<T extends object = any> extends Component<
     const row = (
       <EuiTableRow
         aria-owns={expandedRowId}
-        isSelectable={
-          isSelectable == null ? calculatedHasSelection : isSelectable
-        }
+        hasSelection={!!selection}
+        isSelectable={!rowSelectionDisabled}
         isSelected={selected}
         hasActions={hasActions == null ? calculatedHasActions : hasActions}
         isExpandable={isExpandable}
@@ -1107,7 +1108,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
         );
       }
     };
-    return (
+    return [
       <EuiTableRowCellCheckbox key={key}>
         <EuiI18n token="euiBasicTable.selectThisRow" default="Select this row">
           {(selectThisRow: string) => (
@@ -1123,8 +1124,9 @@ export class EuiBasicTable<T extends object = any> extends Component<
             />
           )}
         </EuiI18n>
-      </EuiTableRowCellCheckbox>
-    );
+      </EuiTableRowCellCheckbox>,
+      disabled,
+    ];
   }
 
   renderItemActionsCell(

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -241,7 +241,6 @@ interface BasicTableProps<T extends object>
    * Indicates which column should be used as the identifying cell in each row. Should match a "field" prop in FieldDataColumn
    */
   rowHeader?: string;
-  isExpandable?: boolean;
   /**
    * Provides an infinite loading indicator
    */
@@ -521,7 +520,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
       compressed,
       itemIdToExpandedRowMap,
       responsiveBreakpoint,
-      isExpandable,
       rowProps,
       cellProps,
       tableCaption,
@@ -961,13 +959,8 @@ export class EuiBasicTable<T extends object = any> extends Component<
   }
 
   renderItemRow(item: T, rowIndex: number) {
-    const {
-      columns,
-      selection,
-      rowHeader,
-      itemIdToExpandedRowMap = {},
-      isExpandable,
-    } = this.props;
+    const { columns, selection, rowHeader, itemIdToExpandedRowMap } =
+      this.props;
 
     const cells = [];
 
@@ -1042,7 +1035,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
     expandedRowColSpan = expandedRowColSpan - mobileOnlyCols;
 
     // We'll use the ID to associate the expanded row with the original.
-    const hasExpandedRow = itemIdToExpandedRowMap.hasOwnProperty(itemId);
+    const hasExpandedRow = itemIdToExpandedRowMap?.hasOwnProperty(itemId);
     const expandedRowId = hasExpandedRow
       ? `row_${itemId}_expansion`
       : undefined;
@@ -1053,7 +1046,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
         hasSelection={!!selection}
       >
         <EuiTableRowCell colSpan={expandedRowColSpan} textOnly={false}>
-          {itemIdToExpandedRowMap[itemId]}
+          {itemIdToExpandedRowMap![itemId]}
         </EuiTableRowCell>
       </EuiTableRow>
     ) : undefined;
@@ -1067,7 +1060,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
         isSelectable={!rowSelectionDisabled}
         isSelected={selected}
         hasActions={hasActions}
-        isExpandable={isExpandable}
+        isExpandable={hasExpandedRow}
         {...rowProps}
       >
         {cells}

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -677,7 +677,6 @@ export class EuiInMemoryTable<T extends object = object> extends Component<
       message,
       error,
       selection,
-      isSelectable,
       hasActions,
       compressed,
       pagination: hasPagination,
@@ -747,7 +746,6 @@ export class EuiInMemoryTable<T extends object = object> extends Component<
         pagination={pagination}
         sorting={sorting}
         selection={selection}
-        isSelectable={isSelectable}
         hasActions={hasActions}
         onChange={this.onTableChange}
         error={error}

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -677,7 +677,6 @@ export class EuiInMemoryTable<T extends object = object> extends Component<
       message,
       error,
       selection,
-      hasActions,
       compressed,
       pagination: hasPagination,
       sorting: hasSorting,
@@ -746,7 +745,6 @@ export class EuiInMemoryTable<T extends object = object> extends Component<
         pagination={pagination}
         sorting={sorting}
         selection={selection}
-        hasActions={hasActions}
         onChange={this.onTableChange}
         error={error}
         loading={loading}

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,4 +1,2 @@
-@import 'variables';
-
 @import 'table';
 @import 'responsive';

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,9 +1,3 @@
-.euiTableRow-isExpandedRow {
-  &.euiTableRow-isSelectable .euiTableCellContent {
-    padding-left: $euiTableCellCheckboxWidth + $euiTableCellContentPadding;
-  }
-}
-
 /**
  * 1. Vertically align all children.
  * 4. Prevent very long single words (e.g. the name of a field in a document) from overflowing

--- a/src/components/table/_variables.scss
+++ b/src/components/table/_variables.scss
@@ -1,6 +1,0 @@
-// Spacing
-
-$euiTableCellContentPadding: $euiSizeS;
-$euiTableCellContentPaddingCompressed: $euiSizeXS;
-
-$euiTableCellCheckboxWidth: $euiSizeXL;

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -20,7 +20,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
   const rowColors = _rowColorVariables(euiThemeContext);
   const expandedAnimationCss = _expandedRowAnimation(euiThemeContext);
 
-  const { cellContentPadding, mobileSizes } =
+  const { cellContentPadding, mobileSizes, checkboxSize } =
     euiTableVariables(euiThemeContext);
 
   return {
@@ -57,6 +57,13 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
           background-color: ${rowColors.selected.hover};
         }
       `,
+      // Offset expanded & selectable rows by the checkbox width to line up content with the 2nd column
+      // Set on the `<td>` because padding can't be applied to `<tr>` elements directly
+      checkboxOffset: css`
+        .euiTableRowCell:first-child {
+          ${logicalCSS('padding-left', checkboxSize)}
+        }
+      `,
     },
 
     mobile: {
@@ -82,7 +89,7 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
        * Left column offset (no border)
        * Used for selection checkbox, which will be absolutely positioned
        */
-      selectable: css`
+      hasLeftColumn: css`
         ${logicalCSS('padding-left', mobileSizes.checkbox.width)}
       `,
       /**

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -23,7 +23,11 @@ import { euiTableRowStyles } from './table_row.styles';
 export interface EuiTableRowProps {
   /**
    * Indicates if the table has a single column of checkboxes for selecting
-   * rows (affects mobile only)
+   * rows (used for mobile styling)
+   */
+  hasSelection?: boolean;
+  /**
+   * Indicates that the current row's checkbox is selectable / not disabled
    */
   isSelectable?: boolean;
   /**
@@ -32,7 +36,7 @@ export interface EuiTableRowProps {
   isSelected?: boolean;
   /**
    * Indicates if the table has a dedicated column for icon-only actions
-   * (affects mobile only)
+   * (used for mobile styling)
    */
   hasActions?: boolean;
   /**
@@ -54,6 +58,7 @@ type Props = CommonProps &
 export const EuiTableRow: FunctionComponent<Props> = ({
   children,
   className,
+  hasSelection,
   isSelected,
   isSelectable,
   hasActions,
@@ -72,7 +77,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         isExpandedRow && styles.mobile.expanded,
         (hasActions || isExpandable || isExpandedRow) &&
           styles.mobile.hasRightColumn,
-        isSelectable && styles.mobile.hasLeftColumn,
+        hasSelection && styles.mobile.hasLeftColumn,
       ]
     : [
         styles.euiTableRow,
@@ -80,7 +85,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         isSelected && styles.desktop.selected,
         isExpandedRow && styles.desktop.expanded,
         onClick && styles.desktop.clickable,
-        isExpandedRow && isSelectable && styles.desktop.checkboxOffset,
+        isExpandedRow && hasSelection && styles.desktop.checkboxOffset,
       ];
 
   const classes = classNames('euiTableRow', className, {

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -69,10 +69,10 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         styles.euiTableRow,
         styles.mobile.mobile,
         isSelected && styles.mobile.selected,
-        isSelectable && styles.mobile.selectable,
         isExpandedRow && styles.mobile.expanded,
         (hasActions || isExpandable || isExpandedRow) &&
           styles.mobile.hasRightColumn,
+        isSelectable && styles.mobile.hasLeftColumn,
       ]
     : [
         styles.euiTableRow,
@@ -80,6 +80,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         isSelected && styles.desktop.selected,
         isExpandedRow && styles.desktop.expanded,
         onClick && styles.desktop.clickable,
+        isExpandedRow && isSelectable && styles.desktop.checkboxOffset,
       ];
 
   const classes = classNames('euiTableRow', className, {


### PR DESCRIPTION
## Summary

> NOTE: This is going into the EuiTable Emotion conversion/cleanup feature branch.

Removes 3 props for basic/memory tables that were apparently literally just there to make styling works on responsive - this isn't an API we really want to perpetuate and we have all the information we need without consumers having to pass extra props, so I'm just going to yeet them out as part of the Emotion conversion.

also closes #7515 while here (adds a new `hasSelection` prop to EuiTableRow that replaces `isSelectable`, and only passes `isSelectable` if the selection checkbox is not disabled).

### ⚠️ Kibana updates needed:

Typescript will help us catch most of these, but here's a quick list from searches (there are many pages, but it should at least be quick removals):
- [isSelectable](https://github.com/search?q=repo%3Aelastic%2Fkibana+isSelectable%3D%7B&type=code)
- [hasActions](https://github.com/search?q=repo%3Aelastic%2Fkibana%20hasActions%3D%7B&type=code)
- [isExpandable](https://github.com/search?q=repo%3Aelastic%2Fkibana+isExpandable%3D%7B&type=code)

`.euiTableRow-isSelectable` impact:
- [Only one usage](https://github.com/elastic/kibana/blob/16787801f8343b95486107cfe1f9194df2829385/test/functional/services/listing_table.ts#L72) and it's the one that the issue was opened for :)

## QA

- [x] Confirm that https://eui.elastic.co/pr_7632/#/tabular-content/tables#responsive-tables still looks and works correctly

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Removed **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A