### PR TITLE
CI: configure `eui-release` pipeline to test merged changes and bump package versions

### DIFF
--- a/.buildkite/pipelines/pipeline_release.yml
+++ b/.buildkite/pipelines/pipeline_release.yml
@@ -1,7 +1,108 @@
+agents:
+  provider: gcp
+  machineType: 'n2-standard-2'
+  preemptible: true
+
 steps:
-  - command: "echo 'This pipeline is currently a no-op'"
-    label: ':shrug: noop'
+  - group: ':hammer: Unit and static tests'
+    key: 'unit-static-tests'
+    steps:
+      - label: ':typescript: Linting'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'lint'
+        agents:
+          machineType: 'n1-standard-1'
+        timeout_in_minutes: 15
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+      - label: ':jest: TS unit tests'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'unit:ts'
+        agents:
+          machineType: 'n1-standard-1'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+      - label: ':jest: TSX unit tests on React 16'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'unit:tsx:16'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+      - label: ':jest: TSX unit tests on React 17'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'unit:tsx:17'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+      - label: ':jest: TSX unit tests on React 18'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'unit:tsx'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+  - group: ':hammer: E2E component tests'
+    key: 'e2e-tests'
+    steps:
+      - label: ':cypress: Cypress tests on React 16'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'cypress:16'
+        artifact_paths:
+          - 'cypress/screenshots/**/*.png'
+          - 'cypress/videos/**/*.mp4'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+      - label: ':cypress: Cypress tests on React 17'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'cypress:17'
+        artifact_paths:
+          - 'cypress/screenshots/**/*.png'
+          - 'cypress/videos/**/*.mp4'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+      - label: ':cypress: Cypress tests on React 18'
+        command: '.buildkite/scripts/pipelines/pipeline_test.sh'
+        env:
+          TEST_TYPE: 'cypress:18'
+        artifact_paths:
+          - 'cypress/screenshots/**/*.png'
+          - 'cypress/videos/**/*.mp4'
+        timeout_in_minutes: 60
+        retry:
+          automatic:
+            - exit_status: '-1'
+              limit: 1
+  - wait
+  - label: ':npm: Update package version'
+    key: 'update-package-version'
+    command: '.buildkite/scripts/release/step_update_version.sh'
     agents:
-      provider: gcp
-    # TODO: remove the test-automatic-releases condition when the pipeline is production-ready
-    if: build.branch == "main" || build.branch == "build/test-automatic-releases"
+      provider: k8s
+      ephemeralStorage: '10G'
+      cpu: '1000m'
+      memory: '1G'
+    # TODO: Remove when tested using build/test-automatic-releases branch
+    if: build.branch != "main"

--- a/.buildkite/pipelines/pipeline_release.yml
+++ b/.buildkite/pipelines/pipeline_release.yml
@@ -100,6 +100,7 @@ steps:
     key: 'update-package-version'
     command: '.buildkite/scripts/release/step_update_version.sh'
     agents:
+      image: 'docker.elastic.co/ci-agent-images/eui/basic-buildkite-agent:latest'
       provider: k8s
       ephemeralStorage: '10G'
       cpu: '1000m'

--- a/.buildkite/scripts/release/step_update_version.sh
+++ b/.buildkite/scripts/release/step_update_version.sh
@@ -108,11 +108,11 @@ git config --local tag.gpgsign true
 git config --local gpg.x509.program gitsign
 git config --local gpg.format x509
 
-echo "Adding and committing package.json"
+echo "+++ :git: Adding and committing package.json"
 git add package.json
 git commit -m "release: @elastic/eui v${new_version} [skip-ci]"
 
-echo "Pushing commit to ${git_branch}"
+echo "+++ :git: Pushing commit to ${git_branch}"
 
 # git push will be rejected by remote if there are any new commits or other
 # changes made to the branch between the start of this build and now.
@@ -134,7 +134,7 @@ if [[ "${release_type}" == "release" ]]; then
   echo "Creating and pushing release tag ${tag_name}"
   git tag --annotate "${tag_name}"
   git push "${git_remote_name}" "${tag_name}"
-  echo "Pushed release tag - https://github.com/elastic/eui/tree/${tag_name}"
+  echo "+++ :git: Pushed release tag - https://github.com/elastic/eui/tree/${tag_name}"
 fi
 
 ##

