### PR TITLE
[EuiComboBox] Fix `Enter`ing to select items within groups

### DIFF
--- a/changelogs/upcoming/7658.md
+++ b/changelogs/upcoming/7658.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBox` to correctly select full matches within groups via the `Enter` key

--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -496,8 +496,8 @@ export const ComboBoxExample = {
       ],
       text: (
         <p>
-          You can group options together. The groups <em>won&rsquo;t</em> match
-          against the search value.
+          You can group options together. The group labels <em>won&rsquo;t</em>{' '}
+          match against the search value.
         </p>
       ),
       props: { EuiComboBox, EuiComboBoxOptionOption },

--- a/src-docs/src/views/combo_box/groups.js
+++ b/src-docs/src/views/combo_box/groups.js
@@ -38,10 +38,8 @@ const soundGroup = {
   ],
 };
 
-const allOptionsStatic = [colorGroup, soundGroup];
-
 export default () => {
-  const [allOptions, setAllOptions] = useState(allOptionsStatic);
+  const [allOptions, setAllOptions] = useState([colorGroup, soundGroup]);
   const [selectedOptions, setSelected] = useState([
     colorGroup.options[2],
     soundGroup.options[3],
@@ -51,46 +49,23 @@ export default () => {
     setSelected(selectedOptions);
   };
 
-  const onCreateOption = (searchValue, flattenedOptions = []) => {
-    if (!searchValue) {
-      return;
-    }
-
-    const normalizedSearchValue = searchValue.trim().toLowerCase();
-
-    if (!normalizedSearchValue) {
-      return;
-    }
-
+  const onCreateOption = (searchValue) => {
     const newOption = {
       label: searchValue,
     };
 
-    // Create the option if it doesn't exist.
-    if (
-      flattenedOptions.findIndex(
-        (option) => option.label.trim().toLowerCase() === normalizedSearchValue
-      ) === -1
-    ) {
-      if (allOptions[allOptions.length - 1].label !== 'Custom') {
-        setAllOptions([
-          ...allOptions,
-          {
-            label: 'Custom',
-            options: [],
-          },
-        ]);
-      }
-      const [colors, sounds, custom] = allOptions;
-      setAllOptions([
+    setAllOptions((allOptions) => {
+      const [colors, sounds, custom = { label: 'Custom', options: [] }] =
+        allOptions;
+      return [
         colors,
         sounds,
         {
           ...custom,
           options: [...custom.options, newOption],
         },
-      ]);
-    }
+      ];
+    });
 
     // Select the option.
     setSelected([...selectedOptions, newOption]);
@@ -98,7 +73,7 @@ export default () => {
 
   return (
     <EuiComboBox
-      aria-label="Accessible screen reader label"
+      aria-label="EuiComboBox example with groups"
       placeholder="These options are grouped"
       options={allOptions}
       selectedOptions={selectedOptions}

--- a/src/components/combo_box/combo_box.test.tsx
+++ b/src/components/combo_box/combo_box.test.tsx
@@ -377,40 +377,73 @@ describe('EuiComboBox', () => {
 
   describe('behavior', () => {
     describe('hitting "Enter"', () => {
-      it('calls the onCreateOption callback when there is input', () => {
-        const onCreateOptionHandler = jest.fn();
+      describe('when the search input matches a value', () => {
+        it('selects the option', () => {
+          const onChange = jest.fn();
+          const { getByTestSubject } = render(
+            <EuiComboBox options={[{ label: 'Red' }]} onChange={onChange} />
+          );
 
-        const { getByTestSubject } = render(
-          <EuiComboBox
-            options={options}
-            selectedOptions={[options[2]]}
-            onCreateOption={onCreateOptionHandler}
-          />
-        );
-        const input = getByTestSubject('comboBoxSearchInput');
+          const input = getByTestSubject('comboBoxSearchInput');
+          fireEvent.change(input, { target: { value: 'red' } });
+          fireEvent.keyDown(input, { key: 'Enter' });
 
-        fireEvent.change(input, { target: { value: 'foo' } });
-        fireEvent.keyDown(input, { key: 'Enter' });
+          expect(onChange).toHaveBeenCalledWith([{ label: 'Red' }]);
+        });
 
-        expect(onCreateOptionHandler).toHaveBeenCalledTimes(1);
-        expect(onCreateOptionHandler).toHaveBeenCalledWith('foo', options);
+        it('accounts for group labels', () => {
+          const onChange = jest.fn();
+          const { getByTestSubject } = render(
+            <EuiComboBox
+              options={[{ label: 'Group', options: [{ label: 'Blue' }] }]}
+              onChange={onChange}
+            />
+          );
+
+          const input = getByTestSubject('comboBoxSearchInput');
+          fireEvent.change(input, { target: { value: 'blue' } });
+          fireEvent.keyDown(input, { key: 'Enter' });
+
+          expect(onChange).toHaveBeenCalledWith([{ label: 'Blue' }]);
+        });
       });
 
-      it('does not call onCreateOption when there is no input', () => {
-        const onCreateOptionHandler = jest.fn();
+      describe('when `onCreateOption` is passed', () => {
+        it('fires the callback when there is input', () => {
+          const onCreateOptionHandler = jest.fn();
 
-        const { getByTestSubject } = render(
-          <EuiComboBox
-            options={options}
-            selectedOptions={[options[2]]}
-            onCreateOption={onCreateOptionHandler}
-          />
-        );
-        const input = getByTestSubject('comboBoxSearchInput');
+          const { getByTestSubject } = render(
+            <EuiComboBox
+              options={options}
+              selectedOptions={[options[2]]}
+              onCreateOption={onCreateOptionHandler}
+            />
+          );
+          const input = getByTestSubject('comboBoxSearchInput');
 
-        fireEvent.keyDown(input, { key: 'Enter' });
+          fireEvent.change(input, { target: { value: 'foo' } });
+          fireEvent.keyDown(input, { key: 'Enter' });
 
-        expect(onCreateOptionHandler).not.toHaveBeenCalled();
+          expect(onCreateOptionHandler).toHaveBeenCalledTimes(1);
+          expect(onCreateOptionHandler).toHaveBeenCalledWith('foo', options);
+        });
+
+        it('does not fire the callback when there is no input', () => {
+          const onCreateOptionHandler = jest.fn();
+
+          const { getByTestSubject } = render(
+            <EuiComboBox
+              options={options}
+              selectedOptions={[options[2]]}
+              onCreateOption={onCreateOptionHandler}
+            />
+          );
+          const input = getByTestSubject('comboBoxSearchInput');
+
+          fireEvent.keyDown(input, { key: 'Enter' });
+
+          expect(onCreateOptionHandler).not.toHaveBeenCalled();
+        });
       });
     });
 

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -331,11 +331,9 @@ export class EuiComboBox<T> extends Component<
       singleSelection,
     } = this.props;
 
-    const { matchingOptions } = this.state;
-
-    if (this.doesSearchMatchOnlyOption()) {
-      this.onAddOption(matchingOptions[0], isContainerBlur);
-      return;
+    const matchedOption = this.doesSearchMatchOnlyOption();
+    if (matchedOption) {
+      return this.onAddOption(matchedOption, isContainerBlur);
     }
 
     if (!onCreateOption) {
@@ -378,19 +376,28 @@ export class EuiComboBox<T> extends Component<
   };
 
   doesSearchMatchOnlyOption = () => {
-    const { searchValue } = this.state;
-    if (this.state.matchingOptions.length !== 1) {
-      return false;
-    }
+    const { isCaseSensitive } = this.props;
+    const { matchingOptions, searchValue } = this.state;
+    if (!matchingOptions.length) return;
+
+    const isMatchWithGroup = matchingOptions[0].isGroupLabelOption;
+    const isOnlyOption = matchingOptions.length === (isMatchWithGroup ? 2 : 1);
+    if (!isOnlyOption) return;
+
+    const matchedOption = matchingOptions[isMatchWithGroup ? 1 : 0];
+
     const normalizedSearchSubject = transformForCaseSensitivity(
-      this.state.matchingOptions[0].label,
-      this.props.isCaseSensitive
+      matchedOption.label,
+      isCaseSensitive
     );
     const normalizedSearchValue = transformForCaseSensitivity(
       searchValue,
-      this.props.isCaseSensitive
+      isCaseSensitive
     );
-    return normalizedSearchSubject === normalizedSearchValue;
+
+    if (normalizedSearchSubject === normalizedSearchValue) {
+      return matchedOption;
+    }
   };
 
   areAllOptionsSelected = () => {


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7653

See the below QA steps

## QA

- Go to https://eui.elastic.co/pr_7658/#/forms/combo-box#groups
- Type in the **full text** (in **lower case**) for any of the options within groups (e.g. `red` or `pop`)
- Once the matching option is the only match aside from its group label (see below example screenshot), press `Enter`
  <img width="489" alt="" src="https://github.com/elastic/eui/assets/549407/57daf229-bf4f-4429-af4d-862c775e2e50">
- [x] Confirm the correctly capitalized label (i.e. the original option) is selected/added
- For comparison against [current production](https://eui.elastic.co/v93.5.2/#/forms/combo-box#groups) - this works but adds the **lower case** text (instead of the actual original option) due to the existing `onCreateOption` callback.

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
- Docs site QA
    - [x] Updated some unclear docs
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A