### PR TITLE
[EuiTable][EuiBasicTable][EuiInMemoryTable] Remove `responsive` prop completely in favor of `responsiveBreakpoint`

### DIFF
--- a/changelogs/upcoming/7625.md
+++ b/changelogs/upcoming/7625.md
@@ -1,7 +1,10 @@
 - Updated `EuiTable`, `EuiBasicTable`, and `EuiInMemoryTable` with a new `responsiveBreakpoint` prop, which allows customizing the point at which the table collapses into a mobile-friendly view with cards
 - Updated `EuiProvider`'s `componentDefaults` prop to allow configuring `EuiTable.responsiveBreakpoint`
 
-**Deprecations**
+**Breaking changes**
 
-- Deprecated the `responsive` prop from `EuiTable`, `EuiBasicTable`, and `EuiInMemoryTable`. Use the new `responsiveBreakpoint` prop instead
+- Removed the `responsive` prop from `EuiTable`, `EuiBasicTable`, and `EuiInMemoryTable`. Use the new `responsiveBreakpoint` prop instead
+
+**DOM changes**
+
 - `EuiTable` mobile headers no longer render in the DOM when not visible (previously rendered with `display: none`). This may affect DOM testing assertions.

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
   data-test-subj="test subject string"
 >
   <table
-    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    class="euiTable emotion-euiTable-fixed-uncompressed-desktop"
     id="__table_generated-id"
     tabindex="-1"
   >
@@ -119,7 +119,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
   class="euiBasicTable"
 >
   <table
-    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    class="euiTable emotion-euiTable-fixed-uncompressed-desktop"
     id="__table_generated-id"
     tabindex="-1"
   >

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`EuiInMemoryTable empty array 1`] = `
   data-test-subj="test subject string"
 >
   <table
-    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    class="euiTable emotion-euiTable-fixed-uncompressed-desktop"
     id="__table_generated-id"
     tabindex="-1"
   >
@@ -236,7 +236,6 @@ exports[`EuiInMemoryTable with executeQueryOptions 1`] = `
     />
   }
   onChange={[Function]}
-  responsive={true}
   tableLayout="fixed"
 />
 `;
@@ -248,7 +247,7 @@ exports[`EuiInMemoryTable with items 1`] = `
   data-test-subj="test subject string"
 >
   <table
-    class="euiTable euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop"
+    class="euiTable emotion-euiTable-fixed-uncompressed-desktop"
     id="__table_generated-id"
     tabindex="-1"
   >

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -324,7 +324,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
   declare context: ContextType<typeof EuiComponentDefaultsContext>;
 
   static defaultProps = {
-    responsive: true,
     tableLayout: 'fixed',
     noItemsMessage: (
       <EuiI18n token="euiBasicTable.noItemsMessage" default="No items found" />
@@ -523,7 +522,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
       noItemsMessage,
       compressed,
       itemIdToExpandedRowMap,
-      responsive,
       responsiveBreakpoint,
       isSelectable,
       isExpandable,
@@ -554,28 +552,19 @@ export class EuiBasicTable<T extends object = any> extends Component<
   }
 
   renderTable() {
-    const {
-      compressed,
-      responsive,
-      responsiveBreakpoint,
-      tableLayout,
-      loading,
-    } = this.props;
+    const { compressed, responsiveBreakpoint, tableLayout, loading } =
+      this.props;
 
     return (
       <>
-        {/* TODO: Remove conditional once `responsive` prop is deprecated */}
-        {responsive && (
-          <EuiTableHeaderMobile responsiveBreakpoint={responsiveBreakpoint}>
-            {this.renderSelectAll(true)}
-            {this.renderTableMobileSort()}
-          </EuiTableHeaderMobile>
-        )}
+        <EuiTableHeaderMobile responsiveBreakpoint={responsiveBreakpoint}>
+          {this.renderSelectAll(true)}
+          {this.renderTableMobileSort()}
+        </EuiTableHeaderMobile>
         <EuiTable
           id={this.tableId}
           tableLayout={tableLayout}
           responsiveBreakpoint={responsiveBreakpoint}
-          responsive={responsive}
           compressed={compressed}
           css={loading && safariLoadingWorkaround}
         >

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -299,7 +299,6 @@ export class EuiInMemoryTable<T extends object = object> extends Component<
   static contextType = EuiComponentDefaultsContext;
 
   static defaultProps = {
-    responsive: true,
     tableLayout: 'fixed',
     searchFormat: 'eql',
   };

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiTable renders 1`] = `
 <table
   aria-label="aria-label"
-  class="euiTable testClass1 testClass2 euiTable--responsive emotion-euiTable-fixed-uncompressed-desktop-euiTestCss"
+  class="euiTable testClass1 testClass2 emotion-euiTable-fixed-uncompressed-desktop-euiTestCss"
   data-test-subj="test subject string"
   tabindex="-1"
 >

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -48,9 +48,7 @@ export const EuiTable: FunctionComponent<EuiTableProps> = ({
 }) => {
   const isResponsive = useIsEuiTableResponsive(responsiveBreakpoint);
 
-  const classes = classNames('euiTable', className, {
-    'euiTable--responsive': responsive,
-  });
+  const classes = classNames('euiTable', className);
 
   const styles = useEuiMemoizedStyles(euiTableStyles);
   const cssStyles = [

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -23,10 +23,6 @@ export interface EuiTableProps
     TableHTMLAttributes<HTMLTableElement> {
   compressed?: boolean;
   /**
-   * @deprecated - use `responsiveBreakpoint` instead
-   */
-  responsive?: boolean;
-  /**
    * Named breakpoint. Below this size, the table will collapse
    * into responsive cards.
    *
@@ -48,11 +44,9 @@ export const EuiTable: FunctionComponent<EuiTableProps> = ({
   compressed,
   tableLayout = 'fixed',
   responsiveBreakpoint, // Default handled by `useIsEuiTableResponsive`
-  responsive = true,
   ...rest
 }) => {
-  const isResponsive =
-    useIsEuiTableResponsive(responsiveBreakpoint) && responsive;
+  const isResponsive = useIsEuiTableResponsive(responsiveBreakpoint);
 
   const classes = classNames('euiTable', className, {
     'euiTable--responsive': responsive,


### PR DESCRIPTION
## Summary

> NOTE: This is going into the EuiTable Emotion conversion/cleanup feature branch.

I figured since we're already breaking/removing table props in #7632 and we're going to have to update a bunch of Kibana usages anyway, I should go ahead and just remove the `responsive` prop entirely that was only deprecated in #7625.

### ⚠️ Kibana updates needed:

Typescript will help us catch most of these, but here's a quick list from searching (~10 found instances):
- [basic/memory tables, `responsive={false}`](https://github.com/search?q=repo%3Aelastic%2Fkibana+EuiBasicTable+EuiInMemoryTable+%22responsive%3D%7Bfalse%7D%22&type=code)

## QA

QA will not look entirely correct until all Sass styles have been converted to Emotion. Also, QA should have already occurred as part of #7625 / will have another pass in the final feature branch

### General checklist

- Browser QA
    - [x] Checked in **mobile**
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A