### PR TITLE
Fix failure of yarn test-unit at 9 hours offset

### DIFF
--- a/src/services/format/format_date.test.ts
+++ b/src/services/format/format_date.test.ts
@@ -160,5 +160,5 @@ function formatTimezoneOffset(offset: number) {
   offset = Math.abs(offset);
   const hrs = Math.floor(offset / 60);
   const mins = offset - hrs * 60;
-  return `${sign}${hrs < 9 ? '0' : ''}${hrs}:${mins < 9 ? '0' : ''}${mins}`;
+  return `${sign}${hrs <= 9 ? '0' : ''}${hrs}:${mins < 9 ? '0' : ''}${mins}`;
 }

--- a/src/services/format/format_date.test.ts
+++ b/src/services/format/format_date.test.ts
@@ -160,5 +160,5 @@ function formatTimezoneOffset(offset: number) {
   offset = Math.abs(offset);
   const hrs = Math.floor(offset / 60);
   const mins = offset - hrs * 60;
-  return `${sign}${hrs <= 9 ? '0' : ''}${hrs}:${mins < 9 ? '0' : ''}${mins}`;
+  return `${sign}${hrs <= 9 ? '0' : ''}${hrs}:${mins <= 9 ? '0' : ''}${mins}`;
 }


### PR DESCRIPTION
## Summary

This PR fixes the following unit test failure at +9 and -9 hours of timezone offset.

```console
sakurai@wsl:~/git/eui$ yarn test-unit src/services/format/format_date.test.ts
yarn run v1.22.22
$ node ./scripts/test-unit src/services/format/format_date.test.ts
cross-env NODE_OPTIONS="" NODE_ENV=test REACT_VERSION=18 jest --config ./scripts/jest/config.js src/services/format/format_date.test.ts
Running tests on React v18
 FAIL  src/services/format/format_date.test.ts
  formatDate
    ✓ no config - date value (2ms)
    ✓ no config - number value
    ✓ no config - string value (1ms)
    ✓ no config - no value
    ✓ with config - no value (1ms)
    ✓ with config - "date" format
    ✓ with config - "longDate" format
    ✓ with config - "shortDate" format
    ✓ with config - "dateTime" format
    ✓ with config - "longDateTime" format
    ✓ with config - "shortDateTime" format (3ms)
    ✕ with config - "iso8601" format (2ms)
    ✓ with config - "calendarDate" format (2ms)
    ✓ with config - "calendarDateTime" format (1ms)
    ✓ with config - custom format

  ● formatDate › with config - "iso8601" format

    expect(received).toBe(expected) // Object.is equality

    Expected: "1999-01-01T02:03:04.005+9:00"
    Received: "1999-01-01T02:03:04.005+09:00"

      59 |
      60 |   test('with config - "iso8601" format', () => {
    > 61 |     expect(formatDate(value, 'iso8601')).toBe(
         |                                          ^
      62 |       `1999-01-01T02:03:04.005${formatTimezoneOffset(
      63 |         value.getTimezoneOffset()
      64 |       )}`

      at Object.<anonymous> (src/services/format/format_date.test.ts:61:42)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 14 passed, 15 total
Snapshots:   0 total
Time:        1.037s
Ran all test suites matching /src\/services\/format\/format_date.test.ts/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## QA

1. Set the time zone to Japan.
2. Run `yarn test-unit src/services/format/format_date.test.ts`.

### General checklist

- [x] CI passes