### PR TITLE
[EuiSearchBar] Allow `@` special character in query string searches

### DIFF
--- a/changelogs/upcoming/7702.md
+++ b/changelogs/upcoming/7702.md
@@ -1,0 +1,1 @@
+- Updated `EuiSearchBar` to allow the `@` special character in query string searches

--- a/src/components/search_bar/query/default_syntax.test.ts
+++ b/src/components/search_bar/query/default_syntax.test.ts
@@ -871,12 +871,12 @@ describe('defaultSyntax', () => {
     });
 
     test('special characters', () => {
-      const ast = defaultSyntax.parse('*_-:');
+      const ast = defaultSyntax.parse('*_-:@');
       const clauses = ast.getTermClauses();
       expect(clauses).toEqual([
         {
           type: 'term',
-          value: '*_-:',
+          value: '*_-:@',
           match: 'must',
         },
       ]);

--- a/src/components/search_bar/query/default_syntax.ts
+++ b/src/components/search_bar/query/default_syntax.ts
@@ -169,7 +169,7 @@ word
 
 wordChar
   = alnum
-  / [-_*:/]
+  / [-_*:/@]
   / escapedChar
   / extendedGlyph
 


### PR DESCRIPTION
## Summary

@iverase's team needs the ability to search for more special characters in `EuiInMemoryTable`'s search bar (uses `EuiSearchBar` under the hood). They primarily need the special characters `*` (already supported) and `@` (in this PR).

(See also https://github.com/elastic/eui/issues/7160#issuecomment-1724175485)

## QA

- Go to https://eui.elastic.co/pr_7702/#/forms/search-bar
- Confirm that typing `test@` (and enter) into the search bar does not generate an error
- Go to https://eui.elastic.co/pr_7702/#/tabular-content/in-memory-tables#in-memory-table-with-search
- Confirm typing `test@` (and enter) into the search bar does not generate an invalid warning icon (should show no results instead)

### General checklist

- Browser QA - N/A, not a frontend/UI change
- Docs site QA - N/A, not documented
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A