### PR TITLE
[Emotion][perf] Remaining unmemoized button styles 

### DIFF
--- a/src/components/button/button_group/button_group_button.styles.ts
+++ b/src/components/button/button_group/button_group_button.styles.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { css } from '@emotion/react';
+import { css, type SerializedStyles } from '@emotion/react';
 import { CSSProperties } from 'react';
 
 import {
@@ -25,6 +25,7 @@ import {
 import {
   euiButtonFillColor,
   _EuiButtonColor,
+  BUTTON_COLORS,
 } from '../../../themes/amsterdam/global_styling/mixins/button';
 import { euiScreenReaderOnly } from '../../accessibility';
 import { euiFormVariables } from '../../form/form.styles';
@@ -74,6 +75,10 @@ export const euiButtonGroupButtonStyles = (euiThemeContext: UseEuiTheme) => {
       uncompressed: css`
         &:is(.euiButtonGroupButton-isSelected) {
           font-weight: ${euiTheme.font.weight.bold};
+        }
+
+        &:focus-visible {
+          ${euiOutline(euiThemeContext, 'inset', euiTheme.colors.fullShade)}
         }
       `,
       get borders() {
@@ -161,29 +166,23 @@ export const euiButtonGroupButtonStyles = (euiThemeContext: UseEuiTheme) => {
   };
 };
 
-export const _compressedButtonFocusColor = (
-  euiThemeContext: UseEuiTheme,
-  color: _EuiButtonColor | 'disabled'
-) => {
-  const { backgroundColor } = euiButtonFillColor(euiThemeContext, color);
+export const _compressedButtonFocusColors = (euiThemeContext: UseEuiTheme) => {
+  const colors = [...BUTTON_COLORS, 'disabled'] as const;
 
-  return css`
-    &:focus-visible {
-      ${euiOutline(euiThemeContext, 'center', backgroundColor)}
+  return colors.reduce((acc, color) => {
+    const { backgroundColor } = euiButtonFillColor(euiThemeContext, color);
 
-      &:is(.euiButtonGroupButton-isSelected) {
-        outline-offset: 0;
-      }
-    }
-  `;
-};
+    return {
+      ...acc,
+      [color]: css`
+        &:focus-visible {
+          ${euiOutline(euiThemeContext, 'center', backgroundColor)}
 
-export const _uncompressedButtonFocus = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
-
-  return css`
-    &:focus-visible {
-      ${euiOutline(euiThemeContext, 'inset', euiTheme.colors.fullShade)}
-    }
-  `;
+          &:is(.euiButtonGroupButton-isSelected) {
+            outline-offset: 0;
+          }
+        }
+      `,
+    };
+  }, {} as Record<_EuiButtonColor | 'disabled', SerializedStyles>);
 };

--- a/src/components/button/button_group/button_group_button.tsx
+++ b/src/components/button/button_group/button_group_button.tsx
@@ -14,7 +14,7 @@ import React, {
 } from 'react';
 import { CSSInterpolation } from '@emotion/css';
 
-import { useEuiTheme } from '../../../services';
+import { useEuiMemoizedStyles } from '../../../services';
 import { useEuiButtonColorCSS } from '../../../themes/amsterdam/global_styling/mixins/button';
 import { useInnerText } from '../../inner_text';
 
@@ -22,8 +22,7 @@ import { EuiButtonDisplay } from '../button_display/_button_display';
 import { EuiButtonGroupOptionProps, EuiButtonGroupProps } from './button_group';
 import {
   euiButtonGroupButtonStyles,
-  _compressedButtonFocusColor,
-  _uncompressedButtonFocus,
+  _compressedButtonFocusColors,
 } from './button_group_button.styles';
 import { EuiToolTip } from '../../../components/tool_tip';
 
@@ -69,13 +68,10 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
   const display = isSelected ? 'fill' : isCompressed ? 'empty' : 'base';
   const hasToolTip = !!toolTipContent;
 
-  const euiTheme = useEuiTheme();
+  const styles = useEuiMemoizedStyles(euiButtonGroupButtonStyles);
+  const focusColorStyles = useEuiMemoizedStyles(_compressedButtonFocusColors);
   const buttonColorStyles = useEuiButtonColorCSS({ display })[color];
-  const focusColorStyles = isCompressed
-    ? _compressedButtonFocusColor(euiTheme, color)
-    : _uncompressedButtonFocus(euiTheme);
 
-  const styles = euiButtonGroupButtonStyles(euiTheme);
   const cssStyles = [
     styles.euiButtonGroupButton,
     isIconOnly && styles.iconOnly,
@@ -83,7 +79,7 @@ export const EuiButtonGroupButton: FunctionComponent<Props> = ({
       (hasToolTip ? styles.uncompressed.hasToolTip : styles.uncompressed[size]),
     isCompressed ? styles.compressed : styles.uncompressed.uncompressed,
     isDisabled && isSelected ? styles.disabledAndSelected : buttonColorStyles,
-    !isDisabled && focusColorStyles,
+    !isDisabled && isCompressed && focusColorStyles[color],
   ];
   const tooltipWrapperStyles = [
     styles.tooltipWrapper,


### PR DESCRIPTION
## Summary

I missed these in #7541!

## QA

- [x] EuiButton loading spinner + icons look the same as before
- [x] EuiButtonGroup compressed focus colors work as before

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist - N/A
- Release checklist - N/A, skipping changelog due to this being perf tech debt that shouldn't impact consumers
- Designer checklist - N/A