### PR TITLE
[ci] Automatically retry flaky Cypress tests

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -51,6 +51,8 @@ steps:
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+    retry:
+      automatic: true
   
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":cypress: Cypress tests on React 17"
@@ -62,6 +64,8 @@ steps:
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+    retry:
+      automatic: true
   
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":cypress: Cypress tests on React 18"
@@ -73,6 +77,8 @@ steps:
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+    retry:
+      automatic: true
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":axe: Cypress accessibility (a11y) tests on React 18"


### PR DESCRIPTION
## Summary

Our Cypress tests are semi-flaky (notably around truncation and data grid cell popovers), and have recently been requiring more manual re-tries at times. Let's just make it automatic as they usually pass after a single retry.

## QA

- [ ] CI passes