### PR TITLE
DRY out new `EuiTableCellContent` internal subcomponent & convert to Emotion

### DIFF
--- a/changelogs/upcoming/7641.md
+++ b/changelogs/upcoming/7641.md
@@ -1,0 +1,3 @@
+**DOM changes**
+
+- `EuiTableRowCell`s with `textOnly` set to `false` will no longer attempt to apply the `.euiTableCellContent__text` className to child elements.

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -22,11 +22,11 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
           role="columnheader"
           scope="col"
         >
-          <span
-            class="euiTableCellContent"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="Name; description"
             >
               Name
@@ -36,7 +36,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
             >
               description
             </span>
-          </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -55,7 +55,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
             Name
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -77,7 +77,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
             Name
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -99,7 +99,7 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
             Name
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -164,11 +164,11 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             data-test-subj="tableHeaderSortButton"
             type="button"
           >
-            <span
-              class="euiTableCellContent"
+            <div
+              class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
             >
               <span
-                class="euiTableCellContent__text"
+                class="eui-textTruncate"
                 title="Name; your name"
               >
                 Name
@@ -182,7 +182,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
                 class="euiTableSortIcon"
                 data-euiicon-type="sortUp"
               />
-            </span>
+            </div>
           </button>
         </th>
         <th
@@ -191,11 +191,11 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           role="columnheader"
           scope="col"
         >
-          <span
-            class="euiTableCellContent"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="ID; your id"
             >
               ID
@@ -205,7 +205,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             >
               your id
             </span>
-          </span>
+          </div>
         </th>
         <th
           class="euiTableHeaderCell emotion-euiTableHeaderCell"
@@ -213,11 +213,11 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           role="columnheader"
           scope="col"
         >
-          <span
-            class="euiTableCellContent euiTableCellContent--alignRight"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="Age; your age"
             >
               Age
@@ -227,23 +227,23 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             >
               your age
             </span>
-          </span>
+          </div>
         </th>
         <th
           class="euiTableHeaderCell emotion-euiTableHeaderCell"
           role="columnheader"
           scope="col"
         >
-          <span
-            class="euiTableCellContent euiTableCellContent--alignRight"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="Actions"
             >
               Actions
             </span>
-          </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -285,7 +285,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             Name
           </div>
           <div
-            class="euiTableCellContent euiTableCellContent--overflowingContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             NAME1
           </div>
@@ -299,7 +299,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             ID
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -317,7 +317,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             Age
           </div>
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight"
+            class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -330,7 +330,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+            class="euiTableCellContent emotion-euiTableCellContent-right-wrapText-actions-desktop"
           >
             <span
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
@@ -406,7 +406,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             Name
           </div>
           <div
-            class="euiTableCellContent euiTableCellContent--overflowingContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             NAME2
           </div>
@@ -420,7 +420,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             ID
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -438,7 +438,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             Age
           </div>
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight"
+            class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -451,7 +451,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+            class="euiTableCellContent emotion-euiTableCellContent-right-wrapText-actions-desktop"
           >
             <span
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
@@ -527,7 +527,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             Name
           </div>
           <div
-            class="euiTableCellContent euiTableCellContent--overflowingContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             NAME3
           </div>
@@ -541,7 +541,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             ID
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -559,7 +559,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             Age
           </div>
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight"
+            class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -572,7 +572,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-desktop-actions"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
+            class="euiTableCellContent emotion-euiTableCellContent-right-wrapText-actions-desktop"
           >
             <span
               class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
@@ -620,7 +620,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableFooterCell emotion-euiTableFooterCell"
         >
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-truncateText"
           >
             <span
               class="euiTableCellContent__text"
@@ -631,7 +631,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableFooterCell emotion-euiTableFooterCell"
         >
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-truncateText"
           >
             <span
               class="euiTableCellContent__text"
@@ -642,7 +642,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableFooterCell emotion-euiTableFooterCell"
         >
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-truncateText"
           >
             <span
               class="euiTableCellContent__text"
@@ -658,7 +658,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableFooterCell emotion-euiTableFooterCell"
         >
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-truncateText"
           >
             <span
               class="euiTableCellContent__text"
@@ -669,7 +669,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableFooterCell emotion-euiTableFooterCell"
         >
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-truncateText"
           >
             <span
               class="euiTableCellContent__text"

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EuiBasicTable actions custom item actions 1`] = `
+<tr
+  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions emotion-euiTableRow-mobile"
+>
+  <td
+    class="euiTableRowCell euiTableRowCell--hasActions emotion-euiTableRowCell-hasActions-middle-mobile-customActions"
+  >
+    <div
+      class="euiTableCellContent emotion-euiTableCellContent-wrapText-actions"
+    >
+      <div
+        class=""
+      >
+        <button
+          data-test-subj="customAction-1"
+        >
+          Custom action
+        </button>
+      </div>
+    </div>
+  </td>
+</tr>
+`;
+
 exports[`EuiBasicTable renders (bare-bones) 1`] = `
 <div
   aria-label="aria-label"

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -170,11 +170,11 @@ exports[`EuiInMemoryTable empty array 1`] = `
           role="columnheader"
           scope="col"
         >
-          <span
-            class="euiTableCellContent"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="Name; description"
             >
               Name
@@ -184,7 +184,7 @@ exports[`EuiInMemoryTable empty array 1`] = `
             >
               description
             </span>
-          </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -199,7 +199,7 @@ exports[`EuiInMemoryTable empty array 1`] = `
           colspan="1"
         >
           <div
-            class="euiTableCellContent euiTableCellContent--alignCenter"
+            class="euiTableCellContent emotion-euiTableCellContent-center-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -262,11 +262,11 @@ exports[`EuiInMemoryTable with items 1`] = `
           role="columnheader"
           scope="col"
         >
-          <span
-            class="euiTableCellContent"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="Name; description"
             >
               Name
@@ -276,7 +276,7 @@ exports[`EuiInMemoryTable with items 1`] = `
             >
               description
             </span>
-          </span>
+          </div>
         </th>
       </tr>
     </thead>
@@ -295,7 +295,7 @@ exports[`EuiInMemoryTable with items 1`] = `
             Name
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -317,7 +317,7 @@ exports[`EuiInMemoryTable with items 1`] = `
             Name
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"
@@ -339,7 +339,7 @@ exports[`EuiInMemoryTable with items 1`] = `
             Name
           </div>
           <div
