### PR TITLE
feat: `EuiFlexGroup` and `EuiFlexItem` component prop type improvements

### DIFF
--- a/changelogs/upcoming/7688.md
+++ b/changelogs/upcoming/7688.md
@@ -1,0 +1,1 @@
+- Updated `EuiFlexGroup` and `EuiFlexItem` prop types to support passing any valid React component type to the `component` prop and ensure proper type checking of the extra props forwarded to the `component`.

--- a/src-docs/src/views/flex/flex_example.js
+++ b/src-docs/src/views/flex/flex_example.js
@@ -246,7 +246,7 @@ export const FlexExample = {
       ),
     },
     {
-      title: 'Spans instead of divs',
+      title: 'Override output component type',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -255,9 +255,12 @@ export const FlexExample = {
       ],
       text: (
         <p>
-          Specify <EuiCode>component=&ldquo;span&rdquo;</EuiCode> on{' '}
+          Pass the <EuiCode>component</EuiCode> property to{' '}
           <strong>EuiFlexGroup</strong> and/or <strong>EuiFlexItem</strong> to
-          change from the default <EuiCode>div</EuiCode>.
+          change the rendered component type from the default {' '}
+          <EuiCode>div</EuiCode>. It can be any valid React component type
+          like a tag name string such as <EuiCode>div</EuiCode>
+          or <EuiCode>span</EuiCode> or a React component.
         </p>
       ),
       snippet: componentSpanSnippet,

--- a/src-docs/src/views/flex/flex_example.js
+++ b/src-docs/src/views/flex/flex_example.js
@@ -257,9 +257,9 @@ export const FlexExample = {
         <p>
           Pass the <EuiCode>component</EuiCode> property to{' '}
           <strong>EuiFlexGroup</strong> and/or <strong>EuiFlexItem</strong> to
-          change the rendered component type from the default {' '}
-          <EuiCode>div</EuiCode>. It can be any valid React component type
-          like a tag name string such as <EuiCode>div</EuiCode>
+          change the rendered component type from the default{' '}
+          <EuiCode>div</EuiCode>. It can be any valid React component type like
+          a tag name string such as <EuiCode>div</EuiCode>
           or <EuiCode>span</EuiCode> or a React component.
         </p>
       ),

--- a/src/components/flex/flex_group.test.tsx
+++ b/src/components/flex/flex_group.test.tsx
@@ -112,18 +112,6 @@ describe('EuiFlexGroup', () => {
         const { getByText } = render(<EuiFlexGroup component={component} />);
         expect(getByText('Custom component test')).toBeInTheDocument();
       });
-
-      // React 18 throws a false error on test unmount for components w/ ref callbacks
-      // that throw in a `useEffect`. Note: This only affects the test env, not prod
-      // @see https://github.com/facebook/react/issues/25675#issuecomment-1363957941
-      // TODO: Remove `testOnReactVersion` once the above bug is fixed
-      testOnReactVersion(['16', '17'])(
-        `invalid component types throw an error`,
-        () => {
-          // @ts-expect-error intentionally passing an invalid value
-          expect(() => render(<EuiFlexGroup component="h2" />)).toThrow();
-        }
-      );
     });
   });
 });

--- a/src/components/flex/flex_group.test.tsx
+++ b/src/components/flex/flex_group.test.tsx
@@ -8,10 +8,7 @@
 
 import React, { JSX } from 'react';
 import { requiredProps } from '../../test';
