### PR TITLE
[EuiDataGrid][CRA] Fix header cell focus when moving columns left/right

### DIFF
--- a/changelogs/upcoming/7698.md
+++ b/changelogs/upcoming/7698.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed a focus bug with `EuiDataGrid`s with `leadingControlColumns` when moving columns to the left/right
+- Fixed a focus bug with `EuiDataGrid`s with `leadingControlColumns` when moving columns to the left/right ([#7701](https://github.com/elastic/eui/pull/7701))

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -49,20 +49,26 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<
   }, [index, setFocusedCell]);
 
   const [isFocused, setIsFocused] = useState(false);
-  useEffect(() => {
-    onFocusUpdate([index, -1], (isFocused: boolean) => {
-      setIsFocused(isFocused);
-    });
-  }, [index, onFocusUpdate]);
 
-  useEffect(() => {
+  const updateFocus = (isFocused: Boolean, headerEl: HTMLDivElement | null) => {
     if (isFocused && headerEl) {
       // Only focus the cell if not already focused on something in the cell
       if (!headerEl.contains(document.activeElement)) {
         headerEl.focus();
       }
     }
-  }, [isFocused, headerEl]);
+  }
+
+  useEffect(() => {
+    onFocusUpdate([index, -1], (isFocused: boolean) => {
+      setIsFocused(isFocused);
+      updateFocus(isFocused, headerEl);
+    });
+  }, [index, onFocusUpdate]);
+
+  useEffect(() => {
+    updateFocus(isFocused, headerEl);
+  }, [headerEl]);
 
   // For cell headers with actions, auto-focus into the button instead of the cell wrapper div
   // The button text is significantly more useful to screen readers (e.g. contains sort order & hints)

--- a/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
+++ b/src/components/datagrid/body/header/data_grid_header_cell_wrapper.tsx
@@ -49,26 +49,17 @@ export const EuiDataGridHeaderCellWrapper: FunctionComponent<
   }, [index, setFocusedCell]);
 
   const [isFocused, setIsFocused] = useState(false);
-
-  const updateFocus = (isFocused: Boolean, headerEl: HTMLDivElement | null) => {
-    if (isFocused && headerEl) {
-      // Only focus the cell if not already focused on something in the cell
-      if (!headerEl.contains(document.activeElement)) {
-        headerEl.focus();
-      }
-    }
-  }
-
   useEffect(() => {
     onFocusUpdate([index, -1], (isFocused: boolean) => {
       setIsFocused(isFocused);
-      updateFocus(isFocused, headerEl);
+      if (isFocused && headerEl) {
+        // Only focus the cell if not already focused on something in the cell
+        if (!headerEl.contains(document.activeElement)) {
+          headerEl.focus();
+        }
+      }
     });
-  }, [index, onFocusUpdate]);
-
-  useEffect(() => {
-    updateFocus(isFocused, headerEl);
-  }, [headerEl]);
+  }, [index, onFocusUpdate, headerEl]);
 
   // For cell headers with actions, auto-focus into the button instead of the cell wrapper div
   // The button text is significantly more useful to screen readers (e.g. contains sort order & hints)


### PR DESCRIPTION
(Note: #7698 fixed the issue for Kibana, but the underlying issue still persists for CRA and likely CodeSandbox - potentially due to various prod vs dev bundled race conditions)

| Before | After |
|--------|--------|
| ![before](https://github.com/elastic/eui/assets/549407/c0e11b13-b9bd-458f-901c-ad93ad1951d3) | ![after](https://github.com/elastic/eui/assets/549407/999a02bb-9d7d-48b7-8118-eb0f5d3535a5) |

## Problem

We noticed that focus was not updating visually after moving columns left or right in certain environments in this PR: https://github.com/elastic/eui/pull/7698.

If you initiate a "Move left" from column 4 -- you're essentially swapping columns. Column 4 becomes moves to position 3 and column 3 moves to position 4.

When you click on the header cell to initiate that action, the column 4 header cell gets focus. After column 4 moves to position 3, we make a call to the focus service to let it know that the column 3 header cell should now have focus.

Subsequently, that service makes a call to the column 3 header to set its `isFocused` property to true, to reflect that it's now focused. If that cell was not already focused, updating `isFocused` will also trigger a call to the underlying element's `.focus()` to focus it.

In this case, this particular column's `isFocused` property **is already** set to true, because it just moved from position 4 to 3. So when its `isFocused` property is updated, it detects that it already has focus, so it doesn't make a call to `.focus()` to focus it.

However, **something** happens in between there that forces the focus away in the browser (likely the focus trap associated with the action's menu in the header cell). So the header cell's `isFocused` prop is essentially out of sync with the browser. The cell thinks that it's already focused, even though it's not, so it simply loses focus.

## Solution

This PR resolves that issue by calling `.focus()` anytime `setFocus` is set, anticipating that there may be cases when the browser gets out of sync with this property.

## QA

- (In EUI) `yarn build-pack` 
- (in CRA) `npx create-react-app my-app`
- Follow the [getting started guide](https://eui.elastic.co/#/guidelines/getting-started) for installing EUI (but point to to the built `tgz` file instead of `@elastic/eui`
- Copy the [first basic datagrid example](https://eui.elastic.co/#/tabular-content/data-grid-schema-columns) here (any examples where columns can be moved left/right also suffice) into the app
- [x] `yarn start` and confirm that clicking left/right in the CRA works as expected, instead of losing focus

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A, bugfix
- Code quality checklist - N/A, appears to only affect production builds
- Release checklist - merging existing changelog
- Designer checklist - N/A