### PR TITLE
[EuiCollapsedNavButton][a11y] Update `aria-label` for enhanced screen reader navigation

### DIFF
--- a/changelogs/upcoming/7740.md
+++ b/changelogs/upcoming/7740.md
@@ -1,3 +1,3 @@
-**Bug fixes**
+**Accessibility**
 
-- [EuiCollapsedNavButton][a11y] Update aria-label for enhanced screen reader navigation
+- Updated `EuiCollapsedNavButton` with improved context for screen reader navigation

--- a/changelogs/upcoming/7740.md
+++ b/changelogs/upcoming/7740.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- [EuiCollapsedNavButton][a11y] Update aria-label for enhanced screen reader navigation

--- a/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`KibanaCollapsibleNavSolution renders docked icons 1`] = `
       class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
     >
       <button
-        aria-label="\\"Some solution\\" quick navigation menu"
+        aria-label="Some solution, quick navigation menu"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"
@@ -33,7 +33,7 @@ exports[`KibanaCollapsibleNavSolution renders docked icons 1`] = `
       class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
     >
       <button
-        aria-label="\\"Solution view\\" quick navigation menu"
+        aria-label="Solution view, quick navigation menu"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"

--- a/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`KibanaCollapsibleNavSolution renders docked icons 1`] = `
       class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
     >
       <button
-        aria-label="Some solution"
+        aria-label="\\"Some solution\\" quick navigation menu"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"
@@ -33,7 +33,7 @@ exports[`KibanaCollapsibleNavSolution renders docked icons 1`] = `
       class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
     >
       <button
-        aria-label="Solution view"
+        aria-label="\\"Solution view\\" quick navigation menu"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"

--- a/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.test.tsx
+++ b/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.test.tsx
@@ -61,7 +61,7 @@ describe('KibanaCollapsibleNavSolution', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    fireEvent.click(getByLabelText('"Solution view" quick navigation menu'));
+    fireEvent.click(getByLabelText('Solution view, quick navigation menu'));
     await waitForEuiPopoverOpen();
     expect(getByText('Some other solution')).toBeInTheDocument();
 

--- a/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.test.tsx
+++ b/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.test.tsx
@@ -61,7 +61,7 @@ describe('KibanaCollapsibleNavSolution', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
 
-    fireEvent.click(getByLabelText('Solution view'));
+    fireEvent.click(getByLabelText('"Solution view" quick navigation menu'));
     await waitForEuiPopoverOpen();
     expect(getByText('Some other solution')).toBeInTheDocument();
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiCollapsibleNavItem renders a collapsed button icon when in a collaps
   data-test-subj="test subject string"
 >
   <button
-    aria-label="Item"
+    aria-label="\\"Item\\" quick navigation menu"
     class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
     data-test-subj="euiCollapsedNavButton"
     type="button"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiCollapsibleNavItem renders a collapsed button icon when in a collaps
   data-test-subj="test subject string"
 >
   <button
-    aria-label="\\"Item\\" quick navigation menu"
+    aria-label="Item, quick navigation menu"
     class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
     data-test-subj="euiCollapsedNavButton"
     type="button"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`EuiCollapsedNavButton renders a tooltip around the icon button 1`] = `
     >
       <button
         aria-describedby="generated-id"
-        aria-label="\\"Nav item\\" quick navigation menu"
+        aria-label="Nav item, quick navigation menu"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"
@@ -55,7 +55,7 @@ exports[`EuiCollapsedNavButton renders isSelected 1`] = `
     class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
   >
     <a
-      aria-label="\\"Nav item\\" quick navigation menu"
+      aria-label="Nav item, quick navigation menu"
       class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton-isSelected"
       data-test-subj="euiCollapsedNavButton"
       href="#"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`EuiCollapsedNavButton renders a tooltip around the icon button 1`] = `
     >
       <button
         aria-describedby="generated-id"
-        aria-label="Nav item"
+        aria-label="\\"Nav item\\" quick navigation menu"
         class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
         data-test-subj="euiCollapsedNavButton"
         type="button"
@@ -55,7 +55,7 @@ exports[`EuiCollapsedNavButton renders isSelected 1`] = `
     class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
   >
     <a
-      aria-label="Nav item"
+      aria-label="\\"Nav item\\" quick navigation menu"
       class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton-isSelected"
       data-test-subj="euiCollapsedNavButton"
       href="#"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`EuiCollapsedNavItem renders a popover if items are passed 1`] = `
     class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
   >
     <button
-      aria-label="Item"
+      aria-label="\\"Item\\" quick navigation menu"
       class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
       data-test-subj="euiCollapsedNavButton"
       type="button"
@@ -32,7 +32,7 @@ exports[`EuiCollapsedNavItem renders an icon button/link if href is passed 1`] =
   data-test-subj="test subject string"
 >
   <a
-    aria-label="Item"
+    aria-label="\\"Item\\" quick navigation menu"
     class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
     data-test-subj="euiCollapsedNavButton"
     href="#"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_item.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`EuiCollapsedNavItem renders a popover if items are passed 1`] = `
     class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
   >
     <button
-      aria-label="\\"Item\\" quick navigation menu"
+      aria-label="Item, quick navigation menu"
       class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
       data-test-subj="euiCollapsedNavButton"
       type="button"
@@ -32,7 +32,7 @@ exports[`EuiCollapsedNavItem renders an icon button/link if href is passed 1`] =
   data-test-subj="test subject string"
 >
   <a
-    aria-label="\\"Item\\" quick navigation menu"
+    aria-label="Item, quick navigation menu"
     class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
     data-test-subj="euiCollapsedNavButton"
     href="#"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`EuiCollapsedNavPopover renders 1`] = `
         class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
       >
         <button
-          aria-label="Item"
+          aria-label="\\"Item\\" quick navigation menu"
           class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
           data-test-subj="euiCollapsedNavButton"
           type="button"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`EuiCollapsedNavPopover renders 1`] = `
         class="euiToolTipAnchor emotion-euiToolTipAnchor-block"
       >
         <button
-          aria-label="\\"Item\\" quick navigation menu"
+          aria-label="Item, quick navigation menu"
           class="euiButtonIcon euiCollapsedNavButton emotion-euiButtonIcon-s-empty-text-euiCollapsedNavButton"
           data-test-subj="euiCollapsedNavButton"
           type="button"

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -66,7 +66,7 @@ export const EuiCollapsedNavButton: FunctionComponent<
 
   const buttonIconAriaLabel = useEuiI18n(
     'euiCollapsedNavButton.ariaLabelButtonIcon',
-    '"{title}" quick navigation menu',
+    '{title}, quick navigation menu',
     { title }
   );
 

--- a/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
+++ b/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.tsx
@@ -23,6 +23,7 @@ import {
   euiCollapsedNavButtonStyles,
   euiCollapsedNavItemTooltipStyles,
 } from './collapsed_nav_button.styles';
+import { useEuiI18n } from '../../../i18n';
 
 export const EuiCollapsedNavButton: FunctionComponent<
   Omit<
@@ -63,6 +64,12 @@ export const EuiCollapsedNavButton: FunctionComponent<
     hideToolTip && tooltipStyles.hidden,
   ];
 
+  const buttonIconAriaLabel = useEuiI18n(
+    'euiCollapsedNavButton.ariaLabelButtonIcon',
+    '"{title}" quick navigation menu',
+    { title }
+  );
+
   return (
     <EuiToolTip
       content={title}
@@ -77,7 +84,7 @@ export const EuiCollapsedNavButton: FunctionComponent<
         color="text"
         href={href}
         onClick={onClick}
-        aria-label={title}
+        aria-label={buttonIconAriaLabel}
         {...(linkProps as EuiButtonIconPropsForAnchor)} // Exclusive union shenanigans
         className={buttonClassName}
         css={buttonCssStyles}


### PR DESCRIPTION
Closes: https://github.com/elastic/security-team/issues/8947

## Summary

The Security icon popover announces "Security, button", then "Security, description" to screen readers. This is caused by the aria-label and tooltip aria-describedby text being the same. Screen reader users do not have context that this will open the Security Solution quick navigation popover (with just the top-level links). We can improve this by updating the information in the EUI Tooltip content prop. Screenshot and linked CodeSandbox below.

## What was changed?: 
1. aria-label attribute was updated

## Screen: 

<img width="583" alt="image" src="https://github.com/elastic/eui/assets/20072247/0afcddf3-a99e-41d2-ae76-754073a73d58">


### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [x] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
    - [x] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
