### PR TITLE
[EuiAccordion] Update component logic to retain focus on `<button>` when clicked

### DIFF
--- a/changelogs/upcoming/7696.md
+++ b/changelogs/upcoming/7696.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Updated `EuiAccordion` to keep focus on accordion trigger instead of moving to content on click/keypress

--- a/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`EuiAccordion behavior closes when clicked twice 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -97,7 +96,6 @@ exports[`EuiAccordion behavior does not open when isDisabled 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -150,7 +148,6 @@ exports[`EuiAccordion behavior opens when clicked once 1`] = `
     id="22"
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -203,7 +200,6 @@ exports[`EuiAccordion behavior opens when div is clicked if element is a div 1`]
     id="24"
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -259,7 +255,6 @@ exports[`EuiAccordion is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -311,7 +306,6 @@ exports[`EuiAccordion isDisabled is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -346,7 +340,6 @@ exports[`EuiAccordion props arrowDisplay none is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -396,7 +389,6 @@ exports[`EuiAccordion props arrowDisplay right is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -448,7 +440,6 @@ exports[`EuiAccordion props arrowProps is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -502,7 +493,6 @@ exports[`EuiAccordion props buttonContent is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -552,7 +542,6 @@ exports[`EuiAccordion props buttonContentClassName is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -600,7 +589,6 @@ exports[`EuiAccordion props buttonElement is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -652,7 +640,6 @@ exports[`EuiAccordion props buttonProps is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -703,7 +690,6 @@ exports[`EuiAccordion props buttonProps paddingSize l 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -754,7 +740,6 @@ exports[`EuiAccordion props buttonProps paddingSize m 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -805,7 +790,6 @@ exports[`EuiAccordion props buttonProps paddingSize s 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -853,7 +837,6 @@ exports[`EuiAccordion props element is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -910,7 +893,6 @@ exports[`EuiAccordion props extraAction is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -960,7 +942,6 @@ exports[`EuiAccordion props forceState closed is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -1013,7 +994,6 @@ exports[`EuiAccordion props forceState open is rendered 1`] = `
     id="17"
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -1066,7 +1046,6 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
     id="12"
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -1129,7 +1108,6 @@ exports[`EuiAccordion props isLoading is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children euiAccordion__children-isLoading emotion-euiAccordion__children-isLoading"
@@ -1188,7 +1166,6 @@ exports[`EuiAccordion props isLoadingMessage is rendered 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children euiAccordion__children-isLoading emotion-euiAccordion__children-isLoading"

--- a/src/components/accordion/accordion.spec.tsx
+++ b/src/components/accordion/accordion.spec.tsx
@@ -47,7 +47,6 @@ describe('EuiAccordion', () => {
       cy.realMount(<EuiAccordion {...sharedProps} />);
       cy.realPress('Tab');
       cy.realPress('Enter');
-      cy.realPress(['Shift', 'Tab']);
       cy.focused().invoke('attr', 'aria-expanded').should('equal', 'true');
       cy.realPress('Space');
       cy.focused().invoke('attr', 'aria-expanded').should('equal', 'false');
@@ -55,23 +54,18 @@ describe('EuiAccordion', () => {
   });
 
   describe('focus management', () => {
-    const expectChildrenIsFocused = () => {
-      cy.focused()
-        .should('have.class', 'euiAccordion__childWrapper')
-        .should('have.attr', 'tabindex', '-1');
-    };
-
-    it('focuses the accordion content when the arrow is clicked', () => {
+    it('maintains focus when the button is clicked', () => {
       cy.realMount(<EuiAccordion {...sharedProps} />);
-      cy.get('.euiAccordion__arrow').realClick();
-      expectChildrenIsFocused();
+      cy.get('.euiAccordion__button').realClick();
+      cy.focused().should('have.class', 'euiAccordion__button');
     });
 
-    it('focuses the accordion content when the button is clicked', () => {
+    it('maintains focus when the button is pressed', () => {
       cy.realMount(<EuiAccordion {...sharedProps} />);
       cy.realPress('Tab');
+      cy.focused().should('have.class', 'euiAccordion__button');
       cy.focused().contains('Click me to toggle').realPress('Enter');
-      expectChildrenIsFocused();
+      cy.focused().should('have.class', 'euiAccordion__button');
     });
 
     describe('forceState', () => {
@@ -111,23 +105,6 @@ describe('EuiAccordion', () => {
         cy.focused()
           .should('not.have.class', 'euiAccordion__childWrapper')
           .should('have.attr', 'data-test-subj', 'toggleForceState');
-      });
-
-      it('attempts to focus the accordion children when `onToggle` controls `forceState`', () => {
-        const ControlledComponent = () => {
-          const [accordionOpen, setAccordionOpen] = useState(false);
-          return (
-            <EuiAccordion
-              {...sharedProps}
-              onToggle={(open) => setAccordionOpen(open)}
-              forceState={accordionOpen ? 'open' : 'closed'}
-            />
-          );
-        };
-        cy.realMount(<ControlledComponent />);
-
-        cy.contains('Click me to toggle').realClick();
-        expectChildrenIsFocused();
       });
     });
   });

--- a/src/components/accordion/accordion.spec.tsx
+++ b/src/components/accordion/accordion.spec.tsx
@@ -10,7 +10,7 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../cypress/support" />
 
-import React, { useState } from 'react';
+import React from 'react';
 import { EuiAccordion, EuiAccordionProps } from './index';
 
 const sharedProps: EuiAccordionProps = {
@@ -53,59 +53,12 @@ describe('EuiAccordion', () => {
     });
   });
 
-  describe('focus management', () => {
-    it('maintains focus when the button is clicked', () => {
-      cy.realMount(<EuiAccordion {...sharedProps} />);
-      cy.get('.euiAccordion__button').realClick();
-      cy.focused().should('have.class', 'euiAccordion__button');
-    });
-
-    it('maintains focus when the button is pressed', () => {
-      cy.realMount(<EuiAccordion {...sharedProps} />);
-      cy.realPress('Tab');
-      cy.focused().should('have.class', 'euiAccordion__button');
-      cy.focused().contains('Click me to toggle').realPress('Enter');
-      cy.focused().should('have.class', 'euiAccordion__button');
-    });
-
-    describe('forceState', () => {
-      it('does not focus the accordion when `forceState` prevents the accordion from opening', () => {
-        cy.realMount(<EuiAccordion {...sharedProps} forceState="closed" />);
-
-        cy.contains('Click me to toggle').realClick();
-        // cy.focused() is flaky here and doesn't always return an element, so use document.activeElement instead
-        cy.then(() => {
-          expect(document.activeElement).not.to.have.class(
-            'euiAccordion__childWrapper'
-          );
-        });
-      });
-
-      it('does not focus the accordion when programmatically toggled from outside the accordion', () => {
-        const ControlledComponent = () => {
-          const [accordionOpen, setAccordionOpen] = useState(false);
-          return (
-            <>
-              <button
-                data-test-subj="toggleForceState"
-                onClick={() => setAccordionOpen(!accordionOpen)}
-              >
-                Control accordion
-              </button>
-              <EuiAccordion
-                {...sharedProps}
-                forceState={accordionOpen ? 'open' : 'closed'}
-              />
-            </>
-          );
-        };
-        cy.realMount(<ControlledComponent />);
-
-        cy.get('[data-test-subj="toggleForceState"]').realClick();
-        cy.focused()
-          .should('not.have.class', 'euiAccordion__childWrapper')
-          .should('have.attr', 'data-test-subj', 'toggleForceState');
-      });
-    });
+  // Note: we used to move focus automatically to the accordion contents on open/
+  // toggle button click, but we no longer do so after receiving a11y audit feedback
+  // that the change of context was confusing/not helpful
+  it('maintains focus on the toggle button when opened', () => {
+    cy.realMount(<EuiAccordion {...sharedProps} />);
+    cy.get('.euiAccordion__button').realClick();
+    cy.focused().should('have.class', 'euiAccordion__button');
   });
 });

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -319,18 +319,5 @@ describe('EuiAccordion', () => {
       expect(onToggleHandler).toBeCalled();
       expect(onToggleHandler).toBeCalledWith(false);
     });
-
-    it('moves focus to the content when expanded', () => {
-      const component = mount(<EuiAccordion id={getId()} />);
-      const childWrapper = component.find('div[role="group"]').getDOMNode();
-
-      expect(childWrapper).not.toBeFalsy();
-      expect(childWrapper).not.toBe(document.activeElement);
-
-      // click the button
-      component.find('button').at(0).simulate('click');
-
-      expect(childWrapper).toBe(document.activeElement);
-    });
   });
 });

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -152,16 +152,6 @@ export class EuiAccordionClass extends Component<
     if (forceState) {
       const nextState = !this.isOpen;
       this.props.onToggle?.(nextState);
-
-      // If the accordion should theoretically be opened, wait a tick (allows
-      // consumer state to update) and attempt to focus the child content.
-      // NOTE: Even if the accordion does not actually open, this is fine -
-      // the `inert` property on the hidden children will prevent focus
-      if (nextState === true) {
-        requestAnimationFrame(() => {
-          this.accordionChildrenEl?.focus();
-        });
-      }
     } else {
       this.setState(
         (prevState) => ({
@@ -169,21 +159,9 @@ export class EuiAccordionClass extends Component<
         }),
         () => {
           this.props.onToggle?.(this.state.isOpen);
-
-          // If the accordion is open, programmatically move focus
-          // from the accordion trigger to the child content
-          if (this.state.isOpen) {
-            this.accordionChildrenEl?.focus();
-          }
         }
       );
     }
-  };
-
-  // Used to focus the accordion children on user trigger click only (vs controlled/programmatic open)
-  accordionChildrenEl: HTMLDivElement | null = null;
-  accordionChildrenRef = (node: HTMLDivElement | null) => {
-    this.accordionChildrenEl = node;
   };
 
   generatedId = htmlIdGenerator()();
@@ -256,7 +234,6 @@ export class EuiAccordionClass extends Component<
           isLoading={isLoading}
           isLoadingMessage={isLoadingMessage}
           isOpen={this.isOpen}
-          accordionChildrenRef={this.accordionChildrenRef}
         >
           {children}
         </EuiAccordionChildren>

--- a/src/components/accordion/accordion_children/accordion_children.tsx
+++ b/src/components/accordion/accordion_children/accordion_children.tsx
@@ -9,7 +9,6 @@
 import React, {
   FunctionComponent,
   HTMLAttributes,
-  Ref,
   useCallback,
   useMemo,
   useState,
@@ -32,14 +31,12 @@ type _EuiAccordionChildrenProps = HTMLAttributes<HTMLDivElement> &
     'role' | 'children' | 'paddingSize' | 'isLoading' | 'isLoadingMessage'
   > & {
     isOpen: boolean;
-    accordionChildrenRef: Ref<HTMLDivElement>;
   };
 export const EuiAccordionChildren: FunctionComponent<
   _EuiAccordionChildrenProps
 > = ({
   role,
   children,
-  accordionChildrenRef,
   paddingSize,
   isLoading,
   isLoadingMessage,
@@ -90,9 +87,7 @@ export const EuiAccordionChildren: FunctionComponent<
       className="euiAccordion__childWrapper"
       css={wrapperCssStyles}
       style={heightInlineStyle}
-      ref={accordionChildrenRef}
       role={role}
-      tabIndex={-1}
       // @ts-expect-error - inert property not yet available in React TS defs. TODO: Remove this once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822 is merged
       inert={!isOpen ? '' : undefined} // Can't pass a boolean currently, Jest throws errors
     >

--- a/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
+++ b/src/components/collapsible_nav/collapsible_nav_group/__snapshots__/collapsible_nav_group.test.tsx.snap
@@ -256,7 +256,6 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true accepts accordion pro
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -321,7 +320,6 @@ exports[`EuiCollapsibleNavGroup when isCollapsible is true will render an accord
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_accordion.test.tsx.snap
@@ -47,7 +47,6 @@ exports[`EuiCollapsibleNavAccordion renders as a sub item 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"
@@ -119,7 +118,6 @@ exports[`EuiCollapsibleNavAccordion renders as a top level item 1`] = `
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -75,7 +75,6 @@ exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] 
     inert=""
     role="group"
     style="block-size: 0;"
-    tabindex="-1"
   >
     <div
       class="euiAccordion__children emotion-euiAccordion__children"


### PR DESCRIPTION
## Summary

This PR updates the `EuiAccordion` component to **not** move focus to the child component when the expand/collapse button is clicked. This came about from an accessibility audit that moving focus in this instance is in violation of [SC 3.2.2: On Input (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/on-input.html).

Specifically, moving focus to the child container caused a [change of context](https://www.w3.org/WAI/WCAG22/Understanding/on-input.html#dfn-changes-of-context) by resetting focus.

I don't **believe** this is a breaking change, but would ask reviewers to speak up early and loudly if they feel it might be a breaking change.

## QA

Remove or strikethrough items that do not apply to your PR.

### Manual QA
I checked in all four browsers. I reviewed the `EuiAccordion` and `EuiCollapsibleNavGroup` in the local staging site, and the beta collapsible nav in Storybook. I reviewed for axe-core violations, keyboard navigation, and screen reader usability with VoiceOver in Safari and Firefox. Reviewed NVDA (Firefox, Chrome) and JAWS (Chrome). All had consistent behavior and announcement.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
