### PR TITLE
[Docs] Add `noindex` and `nofollow` to dev & staging

### DIFF
--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -66,7 +66,7 @@ root.render(
                   to,
                 }) => {
                   const isLocal = window.location.host.includes('803');
-                  const isStaging = window.location.pathname.startsWith('/pr_');
+                  const isStaging = window.location.pathname !== '/';
                   const meta = (
                     <Helmet>
                       <title>{`${name} - Elastic UI Framework`}</title>

--- a/src-docs/src/index.js
+++ b/src-docs/src/index.js
@@ -65,9 +65,14 @@ root.render(
                   from,
                   to,
                 }) => {
+                  const isLocal = window.location.host.includes('803');
+                  const isStaging = window.location.pathname.startsWith('/pr_');
                   const meta = (
                     <Helmet>
                       <title>{`${name} - Elastic UI Framework`}</title>
+                      {(isLocal || isStaging) && (
+                        <meta name="robots" content="noindex,nofollow" />
+                      )}
                     </Helmet>
                   );
                   const mainComponent = (


### PR DESCRIPTION
## Summary

We've gotten a few reports recently that apparently our (far too long-lived) PR staging links are getting indexed by Google. The longevity of our PR docs sites will be addressed separately, but for now let's at least tell the googs to stop stalking us.

EDIT: second commit also removes releases (e.g. https://eui.elastic.co/v90.0.0/#) from being indexed as well. Although it's not retroactive :/ Not totally sure if we need to re-push a bunch of stuff to our host

## QA

- Open https://eui.elastic.co/pr_7657/#/
- Open DOM inspector, look at `<head>`
- [ ] Confirm expected meta tag is there

### General checklist

N/A