### PR TITLE
[EuiTableRowCell] Fix `th scope="row"` text alignment

### DIFF
--- a/changelogs/upcoming/7681.md
+++ b/changelogs/upcoming/7681.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a visual text alignment regression in `EuiTableRowCell`s with the `row` header scope

--- a/src-docs/src/views/tables/auto/auto.tsx
+++ b/src-docs/src/views/tables/auto/auto.tsx
@@ -217,6 +217,7 @@ export default () => {
         tableCaption="Demo of EuiBasicTable's table layout options"
         items={users}
         columns={columns}
+        rowHeader="firstName"
         tableLayout={tableLayout === 'tableLayoutAuto' ? 'auto' : 'fixed'}
       />
     </>

--- a/src/components/table/table_row_cell.styles.ts
+++ b/src/components/table/table_row_cell.styles.ts
@@ -14,6 +14,7 @@ import {
   euiFontSize,
   euiTextTruncate,
   logicalCSS,
+  logicalTextAlignCSS,
 } from '../../global_styling';
 
 import { euiTableVariables } from './table.styles';
@@ -32,8 +33,9 @@ export const euiTableRowCellStyles = (euiThemeContext: UseEuiTheme) => {
       color: ${euiTheme.colors.text};
     `,
     rowHeader: css`
-      /* Unset the automatic browser bolding applied to [th] elements */
+      /* Unset the automatic browser bolding and center alignment applied to [th] elements */
       font-weight: ${euiTheme.font.weight.regular};
+      ${logicalTextAlignCSS('left')}
     `,
     isExpander: css`
       ${hasIcons}


### PR DESCRIPTION
## Summary

> [!note]
> Reported in https://github.com/elastic/kibana/pull/180514#pullrequestreview-1997600737. This PR will need to be a backport/patch release for the tables release.

| Before | After |
|--------|--------|
| <img width="422" alt="" src="https://github.com/elastic/eui/assets/549407/7b35b1f5-3fe5-444f-b75a-8cada543cf25"> | <img width="439" alt="" src="https://github.com/elastic/eui/assets/549407/dcfe4f2c-91ac-45db-9845-b633fba63957"> | 

`th` cells default to `font-weight: bold; text-align: center` ([source](https://www.w3schools.com/cssref/css_default_values.php)) and row cells that are row headers via `setScopeRow` need to have that CSS unset.

This wasn't caught by / didn't affecting our demo examples because our `textOnly` wrapper sets a display flex which automatically justifies to the left, but it **does** affect cells with `textOnly={false} setScopeRow={true}`.

Note for more context: the original Sass `@euiTableCell` mixin unset those properties which I was confused by/thought was unnecessary because `td` cells do not have that CSS, and I didn't realize they were there for `th`. This is now hopefully a bit more clear in our Emotion styles.

## QA

(Opting not to add a specific test/story for this as it has fairly clear CSS comments at this point)
- Regression testing
- Go to https://eui.elastic.co/pr_7681/#/tabular-content/tables#table-layout
- [x] Toggle the left/center/right options and confirm the `First name` column aligns correctly as before

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist
    - ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A