### PR TITLE
[Emotion][perf] Memoize loading components

### DIFF
--- a/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
+++ b/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
@@ -8,16 +8,16 @@ exports[`EuiLoadingChart is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
 </span>
 `;
@@ -25,20 +25,20 @@ exports[`EuiLoadingChart is rendered 1`] = `
 exports[`EuiLoadingChart mono is rendered 1`] = `
 <span
   aria-label="Loading"
-  class="euiLoadingChart euiLoadingChart--mono emotion-euiLoadingChart-m"
+  class="euiLoadingChart emotion-euiLoadingChart-m"
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-mono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-mono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-mono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-mono-m"
   />
 </span>
 `;
@@ -50,16 +50,16 @@ exports[`EuiLoadingChart size l is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-l"
+    class="emotion-euiLoadingChart__bar-nonmono-l"
   />
   <span
-    class="emotion-euiLoadingChart__bar-l"
+    class="emotion-euiLoadingChart__bar-nonmono-l"
   />
   <span
-    class="emotion-euiLoadingChart__bar-l"
+    class="emotion-euiLoadingChart__bar-nonmono-l"
   />
   <span
-    class="emotion-euiLoadingChart__bar-l"
+    class="emotion-euiLoadingChart__bar-nonmono-l"
   />
 </span>
 `;
@@ -71,16 +71,16 @@ exports[`EuiLoadingChart size m is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-m"
+    class="emotion-euiLoadingChart__bar-nonmono-m"
   />
 </span>
 `;
@@ -92,16 +92,16 @@ exports[`EuiLoadingChart size xl is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-xl"
+    class="emotion-euiLoadingChart__bar-nonmono-xl"
   />
   <span
-    class="emotion-euiLoadingChart__bar-xl"
+    class="emotion-euiLoadingChart__bar-nonmono-xl"
   />
   <span
-    class="emotion-euiLoadingChart__bar-xl"
+    class="emotion-euiLoadingChart__bar-nonmono-xl"
   />
   <span
-    class="emotion-euiLoadingChart__bar-xl"
+    class="emotion-euiLoadingChart__bar-nonmono-xl"
   />
 </span>
 `;

--- a/src/components/loading/loading_chart.tsx
+++ b/src/components/loading/loading_chart.tsx
@@ -8,15 +8,16 @@
 
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../common';
-import { useEuiTheme } from '../../services';
 
+import { useEuiMemoizedStyles } from '../../services';
+import { CommonProps } from '../common';
+
+import { useLoadingAriaLabel } from './_loading_strings';
 import {
   euiLoadingChartStyles,
   euiLoadingChartBarStyles,
-  _barIndex,
+  BARS_COUNT,
 } from './loading_chart.styles';
-import { useEuiI18n } from '../i18n';
 
 export const SIZES = ['m', 'l', 'xl'] as const;
 export type EuiLoadingChartSize = (typeof SIZES)[number];
@@ -34,30 +35,19 @@ export const EuiLoadingChart: FunctionComponent<EuiLoadingChartProps> = ({
   'aria-label': ariaLabel,
   ...rest
 }) => {
-  const defaultAriaLabel = useEuiI18n('euiLoadingChart.ariaLabel', 'Loading');
-  const euiTheme = useEuiTheme();
-  const styles = euiLoadingChartStyles(euiTheme);
-  const barStyles = euiLoadingChartBarStyles(euiTheme);
+  const classes = classNames('euiLoadingChart', className);
 
-  const classes = classNames(
-    'euiLoadingChart',
-    { 'euiLoadingChart--mono': mono },
-    className
-  );
-
+  const styles = useEuiMemoizedStyles(euiLoadingChartStyles);
   const cssStyles = [styles.euiLoadingChart, styles[size]];
-  const cssBarStyles = (index: number) => {
-    return [
-      barStyles.euiLoadingChart__bar,
-      barStyles[size],
-      _barIndex(index, mono, euiTheme),
-    ];
-  };
 
-  const bars = [];
-  for (let index = 0; index < 4; index++) {
-    bars.push(<span key={index} css={cssBarStyles(index)} />);
-  }
+  const barStyles = useEuiMemoizedStyles(euiLoadingChartBarStyles);
+  const barCssStyles = [
+    barStyles.euiLoadingChart__bar,
+    mono ? barStyles.mono : barStyles.nonmono,
+    barStyles[size],
+  ];
+
+  const defaultAriaLabel = useLoadingAriaLabel();
 
   return (
     <span
@@ -67,7 +57,9 @@ export const EuiLoadingChart: FunctionComponent<EuiLoadingChartProps> = ({
       aria-label={ariaLabel || defaultAriaLabel}
       {...rest}
     >
-      {bars}
+      {Array.from({ length: BARS_COUNT }, (_, index) => (
+        <span key={index} css={barCssStyles} />
+      ))}
     </span>
   );
 };

--- a/src/components/loading/loading_elastic.styles.ts
+++ b/src/components/loading/loading_elastic.styles.ts
@@ -33,49 +33,47 @@ const loadingElastic = keyframes`
   }
 `;
 
-export const euiLoadingElasticStyles = () => {
-  return {
-    euiLoadingElastic: css`
-      position: relative;
-      display: inline-block;
+export const euiLoadingElasticStyles = {
+  euiLoadingElastic: css`
+    position: relative;
+    display: inline-block;
 
-      & path {
-        ${euiCanAnimate} {
-          animation-name: ${loadingElastic};
-          animation-fill-mode: forwards;
-          animation-direction: alternate;
-          transform-style: preserve-3d;
-          animation-duration: 1s;
-          animation-timing-function: cubic-bezier(0, 0.63, 0.49, 1);
-          animation-iteration-count: infinite;
-          transform-origin: 50% 50%;
-        }
-
-        /* Hide outline mainly for dark mode */
-        &:nth-of-type(1) {
-          display: none;
-        }
-
-        &:nth-of-type(2) {
-          animation-delay: 0.035s;
-        }
-
-        &:nth-of-type(3) {
-          animation-delay: 0.125s;
-        }
-
-        &:nth-of-type(4) {
-          animation-delay: 0.155s;
-        }
-
-        &:nth-of-type(5) {
-          animation-delay: 0.075s;
-        }
-
-        &:nth-of-type(6) {
-          animation-delay: 0.06s;
-        }
+    & path {
+      ${euiCanAnimate} {
+        animation-name: ${loadingElastic};
+        animation-fill-mode: forwards;
+        animation-direction: alternate;
+        transform-style: preserve-3d;
+        animation-duration: 1s;
+        animation-timing-function: cubic-bezier(0, 0.63, 0.49, 1);
+        animation-iteration-count: infinite;
+        transform-origin: 50% 50%;
       }
-    `,
-  };
+
+      /* Hide outline mainly for dark mode */
+      &:nth-of-type(1) {
+        display: none;
+      }
+
+      &:nth-of-type(2) {
+        animation-delay: 0.035s;
+      }
+
+      &:nth-of-type(3) {
+        animation-delay: 0.125s;
+      }
+
+      &:nth-of-type(4) {
+        animation-delay: 0.155s;
+      }
+
+      &:nth-of-type(5) {
+        animation-delay: 0.075s;
+      }
+
+      &:nth-of-type(6) {
+        animation-delay: 0.06s;
+      }
+    }
+  `,
 };

--- a/src/components/loading/loading_elastic.tsx
+++ b/src/components/loading/loading_elastic.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { EuiIcon } from '../icon';
 import { useLoadingAriaLabel } from './_loading_strings';
-import { euiLoadingElasticStyles } from './loading_elastic.styles';
+import { euiLoadingElasticStyles as styles } from './loading_elastic.styles';
 
 export const SIZES = ['m', 'l', 'xl', 'xxl'] as const;
 export type EuiLoadingElasticSize = (typeof SIZES)[number];
@@ -23,16 +23,13 @@ export interface EuiLoadingElasticProps {
 export const EuiLoadingElastic: FunctionComponent<
   CommonProps & HTMLAttributes<HTMLDivElement> & EuiLoadingElasticProps
 > = ({ size = 'm', className, 'aria-label': ariaLabel, ...rest }) => {
-  const styles = euiLoadingElasticStyles();
-  const cssStyles = [styles.euiLoadingElastic];
-  const defaultLabel = useLoadingAriaLabel();
-
   const classes = classNames('euiLoadingElastic', className);
+  const defaultLabel = useLoadingAriaLabel();
 
   return (
     <span
       className={classes}
-      css={cssStyles}
+      css={styles.euiLoadingElastic}
       role="progressbar"
       aria-label={ariaLabel || defaultLabel}
       {...rest}

--- a/src/components/loading/loading_logo.styles.ts
+++ b/src/components/loading/loading_logo.styles.ts
@@ -86,6 +86,13 @@ export const euiLoadingLogoStyles = ({ euiTheme }: UseEuiTheme) => {
         }
       }
     `,
