### PR TITLE
CI: enable `update-build-and-publish` step on `main` in `eui-release` pipeline

### DIFF
--- a/.buildkite/pipelines/pipeline_release.yml
+++ b/.buildkite/pipelines/pipeline_release.yml
@@ -108,4 +108,3 @@ steps:
       ephemeralStorage: '20G'
       cpu: '4000m'
       memory: '8G'
-    if: build.branch != "main"


### PR DESCRIPTION
## Summary

This is a follow-up to the changes introduced in https://github.com/elastic/eui/pull/7662. It enables the automatic prerelease versioning and publishing step in `eui-release` Buildkite pipeline on `main` branch changes.

## QA

Manual QA is necessary after the change is merged.
