### PR TITLE
[Emotion][perf] Memoize low-impact components (D-F)

### DIFF
--- a/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
+++ b/src/components/date_picker/__snapshots__/date_picker_range.test.tsx.snap
@@ -266,7 +266,7 @@ exports[`EuiDatePickerRange props fullWidth 1`] = `
 
 exports[`EuiDatePickerRange props inline renders 1`] = `
 <span
-  class="euiDatePickerRange emotion-euiDatePickerRange-inline-responsive-shadow"
+  class="euiDatePickerRange emotion-euiDatePickerRange-inline-shadow-responsive"
 >
   <div
     class="euiFormControlLayout euiFormControlLayoutDelimited"

--- a/src/components/date_picker/date_picker_range.tsx
+++ b/src/components/date_picker/date_picker_range.tsx
@@ -24,7 +24,7 @@ import {
 import { IconType } from '../icon';
 import { CommonProps } from '../common';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import {
   euiDatePickerRangeStyles,
   euiDatePickerRangeInlineStyles,
@@ -124,25 +124,20 @@ export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
 
   const classes = classNames('euiDatePickerRange', className);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiDatePickerRangeStyles(euiTheme);
-  const cssStyles = [styles.euiDatePickerRange];
-
-  if (inline) {
-    // Determine the inline container query to use based on the width of the react-datepicker
-    const hasTimeSelect =
-      startDateControl.props.showTimeSelect ||
-      endDateControl.props.showTimeSelect;
-
-    const inlineStyles = euiDatePickerRangeInlineStyles(euiTheme);
-    cssStyles.push(inlineStyles.inline);
-    cssStyles.push(
-      hasTimeSelect
-        ? inlineStyles.responsiveWithTimeSelect
-        : inlineStyles.responsive
-    );
-    if (shadow) cssStyles.push(inlineStyles.shadow);
-  }
+  const styles = useEuiMemoizedStyles(euiDatePickerRangeStyles);
+  const inlineStyles = useEuiMemoizedStyles(euiDatePickerRangeInlineStyles);
+  const cssStyles = inline
+    ? [
+        styles.euiDatePickerRange,
+        inlineStyles.inline,
+        shadow && inlineStyles.shadow,
+        // Determine the inline container query to use based on the width of the react-datepicker
+        startDateControl.props.showTimeSelect ||
+        endDateControl.props.showTimeSelect
+          ? inlineStyles.responsiveWithTimeSelect
+          : inlineStyles.responsive,
+      ]
+    : styles.euiDatePickerRange;
 
   let startControl = startDateControl;
   let endControl = endDateControl;

--- a/src/components/drag_and_drop/draggable.tsx
+++ b/src/components/drag_and_drop/draggable.tsx
@@ -15,7 +15,7 @@ import React, {
 import { Draggable, DraggableProps } from '@hello-pangea/dnd';
 import classNames from 'classnames';
 
-import { useEuiTheme, cloneElementWithCss } from '../../services';
+import { useEuiMemoizedStyles, cloneElementWithCss } from '../../services';
 import { CommonProps } from '../common';
 
 import { EuiDroppableContext, SPACINGS } from './droppable';
@@ -65,8 +65,7 @@ export const EuiDraggable: FunctionComponent<EuiDraggableProps> = ({
 }) => {
   const { cloneItems } = useContext(EuiDroppableContext);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiDraggableStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiDraggableStyles);
 
   return (
     <Draggable

--- a/src/components/drag_and_drop/droppable.tsx
+++ b/src/components/drag_and_drop/droppable.tsx
@@ -15,7 +15,7 @@ import React, {
 import { Droppable, DroppableProps } from '@hello-pangea/dnd';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
 import { EuiPanel } from '../panel';
 
@@ -73,8 +73,7 @@ export const EuiDroppable: FunctionComponent<EuiDroppableProps> = ({
   const { isDraggingType } = useContext(EuiDragDropContextContext);
   const dropIsDisabled: boolean = cloneDraggables ? true : isDropDisabled;
 
-  const euiTheme = useEuiTheme();
-  const styles = euiDroppableStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiDroppableStyles);
 
   return (
     <Droppable

--- a/src/components/error_boundary/error_boundary.tsx
+++ b/src/components/error_boundary/error_boundary.tsx
@@ -15,10 +15,10 @@ import React, {
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 
+import { useEuiMemoizedStyles } from '../../services';
 import { EuiTitle } from '../title';
 import { EuiCodeBlock } from '../code';
 import { EuiI18n } from '../i18n';
-import { useEuiTheme } from '../../services';
 
 import { euiErrorBoundaryStyles } from './error_boundary.styles';
 
@@ -94,8 +94,7 @@ ${stackStr}`;
 export const EuiErrorMessage: FunctionComponent<
   CommonProps & { errorMessage?: string }
 > = ({ errorMessage, className, 'data-test-subj': dataTestSubj, ...rest }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiErrorBoundaryStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiErrorBoundaryStyles);
 
   return (
     <div

--- a/src/components/expression/expression.styles.ts
+++ b/src/components/expression/expression.styles.ts
@@ -161,18 +161,16 @@ export const euiExpressionDescriptionStyles = ({ euiTheme }: UseEuiTheme) => {
   };
 };
 
-export const euiExpressionValueStyles = ({}: UseEuiTheme) => {
-  return {
-    euiExpression__value: css``,
-    truncate: css`
-      ${euiTextTruncate()}
-      display: inline-block;
-      vertical-align: bottom;
-    `,
-    columns: css`
-      flex-grow: 1;
-    `,
-  };
+export const euiExpressionValueStyles = {
+  euiExpression__value: css``,
+  truncate: css`
+    ${euiTextTruncate()}
+    display: inline-block;
+    vertical-align: bottom;
+  `,
+  columns: css`
+    flex-grow: 1;
+  `,
 };
 
 export const euiExpressionIconStyles = ({ euiTheme }: UseEuiTheme) => {

--- a/src/components/expression/expression.tsx
+++ b/src/components/expression/expression.tsx
@@ -14,14 +14,15 @@ import React, {
   FunctionComponent,
 } from 'react';
 import classNames from 'classnames';
+
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiIcon } from '../icon';
-import { useEuiTheme } from '../../services';
 
 import {
   euiExpressionStyles,
   euiExpressionDescriptionStyles,
-  euiExpressionValueStyles,
+  euiExpressionValueStyles as valueStyles,
   euiExpressionIconStyles,
 } from './expression.styles';
 
@@ -112,8 +113,7 @@ export const EuiExpression: FunctionComponent<
 }) => {
   const calculatedColor = isInvalid ? 'danger' : color;
 
-  const theme = useEuiTheme();
-  const styles = euiExpressionStyles(theme);
+  const styles = useEuiMemoizedStyles(euiExpressionStyles);
   const cssStyles = [
     styles.euiExpression,
     onClick && styles.isClickable,
@@ -123,7 +123,9 @@ export const EuiExpression: FunctionComponent<
     display === 'columns' && styles.columns,
     textWrap === 'truncate' && styles.truncate,
   ];
-  const descriptionStyles = euiExpressionDescriptionStyles(theme);
+  const descriptionStyles = useEuiMemoizedStyles(
+    euiExpressionDescriptionStyles
+  );
   const cssDescriptionStyles = [
     descriptionStyles.euiExpression__description,
     isInvalid ? descriptionStyles.danger : descriptionStyles[color],
@@ -131,14 +133,13 @@ export const EuiExpression: FunctionComponent<
     textWrap === 'truncate' && descriptionStyles.truncate,
     display === 'columns' && descriptionStyles.columns,
   ];
-  const valueStyles = euiExpressionValueStyles(theme);
   const cssValueStyles = [
     valueStyles.euiExpression__value,
     textWrap === 'truncate' && valueStyles.truncate,
     display === 'columns' && valueStyles.columns,
   ];
 
-  const iconStyles = euiExpressionIconStyles(theme);
+  const iconStyles = useEuiMemoizedStyles(euiExpressionIconStyles);
   const cssIconStyles = [
     iconStyles.euiExpression__icon,
     display === 'columns' && iconStyles.columns,
@@ -152,15 +153,6 @@ export const EuiExpression: FunctionComponent<
     display === 'columns' && descriptionWidth
       ? { flexBasis: descriptionWidth }
       : undefined;
-
-  const invalidIcon = isInvalid ? (
-    <EuiIcon
-      className="euiExpression__icon"
-      type="warning"
-      css={cssIconStyles}
-      color={calculatedColor}
-    />
-  ) : undefined;
 
   return (
     <Component css={cssStyles} className={classes} onClick={onClick} {...rest}>
@@ -184,7 +176,14 @@ export const EuiExpression: FunctionComponent<
           {value}
         </span>
       )}
-      {invalidIcon}
+      {isInvalid && (
+        <EuiIcon
+          className="euiExpression__icon"
+          type="warning"
+          css={cssIconStyles}
+          color={calculatedColor}
+        />
+      )}
     </Component>
   );
 };

--- a/src/components/facet/__snapshots__/facet_button.test.tsx.snap
+++ b/src/components/facet/__snapshots__/facet_button.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`EuiFacetButton props icon is rendered 1`] = `
     class="emotion-euiButtonDisplayContent"
   >
     <span
-      class="euiFacetButton__icon emotion-euiFacetButton__icon"
+      class="euiFacetButton__icon"
       data-euiicon-type="dot"
     />
     <span
@@ -55,7 +55,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
     class="emotion-euiButtonDisplayContent"
   >
     <span
-      class="euiFacetButton__icon emotion-euiFacetButton__icon-isDisabled"
+      class="euiFacetButton__icon emotion-euiFacetButton__disabled"
       color="success"
       data-euiicon-type="dot"
     />
@@ -66,7 +66,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
       Content
     </span>
     <span
-      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued-euiFacetButton__quantity-isDisabled"
+      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued-euiFacetButton__disabled"
     >
       6
     </span>
@@ -92,7 +92,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
     </span>
     <span
       aria-label="Loading"
-      class="euiLoadingSpinner emotion-euiLoadingSpinner-m-euiFacetButton__loadingSpinner"
+      class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
       role="progressbar"
     />
   </span>
@@ -134,7 +134,7 @@ exports[`EuiFacetButton props quantity is rendered 1`] = `
       Content
     </span>
     <span
-      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued-euiFacetButton__quantity"
+      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued"
     >
       60
     </span>

--- a/src/components/facet/facet_button.styles.ts
+++ b/src/components/facet/facet_button.styles.ts
@@ -54,20 +54,7 @@ export const euiFacetButtonTextStyles = ({ euiTheme }: UseEuiTheme) => ({
   unSelected: css``,
 });
 
-export const euiFacetButtonIconStyles = () => ({
-  euiFacetButton__icon: css``,
-  isDisabled: css`
-    opacity: 0.5;
-  `,
-});
-
-export const euiFacetButtonLoadingSpinnerStyles = () => ({
-  euiFacetButton__loadingSpinner: css``,
-});
-
-export const euiFacetButtonQuantityStyles = () => ({
-  euiFacetButton__quantity: css``,
-  isDisabled: css`
-    opacity: 0.5;
-  `,
-});
+// Used by both icon and quantity siblings
+export const euiFacetButton__disabled = css`
+  opacity: 0.5;
+`;

--- a/src/components/facet/facet_group.styles.ts
+++ b/src/components/facet/facet_group.styles.ts
@@ -7,66 +7,56 @@
  */
 
 import { css } from '@emotion/react';
-import { UseEuiTheme, useEuiTheme } from '../../services';
-import { EuiFacetGroupLayout } from './facet_group';
+import { UseEuiTheme } from '../../services';
+import { mathWithUnits } from '../../global_styling';
 
-const _facetGroupGutterSize = ({
-  gutterSize,
-  layout,
-}: {
-  gutterSize: string;
-  layout: EuiFacetGroupLayout;
-}) => {
-  const { euiTheme } = useEuiTheme();
-  const isHorizontalLayout = layout === 'horizontal';
-  const gutterHorizontal = `calc(${euiTheme.size.m} + ${gutterSize})`;
-  const gutterVertical = gutterSize;
+import type { EuiFacetGroupGutterSizes } from './facet_group';
 
-  return isHorizontalLayout
-    ? `gap: ${gutterVertical} ${gutterHorizontal};`
-    : `gap: ${gutterVertical} 0;`;
+export const euiFacetGroupStyles = ({ euiTheme }: UseEuiTheme) => {
+  const gutterSizesMap = {
+    none: 0,
+    s: euiTheme.size.xs,
+    m: euiTheme.size.s,
+    l: euiTheme.size.m,
+  };
+  const _getVerticalGutters = (sizeKey: EuiFacetGroupGutterSizes) => {
+    const size = gutterSizesMap[sizeKey];
+    return `gap: ${size} 0;`;
+  };
+  const _getHorizontalGutters = (sizeKey: EuiFacetGroupGutterSizes) => {
+    const size = gutterSizesMap[sizeKey];
+    return `
+      gap: ${size} ${mathWithUnits([size, euiTheme.size.m], (x, y) => x + y)};
+    `;
+  };
+
+  return {
+    // Base
+    euiFacetGroup: css`
+      display: flex;
+      flex-grow: 1;
+    `,
+    // layouts
+    horizontal: css`
+      flex-direction: row;
+      flex-wrap: wrap;
+    `,
+    vertical: css`
+      flex-direction: column;
+    `,
+    gutterSizes: {
+      vertical: {
+        none: css(_getVerticalGutters('none')),
+        s: css(_getVerticalGutters('s')),
+        m: css(_getVerticalGutters('m')),
+        l: css(_getVerticalGutters('l')),
+      },
+      horizontal: {
+        none: css(_getHorizontalGutters('none')),
+        s: css(_getHorizontalGutters('s')),
+        m: css(_getHorizontalGutters('m')),
+        l: css(_getHorizontalGutters('l')),
+      },
+    },
+  };
 };
-
-export const euiFacetGroupStyles = (
-  { euiTheme }: UseEuiTheme,
-  layout: EuiFacetGroupLayout
-) => ({
-  // Base
-  euiFacetGroup: css`
-    display: flex;
-    flex-grow: 1;
-  `,
-  // Gutter sizes
-  none: css(
-    _facetGroupGutterSize({
-      gutterSize: '0',
-      layout,
-    })
-  ),
-  s: css(
-    _facetGroupGutterSize({
-      gutterSize: euiTheme.size.xs,
-      layout,
-    })
-  ),
-  m: css(
-    _facetGroupGutterSize({
-      gutterSize: euiTheme.size.s,
-      layout,
-    })
-  ),
-  l: css(
-    _facetGroupGutterSize({
-      gutterSize: euiTheme.size.m,
-      layout,
-    })
-  ),
-  // layouts
-  horizontal: css`
-    flex-direction: row;
-    flex-wrap: wrap;
-  `,
-  vertical: css`
-    flex-direction: column;
-  `,
-});

--- a/src/components/facet/facet_group.tsx
+++ b/src/components/facet/facet_group.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../common';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { euiFacetGroupStyles } from './facet_group.styles';
 
 export const LAYOUTS = ['vertical', 'horizontal'] as const;
@@ -40,9 +40,12 @@ export const EuiFacetGroup: FunctionComponent<EuiFacetGroupProps> = ({
   gutterSize = 'm',
   ...rest
 }) => {
-  const theme = useEuiTheme();
-  const styles = euiFacetGroupStyles(theme, layout);
-  const cssStyles = [styles.euiFacetGroup, styles[gutterSize], styles[layout]];
+  const styles = useEuiMemoizedStyles(euiFacetGroupStyles);
+  const cssStyles = [
+    styles.euiFacetGroup,
+    styles.gutterSizes[layout][gutterSize],
+    styles[layout],
+  ];
 
   const classes = classNames('euiFacetGroup', className);
 

--- a/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`EuiFilterButton props numActiveFilters and hasActiveFilters renders 1`]
     />
     <span
       aria-label="5 active filters"
-      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-accent-euiFilterButton__notification-badgeContent"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-accent-euiFilterButton__notification"
       role="marquee"
     >
       5
@@ -132,7 +132,7 @@ exports[`EuiFilterButton props numFilters renders 1`] = `
     />
     <span
       aria-label="5 available filters"
-      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification"
       role="marquee"
     >
       5
@@ -203,7 +203,7 @@ exports[`EuiFilterButton renders zero properly 1`] = `
     />
     <span
       aria-label="0 available filters"
-      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification"
       role="marquee"
     >
       0

--- a/src/components/filter_group/filter_button.tsx
+++ b/src/components/filter_group/filter_button.tsx
@@ -9,7 +9,7 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { useInnerText } from '../inner_text';
 import { DistributiveOmit } from '../common';
@@ -78,8 +78,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   const numActiveFiltersDefined =
     numActiveFilters != null && numActiveFilters > 0;
 
-  const euiTheme = useEuiTheme();
-  const styles = euiFilterButtonStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiFilterButtonStyles);
   const cssStyles = [
     styles.euiFilterButton,
     withNext && styles.withNext,
@@ -91,7 +90,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     content: contentStyles,
     text: textStyles,
     notification: notificationStyles,
-  } = euiFilterButtonChildStyles(euiTheme);
+  } = useEuiMemoizedStyles(euiFilterButtonChildStyles);
 
   const classes = classNames(
     'euiFilterButton',
@@ -118,21 +117,10 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     '{count} available filters',
     { count: badgeCount }
   );
-
-  const badgeContent = showBadge && (
-    <EuiNotificationBadge
-      className="euiFilterButton__notification"
-      css={[
-        notificationStyles.euiFilterButton__notification,
-        isDisabled && notificationStyles.disabled,
-      ]}
-      aria-label={hasActiveFilters ? activeBadgeLabel : availableBadgeLabel}
-      color={isDisabled || !hasActiveFilters ? 'subdued' : badgeColor}
-      role="marquee" // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role
-    >
-      {badgeCount}
-    </EuiNotificationBadge>
-  );
+  const badgeStyles = [
+    notificationStyles.euiFilterButton__notification,
+    isDisabled && notificationStyles.disabled,
+  ];
 
   /**
    * Text
@@ -151,19 +139,6 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   const [ref, innerText] = useInnerText();
   const dataText =
     children && typeof children === 'string' ? children : innerText;
-
-  const textContent = (
-    <span
-      ref={ref}
-      data-text={dataText}
-      title={dataText}
-      {...textProps}
-      className={buttonTextClassNames}
-      css={textCssStyles}
-    >
-      {children}
-    </span>
-  );
 
   return (
     <EuiButtonEmpty
@@ -185,8 +160,28 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
       }}
       {...rest}
     >
-      {textContent}
-      {badgeContent}
+      <span
+        ref={ref}
+        data-text={dataText}
+        title={dataText}
+        {...textProps}
+        className={buttonTextClassNames}
+        css={textCssStyles}
+      >
+        {children}
+      </span>
+
+      {showBadge && (
+        <EuiNotificationBadge
+          className="euiFilterButton__notification"
+          css={badgeStyles}
+          aria-label={hasActiveFilters ? activeBadgeLabel : availableBadgeLabel}
+          color={isDisabled || !hasActiveFilters ? 'subdued' : badgeColor}
+          role="marquee" // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role
+        >
+          {badgeCount}
+        </EuiNotificationBadge>
+      )}
     </EuiButtonEmpty>
   );
 };

--- a/src/components/filter_group/filter_group.tsx
+++ b/src/components/filter_group/filter_group.tsx
@@ -9,7 +9,7 @@
 import React, { HTMLAttributes, ReactNode, FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
 
 import { euiFilterGroupStyles } from './filter_group.styles';
@@ -34,8 +34,7 @@ export const EuiFilterGroup: FunctionComponent<EuiFilterGroupProps> = ({
   compressed,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiFilterGroupStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiFilterGroupStyles);
   const cssStyles = [
     styles.euiFilterGroup,
     fullWidth && styles.fullWidth,

--- a/src/components/form/range/range_draggable.tsx
+++ b/src/components/form/range/range_draggable.tsx
@@ -14,7 +14,11 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useMouseMove, useEuiTheme } from '../../../services';
+import {
+  useMouseMove,
+  useEuiTheme,
+  useEuiMemoizedStyles,
+} from '../../../services';
 import { logicalStyles } from '../../../global_styling';
 
 import type { EuiDualRangeProps } from './types';
@@ -48,7 +52,6 @@ export const EuiRangeDraggable: FunctionComponent<EuiRangeDraggableProps> = ({
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
-
   const outerStyle: React.CSSProperties = useMemo(() => {
     return logicalStyles({
       left: lowerPosition,
@@ -67,13 +70,13 @@ export const EuiRangeDraggable: FunctionComponent<EuiRangeDraggableProps> = ({
 
   const classes = classNames('euiRangeDraggable', className);
 
-  const styles = euiRangeDraggableStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiRangeDraggableStyles);
   const cssStyles = [
     styles.euiRangeDraggable,
     showTicks && styles.hasTicks,
     disabled && styles.disabled,
   ];
-  const innerStyles = euiRangeDraggableInnerStyles(euiTheme);
+  const innerStyles = useEuiMemoizedStyles(euiRangeDraggableInnerStyles);
   const cssInnerStyles = [
     innerStyles.euiRangeDraggable__inner,
     disabled ? styles.disabled : innerStyles.enabled,


### PR DESCRIPTION
## Summary

Basically every component that isn't on the medium impact list (https://github.com/elastic/eui/issues/7561) and was easier to do a quick skim through. Some of the commits/components have extra cleanup in terms of `useMemo` usage, preferring inline JSX, and removing array/obj definitions. As always, I recommend [following by commit](https://github.com/elastic/eui/pull/7635/commits).


## QA

- [ ] Quick smoke test of all the affected components

### General checklist

- Browser QA - Skipping cross-browser testing in favor of smoke testing
- Docs site QA - N/A
- Code quality checklist - N/A
- Release checklist - N/A, skipping changelog due to this being perf tech debt that shouldn't impact consumers
- Designer checklist - N/A