### PR TITLE
[EuiFieldText][EuiFieldNumber] Various `icon` related fixes

### DIFF
--- a/changelogs/upcoming/7666.md
+++ b/changelogs/upcoming/7666.md
@@ -1,0 +1,6 @@
+**Bug fixes**
+
+- Fixed `EuiFieldNumber`'s typing to accept an icon configuration shape
+- Fixed `EuiFieldText` and `EuiFieldNumber` to render the correct paddings for icon shapes set to `side: 'right'`
+- Fixed `EuiFieldText` and `EuiFieldNumber` to fully ignore `icon`/`prepend`/`append` when `controlOnly` is set to true
+- Fixed `EuiColorPicker`'s input not setting the correct right padding for the number of icons displayed

--- a/src/components/color_picker/__snapshots__/color_picker.test.tsx.snap
+++ b/src/components/color_picker/__snapshots__/color_picker.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`renders EuiColorPicker 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFEEDD"
@@ -77,7 +77,7 @@ exports[`renders EuiColorPicker with a clearable input 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--2icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFEEDD"
@@ -137,7 +137,7 @@ exports[`renders EuiColorPicker with a color swatch when color is defined 1`] = 
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFFFFF"
@@ -187,7 +187,7 @@ exports[`renders EuiColorPicker with a custom placeholder 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         placeholder="Auto"
         type="text"
@@ -238,7 +238,7 @@ exports[`renders EuiColorPicker with an empty swatch when color is "" 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         placeholder="Transparent"
         type="text"
@@ -289,7 +289,7 @@ exports[`renders EuiColorPicker with an empty swatch when color is null 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         placeholder="Transparent"
         type="text"
@@ -345,7 +345,7 @@ exports[`renders a EuiColorPicker with a prepend and append 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiColorPicker__input--inGroup euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiColorPicker__input--inGroup euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFEEDD"
@@ -400,7 +400,7 @@ exports[`renders a EuiColorPicker with an alpha range selector 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFEEDD"
@@ -450,7 +450,7 @@ exports[`renders compressed EuiColorPicker 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFieldText--compressed"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons euiFieldText--compressed"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFEEDD"
@@ -500,7 +500,7 @@ exports[`renders disabled EuiColorPicker 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         disabled=""
         type="text"
@@ -538,7 +538,7 @@ exports[`renders fullWidth EuiColorPicker 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFieldText--fullWidth"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons euiFieldText--fullWidth"
         data-test-subj="euiColorPickerAnchor test subject string"
         type="text"
         value="#FFEEDD"
@@ -760,7 +760,7 @@ exports[`renders readOnly EuiColorPicker 1`] = `
       <input
         aria-label="Press the down key to open a popover containing color options"
         autocomplete="off"
-        class="euiFieldText euiColorPicker__input euiFieldText--withIcon"
+        class="euiFieldText euiColorPicker__input euiFieldText--withIcon euiFormControlLayout--1icons"
         data-test-subj="euiColorPickerAnchor test subject string"
         readonly=""
         type="text"

--- a/src/components/color_picker/_color_picker.scss
+++ b/src/components/color_picker/_color_picker.scss
@@ -3,22 +3,6 @@
   width: $euiColorPickerWidth;
 }
 
-.euiColorPicker__popoverAnchor {
-  // Nested needed for specificity of overriding .euiFieldText
-  .euiColorPicker__input {
-    @include euiFormControlWithIcon($isIconOptional: false, $side: 'right');
-
-    &[class*='--compressed'] {
-      @include euiFormControlWithIcon($isIconOptional: false, $side: 'right', $compressed: true);
-    }
-
-    + .euiFormControlLayoutIcons {
-      // Override :disabled state, which obscures the selected color
-      color: inherit;
-    }
-  }
-}
-
 .euiColorPicker__swatches {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/color_picker/color_picker.tsx
+++ b/src/components/color_picker/color_picker.tsx
@@ -28,6 +28,7 @@ import {
   EuiRange,
   EuiRangeProps,
 } from '../form';
+import { getFormControlClassNameForIconCount } from '../form/form_control_layout/_num_icons';
 import { useEuiI18n } from '../i18n';
 import { EuiPopover } from '../popover';
 import { EuiSpacer } from '../spacer';
@@ -286,9 +287,19 @@ export const EuiColorPicker: FunctionComponent<EuiColorPickerProps> = ({
     'euiColorPicker__popoverPanel--customButton': button,
   });
   const swatchClass = 'euiColorPicker__swatchSelect';
-  const inputClasses = classNames('euiColorPicker__input', {
-    'euiColorPicker__input--inGroup': prepend || append,
+
+  const numIconsClass = getFormControlClassNameForIconCount({
+    isDropdown: true,
+    clear: isClearable,
+    isInvalid,
   });
+  const inputClasses = classNames(
+    'euiColorPicker__input',
+    { 'euiColorPicker__input--inGroup': prepend || append },
+    // Manually account for input padding, since `controlOnly` disables that logic
+    'euiFieldText--withIcon',
+    numIconsClass
+  );
 
   const handleOnChange = (text: string) => {
     const output = getOutput(text, showAlpha);

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -25,7 +25,10 @@ import {
   EuiFormControlLayout,
   EuiFormControlLayoutProps,
 } from '../form_control_layout';
-import { getFormControlClassNameForIconCount } from '../form_control_layout/_num_icons';
+import {
+  getFormControlClassNameForIconCount,
+  isRightSideIcon,
+} from '../form_control_layout/_num_icons';
 import { useFormContext } from '../eui_form_context';
 
 export type EuiFieldNumberProps = Omit<
@@ -133,15 +136,17 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     }
   }, [value, min, max, step, checkNativeValidity]);
 
+  const hasRightSideIcon = isRightSideIcon(icon);
   const numIconsClass = controlOnly
     ? false
     : getFormControlClassNameForIconCount({
         isInvalid: isInvalid || isNativelyInvalid,
         isLoading,
+        icon: hasRightSideIcon,
       });
 
   const classes = classNames('euiFieldNumber', className, numIconsClass, {
-    'euiFieldNumber--withIcon': icon,
+    'euiFieldNumber--withIcon': icon && !hasRightSideIcon,
     'euiFieldNumber--fullWidth': fullWidth,
     'euiFieldNumber--compressed': compressed,
     'euiFieldNumber--inGroup': prepend || append,

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -146,10 +146,12 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
       });
 
   const classes = classNames('euiFieldNumber', className, numIconsClass, {
-    'euiFieldNumber--withIcon': icon && !hasRightSideIcon,
     'euiFieldNumber--fullWidth': fullWidth,
     'euiFieldNumber--compressed': compressed,
-    'euiFieldNumber--inGroup': prepend || append,
+    ...(!controlOnly && {
+      'euiFieldNumber--inGroup': prepend || append,
+      'euiFieldNumber--withIcon': icon && !hasRightSideIcon,
+    }),
     'euiFieldNumber-isLoading': isLoading,
   });
 

--- a/src/components/form/field_number/field_number.tsx
+++ b/src/components/form/field_number/field_number.tsx
@@ -19,7 +19,6 @@ import classNames from 'classnames';
 
 import { useCombinedRefs } from '../../../services';
 import { CommonProps } from '../../common';
-import { IconType } from '../../icon';
 
 import { EuiValidatableControl } from '../validatable_control';
 import {
@@ -34,7 +33,7 @@ export type EuiFieldNumberProps = Omit<
   'min' | 'max' | 'readOnly' | 'step'
 > &
   CommonProps & {
-    icon?: IconType;
+    icon?: EuiFormControlLayoutProps['icon'];
     isInvalid?: boolean;
     /**
      * Expand to fill 100% of the parent.

--- a/src/components/form/field_text/field_text.stories.tsx
+++ b/src/components/form/field_text/field_text.stories.tsx
@@ -13,13 +13,12 @@ import {
   moveStorybookControlsToCategory,
 } from '../../../../.storybook/utils';
 
-import { EuiFieldNumber, EuiFieldNumberProps } from './field_number';
+import { EuiFieldText, EuiFieldTextProps } from './field_text';
 
-const meta: Meta<EuiFieldNumberProps> = {
-  title: 'Forms/EuiFieldNumber',
-  component: EuiFieldNumber,
+const meta: Meta<EuiFieldTextProps> = {
+  title: 'Forms/EuiFieldText',
+  component: EuiFieldText,
   argTypes: {
-    step: { control: 'number' },
     // For quicker/easier QA
     icon: { control: 'text' },
     prepend: { control: 'text' },
@@ -35,40 +34,15 @@ const meta: Meta<EuiFieldNumberProps> = {
     readOnly: false,
     controlOnly: false,
     // Added for easier testing
-    placeholder: '0',
+    placeholder: 'EuiFieldText',
   },
 };
 
 export default meta;
-type Story = StoryObj<EuiFieldNumberProps>;
+type Story = StoryObj<EuiFieldTextProps>;
 disableStorybookControls(meta, ['inputRef']);
 
 export const Playground: Story = {};
-
-export const ControlledComponent: Story = {
-  args: {
-    value: 0,
-  },
-  argTypes: {
-    value: { control: 'number' },
-    onChange: () => {},
-  },
-};
-// Hide props that don't impact this story
-hideStorybookControls(ControlledComponent, [
-  'controlOnly',
-  'inputRef',
-  'compressed',
-  'fullWidth',
-  'icon',
-  'isInvalid',
-  'isLoading',
-  'disabled',
-  'readOnly',
-  'placeholder',
-  'prepend',
-  'append',
-]);
 
 export const IconShape: Story = {
   argTypes: { icon: { control: 'object' } },
@@ -87,10 +61,4 @@ moveStorybookControlsToCategory(IconShape, [
   'append',
 ]);
 // Hide props that remove or won't affect the icon or its positioning
-hideStorybookControls(IconShape, [
-  'controlOnly',
-  'inputRef',
-  'min',
-  'max',
-  'step',
-]);
+hideStorybookControls(IconShape, ['controlOnly', 'inputRef']);

--- a/src/components/form/field_text/field_text.tsx
+++ b/src/components/form/field_text/field_text.tsx
@@ -92,10 +92,12 @@ export const EuiFieldText: FunctionComponent<EuiFieldTextProps> = (props) => {
       });
 
   const classes = classNames('euiFieldText', className, numIconsClass, {
-    'euiFieldText--withIcon': icon && !hasRightSideIcon,
     'euiFieldText--fullWidth': fullWidth,
     'euiFieldText--compressed': compressed,
-    'euiFieldText--inGroup': prepend || append,
+    ...(!controlOnly && {
+      'euiFieldText--withIcon': icon && !hasRightSideIcon,
+      'euiFieldText--inGroup': prepend || append,
+    }),
     'euiFieldText-isLoading': isLoading,
   });
 

--- a/src/components/form/field_text/field_text.tsx
+++ b/src/components/form/field_text/field_text.tsx
@@ -16,7 +16,10 @@ import {
 } from '../form_control_layout';
 
 import { EuiValidatableControl } from '../validatable_control';
-import { getFormControlClassNameForIconCount } from '../form_control_layout/_num_icons';
+import {
+  isRightSideIcon,
+  getFormControlClassNameForIconCount,
+} from '../form_control_layout/_num_icons';
 import { useFormContext } from '../eui_form_context';
 
 export type EuiFieldTextProps = InputHTMLAttributes<HTMLInputElement> &
@@ -78,15 +81,18 @@ export const EuiFieldText: FunctionComponent<EuiFieldTextProps> = (props) => {
     ...rest
   } = props;
 
+  const hasRightSideIcon = isRightSideIcon(icon);
+
   const numIconsClass = controlOnly
     ? false
     : getFormControlClassNameForIconCount({
         isInvalid,
         isLoading,
+        icon: hasRightSideIcon,
       });
 
   const classes = classNames('euiFieldText', className, numIconsClass, {
-    'euiFieldText--withIcon': icon,
+    'euiFieldText--withIcon': icon && !hasRightSideIcon,
     'euiFieldText--fullWidth': fullWidth,
     'euiFieldText--compressed': compressed,
     'euiFieldText--inGroup': prepend || append,

--- a/src/components/form/form_control_layout/_num_icons.test.ts
+++ b/src/components/form/form_control_layout/_num_icons.test.ts
@@ -6,7 +6,10 @@
  * Side Public License, v 1.
  */
 
-import { getFormControlClassNameForIconCount } from './_num_icons';
+import {
+  getFormControlClassNameForIconCount,
+  isRightSideIcon,
+} from './_num_icons';
 
 describe('getFormControlClassNameForIconCount', () => {
   it('should return undefined if object is empty', () => {
@@ -45,5 +48,29 @@ describe('getFormControlClassNameForIconCount', () => {
       isDropdown: true,
     });
     expect(numberClass).toEqual('euiFormControlLayout--5icons');
+  });
+});
+
+describe('isRightSideIcon', () => {
+  it('returns true if side has been set to right', () => {
+    expect(isRightSideIcon({ side: 'right', type: 'warning' })).toEqual(true);
+  });
+
+  it('returns false if side has been set to left', () => {
+    expect(isRightSideIcon({ side: 'left', type: 'warning' })).toEqual(false);
+  });
+
+  it('returns false if icon is missing a side definition (defaults to left)', () => {
+    expect(isRightSideIcon({ type: 'warning', color: 'warning' })).toEqual(
+      false
+    );
+  });
+
+  it('returns false if icon is undefined', () => {
+    expect(isRightSideIcon()).toEqual(false);
+  });
+
+  it('returns false if icon is not in an object shape', () => {
+    expect(isRightSideIcon('warning')).toEqual(false);
   });
 });

--- a/src/components/form/form_control_layout/_num_icons.ts
+++ b/src/components/form/form_control_layout/_num_icons.ts
@@ -6,6 +6,11 @@
  * Side Public License, v 1.
  */
 
+import {
+  isIconShape,
+  type EuiFormControlLayoutIconsProps,
+} from './form_control_layout_icons';
+
 /**
  * The `getFormControlClassNameForIconCount` function helps setup the className appendum
  * depending on the form control's current settings/state.
@@ -26,17 +31,23 @@ export type _EuiFormControlLayoutNumIcons = {
   isDropdown?: boolean;
 };
 
-export function getFormControlClassNameForIconCount({
+export const getFormControlClassNameForIconCount = ({
   icon,
   clear,
   isLoading,
   isInvalid,
   isDropdown,
-}: _EuiFormControlLayoutNumIcons): string | undefined {
+}: _EuiFormControlLayoutNumIcons): string | undefined => {
   const numIcons = [icon, clear, isInvalid, isLoading, isDropdown].filter(
     (item) => item === true
   ).length;
 
   // This className is also specifically used in `src/global_styling/mixins/_form.scss`
   return numIcons > 0 ? `euiFormControlLayout--${numIcons}icons` : undefined;
-}
+};
+
+export const isRightSideIcon = (
+  icon?: EuiFormControlLayoutIconsProps['icon']
+): boolean => {
+  return !!icon && isIconShape(icon) && icon.side === 'right';
+};

--- a/src/components/form/form_control_layout/form_control_layout_icons.tsx
+++ b/src/components/form/form_control_layout/form_control_layout_icons.tsx
@@ -33,11 +33,11 @@ export type IconShape = DistributiveOmit<
   ref?: EuiFormControlLayoutCustomIconProps['iconRef'];
 };
 
-function isIconShape(
+export const isIconShape = (
   icon: EuiFormControlLayoutIconsProps['icon']
-): icon is IconShape {
+): icon is IconShape => {
   return !!icon && icon.hasOwnProperty('type');
-}
+};
 
 export interface EuiFormControlLayoutIconsProps {
   icon?: IconType | IconShape;


### PR DESCRIPTION
## Summary

@dplumlee helped us identify a visual bug with customizing `EuiFieldText` and `EuiFieldNumber`'s `icon` prop using object configuration to configure the icon side. While here, I found Even More Bugs (yay!)

| Before | After |
|--------|--------|
| <img width="485" alt="" src="https://github.com/elastic/eui/assets/549407/7dd2cea0-8237-4034-af6e-a3c1659bef3d"> | <img width="485" alt="" src="https://github.com/elastic/eui/assets/549407/60ff4f98-db73-4613-bcfa-5f79ce53ecbd"> | 

## QA

Right side icon fix:
- Go to https://eui.elastic.co/pr_7666/storybook/?path=/story/forms-euifieldnumber--icon-shape
- [x] Confirm the icon renders as expected, including when changing the icon type and color
- In the control panel, change the side to `'right'`
- [x] Confirm the icon renders in the correct position and the input's padding updates accordingly
- [x] Repeat the above side testing for https://eui.elastic.co/pr_7666/storybook/?path=/story/forms-euifieldtext--icon-shape

Control only fix:
- Go to https://eui.elastic.co/pr_7666/storybook/?path=/story/forms-euifieldnumber--playground
- Toggle `controlOnly` to true
- Type in anything for the `icon`, `prepend`, and `append` props
- [x] Confirm that nothing shows up and the input does not visual change whatsoever
- (Optional) Repeat the same test for `EuiFieldText`

Color picker fix:
- Go to https://eui.elastic.co/pr_7666/storybook/?path=/story/forms-euicolorpicker-euicolorpicker--playground
- Set `isInvalid` and `isClearable` to false
- [x] Inspect the input and confirm the `padding-right` on the input accounts for all 3 icons shown

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [x] Added Storybook stories for QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A