### PR TITLE
[EuiBreadcrumb] Update color to ensure min. color contrast

### DIFF
--- a/changelogs/upcoming/7643.md
+++ b/changelogs/upcoming/7643.md
@@ -1,0 +1,1 @@
+- Updated `EuiBreadcrumb` styles to ensure min. required color contrast

--- a/changelogs/upcoming/7643.md
+++ b/changelogs/upcoming/7643.md
@@ -1,1 +1,3 @@
-- Updated `EuiBreadcrumb` styles to ensure min. required color contrast
+**Accessibility**
+
+- Updated `EuiHeaderBreadcrumb` styles to ensure min. required color contrast

--- a/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`EuiBreadcrumbCollapsed renders a ... breadcrumb with collapsed content 
         class="euiPopover emotion-euiPopover-inline-block-euiBreadcrumb__popoverWrapper"
       >
         <button
-          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-application-isInteractive"
+          class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__popoverButton-euiBreadcrumb__content-application"
           title="See collapsed breadcrumbs"
           type="button"
         >

--- a/src/components/breadcrumbs/_breadcrumb_content.styles.ts
+++ b/src/components/breadcrumbs/_breadcrumb_content.styles.ts
@@ -8,7 +8,7 @@
 
 import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
-import { transparentize } from '../../services/color';
+import { tintOrShade } from '../../services/color';
 import {
   euiFontSize,
   euiTextTruncate,
@@ -17,12 +17,23 @@ import {
   logicalBorderRadiusCSS,
   mathWithUnits,
 } from '../../global_styling';
+import { euiButtonColor } from '../../themes/amsterdam/global_styling/mixins/button';
 
 /**
  * Styles cast to inner <a>, <button>, <span> elements
  */
 export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
+  const { euiTheme, colorMode } = euiThemeContext;
+  const breadcrumbButtonColor = euiButtonColor(euiThemeContext, 'primary');
+  const breadcrumbTextColors = {
+    backgroundColor: tintOrShade(
+      euiTheme.colors.darkestShade,
+      colorMode === 'DARK' ? 0.7 : 0.85,
+      colorMode
+    ),
+    color: tintOrShade(euiTheme.colors.darkestShade, 0.2, colorMode),
+  };
+
   return {
     euiBreadcrumb__content: css`
       /* Unset EuiLink's bolder font weight */
@@ -72,7 +83,7 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     application: css`
       ${euiFontSize(euiThemeContext, 'xs')}
-      background-color: ${transparentize(euiTheme.colors.darkestShade, 0.2)};
+      background-color: ${breadcrumbTextColors.backgroundColor};
       clip-path: polygon(
         0 0,
         calc(100% - ${euiTheme.size.s}) 0,
@@ -81,15 +92,15 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
         0 100%,
         ${euiTheme.size.s} 50%
       );
-      color: ${euiTheme.colors.darkestShade};
+      color: ${breadcrumbTextColors.color};
       line-height: ${euiTheme.size.base};
       ${logicalCSS('padding-vertical', euiTheme.size.xs)}
       ${logicalCSS('padding-horizontal', euiTheme.size.base)}
 
       &:is(a),
       &:is(button) {
-        background-color: ${transparentize(euiTheme.colors.primary, 0.2)};
-        color: ${euiTheme.colors.link};
+        background-color: ${breadcrumbButtonColor.backgroundColor};
+        color: ${breadcrumbButtonColor.color};
 
         :focus {
           ${euiFocusRing(euiThemeContext, 'inset')}

--- a/src/components/breadcrumbs/_breadcrumb_content.styles.ts
+++ b/src/components/breadcrumbs/_breadcrumb_content.styles.ts
@@ -88,6 +88,7 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     application: css`
       ${euiFontSize(euiThemeContext, 'xs')}
+      font-weight: ${euiTheme.font.weight.medium};
       background-color: ${applicationTextColors.backgroundColor};
       clip-path: polygon(
         0 0,

--- a/src/components/breadcrumbs/_breadcrumb_content.styles.ts
+++ b/src/components/breadcrumbs/_breadcrumb_content.styles.ts
@@ -24,8 +24,13 @@ import { euiButtonColor } from '../../themes/amsterdam/global_styling/mixins/but
  */
 export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme, colorMode } = euiThemeContext;
