### PR TITLE
Convert table actions hover UX/behavior

### DIFF
--- a/changelogs/upcoming/7640.md
+++ b/changelogs/upcoming/7640.md
@@ -1,3 +1,7 @@
 **Bug fixes**
 
 - `EuiBasicTable` & `EuiInMemoryTable` `isPrimary` actions are now correctly shown on mobile views
+
+**Breaking changes**
+
+- Removed the `showOnHover` prop from `EuiTableRowCell` / `EuiBasicTable`/`EuiInMemoryTable`'s `columns` API. Use the new actions `columns[].actions[].showOnHover` API instead.

--- a/changelogs/upcoming/7640.md
+++ b/changelogs/upcoming/7640.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- `EuiBasicTable` & `EuiInMemoryTable` `isPrimary` actions are now correctly shown on mobile views

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -163,6 +163,11 @@ export default () => {
       if (multiAction) {
         actions = [
           {
+            ...actions[0],
+            isPrimary: true,
+            showOnHover: true,
+          },
+          {
             render: (user: User) => {
               return (
                 <EuiLink color="success" onClick={() => cloneUser(user)}>
@@ -176,7 +181,6 @@ export default () => {
               return <EuiLink onClick={() => {}}>Edit</EuiLink>;
             },
           },
-          ...actions,
         ];
       }
       return actions;

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           </div>
         </td>
         <td
-          class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-middle-desktop-euiBasicTableActionsWrapper"
+          class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
             class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
@@ -448,7 +448,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           </div>
         </td>
         <td
-          class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-middle-desktop-euiBasicTableActionsWrapper"
+          class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
             class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
@@ -569,7 +569,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           </div>
         </td>
         <td
-          class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-middle-desktop-euiBasicTableActionsWrapper"
+          class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
             class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -330,13 +330,13 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
           >
             <span
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
               <button
-                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
                 type="button"
               >
                 <span
@@ -354,7 +354,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
               <button
-                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
                 type="button"
               >
                 <span
@@ -451,13 +451,13 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
           >
             <span
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
               <button
-                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
                 type="button"
               >
                 <span
@@ -475,7 +475,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
               <button
-                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
                 type="button"
               >
                 <span
@@ -572,13 +572,13 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
           >
             <span
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
               <button
-                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
                 type="button"
               >
                 <span
@@ -596,7 +596,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
             >
               <button
-                class="euiButtonEmpty euiTableCellContent__hoverItem emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
                 type="button"
               >
                 <span

--- a/src/components/basic_table/__snapshots__/expanded_item_actions.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/expanded_item_actions.test.tsx.snap
@@ -1,39 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExpandedItemActions render 1`] = `
-<Fragment>
-  <DefaultItemAction
-    action={
-      Object {
-        "description": "default 1",
-        "name": "default1",
-        "onClick": [Function],
-      }
-    }
-    enabled={true}
-    item={
-      Object {
-        "id": "xyz",
-      }
-    }
-    key="item_action_xyz_0"
+exports[`ExpandedItemActions renders 1`] = `
+<div>
+  <span
+    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+  >
+    <button
+      class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+      type="button"
+    >
+      <span
+        class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+      >
+        <span
+          class="eui-textTruncate euiButtonEmpty__text"
+        >
+          default1
+        </span>
+      </span>
+    </button>
+  </span>
+  <div
+    class=""
   />
-  <CustomItemAction
-    action={
-      Object {
-        "description": "custom 1",
-        "name": "custom1",
-        "render": [Function],
-      }
-    }
-    enabled={true}
-    index={1}
-    item={
-      Object {
-        "id": "xyz",
-      }
-    }
-    key="item_action_xyz_1"
-  />
-</Fragment>
+  <span
+    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+  >
+    <a
+      class="euiButtonEmpty euiBasicTableAction-showOnHover emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+      href="#"
+      rel="noreferrer"
+    >
+      <span
+        class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+      >
+        <span
+          class="eui-textTruncate euiButtonEmpty__text"
+        >
+          showOnHover
+        </span>
+      </span>
+    </a>
+  </span>
+</div>
 `;

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -39,8 +39,21 @@ export interface DefaultItemActionBase<T extends object> {
    * A callback function that determines whether the action is enabled
    */
   enabled?: (item: T) => boolean;
-  isPrimary?: boolean;
   'data-test-subj'?: string | ((item: T) => string);
+  /**
+   * If more than 3 actions are passed, 2 primary actions will show (on hover)
+   * next to an expansion menu of all actions.
+   *
+   * On mobile, primary actions will be tucked away in the expansion menu for space.
+   */
+  isPrimary?: boolean;
+  /**
+   * Allows only showing the action on mouse hover or keyboard focus.
+   * If more than 3 actions are passed, this will always be true for `isPrimary` actions.
+   *
+   * Has no effect on mobile, or if `hasActions` is not set.
+   */
+  showOnHover?: boolean;
 }
 
 export interface DefaultItemEmptyButtonAction<T extends object>
@@ -70,7 +83,7 @@ export type DefaultItemAction<T extends object> = ExclusiveUnion<
   DefaultItemIconButtonAction<T>
 >;
 
-export interface CustomItemAction<T> {
+export type CustomItemAction<T> = {
   /**
    * Allows rendering a totally custom action
    */
@@ -83,8 +96,7 @@ export interface CustomItemAction<T> {
    * A callback that defines whether the action is enabled
    */
   enabled?: (item: T) => boolean;
-  isPrimary?: boolean;
-}
+} & Pick<DefaultItemActionBase<{}>, 'isPrimary' | 'showOnHover'>;
 
 export type Action<T extends object> =
   | DefaultItemAction<T>

--- a/src/components/basic_table/basic_table.styles.ts
+++ b/src/components/basic_table/basic_table.styles.ts
@@ -54,12 +54,6 @@ export const euiBasicTableBodyLoading = ({ euiTheme }: UseEuiTheme) => css`
 // Fix to make the loading indicator position correctly in Safari
 // For whatever annoying reason, Safari doesn't respect `position: relative;`
 // on `tbody` without `position: relative` on the parent `table`
-export const safariLoadingWorkaround = () => css`
+export const safariLoadingWorkaround = css`
   position: relative;
-`;
-
-// Unsets the extra height caused by tooltip/popover wrappers around table action buttons
-// Without this, the row height jumps whenever actions are disabled
-export const euiBasicTableActionsWrapper = css`
-  line-height: 1;
 `;

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -664,9 +664,12 @@ describe('EuiBasicTable', () => {
           },
         ],
       };
-      const { getAllByText } = render(<EuiBasicTable {...props} />);
+      const { getAllByText, container } = render(<EuiBasicTable {...props} />);
 
       expect(getAllByText('Delete')).toHaveLength(basicItems.length);
+      expect(
+        container.querySelector('.euiBasicTableAction-showOnHover')
+      ).not.toBeInTheDocument();
     });
 
     test('multiple actions with custom availability', () => {
@@ -680,7 +683,7 @@ describe('EuiBasicTable', () => {
           },
         ],
       };
-      const { getAllByText, getAllByTestSubject } = render(
+      const { getAllByText, getAllByTestSubject, container } = render(
         <EuiBasicTable {...props} />
       );
 
@@ -689,6 +692,12 @@ describe('EuiBasicTable', () => {
       expect(getAllByTestSubject('euiCollapsedItemActionsButton')).toHaveLength(
         4
       );
+      expect(
+        container.querySelector('.euiBasicTable__collapsedActions')
+      ).toBeInTheDocument();
+      expect(
+        container.querySelector('.euiBasicTableAction-showOnHover')
+      ).toBeInTheDocument();
     });
 
     test('custom item actions', () => {

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -78,7 +78,6 @@ import { EuiTableSortMobileProps } from '../table/mobile/table_sort_mobile';
 import {
   euiBasicTableBodyLoading,
   safariLoadingWorkaround,
-  euiBasicTableActionsWrapper,
 } from './basic_table.styles';
 
 type DataTypeProfiles = Record<
@@ -1174,7 +1173,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
         align="right"
         textOnly={false}
         hasActions={hasCustomActions ? 'custom' : true}
-        css={euiBasicTableActionsWrapper}
       >
         <ExpandedItemActions
           actions={actualActions}

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -1168,7 +1168,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
     const key = `record_actions_${itemId}_${columnIndex}`;
     return (
       <EuiTableRowCell
-        showOnHover={true}
         key={key}
         align="right"
         textOnly={false}

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -1139,9 +1139,15 @@ export class EuiBasicTable<T extends object = any> extends Component<
         // If all actions are disabled, do not show any actions but the popover toggle
         actualActions = [];
       } else {
-        // if any of the actions `isPrimary`, add them inline as well, but only the first 2
-        const primaryActions = actualActions.filter((o) => o.isPrimary);
-        actualActions = primaryActions.slice(0, 2);
+        // if any of the actions `isPrimary`, add them inline as well, but only the first 2,
+        // which we'll force to only show on hover for desktop views
+        const primaryActions = actualActions.filter(
+          (action) => action.isPrimary
+        );
+        actualActions = primaryActions.slice(0, 2).map((action) => ({
+          ...action,
+          showOnHover: true,
+        }));
       }
 
       // if we have more than 1 action, we don't show them all in the cell, instead we
@@ -1152,16 +1158,15 @@ export class EuiBasicTable<T extends object = any> extends Component<
 
       actualActions.push({
         name: 'All actions',
-        render: (item: T) => {
-          return (
-            <CollapsedItemActions
-              actions={column.actions}
-              actionsDisabled={allDisabled}
-              itemId={itemId}
-              item={item}
-            />
-          );
-        },
+        render: (item: T) => (
+          <CollapsedItemActions
+            className="euiBasicTable__collapsedActions"
+            actions={column.actions}
+            actionsDisabled={allDisabled}
+            itemId={itemId}
+            item={item}
+          />
+        ),
       });
     }
 

--- a/src/components/basic_table/expanded_item_actions.test.tsx
+++ b/src/components/basic_table/expanded_item_actions.test.tsx
@@ -7,14 +7,15 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '../../test/rtl';
+
 import {
   ExpandedItemActions,
   ExpandedItemActionsProps,
 } from './expanded_item_actions';
 
 describe('ExpandedItemActions', () => {
-  test('render', () => {
+  it('renders', () => {
     const props: ExpandedItemActionsProps<{ id: string }> = {
       actions: [
         {
@@ -27,14 +28,19 @@ describe('ExpandedItemActions', () => {
           description: 'custom 1',
           render: (_item) => <></>,
         },
+        {
+          name: 'showOnHover',
+          description: 'show on hover',
+          href: '#',
+          showOnHover: true,
+        },
       ],
       itemId: 'xyz',
       item: { id: 'xyz' },
       actionsDisabled: false,
     };
+    const { container } = render(<ExpandedItemActions {...props} />);
 
-    const component = shallow(<ExpandedItemActions {...props} />);
-
-    expect(component).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -48,7 +48,7 @@ export const ExpandedItemActions = <T extends {}>({
         const key = `item_action_${itemId}_${index}`;
 
         const classes = classNames(className, {
-          expandedItemActions__completelyHide: moreThanThree && index < 2,
+          'euiBasicTableAction-showOnHover': moreThanThree && index < 2,
         });
 
         if (isCustomItemAction<T>(action)) {

--- a/src/components/basic_table/expanded_item_actions.tsx
+++ b/src/components/basic_table/expanded_item_actions.tsx
@@ -33,8 +33,6 @@ export const ExpandedItemActions = <T extends {}>({
   actionsDisabled,
   className,
 }: ExpandedItemActionsProps<T>): ReactElement => {
-  const moreThanThree = actions.length > 2;
-
   return (
     <>
       {actions.reduce<ReactNode[]>((tools, action, index) => {
@@ -48,7 +46,7 @@ export const ExpandedItemActions = <T extends {}>({
         const key = `item_action_${itemId}_${index}`;
 
         const classes = classNames(className, {
-          'euiBasicTableAction-showOnHover': moreThanThree && index < 2,
+          'euiBasicTableAction-showOnHover': action.showOnHover,
         });
 
         if (isCustomItemAction<T>(action)) {

--- a/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
@@ -68,10 +68,10 @@ exports[`children's className merges new classnames into existing ones 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+          class="euiTableCellContent euiTableCellContent--overflowingContent"
         >
           <div
-            class="testClass euiTableCellContent__hoverItem"
+            class="testClass"
           />
         </div>
       </td>

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -3,24 +3,6 @@
 
 @include euiBreakpoint('xs', 's') {
   .euiTable.euiTable--responsive {
-    // never show hidden items and always show hover items on mobile,
-    .euiTableRow-hasActions .euiTableCellContent--showOnHover {
-      > * {
-        margin-left: 0;
-      }
-
-      .expandedItemActions__completelyHide {
-        display: none;
-      }
-
-      .euiTableCellContent__hoverItem {
-        opacity: 1;
-        filter: none;
-        margin-left: 0;
-        margin-bottom: $euiSizeS;
-      }
-    }
-
     // force all content back to left side
     .euiTableCellContent--alignRight {
       justify-content: flex-start;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -42,27 +42,3 @@
   // /* 4 */ overflow-wrap is not supported on flex parents
   word-break: break-word;
 }
-
-.euiTableRow-hasActions {
-  .euiTableCellContent--showOnHover {
-    .euiTableCellContent__hoverItem {
-      flex-shrink: 0;
-      opacity: .7;
-      filter: grayscale(100%);
-      transition: opacity $euiAnimSpeedNormal $euiAnimSlightResistance, filter $euiAnimSpeedNormal $euiAnimSlightResistance;
-    }
-
-    .expandedItemActions__completelyHide {
-      filter: grayscale(0%);
-      opacity: 0;
-    }
-  }
-
-  &:hover .euiTableCellContent--showOnHover,
-  .euiTableCellContent--showOnHover:focus-within {
-    .euiTableCellContent__hoverItem {
-      opacity: 1;
-      filter: grayscale(0%);
-    }
-  }
-}

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -43,12 +43,6 @@
   word-break: break-word;
 }
 
-.euiTableCellContent--showOnHover {
-  > *:not(:first-child) {
-    margin-left: $euiSizeS;
-  }
-}
-
 .euiTableRow-hasActions {
   .euiTableCellContent--showOnHover {
     .euiTableCellContent__hoverItem {

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -35,8 +35,8 @@ export interface EuiTableRowProps {
    */
   isSelected?: boolean;
   /**
-   * Indicates if the table has a dedicated column for icon-only actions
-   * (used for mobile styling)
+   * Indicates if the table has a dedicated column for actions
+   * (used for mobile styling and desktop action hover behavior)
    */
   hasActions?: boolean;
   /**

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -27,6 +27,13 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
       /* Unsets the extra strut caused by inline-block display of buttons/icons/tooltips.
          Without this, the row height jumps whenever actions are disabled. */
       line-height: 1;
+
+      /* TODO: Move this to EuiTableCellContent, once we're further along in the Emotion conversion */
+      .euiTableCellContent {
+        display: flex;
+        align-items: center;
+        gap: ${euiTheme.size.s};
+      }
     `,
 
     // valign
@@ -43,9 +50,17 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
       vertical-align: bottom;
     `,
 
-    desktop: css`
-      ${logicalCSS('border-vertical', euiTheme.border.thin)}
-    `,
+    desktop: {
+      desktop: css`
+        ${logicalCSS('border-vertical', euiTheme.border.thin)}
+      `,
+      actions: css`
+        /* TODO: Move this to EuiTableCellContent, once we're further along in the Emotion conversion */
+        .euiTableCellContent {
+          flex-wrap: wrap;
+        }
+      `,
+    },
 
     mobile: {
       mobile: css`

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -18,15 +18,19 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
 
   const { mobileSizes } = euiTableVariables(euiThemeContext);
 
+  // Unsets the extra strut caused by inline-block display of buttons/icons/tooltips.
+  // Without this, the row height jumps whenever actions are disabled.
+  const hasIcons = `line-height: 1;`;
+
   return {
     euiTableRowCell: css`
       color: ${euiTheme.colors.text};
     `,
-
+    isExpander: css`
+      ${hasIcons}
+    `,
     hasActions: css`
-      /* Unsets the extra strut caused by inline-block display of buttons/icons/tooltips.
-         Without this, the row height jumps whenever actions are disabled. */
-      line-height: 1;
+      ${hasIcons}
 
       /* TODO: Move this to EuiTableCellContent, once we're further along in the Emotion conversion */
       .euiTableCellContent {

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -59,6 +59,19 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
         .euiTableCellContent {
           flex-wrap: wrap;
         }
+
+        .euiBasicTableAction-showOnHover {
+          opacity: 0;
+          transition: opacity ${euiTheme.animation.normal}
+            ${euiTheme.animation.resistance};
+        }
+
+        &:focus-within,
+        .euiTableRow-hasActions:hover & {
+          .euiBasicTableAction-showOnHover {
+            opacity: 1;
+          }
+        }
       `,
     },
 
@@ -85,6 +98,7 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
         }
       `,
       get actions() {
+        // Note: Visible-on-hover actions on desktop always show on mobile
         return css`
           ${this.rightColumnContent}
           ${logicalCSS('top', mobileSizes.actions.offset)}

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -23,6 +23,12 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
       color: ${euiTheme.colors.text};
     `,
 
+    hasActions: css`
+      /* Unsets the extra strut caused by inline-block display of buttons/icons/tooltips.
+         Without this, the row height jumps whenever actions are disabled. */
+      line-height: 1;
+    `,
+
     // valign
     middle: css`
       vertical-align: middle;

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -128,7 +128,7 @@ describe('truncateText', () => {
 describe("children's className", () => {
   test('merges new classnames into existing ones', () => {
     const { container } = renderInTableRow(
-      <EuiTableRowCell textOnly={false} showOnHover={true}>
+      <EuiTableRowCell textOnly={false}>
         <div className="testClass" />
       </EuiTableRowCell>
     );

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -132,6 +132,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   const styles = useEuiMemoizedStyles(euiTableRowCellStyles);
   const cssStyles = [
     styles.euiTableRowCell,
+    isExpander && styles.isExpander,
     hasActions && styles.hasActions,
     styles[valign],
     ...(isResponsive

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -37,10 +37,6 @@ interface EuiTableRowCellSharedPropsShape {
    */
   align?: HorizontalAlignment;
   /**
-   * _Should only be used for action cells_
-   */
-  showOnHover?: boolean;
-  /**
    * Creates a text wrapper around cell content that helps word break or truncate
    * long text correctly.
    */
@@ -121,7 +117,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   className,
   truncateText,
   setScopeRow,
-  showOnHover,
   textOnly = true,
   hasActions,
   isExpander,
@@ -159,7 +154,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   const contentClasses = classNames('euiTableCellContent', {
     'euiTableCellContent--alignRight': align === RIGHT_ALIGNMENT,
     'euiTableCellContent--alignCenter': align === CENTER_ALIGNMENT,
-    'euiTableCellContent--showOnHover': showOnHover,
     'euiTableCellContent--truncateText': truncateText === true,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
     // purposes for the time-being.
@@ -171,8 +165,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
       mobileOptions.align === RIGHT_ALIGNMENT || align === RIGHT_ALIGNMENT,
     'euiTableCellContent--alignCenter':
       mobileOptions.align === CENTER_ALIGNMENT || align === CENTER_ALIGNMENT,
-    'euiTableCellContent--showOnHover':
-      mobileOptions.showOnHover ?? showOnHover,
     'euiTableCellContent--truncateText':
       mobileOptions.truncateText ?? truncateText,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
@@ -183,7 +175,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
 
   const childClasses = classNames({
     euiTableCellContent__text: textOnly === true,
-    euiTableCellContent__hoverItem: showOnHover,
   });
 
   const widthValue = isResponsive

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -95,8 +95,8 @@ export interface EuiTableRowCellProps extends EuiTableRowCellSharedPropsShape {
    */
   setScopeRow?: boolean;
   /**
-   * Indicates if the column is dedicated to icon-only actions (currently
-   * affects mobile only)
+   * Indicates if the cell is dedicated to row actions
+   * (used for mobile styling and desktop action hover behavior)
    */
   hasActions?: boolean | 'custom';
   /**
@@ -147,7 +147,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
           hasActions === true && styles.mobile.actions,
           isExpander && styles.mobile.expander,
         ]
-      : [styles.desktop]),
+      : [styles.desktop.desktop, hasActions && styles.desktop.actions]),
   ];
 
   const cellClasses = classNames('euiTableRowCell', className, {

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -137,6 +137,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   const styles = useEuiMemoizedStyles(euiTableRowCellStyles);
   const cssStyles = [
     styles.euiTableRowCell,
+    hasActions && styles.hasActions,
     styles[valign],
     ...(isResponsive
       ? [


### PR DESCRIPTION
## Summary

Involves mostly a lot of cleanup (both of CSS and of the props/APIs used 🫠) as there's a lot of legacy code here that I don't love and some styles that (AFAICT) no longer apply. As always, please [follow along by commit](https://github.com/elastic/eui/pull/7640/commits).

The first commit I apparently fixed for `EuiBasicTable` in https://github.com/elastic/eui/pull/6538, but should've applied at a lower level to `EuiTableRowCell` itself. Now's as good a time for that as any!

### ⚠️ Kibana updates needed

`showOnHover` API change:
- 2 usages ([1](https://github.com/elastic/kibana/blob/2f9b90a9ea5a3f3dffecb9caec05db2066870b00/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/metadata/table.tsx#L89), [2](https://github.com/elastic/kibana/blob/2f9b90a9ea5a3f3dffecb9caec05db2066870b00/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/metadata/table.tsx#L161)) in an Observability table. Converting these to `actions` columns with `showOnHover` should be a relatively straightforward migration

className removals:
- `.expandedItemActions__completelyHide`
  - [1 usage](https://github.com/elastic/kibana/blob/2f9b90a9ea5a3f3dffecb9caec05db2066870b00/x-pack/plugins/observability_solution/infra/public/components/asset_details/tabs/metadata/add_pin_to_row.tsx#L62) in the same Observability table above. Changing their API will let us remove the className usage
- `.euiTableCellContent__hoverItem`
  - Same usage as above in Obs table
  - [1 test selector usage](https://github.com/elastic/kibana/blob/3ef768aa45601bc3b089107eeadb2f965e743487/x-pack/plugins/observability_solution/synthetics/e2e/synthetics/journeys/private_locations.journey.ts#L123) that should be updated
- `.euiTableCellContent--showOnHover` - no usages

## QA

First commit/strut fix testing
- Go to https://eui.elastic.co/pr_7640/storybook/?path=/story/tabular-content-euitable-euitablerow--playground
- [x] Confirm that toggling the `hasActions` Storybook control does not cause any height shift/jumping in the table row

Regression & responsive testing
- Go to https://eui.elastic.co/pr_7640/#/tabular-content/tables#adding-actions-to-table
- [x] Confirm that the single action (link) is visible immediately and looks the same as prod
- [x] Toggle the `Multiple Actions` switch. Confirm that on row hover or button focus, delete and share button icons are visible (same as prod)
- [x] Resize your window to less than 768px, and confirm the action icons look correct on mobile, and that the delete and share buttons are visible (different from prod)
- [x] Resize your window back to desktop and toggle the `Custom Actions` switch. Confirm the custom `Delete` action is visible on hover (different from prod)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A