### PR TITLE
[EuiPageTemplate] Add new `EuiPageTemplate.TopBar` component for serverless navigation

### DIFF
--- a/packages/eui/changelogs/upcoming/7777.md
+++ b/packages/eui/changelogs/upcoming/7777.md
@@ -1,0 +1,1 @@
+- Added a new `EuiPageTemplate.TopBar` component, which will scroll/stick to the top of the inner content

--- a/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.stories.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.stories.tsx
@@ -6,10 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EuiSpacer } from '../../spacer';
+import { EuiButton, EuiButtonEmpty } from '../../button';
+import { EuiFlyout } from '../../flyout';
 import { EuiHeader, EuiHeaderSection } from '../../header';
 import { EuiPageTemplate } from '../../page_template';
 
@@ -99,54 +101,76 @@ const meta: Meta<KibanaCollapsibleNavSolutionProps> = {
     ],
   },
   decorators: [
-    (Story) => (
-      <>
-        <EuiHeader position="fixed">
-          <EuiHeaderSection>
-            <EuiCollapsibleNavBeta>
-              <EuiCollapsibleNavBeta.Body>
-                <Story />
-              </EuiCollapsibleNavBeta.Body>
-              <EuiCollapsibleNavBeta.Footer>
-                <EuiCollapsibleNavBeta.Item
-                  title="Recents"
-                  icon="clock"
-                  href="#"
-                />
-                <EuiCollapsibleNavBeta.Item
-                  title="Get started"
-                  icon="launch"
-                  href="#"
-                />
-                <EuiCollapsibleNavBeta.Item
-                  title="Developer tools"
-                  icon="editorCodeBlock"
-                  href="#"
-                />
-                <EuiCollapsibleNavBeta.Item
-                  title="Management"
-                  icon="gear"
-                  items={[
-                    { title: 'Users and roles', href: '#' },
-                    { title: 'Performance', href: '#' },
-                    {
-                      title: 'Billing and subscription',
-                      href: '#',
-                      linkProps: { target: '_blank' },
-                    },
-                  ]}
-                />
-              </EuiCollapsibleNavBeta.Footer>
-            </EuiCollapsibleNavBeta>
-          </EuiHeaderSection>
-        </EuiHeader>
-        <EuiPageTemplate>
-          <EuiPageTemplate.Section>
-            EuiCollapsibleNavBeta.KibanaSolution
-          </EuiPageTemplate.Section>
-        </EuiPageTemplate>
-      </>
-    ),
+    (Story) => {
+      const [isFlyoutOpen, setIsFlyoutOpen] = useState(false);
+      const openFlyout = () => setIsFlyoutOpen(true);
+      const closeFlyout = () => setIsFlyoutOpen(false);
+      return (
+        <>
+          <EuiHeader position="fixed">
+            <EuiHeaderSection>
+              <EuiCollapsibleNavBeta>
+                <EuiCollapsibleNavBeta.Body>
+                  <Story />
+                </EuiCollapsibleNavBeta.Body>
+                <EuiCollapsibleNavBeta.Footer>
+                  <EuiCollapsibleNavBeta.Item
+                    title="Recents"
+                    icon="clock"
+                    href="#"
+                  />
+                  <EuiCollapsibleNavBeta.Item
+                    title="Get started"
+                    icon="launch"
+                    href="#"
+                  />
+                  <EuiCollapsibleNavBeta.Item
+                    title="Developer tools"
+                    icon="editorCodeBlock"
+                    href="#"
+                  />
+                  <EuiCollapsibleNavBeta.Item
+                    title="Management"
+                    icon="gear"
+                    items={[
+                      { title: 'Users and roles', href: '#' },
+                      { title: 'Performance', href: '#' },
+                      {
+                        title: 'Billing and subscription',
+                        href: '#',
+                        linkProps: { target: '_blank' },
+                      },
+                    ]}
+                  />
+                </EuiCollapsibleNavBeta.Footer>
+              </EuiCollapsibleNavBeta>
+            </EuiHeaderSection>
+          </EuiHeader>
+          <EuiPageTemplate>
+            <EuiPageTemplate.TopBar paddingSize="m">
+              <EuiButtonEmpty iconType="indexOpen" onClick={openFlyout}>
+                Add integrations
+              </EuiButtonEmpty>
+              <EuiButtonEmpty iconType="gear" onClick={openFlyout}>
+                Settings
+              </EuiButtonEmpty>
+            </EuiPageTemplate.TopBar>
+            <EuiPageTemplate.Header
+              iconType="logoElastic"
+              pageTitle="Example Kibana solution"
+              rightSideItems={[
+                <EuiButton onClick={openFlyout}>Button</EuiButton>,
+              ]}
+              tabs={[{ label: 'Tab 1', isSelected: true }, { label: 'Tab 2' }]}
+            />
+            <EuiPageTemplate.Section
+              style={{ blockSize: '100vh' }} // Demos the sticky top bar
+            />
+          </EuiPageTemplate>
+          {isFlyoutOpen && <EuiFlyout onClose={closeFlyout} />}
+        </>
+      );
+    },
   ],
 };
 export default meta;

