### PR TITLE
Fix `@storybook/test` - should be in `devDependencies`, not `dependencies`

### DIFF
--- a/changelogs/upcoming/7719.md
+++ b/changelogs/upcoming/7719.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed the `@storybook/test` dependency to be listed in `devDependencies` and not `dependencies`

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   ],
   "dependencies": {
     "@hello-pangea/dnd": "^16.6.0",
-    "@storybook/test": "^8.0.5",
     "@types/lodash": "^4.14.202",
     "@types/numeral": "^2.0.5",
     "@types/react-window": "^1.8.8",
@@ -127,6 +126,7 @@
     "@storybook/blocks": "^8.0.5",
     "@storybook/react": "^8.0.5",
     "@storybook/react-webpack5": "^8.0.5",
+    "@storybook/test": "^8.0.5",
     "@svgr/core": "8.0.0",
     "@svgr/plugin-jsx": "^8.0.1",
     "@svgr/plugin-svgo": "^8.0.1",


### PR DESCRIPTION
## Summary

Needed for https://github.com/elastic/kibana/pull/182023. This is causing several `@testing-library/user-event` related failures in Kibana due to the them being on v13 and not v14 

## QA

N/A, test/deps change

### General checklist

- Browser QA - N/A
- Docs site QA - N/A
- Code quality checklist 
    - [ ] CI/Jest tests pass
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A