### PR TITLE
[EuiBasicTable] Pass click events to `actions` onClick

### DIFF
--- a/changelogs/upcoming/7667.md
+++ b/changelogs/upcoming/7667.md
@@ -1,0 +1,1 @@
+- Updated `EuiBasicTable` and `EuiInMemoryTable`'s `columns[].actions[]`'s to pass back click events to `onClick` callbacks as the second callback

--- a/src/components/basic_table/action_types.ts
+++ b/src/components/basic_table/action_types.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, MouseEvent } from 'react';
 import { EuiIconType } from '../icon/icon';
 import { EuiButtonIconProps } from '../button/button_icon/button_icon';
 import { EuiButtonEmptyProps } from '../button/button_empty';
@@ -26,9 +26,11 @@ export interface DefaultItemActionBase<T extends object> {
    */
   description: string | ((item: T) => string);
   /**
-   * A handler function to execute the action
+   * A handler function to execute the action. Passes back the current row
+   * item as the first argument, and the originating React click event
+   * as a second argument.
    */
-  onClick?: (item: T) => void;
+  onClick?: (item: T, event: MouseEvent) => void;
   href?: string | ((item: T) => string);
   target?: string;
   /**

--- a/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -84,6 +84,48 @@ describe('CollapsedItemActions', () => {
     await waitForEuiPopoverClose();
   });
 
+  test('default actions - passes back the original click event as well as the row item to onClick', async () => {
+    const onClick = jest.fn();
+    const onClickStopPropagation = jest.fn((item, event) => {
+      event.stopPropagation();
+    });
+
+    const props = {
+      actions: [
+        {
+          name: '1',
+          description: '',
+          onClick,
+          'data-test-subj': 'onClick',
+        },
+        {
+          name: '2',
+          description: '',
+          onClick: onClickStopPropagation,
+          'data-test-subj': 'onClickStopPropagation',
+        },
+      ],
+      itemId: 'id',
+      item: { id: 'xyz' },
+      actionsDisabled: false,
+    };
+
+    const { getByTestSubject } = render(<CollapsedItemActions {...props} />);
+    fireEvent.click(getByTestSubject('euiCollapsedItemActionsButton'));
+    await waitForEuiPopoverOpen();
+
+    fireEvent.click(getByTestSubject('onClickStopPropagation'));
+    expect(onClickStopPropagation).toHaveBeenCalledWith(
+      props.item,
+      expect.objectContaining({ stopPropagation: expect.any(Function) })
+    );
+    // Popover should still be open if propagation was stopped
+    await waitForEuiPopoverOpen();
+
+    fireEvent.click(getByTestSubject('onClick'));
+    await waitForEuiPopoverClose();
+  });
+
   test('custom actions', async () => {
     const props = {
       actions: [

--- a/src/components/basic_table/collapsed_item_actions.tsx
+++ b/src/components/basic_table/collapsed_item_actions.tsx
@@ -14,7 +14,6 @@ import React, {
   ReactElement,
 } from 'react';
 
-import { isString } from '../../services/predicate';
 import { EuiContextMenuItem, EuiContextMenuPanel } from '../context_menu';
 import { EuiPopover } from '../popover';
 import { EuiButtonIcon } from '../button';
@@ -69,12 +68,9 @@ export const CollapsedItemActions = <T extends {}>({
           </EuiContextMenuItem>
         );
       } else {
-        const buttonIcon = action.icon;
-        let icon;
-        if (buttonIcon) {
-          icon = isString(buttonIcon) ? buttonIcon : buttonIcon(item);
-        }
-
+        const icon = action.icon
+          ? callWithItemIfFunction(item)(action.icon)
+          : undefined;
         const buttonContent = callWithItemIfFunction(item)(action.name);
         const toolTipContent = callWithItemIfFunction(item)(action.description);
         const href = callWithItemIfFunction(item)(action.href);

--- a/src/components/basic_table/default_item_action.test.tsx
+++ b/src/components/basic_table/default_item_action.test.tsx
@@ -122,4 +122,30 @@ describe('DefaultItemAction', () => {
     await waitForEuiToolTipVisible();
     expect(getByText('goodbye tooltip')).toBeInTheDocument();
   });
+
+  it('passes back the original click event as well as the row item to onClick', () => {
+    const onClick = jest.fn((item, event) => {
+      event.preventDefault();
+    });
+
+    const action: EmptyButtonAction<Item> = {
+      name: 'onClick',
+      description: 'test',
+      onClick,
+      'data-test-subj': 'onClick',
+    };
+    const props = {
+      action,
+      enabled: true,
+      item: { id: 'xyz' },
+    };
+
+    const { getByTestSubject } = render(<DefaultItemAction {...props} />);
+
+    fireEvent.click(getByTestSubject('onClick'));
+    expect(onClick).toHaveBeenCalledWith(
+      props.item,
+      expect.objectContaining({ preventDefault: expect.any(Function) })
+    );
+  });
 });

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, MouseEvent, useCallback } from 'react';
 
 import { isString } from '../../services/predicate';
 import {
@@ -42,7 +42,14 @@ export const DefaultItemAction = <T extends object>({
       or 'href' string. If you want to provide a custom action control, make sure to define the 'render' callback`);
   }
 
-  const onClick = action.onClick ? () => action.onClick!(item) : undefined;
+  const onClick = useCallback(
+    (event: MouseEvent) => {
+      if (!action.onClick) return;
+      event.persist(); // TODO: Remove once React 16 support is dropped
+      action.onClick!(item, event);
+    },
+    [action.onClick, item]
+  );
 
   const buttonColor = action.color;
   let color: EuiButtonIconProps['color'] = 'primary';

--- a/src/components/basic_table/default_item_action.tsx
+++ b/src/components/basic_table/default_item_action.tsx
@@ -8,7 +8,6 @@
 
 import React, { ReactElement, ReactNode, MouseEvent, useCallback } from 'react';
 
-import { isString } from '../../services/predicate';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
@@ -51,19 +50,12 @@ export const DefaultItemAction = <T extends object>({
     [action.onClick, item]
   );
 
-  const buttonColor = action.color;
-  let color: EuiButtonIconProps['color'] = 'primary';
-  if (buttonColor) {
-    color = isString(buttonColor) ? buttonColor : buttonColor(item);
-  }
-
-  const buttonIcon = action.icon;
-  let icon;
-  if (buttonIcon) {
-    icon = isString(buttonIcon) ? buttonIcon : buttonIcon(item);
-  }
-
-  let button;
+  const color: EuiButtonIconProps['color'] = action.color
+    ? callWithItemIfFunction(item)(action.color)
+    : 'primary';
+  const icon = action.icon
+    ? callWithItemIfFunction(item)(action.icon)
+    : undefined;
   const actionContent = callWithItemIfFunction(item)(action.name);
   const tooltipContent = callWithItemIfFunction(item)(action.description);
   const href = callWithItemIfFunction(item)(action.href);
@@ -71,6 +63,7 @@ export const DefaultItemAction = <T extends object>({
 
   const ariaLabelId = useGeneratedHtmlId();
   let ariaLabelledBy: ReactNode;
+  let button;
 
   if (action.type === 'icon') {
     if (!icon) {


### PR DESCRIPTION
## Summary

This PR passes back an `event` to `onClick` callbacks passed to basic/memory tables' `actions` buttons. This allows consumers to do things like `event.preventDefault()` and `event.stopPropagation()`.

In particular, Kibana needs `event.preventDefault()` for their react router utilities that add both a href and SPA routing onClick. This will let us also get rid of Kibana style overrides/workarounds to match our default actions (see https://github.com/elastic/kibana/pull/118434#discussion_r749691551)

## QA

(Optional, tests should cover behavior sufficiently)

- Open `src-docs/src/views/tables/actions/actions.tsx` in your IDE and the following code below line 197 (the `User profile` action):
  ```
          onClick: (item, event) => {
            event.preventDefault();
            event.stopPropagation();
            console.log(item);
          },
  ```
- Go to http://localhost:8030/#/tabular-content/tables#adding-actions-to-table
- [x] Click any non-disabled user link and confirm it does **not** scroll the page like production does
- Toggle the `Multiple actions` switch
- Click the collapsed actions toggle for any non-disabled row
- [x] Click the `User profile` link and confirm it does **not** close the popover

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A