--- a/packages/eui/src/components/page_template/__snapshots__/page_template.test.tsx.snap
+++ b/packages/eui/src/components/page_template/__snapshots__/page_template.test.tsx.snap
@@ -82,6 +82,58 @@ exports[`EuiPageTemplate children detects sidebars and does not place them in th
 </div>
 `;
 
+exports[`EuiPageTemplate children detects top bars and places them above other content 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiPageTemplate testClass1 testClass2 emotion-euiPageOuter-row-grow-euiTestCss"
+  data-test-subj="test subject string"
+  style="min-block-size: max(460px, 100vh); padding-block-start: var(--euiFixedHeadersOffset, 0);"
+>
+  <main
+    class="emotion-euiPageInner"
+    id="EuiPageTemplateInner_generated-id"
+  >
+    <div
+      class="emotion-euiPageTopBar-bordered"
+    >
+      <section
+        class="emotion-euiPageSection-l-top-transparent"
+      >
+        <div
+          class="emotion-euiPageSection__content-l-restrictWidth-euiPageTopBar__content-right-l"
+          style="max-width: 1200px;"
+        >
+          A
+        </div>
+      </section>
+    </div>
+    <header
+      class="euiPageHeader emotion-euiPageHeader-l-border"
+    >
+      <div
+        class="emotion-euiPageHeaderContent-l"
+      >
+        <div
+          class="css-ljpjbj-flex-center"
+        >
+          B
+        </div>
+      </div>
+    </header>
+    <section
+      class="emotion-euiPageSection-grow-l-top-plain"
+    >
+      <div
+        class="emotion-euiPageSection__content-l-restrictWidth"
+        style="max-width: 1200px;"
+      >
+        C
+      </div>
+    </section>
+  </main>
+</div>
+`;
+
 exports[`EuiPageTemplate children renders all other types within the main EuiPageInner 1`] = `
 <div
   aria-label="aria-label"

--- a/packages/eui/src/components/page_template/page_template.stories.tsx
+++ b/packages/eui/src/components/page_template/page_template.stories.tsx
@@ -14,7 +14,7 @@ import {
   moveStorybookControlsToCategory,
 } from '../../../.storybook/utils';
 import { EuiSkeletonText } from '../skeleton';
-import { EuiButton } from '../button';
+import { EuiButton, EuiButtonEmpty } from '../button';
 import { EuiText } from '../text';
 
 import { EuiPageTemplate, EuiPageTemplateProps } from './page_template';
@@ -51,6 +51,11 @@ const sidebarContent = (
   <EuiPageTemplate.Sidebar>
     <EuiSkeletonText lines={10} contentAriaLabel="Page sidebar example text" />
   </EuiPageTemplate.Sidebar>
+);
+const topBarContent = (
+  <EuiPageTemplate.TopBar>
+    <EuiButtonEmpty iconType="gear">Settings</EuiButtonEmpty>
+  </EuiPageTemplate.TopBar>
 );
 const bottomBarContent = (
   <EuiPageTemplate.BottomBar>
@@ -126,24 +131,38 @@ export const Playground: Story = {
         'With everything',
         'Without sidebar',
         'Without header',
-        'Without bottom bar',
+        'Without top/bottom bars',
         'With empty prompt content',
       ],
       mapping: {
         'With everything': [
           sidebarContent,
+          topBarContent,
           headerContent,
           sectionContent,
           bottomBarContent,
         ],
-        'Without sidebar': [headerContent, sectionContent, bottomBarContent],
-        'Without header': [sidebarContent, sectionContent, bottomBarContent],
-        'Without bottom bar': [sidebarContent, headerContent, sectionContent],
+        'Without sidebar': [
+          topBarContent,
+          headerContent,
+          sectionContent,
+          bottomBarContent,
+        ],
+        'Without header': [
+          sidebarContent,
+          topBarContent,
+          sectionContent,
+          bottomBarContent,
+        ],
+        'Without top/bottom bars': [
+          sidebarContent,
+          headerContent,
+          sectionContent,
+        ],
         'With empty prompt content': [
           sidebarContent,
           headerContent,
           emptyPromptContent,
-          bottomBarContent,
         ],
       },
     },

--- a/packages/eui/src/components/page_template/page_template.test.tsx
+++ b/packages/eui/src/components/page_template/page_template.test.tsx
@@ -129,6 +129,18 @@ describe('EuiPageTemplate', () => {
       expect(getByRole('main').childElementCount).toEqual(0);
     });
 
+    it('detects top bars and places them above other content', () => {
+      const { container, getByRole } = render(
+        <EuiPageTemplate {...requiredProps}>
+          <EuiPageTemplate.Header>B</EuiPageTemplate.Header>
+          <EuiPageTemplate.Section>C</EuiPageTemplate.Section>
+          <EuiPageTemplate.TopBar>A</EuiPageTemplate.TopBar>
+        </EuiPageTemplate>
+      );
+      expect(container.firstChild).toMatchSnapshot();
+      expect(getByRole('main')).toHaveTextContent('ABC');
+    });
+
     it('renders all other types within the main EuiPageInner', () => {
       const { container, getByRole } = render(
         <EuiPageTemplate {...requiredProps}>

--- a/packages/eui/src/components/page_template/page_template.tsx
+++ b/packages/eui/src/components/page_template/page_template.tsx
@@ -24,6 +24,10 @@ import {
   _EuiPageBottomBarProps,
 } from './bottom_bar/page_bottom_bar';
 import {
+  _EuiPageTopBar as EuiPageTopBar,
+  _EuiPageTopBarProps,
+} from './top_bar/page_top_bar';
+import {
   _EuiPageEmptyPrompt as EuiPageEmptyPrompt,
   _EuiPageEmptyPromptProps,
 } from './empty_prompt/page_empty_prompt';
@@ -46,6 +50,7 @@ export const TemplateContext = createContext({
   section: {},
   header: {},
   emptyPrompt: {},
+  topBar: {},
   bottomBar: {},
 });
 
@@ -111,8 +116,9 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
   });
 
   // Sections include page header
-  const [sidebar, sections] = useMemo(() => {
+  const [sidebar, topBar, sections] = useMemo(() => {
     const sidebar: React.ReactElement[] = [];
+    const topBar: React.ReactElement[] = [];
     const sections: React.ReactElement[] = [];
 
     React.Children.toArray(children).forEach((child) => {
@@ -123,12 +129,17 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
         child.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__ === _EuiPageSidebar
       ) {
         sidebar.push(child);
+      } else if (
+        child.type === _EuiPageTopBar ||
+        child.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__ === _EuiPageTopBar
+      ) {
+        topBar.push(child);
       } else {
         sections.push(child);
       }
     });
 
-    return [sidebar, sections];
+    return [sidebar, topBar, sections];
   }, [children]);
 
   const classes = classNames('euiPageTemplate', className);
@@ -168,6 +179,12 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
         panelled: innerPanelled ? true : panelled,
         grow: true,
       },
+      topBar: {
+        panelled: innerPanelled,
+        contentBorder: contentBorder ?? true,
+        restrictWidth,
+        paddingSize,
+      },
       bottomBar: {
         restrictWidth,
         paddingSize,
@@ -182,6 +199,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
     paddingSize,
     panelled,
     innerPanelled,
+    contentBorder,
     headerBottomBorder,
   ]);
 
@@ -203,6 +221,7 @@ export const _EuiPageTemplate: FunctionComponent<EuiPageTemplateProps> = ({
           panelled={innerPanelled}
           responsive={responsive}
         >
+          {topBar}
           {sections}
         </EuiPageInner>
       </EuiPageOuter>
@@ -244,10 +263,17 @@ const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = (
   return <EuiPageBottomBar {...bottomBar} {...props} />;
 };
 
+const _EuiPageTopBar: FunctionComponent<_EuiPageTopBarProps> = (props) => {
+  const { topBar } = useContext(TemplateContext);
+
+  return <EuiPageTopBar {...topBar} {...props} />;
+};
+
 export const EuiPageTemplate = Object.assign(_EuiPageTemplate, {
   Sidebar: _EuiPageSidebar,
   Header: _EuiPageHeader,
   Section: _EuiPageSection,
+  TopBar: _EuiPageTopBar,
   BottomBar: _EuiPageBottomBar,
   EmptyPrompt: _EuiPageEmptyPrompt,
 });

--- a/packages/eui/src/components/page_template/top_bar/__snapshots__/page_top_bar.test.tsx.snap
+++ b/packages/eui/src/components/page_template/top_bar/__snapshots__/page_top_bar.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_EuiPageTopBar renders 1`] = `
+<div
+  aria-label="aria-label"
+  class="testClass1 testClass2 emotion-euiPageTopBar-bordered-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <section
+    class="emotion-euiPageSection-m-top-transparent"
+  >
+    <div
+      class="emotion-euiPageSection__content-m-euiPageTopBar__content-right-m"
+    />
+  </section>
+</div>
+`;

--- a/packages/eui/src/components/page_template/top_bar/page_top_bar.styles.ts
+++ b/packages/eui/src/components/page_template/top_bar/page_top_bar.styles.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+import { UseEuiTheme } from '../../../services';
+import { logicalCSS } from '../../../global_styling';
+
+export const euiPageTopBarStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiPageTopBar: css`
+      /* -1 makes the bar sit below serverless nav shadows */
+      z-index: ${Number(euiTheme.levels.header) - 1};
+      position: sticky;
+      ${logicalCSS('top', 'var(--euiFixedHeadersOffset, 0)')}
+      ${logicalCSS('horizontal', 0)}
+    `,
+    // Deliberately skipping css`` on the this to avoid an extra Emotion className
+    unpanelled: `
+      background-color: ${euiTheme.colors.body};
+    `,
+    panelled: css`
+      background-color: ${euiTheme.colors.emptyShade};
+    `,
+    bordered: css`
+      ${logicalCSS('border-bottom', euiTheme.border.thin)}
+    `,
+
+    euiPageTopBar__content: css`
+      display: flex;
+      align-items: center;
+    `,
+    align: {
+      left: css`
+        justify-content: flex-start;
+      `,
+      right: css`
+        justify-content: flex-end;
+      `,
+      center: css`
+        justify-content: center;
+      `,
+    },
+    sizes: {
+      none: null,
+      xs: css`
+        gap: ${euiTheme.size.xs};
+        padding-block: 0;
+      `,
+      s: css`
+        gap: ${euiTheme.size.s};
+        padding-block: ${euiTheme.size.xxs};
+      `,
+      m: css`
+        gap: ${euiTheme.size.m};
+        padding-block: ${euiTheme.size.xs};
+      `,
+      l: css`
+        gap: ${euiTheme.size.l};
+        padding-block: ${euiTheme.size.s};
+      `,
+      xl: css`
+        gap: ${euiTheme.size.xl};
+        padding-block: ${euiTheme.size.m};
+      `,
+    },
+  };
+};

