### PR TITLE
feat: Add `optionMatcher` prop to `EuiSelectable` and `EuiComboBox` components

### DIFF
--- a/changelogs/upcoming/7709.md
+++ b/changelogs/upcoming/7709.md
@@ -1,0 +1,1 @@
+- Added a new, optional `optionMatcher` prop to `EuiSelectable` and `EuiComboBox` allowing passing a custom option matcher function to these components and controlling option filtering for given search string

--- a/src-docs/src/views/combo_box/combo_box_example.js
+++ b/src-docs/src/views/combo_box/combo_box_example.js
@@ -258,6 +258,17 @@ const labelledbySnippet = `<EuiComboBox
   isClearable={true}
 />`;
 
+import OptionMatcher from './option_matcher';
+const optionMatcherSource = require('!!raw-loader!./option_matcher');
+const optionMatcherSnippet = `<EuiComboBox
+  aria-label="Accessible screen reader label"
+  placeholder="Select or create options"
+  options={options}
+  onChange={onChange}
+  onCreateOption={onCreateOption}
+  optionMatcher={optionMatcher}
+/>`;
+
 export const ComboBoxExample = {
   title: 'Combo box',
   intro: (
@@ -676,6 +687,35 @@ export const ComboBoxExample = {
       props: { EuiComboBox, EuiComboBoxOptionOption },
       snippet: startingWithSnippet,
       demo: <StartingWith />,
+    },
+    {
+      title: 'Custom option matcher',
+      text: (
+        <>
+          <p>
+            When searching for options, <EuiCode>EuiComboBox</EuiCode> uses a
+            partial equality string matcher by default, displaying all options
+            whose labels include the searched string and taking{' '}
+            <EuiCode>isCaseSensitive</EuiCode> prop value into account.
+          </p>
+          <p>
+            In rare cases, you may want to customize this behavior. You can do
+            so by passing a custom option matcher function to the{' '}
+            <EuiCode>optionMatcher</EuiCode> prop. The function must be of type{' '}
+            <EuiCode>EuiComboBoxOptionMatcher</EuiCode> and return
+            <EuiCode>true</EuiCode> for options that should be visible for given
+            search string.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: optionMatcherSource,
+        },
+      ],
+      snippet: optionMatcherSnippet,
+      demo: <OptionMatcher />,
     },
     {
       title: 'Duplicate labels',

--- a/src-docs/src/views/combo_box/option_matcher.tsx
+++ b/src-docs/src/views/combo_box/option_matcher.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from 'react';
+
+import {
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiComboBoxOptionMatcher,
+} from '../../../../src';
+
+const options: EuiComboBoxOptionOption[] = [
+  {
+    label: 'Titan',
+    'data-test-subj': 'titanOption',
+  },
+  {
+    label: 'Enceladus',
+  },
+  {
+    label: 'Mimas',
+  },
+  {
+    label: 'Dione',
+  },
+  {
+    label: 'Iapetus',
+  },
+  {
+    label: 'Phoebe',
+  },
+  {
+    label: 'Rhea',
+  },
+  {
+    label:
+      "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
+  },
+  {
+    label: 'Tethys',
+  },
+  {
+    label: 'Hyperion',
+  },
+];
+
+export default () => {
+  const [selectedOptions, setSelected] = useState<EuiComboBoxOptionOption[]>(
+    []
+  );
+  const onChange = (selectedOptions: EuiComboBoxOptionOption[]) => {
+    setSelected(selectedOptions);
+  };
+
+  const startsWithMatcher = useCallback<EuiComboBoxOptionMatcher<unknown>>(
+    ({ option, searchValue }) => {
+      return option.label.startsWith(searchValue);
+    },
+    []
+  );
+
+  return (
+    <EuiComboBox
+      placeholder="Select options"
+      options={options}
+      selectedOptions={selectedOptions}
+      onChange={onChange}
+      isClearable={true}
+      optionMatcher={startsWithMatcher}
+    />
+  );
+};

--- a/src-docs/src/views/selectable/selectable_example.js
+++ b/src-docs/src/views/selectable/selectable_example.js
@@ -45,6 +45,9 @@ const truncationSource = require('!!raw-loader!./selectable_truncation');
 import SelectableCustomRender from './selectable_custom_render';
 const selectableCustomRenderSource = require('!!raw-loader!./selectable_custom_render');
 
+import SelectableOptionMatcher from './selectable_option_matcher';
+const selectableOptionMatcherSource = require('!!raw-loader!./selectable_option_matcher');
+
 const props = {
   EuiSelectable,
   EuiSelectableOptionProps,
@@ -525,6 +528,40 @@ export const SelectableExample = {
   {list => list}
 </EuiSelectable>`,
       props,
+    },
+    {
+      title: 'Custom option matcher',
+      text: (
+        <>
+          <p>
+            When searching for options, <EuiCode>EuiSelectable</EuiCode> uses a
+            partial equality string matcher by default, displaying all options
+            whose labels include the searched string.
+          </p>
+          <p>
+            In rare cases, you may want to customize this behavior. You can do
+            so by passing a custom option matcher function to the{' '}
+            <EuiCode>optionMatcher</EuiCode> prop. The function must be of type{' '}
+            <EuiCode>EuiSelectableOptionMatcher</EuiCode> and return
+            <EuiCode>true</EuiCode> for options that should be visible for given
+            search string.
+          </p>
+        </>
+      ),
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: selectableOptionMatcherSource,
+        },
+      ],
+      demo: <SelectableOptionMatcher />,
+      snippet: `<EuiSelectable
+  options={[]}
+  onChange={newOptions => setOptions(newOptions)}
+  optionMatcher={optionMatcher}
+>
+  {list => list}
+</EuiSelectable>`,
     },
   ],
 };

--- a/src-docs/src/views/selectable/selectable_option_matcher.tsx
+++ b/src-docs/src/views/selectable/selectable_option_matcher.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useState } from 'react';
+
+import { EuiSelectable, EuiSelectableOption } from '../../../../src';
+import { EuiSelectableOptionMatcher } from '../../../../src/components/selectable/selectable';
+
+export default () => {
+  const [options, setOptions] = useState<EuiSelectableOption[]>([
+    {
+      label: 'Titan',
+      'data-test-subj': 'titanOption',
+    },
+    {
+      label: 'Enceladus is disabled',
+      disabled: true,
+    },
+    {
+      label: 'Mimas',
+      checked: 'on',
+    },
+    {
+      label: 'Dione',
+    },
+    {
+      label: 'Iapetus',
+      checked: 'on',
+    },
+    {
+      label: 'Phoebe',
+    },
+    {
+      label: 'Rhea',
+    },
+    {
+      label:
+        "Pandora is one of Saturn's moons, named for a Titaness of Greek mythology",
+    },
+    {
+      label: 'Tethys',
+    },
+    {
+      label: 'Hyperion',
+    },
+  ]);
+
+  const startsWithMatcher = useCallback<EuiSelectableOptionMatcher<unknown>>(
+    ({ option, searchValue }) => {
+      return option.label.startsWith(searchValue);
+    },
+    []
+  );
+
+  return (
+    <EuiSelectable
+      aria-label="Searchable example"
+      searchable
+      searchProps={{
+        'data-test-subj': 'selectableSearchHere',
+      }}
+      options={options}
+      onChange={(newOptions) => setOptions(newOptions)}
+      optionMatcher={startsWithMatcher}
+    >
+      {(list, search) => (
+        <>
+          {search}
+          {list}
+        </>
+      )}
+    </EuiSelectable>
+  );
+};

--- a/src/components/combo_box/combo_box.stories.tsx
+++ b/src/components/combo_box/combo_box.stories.tsx
@@ -6,11 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { EuiComboBox, EuiComboBoxProps } from './combo_box';
+import { EuiComboBoxOptionMatcher } from './types';
+import { EuiCode } from '../code';
 
 const options = [
   { label: 'Item 1' },
@@ -95,6 +97,48 @@ export const Playground: Story = {
         onChange={onChange}
         onCreateOption={onCreateOption ? _onCreateOption : undefined}
       />
+    );
+  },
+};
+
+export const CustomMatcher: Story = {
+  render: function Render({ singleSelection, onCreateOption, ...args }) {
+    const [selectedOptions, setSelectedOptions] = useState(
+      args.selectedOptions
+    );
+    const onChange: EuiComboBoxProps<{}>['onChange'] = (options, ...args) => {
+      setSelectedOptions(options);
+      action('onChange')(options, ...args);
+    };
+
+    const optionMatcher = useCallback<EuiComboBoxOptionMatcher<unknown>>(
+      ({ option, searchValue }) => {
+        return option.label.startsWith(searchValue);
+      },
+      []
+    );
+
+    return (
+      <>
+        <p>
+          This matcher example uses <EuiCode>option.label.startsWith()</EuiCode>
+          . Only options that start exactly like the given search string will be
+          matched.
+        </p>
+        <br />
+        <EuiComboBox
+          singleSelection={
+            // @ts-ignore Specific to Storybook control
+            singleSelection === 'asPlainText'
+              ? { asPlainText: true }
+              : Boolean(singleSelection)
+          }
+          {...args}
+          selectedOptions={selectedOptions}
+          onChange={onChange}
+          optionMatcher={optionMatcher}
+        />
+      </>
     );
   },
 };

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -743,6 +743,7 @@ export class EuiComboBox<T> extends Component<
       autoFocus,
       truncationProps,
       inputPopoverProps,
+      optionMatcher,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledby,
       ...rest

--- a/src/components/combo_box/combo_box.tsx
+++ b/src/components/combo_box/combo_box.tsx
@@ -32,6 +32,7 @@ import {
   getSelectedOptionForSearchValue,
   transformForCaseSensitivity,
   SortMatchesBy,
+  createPartialStringEqualityOptionMatcher,
 } from './matching_options';
 import {
   EuiComboBoxInputProps,
@@ -43,6 +44,7 @@ import {
   RefInstance,
   EuiComboBoxOptionOption,
   EuiComboBoxSingleSelectionShape,
+  EuiComboBoxOptionMatcher,
 } from './types';
 import { EuiComboBoxOptionsList } from './combo_box_options_list';
 
@@ -126,6 +128,15 @@ export interface _EuiComboBoxProps<T>
    */
   isCaseSensitive?: boolean;
   /**
+   * Optional custom option matcher function
+   *
+   * @example
+   * const exactEqualityMatcher: EuiComboBoxOptionMatcher = ({ option, searchValue }) => {
+   *   return option.label === searchValue;
+   * }
+   */
+  optionMatcher?: EuiComboBoxOptionMatcher<T>;
+  /**
    * Creates an input group with element(s) coming before input. It won't show if `singleSelection` is set to `false`.
    * `string` | `ReactElement` or an array of these
    */
@@ -181,10 +192,11 @@ export interface _EuiComboBoxProps<T>
  */
 type DefaultProps<T> = Omit<
   (typeof EuiComboBox)['defaultProps'],
-  'options' | 'selectedOptions'
+  'options' | 'selectedOptions' | 'optionMatcher'
 > & {
   options: Array<EuiComboBoxOptionOption<T>>;
   selectedOptions: Array<EuiComboBoxOptionOption<T>>;
+  optionMatcher: EuiComboBoxOptionMatcher<T>;
 };
 export type EuiComboBoxProps<T> = Omit<
   _EuiComboBoxProps<T>,
@@ -217,6 +229,7 @@ export class EuiComboBox<T> extends Component<
     prepend: undefined,
     append: undefined,
     sortMatchesBy: 'none' as const,
+    optionMatcher: createPartialStringEqualityOptionMatcher(),
   };
 
   state: EuiComboBoxState<T> = {
@@ -227,6 +240,7 @@ export class EuiComboBox<T> extends Component<
       options: this.props.options,
       selectedOptions: this.props.selectedOptions,
       searchValue: initialSearchValue,
+      optionMatcher: this.props.optionMatcher!,
       isCaseSensitive: this.props.isCaseSensitive,
       isPreFiltered: this.props.async,
       showPrevSelected: Boolean(this.props.singleSelection),
@@ -670,6 +684,7 @@ export class EuiComboBox<T> extends Component<
       selectedOptions,
       singleSelection,
       sortMatchesBy,
+      optionMatcher,
     } = nextProps;
     const { activeOptionIndex, searchValue } = prevState;
 
@@ -683,6 +698,7 @@ export class EuiComboBox<T> extends Component<
       isPreFiltered: async,
       showPrevSelected: Boolean(singleSelection),
       sortMatchesBy,
+      optionMatcher: optionMatcher!,
     });
 
     const stateUpdate: Partial<EuiComboBoxState<T>> = { matchingOptions };

--- a/src/components/combo_box/index.ts
+++ b/src/components/combo_box/index.ts
@@ -13,4 +13,7 @@ export * from './combo_box_options_list';
 export type {
   EuiComboBoxOptionOption,
   EuiComboBoxSingleSelectionShape,
+  EuiComboBoxOptionMatcher,
+  EuiComboBoxOptionMatcherArgs,
 } from './types';
+export { createPartialStringEqualityOptionMatcher } from './matching_options';

--- a/src/components/combo_box/matching_options.test.ts
+++ b/src/components/combo_box/matching_options.test.ts
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-import { EuiComboBoxOptionOption } from './types';
+import { EuiComboBoxOptionOption, EuiComboBoxOptionMatcher } from './types';
 import {
   SortMatchesBy,
   flattenOptionGroups,
   getMatchingOptions,
   getSelectedOptionForSearchValue,
+  createPartialStringEqualityOptionMatcher,
 } from './matching_options';
 
 const options = [
@@ -109,7 +110,11 @@ interface GetMatchingOptionsTestCase {
   selectedOptions: EuiComboBoxOptionOption[];
   showPrevSelected: boolean;
   sortMatchesBy: SortMatchesBy;
+  optionMatcher: EuiComboBoxOptionMatcher<unknown>;
 }
+
+const defaultOptionMatcher =
+  createPartialStringEqualityOptionMatcher<unknown>();
 
 const testCases: GetMatchingOptionsTestCase[] = [
   {
@@ -126,6 +131,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
     showPrevSelected: false,
     expected: [],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
   },
   {
     options,
@@ -144,6 +150,8 @@ const testCases: GetMatchingOptionsTestCase[] = [
       { label: 'Mimas' },
     ],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
+
   },
   {
     options,
@@ -159,6 +167,8 @@ const testCases: GetMatchingOptionsTestCase[] = [
     showPrevSelected: true,
     expected: [{ 'data-test-subj': 'saturnOption', label: 'Saturn' }],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
+
   },
   {
     options,
@@ -178,6 +188,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
       { label: 'Mimas' },
     ],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
   },
   {
     options: [{ label: 'Titan' }, { label: 'Titan' }],
@@ -194,6 +205,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
       // Duplicate options without an key will be treated as the same option
     ],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
   },
   {
     options: [
@@ -215,6 +227,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
       { label: 'Titan', key: 'titan1' },
     ],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
   },
   // Case sensitivity
   {
@@ -231,6 +244,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
       },
     ],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
   },
   {
     options,
@@ -241,6 +255,7 @@ const testCases: GetMatchingOptionsTestCase[] = [
     showPrevSelected: false,
     expected: [],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
   },
   {
     options,
@@ -256,6 +271,29 @@ const testCases: GetMatchingOptionsTestCase[] = [
       },
     ],
     sortMatchesBy: 'none',
+    optionMatcher: defaultOptionMatcher,
+  },
+  {
+    options,
+    selectedOptions: [],
+    searchValue: 'Titan',
+    isCaseSensitive: false,
+    isPreFiltered: false,
+    showPrevSelected: false,
+    expected: options,
+    sortMatchesBy: 'none',
+    optionMatcher: () => true,
+  },
+  {
+    options,
+    selectedOptions: [],
+    searchValue: 'Titan',
+    isCaseSensitive: false,
+    isPreFiltered: false,
+    showPrevSelected: false,
+    expected: [],
+    sortMatchesBy: 'none',
+    optionMatcher: () => false,
   },
 ];
 

--- a/src/components/combo_box/matching_options.test.ts
+++ b/src/components/combo_box/matching_options.test.ts
@@ -151,7 +151,6 @@ const testCases: GetMatchingOptionsTestCase[] = [
     ],
     sortMatchesBy: 'none',
     optionMatcher: defaultOptionMatcher,
-
   },
   {
     options,
@@ -168,7 +167,6 @@ const testCases: GetMatchingOptionsTestCase[] = [
     expected: [{ 'data-test-subj': 'saturnOption', label: 'Saturn' }],
     sortMatchesBy: 'none',
     optionMatcher: defaultOptionMatcher,
-
   },
   {
     options,

--- a/src/components/combo_box/types.ts
+++ b/src/components/combo_box/types.ts
@@ -33,3 +33,35 @@ export type RefInstance<T> = T | null;
 export interface EuiComboBoxSingleSelectionShape {
   asPlainText?: boolean;
 }
+
+export interface EuiComboBoxOptionMatcherArgs<TOption> {
+  /**
+   * Option being currently processed
+   */
+  option: EuiComboBoxOptionOption<TOption>;
+  /**
+   * Raw search input value
+   */
+  searchValue: string;
+  /**
+   * Search input value normalized for case-sensitivity
+   * and with leading and trailing whitespace characters trimmed
+   */
+  normalizedSearchValue: string;
+  /**
+   * Whether to match the option with case-sensitivity
+   */
+  isCaseSensitive: boolean;
+}
+
+/**
+ * Option matcher function for EuiComboBox component.
+ *
+ * @example
+ * const equalityMatcher: EuiComboBoxOptionMatcher = ({ option, searchValue }) => {
+ *   return option.label === searchValue;
+ * }
+ */
+export type EuiComboBoxOptionMatcher<TOption> = (
+  args: EuiComboBoxOptionMatcherArgs<TOption>
+) => boolean;

--- a/src/components/selectable/selectable_search/selectable_search.test.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.test.tsx
@@ -12,6 +12,7 @@ import { render } from '../../../test/rtl';
 import { requiredProps } from '../../../test/required_props';
 
 import { EuiSelectableSearch } from './selectable_search';
+import { createPartialStringEqualityOptionMatcher } from '../matching_options';
 
 describe('EuiSelectableSearch', () => {
   const onChange = jest.fn();
@@ -21,6 +22,7 @@ describe('EuiSelectableSearch', () => {
     options: [{ label: 'hello' }, { label: 'world' }],
     value: '',
     isPreFiltered: false,
+    optionMatcher: createPartialStringEqualityOptionMatcher(),
   };
 
   beforeEach(() => jest.clearAllMocks());

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -12,6 +12,7 @@ import { CommonProps } from '../../common';
 import { EuiFieldSearch, EuiFieldSearchProps } from '../../form';
 import { getMatchingOptions } from '../matching_options';
 import { EuiSelectableOption } from '../selectable_option';
+import type { EuiSelectableOptionMatcher } from '../selectable';
 
 export type EuiSelectableSearchProps<T> = CommonProps &
   Omit<
@@ -40,6 +41,10 @@ type _EuiSelectableSearchProps<T> = EuiSelectableSearchProps<T> & {
    */
   listId?: string;
   isPreFiltered: boolean;
+  /**
+   * Optional custom option matcher function
+   */
+  optionMatcher: EuiSelectableOptionMatcher<T>;
 };
 
 export const EuiSelectableSearch = <T,>({
@@ -50,19 +55,21 @@ export const EuiSelectableSearch = <T,>({
   isPreFiltered,
   listId,
   className,
+  optionMatcher,
   ...rest
 }: _EuiSelectableSearchProps<T>) => {
   const onChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const searchValue = e.target.value;
-      const matchingOptions = getMatchingOptions<T>(
+      const matchingOptions = getMatchingOptions<T>({
         options,
         searchValue,
-        isPreFiltered
-      );
+        isPreFiltered,
+        optionMatcher,
+      });
       onChangeCallback(searchValue, matchingOptions);
     },
-    [options, isPreFiltered, onChangeCallback]
+    [options, isPreFiltered, onChangeCallback, optionMatcher]
   );
 
   const classes = classNames('euiSelectableSearch', className);

--- a/src/components/selectable/selectable_search/selectable_search.tsx
+++ b/src/components/selectable/selectable_search/selectable_search.tsx
@@ -42,7 +42,7 @@ type _EuiSelectableSearchProps<T> = EuiSelectableSearchProps<T> & {
   listId?: string;
   isPreFiltered: boolean;
   /**
-   * Optional custom option matcher function
+   * Option matcher function
    */
   optionMatcher: EuiSelectableOptionMatcher<T>;
 };


### PR DESCRIPTION
## Summary

This PR resolves #2199 by allowing passing a custom matcher function to `EuiComboBox` and `EuiSelectable` using the new optional `optionMatcher` prop.

I kept the tests the same, just moved code around to extract the specific filtering logic while keeping component internals intact and not overridable (like `isPreFiltered` logic), so consumers don't have to reimplement them.

## QA

The default option matcher should behave exactly as before the prop was introduced. 

- [x] Compare option filtering of `EuiComboBox` on [PR env](https://eui.elastic.co/pr_7709/#/forms/combo-box) and [production](https://eui.elastic.co/#/forms/combo-box) and confirm there are no behavior changes
- [x] Compare option filtering of `EuiSelectable` on [PR env](https://eui.elastic.co/pr_7709/#/forms/selectable) and [production](https://eui.elastic.co/#/forms/selectable) and confirm there are no behavior changes 
- [x] Confirm the `Custom option matcher` example uses `startsWith` matcher and only labels starting with search value are being matched

### General checklist

- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
