### PR TITLE
[EuiTextTruncate] Remove beta status in docs

### DIFF
--- a/src-docs/src/views/text_truncate/text_truncate_example.js
+++ b/src-docs/src/views/text_truncate/text_truncate_example.js
@@ -35,15 +35,6 @@ const multiLineSource = require('!!raw-loader!./multi_line');
 
 export const TextTruncateExample = {
   title: 'Text truncation',
-  isBeta: true,
-  notice: (
-    <EuiCallOut iconType="beta" title="Beta development" color="warning">
-      <strong>EuiTextTruncate</strong> is a beta component that is still
-      undergoing <Link to="#performance">performance investigation</Link>. We
-      would particularly caution in high-usage scenarios (e.g. over 500 usages
-      per page).
-    </EuiCallOut>
-  ),
   pages: [
     {
       title: 'Single line',


### PR DESCRIPTION
## Summary

Per our deprecation schedule (#1469)

`EuiTextTruncate` is fairly stable at this point, and several fixes/perf enhancements have been implemented during its beta phase. I feel fairly confident in its current docs & usage as-is without the warning.

## QA

- [x] Beta callout and sidebar badge is gone in https://eui.elastic.co/pr_7639/#/utilities/text-truncation/single-line

### General checklist

N/A, mostly a docs change only. AFAIK we've never noted beta status in our changelog?