### PR TITLE
[EuiToolTip] Close tooltips on escape keydown

### DIFF
--- a/packages/eui/changelogs/upcoming/7751.md
+++ b/packages/eui/changelogs/upcoming/7751.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- `EuiToolTip`s can now additionally be dismissed via `Escape` keypress as well as on focus blur.

--- a/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
@@ -16,26 +16,47 @@ import { EuiButton } from '../../components';
 import { EuiToolTip } from './tool_tip';
 
 describe('EuiToolTip', () => {
-  it('shows the tooltip on hover', () => {
+  it('shows the tooltip on hover and hides it on mouseout', () => {
     cy.mount(
       <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
         <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
       </EuiToolTip>
     );
     cy.get('[data-test-subj="tooltip"]').should('not.exist');
+
     cy.get('[data-test-subj="toggleToolTip"]').trigger('mouseover');
     cy.get('[data-test-subj="tooltip"]').should('exist');
+
+    cy.get('[data-test-subj="toggleToolTip"]').trigger('mouseout');
+    cy.get('[data-test-subj="tooltip"]').should('not.exist');
   });
 
-  it('shows the tooltip on keyboard focus', () => {
+  it('shows the tooltip on keyboard focus and hides it on blur', () => {
     cy.mount(
       <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
         <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
       </EuiToolTip>
     );
     cy.get('[data-test-subj="tooltip"]').should('not.exist');
+
     cy.get('[data-test-subj="toggleToolTip"]').focus();
     cy.get('[data-test-subj="tooltip"]').should('exist');
+
+    cy.get('[data-test-subj="toggleToolTip"]').blur();
+    cy.get('[data-test-subj="tooltip"]').should('not.exist');
+  });
+
+  it('hides the tooltip on Escape key down', () => {
+    cy.realMount(
+      <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
+        <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
+      </EuiToolTip>
+    );
+    cy.realPress('Tab');
+    cy.get('[data-test-subj="tooltip"]').should('exist');
+
+    cy.realPress('Escape');
+    cy.get('[data-test-subj="tooltip"]').should('not.exist');
   });
 
   it('does not show multiple tooltips if one tooltip toggle is focused and another tooltip toggle is hovered', () => {

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -16,7 +16,7 @@ import React, {
 import classNames from 'classnames';
 
 import { CommonProps } from '../common';
-import { findPopoverPosition, htmlIdGenerator } from '../../services';
+import { findPopoverPosition, htmlIdGenerator, keys } from '../../services';
 import { enqueueStateChange } from '../../services/react';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { EuiPortal } from '../portal';
@@ -278,6 +278,13 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
     this.hideToolTip();
   };
 
+  onEscapeKey = (event: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === keys.ESCAPE) {
+      this.setState({ hasFocus: false }); // Allows mousing over back into the tooltip to work correctly
+      this.hideToolTip();
+    }
+  };
+
   onMouseOut = (event: ReactMouseEvent<HTMLSpanElement, MouseEvent>) => {
     // Prevent mousing over children from hiding the tooltip by testing for whether the mouse has
     // left the anchor for a non-child.
@@ -323,6 +330,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           ref={this.setAnchorRef}
           onBlur={this.onBlur}
           onFocus={this.onFocus}
+          onKeyDown={this.onEscapeKey}
           onMouseOver={this.showToolTip}
           onMouseOut={this.onMouseOut}
           id={id}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7741

![tooltip_escape](https://github.com/elastic/eui/assets/549407/b9500512-5960-4ec3-b88e-2c0760f4b69b)

## QA

- Go to https://eui.elastic.co/pr_7751/#/display/tooltip
- Keyboard tab to the first tooltip link
- [x] Press the `Escape` key and confirm that the tooltip is dismissed/hidden
- [x] (regression testing) With the tooltip trigger still focused, move your mouse cursor over it and confirm the tooltip correctly appears and disappears as usual on hover/mouseout

### General checklist

- Browser QA
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only ~and screenreader modes~
- Docs site QA - Skipped docs - see below conversation with Trevor
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    ~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A