+    euiLoadingLogo__icon: css`
+      display: inline-block;
+
+      ${euiCanAnimate} {
+        animation: 1s ${loadingBounce} ${euiTheme.animation.resistance} infinite;
+      }
+    `,
 
     /**
      * 1. Requires pixel math for animation
@@ -127,18 +134,6 @@ export const euiLoadingLogoStyles = ({ euiTheme }: UseEuiTheme) => {
       &::after {
         block-size: ${euiTheme.base * 0.5}px; /* 1 */
         inset-block-end: -${euiTheme.size.m};
-      }
-    `,
-  };
-};
-
-export const euiLoadingLogoIconStyles = ({ euiTheme }: UseEuiTheme) => {
-  return {
-    euiLoadingLogo__icon: css`
-      display: inline-block;
-
-      ${euiCanAnimate} {
-        animation: 1s ${loadingBounce} ${euiTheme.animation.resistance} infinite;
       }
     `,
   };

--- a/src/components/loading/loading_logo.tsx
+++ b/src/components/loading/loading_logo.tsx
@@ -8,14 +8,13 @@
 
 import React, { HTMLAttributes, FunctionComponent } from 'react';
 import classNames from 'classnames';
+
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
 import { EuiIcon, IconType } from '../icon';
-import { useEuiTheme } from '../../services';
+
 import { useLoadingAriaLabel } from './_loading_strings';
-import {
-  euiLoadingLogoStyles,
-  euiLoadingLogoIconStyles,
-} from './loading_logo.styles';
+import { euiLoadingLogoStyles } from './loading_logo.styles';
 
 export const SIZES = ['m', 'l', 'xl'] as const;
 export type EuiLoadingLogoSize = (typeof SIZES)[number];
@@ -36,16 +35,12 @@ export const EuiLoadingLogo: FunctionComponent<EuiLoadingLogoProps> = ({
   className,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const defaultLabel = useLoadingAriaLabel();
+  const classes = classNames('euiLoadingLogo', className);
 
-  const styles = euiLoadingLogoStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiLoadingLogoStyles);
   const cssStyles = [styles.euiLoadingLogo, styles[size]];
 
-  const iconStyles = euiLoadingLogoIconStyles(euiTheme);
-  const iconCssStyles = [iconStyles.euiLoadingLogo__icon];
-
-  const classes = classNames('euiLoadingLogo', className);
+  const defaultLabel = useLoadingAriaLabel();
 
   return (
     <span
@@ -55,7 +50,7 @@ export const EuiLoadingLogo: FunctionComponent<EuiLoadingLogoProps> = ({
       aria-label={ariaLabel || defaultLabel}
       {...rest}
     >
-      <span css={iconCssStyles}>
+      <span css={styles.euiLoadingLogo__icon}>
         <EuiIcon type={logo} size={size} />
       </span>
     </span>

--- a/src/components/loading/loading_spinner.stories.tsx
+++ b/src/components/loading/loading_spinner.stories.tsx
@@ -22,3 +22,9 @@ export default meta;
 type Story = StoryObj<EuiLoadingSpinnerProps>;
 
 export const Playground: Story = {};
+
+export const CustomColor: Story = {
+  args: {
+    color: { border: 'pink', highlight: 'purple' },
+  },
+};

--- a/src/components/loading/loading_spinner.tsx
+++ b/src/components/loading/loading_spinner.tsx
@@ -7,9 +7,11 @@
  */
 
 import React, { HTMLAttributes, FunctionComponent, CSSProperties } from 'react';
-import { CommonProps } from '../common';
 import classNames from 'classnames';
-import { useEuiTheme } from '../..//services';
+
+import { useEuiTheme, useEuiMemoizedStyles } from '../../services';
+import { CommonProps } from '../common';
+
 import { useLoadingAriaLabel } from './_loading_strings';
 import {
   euiLoadingSpinnerStyles,
@@ -43,14 +45,17 @@ export const EuiLoadingSpinner: FunctionComponent<EuiLoadingSpinnerProps> = ({
   style,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiLoadingSpinnerStyles(euiTheme);
-  const cssStyles = [styles.euiLoadingSpinner, styles[size]];
   const classes = classNames('euiLoadingSpinner', className);
-  const defaultLabel = useLoadingAriaLabel();
+
+  const styles = useEuiMemoizedStyles(euiLoadingSpinnerStyles);
+  const cssStyles = [styles.euiLoadingSpinner, styles[size]];
+
+  const euiTheme = useEuiTheme();
   const customColorStyle = color
     ? { ...style, borderColor: euiSpinnerBorderColorsCSS(euiTheme, color) }
     : style;
+
+  const defaultLabel = useLoadingAriaLabel();
 
   return (
     <span


### PR DESCRIPTION
## Summary

Part of #7561 efforts

This PR:

- Memoizes all `EuiLoading*` components
- Refactors how `EuiLoadingChart` styles are written/generated to use static `:nth-child` CSS instead of dynamic JS styles (98ebe26). Also removes its `--mono` className modifier - no usages in Kibana
- All other components were fairly straightforward

## QA

- [x] https://eui.elastic.co/pr_7649/#/display/loading smoke check - should look the same as production
- [x] https://eui.elastic.co/pr_7649/storybook/?path=/story/display-euiloadingspinner--custom-color - custom colors for loading spinner should work as before

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including ~keyboard-only and~ screenreader modes. Also checked with `Reduced motion` setting
- Docs site QA - N/A
- Code quality checklist - N/A, all tests should pass
- Release checklist - N/A, skipping a changelog as this is mostly tech debt and shouldn't affect either consumers or end-users
- Designer checklist - N/A