### PR TITLE
Final tables PR: cleanup, tests, stories

### DIFF
--- a/changelogs/upcoming/7642.md
+++ b/changelogs/upcoming/7642.md
@@ -1,0 +1,11 @@
+**Bug fixes**
+
+- Table `mobileOptions`:
+  - `mobileOptions.align` is now respected instead of all cells being forced to left alignment
+  - `textTruncate` and `textOnly` are now respected even if a `render` function is not passed
+
+**DOM changes**
+
+- `EuiTableRowCell` no longer renders mobile headers to the DOM unless the current table is displaying its responsive view.
+- `EuiTableHeaderCell` and `EuiTableRowCell` will no longer render in the DOM at all on mobile if their columns' `mobileOptions.show` is set to `false`.
+- `EuiTableHeaderCell` and `EuiTableRowCell` will no longer render in the DOM at all on desktop if their columns' `mobileOptions.only` is set to `true`.

--- a/changelogs/upcoming/7642.md
+++ b/changelogs/upcoming/7642.md
@@ -4,6 +4,10 @@
   - `mobileOptions.align` is now respected instead of all cells being forced to left alignment
   - `textTruncate` and `textOnly` are now respected even if a `render` function is not passed
 
+**Breaking changes**
+
+- Removed top-level `textOnly` prop from `EuiBasicTable` and `EuiInMemoryTable`. Use `columns[].textOnly` instead.
+
 **DOM changes**
 
 - `EuiTableRowCell` no longer renders mobile headers to the DOM unless the current table is displaying its responsive view.

