### PR TITLE
[EuiMarkdownEditor] Allow more plugins to be excludable

### DIFF
--- a/changelogs/upcoming/7676.md
+++ b/changelogs/upcoming/7676.md
@@ -1,2 +1,5 @@
-- Added a way to exclude the line-breaks plugin from defaults in EuiMarkdownEditor.
-
+- Updated `getDefaultEuiMarkdownPlugins()` to allow excluding the following plugins in addition to `tooltip`:
+  - `checkbox`
+  - `linkValidator`
+  - `lineBreaks`
+  - `emoji`

--- a/changelogs/upcoming/7676.md
+++ b/changelogs/upcoming/7676.md
@@ -1,0 +1,2 @@
+- Added a way to exclude the line-breaks plugin from defaults in EuiMarkdownEditor.
+

--- a/src-docs/src/views/markdown_editor/markdown_editor.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor.js
@@ -21,7 +21,6 @@ The editor also ships with some built in plugins. For example it can handle chec
 - [ ] Or empty
 
 It can also handle emojis! :smile:
-
 And it can render !{tooltip[tooltips like this](Look! I'm a very helpful tooltip content!)}
 `;
 

--- a/src-docs/src/views/markdown_editor/markdown_editor_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_example.js
@@ -60,7 +60,15 @@ const markdownEditorNoPluginsSnippet = `const {
   parsingPlugins,
   processingPlugins,
   uiPlugins,
-} = getDefaultEuiMarkdownPlugins({ exclude: ['tooltip', 'line-breaks'] });
+} = getDefaultEuiMarkdownPlugins({
+  exclude: [
+    'tooltip',
+    'checkbox',
+    'linkValidator',
+    'lineBreaks',
+    'emoji',
+  ],
+});
 
   <EuiMarkdownEditor
     value={value}
@@ -133,16 +141,15 @@ export const MarkdownEditorExample = {
       title: 'Unregistering plugins',
       text: (
         <p>
-          The <strong>EuiMarkdownEditor</strong> comes with default plugins such
-          as <EuiCode>tooltip</EuiCode> and <EuiCode>line-breaks</EuiCode>.{' '}
-          However, these may be unfamiliar or unnecessary in some contexts, and
-          you can unregister these plugins by excluding them from the
-          <EuiCode>parsingPlugins</EuiCode>,{' '}
+          The <strong>EuiMarkdownEditor</strong> comes with several default
+          plugins, demo'd below. If these defaults are unnecessary for your
+          use-case or context, you can unregister these plugins by excluding
+          them from the <EuiCode>parsingPlugins</EuiCode>,{' '}
           <EuiCode>processingPlugins</EuiCode> and <EuiCode>uiPlugins</EuiCode>{' '}
           options with a single <EuiCode>exclude</EuiCode> parameter passed to{' '}
           <EuiCode>getDefaultEuiMarkdownPlugins()</EuiCode>. This will ensure
-          the syntax won&apos;t be identified or rendered and no additional UI,
-          like the button and help syntax, will be displayed by the unregistered
+          the syntax won't be identified or rendered, and no additional UI (like
+          toolbar buttons or help syntax) will be displayed by the unregistered
           plugins.
         </p>
       ),

--- a/src-docs/src/views/markdown_editor/markdown_editor_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_example.js
@@ -60,7 +60,7 @@ const markdownEditorNoPluginsSnippet = `const {
   parsingPlugins,
   processingPlugins,
   uiPlugins,
-} = getDefaultEuiMarkdownPlugins({ exclude: ['tooltip'] });
+} = getDefaultEuiMarkdownPlugins({ exclude: ['tooltip', 'line-breaks'] });
 
   <EuiMarkdownEditor
     value={value}

--- a/src-docs/src/views/markdown_editor/markdown_editor_example.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_example.js
@@ -133,16 +133,17 @@ export const MarkdownEditorExample = {
       title: 'Unregistering plugins',
       text: (
         <p>
-          The <strong>EuiMarkdownEditor</strong> comes with a default plugin for{' '}
-          <EuiCode>tooltip</EuiCode> support. However, this may be unfamiliar or
-          unnecessary in some contexts, and you can unregister this plugin by
-          excluding it from the
+          The <strong>EuiMarkdownEditor</strong> comes with default plugins such
+          as <EuiCode>tooltip</EuiCode> and <EuiCode>line-breaks</EuiCode>.{' '}
+          However, these may be unfamiliar or unnecessary in some contexts, and
+          you can unregister these plugins by excluding them from the
           <EuiCode>parsingPlugins</EuiCode>,{' '}
           <EuiCode>processingPlugins</EuiCode> and <EuiCode>uiPlugins</EuiCode>{' '}
           options with a single <EuiCode>exclude</EuiCode> parameter passed to{' '}
           <EuiCode>getDefaultEuiMarkdownPlugins()</EuiCode>. This will ensure
           the syntax won&apos;t be identified or rendered and no additional UI,
-          like the button and help syntax, will be displayed.
+          like the button and help syntax, will be displayed by the unregistered
+          plugins.
         </p>
       ),
       props: {

--- a/src-docs/src/views/markdown_editor/markdown_editor_no_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_no_plugins.js
@@ -7,15 +7,25 @@ import {
 
 const initialContent = `## This is how we do it :smile:
 
-In this example, we unregistered the built in **tooltip** plugin. So the button in the toolbar and the help syntax won't be displayed.
+In this example, we unregistered the built in **tooltip** and **line-breaks** plugins.
 
+### tooltip
+
+The button in the toolbar and the help syntax won't be displayed.  
 And the following syntax no longer works.
 
 !{tooltip[anchor text](Tooltip content)}
+
+### line-breaks
+
+More than two trailing spaces break consecutive lines,
+but not otherwise.
+
+A blank line separates sections as usual.
 `;
 
 const { parsingPlugins, processingPlugins, uiPlugins } =
-  getDefaultEuiMarkdownPlugins({ exclude: ['tooltip'] });
+  getDefaultEuiMarkdownPlugins({ exclude: ['tooltip', 'line-breaks'] });
 
 export default () => {
   const [value, setValue] = useState(initialContent);

--- a/src-docs/src/views/markdown_editor/markdown_editor_no_plugins.js
+++ b/src-docs/src/views/markdown_editor/markdown_editor_no_plugins.js
@@ -1,45 +1,112 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 
 import {
   EuiMarkdownEditor,
   getDefaultEuiMarkdownPlugins,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSwitch,
 } from '../../../../src/components';
 
-const initialContent = `## This is how we do it :smile:
-
-In this example, we unregistered the built in **tooltip** and **line-breaks** plugins.
-
+const initialContent = `
 ### tooltip
 
-The button in the toolbar and the help syntax won't be displayed.  
-And the following syntax no longer works.
+When disabled, the button in the toolbar and the help syntax won't be displayed, and the following syntax will no longer works.
 
 !{tooltip[anchor text](Tooltip content)}
 
-### line-breaks
+### checkbox
 
-More than two trailing spaces break consecutive lines,
-but not otherwise.
+When disabled, a EuiCheckbox will no longer render.
 
-A blank line separates sections as usual.
+- [ ] TODO: Disable some default plugins
+
+### emoji
+
+When disabled, text will render instead of an emoji.
+
+:smile:
+
+### linkValidator
+
+When disabled, all links will render as links instead of as text.
+
+[This is a sus link](file://)
+
+### lineBreaks
+
+When disabled, these sentence will be in the same line.
+When enabled, these sentences will be separated by a line break.
+
+Two blank lines in a row will create a new paragraph as usual.
 `;
-
-const { parsingPlugins, processingPlugins, uiPlugins } =
-  getDefaultEuiMarkdownPlugins({ exclude: ['tooltip', 'line-breaks'] });
 
 export default () => {
   const [value, setValue] = useState(initialContent);
 
+  const [tooltip, excludeTooltips] = useState(false);
+  const [checkbox, excludeCheckboxes] = useState(true);
+  const [emoji, excludeEmojis] = useState(true);
+  const [linkValidator, excludeLinkValidator] = useState(true);
+  const [lineBreaks, excludeLineBreaks] = useState(false);
+
+  const { parsingPlugins, processingPlugins, uiPlugins } = useMemo(() => {
+    const excludedPlugins = [];
+    if (!tooltip) excludedPlugins.push('tooltip');
+    if (!checkbox) excludedPlugins.push('checkbox');
+    if (!emoji) excludedPlugins.push('emoji');
+    if (!linkValidator) excludedPlugins.push('linkValidator');
+    if (!lineBreaks) excludedPlugins.push('lineBreaks');
+
+    return getDefaultEuiMarkdownPlugins({
+      exclude: excludedPlugins,
+    });
+  }, [tooltip, checkbox, emoji, linkValidator, lineBreaks]);
+
   return (
     <>
-      <EuiMarkdownEditor
-        aria-label="EUI markdown editor with no default plugins demo"
-        value={value}
-        onChange={setValue}
-        parsingPluginList={parsingPlugins}
-        processingPluginList={processingPlugins}
-        uiPlugins={uiPlugins}
-      />
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false} css={{ gap: 20 }}>
+          <EuiSwitch
+            label="tooltip"
+            checked={tooltip}
+            onChange={() => excludeTooltips(!tooltip)}
+          />
+          <EuiSwitch
+            label="checkbox"
+            checked={checkbox}
+            onChange={() => excludeCheckboxes(!checkbox)}
+          />
+          <EuiSwitch
+            label="emoji"
+            checked={emoji}
+            onChange={() => excludeEmojis(!emoji)}
+          />
+          <EuiSwitch
+            label="linkValidator"
+            checked={linkValidator}
+            onChange={() => excludeLinkValidator(!linkValidator)}
+          />
+          <EuiSwitch
+            label="lineBreaks"
+            checked={lineBreaks}
+            onChange={() => excludeLineBreaks(!lineBreaks)}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiMarkdownEditor
+            aria-label="Demo with excluded default plugins"
+            value={value}
+            onChange={setValue}
+            parsingPluginList={parsingPlugins}
+            processingPluginList={processingPlugins}
+            uiPlugins={uiPlugins}
+            initialViewMode="viewing"
+            autoExpandPreview={false}
+            height={400}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </>
   );
 };

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/parsing_plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/parsing_plugins.ts
@@ -32,35 +32,40 @@ import {
   euiMarkdownLinkValidator,
   EuiMarkdownLinkValidatorOptions,
 } from '../markdown_link_validator';
