### PR TITLE
[EuiDataGrid] Fix column header move left focus bug

### DIFF
--- a/changelogs/upcoming/7698.md
+++ b/changelogs/upcoming/7698.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a focus bug with `EuiDataGrid`s with `leadingControlColumns` when moving columns to the left/right

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -27,6 +27,7 @@ describe('getColumnActions', () => {
   const testArgs = {
     column: { id: 'B' },
     columns: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+    columnFocusIndex: 1,
     schema: {},
     schemaDetectors,
     setVisibleColumns,
@@ -199,6 +200,25 @@ describe('getColumnActions', () => {
         // Quick note about the -1 row index above: `-1` is the index we set for our
         // sticky header row, and these column actions can only ever be called by an
         // interactive header cell, so we can safely and statically set the -1 index
+      });
+    });
+
+    describe('focus behavior with leading control columns', () => {
+      const items = getColumnActions({
+        ...testArgs,
+        columnFocusIndex: testArgs.columnFocusIndex + 2, // "Add" 2 leading control columns
+      });
+      const moveLeft = items[1];
+      const moveRight = items[2];
+
+      it('correctly calls the focused cell x index accounting for leading control columns', () => {
+        callActionOnClick(moveLeft);
+        expect(switchColumnPos).toHaveBeenCalledWith('B', 'A');
+        expect(setFocusedCell).toHaveBeenLastCalledWith([2, -1]);
+
+        callActionOnClick(moveRight);
+        expect(switchColumnPos).toHaveBeenCalledWith('B', 'C');
+        expect(setFocusedCell).toHaveBeenLastCalledWith([4, -1]);
       });
     });
 

--- a/src/components/datagrid/body/header/column_actions.test.tsx
+++ b/src/components/datagrid/body/header/column_actions.test.tsx
@@ -151,6 +151,8 @@ describe('getColumnActions', () => {
   });
 
   describe('column reordering', () => {
+    jest.useFakeTimers();
+
     describe('default enabled behavior', () => {
       const items = getColumnActions(testArgs);
       const moveLeft = items[1];
@@ -190,10 +192,12 @@ describe('getColumnActions', () => {
 
       it('calls switchColumnPos and updates the focused cell column index on click', () => {
         callActionOnClick(moveLeft);
+        jest.runAllTimers();
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'A');
         expect(setFocusedCell).toHaveBeenLastCalledWith([0, -1]);
 
         callActionOnClick(moveRight);
+        jest.runAllTimers();
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'C');
         expect(setFocusedCell).toHaveBeenLastCalledWith([2, -1]);
 
@@ -213,10 +217,12 @@ describe('getColumnActions', () => {
 
       it('correctly calls the focused cell x index accounting for leading control columns', () => {
         callActionOnClick(moveLeft);
+        jest.runAllTimers();
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'A');
         expect(setFocusedCell).toHaveBeenLastCalledWith([2, -1]);
 
         callActionOnClick(moveRight);
+        jest.runAllTimers();
         expect(switchColumnPos).toHaveBeenCalledWith('B', 'C');
         expect(setFocusedCell).toHaveBeenLastCalledWith([4, -1]);
       });

--- a/src/components/datagrid/body/header/column_actions.tsx
+++ b/src/components/datagrid/body/header/column_actions.tsx
@@ -34,6 +34,7 @@ interface GetColumnActions {
   sorting: EuiDataGridSorting | undefined;
   switchColumnPos: (colFromId: string, colToId: string) => void;
   setFocusedCell: DataGridFocusContextShape['setFocusedCell'];
+  columnFocusIndex: number; // Index including leadingControlColumns
 }
 
 export const getColumnActions = ({
@@ -47,6 +48,7 @@ export const getColumnActions = ({
   sorting,
   switchColumnPos,
   setFocusedCell,
+  columnFocusIndex,
 }: GetColumnActions): EuiListGroupItemProps[] => {
   if (column.actions === false) {
     return [];
@@ -70,6 +72,7 @@ export const getColumnActions = ({
       columns,
       switchColumnPos,
       setFocusedCell,
+      columnFocusIndex,
     }),
     ...(column.actions?.additional || []),
   ];
@@ -136,7 +139,11 @@ export const getHideColumnAction = ({
  */
 type MoveColumnActions = Pick<
   GetColumnActions,
-  'column' | 'columns' | 'switchColumnPos' | 'setFocusedCell'
+  | 'column'
+  | 'columns'
+  | 'switchColumnPos'
+  | 'setFocusedCell'
+  | 'columnFocusIndex'
 >;
 
 const getMoveColumnActions = ({
@@ -144,6 +151,7 @@ const getMoveColumnActions = ({
   columns,
   switchColumnPos,
   setFocusedCell,
+  columnFocusIndex,
 }: MoveColumnActions): EuiListGroupItemProps[] => {
   const items = [];
 
@@ -154,7 +162,7 @@ const getMoveColumnActions = ({
       const targetCol = columns[colIdx - 1];
       if (targetCol) {
         switchColumnPos(column.id, targetCol.id);
-        setFocusedCell([colIdx - 1, -1]);
+        setFocusedCell([columnFocusIndex - 1, -1]);
       }
     };
     const action = {
@@ -174,7 +182,7 @@ const getMoveColumnActions = ({
       const targetCol = columns[colIdx + 1];
       if (targetCol) {
         switchColumnPos(column.id, targetCol.id);
-        setFocusedCell([colIdx + 1, -1]);
+        setFocusedCell([columnFocusIndex + 1, -1]);
       }
     };
     const action = {

--- a/src/components/datagrid/body/header/column_actions.tsx
+++ b/src/components/datagrid/body/header/column_actions.tsx
@@ -157,12 +157,21 @@ const getMoveColumnActions = ({
 
   const colIdx = columns.findIndex((col) => col.id === column.id);
 
+  const moveFocus = (direction: 'left' | 'right') => {
+    const newIndex = direction === 'left' ? -1 : 1;
+    // Wait a beat to move focus, otherwise the EuiPopover's EuiFocusTrap's
+    // returnFocus logic sometimes steals it (depending on rerenders)
+    setTimeout(() => {
+      setFocusedCell([columnFocusIndex + newIndex, -1]); // -1 is the static y-index of the header
+    });
+  };
+
   if (isColumnActionEnabled('showMoveLeft', column.actions)) {
     const onClickMoveLeft = () => {
       const targetCol = columns[colIdx - 1];
       if (targetCol) {
         switchColumnPos(column.id, targetCol.id);
-        setFocusedCell([columnFocusIndex - 1, -1]);
+        moveFocus('left');
       }
     };
     const action = {
@@ -182,7 +191,7 @@ const getMoveColumnActions = ({
       const targetCol = columns[colIdx + 1];
       if (targetCol) {
         switchColumnPos(column.id, targetCol.id);
-        setFocusedCell([columnFocusIndex + 1, -1]);
+        moveFocus('right');
       }
     };
     const action = {

--- a/src/components/datagrid/body/header/data_grid_header_cell.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell.tsx
@@ -87,6 +87,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
           sorting,
           switchColumnPos,
           setFocusedCell,
+          columnFocusIndex: index,
         });
       }, [
         column,
@@ -99,6 +100,7 @@ export const EuiDataGridHeaderCell: FunctionComponent<EuiDataGridHeaderCellProps
         sorting,
         switchColumnPos,
         setFocusedCell,
+        index,
       ]);
 
       const showColumnActions = columnActions && columnActions.length > 0;


### PR DESCRIPTION
## Summary

Should resolve both https://github.com/elastic/kibana/issues/177527 and https://github.com/elastic/kibana/pull/180064

I apparently attempted to resolve this in https://github.com/elastic/eui/pull/5530 but past-me didn't account for two things:

1. Leading control column count
2. The popover's focus trap's `returnFocus` logic interfering with `setFocusedCell`
    - I actually assume this is [why our docs work](https://eui.elastic.co/v93.6.0/#/tabular-content/data-grid-schema-columns#control-columns) and Kibana doesn't(??)

| Before | After |
|--------|--------|
| ![before](https://github.com/elastic/eui/assets/549407/781ca8f0-aefd-4cff-aff6-57287d5bd58c) | ![after](https://github.com/elastic/eui/assets/549407/b4ef47de-54fb-462b-82d6-2e3900963465) | 

## QA

Since I can't seem to repro this at all in EUI, it has to be QA'd in Kibana 🫠

- Check out this PR
- `yarn build-pack`, wait for `.tgz` output
- In Kibana, point at the built TGZ ([see wiki for step by step how to](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#testing-local-eui-in-local-kibana))
- Follow the repro steps in https://github.com/elastic/kibana/issues/177527#issuecomment-2049197563 (don't forget to change the timestamp)
- [x] Go to [Security > Findings](http://localhost:5601/app/security/cloud_security_posture/findings/configurations?sourcerer=(default:(id:security-solution-default,selectedPatterns:!(%27logs-*%27)))&timeline=(activeTab:query,graphEventId:%27%27,isOpen:!f)) in Kibana and confirm that focus when columns moving left and right now works as expected

**Regression testing**
- [x] https://eui.elastic.co/pr_7698/#/tabular-content/data-grid-schema-columns#control-columns - move left/right should work as before with no regressions
- [x] https://eui.elastic.co/pr_7698/#/tabular-content/data-grid - move left/right should work as before with no regressions

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A