--- a/.buildkite/scripts/release/step_update_version.sh
+++ b/.buildkite/scripts/release/step_update_version.sh
@@ -9,14 +9,6 @@ set -eo pipefail
 
 # TODO: Support releasing non-HEAD commits when FORCE_SKIP_GIT_UPDATES=true
 
-##
-# Install gitsign
-# TODO: Move to agent image
-##
-
-wget https://github.com/sigstore/gitsign/releases/download/v0.10.1/gitsign_0.10.1_linux_amd64.deb -O /tmp/gitsign.deb
-dpkg -i /tmp/gitsign.deb
-
 # Begin configuration
 
 npm_version_prerelease_prefix="next"
@@ -59,6 +51,7 @@ echo "npm version prerelease prefix: ${npm_version_prerelease_prefix}"
 echo "git branch: ${git_branch}"
 echo "git push flags: ${git_push_flags}"
 echo "git remote URL: $(git remote get-url "${git_remote_name}")"
+echo "node version: $(node -v)"
 
 ##
 # Update package.json version string

--- a/.buildkite/scripts/release/step_update_version.sh
+++ b/.buildkite/scripts/release/step_update_version.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Update version number and commit it back to the repository.
+#
+# Supported configuration via environment variables:
+#  * RELEASE_TYPE (optional) - Type of release that should be performed. Defaults to prerelease (possible values: "release", "prerelease")
+#  * RELEASE_VERSION (required when RELEASE_TYPE="release") - The new package.json version string. Must follow semver notation.
+
+set -eo pipefail
+
+# TODO: Support releasing non-HEAD commits when FORCE_SKIP_GIT_UPDATES=true
+
+##
+# Install gitsign
+# TODO: Move to agent image
+##
+
+wget https://github.com/sigstore/gitsign/releases/download/v0.10.1/gitsign_0.10.1_linux_amd64.deb -O /tmp/gitsign.deb
+dpkg -i /tmp/gitsign.deb
+
+# Begin configuration
+
+npm_version_prerelease_prefix="next"
+git_remote_name="origin"
+git_branch="${BUILDKITE_BRANCH}"
+
+# End configuration
+
+if [[ -z "${git_branch}" ]]; then
+  >&2 echo "BUILDKITE_BRANCH is not set. This usually means you're trying to execute this script from the outside of Buildkite pipeline which is unsupported."
+  exit 1
+fi
+
+##
+# Check release type (prerelease or regular release)
+##
+
+release_type="prerelease"
+if [[ "${RELEASE_TYPE}" == "release" ]]; then
+  release_type="release"
+fi
+
+##
+# Check version number
+##
+
+if [[ "${release_type}" == "release" ]] && [[ -z "${RELEASE_VERSION}" ]]; then
+  >&2 echo "RELEASE_VERSION must be set when RELEASE_TYPE is 'release'"
+  exit 1
+fi
+
+##
+# Print run's configuration
+##
+
+echo "+++ Updating version on branch ${git_branch}"
+echo "release type: ${release_type}"
+echo "release version: ${RELEASE_VERSION}"
+echo "npm version prerelease prefix: ${npm_version_prerelease_prefix}"
+echo "git branch: ${git_branch}"
+echo "git push flags: ${git_push_flags}"
+echo "git remote URL: $(git remote get-url "${git_remote_name}")"
+
+##
+# Update package.json version string
+##
+
+echo "+++ Updating @elastic/eui version string"
+
+npm_version_args=(
+  --git-tag-version=false # disable tagging the new version
+  --sign-git-tag=false # disable signing the git tag
+  --commit-hooks=false # disable all git commit hooks
+)
+
+new_version=""
+if [[ "${release_type}" == "release" ]]; then
+  new_version=$(npm version "${npm_version_args[@]}" "${RELEASE_VERSION}")
+else
+  new_version=$(npm version "${npm_version_args[@]}" --preid=${npm_version_prerelease_prefix} prerelease)
+fi
+
+# npm version output prefixes the new version with 'v'
+new_version="${new_version:1}"
+
+echo "Updated @elastic/eui version string to ${new_version}"
+
+##
+# Check if version isn't already published if RELEASE_VERSION is set
+##
+
+echo "+++ :npm: Checking npm registry"
+if [[ "$(npm show @elastic/eui versions --json | jq 'index("${new_version}")')" != "null" ]]; then
+  >&2 echo "Version ${new_version} has already been published to npm and can't be overridden:"
+  >&2 echo "https://www.npmjs.com/package/@elastic/eui/v/${new_version}"
+  exit 2
+fi
+
+echo "Version ${new_version} hasn't been published to npm yet"
+
+##
+# Commit package.json
+##
+
+echo "+++ :git: Committing the version update"
+
+echo "Fetching OIDC token to sign the commit"
+SIGSTORE_ID_TOKEN="$(buildkite-agent oidc request-token --audience sigstore)"
+
+github_user_vault="secret/ci/elastic-eui/github_machine_user"
+
+git config --local user.name "$(vault read -field=name "${github_user_vault}")"
+git config --local user.email "$(vault read -field=email "${github_user_vault}")"
+git config --local commit.gpgsign true
+git config --local tag.gpgsign true
+git config --local gpg.x509.program gitsign
+git config --local gpg.format x509
+
+echo "Adding and committing package.json"
+git add package.json
+git commit -m "release: @elastic/eui v${new_version} [skip-ci]"
+
+echo "Pushing commit to ${git_branch}"
+
+# git push will be rejected by remote if there are any new commits or other
+# changes made to the branch between the start of this build and now.
+if ! git push "${git_remote_name}" HEAD:"${git_branch}"; then
+  # fetch remote objects and refs without changing the local state
+  git fetch upstream
+
+  latest_commit_on_branch=$(git rev-parse "${git_remote_name}/${git_branch}")
+  latest_commit_on_branch_subject=$(git rev-list --max-count=1 --no-commit-header --format=%s "${latest_commit_on_branch}")
+  expected_commit_on_branch_subject=$(git rev-list --max-count=1 --no-commit-header --format=%s "${BUILDKITE_COMMIT}")
+
+  >&2 echo "Git push failed. This usually means the remote branch (${git_branch}) has changed since this build started."
+  >&2 echo "This script expected commit ${BUILDKITE_COMMIT} (${expected_commit_on_branch_subject}) to be the HEAD of branch ${git_branch} but instead it's ${latest_commit_on_branch} (${latest_commit_on_branch_subject})"
+  exit 3
+fi
+
+if [[ "${release_type}" == "release" ]]; then
+  tag_name="v${new_version}"
+  echo "Creating and pushing release tag ${tag_name}"
+  git tag --annotate "${tag_name}"
+  git push "${git_remote_name}" "${tag_name}"
+  echo "Pushed release tag - https://github.com/elastic/eui/tree/${tag_name}"
+fi
+
+##
+# Success!
+##
+
+echo "+++ :white_check_mark: Version successfully updated"