+import type { ExcludableDefaultPlugins, DefaultPluginsConfig } from './plugins';
 
 export type DefaultEuiMarkdownParsingPlugins = PluggableList;
 
+const DEFAULT_PARSING_PLUGINS: Record<
+  ExcludableDefaultPlugins,
+  DefaultEuiMarkdownParsingPlugins[0]
+> = {
+  emoji: [emoji, { emoticon: false }],
+  lineBreaks: [breaks, {}],
+  linkValidator: [
+    euiMarkdownLinkValidator,
+    {
+      allowRelative: true,
+      allowProtocols: ['https:', 'http:', 'mailto:'],
+    } as EuiMarkdownLinkValidatorOptions,
+  ],
+  checkbox: [MarkdownCheckbox.parser, {}],
+  tooltip: [MarkdownTooltip.parser, {}],
+};
+
 export const getDefaultEuiMarkdownParsingPlugins = ({
   exclude,
-}: {
-  exclude?: Array<'tooltip' | 'line-breaks'>;
-} = {}): DefaultEuiMarkdownParsingPlugins => {
-  const excludeSet = new Set(exclude);
+}: DefaultPluginsConfig = {}): DefaultEuiMarkdownParsingPlugins => {
   const parsingPlugins: PluggableList = [
     [markdown, {}],
     [highlight, {}],
-    [emoji, { emoticon: false }],
-    [
-      euiMarkdownLinkValidator,
-      {
-        allowRelative: true,
-        allowProtocols: ['https:', 'http:', 'mailto:'],
-      } as EuiMarkdownLinkValidatorOptions,
-    ],
-    [MarkdownCheckbox.parser, {}],
   ];
 
-  if (!excludeSet.has('tooltip'))
-    parsingPlugins.push([MarkdownTooltip.parser, {}]);
-
-  if (!excludeSet.has('line-breaks')) {
-    parsingPlugins.push([breaks, {}]);
-  }
+  Object.entries(DEFAULT_PARSING_PLUGINS).forEach(([pluginName, plugin]) => {
+    if (!exclude?.includes(pluginName as ExcludableDefaultPlugins)) {
+      parsingPlugins.push(plugin);
+    }
+  });
 
   return parsingPlugins;
 };

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/parsing_plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/parsing_plugins.ts
@@ -37,13 +37,14 @@ export type DefaultEuiMarkdownParsingPlugins = PluggableList;
 
 export const getDefaultEuiMarkdownParsingPlugins = ({
   exclude,
-}: { exclude?: Array<'tooltip'> } = {}): DefaultEuiMarkdownParsingPlugins => {
+}: {
+  exclude?: Array<'tooltip' | 'line-breaks'>;
+} = {}): DefaultEuiMarkdownParsingPlugins => {
   const excludeSet = new Set(exclude);
   const parsingPlugins: PluggableList = [
     [markdown, {}],
     [highlight, {}],
     [emoji, { emoticon: false }],
-    [breaks, {}],
     [
       euiMarkdownLinkValidator,
       {
@@ -56,6 +57,10 @@ export const getDefaultEuiMarkdownParsingPlugins = ({
 
   if (!excludeSet.has('tooltip'))
     parsingPlugins.push([MarkdownTooltip.parser, {}]);
+
+  if (!excludeSet.has('line-breaks')) {
+    parsingPlugins.push([breaks, {}]);
+  }
 
   return parsingPlugins;
 };

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.test.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.test.ts
@@ -6,79 +6,57 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
-import breaks from 'remark-breaks';
-
-import * as MarkdownTooltip from '../markdown_tooltip';
 import { getDefaultEuiMarkdownPlugins } from './plugins';
 
-import type { Pluggable, PluginTuple, Settings } from 'unified';
-import type { EuiMarkdownEditorUiPlugin } from '../../markdown_types';
-
-const excludableDefaultPlugins: Array<
-  [
-    'tooltip' | 'line-breaks',
-    Pluggable<any[], Settings> | null,
-    React.ComponentType<any> | null,
-    EuiMarkdownEditorUiPlugin | null
-  ]
-> = [
-  [
-    'tooltip',
-    MarkdownTooltip.parser,
-    MarkdownTooltip.renderer,
-    MarkdownTooltip.plugin,
-  ],
-  ['line-breaks', breaks, null, null],
-];
-
-describe('opt out of default plugins', () => {
-  it('exclude nothing', () => {
+describe('default plugins', () => {
+  test('no exclusions', () => {
     const { parsingPlugins, processingPlugins, uiPlugins } =
-      getDefaultEuiMarkdownPlugins({});
+      getDefaultEuiMarkdownPlugins();
 
-    excludableDefaultPlugins.forEach(
-      ([, parsingPlugin, processingPlugin, uiPlugin]) => {
-        if (parsingPlugin !== null) {
-          expect(
-            parsingPlugins.find((p) => (p as PluginTuple)[0] === parsingPlugin)
-          ).not.toBeUndefined();
-        }
+    expect(parsingPlugins).toHaveLength(7);
+    expect(Object.keys(processingPlugins[1][1].components)).toHaveLength(8);
+    expect(uiPlugins).toHaveLength(1);
 
-        if (processingPlugin !== null) {
-          expect(Object.values(processingPlugins[1][1].components)).toContain(
-            processingPlugin
-          );
-        }
-
-        if (uiPlugin !== null) {
-          expect(uiPlugins).toContain(uiPlugin);
-        }
-      }
-    );
+    expect(processingPlugins[1][1].components.tooltipPlugin).toBeDefined();
+    expect(processingPlugins[1][1].components.checkboxPlugin).toBeDefined();
   });
 
-  test.each(excludableDefaultPlugins)(
-    'exclude %s',
-    (plugin, parsingPlugin, processingPlugin, uiPlugin) => {
-      const { parsingPlugins, processingPlugins, uiPlugins } =
-        getDefaultEuiMarkdownPlugins({ exclude: [plugin] });
+  test('exclude tooltips', () => {
+    const { parsingPlugins, processingPlugins, uiPlugins } =
+      getDefaultEuiMarkdownPlugins({
+        exclude: ['tooltip'],
+      });
 
-      if (parsingPlugin !== null) {
-        expect(
-          parsingPlugins.find((p) => (p as PluginTuple)[0] === parsingPlugin)
-        ).toBeUndefined();
-      }
+    expect(parsingPlugins).toHaveLength(6);
+    expect(processingPlugins[1][1].components.tooltipPlugin).toBeUndefined();
+    expect(uiPlugins).toHaveLength(0);
+  });
 
-      if (processingPlugin !== null) {
-        expect(Object.values(processingPlugins[1][1].components)).not.toContain(
-          processingPlugin
-        );
-      }
+  test('exclude checkboxes', () => {
+    const { parsingPlugins, processingPlugins, uiPlugins } =
+      getDefaultEuiMarkdownPlugins({
+        exclude: ['checkbox'],
+      });
 
-      if (uiPlugin !== null) {
-        expect(uiPlugins).not.toContain(uiPlugin);
-      }
-    }
-  );
+    expect(parsingPlugins).toHaveLength(6);
+    expect(processingPlugins[1][1].components.checkboxPlugin).toBeUndefined();
+    expect(uiPlugins).toHaveLength(1);
+  });
+
+  test('all exclusions', () => {
+    const { parsingPlugins, processingPlugins, uiPlugins } =
+      getDefaultEuiMarkdownPlugins({
+        exclude: [
+          'tooltip',
+          'checkbox',
+          'lineBreaks',
+          'linkValidator',
+          'emoji',
+        ],
+      });
+
+    expect(parsingPlugins).toHaveLength(2);
+    expect(Object.keys(processingPlugins[1][1].components)).toHaveLength(6);
+    expect(uiPlugins).toHaveLength(0);
+  });
 });

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.test.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import breaks from 'remark-breaks';
+
+import * as MarkdownTooltip from '../markdown_tooltip';
+import { getDefaultEuiMarkdownPlugins } from './plugins';
+
+import type { Pluggable, PluginTuple, Settings } from 'unified';
+import type { EuiMarkdownEditorUiPlugin } from '../../markdown_types';
+
+const excludableDefaultPlugins: Array<
+  [
+    'tooltip' | 'line-breaks',
+    Pluggable<any[], Settings> | null,
+    React.ComponentType<any> | null,
+    EuiMarkdownEditorUiPlugin | null
+  ]
+> = [
+  [
+    'tooltip',
+    MarkdownTooltip.parser,
+    MarkdownTooltip.renderer,
+    MarkdownTooltip.plugin,
+  ],
+  ['line-breaks', breaks, null, null],
+];
+
+describe('opt out of default plugins', () => {
+  it('exclude nothing', () => {
+    const { parsingPlugins, processingPlugins, uiPlugins } =
+      getDefaultEuiMarkdownPlugins({});
+
+    excludableDefaultPlugins.forEach(
+      ([, parsingPlugin, processingPlugin, uiPlugin]) => {
+        if (parsingPlugin !== null) {
+          expect(
+            parsingPlugins.find((p) => (p as PluginTuple)[0] === parsingPlugin)
+          ).not.toBeUndefined();
+        }
+
+        if (processingPlugin !== null) {
+          expect(Object.values(processingPlugins[1][1].components)).toContain(
+            processingPlugin
+          );
+        }
+
+        if (uiPlugin !== null) {
+          expect(uiPlugins).toContain(uiPlugin);
+        }
+      }
+    );
+  });
+
+  test.each(excludableDefaultPlugins)(
+    'exclude %s',
+    (plugin, parsingPlugin, processingPlugin, uiPlugin) => {
+      const { parsingPlugins, processingPlugins, uiPlugins } =
+        getDefaultEuiMarkdownPlugins({ exclude: [plugin] });
+
+      if (parsingPlugin !== null) {
+        expect(
+          parsingPlugins.find((p) => (p as PluginTuple)[0] === parsingPlugin)
+        ).toBeUndefined();
+      }
+
+      if (processingPlugin !== null) {
+        expect(Object.values(processingPlugins[1][1].components)).not.toContain(
+          processingPlugin
+        );
+      }
+
+      if (uiPlugin !== null) {
+        expect(uiPlugins).not.toContain(uiPlugin);
+      }
+    }
+  );
+});

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.ts
@@ -19,8 +19,19 @@ import {
   DefaultEuiMarkdownProcessingPlugins,
 } from './processing_plugins';
 
+export type ExcludableDefaultPlugins =
+  | 'emoji'
+  | 'lineBreaks'
+  | 'linkValidator'
+  | 'checkbox'
+  | 'tooltip';
+
+export type DefaultPluginsConfig =
+  | undefined
+  | { exclude?: ExcludableDefaultPlugins[] };
+
 export const getDefaultEuiMarkdownPlugins = (
-  config: undefined | { exclude?: Array<'tooltip' | 'line-breaks'> }
+  config?: DefaultPluginsConfig
 ): {
   parsingPlugins: DefaultEuiMarkdownParsingPlugins;
   processingPlugins: DefaultEuiMarkdownProcessingPlugins;

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/plugins.ts
@@ -20,7 +20,7 @@ import {
 } from './processing_plugins';
 
 export const getDefaultEuiMarkdownPlugins = (
-  config: undefined | { exclude?: Array<'tooltip'> }
+  config: undefined | { exclude?: Array<'tooltip' | 'line-breaks'> }
 ): {
   parsingPlugins: DefaultEuiMarkdownParsingPlugins;
   processingPlugins: DefaultEuiMarkdownProcessingPlugins;

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
@@ -53,7 +53,7 @@ export type DefaultEuiMarkdownProcessingPlugins = [
 export const getDefaultEuiMarkdownProcessingPlugins = ({
   exclude,
 }: {
-  exclude?: Array<'tooltip'>;
+  exclude?: Array<'tooltip' | 'line-breaks'>;
 } = {}): DefaultEuiMarkdownProcessingPlugins => {
   const excludeSet = new Set(exclude);
 

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
@@ -28,12 +28,15 @@ import { Options as Remark2RehypeOptions, Handler } from 'mdast-util-to-hast';
 import all from 'mdast-util-to-hast/lib/all';
 import rehype2react from 'rehype-react';
 import remark2rehype from 'remark-rehype';
-import * as MarkdownTooltip from '../markdown_tooltip';
-import * as MarkdownCheckbox from '../markdown_checkbox';
-import { FENCED_CLASS } from '../remark/remark_prismjs';
+
 import { EuiLink } from '../../../link';
 import { EuiCodeBlock, EuiCode } from '../../../code';
 import { EuiHorizontalRule } from '../../../horizontal_rule';
+
+import { FENCED_CLASS } from '../remark/remark_prismjs';
+import * as MarkdownTooltip from '../markdown_tooltip';
+import * as MarkdownCheckbox from '../markdown_checkbox';
+import type { ExcludableDefaultPlugins, DefaultPluginsConfig } from './plugins';
 
 const unknownHandler: Handler = (h, node) => {
   return h(node, node.type, node, all(h, node));
@@ -50,12 +53,26 @@ export type DefaultEuiMarkdownProcessingPlugins = [
   ...PluggableList // any additional are generic
 ];
 
+const DEFAULT_COMPONENT_RENDERERS: Partial<
+  Record<ExcludableDefaultPlugins, React.ComponentType<any>>
+> = {
+  checkbox: MarkdownCheckbox.renderer,
+  tooltip: MarkdownTooltip.renderer,
+};
+
 export const getDefaultEuiMarkdownProcessingPlugins = ({
   exclude,
-}: {
-  exclude?: Array<'tooltip' | 'line-breaks'>;
-} = {}): DefaultEuiMarkdownProcessingPlugins => {
-  const excludeSet = new Set(exclude);
+}: DefaultPluginsConfig = {}): DefaultEuiMarkdownProcessingPlugins => {
+  const componentPluginsWithExclusions: Rehype2ReactOptions['components'] = {};
+
+  Object.entries(DEFAULT_COMPONENT_RENDERERS).forEach(
+    ([excludeName, renderer]) => {
+      if (!exclude?.includes(excludeName as ExcludableDefaultPlugins)) {
+        const pluginName = `${excludeName}Plugin`;
+        componentPluginsWithExclusions[pluginName] = renderer;
+      }
+    }
+  );
 
   const plugins: DefaultEuiMarkdownProcessingPlugins = [
     [
@@ -99,14 +116,11 @@ export const getDefaultEuiMarkdownProcessingPlugins = ({
             <table className="euiMarkdownFormat__table" {...props} />
           ),
           hr: (props) => <EuiHorizontalRule {...props} />,
-          checkboxPlugin: MarkdownCheckbox.renderer,
+          ...componentPluginsWithExclusions,
         },
       },
     ],
   ];
-
-  if (!excludeSet.has('tooltip'))
-    plugins[1][1].components.tooltipPlugin = MarkdownTooltip.renderer;
 
   return plugins;
 };

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/ui_plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/ui_plugins.ts
@@ -13,7 +13,9 @@ export type DefaultEuiMarkdownUiPlugins = EuiMarkdownEditorUiPlugin[];
 
 export const getDefaultEuiMarkdownUiPlugins = ({
   exclude,
-}: { exclude?: Array<'tooltip'> } = {}): DefaultEuiMarkdownUiPlugins => {
+}: {
+  exclude?: Array<'tooltip' | 'line-breaks'>;
+} = {}): DefaultEuiMarkdownUiPlugins => {
   const excludeSet = new Set(exclude);
   const uiPlugins = [];
 

--- a/src/components/markdown_editor/plugins/markdown_default_plugins/ui_plugins.ts
+++ b/src/components/markdown_editor/plugins/markdown_default_plugins/ui_plugins.ts
@@ -6,20 +6,28 @@
  * Side Public License, v 1.
  */
 
-import * as MarkdownTooltip from '../markdown_tooltip';
 import { EuiMarkdownEditorUiPlugin } from './../../markdown_types';
+import * as MarkdownTooltip from '../markdown_tooltip';
+import type { ExcludableDefaultPlugins, DefaultPluginsConfig } from './plugins';
 
 export type DefaultEuiMarkdownUiPlugins = EuiMarkdownEditorUiPlugin[];
 
+const DEFAULT_UI_PLUGINS: Partial<
+  Record<ExcludableDefaultPlugins, EuiMarkdownEditorUiPlugin>
+> = {
+  tooltip: MarkdownTooltip.plugin,
+};
+
 export const getDefaultEuiMarkdownUiPlugins = ({
   exclude,
-}: {
-  exclude?: Array<'tooltip' | 'line-breaks'>;
-} = {}): DefaultEuiMarkdownUiPlugins => {
-  const excludeSet = new Set(exclude);
-  const uiPlugins = [];
+}: DefaultPluginsConfig = {}): DefaultEuiMarkdownUiPlugins => {
+  const uiPlugins: EuiMarkdownEditorUiPlugin[] = [];
 
-  if (!excludeSet.has('tooltip')) uiPlugins.push(MarkdownTooltip.plugin);
+  Object.entries(DEFAULT_UI_PLUGINS).forEach(([pluginName, plugin]) => {
+    if (!exclude?.includes(pluginName as ExcludableDefaultPlugins)) {
+      uiPlugins.push(plugin);
+    }
+  });
 
   return uiPlugins;
 };


### PR DESCRIPTION
## Summary

This PR adds a way to exclude the `line-breaks` plugin from what `getDefaultEuiMarkdownPlugins()` defaults and revive the original line-breaking by two trailing spaces in markdown.

![screenshot](https://github.com/elastic/eui/assets/721858/870be0f6-16cb-48c1-b1f0-940a98a55ab4)

Closes #7673

## QA

- Go to https://eui.elastic.co/pr_7676/#/editors-syntax/markdown-editor#unregistering-plugins
- [x] Confirm that toggling on/off the various plugin switches affects the markdown output as expected

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    ~~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist - N/A

### Q. Without line-breaks plugin, does EuiMarkdownEditor still use "GitHub flavored markdown"?

![image](https://github.com/elastic/eui/assets/721858/a3955cd0-426e-47b8-8926-53d6fc00410c)

- The link points to `https://guides.github.com/features/mastering-markdown/`, which was changed from `https://github.github.com/gfm/` in https://github.com/elastic/eui/pull/5147/commits/6d94f22d382b5d3ed1874733a3a9d073c2ef81e2.
- Excluding `line-breaks` plugin results in a line-breaking manner defined in the latter, which is "GitHub Flavored Markdown Spec Version 0.29-gfm (2019-04-06)".

So, the answer is probably YES, but it might be better to replace the link depending on `line-breaks` plugin. Because of this, I'm leaving the text (no reason to change) and link (potentially preferable but not mandatory) as they are. I will appreciate any comments on this point.