### PR TITLE
[EuiPageTemplate] Ensure context provides updates to template children

### DIFF
--- a/changelogs/upcoming/7663.md
+++ b/changelogs/upcoming/7663.md
@@ -1,0 +1,1 @@
+- Refactored `EuiPageTemplate` to use context only to update and pass props to subcomponents

--- a/src-docs/src/views/page_template/examples.tsx
+++ b/src-docs/src/views/page_template/examples.tsx
@@ -270,13 +270,7 @@ export const PageTemplateExample = () => (
             iconType="warning"
             color="warning"
             title="Sidebars must be direct children declared in the same component."
-          >
-            <p>
-              In order for the template configurations to properly account for
-              the existence of a sidebar, it needs to clone the element which
-              can only be performed on direct children.
-            </p>
-          </EuiCallOut>
+          />
           <PageDemo
             slug="sidebar"
             toggle={{


### PR DESCRIPTION
## Summary

> ⚠️ This PR should be rebased with this [PR](https://github.com/elastic/eui/pull/7648) to ensure storybook stories for EuiPageTemplate are available

This PR is a follow-up to an issue noticed [here](https://github.com/elastic/eui/pull/7648#discussion_r1557146196).

`EuiPageTemplate` did not properly pass down props to the page template subcomponents.
The reason was that changes on the context did not actually trigger updates on the children using that context.

To ensure this, this PR adds a provider wrapper for `EuiPageTemplate` which ensures that 
a) all nested children AND the page template itself correctly consume the context and that 
b) there is a state update which triggers context updates inside the consumers.

## QA

- [ ] ensure that the staging [docs](https://eui.elastic.co/pr_7663/#/templates/page-template/examples) for `EuiPageTemplate` is the same as [production](https://eui.elastic.co/#/templates/page-template/examples)
- [ ] ensure that the staging storybook for `EuiPageTemplate` is the same as production (⚠️ waiting for previous [PR](https://github.com/elastic/eui/pull/7648) to be merged for this to be available)

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