-  const breadcrumbButtonColor = euiButtonColor(euiThemeContext, 'primary');
-  const breadcrumbTextColors = {
+
+  // Reuse button colors for `type="application`" clickable breadcrumbs
+  const applicationButtonColors = euiButtonColor(euiThemeContext, 'primary');
+
+  // Create custom darker gray colors for non-clickable application breadcrumbs
+  // The numbers/ratios are fairly specific here to pass WCAG AA contrast minimums
+  const applicationTextColors = {
     backgroundColor: tintOrShade(
       euiTheme.colors.darkestShade,
       colorMode === 'DARK' ? 0.7 : 0.85,
@@ -83,7 +88,7 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     application: css`
       ${euiFontSize(euiThemeContext, 'xs')}
-      background-color: ${breadcrumbTextColors.backgroundColor};
+      background-color: ${applicationTextColors.backgroundColor};
       clip-path: polygon(
         0 0,
         calc(100% - ${euiTheme.size.s}) 0,
@@ -92,15 +97,15 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
         0 100%,
         ${euiTheme.size.s} 50%
       );
-      color: ${breadcrumbTextColors.color};
+      color: ${applicationTextColors.color};
       line-height: ${euiTheme.size.base};
       ${logicalCSS('padding-vertical', euiTheme.size.xs)}
       ${logicalCSS('padding-horizontal', euiTheme.size.base)}
 
       &:is(a),
       &:is(button) {
-        background-color: ${breadcrumbButtonColor.backgroundColor};
-        color: ${breadcrumbButtonColor.color};
+        background-color: ${applicationButtonColors.backgroundColor};
+        color: ${applicationButtonColors.color};
 
         :focus {
           ${euiFocusRing(euiThemeContext, 'inset')}

--- a/src/components/breadcrumbs/_breadcrumb_content.tsx
+++ b/src/components/breadcrumbs/_breadcrumb_content.tsx
@@ -49,11 +49,13 @@ export const EuiBreadcrumbContent: FunctionComponent<
   truncateLastBreadcrumb,
   ...rest
 }) => {
+  const isApplication = type === 'application';
+
   const classes = classNames('euiBreadcrumb__content', className);
 
   const styles = useEuiMemoizedStyles(euiBreadcrumbContentStyles);
   const cssStyles = [styles.euiBreadcrumb__content, styles[type]];
-  if (type === 'application') {
+  if (isApplication) {
     if (isOnlyBreadcrumb) {
       cssStyles.push(styles.applicationStyles.onlyChild);
     } else if (isFirstBreadcrumb) {
@@ -74,6 +76,7 @@ export const EuiBreadcrumbContent: FunctionComponent<
 
   const interactionStyles =
     (isInteractiveBreadcrumb || isBreadcrumbWithPopover) &&
+    !isApplication &&
     styles.isInteractive;
 
   return (

--- a/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
+++ b/src/components/header/header_breadcrumbs/__snapshots__/header_breadcrumbs.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EuiHeaderBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-subdued-euiBreadcrumb__content-application-firstChild-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-subdued-euiBreadcrumb__content-application-firstChild-isTruncated"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -28,7 +28,7 @@ exports[`EuiHeaderBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <button
-        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-application-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-application-isTruncated"
         title="Reptiles"
         type="button"
       >
@@ -40,7 +40,7 @@ exports[`EuiHeaderBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-application-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content emotion-euiLink-subdued-euiBreadcrumb__content-application-isTruncated"
         href="#"
         rel="noreferrer"
         title="Boa constrictor"

--- a/src/components/header/header_breadcrumbs/header_breadcrumbs.stories.tsx
+++ b/src/components/header/header_breadcrumbs/header_breadcrumbs.stories.tsx
@@ -50,7 +50,6 @@ export const Playground: Story = {
       },
       {
         text: 'Breadcrumb 2',
-        href: '#',
       },
       {
         text: 'Current',


### PR DESCRIPTION
## Summary

closes #7514 

This PR updates the styles of `EuiBreadcrumb` with `type="application"` to increase color contrast to ensure the required [contrast minimum level (AA)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum) of `4.5` 

### Changes

* uses `primary` button colors for interactive breadcrumbs
* replaces `transparentize` with `tintOrShade` on non-interactive breadcrumb styles and adjusts values to result in contrast above `4.5`

_light mode_

https://github.com/elastic/eui/assets/44670957/7e726543-d451-475e-90e7-04ff6d388c12

![Screenshot 2024-04-02 at 10 51 48](https://github.com/elastic/eui/assets/44670957/2a55b1f8-7f8a-4309-8479-394679ad8a6c)
![Screenshot 2024-04-02 at 10 51 54](https://github.com/elastic/eui/assets/44670957/b9eac7ee-e3c3-41ed-b2d8-1b3d71ad4224)

_dark mode_

https://github.com/elastic/eui/assets/44670957/4527d7eb-dd66-4a3f-acbc-d3a8deeba178

![Screenshot 2024-04-02 at 10 52 10](https://github.com/elastic/eui/assets/44670957/c87a61d9-8012-40d8-9060-906142a9a027)
![Screenshot 2024-04-02 at 10 52 16](https://github.com/elastic/eui/assets/44670957/ca073c4f-df3c-4902-9216-bbf433106d43)


## QA

- [ ] review `EuiBreadcrumbs` ([storybook](https://eui.elastic.co/pr_7643/storybook/index.html?path=/story/navigation-euibreadcrumbs--playground&args=type:application)) and `EuiHeaderBreadcrumbs` ([storybook](https://eui.elastic.co/pr_7643/storybook/index.html?path=/story/layout-euiheader-euiheaderbreadcrumbs--playground)) and verify the min. required color contrast
    - [ ] and set `type` to `application` (if not preset)
    - [ ] use the devTools to inspect the breadcrumbs and their color contrast (in Chrome use the selection tool and hover the element) OR run axe DevTools and confirm no color contrast issue is raised for the breadcrumbs

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md)** and ~[cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
