### PR TITLE
Remove unused scripts

### DIFF
--- a/scripts/docker-ci/README.md
+++ b/scripts/docker-ci/README.md
@@ -5,9 +5,6 @@ Built containers can be published to the [Elastic Docker Registry](https://conta
 
 ## Getting started
 
-### `test-docker` script
-The [`test-docker`](../test-docker.js) script is the primary user of this container. Specifically, the [`a11y-testing`](../a11y-testing.js) script therein uses the headless Chromium environment to run EUI's automated axe accessibility testing suite.
-
 ### Generic node application
 Run the container by passing `node -e "<yourscript.js content as a string>"` as the command:
 
@@ -36,10 +33,6 @@ docker build [--no-cache] [--tag ci:x.x] .
 
 > :warning: If you receive a `Cannot connect to Docker daemon` error, you can use [Docker Desktop](https://docs.docker.com/desktop/#download-and-install) (without signing in). Simply starting the app will create the Docker engine/daemon needed.
 
-
-### Test a new image locally
-
-To run the [`test-docker`](../test-docker.js) script with the new image locally, you'll need to replace the image name line in the `docker run ...` command (`docker.elastic.co/eui/ci:x.x`) with the new image ID or tag name (if set during the build with `--tag`).
 
 ### Publish a built image
 
@@ -76,5 +69,3 @@ docker pull docker.elastic.co/eui/ci:x.x
 
 docker run [...]
 ```
-
-See the [`test-docker`](../test-docker.js) script as an example.

--- a/wiki/contributing-to-eui/testing/automated-accessibility-testing.md
+++ b/wiki/contributing-to-eui/testing/automated-accessibility-testing.md
@@ -12,7 +12,6 @@ Automated testing can't replace manual testing, but it's an important baseline f
 ## How to run the Cypress accessibility tests?
 
 * `test-cypress-a11y` runs the accessibility test suite in a local headless Cypress environment.
-* `test-a11y-docker` runs the test suite in the EUI team's CI Docker container.
 * `test-cypress-dev` runs the test suite using your dev server (assumed to be `http://localhost:8030`) and the Cypress test runner.
 
 ### How to run accessibility tests against 1 component?

--- a/wiki/eui-team-processes/upgrading-node.md
+++ b/wiki/eui-team-processes/upgrading-node.md
@@ -30,8 +30,6 @@ Find all instances of `docker.elastic.co/eui/ci:` in EUI. You will want to chang
 
 For non-major Node upgrades, you will likely only need to follow the [Build a new image](https://github.com/elastic/eui/tree/main/scripts/docker-ci#build-a-new-image) step and [Publish a built image](https://github.com/elastic/eui/tree/main/scripts/docker-ci#publish-a-built-image) step.
 
-Skipping the "Test a new image step" allows you to save some time running tests locally and instead have CI run tests for you.
-
 #### When upgrading to major Node versions
 
 For major Node upgrades, where it's possible that either that our local environment or CI will break, we strongly recommend ensuring the following steps pass locally first before publishing the Docker image:
@@ -39,7 +37,6 @@ For major Node upgrades, where it's possible that either that our local environm
 - `yarn && yarn start`
 - `yarn build-pack`
 - `yarn test`
-- [Test a new image locally](https://github.com/elastic/eui/tree/main/scripts/docker-ci#test-a-new-image-locally)
 
 #### Confirming the published Docker image
 


### PR DESCRIPTION
## Summary

These two scripts [were removed](https://github.com/elastic/eui/pull/7379) from our Repository, but our README and Wiki content was not updated accordingly. I removed references from both places.

There is a Chore in our backlog to [replace these scripts](https://github.com/elastic/eui/pull/7379).