-            class="euiTableCellContent"
+            class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
               class="euiTableCellContent__text"

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -704,7 +704,6 @@ describe('EuiBasicTable', () => {
       const props: EuiBasicTableProps<BasicItem> = {
         items: basicItems,
         columns: [
-          ...basicColumns,
           {
             name: 'Actions',
             actions: [
@@ -729,9 +728,21 @@ describe('EuiBasicTable', () => {
       expect(queryByTestSubject('customAction-2')).toBeInTheDocument();
       expect(queryByTestSubject('customAction-3')).not.toBeInTheDocument();
 
+      // TODO: These assertions should ideally be visual regression snapshots instead
       expect(
         container.querySelector('.euiTableRowCell--hasActions')!.className
       ).toContain('-customActions');
+      expect(
+        container.querySelector(
+          '.euiTableRowCell--hasActions .euiTableCellContent'
+        )!.className
+      ).not.toContain('-actions-mobile');
+      expect(
+        container.querySelector('.euiTableRow-hasActions')!.className
+      ).not.toContain('-hasRightColumn');
+      expect(
+        container.querySelector('.euiTableRow-hasActions')
+      ).toMatchSnapshot();
     });
 
     describe('are disabled on selection', () => {

--- a/src/components/basic_table/basic_table.test.tsx
+++ b/src/components/basic_table/basic_table.test.tsx
@@ -564,7 +564,7 @@ describe('EuiBasicTable', () => {
 
       // Numbers should be right aligned
       expect(
-        container.querySelectorAll('.euiTableCellContent--alignRight')
+        container.querySelectorAll('[class*="euiTableCellContent-right"]')
       ).toHaveLength(3);
 
       // Booleans should output as Yes or No

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -1438,7 +1438,7 @@ describe('EuiInMemoryTable', () => {
       const columns = [{ field: 'title', name: 'Title' }];
       const query = Query.parse('baz');
 
-      const component = mount(
+      const { container } = render(
         <EuiInMemoryTable
           items={items}
           search={{ query }}
@@ -1447,12 +1447,12 @@ describe('EuiInMemoryTable', () => {
         />
       );
 
-      const tableContent = component.find(
+      const tableContent = container.querySelectorAll(
         '.euiTableRowCell .euiTableCellContent'
       );
 
       expect(tableContent.length).toBe(1); // only 1 match
-      expect(tableContent.at(0).text()).toBe('baz');
+      expect(tableContent[0]).toHaveTextContent('baz');
     });
 
     it('does not execute the Query and renders the items passed as is', () => {
@@ -1460,7 +1460,7 @@ describe('EuiInMemoryTable', () => {
       const columns = [{ field: 'title', name: 'Title' }];
       const query = Query.parse('baz');
 
-      const component = mount(
+      const { container } = render(
         <EuiInMemoryTable
           items={items}
           search={{ query }}
@@ -1469,14 +1469,14 @@ describe('EuiInMemoryTable', () => {
         />
       );
 
-      const tableContent = component.find(
+      const tableContent = container.querySelectorAll(
         '.euiTableRowCell .euiTableCellContent'
       );
 
       expect(tableContent.length).toBe(3);
-      expect(tableContent.at(0).text()).toBe('foo');
-      expect(tableContent.at(1).text()).toBe('bar');
-      expect(tableContent.at(2).text()).toBe('baz');
+      expect(tableContent[0]).toHaveTextContent('foo');
+      expect(tableContent[1]).toHaveTextContent('bar');
+      expect(tableContent[2]).toHaveTextContent('baz');
     });
   });
 

--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -121,9 +121,12 @@ export interface EuiTableComputedColumnType<T>
    */
   width?: string;
   /**
-   * Indicates whether this column should truncate its content when it doesn't fit
+   * Indicates whether this column should truncate overflowing text content.
+   * - Set to `true` to enable single-line truncation.
+   * - To enable multi-line truncation, use a configuration object with `lines`
+   * set to a number of lines to truncate to.
    */
-  truncateText?: boolean;
+  truncateText?: EuiTableRowCellProps['truncateText'];
   isExpander?: boolean;
   align?: HorizontalAlignment;
   /**

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -7,4 +7,3 @@
 @import 'form/index';
 @import 'markdown_editor/index';
 @import 'selectable/index';
-@import 'table/index';

--- a/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__snapshots__/table.test.tsx.snap
@@ -14,32 +14,32 @@ exports[`EuiTable renders 1`] = `
         role="columnheader"
         scope="col"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Hi Title"
           >
             Hi Title
           </span>
-        </span>
+        </div>
       </th>
       <th
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
         scope="col"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Bye Title"
           >
             Bye Title
           </span>
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -51,7 +51,7 @@ exports[`EuiTable renders 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -68,7 +68,7 @@ exports[`EuiTable renders 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"

--- a/src/components/table/__snapshots__/table_footer_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_footer_cell.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiTableFooterCell align defaults to left 1`] = `
         class="euiTableFooterCell emotion-euiTableFooterCell"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -28,7 +28,7 @@ exports[`EuiTableFooterCell align renders center when specified 1`] = `
         class="euiTableFooterCell emotion-euiTableFooterCell"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--alignCenter"
+          class="euiTableCellContent emotion-euiTableCellContent-center-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -48,7 +48,7 @@ exports[`EuiTableFooterCell align renders right when specified 1`] = `
         class="euiTableFooterCell emotion-euiTableFooterCell"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--alignRight"
+          class="euiTableCellContent emotion-euiTableCellContent-right-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -70,7 +70,7 @@ exports[`EuiTableFooterCell is rendered 1`] = `
         data-test-subj="test subject string"
       >
         <div
-          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -93,7 +93,7 @@ exports[`EuiTableFooterCell width and style accepts style attribute 1`] = `
         style="width: 20%;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -116,7 +116,7 @@ exports[`EuiTableFooterCell width and style accepts width attribute 1`] = `
         style="width: 10%;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -139,7 +139,7 @@ exports[`EuiTableFooterCell width and style accepts width attribute as number 1`
         style="width: 100px;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -162,7 +162,7 @@ exports[`EuiTableFooterCell width and style resolves style and width attribute 1
         style="width: 10%;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`align defaults to left 1`] = `
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
           />
-        </span>
+        </div>
       </td>
     </tr>
   </thead>
@@ -29,13 +29,13 @@ exports[`align renders center when specified 1`] = `
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
       >
-        <span
-          class="euiTableCellContent euiTableCellContent--alignCenter"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-center-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
           />
-        </span>
+        </div>
       </td>
     </tr>
   </thead>
@@ -50,13 +50,13 @@ exports[`align renders right when specified 1`] = `
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
       >
-        <span
-          class="euiTableCellContent euiTableCellContent--alignRight"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-right-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
           />
-        </span>
+        </div>
       </td>
     </tr>
   </thead>
@@ -74,16 +74,16 @@ exports[`renders EuiTableHeaderCell 1`] = `
         role="columnheader"
         scope="col"
       >
-        <span
-          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="children"
           >
             children
           </span>
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -100,13 +100,13 @@ exports[`renders td when children is null/undefined 1`] = `
         data-test-subj="test subject string"
         role="columnheader"
       >
-        <span
-          class="euiTableCellContent testClass1 testClass2 emotion-euiTestCss"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
           />
-        </span>
+        </div>
       </td>
     </tr>
   </thead>
@@ -124,11 +124,11 @@ exports[`sorting does not render a button with readOnly 1`] = `
         role="columnheader"
         scope="col"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
@@ -137,7 +137,7 @@ exports[`sorting does not render a button with readOnly 1`] = `
             class="euiTableSortIcon"
             data-euiicon-type="sortDown"
           />
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -155,11 +155,11 @@ exports[`sorting is rendered with isSortAscending 1`] = `
         role="columnheader"
         scope="col"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
@@ -168,7 +168,7 @@ exports[`sorting is rendered with isSortAscending 1`] = `
             class="euiTableSortIcon"
             data-euiicon-type="sortUp"
           />
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -186,11 +186,11 @@ exports[`sorting is rendered with isSorted 1`] = `
         role="columnheader"
         scope="col"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
@@ -199,7 +199,7 @@ exports[`sorting is rendered with isSorted 1`] = `
             class="euiTableSortIcon"
             data-euiicon-type="sortDown"
           />
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -222,11 +222,11 @@ exports[`sorting renders a button with onSort 1`] = `
           data-test-subj="tableHeaderSortButton"
           type="button"
         >
-          <span
-            class="euiTableCellContent"
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
           >
             <span
-              class="euiTableCellContent__text"
+              class="eui-textTruncate"
               title="Test"
             >
               Test
@@ -235,7 +235,7 @@ exports[`sorting renders a button with onSort 1`] = `
               class="euiTableSortIcon"
               data-euiicon-type="sortDown"
             />
-          </span>
+          </div>
         </button>
       </th>
     </tr>
@@ -253,16 +253,16 @@ exports[`width and style accepts style attribute 1`] = `
         scope="col"
         style="width: 20%;"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
           </span>
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -279,16 +279,16 @@ exports[`width and style accepts width attribute 1`] = `
         scope="col"
         style="width: 10%;"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
           </span>
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -305,16 +305,16 @@ exports[`width and style accepts width attribute as number 1`] = `
         scope="col"
         style="width: 100px;"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
           </span>
-        </span>
+        </div>
       </th>
     </tr>
   </thead>
@@ -331,16 +331,16 @@ exports[`width and style resolves style and width attribute 1`] = `
         scope="col"
         style="width: 10%;"
       >
-        <span
-          class="euiTableCellContent"
+        <div
+          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
         >
           <span
-            class="euiTableCellContent__text"
+            class="eui-textTruncate"
             title="Test"
           >
             Test
           </span>
-        </span>
+        </div>
       </th>
     </tr>
   </thead>

--- a/src/components/table/__snapshots__/table_row.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`isSelected renders true when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -34,7 +34,7 @@ exports[`renders EuiTableRow 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"

--- a/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`align defaults to left 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -28,7 +28,7 @@ exports[`align renders center when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent-center"
+          class="euiTableCellContent emotion-euiTableCellContent-center-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -48,7 +48,7 @@ exports[`align renders right when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent-right"
+          class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -68,7 +68,7 @@ exports[`children's className merges new classnames into existing ones 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent euiTableCellContent--overflowingContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <div
             class="testClass"
@@ -90,7 +90,7 @@ exports[`renders EuiTableRowCell 1`] = `
         data-test-subj="test subject string"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -112,7 +112,7 @@ exports[`textOnly defaults to true 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -132,7 +132,7 @@ exports[`textOnly is rendered when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent euiTableCellContent--overflowingContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         />
       </td>
     </tr>
@@ -148,7 +148,7 @@ exports[`truncateText defaults to false 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -168,7 +168,7 @@ exports[`truncateText renders lines configuration 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text euiTextBlockTruncate emotion-euiTextBlockTruncate"
@@ -188,7 +188,7 @@ exports[`truncateText renders true 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent euiTableCellContent--truncateText emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-truncateText"
         >
           <span
             class="euiTableCellContent__text"
@@ -208,7 +208,7 @@ exports[`valign defaults to middle 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -228,7 +228,7 @@ exports[`valign renders bottom when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-bottom-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -248,7 +248,7 @@ exports[`valign renders top when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-top-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -269,7 +269,7 @@ exports[`width and style accepts style attribute 1`] = `
         style="width: 20%;"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -292,7 +292,7 @@ exports[`width and style accepts width attribute 1`] = `
         style="width: 10%;"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -315,7 +315,7 @@ exports[`width and style accepts width attribute as number 1`] = `
         style="width: 100px;"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"
@@ -338,7 +338,7 @@ exports[`width and style resolves style and width attribute 1`] = `
         style="width: 10%;"
       >
         <div
-          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
+          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
         >
           <span
             class="euiTableCellContent__text"

--- a/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`align defaults to left 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -28,7 +28,7 @@ exports[`align renders center when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--alignCenter"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent-center"
         >
           <span
             class="euiTableCellContent__text"
@@ -48,7 +48,7 @@ exports[`align renders right when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--alignRight"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent-right"
         >
           <span
             class="euiTableCellContent__text"
@@ -68,7 +68,7 @@ exports[`children's className merges new classnames into existing ones 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--overflowingContent"
+          class="euiTableCellContent euiTableCellContent euiTableCellContent--overflowingContent emotion-euiTableCellContent"
         >
           <div
             class="testClass"
@@ -90,7 +90,7 @@ exports[`renders EuiTableRowCell 1`] = `
         data-test-subj="test subject string"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -112,7 +112,7 @@ exports[`textOnly defaults to true 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -132,7 +132,7 @@ exports[`textOnly is rendered when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--overflowingContent"
+          class="euiTableCellContent euiTableCellContent euiTableCellContent--overflowingContent emotion-euiTableCellContent"
         />
       </td>
     </tr>
@@ -148,7 +148,7 @@ exports[`truncateText defaults to false 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -168,7 +168,7 @@ exports[`truncateText renders lines configuration 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text euiTextBlockTruncate emotion-euiTextBlockTruncate"
@@ -188,7 +188,7 @@ exports[`truncateText renders true 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent euiTableCellContent--truncateText"
+          class="euiTableCellContent euiTableCellContent euiTableCellContent--truncateText emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -208,7 +208,7 @@ exports[`valign defaults to middle 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -228,7 +228,7 @@ exports[`valign renders bottom when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-bottom-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -248,7 +248,7 @@ exports[`valign renders top when specified 1`] = `
         class="euiTableRowCell emotion-euiTableRowCell-top-desktop"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -269,7 +269,7 @@ exports[`width and style accepts style attribute 1`] = `
         style="width: 20%;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -292,7 +292,7 @@ exports[`width and style accepts width attribute 1`] = `
         style="width: 10%;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -315,7 +315,7 @@ exports[`width and style accepts width attribute as number 1`] = `
         style="width: 100px;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"
@@ -338,7 +338,7 @@ exports[`width and style resolves style and width attribute 1`] = `
         style="width: 10%;"
       >
         <div
-          class="euiTableCellContent"
+          class="euiTableCellContent euiTableCellContent emotion-euiTableCellContent"
         >
           <span
             class="euiTableCellContent__text"

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,2 +1,0 @@
-@import 'table';
-@import 'responsive';

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -1,7 +1,0 @@
-// TODO: Address nesting during Emotion conversion, if possible
-// stylelint-disable max-nesting-depth
-
-@include euiBreakpoint('xs', 's') {
-  .euiTable.euiTable--responsive {
-  }
-}

--- a/src/components/table/_responsive.scss
+++ b/src/components/table/_responsive.scss
@@ -3,13 +3,5 @@
 
 @include euiBreakpoint('xs', 's') {
   .euiTable.euiTable--responsive {
-    // force all content back to left side
-    .euiTableCellContent--alignRight {
-      justify-content: flex-start;
-    }
-
-    .euiTableCellContent--alignCenter {
-      justify-content: flex-start;
-    }
   }
 }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,8 +1,0 @@
-// TODO: Address this in upcoming EuiTableCellContent PR
-.euiTableHeaderCell {
-  @include euiTextTruncate;
-
-  .euiTableCellContent__text {
-    overflow: hidden;
-  }
-}

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,28 +1,15 @@
 /**
- * 1. Vertically align all children.
  * 4. Prevent very long single words (e.g. the name of a field in a document) from overflowing
  *    the cell.
  */
 .euiTableCellContent {
   overflow: hidden; /* 4 */
-  display: flex;
-  align-items: center; /* 1 */
 }
 
 .euiTableCellContent__text {
   @include euiTextBreakWord; /* 4 */
   min-width: 0;
   text-overflow: ellipsis;
-}
-
-.euiTableCellContent--alignRight {
-  justify-content: flex-end;
-  text-align: right;
-}
-
-.euiTableCellContent--alignCenter {
-  justify-content: center;
-  text-align: center;
 }
 
 // TODO: Address this in upcoming EuiTableCellContent PR

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,6 +1,5 @@
 // TODO: Address this in upcoming EuiTableCellContent PR
-.euiTableHeaderCell,
-.euiTableFooterCell {
+.euiTableHeaderCell {
   @include euiTextTruncate;
 
   .euiTableCellContent__text {

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,31 +1,9 @@
-/**
- * 4. Prevent very long single words (e.g. the name of a field in a document) from overflowing
- *    the cell.
- */
-.euiTableCellContent {
-  overflow: hidden; /* 4 */
-}
-
-.euiTableCellContent__text {
-  @include euiTextBreakWord; /* 4 */
-  min-width: 0;
-  text-overflow: ellipsis;
-}
-
 // TODO: Address this in upcoming EuiTableCellContent PR
 .euiTableHeaderCell,
-.euiTableFooterCell,
-.euiTableCellContent--truncateText {
+.euiTableFooterCell {
   @include euiTextTruncate;
 
   .euiTableCellContent__text {
     overflow: hidden;
   }
-}
-
-.euiTableCellContent--overflowingContent {
-  overflow: visible;
-  white-space: normal;
-  // /* 4 */ overflow-wrap is not supported on flex parents
-  word-break: break-word;
 }

--- a/src/components/table/_table_cell_content.styles.ts
+++ b/src/components/table/_table_cell_content.styles.ts
@@ -8,7 +8,11 @@
 
 import { css } from '@emotion/react';
 
-import { logicalTextAlignCSS } from '../../global_styling';
+import {
+  euiTextTruncate,
+  euiTextBreakWord,
+  logicalTextAlignCSS,
+} from '../../global_styling';
 
 export const euiTableCellContentStyles = {
   euiTableCellContent: css`
@@ -25,5 +29,19 @@ export const euiTableCellContentStyles = {
   center: css`
     justify-content: center;
     text-align: center;
+  `,
+
+  // Text wrapping
+  truncateText: css`
+    ${euiTextTruncate()}
+
+    /* Text truncation on flex parents doesn't work - this wrapper + extra CSS is required */
+    .euiTableCellContent__text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  `,
+  wrapText: css`
+    ${euiTextBreakWord()}
   `,
 };

--- a/src/components/table/_table_cell_content.styles.ts
+++ b/src/components/table/_table_cell_content.styles.ts
@@ -8,13 +8,14 @@
 
 import { css } from '@emotion/react';
 
+import { UseEuiTheme } from '../../services';
 import {
   euiTextTruncate,
   euiTextBreakWord,
   logicalTextAlignCSS,
 } from '../../global_styling';
 
-export const euiTableCellContentStyles = {
+export const euiTableCellContentStyles = ({ euiTheme }: UseEuiTheme) => ({
   euiTableCellContent: css`
     display: flex;
     align-items: center; /* Vertically align all children */
@@ -44,4 +45,18 @@ export const euiTableCellContentStyles = {
   wrapText: css`
     ${euiTextBreakWord()}
   `,
-};
+
+  // Action cells
+  hasActions: {
+    actions: css`
+      gap: ${euiTheme.size.s};
+    `,
+    desktop: css`
+      flex-wrap: wrap;
+    `,
+    mobile: css`
+      flex-direction: column;
+      padding: 0;
+    `,
+  },
+});

--- a/src/components/table/_table_cell_content.styles.ts
+++ b/src/components/table/_table_cell_content.styles.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { logicalTextAlignCSS } from '../../global_styling';
+
+export const euiTableCellContentStyles = {
+  euiTableCellContent: css`
+    display: flex;
+    align-items: center; /* Vertically align all children */
+  `,
+
+  // Align
+  left: null, // Default, no CSS needed
+  right: css`
+    justify-content: flex-end;
+    ${logicalTextAlignCSS('right')}
+  `,
+  center: css`
+    justify-content: center;
+    text-align: center;
+  `,
+};

--- a/src/components/table/_table_cell_content.tsx
+++ b/src/components/table/_table_cell_content.tsx
@@ -6,11 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
 import { CommonProps } from '../common';
 import classNames from 'classnames';
 
 import { LEFT_ALIGNMENT } from '../../services';
+import { isObject } from '../../services/predicate';
+import { EuiTextBlockTruncate } from '../text_truncate';
 
 import type { EuiTableRowCellProps } from './table_row_cell';
 import { useEuiTableIsResponsive } from './mobile/responsive_context';
@@ -18,7 +20,7 @@ import { euiTableCellContentStyles as styles } from './_table_cell_content.style
 
 export type EuiTableCellContentProps = CommonProps &
   HTMLAttributes<HTMLDivElement> &
-  Pick<EuiTableRowCellProps, 'align'>;
+  Pick<EuiTableRowCellProps, 'align' | 'textOnly' | 'truncateText'>;
 
 export const EuiTableCellContent: FunctionComponent<
   EuiTableCellContentProps
@@ -26,6 +28,8 @@ export const EuiTableCellContent: FunctionComponent<
   children,
   className,
   align = LEFT_ALIGNMENT,
+  textOnly,
+  truncateText = false,
   ...rest
 }) => {
   const isResponsive = useEuiTableIsResponsive();
@@ -33,14 +37,31 @@ export const EuiTableCellContent: FunctionComponent<
   const cssStyles = [
     styles.euiTableCellContent,
     !isResponsive && styles[align], // On mobile, always align cells to the left
+    truncateText === true && styles.truncateText,
+    truncateText === false && styles.wrapText,
   ];
 
   const classes = classNames('euiTableCellContent', className);
 
+  const renderedChildren = useMemo(() => {
+    const textClasses = 'euiTableCellContent__text';
+
+    if (isObject(truncateText) && truncateText.lines) {
+      return (
+        <EuiTextBlockTruncate lines={truncateText.lines} cloneElement>
+          <span className={textClasses}>{children}</span>
+        </EuiTextBlockTruncate>
+      );
+    }
+    if (textOnly === true || truncateText === true) {
+      return <span className={textClasses}>{children}</span>;
+    }
+    return children;
+  }, [children, textOnly, truncateText]);
+
   return (
     <div css={cssStyles} className={classes} {...rest}>
-      {/* TODO: __text children */}
-      {children}
+      {renderedChildren}
     </div>
   );
 };

--- a/src/components/table/_table_cell_content.tsx
+++ b/src/components/table/_table_cell_content.tsx
@@ -20,10 +20,9 @@ import { euiTableCellContentStyles } from './_table_cell_content.styles';
 
 export type EuiTableCellContentProps = CommonProps &
   HTMLAttributes<HTMLDivElement> &
-  Pick<
-    EuiTableRowCellProps,
-    'align' | 'hasActions' | 'textOnly' | 'truncateText'
-  >;
+  Pick<EuiTableRowCellProps, 'align' | 'hasActions' | 'textOnly'> & {
+    truncateText?: EuiTableRowCellProps['truncateText'] | null;
+  };
 
 export const EuiTableCellContent: FunctionComponent<
   EuiTableCellContentProps

--- a/src/components/table/_table_cell_content.tsx
+++ b/src/components/table/_table_cell_content.tsx
@@ -43,9 +43,13 @@ export const EuiTableCellContent: FunctionComponent<
     !isResponsive && styles[align], // On mobile, always align cells to the left
     truncateText === true && styles.truncateText,
     truncateText === false && styles.wrapText,
-    hasActions && styles.hasActions.actions,
-    hasActions &&
-      (isResponsive ? styles.hasActions.mobile : styles.hasActions.desktop),
+    ...(hasActions
+      ? [
+          styles.hasActions.actions,
+          !isResponsive && styles.hasActions.desktop,
+          isResponsive && hasActions !== 'custom' && styles.hasActions.mobile,
+        ]
+      : []),
   ];
 
   const classes = classNames('euiTableCellContent', className);

--- a/src/components/table/_table_cell_content.tsx
+++ b/src/components/table/_table_cell_content.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, HTMLAttributes } from 'react';
+import { CommonProps } from '../common';
+import classNames from 'classnames';
+
+import { LEFT_ALIGNMENT } from '../../services';
+
+import type { EuiTableRowCellProps } from './table_row_cell';
+import { useEuiTableIsResponsive } from './mobile/responsive_context';
+import { euiTableCellContentStyles as styles } from './_table_cell_content.styles';
+
+export type EuiTableCellContentProps = CommonProps &
+  HTMLAttributes<HTMLDivElement> &
+  Pick<EuiTableRowCellProps, 'align'>;
+
+export const EuiTableCellContent: FunctionComponent<
+  EuiTableCellContentProps
+> = ({
+  children,
+  className,
+  align = LEFT_ALIGNMENT,
+  ...rest
+}) => {
+  const isResponsive = useEuiTableIsResponsive();
+
+  const cssStyles = [
+    styles.euiTableCellContent,
+    !isResponsive && styles[align], // On mobile, always align cells to the left
+  ];
+
+  const classes = classNames('euiTableCellContent', className);
+
+  return (
+    <div css={cssStyles} className={classes} {...rest}>
+      {/* TODO: __text children */}
+      {children}
+    </div>
+  );
+};

--- a/src/components/table/_table_cell_content.tsx
+++ b/src/components/table/_table_cell_content.tsx
@@ -10,17 +10,20 @@ import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
 import { CommonProps } from '../common';
 import classNames from 'classnames';
 
-import { LEFT_ALIGNMENT } from '../../services';
+import { LEFT_ALIGNMENT, useEuiMemoizedStyles } from '../../services';
 import { isObject } from '../../services/predicate';
 import { EuiTextBlockTruncate } from '../text_truncate';
 
 import type { EuiTableRowCellProps } from './table_row_cell';
 import { useEuiTableIsResponsive } from './mobile/responsive_context';
-import { euiTableCellContentStyles as styles } from './_table_cell_content.styles';
+import { euiTableCellContentStyles } from './_table_cell_content.styles';
 
 export type EuiTableCellContentProps = CommonProps &
   HTMLAttributes<HTMLDivElement> &
-  Pick<EuiTableRowCellProps, 'align' | 'textOnly' | 'truncateText'>;
+  Pick<
+    EuiTableRowCellProps,
+    'align' | 'hasActions' | 'textOnly' | 'truncateText'
+  >;
 
 export const EuiTableCellContent: FunctionComponent<
   EuiTableCellContentProps
@@ -30,15 +33,20 @@ export const EuiTableCellContent: FunctionComponent<
   align = LEFT_ALIGNMENT,
   textOnly,
   truncateText = false,
+  hasActions,
   ...rest
 }) => {
   const isResponsive = useEuiTableIsResponsive();
 
+  const styles = useEuiMemoizedStyles(euiTableCellContentStyles);
   const cssStyles = [
     styles.euiTableCellContent,
     !isResponsive && styles[align], // On mobile, always align cells to the left
     truncateText === true && styles.truncateText,
     truncateText === false && styles.wrapText,
+    hasActions && styles.hasActions.actions,
+    hasActions &&
+      (isResponsive ? styles.hasActions.mobile : styles.hasActions.desktop),
   ];
 
   const classes = classNames('euiTableCellContent', className);

--- a/src/components/table/table_cells_shared.styles.ts
+++ b/src/components/table/table_cells_shared.styles.ts
@@ -29,11 +29,10 @@ export const euiTableHeaderFooterCellStyles = (
   return {
     euiTableHeaderCell: css`
       ${sharedStyles}
-
-      .euiTableCellContent {
-        /* Spacing between text and sort icon */
-        gap: ${euiTheme.size.xs};
-      }
+    `,
+    euiTableHeaderCell__content: css`
+      /* Spacing between text and sort icon */
+      gap: ${euiTheme.size.xs};
     `,
     euiTableHeaderCell__button: css`
       ${logicalCSS('width', '100%')}
@@ -42,10 +41,7 @@ export const euiTableHeaderFooterCellStyles = (
       &:hover,
       &:focus {
         color: ${euiTheme.colors.primaryText};
-
-        .euiTableCellContent__text {
-          text-decoration: underline;
-        }
+        text-decoration: underline;
       }
     `,
     euiTableFooterCell: css`

--- a/src/components/table/table_footer_cell.tsx
+++ b/src/components/table/table_footer_cell.tsx
@@ -13,12 +13,11 @@ import {
   useEuiMemoizedStyles,
   HorizontalAlignment,
   LEFT_ALIGNMENT,
-  RIGHT_ALIGNMENT,
-  CENTER_ALIGNMENT,
 } from '../../services';
 import { CommonProps } from '../common';
 
 import { resolveWidthAsStyle } from './utils';
+import { EuiTableCellContent } from './_table_cell_content';
 import { euiTableHeaderFooterCellStyles } from './table_cells_shared.styles';
 
 export type EuiTableFooterCellProps = CommonProps &
@@ -36,10 +35,6 @@ export const EuiTableFooterCell: FunctionComponent<EuiTableFooterCellProps> = ({
   ...rest
 }) => {
   const classes = classNames('euiTableFooterCell', className);
-  const contentClasses = classNames('euiTableCellContent', className, {
-    'euiTableCellContent--alignRight': align === RIGHT_ALIGNMENT,
-    'euiTableCellContent--alignCenter': align === CENTER_ALIGNMENT,
-  });
   const inlineStyles = resolveWidthAsStyle(style, width);
   const styles = useEuiMemoizedStyles(euiTableHeaderFooterCellStyles);
 
@@ -50,9 +45,9 @@ export const EuiTableFooterCell: FunctionComponent<EuiTableFooterCellProps> = ({
       style={inlineStyles}
       {...rest}
     >
-      <div className={contentClasses}>
-        <span className="euiTableCellContent__text">{children}</span>
-      </div>
+      <EuiTableCellContent align={align} truncateText={true} textOnly={true}>
+        {children}
+      </EuiTableCellContent>
     </td>
   );
 };

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -17,8 +17,6 @@ import {
   useEuiMemoizedStyles,
   HorizontalAlignment,
   LEFT_ALIGNMENT,
-  RIGHT_ALIGNMENT,
-  CENTER_ALIGNMENT,
 } from '../../services';
 import { EuiI18n } from '../i18n';
 import { EuiScreenReaderOnly } from '../accessibility';
@@ -27,6 +25,7 @@ import { EuiIcon } from '../icon';
 import { EuiInnerText } from '../inner_text';
 
 import { resolveWidthAsStyle } from './utils';
+import { EuiTableCellContent } from './_table_cell_content';
 import { euiTableHeaderFooterCellStyles } from './table_cells_shared.styles';
 
 export type TableHeaderCellScope = 'col' | 'row' | 'colgroup' | 'rowgroup';
@@ -62,13 +61,15 @@ export type EuiTableHeaderCellProps = CommonProps &
 
 const CellContents = ({
   className,
+  align,
   description,
   children,
   isSorted,
   isSortAscending,
   showSortMsg,
 }: {
-  className: string;
+  className?: string;
+  align: HorizontalAlignment;
   description: EuiTableHeaderCellProps['description'];
   children: EuiTableHeaderCellProps['children'];
   isSorted: EuiTableHeaderCellProps['isSorted'];
@@ -76,7 +77,12 @@ const CellContents = ({
   showSortMsg: boolean;
 }) => {
   return (
-    <span className={className}>
+    <EuiTableCellContent
+      className={className}
+      align={align}
+      textOnly={false}
+      truncateText={null}
+    >
       <EuiInnerText>
         {(ref, innerText) => (
           <EuiI18n
@@ -88,7 +94,7 @@ const CellContents = ({
               <span
                 title={description ? titleTextWithDesc : innerText}
                 ref={ref}
-                className="euiTableCellContent__text"
+                className="eui-textTruncate"
               >
                 {children}
               </span>
@@ -108,7 +114,7 @@ const CellContents = ({
           size="m"
         />
       )}
-    </span>
+    </EuiTableCellContent>
   );
 };
 
@@ -136,15 +142,23 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
     'euiTableHeaderCell--hideForMobile': !mobileOptions.show,
   });
 
-  const contentClasses = classNames('euiTableCellContent', className, {
-    'euiTableCellContent--alignRight': align === RIGHT_ALIGNMENT,
-    'euiTableCellContent--alignCenter': align === CENTER_ALIGNMENT,
-  });
-
   const inlineStyles = resolveWidthAsStyle(style, width);
 
   const CellComponent = children ? 'th' : 'td';
   const cellScope = CellComponent === 'th' ? scope ?? 'col' : undefined; // `scope` is only valid on `th` elements
+
+  const cellContents = (
+    <CellContents
+      css={styles.euiTableHeaderCell__content}
+      align={align}
+      description={description}
+      showSortMsg={true}
+      isSorted={isSorted}
+      isSortAscending={isSortAscending}
+    >
+      {children}
+    </CellContents>
+  );
 
   if (onSort || isSorted) {
     const buttonClasses = classNames('euiTableHeaderButton', {
@@ -155,17 +169,6 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
     if (isSorted) {
       ariaSortValue = isSortAscending ? 'ascending' : 'descending';
     }
-
-    const cellContents = (
-      <CellContents
-        className={contentClasses}
-        description={description}
-        showSortMsg={true}
-        children={children}
-        isSorted={isSorted}
-        isSortAscending={isSortAscending}
-      />
-    );
 
     return (
       <CellComponent
@@ -204,14 +207,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       style={inlineStyles}
       {...rest}
     >
-      <CellContents
-        className={contentClasses}
-        description={description}
-        showSortMsg={false}
-        children={children}
-        isSorted={isSorted}
-        isSortAscending={isSortAscending}
-      />
+      {cellContents}
     </CellComponent>
   );
 };

--- a/src/components/table/table_row.tsx
+++ b/src/components/table/table_row.tsx
@@ -38,7 +38,7 @@ export interface EuiTableRowProps {
    * Indicates if the table has a dedicated column for actions
    * (used for mobile styling and desktop action hover behavior)
    */
-  hasActions?: boolean;
+  hasActions?: boolean | 'custom';
   /**
    * Indicates if the row will have an expanded row
    */
@@ -75,7 +75,7 @@ export const EuiTableRow: FunctionComponent<Props> = ({
         styles.mobile.mobile,
         isSelected && styles.mobile.selected,
         isExpandedRow && styles.mobile.expanded,
-        (hasActions || isExpandable || isExpandedRow) &&
+        (hasActions === true || isExpandable || isExpandedRow) &&
           styles.mobile.hasRightColumn,
         hasSelection && styles.mobile.hasLeftColumn,
       ]

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -31,13 +31,6 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     hasActions: css`
       ${hasIcons}
-
-      /* TODO: Move this to EuiTableCellContent, once we're further along in the Emotion conversion */
-      .euiTableCellContent {
-        display: flex;
-        align-items: center;
-        gap: ${euiTheme.size.s};
-      }
     `,
 
     // valign
@@ -59,11 +52,6 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('border-vertical', euiTheme.border.thin)}
       `,
       actions: css`
-        /* TODO: Move this to EuiTableCellContent, once we're further along in the Emotion conversion */
-        .euiTableCellContent {
-          flex-wrap: wrap;
-        }
-
         .euiBasicTableAction-showOnHover {
           opacity: 0;
           transition: opacity ${euiTheme.animation.normal}
@@ -91,15 +79,6 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('right', 0)}
         ${logicalCSS('min-width', '0')}
         ${logicalCSS('width', mobileSizes.actions.width)}
-
-        /* TODO: Move this to EuiTableCellContent, once we're further along in the Emotion conversion */
-        .euiTableCellContent {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          gap: ${euiTheme.size.s};
-          padding: 0;
-        }
       `,
       get actions() {
         // Note: Visible-on-hover actions on desktop always show on mobile

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -97,6 +97,9 @@ describe('truncateText', () => {
     const { container } = renderInTableRow(<EuiTableRowCell />);
 
     expect(container.firstChild).toMatchSnapshot();
+    expect(
+      container.querySelector('.euiTableCellContent')!.className
+    ).toContain('euiTableCellContent-wrapText');
   });
 
   it('renders true', () => {
@@ -104,10 +107,10 @@ describe('truncateText', () => {
       <EuiTableRowCell truncateText={true} />
     );
 
-    expect(
-      container.querySelector('.euiTableCellContent--truncateText')
-    ).toBeInTheDocument();
     expect(container.firstChild).toMatchSnapshot();
+    expect(
+      container.querySelector('.euiTableCellContent')!.className
+    ).toContain('euiTableCellContent-truncateText');
   });
 
   test('renders lines configuration', () => {
@@ -115,13 +118,10 @@ describe('truncateText', () => {
       <EuiTableRowCell truncateText={{ lines: 2 }} />
     );
 
-    expect(
-      container.querySelector('.euiTableCellContent--truncateText')
-    ).not.toBeInTheDocument();
+    expect(container.firstChild).toMatchSnapshot();
     expect(container.querySelector('.euiTableCellContent__text')).toHaveClass(
       'euiTextBlockTruncate'
     );
-    expect(container.firstChild).toMatchSnapshot();
   });
 });
 

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -21,14 +21,13 @@ import {
   useEuiMemoizedStyles,
   HorizontalAlignment,
   LEFT_ALIGNMENT,
-  RIGHT_ALIGNMENT,
-  CENTER_ALIGNMENT,
 } from '../../services';
 import { isObject } from '../../services/predicate';
 import { EuiTextBlockTruncate } from '../text_truncate';
 
 import { useEuiTableIsResponsive } from './mobile/responsive_context';
 import { resolveWidthAsStyle } from './utils';
+import { EuiTableCellContent } from './_table_cell_content';
 import { euiTableRowCellStyles } from './table_row_cell.styles';
 
 interface EuiTableRowCellSharedPropsShape {
@@ -153,8 +152,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   });
 
   const contentClasses = classNames('euiTableCellContent', {
-    'euiTableCellContent--alignRight': align === RIGHT_ALIGNMENT,
-    'euiTableCellContent--alignCenter': align === CENTER_ALIGNMENT,
     'euiTableCellContent--truncateText': truncateText === true,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
     // purposes for the time-being.
@@ -162,10 +159,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   });
 
   const mobileContentClasses = classNames('euiTableCellContent', {
-    'euiTableCellContent--alignRight':
-      mobileOptions.align === RIGHT_ALIGNMENT || align === RIGHT_ALIGNMENT,
-    'euiTableCellContent--alignCenter':
-      mobileOptions.align === CENTER_ALIGNMENT || align === CENTER_ALIGNMENT,
     'euiTableCellContent--truncateText':
       mobileOptions.truncateText ?? truncateText,
     // We're doing this rigamarole instead of creating `euiTableCellContent--textOnly` for BWC
@@ -227,13 +220,20 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     css: cssStyles,
     ...rest,
   };
+  const sharedContentProps = {
+    align,
+    className: isResponsive ? mobileContentClasses : contentClasses,
+  };
+
   if (mobileOptions.show === false) {
     return (
       <Element
         className={`${cellClasses} ${hideForMobileClasses}`}
         {...sharedProps}
       >
-        <div className={contentClasses}>{childrenNode}</div>
+        <EuiTableCellContent {...sharedContentProps}>
+          {childrenNode}
+        </EuiTableCellContent>
       </Element>
     );
   } else {
@@ -252,15 +252,23 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
         {/* Content depending on mobile render existing */}
         {mobileOptions.render ? (
           <>
-            <div className={`${mobileContentClasses} ${showForMobileClasses}`}>
+            <EuiTableCellContent
+              className={showForMobileClasses}
+              align={mobileOptions.align ?? align}
+            >
               {modifyChildren(mobileOptions.render)}
-            </div>
-            <div className={`${contentClasses} ${hideForMobileClasses}`}>
+            </EuiTableCellContent>
+            <EuiTableCellContent
+              {...sharedContentProps}
+              className={hideForMobileClasses}
+            >
               {childrenNode}
-            </div>
+            </EuiTableCellContent>
           </>
         ) : (
-          <div className={contentClasses}>{childrenNode}</div>
+          <EuiTableCellContent {...sharedContentProps}>
+            {childrenNode}
+          </EuiTableCellContent>
         )}
       </Element>
     );

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -171,6 +171,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     align,
     textOnly,
     truncateText,
+    hasActions: hasActions || isExpander,
   };
 
   if (mobileOptions.show === false) {

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -34,6 +34,7 @@ interface EuiTableRowCellSharedPropsShape {
   /**
    * Creates a text wrapper around cell content that helps word break or truncate
    * long text correctly.
+   * @default true
    */
   textOnly?: boolean;
   /**
@@ -41,6 +42,7 @@ interface EuiTableRowCellSharedPropsShape {
    * - Set to `true` to enable single-line truncation.
    * - To enable multi-line truncation, use a configuration object with `lines`
    * set to a number of lines to truncate to.
+   * @default false
    */
   truncateText?: boolean | { lines: number };
   width?: CSSProperties['width'];


### PR DESCRIPTION
## Summary

> NOTE: This is going into the EuiTable Emotion conversion/cleanup feature branch.

As always this is A Lot so I recommend [following along by commit](https://github.com/elastic/eui/pull/7641/commits)!

`EuiTableRowCell`, `EuiTableHeaderCell`, and `EuiTableFooterCell` were all manually creating and setting internal `<div/span className="euiTableCellContent">` and `.euiTableCellContent__text` nodes.

This PR DRYs out the cell content wrapper (and its text child) to a new internal `EuiTableCellContent` subcomponent, and also simplifies/removes some `React.cloneElement` shenanigans that was very unclear was needed or not (I leaned not).

With this PR, the last of the Sass files are now fully converted/deleted! 🎉 (there will be 1 more PR after this with some extra cleanup, tests, storybooks for QA, and one or two bug fixes).

## QA

- [x] [Responsive tables](https://eui.elastic.co/pr_7641/#/tabular-content/tables#responsive-tables) should now fully work and look the same as production mobile regardless of window breakpoint
- [x] [Text alignment and truncation](https://eui.elastic.co/pr_7641/#/tabular-content/tables#table-layout) should look the same as production (DOB should wrap, job title should truncate at 1 line, and address should truncate at 2 lines)
- [x] (bugfix testing) Toggling between [custom actions and regular actions](https://eui.elastic.co/pr_7641/#/tabular-content/tables#adding-actions-to-table) should display the correct right column vs bottom 'row'

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    ~- [ ] Checked in both **light and dark** modes~
- Docs site QA - N/A
- Code quality checklist
    - Skipped unit tests for the new internal subcomponent but updated basic tables a bit. Let me know if you think I should be more gung-ho about writing tests!
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A