### PR TITLE
[FieldValueSelectionFilter] [i18n] Let `EuiSelectable` handle default loading and empty messages

### DIFF
--- a/changelogs/upcoming/7718.md
+++ b/changelogs/upcoming/7718.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed i18n of empty and loading state messages for the `FieldValueSelectionFilter` component
+

--- a/src/components/search_bar/filters/field_value_selection_filter.tsx
+++ b/src/components/search_bar/filters/field_value_selection_filter.tsx
@@ -66,8 +66,6 @@ const defaults = {
   config: {
     multiSelect: true,
     filterWith: 'prefix',
-    loadingMessage: 'Loading...',
-    noOptionsMessage: 'No options found',
     searchThreshold: 10,
   },
 };
@@ -400,16 +398,10 @@ export class FieldValueSelectionFilter extends Component<
               options={items}
               renderOption={(option) => option.view}
               isLoading={isNil(this.state.options)}
-              loadingMessage={
-                config.loadingMessage || defaults.config.loadingMessage
-              }
-              emptyMessage={
-                config.noOptionsMessage || defaults.config.noOptionsMessage
-              }
+              loadingMessage={config.loadingMessage}
+              emptyMessage={config.noOptionsMessage}
               errorMessage={this.state.error}
-              noMatchesMessage={
-                config.noOptionsMessage || defaults.config.noOptionsMessage
-              }
+              noMatchesMessage={config.noOptionsMessage}
               listProps={{
                 isVirtualized: isOverSearchThreshold || false,
               }}


### PR DESCRIPTION
Closes https://github.com/elastic/eui/issues/7714

## Summary

The `EuiSelectable` component already handles `i18n` for the empty and loading states, so I figured it was easiest to simply let that component handle things instead - note that the empty state text will be changed from "No options found" to "No options available" because of this change which, IMO, is actually better copy for this scenario anyway :+1: 

## QA

### General checklist

- Docs site QA
    - The `FieldValueSelectionFilter` doesn't seem to have direct documentation since it's all part of the `EuiSearchBar` component - so not sure how to handle documentation in this case? LMK if something should be changed documentation-wise though :+1: 
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