--- a/.buildkite/scripts/release/step_update_version.sh
+++ b/.buildkite/scripts/release/step_update_version.sh
@@ -7,6 +7,8 @@
 
 set -eo pipefail
 
+source .buildkite/scripts/common/utils.sh
+
 # TODO: Support releasing non-HEAD commits when FORCE_SKIP_GIT_UPDATES=true
 
 # Begin configuration
@@ -101,8 +103,8 @@ SIGSTORE_ID_TOKEN="$(buildkite-agent oidc request-token --audience sigstore)"
 
 github_user_vault="secret/ci/elastic-eui/github_machine_user"
 
-git config --local user.name "$(vault read -field=name "${github_user_vault}")"
-git config --local user.email "$(vault read -field=email "${github_user_vault}")"
+git config --local user.name "$(retry 5 vault read -field=name "${github_user_vault}")"
+git config --local user.email "$(retry 5 vault read -field=email "${github_user_vault}")"
 git config --local commit.gpgsign true
 git config --local tag.gpgsign true
 git config --local gpg.x509.program gitsign


### PR DESCRIPTION
## Summary

This PR adds testing steps to the `eui-release` pipeline, which is triggered on every change of the `main` or `build/test-automatic-releases` branches. When all test steps pass, it proceeds to bump the version number to the next prerelease version as described in the [architecture](https://docs.google.com/document/d/1C9p71SnuUecZ236kYa9ZF-wU-Be6pcmoajkvQPouRq8/edit) doc.

There are several protections in place to ensure `elastic/eui` git history never gets overridden. It also fails early when the new version is already published on npm.

With all that said, I disabled the version update step on the `main` branch for testing purposes and will enable it in a follow-up PR after manual QA.

## QA

Manual QA will be done by @tkajtoch after merging changes to `main`.