### PR TITLE
[EuiStepsHorizontal] Added `aria-disabled` attribute when status is "disabled"

### DIFF
--- a/changelogs/upcoming/7699.md
+++ b/changelogs/upcoming/7699.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Added `aria-disabled` attribute to `EuiHorizontalSteps` when status is "disabled"

--- a/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`EuiStepHorizontal is rendered 1`] = `
 <button
+  aria-disabled="false"
   aria-label="aria-label"
   class="euiStepHorizontal testClass1 testClass2 emotion-euiStepHorizontal-enabled-euiTestCss"
   data-step-status="incomplete"
@@ -31,6 +32,7 @@ exports[`EuiStepHorizontal is rendered 1`] = `
 
 exports[`EuiStepHorizontal props size m is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1 is incomplete"
@@ -58,6 +60,7 @@ exports[`EuiStepHorizontal props size m is rendered 1`] = `
 
 exports[`EuiStepHorizontal props size s is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1 is incomplete"
@@ -85,6 +88,7 @@ exports[`EuiStepHorizontal props size s is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status complete is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="complete"
   title="Step 1 is complete"
@@ -107,6 +111,7 @@ exports[`EuiStepHorizontal props status complete is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status current is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="current"
   title="Current step is 1"
@@ -134,6 +139,7 @@ exports[`EuiStepHorizontal props status current is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status danger is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="danger"
   title="Step 1 has errors"
@@ -156,6 +162,7 @@ exports[`EuiStepHorizontal props status danger is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status disabled is rendered 1`] = `
 <button
+  aria-disabled="true"
   class="euiStepHorizontal emotion-euiStepHorizontal-disabled"
   data-step-status="disabled"
   title="Step 1 is disabled"
@@ -183,6 +190,7 @@ exports[`EuiStepHorizontal props status disabled is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status disabled overrides the passed status 1`] = `
 <button
+  aria-disabled="true"
   class="euiStepHorizontal emotion-euiStepHorizontal-disabled"
   data-step-status="disabled"
   disabled=""
@@ -211,6 +219,7 @@ exports[`EuiStepHorizontal props status disabled overrides the passed status 1`]
 
 exports[`EuiStepHorizontal props status incomplete is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1 is incomplete"
@@ -238,6 +247,7 @@ exports[`EuiStepHorizontal props status incomplete is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status loading is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="loading"
   title="Step 1 is loading"
@@ -264,6 +274,7 @@ exports[`EuiStepHorizontal props status loading is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status warning is rendered 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="warning"
   title="Step 1 has warnings"
@@ -286,6 +297,7 @@ exports[`EuiStepHorizontal props status warning is rendered 1`] = `
 
 exports[`EuiStepHorizontal props step 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 5 is incomplete"
@@ -313,6 +325,7 @@ exports[`EuiStepHorizontal props step 1`] = `
 
 exports[`EuiStepHorizontal props title 1`] = `
 <button
+  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1: First step is incomplete"

--- a/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/step_horizontal.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`EuiStepHorizontal is rendered 1`] = `
 <button
-  aria-disabled="false"
   aria-label="aria-label"
   class="euiStepHorizontal testClass1 testClass2 emotion-euiStepHorizontal-enabled-euiTestCss"
   data-step-status="incomplete"
@@ -32,7 +31,6 @@ exports[`EuiStepHorizontal is rendered 1`] = `
 
 exports[`EuiStepHorizontal props size m is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1 is incomplete"
@@ -60,7 +58,6 @@ exports[`EuiStepHorizontal props size m is rendered 1`] = `
 
 exports[`EuiStepHorizontal props size s is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1 is incomplete"
@@ -88,7 +85,6 @@ exports[`EuiStepHorizontal props size s is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status complete is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="complete"
   title="Step 1 is complete"
@@ -111,7 +107,6 @@ exports[`EuiStepHorizontal props status complete is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status current is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="current"
   title="Current step is 1"
@@ -139,7 +134,6 @@ exports[`EuiStepHorizontal props status current is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status danger is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="danger"
   title="Step 1 has errors"
@@ -219,7 +213,6 @@ exports[`EuiStepHorizontal props status disabled overrides the passed status 1`]
 
 exports[`EuiStepHorizontal props status incomplete is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1 is incomplete"
@@ -247,7 +240,6 @@ exports[`EuiStepHorizontal props status incomplete is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status loading is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="loading"
   title="Step 1 is loading"
@@ -274,7 +266,6 @@ exports[`EuiStepHorizontal props status loading is rendered 1`] = `
 
 exports[`EuiStepHorizontal props status warning is rendered 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="warning"
   title="Step 1 has warnings"
@@ -297,7 +288,6 @@ exports[`EuiStepHorizontal props status warning is rendered 1`] = `
 
 exports[`EuiStepHorizontal props step 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 5 is incomplete"
@@ -325,7 +315,6 @@ exports[`EuiStepHorizontal props step 1`] = `
 
 exports[`EuiStepHorizontal props title 1`] = `
 <button
-  aria-disabled="false"
   class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
   data-step-status="incomplete"
   title="Step 1: First step is incomplete"

--- a/src/components/steps/__snapshots__/steps_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/steps_horizontal.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
+      aria-disabled="false"
       class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
       data-step-status="complete"
       title="Step 1: Completed Step 1 is complete"
@@ -36,6 +37,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
+      aria-disabled="false"
       class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
       data-step-status="current"
       title="Current step 2: Selected Step 2"
@@ -66,6 +68,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
+      aria-disabled="false"
       class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
       data-step-status="incomplete"
       title="Step 3: Incomplete Step 3 is incomplete"
@@ -96,6 +99,7 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
+      aria-disabled="true"
       class="euiStepHorizontal emotion-euiStepHorizontal-disabled"
       data-step-status="disabled"
       title="Step 4: Disabled Step 4 is disabled"

--- a/src/components/steps/__snapshots__/steps_horizontal.test.tsx.snap
+++ b/src/components/steps/__snapshots__/steps_horizontal.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
-      aria-disabled="false"
       class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
       data-step-status="complete"
       title="Step 1: Completed Step 1 is complete"
@@ -37,7 +36,6 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
-      aria-disabled="false"
       class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
       data-step-status="current"
       title="Current step 2: Selected Step 2"
@@ -68,7 +66,6 @@ exports[`EuiStepsHorizontal is rendered 1`] = `
     class="euiStepsHorizontal__item emotion-euiStepsHorizontal__item"
   >
     <button
-      aria-disabled="false"
       class="euiStepHorizontal emotion-euiStepHorizontal-enabled"
       data-step-status="incomplete"
       title="Step 3: Incomplete Step 3 is incomplete"

--- a/src/components/steps/step_horizontal.tsx
+++ b/src/components/steps/step_horizontal.tsx
@@ -97,6 +97,7 @@ export const EuiStepHorizontal: FunctionComponent<EuiStepHorizontalProps> = ({
     loading: useI18nLoadingStep({ number: step, title }),
   };
   const titleAttr = titleAttrsMap[status || 'step'];
+  const buttonAriaDisabled = status === 'disabled';
 
   const onStepClick = (
     event: ReactMouseEvent<HTMLButtonElement, MouseEvent>
@@ -106,6 +107,7 @@ export const EuiStepHorizontal: FunctionComponent<EuiStepHorizontalProps> = ({
 
   return (
     <button
+      aria-disabled={buttonAriaDisabled}
       className={classes}
       title={titleAttr}
       onClick={onStepClick}

--- a/src/components/steps/step_horizontal.tsx
+++ b/src/components/steps/step_horizontal.tsx
@@ -97,7 +97,6 @@ export const EuiStepHorizontal: FunctionComponent<EuiStepHorizontalProps> = ({
     loading: useI18nLoadingStep({ number: step, title }),
   };
   const titleAttr = titleAttrsMap[status || 'step'];
-  const buttonAriaDisabled = status === 'disabled';
 
   const onStepClick = (
     event: ReactMouseEvent<HTMLButtonElement, MouseEvent>
@@ -107,7 +106,7 @@ export const EuiStepHorizontal: FunctionComponent<EuiStepHorizontalProps> = ({
 
   return (
     <button
-      aria-disabled={buttonAriaDisabled}
+      aria-disabled={status === 'disabled' ? true : undefined}
       className={classes}
       title={titleAttr}
       onClick={onStepClick}


### PR DESCRIPTION
## Summary

PR closes #7686. This pull request adds an `aria-hidden` boolean attribute to the `EuiHorizontalStep` component. It allows us to better inform screen reader users when a button is temporarily unavailable while keeping the button in the tab order. Screen reader users get a more informative message, sighted users get the same UX as in production now.

I tested locally with axe browser plugin, keyboard navigation, and Safari + VO screen reader combination. Will test in NVDA and JAWS before merging.

---

<img width="709" alt="Screenshot 2024-04-18 at 4 10 46 PM" src="https://github.com/elastic/eui/assets/934879/e29f2131-f8af-4e00-ba9f-fda916649a28">


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
