### PR TITLE
[EuiTableHeaderCell] Add a subdued `sortable` icon for columns that can be sorted

### DIFF
--- a/changelogs/upcoming/7656.md
+++ b/changelogs/upcoming/7656.md
@@ -1,0 +1,1 @@
+- Updated `EuiTableHeaderCell` to show a subdued `sortable` icon for columns that are not currently sorted but can be

--- a/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -161,7 +161,6 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           </div>
         </th>
         <th
-          aria-live="polite"
           aria-sort="ascending"
           class="euiTableHeaderCell emotion-euiTableHeaderCell"
           data-test-subj="tableHeaderCell_name_0"

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`EuiTableHeaderCell sorting renders with a sortable icon if \`onSort\` i
               Test
             </span>
             <span
-              class="euiTableSortIcon"
+              class="euiTableSortIcon euiTableSortIcon--sortable"
               color="subdued"
               data-euiicon-type="sortable"
             />

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
 </table>
 `;
 
-exports[`EuiTableHeaderCell sorting renders a sort arrow upwards isSortAscending 1`] = `
+exports[`EuiTableHeaderCell sorting renders a sort arrow upwards with isSortAscending 1`] = `
 <table>
   <thead>
     <tr>

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -115,7 +115,44 @@ exports[`EuiTableHeaderCell sorting does not render a button with readOnly 1`] =
 </table>
 `;
 
-exports[`EuiTableHeaderCell sorting is rendered with isSortAscending 1`] = `
+exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
+<table>
+  <thead>
+    <tr>
+      <th
+        aria-live="polite"
+        aria-sort="descending"
+        class="euiTableHeaderCell emotion-euiTableHeaderCell"
+        role="columnheader"
+        scope="col"
+      >
+        <button
+          class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+          data-test-subj="tableHeaderSortButton"
+          type="button"
+        >
+          <div
+            class="euiTableCellContent emotion-euiTableCellContent-euiTableHeaderCell__content"
+          >
+            <span
+              class="eui-textTruncate"
+              title="Test"
+            >
+              Test
+            </span>
+            <span
+              class="euiTableSortIcon"
+              data-euiicon-type="sortDown"
+            />
+          </div>
+        </button>
+      </th>
+    </tr>
+  </thead>
+</table>
+`;
+
+exports[`EuiTableHeaderCell sorting renders a sort arrow upwards isSortAscending 1`] = `
 <table>
   <thead>
     <tr>
@@ -146,7 +183,7 @@ exports[`EuiTableHeaderCell sorting is rendered with isSortAscending 1`] = `
 </table>
 `;
 
-exports[`EuiTableHeaderCell sorting is rendered with isSorted 1`] = `
+exports[`EuiTableHeaderCell sorting renders a sort arrow with isSorted 1`] = `
 <table>
   <thead>
     <tr>
@@ -177,19 +214,19 @@ exports[`EuiTableHeaderCell sorting is rendered with isSorted 1`] = `
 </table>
 `;
 
-exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
+exports[`EuiTableHeaderCell sorting renders with a sortable icon if \`onSort\` is passed 1`] = `
 <table>
   <thead>
     <tr>
       <th
         aria-live="polite"
-        aria-sort="descending"
+        aria-sort="none"
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
         scope="col"
       >
         <button
-          class="euiTableHeaderButton euiTableHeaderButton-isSorted emotion-euiTableHeaderCell__button"
+          class="euiTableHeaderButton emotion-euiTableHeaderCell__button"
           data-test-subj="tableHeaderSortButton"
           type="button"
         >
@@ -204,7 +241,8 @@ exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
             </span>
             <span
               class="euiTableSortIcon"
-              data-euiicon-type="sortDown"
+              color="subdued"
+              data-euiicon-type="sortable"
             />
           </div>
         </button>

--- a/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -89,7 +89,6 @@ exports[`EuiTableHeaderCell sorting does not render a button with readOnly 1`] =
   <thead>
     <tr>
       <th
-        aria-live="polite"
         aria-sort="descending"
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
@@ -120,7 +119,6 @@ exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
   <thead>
     <tr>
       <th
-        aria-live="polite"
         aria-sort="descending"
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
@@ -157,7 +155,6 @@ exports[`EuiTableHeaderCell sorting renders a sort arrow upwards isSortAscending
   <thead>
     <tr>
       <th
-        aria-live="polite"
         aria-sort="ascending"
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
@@ -188,7 +185,6 @@ exports[`EuiTableHeaderCell sorting renders a sort arrow with isSorted 1`] = `
   <thead>
     <tr>
       <th
-        aria-live="polite"
         aria-sort="descending"
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"
@@ -219,7 +215,6 @@ exports[`EuiTableHeaderCell sorting renders with a sortable icon if \`onSort\` i
   <thead>
     <tr>
       <th
-        aria-live="polite"
         aria-sort="none"
         class="euiTableHeaderCell emotion-euiTableHeaderCell"
         role="columnheader"

--- a/src/components/table/table_cells_shared.styles.ts
+++ b/src/components/table/table_cells_shared.styles.ts
@@ -45,6 +45,7 @@ export const euiTableHeaderFooterCellStyles = (
     euiTableHeaderCell__button: css`
       ${logicalCSS('width', '100%')}
       font-weight: inherit;
