### PR TITLE
[EuiSuperDatePicker] Fix absolute tab for small mobile screens

### DIFF
--- a/changelogs/upcoming/7708.md
+++ b/changelogs/upcoming/7708.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a visual bug with `EuiSuperDatePicker`'s absolute tab on small mobile screens

--- a/src/components/date_picker/super_date_picker/date_popover/_date_popover_content.scss
+++ b/src/components/date_picker/super_date_picker/date_popover/_date_popover_content.scss
@@ -2,6 +2,10 @@
 .euiDatePopoverContent .react-datepicker {
   width: $euiFormMaxWidth;
   max-width: 100%;
+
+  @include euiBreakpoint('xs') {
+    width: $euiDatePickerCalendarWidth;
+  }
 }
 
 .euiDatePopoverContent__padded {
@@ -10,11 +14,4 @@
 
 .euiDatePopoverContent__padded--large {
   padding: $euiSize;
-}
-
-@include euiBreakpoint('xs') {
-  .euiDatePopoverContent {
-    // Small screens drop the time selector
-    width: $euiDatePickerCalendarWidth;
-  }
 }


### PR DESCRIPTION
## Summary

closes #7706

| Before | After |
|--------|--------|
| <img width="439" alt="" src="https://github.com/elastic/eui/assets/549407/e823c9f0-bfc1-4ab8-972c-156643a763cf"> | <img width="417" alt="" src="https://github.com/elastic/eui/assets/549407/5e50e097-343d-42e4-a82d-82cea5d515eb"> | 

## QA

- Go to https://eui.elastic.co/pr_7708/#/templates/super-date-picker
- Make your browser window smaller than 574px
- Scroll down to the first super date picker, click the date, then click the `Absolute` tab
- [x] Confirm the calendar does not break out of the popover

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist - N/A, CSS-only change
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A, bugfix