--- a/src-docs/src/views/tables/actions/actions.tsx
+++ b/src-docs/src/views/tables/actions/actions.tsx
@@ -74,9 +74,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     sortable: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,
@@ -202,7 +202,7 @@ export default () => {
       if (multiAction) {
         actions = [
           {
-            name: <span>Clone</span>,
+            name: <>Clone</>,
             description: 'Clone this user',
             icon: 'copy',
             type: 'icon',

--- a/src-docs/src/views/tables/auto/auto.tsx
+++ b/src-docs/src/views/tables/auto/auto.tsx
@@ -46,9 +46,9 @@ const columns: Array<EuiTableFieldDataColumnType<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/basic/basic.tsx
+++ b/src-docs/src/views/tables/basic/basic.tsx
@@ -48,9 +48,9 @@ export default () => {
       'data-test-subj': 'firstNameCell',
       mobileOptions: {
         render: (user: User) => (
-          <span>
+          <>
             {user.firstName} {user.lastName}
-          </span>
+          </>
         ),
         header: false,
         truncateText: false,

--- a/src-docs/src/views/tables/basic/basic_section.js
+++ b/src-docs/src/views/tables/basic/basic_section.js
@@ -10,13 +10,15 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
-import { DefaultItemActionProps as DefaultItemAction } from '../props/props';
+import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
+  DefaultItemActionProps as DefaultItemAction,
+} from '../props/props';
 
 const source = require('!!raw-loader!./basic');
 

--- a/src-docs/src/views/tables/custom/custom.tsx
+++ b/src-docs/src/views/tables/custom/custom.tsx
@@ -113,10 +113,10 @@ export default class extends Component<{}, State> {
     {
       id: 2,
       title: (
-        <span>
+        <>
           A very long line in an ELEMENT which will wrap on narrower screens and
           NOT become truncated and replaced by an ellipsis
-        </span>
+        </>
       ),
       type: 'user',
       dateCreated: 'Tue Dec 01 2016',
@@ -127,11 +127,11 @@ export default class extends Component<{}, State> {
       id: 3,
       title: {
         value: (
-          <span>
+          <>
             A very long line in an ELEMENT which will not wrap on narrower
             screens and instead will become truncated and replaced by an
             ellipsis
-          </span>
+          </>
         ),
         truncateText: true,
       },
@@ -290,14 +290,14 @@ export default class extends Component<{}, State> {
         width: '100%',
       },
       render: (title: DataItem['title'], item: DataItem) => (
-        <span>
+        <>
           <EuiIcon
             type={item.type}
             size="m"
             style={{ verticalAlign: 'text-top' }}
           />{' '}
           {title as ReactNode}
-        </span>
+        </>
       ),
     },
     {

--- a/src-docs/src/views/tables/custom/custom_section.js
+++ b/src-docs/src/views/tables/custom/custom_section.js
@@ -29,7 +29,7 @@ export const section = {
     },
   ],
   text: (
-    <div>
+    <>
       <p>
         As an alternative to <strong>EuiBasicTable</strong> you can instead
         construct a table from individual{' '}
@@ -58,7 +58,7 @@ export const section = {
         &nbsp;and <strong>EuiTableSortMobileItem</strong> components to supply
         mobile sorting. See demo below.
       </p>
-    </div>
+    </>
   ),
   components: { EuiTable },
   props: {

--- a/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
+++ b/src-docs/src/views/tables/expanding_rows/expanding_rows.tsx
@@ -52,9 +52,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,
@@ -134,9 +134,10 @@ export default () => {
       isExpander: true,
       name: (
         <EuiScreenReaderOnly>
-          <span>Expand rows</span>
+          <span>Expand row</span>
         </EuiScreenReaderOnly>
       ),
+      mobileOptions: { header: false },
       render: (user: User) => {
         const itemIdToExpandedRowMapValues = { ...itemIdToExpandedRowMap };
 

--- a/src-docs/src/views/tables/footer/footer.tsx
+++ b/src-docs/src/views/tables/footer/footer.tsx
@@ -51,9 +51,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,
@@ -72,7 +72,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
   {
     field: 'github',
     name: 'Github',
-    footer: ({ items }: { items: User[] }) => <span>{items.length} users</span>,
+    footer: ({ items }: { items: User[] }) => <>{items.length} users</>,
     render: (username: User['github']) => (
       <EuiLink href="#" target="_blank">
         {username}
@@ -96,7 +96,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
       const uniqueCountries = new Set(
         items.map((user) => user.location.country)
       );
-      return <span>{uniqueCountries.size} countries</span>;
+      return <>{uniqueCountries.size} countries</>;
     },
     render: (location: User['location']) => {
       return `${location.city}, ${location.country}`;
@@ -106,9 +106,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     field: 'online',
     name: 'Online',
     footer: ({ items }: { items: User[] }) => {
-      return (
-        <span>{items.filter((user: User) => !!user.online).length} online</span>
-      );
+      return <>{items.filter((user: User) => !!user.online).length} online</>;
     },
     dataType: 'boolean',
     render: (online: User['online']) => {

--- a/src-docs/src/views/tables/in_memory/in_memory.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory.tsx
@@ -47,9 +47,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination.tsx
@@ -49,9 +49,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
@@ -12,13 +12,13 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
 import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
   DefaultItemActionProps as DefaultItemAction,
   SearchProps as Search,
   SearchFilterConfigProps as SearchFilterConfig,

--- a/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
@@ -37,7 +37,7 @@ export const controlledPaginationSection = {
     },
   ],
   text: (
-    <div>
+    <>
       <p>
         By default <EuiCode>EuiInMemoryTable</EuiCode> resets its page index
         when receiving a new <EuiCode>EuiInMemoryTable</EuiCode> array. To avoid
@@ -52,7 +52,7 @@ export const controlledPaginationSection = {
         toggling their online status. Pagination state is maintained by the app,
         preventing it from being reset by the updates.
       </p>
-    </div>
+    </>
   ),
   props: {
     EuiInMemoryTable,

--- a/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_controlled_pagination_section.js
@@ -41,10 +41,10 @@ export const controlledPaginationSection = {
       <p>
         By default <EuiCode>EuiInMemoryTable</EuiCode> resets its page index
         when receiving a new <EuiCode>EuiInMemoryTable</EuiCode> array. To avoid
-        this behavior the pagination object optionally takes a
+        this behavior the pagination object optionally takes a{' '}
         <EuiCode>pageIndex</EuiCode> value to control this yourself.
         Additionally, <EuiCode>pageSize</EuiCode> can also be controlled the
-        same way. Both of these are provided to your app during the
+        same way. Both of these are provided to your app during the{' '}
         <EuiCode>onTableChange</EuiCode> callback.
       </p>
       <p>

--- a/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
@@ -37,16 +37,14 @@ export const customSortingSection = {
     },
   ],
   text: (
-    <div>
-      <p>
-        Sometimes the value displayed in a column is not appropriate to use for
-        sorting, such as pre-formatting values to be human-readable. In these
-        cases it&apos;s possible to pass the <EuiCode>sortable</EuiCode> prop as
-        a function instead of <EuiCode>true</EuiCode> or{' '}
-        <EuiCode>false</EuiCode>. The function is used to extract or calculate
-        the intended sort value for each <EuiCode>item</EuiCode>.
-      </p>
-    </div>
+    <p>
+      Sometimes the value displayed in a column is not appropriate to use for
+      sorting, such as pre-formatting values to be human-readable. In these
+      cases it&apos;s possible to pass the <EuiCode>sortable</EuiCode> prop as a
+      function instead of <EuiCode>true</EuiCode> or <EuiCode>false</EuiCode>.
+      The function is used to extract or calculate the intended sort value for
+      each <EuiCode>item</EuiCode>.
+    </p>
   ),
   props: {
     EuiInMemoryTable,

--- a/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_custom_sorting_section.js
@@ -12,13 +12,13 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
 import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
   DefaultItemActionProps as DefaultItemAction,
   SearchProps as Search,
   SearchFilterConfigProps as SearchFilterConfig,

--- a/src-docs/src/views/tables/in_memory/in_memory_search.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_search.tsx
@@ -54,9 +54,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_callback.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_callback.tsx
@@ -48,9 +48,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_callback_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_callback_section.js
@@ -11,13 +11,13 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
 import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
   DefaultItemActionProps as DefaultItemAction,
   SearchProps as Search,
   SearchFilterConfigProps as SearchFilterConfig,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_external.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_external.tsx
@@ -77,9 +77,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_external_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_external_section.js
@@ -11,13 +11,13 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
 import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
   DefaultItemActionProps as DefaultItemAction,
   SearchProps as Search,
   SearchFilterConfigProps as SearchFilterConfig,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_external_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_external_section.js
@@ -36,12 +36,10 @@ export const searchExternalSection = {
     },
   ],
   text: (
-    <div>
-      <p>
-        The example shows how to configure <strong>EuiInMemoryTable</strong>{' '}
-        when both external and internal search/filter states are in use.
-      </p>
-    </div>
+    <p>
+      The example shows how to configure <strong>EuiInMemoryTable</strong> when
+      both external and internal search/filter states are in use.
+    </p>
   ),
   props: {
     EuiInMemoryTable,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_section.js
@@ -12,13 +12,13 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
 import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
   DefaultItemActionProps as DefaultItemAction,
   SearchProps as Search,
   SearchFilterConfigProps as SearchFilterConfig,

--- a/src-docs/src/views/tables/in_memory/in_memory_search_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_search_section.js
@@ -37,17 +37,15 @@ export const searchSection = {
     },
   ],
   text: (
-    <div>
-      <p>
-        The example shows how to configure <strong>EuiInMemoryTable </strong>
-        to display a search bar by passing the search prop. You can read more
-        about the search bar&apos;s properties and its syntax{' '}
-        <Link to="/forms/search-bar">
-          <strong>here</strong>
-        </Link>{' '}
-        .
-      </p>
-    </div>
+    <p>
+      The example shows how to configure <strong>EuiInMemoryTable </strong>
+      to display a search bar by passing the search prop. You can read more
+      about the search bar&apos;s properties and its syntax{' '}
+      <Link to="/forms/search-bar">
+        <strong>here</strong>
+      </Link>{' '}
+      .
+    </p>
   ),
   props: {
     EuiInMemoryTable,

--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -12,13 +12,13 @@ import {
 import { Pagination } from '../paginated/_props';
 import {
   EuiTableFieldDataColumnType,
-  EuiTableComputedColumnType,
-  EuiTableActionsColumnType,
   EuiTableSelectionType,
   EuiTableSortingType,
 } from '!!prop-loader!../../../../../src/components/basic_table/table_types';
 import { CustomItemAction } from '!!prop-loader!../../../../../src/components/basic_table/action_types';
 import {
+  EuiTableComputedColumnType,
+  EuiTableActionsColumnType,
   DefaultItemActionProps as DefaultItemAction,
   SearchProps as Search,
   SearchFilterConfigProps as SearchFilterConfig,

--- a/src-docs/src/views/tables/in_memory/in_memory_section.js
+++ b/src-docs/src/views/tables/in_memory/in_memory_section.js
@@ -36,7 +36,7 @@ export const section = {
     },
   ],
   text: (
-    <div>
+    <>
       <p>
         The <strong>EuiInMemoryTable</strong> is a higher level component
         wrapper around <strong>EuiBasicTable</strong> aimed at displaying tables
@@ -57,7 +57,7 @@ export const section = {
           and preserved between renders.
         </p>
       </EuiCallOut>
-    </div>
+    </>
   ),
   props: {
     EuiInMemoryTable,

--- a/src-docs/src/views/tables/in_memory/in_memory_selection_controlled.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection_controlled.tsx
@@ -46,9 +46,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/in_memory/in_memory_selection_uncontrolled.tsx
+++ b/src-docs/src/views/tables/in_memory/in_memory_selection_uncontrolled.tsx
@@ -47,9 +47,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/mobile/mobile.tsx
+++ b/src-docs/src/views/tables/mobile/mobile.tsx
@@ -193,7 +193,7 @@ export default () => {
    * Pagination & sorting
    */
   const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(5);
+  const [pageSize, setPageSize] = useState(3);
   const [sortField, setSortField] = useState<keyof User>('firstName');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 

--- a/src-docs/src/views/tables/mobile/mobile.tsx
+++ b/src-docs/src/views/tables/mobile/mobile.tsx
@@ -79,9 +79,9 @@ export default () => {
       mobileOptions: {
         render: customHeader
           ? (user: User) => (
-              <span>
+              <>
                 {user.firstName} {user.lastName}
-              </span>
+              </>
             )
           : undefined,
         header: customHeader ? false : true,

--- a/src-docs/src/views/tables/mobile/mobile_section.js
+++ b/src-docs/src/views/tables/mobile/mobile_section.js
@@ -2,22 +2,23 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { GuideSectionTypes } from '../../../components';
 
+import { EuiCode } from '../../../../../src/components/code';
+
 import Table from './mobile';
-import { EuiCode, EuiCodeBlock } from '../../../../../src/components/code';
 const source = require('!!raw-loader!./mobile');
 import { EuiTableRowCellMobileOptionsShape } from '../props/props';
 
 /* eslint-disable local/css-logical-properties */
-const exampleItem = `{
+const exampleColumnSnippet = `{
   field: 'firstName',
   name: 'First Name',
   truncateText: true,
   mobileOptions: {
-    render: (item) => (<span>{item.firstName} {item.lastName}</span>), // Custom renderer for mobile view only
-    header: false,   // Won't show inline header in mobile view
+    render: (item) => (<>{item.firstName} {item.lastName}</>), // Custom renderer for mobile view only
+    header: false, // Won't show inline header in mobile view
     width: '100%', // Applies a specific width
-    enlarge: true,   // Increase text size compared to rest of cells
-    truncateText: false, // Only works if a 'render()' is also provided
+    enlarge: true, // Increase text size compared to rest of cells
+    truncateText: false, // Text will wrap instead of truncating to one line
   }
 }`;
 
@@ -48,22 +49,21 @@ export const section = {
         columns), you may set{' '}
         <EuiCode language="js">{'responsiveBreakpoint={false}'}</EuiCode>.
         Inversely, if you always want your table to render in a mobile-friendly
-        manner, pass <EuiCode>true</EuiCode>.
+        manner, pass <EuiCode>true</EuiCode>. The below example table switches
+        between <EuiCode>true/false</EuiCode> for quick/easy preview between
+        mobile and desktop table UIs at all breakpoints.
       </p>
       <p>
-        The <EuiCode>mobileOptions</EuiCode> object can be passed to the{' '}
-        <strong>EuiTableRowCell</strong> directly or with each column item
-        provided to <strong>EuiBasicTable</strong>.
-      </p>
-      <EuiCodeBlock language="js">{exampleItem}</EuiCodeBlock>
-      <p>
-        <strong>Note:</strong> You can also change basic table row cell props
-        like <EuiCode>truncateText</EuiCode> and <EuiCode>textOnly</EuiCode> for
-        mobile layouts, though you must also be passing a mobile specific render
-        function.
+        To customize your cell's appearance/rendering in mobile vs. desktop
+        view, use the <EuiCode>mobileOptions</EuiCode> configuration. This
+        object can be passed to each column item in{' '}
+        <strong>EuiBasicTable</strong> or to <strong>EuiTableRowCell</strong>{' '}
+        directly. See the "Snippet" tab in the below example, or the "Props" tab
+        for a full list of configuration options.
       </p>
     </>
   ),
   props: { EuiTableRowCellMobileOptionsShape },
+  snippet: exampleColumnSnippet,
   demo: <Table />,
 };

--- a/src-docs/src/views/tables/paginated/paginated.tsx
+++ b/src-docs/src/views/tables/paginated/paginated.tsx
@@ -52,9 +52,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,
@@ -169,10 +169,10 @@ export default () => {
       <EuiSwitch
         checked={!showPerPageOptions}
         label={
-          <span>
+          <>
             Hide per page options with{' '}
             <EuiCode>pagination.showPerPageOptions = false</EuiCode>
-          </span>
+          </>
         }
         onChange={togglePerPageOptions}
       />

--- a/src-docs/src/views/tables/props/props.tsx
+++ b/src-docs/src/views/tables/props/props.tsx
@@ -1,4 +1,8 @@
 import React, { FunctionComponent } from 'react';
+import {
+  EuiTableComputedColumnType as _EuiTableComputedColumnType,
+  EuiTableActionsColumnType as _EuiTableActionsColumnType,
+} from '../../../../../src/components/basic_table/table_types';
 import { DefaultItemAction } from '../../../../../src/components/basic_table/action_types';
 import { Search } from '../../../../../src/components/basic_table/in_memory_table';
 import { SearchFilterConfig } from '../../../../../src/components/search_bar/filters';
@@ -19,4 +23,12 @@ export const SearchFilterConfigProps: FunctionComponent<
 
 export const EuiTableRowCellMobileOptionsShape: FunctionComponent<
   _EuiTableRowCellMobileOptionsShape
+> = () => <div />;
+
+export const EuiTableComputedColumnType: FunctionComponent<
+  _EuiTableComputedColumnType<T>
+> = () => <div />;
+
+export const EuiTableActionsColumnType: FunctionComponent<
+  _EuiTableActionsColumnType<T>
 > = () => <div />;

--- a/src-docs/src/views/tables/selection/selection_controlled.tsx
+++ b/src-docs/src/views/tables/selection/selection_controlled.tsx
@@ -60,9 +60,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/selection/selection_uncontrolled.tsx
+++ b/src-docs/src/views/tables/selection/selection_uncontrolled.tsx
@@ -58,9 +58,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,

--- a/src-docs/src/views/tables/sorting/sorting.tsx
+++ b/src-docs/src/views/tables/sorting/sorting.tsx
@@ -56,9 +56,9 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     truncateText: true,
     mobileOptions: {
       render: (user: User) => (
-        <span>
+        <>
           {user.firstName} {user.lastName}
-        </span>
+        </>
       ),
       header: false,
       truncateText: false,
@@ -78,7 +78,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     field: 'github',
     name: (
       <EuiToolTip content="Their mascot is the Octokitty">
-        <span>
+        <>
           Github{' '}
           <EuiIcon
             size="s"
@@ -86,7 +86,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
             type="questionInCircle"
             className="eui-alignTop"
           />
-        </span>
+        </>
       </EuiToolTip>
     ),
     render: (username: User['github']) => (
@@ -99,7 +99,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     field: 'dateOfBirth',
     name: (
       <EuiToolTip content="Colloquially known as a 'birthday'">
-        <span>
+        <>
           Date of Birth{' '}
           <EuiIcon
             size="s"
@@ -107,7 +107,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
             type="questionInCircle"
             className="eui-alignTop"
           />
-        </span>
+        </>
       </EuiToolTip>
     ),
     render: (dateOfBirth: User['dateOfBirth']) =>
@@ -117,7 +117,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     field: 'location',
     name: (
       <EuiToolTip content="The city and country in which this person resides">
-        <span>
+        <>
           Nationality{' '}
           <EuiIcon
             size="s"
@@ -125,7 +125,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
             type="questionInCircle"
             className="eui-alignTop"
           />
-        </span>
+        </>
       </EuiToolTip>
     ),
     render: (location: User['location']) => {
@@ -138,7 +138,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
     field: 'online',
     name: (
       <EuiToolTip content="Free to talk or busy with business">
-        <span>
+        <>
           Online{' '}
           <EuiIcon
             size="s"
@@ -146,7 +146,7 @@ const columns: Array<EuiBasicTableColumn<User>> = [
             type="questionInCircle"
             className="eui-alignTop"
           />
-        </span>
+        </>
       </EuiToolTip>
     ),
     render: (online: User['online']) => {

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -74,11 +74,6 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
@@ -96,11 +91,6 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
@@ -117,11 +107,6 @@ exports[`EuiBasicTable renders (bare-bones) 1`] = `
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
@@ -304,11 +289,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             NAME1
@@ -317,11 +297,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            ID
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
@@ -335,11 +310,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Age
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
           >
@@ -425,11 +395,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             NAME2
@@ -438,11 +403,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            ID
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
@@ -456,11 +416,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Age
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
           >
@@ -546,11 +501,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             NAME3
@@ -559,11 +509,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            ID
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
@@ -577,11 +522,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Age
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-right-wrapText"
           >

--- a/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -290,11 +290,6 @@ exports[`EuiInMemoryTable with items 1`] = `
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
@@ -312,11 +307,6 @@ exports[`EuiInMemoryTable with items 1`] = `
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
           <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
-          <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >
             <span
@@ -333,11 +323,6 @@ exports[`EuiInMemoryTable with items 1`] = `
         <td
           class="euiTableRowCell emotion-euiTableRowCell-middle-desktop"
         >
-          <div
-            class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop emotion-euiTableRowCell__mobileHeader"
-          >
-            Name
-          </div>
           <div
             class="euiTableCellContent emotion-euiTableCellContent-wrapText"
           >

--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -272,13 +272,6 @@ interface BasicTableProps<T extends object>
    * Sets the table-layout CSS property. Note that auto tableLayout prevents truncateText from working properly.
    */
   tableLayout?: 'fixed' | 'auto';
-  /**
-   * Applied to table cells. Any cell using a render function will set this to be false.
-   *
-   * Creates a text wrapper around cell content that helps word break or truncate
-   * long text correctly.
-   */
-  textOnly?: boolean;
 }
 
 type BasicTableWithPaginationProps<T extends object> = Omit<

--- a/src/components/basic_table/in_memory_table.stories.tsx
+++ b/src/components/basic_table/in_memory_table.stories.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { faker } from '@faker-js/faker';
+import { moveStorybookControlsToCategory } from '../../../.storybook/utils';
+
+import { EuiLink } from '../link';
+import { EuiHealth } from '../health';
+import type { EuiBasicTableColumn } from './basic_table';
+
+import { EuiInMemoryTable, EuiInMemoryTableProps } from './in_memory_table';
+
+const meta: Meta<EuiInMemoryTableProps> = {
+  title: 'Tabular Content/EuiInMemoryTable',
+  // @ts-ignore complex
+  component: EuiInMemoryTable,
+  args: {
+    allowNeutralSort: true,
+    searchFormat: 'eql',
+    error: '',
+    loading: false,
+    // Set to strings for easier testing
+    message: '',
+    childrenBetween: '',
+    // Inherited from EuiTable
+    responsiveBreakpoint: 'm',
+    tableLayout: 'fixed',
+  },
+};
+moveStorybookControlsToCategory(
+  meta,
+  ['responsiveBreakpoint', 'tableLayout'],
+  'EuiTable props'
+);
+
+export default meta;
+type Story = StoryObj<EuiInMemoryTableProps<User>>;
+
+type User = {
+  id: number;
+  firstName: string | null | undefined;
+  lastName: string;
+  online: boolean;
+  location: {
+    city: string;
+    country: string;
+  };
+};
+
+const users: User[] = [];
+
+for (let i = 0; i < 20; i++) {
+  users.push({
+    id: i + 1,
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    online: faker.datatype.boolean(),
+    location: {
+      city: faker.location.city(),
+      country: faker.location.country(),
+    },
+  });
+}
+
+const columns: Array<EuiBasicTableColumn<User>> = [
+  {
+    field: 'firstName',
+    name: 'First Name',
+    sortable: true,
+    truncateText: true,
+    mobileOptions: {
+      render: (user: User) => (
+        <span>
+          {user.firstName} {user.lastName}
+        </span>
+      ),
+      header: false,
+      truncateText: false,
+      enlarge: true,
+      width: '100%',
+    },
+  },
+  {
+    field: 'lastName',
+    name: 'Last Name',
+    truncateText: true,
+    sortable: true,
+    mobileOptions: {
+      show: false,
+    },
+  },
+  {
+    field: 'location',
+    name: 'Location',
+    truncateText: true,
+    textOnly: true,
+    render: (location: User['location']) => {
+      return `${location.city}, ${location.country}`;
+    },
+  },
+  {
+    field: 'online',
+    name: 'Online',
+    dataType: 'boolean',
+    render: (online: User['online']) => {
+      const color = online ? 'success' : 'danger';
+      const label = online ? 'Online' : 'Offline';
+      return <EuiHealth color={color}>{label}</EuiHealth>;
+    },
+    sortable: true,
+    mobileOptions: {
+      show: false,
+    },
+  },
+  {
+    name: 'Actions',
+    actions: [
+      {
+        name: 'User profile',
+        description: ({ firstName, lastName }) =>
+          `Visit ${firstName} ${lastName}'s profile`,
+        icon: 'editorLink',
+        color: 'primary',
+        type: 'icon',
+        enabled: ({ online }) => !!online,
+        href: ({ id }) => `${window.location.href}?id=${id}`,
+        target: '_self',
+        'data-test-subj': 'action-outboundlink',
+      },
+      {
+        name: <>Clone</>,
+        description: 'Clone this user',
+        icon: 'copy',
+        type: 'icon',
+        onClick: () => {},
+        'data-test-subj': 'action-clone',
+      },
+      {
+        name: (user: User) => (user.id ? 'Delete' : 'Remove'),
+        description: ({ firstName, lastName }) =>
+          `Delete ${firstName} ${lastName}`,
+        icon: 'trash',
+        color: 'danger',
+        type: 'icon',
+        onClick: () => {},
+        isPrimary: true,
+        'data-test-subj': ({ id }) => `action-delete-${id}`,
+      },
+      {
+        name: 'Edit',
+        isPrimary: true,
+        available: ({ online }) => !online,
+        enabled: ({ online }) => !!online,
+        description: 'Edit this user',
+        icon: 'pencil',
+        type: 'icon',
+        onClick: () => {},
+        'data-test-subj': 'action-edit',
+      },
+      {
+        name: 'Share',
+        isPrimary: true,
+        description: 'Share this user',
+        icon: 'share',
+        type: 'icon',
+        onClick: () => {},
+        'data-test-subj': 'action-share',
+      },
+    ],
+  },
+  {
+    name: 'Custom actions',
+    actions: [
+      {
+        render: () => (
+          <EuiLink onClick={() => {}} color="danger">
+            Delete
+          </EuiLink>
+        ),
+        showOnHover: true,
+      },
+      {
+        render: () => <EuiLink onClick={() => {}}>Edit</EuiLink>,
+      },
+    ],
+  },
+];
+
+export const KitchenSink: Story = {
+  args: {
+    tableCaption: 'Kitchen sink story',
+    items: users,
+    itemId: 'id',
+    rowHeader: 'firstName',
+    columns,
+    pagination: {
+      initialPageSize: 5,
+      pageSizeOptions: [3, 5, 8],
+    },
+    sorting: {
+      sort: {
+        field: 'lastName',
+        direction: 'asc' as const,
+      },
+    },
+    selection: {
+      selectable: (user) => user.online,
+      selectableMessage: (selectable) =>
+        !selectable ? 'User is currently offline' : '',
+    },
+    search: {
+      box: {
+        incremental: true,
+      },
+      filters: [
+        {
+          type: 'is',
+          field: 'online',
+          name: 'Online',
+          negatedName: 'Offline',
+        },
+        {
+          type: 'field_value_selection',
+          field: 'location.country',
+          name: 'Country',
+          multiSelect: false,
+          options: users.map(({ location: { country } }) => ({
+            value: country,
+          })),
+        },
+      ],
+    },
+  },
+  // Don't pass the default Storybook action listener for `onChange`,
+  // or the automatic uncontrolled pagination & sorting won't work
+  render: ({ onChange, ...args }: EuiInMemoryTableProps<User>) => (
+    <EuiInMemoryTable {...args} />
+  ),
+};

--- a/src/components/basic_table/in_memory_table.test.tsx
+++ b/src/components/basic_table/in_memory_table.test.tsx
@@ -1325,8 +1325,8 @@ describe('EuiInMemoryTable', () => {
 
       // ensure table is on 2nd page (pageIndex=1)
       expect(getByTestSubject('pagination-button-1')).toBeDisabled();
-      expect(container.querySelectorAll('td')[0]).toHaveTextContent('Index2');
-      expect(container.querySelectorAll('td')[1]).toHaveTextContent('Index3');
+      expect(container.querySelectorAll('td')[0]).toHaveTextContent('2');
+      expect(container.querySelectorAll('td')[1]).toHaveTextContent('3');
 
       // click the first pagination button
       fireEvent.click(getByTestSubject('pagination-button-0'));
@@ -1341,8 +1341,8 @@ describe('EuiInMemoryTable', () => {
 
       // ensure table is still on the 2nd page (pageIndex=1)
       expect(getByTestSubject('pagination-button-1')).toBeDisabled();
-      expect(container.querySelectorAll('td')[0]).toHaveTextContent('Index2');
-      expect(container.querySelectorAll('td')[1]).toHaveTextContent('Index3');
+      expect(container.querySelectorAll('td')[0]).toHaveTextContent('2');
+      expect(container.querySelectorAll('td')[1]).toHaveTextContent('3');
 
       // re-render with an updated `pageIndex` value
       rerender(
@@ -1356,8 +1356,8 @@ describe('EuiInMemoryTable', () => {
 
       // ensure table is on 3rd page (pageIndex=2)
       expect(getByTestSubject('pagination-button-2')).toBeDisabled();
-      expect(container.querySelectorAll('td')[0]).toHaveTextContent('Index4');
-      expect(container.querySelectorAll('td')[1]).toHaveTextContent('Index5');
+      expect(container.querySelectorAll('td')[0]).toHaveTextContent('4');
+      expect(container.querySelectorAll('td')[1]).toHaveTextContent('5');
     });
 
     it('respects pageSize', () => {
@@ -1381,7 +1381,7 @@ describe('EuiInMemoryTable', () => {
         },
       ];
       const onTableChange = jest.fn();
-      const component = mount(
+      const { container, getByTestSubject, rerender } = render(
         <EuiInMemoryTable
           items={items}
           columns={columns}
@@ -1391,18 +1391,14 @@ describe('EuiInMemoryTable', () => {
       );
 
       // check that the first 2 items rendered
-      expect(component.find('td').length).toBe(2);
-      expect(component.find('td').at(0).text()).toBe('Index0');
-      expect(component.find('td').at(1).text()).toBe('Index1');
+      let cells = container.querySelectorAll('td');
+      expect(cells.length).toBe(2);
+      expect(cells[0]).toHaveTextContent('0');
+      expect(cells[1]).toHaveTextContent('1');
 
       // change the page size
-      component
-        .find('button[data-test-subj="tablePaginationPopoverButton"]')
-        .simulate('click');
-      component.update();
-      component
-        .find('button[data-test-subj="tablePagination-4-rows"]')
-        .simulate('click');
+      fireEvent.click(getByTestSubject('tablePaginationPopoverButton'));
+      fireEvent.click(getByTestSubject('tablePagination-4-rows'));
 
       // check callback
       expect(onTableChange).toHaveBeenCalledTimes(1);
@@ -1415,20 +1411,28 @@ describe('EuiInMemoryTable', () => {
       });
 
       // verify still only rendering the first 2 rows
-      expect(component.find('td').length).toBe(2);
-      expect(component.find('td').at(0).text()).toBe('Index0');
-      expect(component.find('td').at(1).text()).toBe('Index1');
+      cells = container.querySelectorAll('td');
+      expect(cells.length).toBe(2);
+      expect(cells[0]).toHaveTextContent('0');
+      expect(cells[1]).toHaveTextContent('1');
 
       // update the controlled page size
-      pagination.pageSize = 4;
-      component.setProps({ pagination });
+      rerender(
+        <EuiInMemoryTable
+          items={items}
+          columns={columns}
+          pagination={{ ...pagination, pageSize: 4 }}
+          onTableChange={onTableChange}
+        />
+      );
 
       // verify it now renders 4 rows
-      expect(component.find('td').length).toBe(4);
-      expect(component.find('td').at(0).text()).toBe('Index0');
-      expect(component.find('td').at(1).text()).toBe('Index1');
-      expect(component.find('td').at(2).text()).toBe('Index2');
-      expect(component.find('td').at(3).text()).toBe('Index3');
+      cells = container.querySelectorAll('td');
+      expect(cells.length).toBe(4);
+      expect(cells[0]).toHaveTextContent('0');
+      expect(cells[1]).toHaveTextContent('1');
+      expect(cells[2]).toHaveTextContent('2');
+      expect(cells[3]).toHaveTextContent('3');
     });
   });
 

--- a/src/components/basic_table/table_types.ts
+++ b/src/components/basic_table/table_types.ts
@@ -33,7 +33,7 @@ export interface EuiTableFooterProps<T> {
 }
 export interface EuiTableFieldDataColumnType<T>
   extends CommonProps,
-    TdHTMLAttributes<HTMLTableDataCellElement> {
+    Omit<TdHTMLAttributes<HTMLTableCellElement>, 'width' | 'align'> {
   /**
    * A field of the item (may be a nested field)
    */
@@ -60,16 +60,22 @@ export interface EuiTableFieldDataColumnType<T>
    * Defines whether the user can sort on this column. If a function is provided, this function returns the value to sort against
    */
   sortable?: boolean | ((item: T) => Primitive);
-  isExpander?: boolean;
+  /**
+   * Disables the user's ability to change the sort, but will still
+   * show the current sort direction in the column header
+   */
+  readOnly?: boolean;
+  /**
+   * Defines the horizontal alignment of the column
+   * @default left
+   */
+  align?: HorizontalAlignment;
   /**
    * Creates a text wrapper around cell content that helps word break or truncate
    * long text correctly.
+   * @default true
    */
   textOnly?: boolean;
-  /**
-   * Defines the horizontal alignment of the column
-   */
-  align?: HorizontalAlignment;
   /**
    * Indicates whether this column should truncate overflowing text content.
    * - Set to `true` to enable single-line truncation.
@@ -77,6 +83,10 @@ export interface EuiTableFieldDataColumnType<T>
    * set to a number of lines to truncate to.
    */
   truncateText?: EuiTableRowCellProps['truncateText'];
+  /**
+   * Allows configuring custom render options or appearances for column cells
+   * when the table responsively collapses into a mobile-friendly view
+   */
   mobileOptions?: Omit<EuiTableRowCellMobileOptionsShape, 'render'> & {
     render?: (item: T) => ReactNode;
   };
@@ -92,50 +102,37 @@ export interface EuiTableFieldDataColumnType<T>
     | ReactElement
     | ((props: EuiTableFooterProps<T>) => ReactNode);
   /**
-   * Disables the user's ability to change the sort but still shows the current direction
+   * If passing `itemIdToExpandedRowMap` to your table, set this flag to `true`
+   * for the custom column or cell used to toggle the expanded row.
    */
-  readOnly?: boolean;
-}
-
-export interface EuiTableComputedColumnType<T>
-  extends CommonProps,
-    TdHTMLAttributes<HTMLTableDataCellElement> {
-  /**
-   * A function that computes the value for each item and renders it
-   */
-  render: (record: T) => ReactNode;
-  /**
-   * The display name of the column
-   */
-  name?: ReactNode;
-  /**
-   * A description of the column (will be presented as a title over the column header
-   */
-  description?: string;
-  /**
-   * If provided, allows this column to be sorted on. Must return the value to sort against.
-   */
-  sortable?: (item: T) => Primitive;
-  /**
-   * A CSS width property. Hints for the required width of the column
-   */
-  width?: string;
-  /**
-   * Indicates whether this column should truncate overflowing text content.
-   * - Set to `true` to enable single-line truncation.
-   * - To enable multi-line truncation, use a configuration object with `lines`
-   * set to a number of lines to truncate to.
-   */
-  truncateText?: EuiTableRowCellProps['truncateText'];
   isExpander?: boolean;
-  align?: HorizontalAlignment;
-  /**
-   * Disables the user's ability to change the sort but still shows the current direction
-   */
-  readOnly?: boolean;
 }
 
-export interface EuiTableActionsColumnType<T extends object> {
+export type EuiTableComputedColumnType<T> = CommonProps &
+  Omit<TdHTMLAttributes<HTMLTableCellElement>, 'width' | 'align'> & {
+    /**
+     * A function that computes the value for each item and renders it
+     */
+    render: (record: T) => ReactNode;
+    /**
+     * The display name of the column
+     */
+    name?: ReactNode;
+    /**
+     * If provided, allows this column to be sorted on. Must return the value to sort against.
+     */
+    sortable?: (item: T) => Primitive;
+  } & Pick<
+    EuiTableFieldDataColumnType<T>,
+    | 'readOnly'
+    | 'description'
+    | 'width'
+    | 'align'
+    | 'truncateText'
+    | 'isExpander'
+  >;
+
+export type EuiTableActionsColumnType<T extends object> = {
   /**
    * An array of one of the objects: #DefaultItemAction or #CustomItemAction
    */
@@ -144,15 +141,7 @@ export interface EuiTableActionsColumnType<T extends object> {
    * The display name of the column
    */
   name?: ReactNode;
-  /**
-   * A description of the column (will be presented as a title over the column header
-   */
-  description?: string;
-  /**
-   * A CSS width property. Hints for the required width of the column
-   */
-  width?: string;
-}
+} & Pick<EuiTableFieldDataColumnType<T>, 'description' | 'width'>;
 
 export interface EuiTableSortingType<T> {
   /**

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`align defaults to left 1`] = `
+exports[`EuiTableHeaderCell align defaults to left 1`] = `
 <table>
   <thead>
     <tr>
@@ -21,7 +21,7 @@ exports[`align defaults to left 1`] = `
 </table>
 `;
 
-exports[`align renders center when specified 1`] = `
+exports[`EuiTableHeaderCell align renders center when specified 1`] = `
 <table>
   <thead>
     <tr>
@@ -42,7 +42,7 @@ exports[`align renders center when specified 1`] = `
 </table>
 `;
 
-exports[`align renders right when specified 1`] = `
+exports[`EuiTableHeaderCell align renders right when specified 1`] = `
 <table>
   <thead>
     <tr>
@@ -63,57 +63,28 @@ exports[`align renders right when specified 1`] = `
 </table>
 `;
 
-exports[`renders EuiTableHeaderCell 1`] = `
-<table>
-  <thead>
-    <tr>
-      <th
-        aria-label="aria-label"
-        class="euiTableHeaderCell testClass1 testClass2 emotion-euiTableHeaderCell-euiTestCss"
-        data-test-subj="test subject string"
-        role="columnheader"
-        scope="col"
-      >
-        <div
-          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
-        >
-          <span
-            class="eui-textTruncate"
-            title="children"
-          >
-            children
-          </span>
-        </div>
-      </th>
-    </tr>
-  </thead>
-</table>
+exports[`EuiTableHeaderCell renders 1`] = `
+<th
+  aria-label="aria-label"
+  class="euiTableHeaderCell testClass1 testClass2 emotion-euiTableHeaderCell-euiTestCss"
+  data-test-subj="test subject string"
+  role="columnheader"
+  scope="col"
+>
+  <div
+    class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+  >
+    <span
+      class="eui-textTruncate"
+      title="children"
+    >
+      children
+    </span>
+  </div>
+</th>
 `;
 
-exports[`renders td when children is null/undefined 1`] = `
-<table>
-  <thead>
-    <tr>
-      <td
-        aria-label="aria-label"
-        class="euiTableHeaderCell testClass1 testClass2 emotion-euiTableHeaderCell-euiTestCss"
-        data-test-subj="test subject string"
-        role="columnheader"
-      >
-        <div
-          class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
-        >
-          <span
-            class="eui-textTruncate"
-          />
-        </div>
-      </td>
-    </tr>
-  </thead>
-</table>
-`;
-
-exports[`sorting does not render a button with readOnly 1`] = `
+exports[`EuiTableHeaderCell sorting does not render a button with readOnly 1`] = `
 <table>
   <thead>
     <tr>
@@ -144,7 +115,7 @@ exports[`sorting does not render a button with readOnly 1`] = `
 </table>
 `;
 
-exports[`sorting is rendered with isSortAscending 1`] = `
+exports[`EuiTableHeaderCell sorting is rendered with isSortAscending 1`] = `
 <table>
   <thead>
     <tr>
@@ -175,7 +146,7 @@ exports[`sorting is rendered with isSortAscending 1`] = `
 </table>
 `;
 
-exports[`sorting is rendered with isSorted 1`] = `
+exports[`EuiTableHeaderCell sorting is rendered with isSorted 1`] = `
 <table>
   <thead>
     <tr>
@@ -206,7 +177,7 @@ exports[`sorting is rendered with isSorted 1`] = `
 </table>
 `;
 
-exports[`sorting renders a button with onSort 1`] = `
+exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
 <table>
   <thead>
     <tr>
@@ -243,7 +214,7 @@ exports[`sorting renders a button with onSort 1`] = `
 </table>
 `;
 
-exports[`width and style accepts style attribute 1`] = `
+exports[`EuiTableHeaderCell width and style accepts style attribute 1`] = `
 <table>
   <thead>
     <tr>
@@ -269,7 +240,7 @@ exports[`width and style accepts style attribute 1`] = `
 </table>
 `;
 
-exports[`width and style accepts width attribute 1`] = `
+exports[`EuiTableHeaderCell width and style accepts width attribute 1`] = `
 <table>
   <thead>
     <tr>
@@ -295,7 +266,7 @@ exports[`width and style accepts width attribute 1`] = `
 </table>
 `;
 
-exports[`width and style accepts width attribute as number 1`] = `
+exports[`EuiTableHeaderCell width and style accepts width attribute as number 1`] = `
 <table>
   <thead>
     <tr>
@@ -321,7 +292,7 @@ exports[`width and style accepts width attribute as number 1`] = `
 </table>
 `;
 
-exports[`width and style resolves style and width attribute 1`] = `
+exports[`EuiTableHeaderCell width and style resolves style and width attribute 1`] = `
 <table>
   <thead>
     <tr>

--- a/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_row_cell.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`align defaults to left 1`] = `
+exports[`EuiTableRowCell align defaults to left 1`] = `
 <table>
   <tbody>
     <tr>
@@ -20,7 +20,7 @@ exports[`align defaults to left 1`] = `
 </table>
 `;
 
-exports[`align renders center when specified 1`] = `
+exports[`EuiTableRowCell align renders center when specified 1`] = `
 <table>
   <tbody>
     <tr>
@@ -40,7 +40,7 @@ exports[`align renders center when specified 1`] = `
 </table>
 `;
 
-exports[`align renders right when specified 1`] = `
+exports[`EuiTableRowCell align renders right when specified 1`] = `
 <table>
   <tbody>
     <tr>
@@ -60,7 +60,7 @@ exports[`align renders right when specified 1`] = `
 </table>
 `;
 
-exports[`children's className merges new classnames into existing ones 1`] = `
+exports[`EuiTableRowCell children's className merges new classnames into existing ones 1`] = `
 <table>
   <tbody>
     <tr>
@@ -80,31 +80,46 @@ exports[`children's className merges new classnames into existing ones 1`] = `
 </table>
 `;
 
-exports[`renders EuiTableRowCell 1`] = `
-<table>
-  <tbody>
-    <tr>
-      <td
-        aria-label="aria-label"
-        class="euiTableRowCell testClass1 testClass2 emotion-euiTableRowCell-middle-desktop-euiTestCss"
-        data-test-subj="test subject string"
-      >
-        <div
-          class="euiTableCellContent emotion-euiTableCellContent-wrapText"
-        >
-          <span
-            class="euiTableCellContent__text"
-          >
-            children
-          </span>
-        </div>
-      </td>
-    </tr>
-  </tbody>
-</table>
+exports[`EuiTableRowCell renders 1`] = `
+<td
+  aria-label="aria-label"
+  class="euiTableRowCell testClass1 testClass2 emotion-euiTableRowCell-middle-desktop-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <div
+    class="euiTableCellContent emotion-euiTableCellContent-wrapText"
+  >
+    <span
+      class="euiTableCellContent__text"
+    >
+      children
+    </span>
+  </div>
+</td>
 `;
 
-exports[`textOnly defaults to true 1`] = `
+exports[`EuiTableRowCell renders mobile views 1`] = `
+<td
+  class="euiTableRowCell emotion-euiTableRowCell-middle-mobile-enlarge"
+>
+  <div
+    class="euiTableRowCell__mobileHeader emotion-euiTableRowCell__mobileHeader"
+  >
+    mobile header
+  </div>
+  <div
+    class="euiTableCellContent emotion-euiTableCellContent-truncateText"
+  >
+    <span
+      class="euiTableCellContent__text"
+    >
+      mobile render
+    </span>
+  </div>
+</td>
+`;
+
+exports[`EuiTableRowCell textOnly defaults to true 1`] = `
 <table>
   <tbody>
     <tr>
@@ -124,7 +139,7 @@ exports[`textOnly defaults to true 1`] = `
 </table>
 `;
 
-exports[`textOnly is rendered when specified 1`] = `
+exports[`EuiTableRowCell textOnly is rendered when specified 1`] = `
 <table>
   <tbody>
     <tr>
@@ -140,7 +155,7 @@ exports[`textOnly is rendered when specified 1`] = `
 </table>
 `;
 
-exports[`truncateText defaults to false 1`] = `
+exports[`EuiTableRowCell truncateText defaults to false 1`] = `
 <table>
   <tbody>
     <tr>
@@ -160,7 +175,7 @@ exports[`truncateText defaults to false 1`] = `
 </table>
 `;
 
-exports[`truncateText renders lines configuration 1`] = `
+exports[`EuiTableRowCell truncateText renders lines configuration 1`] = `
 <table>
   <tbody>
     <tr>
@@ -180,7 +195,7 @@ exports[`truncateText renders lines configuration 1`] = `
 </table>
 `;
 
-exports[`truncateText renders true 1`] = `
+exports[`EuiTableRowCell truncateText renders true 1`] = `
 <table>
   <tbody>
     <tr>
@@ -200,7 +215,7 @@ exports[`truncateText renders true 1`] = `
 </table>
 `;
 
-exports[`valign defaults to middle 1`] = `
+exports[`EuiTableRowCell valign defaults to middle 1`] = `
 <table>
   <tbody>
     <tr>
@@ -220,7 +235,7 @@ exports[`valign defaults to middle 1`] = `
 </table>
 `;
 
-exports[`valign renders bottom when specified 1`] = `
+exports[`EuiTableRowCell valign renders bottom when specified 1`] = `
 <table>
   <tbody>
     <tr>
@@ -240,7 +255,7 @@ exports[`valign renders bottom when specified 1`] = `
 </table>
 `;
 
-exports[`valign renders top when specified 1`] = `
+exports[`EuiTableRowCell valign renders top when specified 1`] = `
 <table>
   <tbody>
     <tr>
@@ -260,7 +275,7 @@ exports[`valign renders top when specified 1`] = `
 </table>
 `;
 
-exports[`width and style accepts style attribute 1`] = `
+exports[`EuiTableRowCell width and style accepts style attribute 1`] = `
 <table>
   <tbody>
     <tr>
@@ -283,7 +298,7 @@ exports[`width and style accepts style attribute 1`] = `
 </table>
 `;
 
-exports[`width and style accepts width attribute 1`] = `
+exports[`EuiTableRowCell width and style accepts width attribute 1`] = `
 <table>
   <tbody>
     <tr>
@@ -306,7 +321,7 @@ exports[`width and style accepts width attribute 1`] = `
 </table>
 `;
 
-exports[`width and style accepts width attribute as number 1`] = `
+exports[`EuiTableRowCell width and style accepts width attribute as number 1`] = `
 <table>
   <tbody>
     <tr>
@@ -329,7 +344,7 @@ exports[`width and style accepts width attribute as number 1`] = `
 </table>
 `;
 
-exports[`width and style resolves style and width attribute 1`] = `
+exports[`EuiTableRowCell width and style resolves style and width attribute 1`] = `
 <table>
   <tbody>
     <tr>

--- a/src/components/table/_table_cell_content.tsx
+++ b/src/components/table/_table_cell_content.tsx
@@ -40,7 +40,7 @@ export const EuiTableCellContent: FunctionComponent<
   const styles = useEuiMemoizedStyles(euiTableCellContentStyles);
   const cssStyles = [
     styles.euiTableCellContent,
-    !isResponsive && styles[align], // On mobile, always align cells to the left
+    styles[align],
     truncateText === true && styles.truncateText,
     truncateText === false && styles.wrapText,
     ...(hasActions

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import {
+  EuiTableBody,
+  EuiTableFooter,
+  EuiTableFooterCell,
+  EuiTableHeader,
+  EuiTableHeaderCell,
+  EuiTableRow,
+  EuiTableRowCell,
+} from './index';
+
+import { EuiTable, EuiTableProps } from './table';
+
+const meta: Meta<EuiTableProps> = {
+  title: 'Tabular Content/EuiTable/EuiTable',
+  component: EuiTable,
+  args: {
+    responsiveBreakpoint: 'm',
+    tableLayout: 'fixed',
+    compressed: false, // TODO: Where is this prop even used, and why isn't this documented?
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiTableProps>;
+
+export const Playground: Story = {
+  argTypes: {
+    responsiveBreakpoint: {
+      control: 'select',
+      options: ['xs', 's', 'm', 'l', 'xl', true, false],
+    },
+  },
+  render: ({ ...args }) => (
+    <EuiTable {...args}>
+      <EuiTableHeader>
+        <EuiTableHeaderCell>Column 1</EuiTableHeaderCell>
+        <EuiTableHeaderCell>Column 2</EuiTableHeaderCell>
+        <EuiTableHeaderCell>
+          Long text that will truncate, because header cells default to that
+        </EuiTableHeaderCell>
+      </EuiTableHeader>
+      <EuiTableBody>
+        {Array.from({ length: 20 }, (_, i) => (
+          <EuiTableRow key={i}>
+            {Array.from({ length: 3 }, (_, j) => (
+              <EuiTableRowCell key={`${i}_${j}`}>
+                {j === 2 ? (
+                  'Long text that will change width when table layout is set to auto'
+                ) : (
+                  <>
+                    Row {i + 1}, Cell {j + 1}
+                  </>
+                )}
+              </EuiTableRowCell>
+            ))}
+          </EuiTableRow>
+        ))}
+      </EuiTableBody>
+      <EuiTableFooter>
+        <EuiTableFooterCell>Total: 20</EuiTableFooterCell>
+        <EuiTableFooterCell>Total: 20</EuiTableFooterCell>
+        <EuiTableFooterCell>
+          Long text that will truncate, because footer cells default to that
+        </EuiTableFooterCell>
+      </EuiTableFooter>
+    </EuiTable>
+  ),
+};

--- a/src/components/table/table.styles.ts
+++ b/src/components/table/table.styles.ts
@@ -91,19 +91,10 @@ export const euiTableStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     /**
      * Responsive/mobile vs desktop styles
+     * Individual row/cells handle their own desktop vs mobile styles
      */
-    desktop: css`
-      .euiTableHeaderCell--hideForDesktop,
-      .euiTableRowCell--hideForDesktop,
-      .euiTableRowCell__mobileHeader {
-        display: none;
-      }
-    `,
+    desktop: css``,
     mobile: css`
-      .euiTableRowCell--hideForMobile {
-        display: none;
-      }
-
       thead {
         display: none; /* Use mobile versions of selecting and filtering instead */
       }

--- a/src/components/table/table_cells_shared.styles.ts
+++ b/src/components/table/table_cells_shared.styles.ts
@@ -9,7 +9,11 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import { euiFontSize, logicalCSS } from '../../global_styling';
+import {
+  euiFontSize,
+  logicalCSS,
+  logicalTextAlignCSS,
+} from '../../global_styling';
 
 import { euiTableVariables } from './table.styles';
 
@@ -64,6 +68,10 @@ export const euiTableCellCheckboxStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     euiTableHeaderCellCheckbox: css`
       ${sharedCheckboxStyles}
+
+      /* Without this the visually hidden checkbox doesn't line up properly with the custom render 🙃
+         TODO: Could be removed if we use inset: 0 on checkboxes once they're converted to Emotion */
+      ${logicalTextAlignCSS('left')}
     `,
     euiTableRowCellCheckbox: css`
       ${sharedCheckboxStyles}

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -10,10 +10,11 @@ import React from 'react';
 import { requiredProps } from '../../test/required_props';
 import { render } from '../../test/rtl';
 
-import { EuiTableHeaderCell } from './table_header_cell';
-
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
 import { WARNING_MESSAGE } from './utils';
+import { EuiTableIsResponsiveContext } from './mobile/responsive_context';
+
+import { EuiTableHeaderCell } from './table_header_cell';
 
 const renderInTableHeader = (cell: React.ReactElement) =>
   render(
@@ -24,129 +25,156 @@ const renderInTableHeader = (cell: React.ReactElement) =>
     </table>
   );
 
-test('renders EuiTableHeaderCell', () => {
-  const { container } = renderInTableHeader(
-    <EuiTableHeaderCell {...requiredProps}>children</EuiTableHeaderCell>
-  );
-
-  expect(container.firstChild).toMatchSnapshot();
-});
-
-test('renders td when children is null/undefined', () => {
-  const { container } = renderInTableHeader(
-    <EuiTableHeaderCell {...requiredProps} />
-  );
-
-  expect(container.firstChild).toMatchSnapshot();
-});
-
-describe('align', () => {
-  test('defaults to left', () => {
-    const { container } = renderInTableHeader(<EuiTableHeaderCell />);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  test('renders right when specified', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell align={RIGHT_ALIGNMENT} />
+describe('EuiTableHeaderCell', () => {
+  it('renders', () => {
+    const { getByRole } = renderInTableHeader(
+      <EuiTableHeaderCell {...requiredProps}>children</EuiTableHeaderCell>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(getByRole('columnheader')).toMatchSnapshot();
+    expect(getByRole('columnheader').nodeName).toEqual('TH');
   });
 
-  test('renders center when specified', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell align={CENTER_ALIGNMENT} />
+  it('renders td when children is null/undefined', () => {
+    const { getByRole } = renderInTableHeader(
+      <EuiTableHeaderCell {...requiredProps} />
     );
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
-
-describe('sorting', () => {
-  test('is rendered with isSorted', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell isSorted>Test</EuiTableHeaderCell>
-    );
-
-    expect(container.firstChild).toMatchSnapshot();
+    expect(getByRole('columnheader').nodeName).toEqual('TD');
   });
 
-  test('is rendered with isSortAscending', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell isSorted isSortAscending>
-        Test
+  it('does not render if on desktop and mobileOptions.only is set to true', () => {
+    const { queryByRole } = renderInTableHeader(
+      <EuiTableHeaderCell mobileOptions={{ only: true }}>
+        children
       </EuiTableHeaderCell>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(queryByRole('columnheader')).not.toBeInTheDocument();
   });
 
-  test('renders a button with onSort', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell isSorted onSort={() => {}}>
-        Test
-      </EuiTableHeaderCell>
+  it('does not render if on mobile and mobileOptions.show is set to false', () => {
+    const { queryByRole } = renderInTableHeader(
+      // Context provider mocks mobile state
+      <EuiTableIsResponsiveContext.Provider value={true}>
+        <EuiTableHeaderCell mobileOptions={{ show: false }}>
+          children
+        </EuiTableHeaderCell>
+      </EuiTableIsResponsiveContext.Provider>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(queryByRole('columnheader')).not.toBeInTheDocument();
   });
 
-  test('does not render a button with readOnly', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell readOnly isSorted onSort={() => {}}>
-        Test
-      </EuiTableHeaderCell>
-    );
+  // TODO: These should likely be visual snapshots instead
+  describe('align', () => {
+    it('defaults to left', () => {
+      const { container } = renderInTableHeader(<EuiTableHeaderCell />);
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
+      expect(container.firstChild).toMatchSnapshot();
+    });
 
-describe('width and style', () => {
-  const _consoleWarn = console.warn;
-  beforeAll(() => {
-    console.warn = (...args: [any?, ...any[]]) => {
-      // Suppress an expected warning
-      if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
-      _consoleWarn.apply(console, args);
-    };
-  });
-  afterAll(() => {
-    console.warn = _consoleWarn;
-  });
+    it('renders right when specified', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell align={RIGHT_ALIGNMENT} />
+      );
 
-  test('accepts style attribute', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell style={{ width: '20%' }}>Test</EuiTableHeaderCell>
-    );
+      expect(container.firstChild).toMatchSnapshot();
+    });
 
-    expect(container.firstChild).toMatchSnapshot();
+    it('renders center when specified', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell align={CENTER_ALIGNMENT} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 
-  test('accepts width attribute', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell width="10%">Test</EuiTableHeaderCell>
-    );
+  describe('sorting', () => {
+    it('is rendered with isSorted', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell isSorted>Test</EuiTableHeaderCell>
+      );
 
-    expect(container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('is rendered with isSortAscending', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell isSorted isSortAscending>
+          Test
+        </EuiTableHeaderCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('renders a button with onSort', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell isSorted onSort={() => {}}>
+          Test
+        </EuiTableHeaderCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('does not render a button with readOnly', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell readOnly isSorted onSort={() => {}}>
+          Test
+        </EuiTableHeaderCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 
-  test('accepts width attribute as number', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell width={100}>Test</EuiTableHeaderCell>
-    );
+  describe('width and style', () => {
+    const _consoleWarn = console.warn;
+    beforeAll(() => {
+      console.warn = (...args: [any?, ...any[]]) => {
+        // Suppress an expected warning
+        if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
+        _consoleWarn.apply(console, args);
+      };
+    });
+    afterAll(() => {
+      console.warn = _consoleWarn;
+    });
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
+    it('accepts style attribute', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell style={{ width: '20%' }}>Test</EuiTableHeaderCell>
+      );
 
-  test('resolves style and width attribute', () => {
-    const { container } = renderInTableHeader(
-      <EuiTableHeaderCell width="10%" style={{ width: '20%' }}>
-        Test
-      </EuiTableHeaderCell>
-    );
-    expect(container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('accepts width attribute', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell width="10%">Test</EuiTableHeaderCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('accepts width attribute as number', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell width={100}>Test</EuiTableHeaderCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('resolves style and width attribute', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell width="10%" style={{ width: '20%' }}>
+          Test
+        </EuiTableHeaderCell>
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -24,6 +24,7 @@ import { CommonProps, NoArgCallback } from '../common';
 import { EuiIcon } from '../icon';
 import { EuiInnerText } from '../inner_text';
 
+import type { EuiTableRowCellMobileOptionsShape } from './table_row_cell';
 import { resolveWidthAsStyle } from './utils';
 import { useEuiTableIsResponsive } from './mobile/responsive_context';
 import { EuiTableCellContent } from './_table_cell_content';
@@ -36,20 +37,7 @@ export type EuiTableHeaderCellProps = CommonProps &
     align?: HorizontalAlignment;
     isSortAscending?: boolean;
     isSorted?: boolean;
-    /**
-     * Mobile options for displaying differently at small screens
-     */
-    mobileOptions?: {
-      /**
-       * If false, will not render the column at all for mobile
-       */
-      show?: boolean;
-      /**
-       * Only show for mobile? If true, will not render the column at all
-       * for desktop
-       */
-      only?: boolean;
-    };
+    mobileOptions?: Pick<EuiTableRowCellMobileOptionsShape, 'only' | 'show'>;
     onSort?: NoArgCallback<void>;
     scope?: TableHeaderCellScope;
     width?: string | number;
@@ -127,9 +115,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
   isSortAscending,
   className,
   scope,
-  mobileOptions = {
-    show: true,
-  },
+  mobileOptions,
   width,
   style,
   readOnly,
@@ -140,7 +126,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 
   const isResponsive = useEuiTableIsResponsive();
   const hideForDesktop = !isResponsive && mobileOptions?.only;
-  const hideForMobile = isResponsive && !mobileOptions?.show;
+  const hideForMobile = isResponsive && mobileOptions?.show === false;
   if (hideForDesktop || hideForMobile) return null;
 
   const classes = classNames('euiTableHeaderCell', className);

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -25,6 +25,7 @@ import { EuiIcon } from '../icon';
 import { EuiInnerText } from '../inner_text';
 
 import { resolveWidthAsStyle } from './utils';
+import { useEuiTableIsResponsive } from './mobile/responsive_context';
 import { EuiTableCellContent } from './_table_cell_content';
 import { euiTableHeaderFooterCellStyles } from './table_cells_shared.styles';
 
@@ -137,11 +138,12 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 }) => {
   const styles = useEuiMemoizedStyles(euiTableHeaderFooterCellStyles);
 
-  const classes = classNames('euiTableHeaderCell', className, {
-    'euiTableHeaderCell--hideForDesktop': mobileOptions.only,
-    'euiTableHeaderCell--hideForMobile': !mobileOptions.show,
-  });
+  const isResponsive = useEuiTableIsResponsive();
+  const hideForDesktop = !isResponsive && mobileOptions?.only;
+  const hideForMobile = isResponsive && !mobileOptions?.show;
+  if (hideForDesktop || hideForMobile) return null;
 
+  const classes = classNames('euiTableHeaderCell', className);
   const inlineStyles = resolveWidthAsStyle(style, width);
 
   const CellComponent = children ? 'th' : 'td';

--- a/src/components/table/table_row.stories.tsx
+++ b/src/components/table/table_row.stories.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { EuiButtonIcon } from '../button';
+import { EuiButtonIcon, EuiButtonEmpty } from '../button';
 import { EuiCheckbox } from '../form';
 import {
   EuiTable,
@@ -24,6 +24,12 @@ import { EuiTableRow, EuiTableRowProps } from './table_row';
 const meta: Meta<EuiTableRowProps> = {
   title: 'Tabular Content/EuiTable/EuiTableRow',
   component: EuiTableRow,
+  argTypes: {
+    hasActions: {
+      control: 'select',
+      options: [false, true, 'custom'],
+    },
+  },
 };
 
 export default meta;
@@ -41,6 +47,7 @@ export const Playground: Story = {
     hasActions: false,
     isExpandable: false,
     isExpandedRow: false,
+    hasSelection: false,
     isSelectable: false,
     isSelected: false,
   },
@@ -75,8 +82,14 @@ export const Playground: Story = {
           <EuiTableRowCell>Last name</EuiTableRowCell>
           <EuiTableRowCell>Some other data</EuiTableRowCell>
           {hasActions && (
-            <EuiTableRowCell width="1%" hasActions={true}>
-              <EuiButtonIcon iconType="copy" />
+            <EuiTableRowCell width="1%" hasActions={hasActions}>
+              {hasActions === 'custom' ? (
+                <EuiButtonEmpty size="s" css={{ height: 'auto' }}>
+                  Copy
+                </EuiButtonEmpty>
+              ) : (
+                <EuiButtonIcon iconType="copy" />
+              )}
             </EuiTableRowCell>
           )}
           {isExpandable && (

--- a/src/components/table/table_row.stories.tsx
+++ b/src/components/table/table_row.stories.tsx
@@ -24,12 +24,6 @@ import { EuiTableRow, EuiTableRowProps } from './table_row';
 const meta: Meta<EuiTableRowProps> = {
   title: 'Tabular Content/EuiTable/EuiTableRow',
   component: EuiTableRow,
-  argTypes: {
-    hasActions: {
-      control: 'select',
-      options: [false, true, 'custom'],
-    },
-  },
 };
 
 export default meta;
@@ -39,6 +33,10 @@ export const Playground: Story = {
   argTypes: {
     // For quicker/easier testing
     onClick: { control: 'boolean' },
+    hasActions: {
+      control: 'select',
+      options: [false, true, 'custom'],
+    },
   },
   args: {
     // @ts-ignore - using a switch for easiser testing

--- a/src/components/table/table_row.styles.ts
+++ b/src/components/table/table_row.styles.ts
@@ -9,7 +9,11 @@
 import { css, keyframes } from '@emotion/react';
 
 import { UseEuiTheme, tint, shade, transparentize } from '../../services';
-import { euiBackgroundColor, logicalCSS } from '../../global_styling';
+import {
+  euiCanAnimate,
+  euiBackgroundColor,
+  logicalCSS,
+} from '../../global_styling';
 import { euiShadow } from '../../themes/amsterdam/global_styling/mixins';
 
 import { euiTableVariables } from './table.styles';
@@ -146,9 +150,11 @@ const _expandedRowAnimation = ({ euiTheme }: UseEuiTheme) => {
 
   // Animation must be on the contents div inside, not the row itself
   return css`
-    .euiTableCellContent {
-      animation: ${euiTheme.animation.fast} ${euiTheme.animation.resistance} 1
-        normal none ${expandRow};
+    ${euiCanAnimate} {
+      .euiTableCellContent {
+        animation: ${euiTheme.animation.fast} ${euiTheme.animation.resistance} 1
+          normal none ${expandRow};
+      }
     }
   `;
 };

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -26,6 +26,10 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
     euiTableRowCell: css`
       color: ${euiTheme.colors.text};
     `,
+    rowHeader: css`
+      /* Unset the automatic browser bolding applied to [th] elements */
+      font-weight: ${euiTheme.font.weight.regular};
+    `,
     isExpander: css`
       ${hasIcons}
     `,

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -9,7 +9,12 @@
 import { css } from '@emotion/react';
 
 import { UseEuiTheme } from '../../services';
-import { euiFontSize, euiTextTruncate, logicalCSS } from '../../global_styling';
+import {
+  euiCanAnimate,
+  euiFontSize,
+  euiTextTruncate,
+  logicalCSS,
+} from '../../global_styling';
 
 import { euiTableVariables } from './table.styles';
 
@@ -58,8 +63,11 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
       actions: css`
         .euiBasicTableAction-showOnHover {
           opacity: 0;
-          transition: opacity ${euiTheme.animation.normal}
-            ${euiTheme.animation.resistance};
+
+          ${euiCanAnimate} {
+            transition: opacity ${euiTheme.animation.normal}
+              ${euiTheme.animation.resistance};
+          }
         }
 
         &:focus-within,

--- a/src/components/table/table_row_cell.test.tsx
+++ b/src/components/table/table_row_cell.test.tsx
@@ -10,10 +10,11 @@ import React from 'react';
 import { requiredProps } from '../../test/required_props';
 import { render } from '../../test/rtl';
 
-import { EuiTableRowCell } from './table_row_cell';
-
 import { CENTER_ALIGNMENT, RIGHT_ALIGNMENT } from '../../services/alignment';
 import { WARNING_MESSAGE } from './utils';
+import { EuiTableIsResponsiveContext } from './mobile/responsive_context';
+
+import { EuiTableRowCell } from './table_row_cell';
 
 const renderInTableRow = (cell: React.ReactElement) =>
   render(
@@ -24,163 +25,210 @@ const renderInTableRow = (cell: React.ReactElement) =>
     </table>
   );
 
-test('renders EuiTableRowCell', () => {
-  const { container } = renderInTableRow(
-    <EuiTableRowCell {...requiredProps}>children</EuiTableRowCell>
-  );
-
-  expect(container.firstChild).toMatchSnapshot();
-});
-
-describe('align', () => {
-  test('defaults to left', () => {
-    const { container } = renderInTableRow(<EuiTableRowCell />);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  test('renders right when specified', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell align={RIGHT_ALIGNMENT} />
+describe('EuiTableRowCell', () => {
+  it('renders', () => {
+    const { getByRole } = renderInTableRow(
+      <EuiTableRowCell {...requiredProps}>children</EuiTableRowCell>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    expect(getByRole('cell')).toMatchSnapshot();
   });
 
-  test('renders center when specified', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell align={CENTER_ALIGNMENT} />
+  it('renders mobile views', () => {
+    const { getByRole } = renderInTableRow(
+      // Context provider mocks mobile state
+      <EuiTableIsResponsiveContext.Provider value={true}>
+        <EuiTableRowCell
+          mobileOptions={{
+            header: 'mobile header',
+            render: 'mobile render',
+            enlarge: true,
+            truncateText: true,
+          }}
+        >
+          children
+        </EuiTableRowCell>
+      </EuiTableIsResponsiveContext.Provider>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
-
-describe('valign', () => {
-  test('defaults to middle', () => {
-    const { container } = renderInTableRow(<EuiTableRowCell />);
-
-    expect(container.firstChild).toMatchSnapshot();
+    expect(getByRole('cell')).toMatchSnapshot();
+    expect(getByRole('cell')).toHaveTextContent('mobile headermobile render');
   });
 
-  test('renders top when specified', () => {
-    const { container } = renderInTableRow(<EuiTableRowCell valign="top" />);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  test('renders bottom when specified', () => {
-    const { container } = renderInTableRow(<EuiTableRowCell valign="bottom" />);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
-
-describe('textOnly', () => {
-  test('defaults to true', () => {
-    const { container } = renderInTableRow(<EuiTableRowCell />);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
-  test('is rendered when specified', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell textOnly={false} />
+  it('does not render if on desktop and mobileOptions.only is set to true', () => {
+    const { queryByRole } = renderInTableRow(
+      <EuiTableRowCell mobileOptions={{ only: true }}>children</EuiTableRowCell>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
-
-describe('truncateText', () => {
-  it('defaults to false', () => {
-    const { container } = renderInTableRow(<EuiTableRowCell />);
-
-    expect(container.firstChild).toMatchSnapshot();
-    expect(
-      container.querySelector('.euiTableCellContent')!.className
-    ).toContain('euiTableCellContent-wrapText');
+    expect(queryByRole('cell')).not.toBeInTheDocument();
   });
 
-  it('renders true', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell truncateText={true} />
+  it('does not render if on mobile and mobileOptions.show is set to false', () => {
+    const { queryByRole } = renderInTableRow(
+      // Context provider mocks mobile state
+      <EuiTableIsResponsiveContext.Provider value={true}>
+        <EuiTableRowCell mobileOptions={{ show: false }}>
+          children
+        </EuiTableRowCell>
+      </EuiTableIsResponsiveContext.Provider>
     );
 
-    expect(container.firstChild).toMatchSnapshot();
-    expect(
-      container.querySelector('.euiTableCellContent')!.className
-    ).toContain('euiTableCellContent-truncateText');
+    expect(queryByRole('cell')).not.toBeInTheDocument();
   });
 
-  test('renders lines configuration', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell truncateText={{ lines: 2 }} />
-    );
+  // TODO: These should likely be visual snapshots instead
+  describe('align', () => {
+    it('defaults to left', () => {
+      const { container } = renderInTableRow(<EuiTableRowCell />);
 
-    expect(container.firstChild).toMatchSnapshot();
-    expect(container.querySelector('.euiTableCellContent__text')).toHaveClass(
-      'euiTextBlockTruncate'
-    );
-  });
-});
+      expect(container.firstChild).toMatchSnapshot();
+    });
 
-describe("children's className", () => {
-  test('merges new classnames into existing ones', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell textOnly={false}>
-        <div className="testClass" />
-      </EuiTableRowCell>
-    );
+    it('renders right when specified', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell align={RIGHT_ALIGNMENT} />
+      );
 
-    expect(container.firstChild).toMatchSnapshot();
-  });
-});
+      expect(container.firstChild).toMatchSnapshot();
+    });
 
-describe('width and style', () => {
-  const _consoleWarn = console.warn;
-  beforeAll(() => {
-    console.warn = (...args: [any?, ...any[]]) => {
-      // Suppress an expected warning
-      if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
-      _consoleWarn.apply(console, args);
-    };
-  });
-  afterAll(() => {
-    console.warn = _consoleWarn;
+    it('renders center when specified', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell align={CENTER_ALIGNMENT} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 
-  test('accepts style attribute', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell style={{ width: '20%' }}>Test</EuiTableRowCell>
-    );
+  describe('valign', () => {
+    it('defaults to middle', () => {
+      const { container } = renderInTableRow(<EuiTableRowCell />);
 
-    expect(container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('renders top when specified', () => {
+      const { container } = renderInTableRow(<EuiTableRowCell valign="top" />);
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('renders bottom when specified', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell valign="bottom" />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 
-  test('accepts width attribute', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell width="10%">Test</EuiTableRowCell>
-    );
+  describe('textOnly', () => {
+    it('defaults to true', () => {
+      const { container } = renderInTableRow(<EuiTableRowCell />);
 
-    expect(container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('is rendered when specified', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell textOnly={false} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 
-  test('accepts width attribute as number', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell width={100}>Test</EuiTableRowCell>
-    );
+  describe('truncateText', () => {
+    it('defaults to false', () => {
+      const { container } = renderInTableRow(<EuiTableRowCell />);
 
-    expect(container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
+      expect(
+        container.querySelector('.euiTableCellContent')!.className
+      ).toContain('euiTableCellContent-wrapText');
+    });
+
+    it('renders true', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell truncateText={true} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+      expect(
+        container.querySelector('.euiTableCellContent')!.className
+      ).toContain('euiTableCellContent-truncateText');
+    });
+
+    it('renders lines configuration', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell truncateText={{ lines: 2 }} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+      expect(container.querySelector('.euiTableCellContent__text')).toHaveClass(
+        'euiTextBlockTruncate'
+      );
+    });
   });
 
-  test('resolves style and width attribute', () => {
-    const { container } = renderInTableRow(
-      <EuiTableRowCell width="10%" style={{ width: '20%' }}>
-        Test
-      </EuiTableRowCell>
-    );
+  describe("children's className", () => {
+    it('merges new classnames into existing ones', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell textOnly={false}>
+          <div className="testClass" />
+        </EuiTableRowCell>
+      );
 
-    expect(container.firstChild).toMatchSnapshot();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('width and style', () => {
+    const _consoleWarn = console.warn;
+    beforeAll(() => {
+      console.warn = (...args: [any?, ...any[]]) => {
+        // Suppress an expected warning
+        if (args.length === 1 && args[0] === WARNING_MESSAGE) return;
+        _consoleWarn.apply(console, args);
+      };
+    });
+    afterAll(() => {
+      console.warn = _consoleWarn;
+    });
+
+    it('accepts style attribute', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell style={{ width: '20%' }}>Test</EuiTableRowCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('accepts width attribute', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell width="10%">Test</EuiTableRowCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('accepts width attribute as number', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell width={100}>Test</EuiTableRowCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('resolves style and width attribute', () => {
+      const { container } = renderInTableRow(
+        <EuiTableRowCell width="10%" style={{ width: '20%' }}>
+          Test
+        </EuiTableRowCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -146,7 +146,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   const cellClasses = classNames('euiTableRowCell', className, {
     'euiTableRowCell--hasActions': hasActions,
     'euiTableRowCell--isExpander': isExpander,
-    'euiTableRowCell--hideForDesktop': mobileOptions.only,
   });
 
   const widthValue = isResponsive
@@ -156,9 +155,6 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     : width;
 
   const styleObj = resolveWidthAsStyle(style, widthValue);
-
-  const hideForMobileClasses = 'euiTableRowCell--hideForMobile';
-  const showForMobileClasses = 'euiTableRowCell--hideForDesktop';
 
   const Element = setScopeRow ? 'th' : 'td';
   const sharedProps = {
@@ -174,54 +170,42 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     hasActions: hasActions || isExpander,
   };
 
-  if (mobileOptions.show === false) {
-    return (
-      <Element
-        className={`${cellClasses} ${hideForMobileClasses}`}
-        {...sharedProps}
-      >
-        <EuiTableCellContent {...sharedContentProps}>
-          {children}
-        </EuiTableCellContent>
-      </Element>
-    );
-  } else {
-    return (
-      <Element className={cellClasses} {...sharedProps}>
-        {/* Mobile-only header */}
-        {mobileOptions.header && (
-          <div
-            css={styles.euiTableRowCell__mobileHeader}
-            className={`euiTableRowCell__mobileHeader ${showForMobileClasses}`}
+  if (isResponsive) {
+    if (mobileOptions.show === false) {
+      return null;
+    } else {
+      return (
+        <Element className={cellClasses} {...sharedProps}>
+          {mobileOptions.header && (
+            <div
+              className="euiTableRowCell__mobileHeader"
+              css={styles.euiTableRowCell__mobileHeader}
+            >
+              {mobileOptions.header}
+            </div>
+          )}
+          <EuiTableCellContent
+            {...sharedContentProps}
+            align={mobileOptions.align ?? 'left'} // Default to left aligned mobile cells, unless consumers specifically set an alignment for mobile
+            truncateText={mobileOptions.truncateText ?? truncateText}
+            textOnly={mobileOptions.textOnly ?? textOnly}
           >
-            {mobileOptions.header}
-          </div>
-        )}
-
-        {/* Content depending on mobile render existing */}
-        {mobileOptions.render ? (
-          <>
-            <EuiTableCellContent
-              className={showForMobileClasses}
-              align={mobileOptions.align ?? align}
-              truncateText={mobileOptions.truncateText ?? truncateText}
-              textOnly={mobileOptions.textOnly ?? textOnly}
-            >
-              {mobileOptions.render}
-            </EuiTableCellContent>
-            <EuiTableCellContent
-              {...sharedContentProps}
-              className={hideForMobileClasses}
-            >
-              {children}
-            </EuiTableCellContent>
-          </>
-        ) : (
+            {mobileOptions.render || children}
+          </EuiTableCellContent>
+        </Element>
+      );
+    }
+  } else {
+    if (mobileOptions.only) {
+      return null;
+    } else {
+      return (
+        <Element className={cellClasses} {...sharedProps}>
           <EuiTableCellContent {...sharedContentProps}>
             {children}
           </EuiTableCellContent>
-        )}
-      </Element>
-    );
+        </Element>
+      );
+    }
   }
 };

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -52,10 +52,12 @@ export interface EuiTableRowCellMobileOptionsShape
   extends EuiTableRowCellSharedPropsShape {
   /**
    * If false, will not render the cell at all for mobile
+   * @default true
    */
   show?: boolean;
   /**
    * Only show for mobile? If true, will not render the column at all for desktop
+   * @default false
    */
   only?: boolean;
   /**
@@ -70,10 +72,12 @@ export interface EuiTableRowCellMobileOptionsShape
   header?: ReactNode | boolean;
   /**
    * Increase text size compared to rest of cells
+   * @default false
    */
   enlarge?: boolean;
   /**
    * Applies the value to the width of the cell in mobile view (typically 50%)
+   * @default 50%
    */
   width?: CSSProperties['width'];
 }
@@ -120,9 +124,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   style,
   width,
   valign = 'middle',
-  mobileOptions = {
-    show: true,
-  },
+  mobileOptions,
   ...rest
 }) => {
   const isResponsive = useEuiTableIsResponsive();
@@ -135,7 +137,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
     ...(isResponsive
       ? [
           styles.mobile.mobile,
-          mobileOptions.enlarge && styles.mobile.enlarge,
+          mobileOptions?.enlarge && styles.mobile.enlarge,
           hasActions === 'custom' && styles.mobile.customActions,
           hasActions === true && styles.mobile.actions,
           isExpander && styles.mobile.expander,
@@ -151,7 +153,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   const widthValue = isResponsive
     ? hasActions || isExpander
       ? undefined // On mobile, actions are shifted to a right column via CSS
-      : mobileOptions.width
+      : mobileOptions?.width
     : width;
 
   const styleObj = resolveWidthAsStyle(style, widthValue);
@@ -171,12 +173,12 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   };
 
   if (isResponsive) {
-    if (mobileOptions.show === false) {
+    if (mobileOptions?.show === false) {
       return null;
     } else {
       return (
         <Element className={cellClasses} {...sharedProps}>
-          {mobileOptions.header && (
+          {mobileOptions?.header && (
             <div
               className="euiTableRowCell__mobileHeader"
               css={styles.euiTableRowCell__mobileHeader}
@@ -186,17 +188,17 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
           )}
           <EuiTableCellContent
             {...sharedContentProps}
-            align={mobileOptions.align ?? 'left'} // Default to left aligned mobile cells, unless consumers specifically set an alignment for mobile
-            truncateText={mobileOptions.truncateText ?? truncateText}
-            textOnly={mobileOptions.textOnly ?? textOnly}
+            align={mobileOptions?.align ?? 'left'} // Default to left aligned mobile cells, unless consumers specifically set an alignment for mobile
+            truncateText={mobileOptions?.truncateText ?? truncateText}
+            textOnly={mobileOptions?.textOnly ?? textOnly}
           >
-            {mobileOptions.render || children}
+            {mobileOptions?.render || children}
           </EuiTableCellContent>
         </Element>
       );
     }
   } else {
-    if (mobileOptions.only) {
+    if (mobileOptions?.only) {
       return null;
     } else {
       return (

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -174,6 +174,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   };
 
   if (isResponsive) {
+    // Mobile view
     if (mobileOptions?.show === false) {
       return null;
     } else {
@@ -199,6 +200,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
       );
     }
   } else {
+    // Desktop view
     if (mobileOptions?.only) {
       return null;
     } else {

--- a/src/components/table/table_row_cell.tsx
+++ b/src/components/table/table_row_cell.tsx
@@ -131,6 +131,7 @@ export const EuiTableRowCell: FunctionComponent<Props> = ({
   const styles = useEuiMemoizedStyles(euiTableRowCellStyles);
   const cssStyles = [
     styles.euiTableRowCell,
+    setScopeRow && styles.rowHeader,
     isExpander && styles.isExpander,
     hasActions && styles.hasActions,
     styles[valign],


### PR DESCRIPTION
## Summary

> NOTE: This is going into the EuiTable Emotion conversion/cleanup feature branch.

This PR is primarily a polish pass, containing a final set of (opinionated/slightly spicy) responsive cleanups (5634d4c), a final Storybook/tests/docs pass, and some last-minute bugfixes.

A lot of the line diffs are caused by new stories/tests/docs and not changes to source code. As always, I strongly recommend [reviewing by commit](https://github.com/elastic/eui/pull/7642/commits) and turning off whitespace changes, especially for the commits that add a `describe()` block (i.e. lots of indentation changes) to tests.

### ⚠️ Kibana updates as a result of breaking/DOM changes:

- Table `textOnly` prop removal (Typescript should catch most of these in the upgrade):
  - [3](https://github.com/elastic/kibana/blob/148f9d757fdfc1a755ffda58af78206c830217fc/examples/field_formats_example/public/app.tsx#L103) [in](https://github.com/elastic/kibana/blob/148f9d757fdfc1a755ffda58af78206c830217fc/examples/partial_results_example/public/app/app.tsx#L57) examples - also no, I have no idea what the kibana examples folder is for 😅
  - Rest of usages appear to be on `EuiTableRowCell` directly, which is still valid usage
- ⚠️ The decision to remove rendering completely for `mobileOnly.show/only` is a potentially spicy one that may affect test assertions that rely on the DOM being there (but hidden via `display: none`). We'll have to see in the upgrade how that goes, but I lean toward it being right call to make because it's significantly cleaner and more performant at scale. Would be interested in hearing other folks' thoughts!

## QA

**Storybooks QA**: confirm the below table stories have no noticeable UI/UX bugs and prop controls work as expected
- [x] [EuiInMemoryTable](https://eui.elastic.co/pr_7642/storybook/?path=/story/tabular-content-euiinmemorytable--kitchen-sink)
- [x] [EuiTable](https://eui.elastic.co/pr_7642/storybook/?path=/story/tabular-content-euitable-euitable--playground)
- [x] [EuiTableRow](https://eui.elastic.co/pr_7642/storybook/?path=/story/tabular-content-euitable-euitablerow--playground)

**Docs QA**:
- [x] Confirm the [basic tables docs page](https://eui.elastic.co/pr_7642/#/tabular-content/tables) looks the same as [production](https://eui.elastic.co/#/tabular-content/tables) in both **desktop** and **mobile** views (except for intentional changes made as part of this feature branch)
- [x] Confirm the basic table examples have copy/documentation that make sense and are not inaccurate with the changes deliberately made as part of this feature branch
- [x] Quick smoke check that [in memory tables](https://eui.elastic.co/pr_7642/#/tabular-content/in-memory-tables) look the same as [production](https://eui.elastic.co/#/tabular-content/in-memory-tables) and their docs copy makes sense

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~ - Will have Trevor do a final screen reader pass either when he gets back or on the feature branch PR into main
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A