### PR TITLE
[EuiDualRange] Fix incorrect input min/max values when empty string values exist

### DIFF
--- a/packages/eui/changelogs/upcoming/7767.md
+++ b/packages/eui/changelogs/upcoming/7767.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiDualRange`s with `showInput` bug, where `min`/`max` values and invalid states were not being correctly set if values were empty strings

--- a/packages/eui/src/components/form/range/dual_range.test.tsx
+++ b/packages/eui/src/components/form/range/dual_range.test.tsx
@@ -217,6 +217,31 @@ describe('EuiDualRange', () => {
 
         jest.restoreAllMocks();
       });
+
+      it('correctly defaults to min/max props if the lower or upper value is an empty string', () => {
+        const props = {
+          showInput: true,
+          min: -50,
+          max: 50,
+          minInputProps: { 'aria-label': 'Min value' },
+          maxInputProps: { 'aria-label': 'Max value' },
+          onChange: () => {},
+        };
+
+        const { getByLabelText, rerender } = render(
+          <EuiDualRange {...props} value={['20', '']} />
+        );
+        expect(getByLabelText('Min value')).toHaveAttribute('min', '-50');
+        expect(getByLabelText('Min value')).toHaveAttribute('max', '50');
+
+        rerender(<EuiDualRange {...props} value={['', '30']} />);
+        expect(getByLabelText('Max value')).toHaveAttribute('min', '-50');
+        expect(getByLabelText('Max value')).toHaveAttribute('max', '50');
+
+        rerender(<EuiDualRange {...props} value={['', '']} />);
+        expect(getByLabelText('Min value')).not.toBeInvalid();
+        expect(getByLabelText('Max value')).not.toBeInvalid();
+      });
     });
 
     describe('loading', () => {

--- a/packages/eui/src/components/form/range/dual_range.tsx
+++ b/packages/eui/src/components/form/range/dual_range.tsx
@@ -458,7 +458,7 @@ export class EuiDualRangeClass extends Component<
         // Non-overridable props
         side="min"
         min={min}
-        max={Number(this.upperValue)}
+        max={this.upperValue === '' ? max : Number(this.upperValue)}
         step={step}
         compressed={compressed}
         autoSize={!showInputOnly}
@@ -513,7 +513,7 @@ export class EuiDualRangeClass extends Component<
         {...maxInputProps}
         // Non-overridable props
         side="max"
-        min={Number(this.lowerValue)}
+        min={this.lowerValue === '' ? min : Number(this.lowerValue)}
         max={max}
         step={step}
         compressed={compressed}


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7764

| Before | After |
|--------|--------|
| <img width="690" alt="invalid" src="https://github.com/elastic/eui/assets/549407/9f92f1b1-6230-42b6-8880-096191928717"> | <img width="702" alt="valid" src="https://github.com/elastic/eui/assets/549407/37617a3e-5942-4f10-afbd-8da5c2a12f73"> | 

`Number('')` evals to `0` which is why the bug was happening. The new code checks for `value === ''` and more manually falls back to the min/max if so. Sadly we can't DRY this out in the getter because the getter is used too many other places / we do actually need to render `''` for the value.

Added a unit regression test to check for the correct applied `min`/`max` props when values are empty strings.

## QA

- Go to https://eui.elastic.co/pr_7767/#/forms/range-sliders#inputs
- Clear the rightmost dual range input
- [x] Confirm that the leftmost input does not display an invalid error

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes - _VO reads out `NaN` for empty inputs which is the same as production_
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added ~or updated~ **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md)~ tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A