### PR TITLE
[changelogs] Add an accessibility prompt/heading to `yo` generator

### DIFF
--- a/generator-eui/changelog/index.js
+++ b/generator-eui/changelog/index.js
@@ -36,6 +36,12 @@ module.exports = class extends Generator {
         default: false,
       },
       {
+        message: 'Does your PR contain accessibility improvements?',
+        name: 'a11y',
+        type: 'confirm',
+        default: false,
+      },
+      {
         message: 'Does your PR contain deprecations?',
         name: 'deprecations',
         type: 'confirm',

--- a/generator-eui/changelog/templates/changelog.md
+++ b/generator-eui/changelog/templates/changelog.md
@@ -8,6 +8,12 @@
 - Fixed ...
 
 <%_ } -%>
+<%_ if (a11y) { -%>
+**Accessibility**
+
+- Improved the accessibility experience of ...
+
+<%_ } -%>
 <%_ if (deprecations) { -%>
 **Deprecations**
 


### PR DESCRIPTION
## Summary

The discussion in https://github.com/elastic/eui/pull/7740#discussion_r1592660797 inspired me to update our `yarn yo-changelog` generator util to include a prompt and generated heading for a11y improvements, now that we have more folks contributing to that area! 🎉 🥳 

We've historically already been using the `**Accessibility**` heading in any case for changelog, this just makes it more official and easier for new contributors to find.

<img width="504" alt="" src="https://github.com/elastic/eui/assets/549407/0dc2e72b-3b0d-4497-99ee-1f7afecf5788">

## QA

- [x] Pull down branch and run `yarn yo-changelog 1` and type Y for the accessibility prompt, confirm the output `.md` looks as expected with the correct heading

### General checklist

N/A, dev only change