### PR TITLE
[buildkite] Set up pipeline that will eventually automatically delete old PR staging directories

### DIFF
--- a/.buildkite/pipelines/pipeline_prune_staging_docs.yml
+++ b/.buildkite/pipelines/pipeline_prune_staging_docs.yml
@@ -1,0 +1,6 @@
+## 🏠/.buildkite/pipelines/pipeline_prune_staging_docs.yml
+
+steps:
+  - agents:
+      provider: "gcp"
+    command: .buildkite/scripts/pipelines/pipeline_prune_staging_docs.sh

--- a/.buildkite/scripts/pipelines/pipeline_prune_staging_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_prune_staging_docs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euo pipefail
+set +x
+
+# Expected env variables:
+# * GPROJECT - GCE project name, e.g. elastic-bekitzur
+# * GCE_ACCOUNT - credentials for the google service account (JSON blob)
+if [[ -z "${GCE_ACCOUNT}" ]]; then
+  echo ":fire: GCP credentials not set." 1>&2
+  exit 1
+fi
+if [[ -z "${GPROJECT}" ]]; then
+    echo "GPROJECT is not set, e.g. 'GPROJECT=elastic-bekitzur'"
+    exit 1
+fi
+
+# Login to the cloud with the service account
+gcloud auth activate-service-account --key-file <(echo "${GCE_ACCOUNT}")
+unset GCE_ACCOUNT
+
+EUI_DOCS_PROJECT=eui-docs-live
+BUCKET=${GPROJECT}-${EUI_DOCS_PROJECT}
+
+# https://cloud.google.com/storage/docs/gsutil/commands/ls
+ls_options=(
+  -d # only list directories
+  -l # Print additional details about the subdir
+)
+echo "Listing all PR staging links"
+gsutil ls "${ls_options[@]}" "gs://${BUCKET}/pr_*" | sort -k 2 #
+
+# https://cloud.google.com/storage/docs/gsutil/commands/rm
+rm_options=(
+  -r # recursive, delete everything inside subdir
+  -m # enables multi-threading for large numbers of objects
+)
+# gsutil rm "${rm_options[@]}" "gs://${BUCKET}/pr_TODO"


### PR DESCRIPTION
## Summary

From my understanding of @1Copenut and @tkajtoch's previous work this needs to be in EUI main first before I can start testing it.

My goal with this PR is:

1. To create a pipeline that I can run manually from Buildkite's web UI
2. To ensure that the `gcloud auth` step works as expected
3. To see the output of `gsutil ls` (so I can start building on it more and filtering subdirs based on creation date)

## QA

N/A, infra only