+      line-height: inherit;
 
       /* Tint the sortable icon a bit further */
       .euiTableSortIcon--sortable {

--- a/src/components/table/table_cells_shared.styles.ts
+++ b/src/components/table/table_cells_shared.styles.ts
@@ -8,7 +8,11 @@
 
 import { css } from '@emotion/react';
 
-import { UseEuiTheme } from '../../services';
+import {
+  UseEuiTheme,
+  makeHighContrastColor,
+  tintOrShade,
+} from '../../services';
 import {
   euiFontSize,
   logicalCSS,
@@ -20,7 +24,7 @@ import { euiTableVariables } from './table.styles';
 export const euiTableHeaderFooterCellStyles = (
   euiThemeContext: UseEuiTheme
 ) => {
-  const { euiTheme } = euiThemeContext;
+  const { euiTheme, colorMode } = euiThemeContext;
 
   // euiFontSize returns an object, so we keep object notation here to merge into css``
   const sharedStyles = {
@@ -42,10 +46,23 @@ export const euiTableHeaderFooterCellStyles = (
       ${logicalCSS('width', '100%')}
       font-weight: inherit;
 
+      /* Tint the sortable icon a bit further */
+      .euiTableSortIcon--sortable {
+        color: ${makeHighContrastColor(
+          // Tint it arbitrarily high, the contrast util will take care of lowering back down to WCAG
+          tintOrShade(euiTheme.colors.subduedText, 0.9, colorMode),
+          3 // 3:1 ratio from https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html
+        )(euiTheme.colors.emptyShade)};
+      }
+
       &:hover,
       &:focus {
         color: ${euiTheme.colors.primaryText};
         text-decoration: underline;
+
+        .euiTableSortIcon--sortable {
+          color: ${euiTheme.colors.primaryText};
+        }
       }
     `,
     euiTableFooterCell: css`

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -108,7 +108,7 @@ describe('EuiTableHeaderCell', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    it('renders a sort arrow upwards isSortAscending', () => {
+    it('renders a sort arrow upwards with isSortAscending', () => {
       const { container } = renderInTableHeader(
         <EuiTableHeaderCell isSorted isSortAscending>
           Test

--- a/src/components/table/table_header_cell.test.tsx
+++ b/src/components/table/table_header_cell.test.tsx
@@ -92,7 +92,15 @@ describe('EuiTableHeaderCell', () => {
   });
 
   describe('sorting', () => {
-    it('is rendered with isSorted', () => {
+    it('renders with a sortable icon if `onSort` is passed', () => {
+      const { container } = renderInTableHeader(
+        <EuiTableHeaderCell onSort={() => {}}>Test</EuiTableHeaderCell>
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    it('renders a sort arrow with isSorted', () => {
       const { container } = renderInTableHeader(
         <EuiTableHeaderCell isSorted>Test</EuiTableHeaderCell>
       );
@@ -100,7 +108,7 @@ describe('EuiTableHeaderCell', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
-    it('is rendered with isSortAscending', () => {
+    it('renders a sort arrow upwards isSortAscending', () => {
       const { container } = renderInTableHeader(
         <EuiTableHeaderCell isSorted isSortAscending>
           Test

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -53,17 +53,17 @@ const CellContents = ({
   align,
   description,
   children,
+  canSort,
   isSorted,
   isSortAscending,
-  showSortMsg,
 }: {
   className?: string;
   align: HorizontalAlignment;
   description: EuiTableHeaderCellProps['description'];
   children: EuiTableHeaderCellProps['children'];
+  canSort?: boolean;
   isSorted: EuiTableHeaderCellProps['isSorted'];
   isSortAscending?: EuiTableHeaderCellProps['isSortAscending'];
-  showSortMsg: boolean;
 }) => {
   return (
     <EuiTableCellContent
@@ -96,13 +96,20 @@ const CellContents = ({
           <span>{description}</span>
         </EuiScreenReaderOnly>
       )}
-      {showSortMsg && isSorted && (
+      {isSorted ? (
         <EuiIcon
           className="euiTableSortIcon"
           type={isSortAscending ? 'sortUp' : 'sortDown'}
           size="m"
         />
-      )}
+      ) : canSort ? (
+        <EuiIcon
+          className="euiTableSortIcon"
+          type="sortable"
+          size="m"
+          color="subdued"
+        />
+      ) : null}
     </EuiTableCellContent>
   );
 };
@@ -140,7 +147,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       css={styles.euiTableHeaderCell__content}
       align={align}
       description={description}
-      showSortMsg={true}
+      canSort={onSort && !readOnly}
       isSorted={isSorted}
       isSortAscending={isSortAscending}
     >

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -100,13 +100,13 @@ const CellContents = ({
         <EuiIcon
           className="euiTableSortIcon"
           type={isSortAscending ? 'sortUp' : 'sortDown'}
-          size="m"
+          size="s"
         />
       ) : canSort ? (
         <EuiIcon
           className="euiTableSortIcon euiTableSortIcon--sortable"
           type="sortable"
-          size="m"
+          size="s"
           color="subdued" // Tinted a bit further via CSS
         />
       ) : null}

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -142,56 +142,23 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
   const CellComponent = children ? 'th' : 'td';
   const cellScope = CellComponent === 'th' ? scope ?? 'col' : undefined; // `scope` is only valid on `th` elements
 
-  const cellContents = (
-    <CellContents
-      css={styles.euiTableHeaderCell__content}
-      align={align}
-      description={description}
-      canSort={onSort && !readOnly}
-      isSorted={isSorted}
-      isSortAscending={isSortAscending}
-    >
-      {children}
-    </CellContents>
-  );
-
-  if (onSort || isSorted) {
-    const buttonClasses = classNames('euiTableHeaderButton', {
-      'euiTableHeaderButton-isSorted': isSorted,
-    });
-
-    let ariaSortValue: HTMLAttributes<any>['aria-sort'] = 'none';
-    if (isSorted) {
-      ariaSortValue = isSortAscending ? 'ascending' : 'descending';
-    }
-
-    return (
-      <CellComponent
-        css={styles.euiTableHeaderCell}
-        className={classes}
-        scope={cellScope}
-        role="columnheader"
-        aria-sort={ariaSortValue}
-        aria-live="polite"
-        style={inlineStyles}
-        {...rest}
-      >
-        {onSort && !readOnly ? (
-          <button
-            type="button"
-            css={styles.euiTableHeaderCell__button}
-            className={buttonClasses}
-            onClick={onSort}
-            data-test-subj="tableHeaderSortButton"
-          >
-            {cellContents}
-          </button>
-        ) : (
-          cellContents
-        )}
-      </CellComponent>
-    );
+  const canSort = !!(onSort && !readOnly);
+  let ariaSortValue: HTMLAttributes<HTMLTableCellElement>['aria-sort'];
+  if (isSorted) {
+    ariaSortValue = isSortAscending ? 'ascending' : 'descending';
+  } else if (canSort) {
+    ariaSortValue = 'none';
   }
+
+  const cellContentsProps = {
+    css: styles.euiTableHeaderCell__content,
+    align,
+    description,
+    canSort,
+    isSorted,
+    isSortAscending,
+    children,
+  };
 
   return (
     <CellComponent
@@ -199,10 +166,26 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       className={classes}
       scope={cellScope}
       role="columnheader"
+      aria-sort={ariaSortValue}
+      // aria-live="polite" TODO: this doesn't seem to do anything - ask Trevor
       style={inlineStyles}
       {...rest}
     >
-      {cellContents}
+      {canSort ? (
+        <button
+          type="button"
+          css={styles.euiTableHeaderCell__button}
+          className={classNames('euiTableHeaderButton', {
+            'euiTableHeaderButton-isSorted': isSorted,
+          })}
+          onClick={onSort}
+          data-test-subj="tableHeaderSortButton"
+        >
+          <CellContents {...cellContentsProps} />
+        </button>
+      ) : (
+        <CellContents {...cellContentsProps} />
+      )}
     </CellComponent>
   );
 };

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -167,7 +167,6 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       scope={cellScope}
       role="columnheader"
       aria-sort={ariaSortValue}
-      // aria-live="polite" TODO: this doesn't seem to do anything - ask Trevor
       style={inlineStyles}
       {...rest}
     >

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -100,13 +100,13 @@ const CellContents = ({
         <EuiIcon
           className="euiTableSortIcon"
           type={isSortAscending ? 'sortUp' : 'sortDown'}
-          size="s"
+          size="m"
         />
       ) : canSort ? (
         <EuiIcon
           className="euiTableSortIcon euiTableSortIcon--sortable"
           type="sortable"
-          size="s"
+          size="m"
           color="subdued" // Tinted a bit further via CSS
         />
       ) : null}

--- a/src/components/table/table_header_cell.tsx
+++ b/src/components/table/table_header_cell.tsx
@@ -104,10 +104,10 @@ const CellContents = ({
         />
       ) : canSort ? (
         <EuiIcon
-          className="euiTableSortIcon"
+          className="euiTableSortIcon euiTableSortIcon--sortable"
           type="sortable"
           size="m"
-          color="subdued"
+          color="subdued" // Tinted a bit further via CSS
         />
       ) : null}
     </EuiTableCellContent>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7610

<img width="566" alt="m" src="https://github.com/elastic/eui/assets/549407/bc74d820-a0c6-4156-ba44-0b383b27dbbe">

## QA

- Go to https://eui.elastic.co/pr_7656/#/tabular-content/tables#adding-sorting-to-a-table
- Toggle the `enableAllColumns` switch
- [x] Confirm the subdued `sortable` icon appears next to all non-sorted columns, but not on the column that is currently sorted
- Toggle the `readOnly` switch
- [x] Confirm the sortable icon goes away

### General checklist

- Browser QA
    - [x] Checked for **accessibility** ~including keyboard-only and screenreader modes~ in WCAG contrast checker
    - [x] Checked in both **light and dark** modes
    ~- [ ] Checked in **mobile**~ N/A, header cells don't show on mobile
    ~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