--- a/packages/eui/src/components/page_template/top_bar/page_top_bar.test.tsx
+++ b/packages/eui/src/components/page_template/top_bar/page_top_bar.test.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { shouldRenderCustomStyles } from '../../../test/internal';
+import { requiredProps } from '../../../test/required_props';
+import { render } from '../../../test/rtl';
+
+import { _EuiPageTopBar as EuiPageTopBar } from './page_top_bar';
+
+describe('_EuiPageTopBar', () => {
+  shouldRenderCustomStyles(<EuiPageTopBar />);
+
+  it('renders', () => {
+    const { container } = render(<EuiPageTopBar {...requiredProps} />);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  // TODO: Props should likely be VRTs?
+});

--- a/packages/eui/src/components/page_template/top_bar/page_top_bar.tsx
+++ b/packages/eui/src/components/page_template/top_bar/page_top_bar.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FunctionComponent, PropsWithChildren } from 'react';
+
+import { useEuiMemoizedStyles } from '../../../services';
+import { EuiPageSection, EuiPageSectionProps } from '../../page/page_section';
+
+import { euiPageTopBarStyles } from './page_top_bar.styles';
+
+export type _EuiPageTopBarProps = PropsWithChildren & {
+  /**
+   * Determines bar background color
+   */
+  panelled?: boolean;
+  /**
+   * Determines whether a bottom border separating the bar and page sections is rendered
+   */
+  contentBorder?: boolean;
+  /**
+   * Aligns bar content to the left, right, or center
+   */
+  align?: 'left' | 'right' | 'center';
+} & Pick<EuiPageSectionProps, 'restrictWidth' | 'paddingSize'>;
+
+export const _EuiPageTopBar: FunctionComponent<_EuiPageTopBarProps> = ({
+  panelled,
+  contentBorder = true,
+  align = 'right',
+  restrictWidth,
+  paddingSize = 'm',
+  children,
+  ...rest
+}) => {
+  const styles = useEuiMemoizedStyles(euiPageTopBarStyles);
+  const cssStyles = [
+    styles.euiPageTopBar,
+    panelled ? styles.panelled : styles.unpanelled,
+    contentBorder && styles.bordered,
+  ];
+  const contentStyles = [
+    styles.euiPageTopBar__content,
+    styles.align[align],
+    paddingSize && styles.sizes[paddingSize],
+  ];
+
+  return (
+    <div css={cssStyles} {...rest}>
+      {/* Wrapping the contents with EuiPageSection allows us to match the restrictWidth to keep the contents aligned */}
+      <EuiPageSection
+        paddingSize={paddingSize}
+        restrictWidth={restrictWidth}
+        contentProps={{ css: contentStyles }}
+      >
+        {children}
+      </EuiPageSection>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7765

![top_bar](https://github.com/elastic/eui/assets/549407/eb2dbf69-d8ec-486b-9724-464b4b4a6a6b)

⚠️ TODOS:
- [ ] Figure out child API for links? leave it flexible or try to make it opinionated? need to figure out what layouts are being used by Kibana solutions
- [ ] Documentation

## QA

- https://eui.elastic.co/pr_7777/storybook/?path=/story/templates-euipagetemplate--playground
- https://eui.elastic.co/pr_7777/storybook/?path=/story/navigation-euicollapsiblenav-beta-kibanasolution--playground

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - [ ] Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart
