### PR TITLE
[EuiFlyoutResizable] Allow consumers to update the `size` prop

### DIFF
--- a/packages/eui/changelogs/upcoming/7759.md
+++ b/packages/eui/changelogs/upcoming/7759.md
@@ -1,0 +1,1 @@
+- `EuiFlyoutResizable` now respects `size` prop updates, allowing for controlled `size` usage

--- a/packages/eui/src/components/flyout/flyout_resizable.tsx
+++ b/packages/eui/src/components/flyout/flyout_resizable.tsx
@@ -65,12 +65,20 @@ export const EuiFlyoutResizable = forwardRef(
     // Must use state for the flyout ref in order for the useEffect to be correctly called after render
     const [flyoutRef, setFlyoutRef] = useState<HTMLElement | null>(null);
     const setRefs = useCombinedRefs([setFlyoutRef, ref]);
+
     useEffect(() => {
-      setCallOnResize(false); // Don't call `onResize` for non-user width changes
-      setFlyoutWidth(
-        flyoutRef ? getFlyoutMinMaxWidth(flyoutRef.offsetWidth) : 0
-      );
-    }, [flyoutRef, getFlyoutMinMaxWidth, size]);
+      if (!flyoutWidth && flyoutRef) {
+        setCallOnResize(false); // Don't call `onResize` for non-user width changes
+        setFlyoutWidth(getFlyoutMinMaxWidth(flyoutRef.offsetWidth));
+      }
+    }, [flyoutWidth, flyoutRef, getFlyoutMinMaxWidth]);
+
+    // Update flyout width when consumers pass in a new `size`
+    useEffect(() => {
+      setCallOnResize(false);
+      // For string `size`s, resetting flyoutWidth to 0 will trigger the above useEffect's recalculation
+      setFlyoutWidth(typeof size === 'number' ? getFlyoutMinMaxWidth(size) : 0);
+    }, [size, getFlyoutMinMaxWidth]);
 
     // Initial numbers to calculate from, on resize drag start
     const initialWidth = useRef(0);


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7536

Currently, `size` stops updating/being respected after the first time a user resizes the flyout. I've tweaked the `useEffect`s of the resizable flyout component slightly to allow consumers to control/override the internal flyout width state.

![flyout_resizable](https://github.com/elastic/eui/assets/549407/ef7ce7c4-7e23-44a8-96f1-0ebd67837612)

## QA

- Go to https://eui.elastic.co/pr_7759/storybook/?path=/story/layout-euiflyout-euiflyoutresizable--playground
- Resize the flyout (mouse, keyboard focus, etc). That should work normally/as expected
- Scroll down in the controls pane to the `size` prop, and change it (e.g. to `s`, `l`, `2000px`, `400`, etc)
- [x] Confirm that once you click away from the input, the flyout size updates accordingly
- [x] (Regression testing) Confirm [staging's uncontrolled resizable flyout](https://eui.elastic.co/pr_7759/#/layout/flyout#resizable-flyouts) behaves the same as [production](https://eui.elastic.co/#/layout/flyout#resizable-flyouts)

### General checklist

- Browser QA - N/A, logical/state JS changes only
- Docs site QA - N/A, I skipped extra docs for this as this is likely how it should have worked all along 🙈 
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A