### PR TITLE
[Wiki] Add troubleshooting section

### DIFF
--- a/wiki/contributing-to-eui/running-eui-locally.md
+++ b/wiki/contributing-to-eui/running-eui-locally.md
@@ -59,7 +59,7 @@ If another process is already listening on port 8030, the next free port will be
 yarn start --port 9000
 ```
 
-## Troubleshooting
+## VSCode setup
 
 ### Eslint
 

--- a/wiki/contributing-to-eui/running-eui-locally.md
+++ b/wiki/contributing-to-eui/running-eui-locally.md
@@ -35,9 +35,9 @@ yarn
 If you're on an Apple arm64 machine and receive an error on `yarn` about Puppeteer/the chromium binary not being available, you have two options:
 
 1. If you don't need to run Puppeteer tests locally:
-    - Paste `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` into your terminal as an environment variable
+   - Paste `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` into your terminal as an environment variable
 2. If you do need need to run Puppeteer locally:
-    - [Follow these steps](https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-787912758) to install the Chromium binary globally and update your `~/.zshrc`.
+   - [Follow these steps](https://github.com/puppeteer/puppeteer/issues/6622#issuecomment-787912758) to install the Chromium binary globally and update your `~/.zshrc`.
 
 ## Running
 
@@ -57,4 +57,17 @@ If another process is already listening on port 8030, the next free port will be
 
 ```shell
 yarn start --port 9000
+```
+
+## Troubleshooting
+
+### Eslint
+
+If you're developing in VSCode and you are using the [`ESLint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension for VSCode you will notice that ESLint is showing errors about not finding config files _since the monorepo setup changes_.
+To fix this add `eslint.workingDirectories` to your VSCode settings and pass all working directories as relative paths.
+
+```json
+{
+  "eslint.workingDirectories": ["./packages/eui"]
+}
 ```


### PR DESCRIPTION
## Summary

📄 This PR adds a "Troubleshooting" section to our `running-eui-locally.md` docs and adds steps on how to deal with errors due to missing config files for the [VSCode ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) since the recent changes towards a monorepo setup.