-import {
-  shouldRenderCustomStyles,
-  testOnReactVersion,
-} from '../../test/internal';
+import { shouldRenderCustomStyles } from '../../test/internal';
 import { render } from '../../test/rtl';
 
 import {

--- a/src/components/flex/flex_group.test.tsx
+++ b/src/components/flex/flex_group.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { JSX } from 'react';
 import { requiredProps } from '../../test';
 import {
   shouldRenderCustomStyles,
@@ -20,7 +20,6 @@ import {
   ALIGN_ITEMS,
   JUSTIFY_CONTENTS,
   DIRECTIONS,
-  COMPONENT_TYPES,
 } from './flex_group';
 
 describe('EuiFlexGroup', () => {
@@ -98,12 +97,20 @@ describe('EuiFlexGroup', () => {
     });
 
     describe('component', () => {
-      COMPONENT_TYPES.forEach((value) => {
+      ['div', 'span'].forEach((value) => {
         test(`${value} is rendered`, () => {
-          const { container } = render(<EuiFlexGroup component={value} />);
+          const { container } = render(
+            <EuiFlexGroup component={value as keyof JSX.IntrinsicElements} />
+          );
 
           expect(container.firstChild!.nodeName).toEqual(value.toUpperCase());
         });
+      });
+
+      test('custom component is rendered', () => {
+        const component = () => <span>Custom component test</span>;
+        const { getByText } = render(<EuiFlexGroup component={component} />);
+        expect(getByText('Custom component test')).toBeInTheDocument();
       });
 
       // React 18 throws a false error on test unmount for components w/ ref callbacks

--- a/src/components/flex/flex_group.tsx
+++ b/src/components/flex/flex_group.tsx
@@ -123,5 +123,5 @@ export const EuiFlexGroup = forwardRef(EuiFlexGroupInternal) as <
   props: EuiFlexGroupProps<TComponent> & { ref?: any }
 ) => ReturnType<typeof EuiFlexGroupInternal>;
 
-// Cast here is required because of the cast above
+// Cast is required here because of the cast above
 (EuiFlexGroup as FunctionComponent).displayName = 'EuiFlexGroup';

--- a/src/components/flex/flex_group.tsx
+++ b/src/components/flex/flex_group.tsx
@@ -13,6 +13,7 @@ import React, {
   ForwardedRef,
   forwardRef,
   FunctionComponent,
+  Ref,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
@@ -120,7 +121,9 @@ const EuiFlexGroupInternal = <TComponent extends ComponentPropType>(
 export const EuiFlexGroup = forwardRef(EuiFlexGroupInternal) as <
   TComponent extends ComponentPropType
 >(
-  props: EuiFlexGroupProps<TComponent> & { ref?: any }
+  props: EuiFlexGroupProps<TComponent> & {
+    ref?: Ref<typeof EuiFlexGroupInternal>;
+  }
 ) => ReturnType<typeof EuiFlexGroupInternal>;
 
 // Cast is required here because of the cast above

--- a/src/components/flex/flex_group.tsx
+++ b/src/components/flex/flex_group.tsx
@@ -6,7 +6,14 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, Ref, forwardRef, useEffect } from 'react';
+import React, {
+  ComponentPropsWithoutRef,
+  ComponentType,
+  ElementType,
+  ForwardedRef,
+  forwardRef,
+  FunctionComponent,
+} from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 
@@ -43,80 +50,78 @@ export const DIRECTIONS = [
 ] as const;
 type FlexGroupDirection = (typeof DIRECTIONS)[number];
 
-export const COMPONENT_TYPES = ['div', 'span'] as const;
-type FlexGroupComponentType = (typeof COMPONENT_TYPES)[number];
+type ComponentPropType = ElementType<CommonProps>;
 
-export interface EuiFlexGroupProps
-  extends CommonProps,
-    HTMLAttributes<HTMLDivElement | HTMLSpanElement> {
-  alignItems?: FlexGroupAlignItems;
-  component?: FlexGroupComponentType;
-  direction?: FlexGroupDirection;
-  gutterSize?: EuiFlexGroupGutterSize;
-  justifyContent?: FlexGroupJustifyContent;
-  responsive?: boolean;
-  wrap?: boolean;
-}
+export type EuiFlexGroupProps<TComponent extends ComponentPropType> =
+  ComponentPropsWithoutRef<TComponent> & {
+    alignItems?: FlexGroupAlignItems;
+    /**
+     * Customize the component type that is rendered.
+     *
+     * It can be any valid React component type like a tag name string
+     * such as `'div'` or `'span'`, a React component (a function, a class,
+     * or an exotic component like `memo()`).
+     *
+     * `<EuiFlexGroup>` accepts and forwards all extra props to the custom
+     * component.
+     *
+     * @example
+     * // Renders a <button> element
+     * <EuiFlexGroup component="button">
+     *   Submit form
+     * </EuiFlexGroup>
+     * @default "div"
+     */
+    component?: TComponent;
+    direction?: FlexGroupDirection;
+    gutterSize?: EuiFlexGroupGutterSize;
+    justifyContent?: FlexGroupJustifyContent;
+    responsive?: boolean;
+    wrap?: boolean;
+  };
 
-export const EuiFlexGroup = forwardRef<
-  HTMLDivElement | HTMLSpanElement,
-  EuiFlexGroupProps
+const EuiFlexGroupInternal = <TComponent extends ComponentPropType>(
+  {
+    className,
+    component = 'div' as TComponent,
+    gutterSize = 'l',
+    alignItems = 'stretch',
+    responsive = true,
+    justifyContent = 'flexStart',
+    direction = 'row',
+    wrap = false,
+    ...rest
+  }: EuiFlexGroupProps<TComponent>,
+  ref: ForwardedRef<TComponent>
+) => {
+  const styles = useEuiMemoizedStyles(euiFlexGroupStyles);
+  const cssStyles = [
+    styles.euiFlexGroup,
+    responsive && !direction.includes('column') && styles.responsive,
+    wrap && styles.wrap,
+    styles.gutterSizes[gutterSize],
+    styles.justifyContent[justifyContent],
+    styles.alignItems[alignItems],
+    styles.direction[direction],
+  ];
+
+  const classes = classNames('euiFlexGroup', className);
+
+  // Cast the resolved component prop type to ComponentType to help TS
+  // process multiple infers and the overall type complexity.
+  // This might not be needed in TypeScript 5
+  const Component = component as ComponentType<CommonProps & typeof rest>;
+
+  return <Component {...rest} ref={ref} className={classes} css={cssStyles} />;
+};
+
+// Cast forwardRef return type to work with the generic TComponent type
+// and not fallback to implicit any typing
+export const EuiFlexGroup = forwardRef(EuiFlexGroupInternal) as <
+  TComponent extends ComponentPropType
 >(
-  (
-    {
-      children,
-      className,
-      gutterSize = 'l',
-      alignItems = 'stretch',
-      responsive = true,
-      justifyContent = 'flexStart',
-      direction = 'row',
-      wrap = false,
-      component = 'div',
-      ...rest
-    },
-    ref: Ref<HTMLDivElement> | Ref<HTMLSpanElement>
-  ) => {
-    const styles = useEuiMemoizedStyles(euiFlexGroupStyles);
-    const cssStyles = [
-      styles.euiFlexGroup,
-      responsive && !direction.includes('column') && styles.responsive,
-      wrap && styles.wrap,
-      styles.gutterSizes[gutterSize],
-      styles.justifyContent[justifyContent],
-      styles.alignItems[alignItems],
-      styles.direction[direction],
-    ];
+  props: EuiFlexGroupProps<TComponent> & { ref?: any }
+) => ReturnType<typeof EuiFlexGroupInternal>;
 
-    const classes = classNames('euiFlexGroup', className);
-
-    useEffect(() => {
-      if (!COMPONENT_TYPES.includes(component)) {
-        throw new Error(
-          `${component} is not a valid element type. Use \`div\` or \`span\`.`
-        );
-      }
-    }, [component]);
-
-    return component === 'span' ? (
-      <span
-        css={cssStyles}
-        className={classes}
-        ref={ref as Ref<HTMLSpanElement>}
-        {...rest}
-      >
-        {children}
-      </span>
-    ) : (
-      <div
-        css={cssStyles}
-        className={classes}
-        ref={ref as Ref<HTMLDivElement>}
-        {...rest}
-      >
-        {children}
-      </div>
-    );
-  }
-);
-EuiFlexGroup.displayName = 'EuiFlexGroup';
+// Cast here is required because of the cast above
+(EuiFlexGroup as FunctionComponent).displayName = 'EuiFlexGroup';

--- a/src/components/flex/flex_group.tsx
+++ b/src/components/flex/flex_group.tsx
@@ -52,7 +52,7 @@ type FlexGroupDirection = (typeof DIRECTIONS)[number];
 
 type ComponentPropType = ElementType<CommonProps>;
 
-export type EuiFlexGroupProps<TComponent extends ComponentPropType> =
+export type EuiFlexGroupProps<TComponent extends ComponentPropType = 'div'> =
   ComponentPropsWithoutRef<TComponent> & {
     alignItems?: FlexGroupAlignItems;
     /**

--- a/src/components/flex/flex_item.test.tsx
+++ b/src/components/flex/flex_item.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { JSX } from 'react';
 import {
   requiredProps,
   startThrowingReactWarnings,
@@ -29,10 +29,23 @@ describe('EuiFlexItem', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('renders as the passed component element', () => {
-    const { container } = render(<EuiFlexItem component="span" />);
+  describe('component', () => {
+    ['div', 'span'].forEach((value) => {
+      test(`${value} is rendered`, () => {
+        const { container } = render(
+          <EuiFlexItem component={value as keyof JSX.IntrinsicElements} />
+        );
 
-    expect(container.firstChild?.nodeName).toEqual('SPAN');
+        expect(container.firstChild?.nodeName).toEqual(value.toUpperCase());
+      });
+    });
+
+    test('custom component is rendered', () => {
+      const component = () => <span>Custom component test</span>;
+      const { getByText } = render(<EuiFlexItem component={component} />);
+
+      expect(getByText('Custom component test')).toBeInTheDocument();
+    });
   });
 
   describe('grow', () => {

--- a/src/components/flex/flex_item.test.tsx
+++ b/src/components/flex/flex_item.test.tsx
@@ -12,7 +12,10 @@ import {
   startThrowingReactWarnings,
   stopThrowingReactWarnings,
 } from '../../test';
-import { shouldRenderCustomStyles } from '../../test/internal';
+import {
+  shouldRenderCustomStyles,
+  testOnReactVersion,
+} from '../../test/internal';
 import { render } from '../../test/rtl';
 
 import { EuiFlexItem } from './flex_item';
@@ -91,9 +94,16 @@ describe('EuiFlexItem', () => {
       });
     });
 
-    it('throws an error for invalid values', () => {
-      // @ts-expect-error testing invalid type
-      expect(() => render(<EuiFlexItem grow={11} />)).toThrowError();
-    });
+    // React 18 throws a false error on test unmount for components w/ ref callbacks
+    // that throw in a `useEffect`. Note: This only affects the test env, not prod
+    // @see https://github.com/facebook/react/issues/25675#issuecomment-1363957941
+    // TODO: Remove `testOnReactVersion` once the above bug is fixed
+    testOnReactVersion(['16', '17'])(
+      `invalid component types throw an error`,
+      () => {
+        // @ts-expect-error intentionally passing an invalid value
+        expect(() => render(<EuiFlexItem grow={11} />)).toThrow();
+      }
+    );
   });
 });

--- a/src/components/flex/flex_item.tsx
+++ b/src/components/flex/flex_item.tsx
@@ -7,10 +7,11 @@
  */
 
 import React, {
-  HTMLAttributes,
-  FunctionComponent,
   ElementType,
   useEffect,
+  ComponentPropsWithoutRef,
+  PropsWithChildren,
+  ComponentType,
 } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
@@ -35,25 +36,40 @@ const VALID_GROW_VALUES = [
   10,
 ] as const;
 
-export interface EuiFlexItemProps {
-  grow?: boolean | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | null; // Leave this as an inline string enum so the props table properly parses it
-  /**
-   * @default div
-   */
-  component?: ElementType;
-}
+type ComponentPropType = ElementType<CommonProps>;
 
-export const EuiFlexItem: FunctionComponent<
-  CommonProps &
-    HTMLAttributes<HTMLDivElement | HTMLSpanElement> &
-    EuiFlexItemProps
-> = ({
+export type EuiFlexItemProps<TComponent extends ComponentPropType> =
+  PropsWithChildren &
+    CommonProps &
+    ComponentPropsWithoutRef<TComponent> & {
+      grow?: boolean | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | null; // Leave this as an inline string enum so the props table properly parses it
+      /**
+       * Customize the component type that is rendered.
+       *
+       * It can be any valid React component type like a tag name string
+       * such as `'div'` or `'span'`, a React component (a function, a class,
+       * or an exotic component like `memo()`).
+       *
+       * `<EuiFlexGroup>` accepts and forwards all extra props to the custom
+       * component.
+       *
+       * @example
+       * // Renders a <button> element
+       * <EuiFlexGroup component="button">
+       *   Submit form
+       * </EuiFlexGroup>
+       * @default "div"
+       */
+      component?: TComponent;
+    };
+
+export const EuiFlexItem = <TComponent extends ComponentPropType>({
   children,
   className,
   grow = true,
-  component: Component = 'div',
+  component = 'div' as TComponent,
   ...rest
-}) => {
+}: EuiFlexItemProps<TComponent>) => {
   useEffect(() => {
     if (VALID_GROW_VALUES.indexOf(grow) === -1) {
       throw new Error(
@@ -72,6 +88,11 @@ export const EuiFlexItem: FunctionComponent<
   ];
 
   const classes = classNames('euiFlexItem', className);
+
+  // Cast the resolved component prop type to ComponentType to help TS
+  // process multiple infers and the overall type complexity.
+  // This might not be needed in TypeScript 5
+  const Component = component as ComponentType<CommonProps & typeof rest>;
 
   return (
     <Component css={cssStyles} className={classes} {...rest}>

--- a/src/components/flex/flex_item.tsx
+++ b/src/components/flex/flex_item.tsx
@@ -42,7 +42,7 @@ const VALID_GROW_VALUES = [
 
 type ComponentPropType = ElementType<CommonProps>;
 
-export type EuiFlexItemProps<TComponent extends ComponentPropType> =
+export type EuiFlexItemProps<TComponent extends ComponentPropType = 'div'> =
   PropsWithChildren &
     CommonProps &
     ComponentPropsWithoutRef<TComponent> & {

--- a/src/components/flex/flex_item.tsx
+++ b/src/components/flex/flex_item.tsx
@@ -59,7 +59,7 @@ export type EuiFlexItemProps<TComponent extends ComponentPropType = 'div'> =
        *
        * @example
        * // Renders a <button> element
-       * <EuiFlexGroup component="button">
+       * <EuiFlexItem component="button">
        *   Submit form
        * </EuiFlexGroup>
        * @default "div"


### PR DESCRIPTION
## Summary

This resolves https://github.com/elastic/eui/issues/7612 by updating `EuiFlexGroup` and `EuiFlexItem` to support dynamic prop type resolution with generics. It also cleans up the code and adds ref forwarding to `EuiFlexItem` to keep these two consistent.

The generic argument falls back to `'div'` to keep the API backward compatible in cases where a customer would import and use the `EuiFlexGroupProps` or `EuiFlexItemProps` type.

There are a couple of type casts added to ensure TypeScript and IDEs can resolve the full complex type and provide meaningful code suggestions.

## QA

- [x] Ensure all tests are passing
- [x] Checkout the branch locally, import `EuiFlexGroup`/`EuiFlexItem` and confirm the types are correctly resolved, suggesting and type checking props of the passed `component`.

### General checklist

- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
