### PR TITLE
[Fix] Revert removed setTimeout on EuiInputPopover scroll listener

### DIFF
--- a/packages/eui/src/components/popover/input_popover.tsx
+++ b/packages/eui/src/components/popover/input_popover.tsx
@@ -190,15 +190,18 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
         closePopover();
       };
 
-      window.addEventListener('scroll', closePopoverOnScroll, {
-        passive: true, // for better performance as we won't call preventDefault
-        capture: true, // scroll events don't bubble, they must be captured instead
-      });
+      const timeoutId = setTimeout(() => {
+        window.addEventListener('scroll', closePopoverOnScroll, {
+          passive: true, // for better performance as we won't call preventDefault
+          capture: true, // scroll events don't bubble, they must be captured instead
+        });
+      }, 500);
 
       return () => {
         window.removeEventListener('scroll', closePopoverOnScroll, {
           capture: true,
         });
+        clearTimeout(timeoutId);
       };
     }
   }, [closeOnScroll, closePopover, panelEl, inputEl]);


### PR DESCRIPTION
## Summary

This PR reverts earlier changes done in this PR which remove a `setTimeout` on `EuiInputPopover`'s scroll listener.
This change triggered flaky e2e test behaviors in Kibana (observed from version `94.3.0`).

## QA

1. on EUI side
- checkout this PR: `gh pr checkout xxxx`
- build the package locally with `yarn build-pack`

2. on Kibana side
- follow the steps listed in this [wiki](https://github.com/elastic/eui/blob/5c4031565d1f0fef7e08e2377ea5b29bf8963b54/wiki/contributing-to-eui/testing/testing-in-kibana.md?plain=1#L12) to add the local package to Kibana
- run Kibana locally (`yarn es snapshot`, `yarn kbn bootstrap --no-validate && yarn start`)
- navigate to the `security_solution` test directory and run the cypress tests
```
cd x-pack/test/security_solution_cypress
yarn cypress:open:ess
```
- wait until the tests are up and running and choose the test `rule_creation/common_flows.cy.ts` to run
- verify the test finishes (on the broken version the test hangs when navigating combo boxes and won't finish)
- rerun the test a couple times to be sure it's not flaky