### PR TITLE
[EuiDatePicker][a11y] Fix screen reader announcements on time selection and intermittently broken up/down navigation on NVDA/JAWS

### DIFF
--- a/packages/eui/changelogs/upcoming/7726.md
+++ b/packages/eui/changelogs/upcoming/7726.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Improved `EuiDatePicker` and `EuiSuperDatePicker`'s time selection screen reader UX

--- a/packages/eui/src/components/date_picker/react-datepicker/src/time.js
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/time.js
@@ -341,7 +341,7 @@ export default class Time extends React.Component {
     let screenReaderInstructions;
     if (this.state.readInstructions) {
       screenReaderInstructions = (
-        <p aria-live>
+        <p>
           You are a in a time selector. Use the up and down keys to select from
           other common times then press enter to confirm.
           {this.state.preSelection ? `${formatDate(this.state.preSelection, this.timeFormat)} is currently
@@ -362,7 +362,7 @@ export default class Time extends React.Component {
             {this.props.timeCaption}
           </div>
           <EuiScreenReaderOnly>
-            <span>{screenReaderInstructions}</span>
+            <span aria-live="polite">{screenReaderInstructions}</span>
           </EuiScreenReaderOnly>
         </div>
         <div className="react-datepicker__time">

--- a/packages/eui/src/components/date_picker/react-datepicker/src/time.js
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/time.js
@@ -341,12 +341,17 @@ export default class Time extends React.Component {
     let screenReaderInstructions;
     if (this.state.readInstructions) {
       screenReaderInstructions = (
-        <p>
-          You are a in a time selector. Use the up and down keys to select from
-          other common times then press enter to confirm.
-          {this.state.preSelection ? `${formatDate(this.state.preSelection, this.timeFormat)} is currently
-          focused.`: `No time is currently focused.`}
-        </p>
+        <>
+          <p>
+            You are a in a time selector. Use the up and down keys to select from
+            other common times then press enter to confirm.
+          </p>
+          {/* Note: needs to be separate paragraph nodes for aria-atomic="false" to work correctly */}
+          <p>
+            {this.state.preSelection ? `${formatDate(this.state.preSelection, this.timeFormat)} is currently
+            focused.`: `No time is currently focused.`}
+          </p>
+        </>
       );
     }
 
@@ -362,7 +367,9 @@ export default class Time extends React.Component {
             {this.props.timeCaption}
           </div>
           <EuiScreenReaderOnly>
-            <span aria-live="polite">{screenReaderInstructions}</span>
+            <span aria-live="polite" aria-atomic="false">
+              {screenReaderInstructions}
+            </span>
           </EuiScreenReaderOnly>
         </div>
         <div className="react-datepicker__time">

--- a/packages/eui/src/components/date_picker/react-datepicker/src/time.js
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/time.js
@@ -369,8 +369,8 @@ export default class Time extends React.Component {
           <div
             className={timeBoxClassNames}
             onKeyDown={this.onInputKeyDown}
-            onFocusCapture={this.onFocus}
-            onBlurCapture={this.onBlur}
+            onFocus={this.onFocus}
+            onBlur={this.onBlur}
           >
             <ul
               aria-label={this.props.timeCaption}

--- a/packages/eui/src/components/date_picker/react-datepicker/src/time.js
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/time.js
@@ -369,8 +369,8 @@ export default class Time extends React.Component {
           <div
             className={timeBoxClassNames}
             onKeyDown={this.onInputKeyDown}
-            onFocus={this.onFocus}
-            onBlur={this.onBlur}
+            onFocusCapture={this.onFocus}
+            onBlurCapture={this.onBlur}
           >
             <ul
               aria-label={this.props.timeCaption}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/6687

## QA

- https://eui.elastic.co/pr_7726/#/templates/super-date-picker

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA - N/A
- Code quality checklist - N/A, technically a 3rd party library?...
    ~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
- Designer checklist - N/A