### PR TITLE
[EuiDatePicker] Handle invalid `selected` moment formats

### DIFF
--- a/packages/eui/changelogs/upcoming/7784.md
+++ b/packages/eui/changelogs/upcoming/7784.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDatePicker` to more gracefully handle incorrectly formatted `selected` Moment dates, instead of simply crashing

--- a/packages/eui/src-docs/src/views/date_picker/date_picker.js
+++ b/packages/eui/src-docs/src/views/date_picker/date_picker.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { EuiDatePicker, EuiFormRow } from '../../../../src/components';
 
 export default () => {
-  const [startDate, setStartDate] = useState(moment('invalid'));
+  const [startDate, setStartDate] = useState(moment());
 
   const handleChange = (date) => {
     setStartDate(date);

--- a/packages/eui/src-docs/src/views/date_picker/date_picker.js
+++ b/packages/eui/src-docs/src/views/date_picker/date_picker.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { EuiDatePicker, EuiFormRow } from '../../../../src/components';
 
 export default () => {
-  const [startDate, setStartDate] = useState(moment());
+  const [startDate, setStartDate] = useState(moment('invalid'));
 
   const handleChange = (date) => {
     setStartDate(date);

--- a/packages/eui/src/components/date_picker/date_picker.test.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.test.tsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
-import { render } from '../../test/rtl';
-import { requiredProps } from '../../test';
 import moment from 'moment';
+import { fireEvent } from '@testing-library/react';
+import { render, waitForEuiPopoverOpen } from '../../test/rtl';
+import { requiredProps } from '../../test';
 
 import { EuiDatePicker } from './date_picker';
 import { EuiContext } from '../context';
@@ -21,7 +22,7 @@ describe('EuiDatePicker', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('handles invalid `selected` dates', () => {
+  it('handles invalid `selected` dates', async () => {
     const { container } = render(
       <EuiDatePicker selected={moment('invalid')} />
     );
@@ -29,6 +30,14 @@ describe('EuiDatePicker', () => {
 
     expect(datepickerInput).toHaveValue('Invalid date');
     expect(datepickerInput).toBeInvalid();
+
+    // The calendar date picker should load in a popover, but no date should be selected
+    fireEvent.focus(datepickerInput!);
+    await waitForEuiPopoverOpen();
+    const calendar = document.querySelector('.react-datepicker__month');
+    expect(calendar).toBeInTheDocument();
+    const selected = document.querySelector('.react-datepicker__day--selected');
+    expect(selected).not.toBeInTheDocument();
   });
 
   test('compressed', () => {

--- a/packages/eui/src/components/date_picker/date_picker.test.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.test.tsx
@@ -23,6 +23,8 @@ describe('EuiDatePicker', () => {
   });
 
   it('handles invalid `selected` dates', async () => {
+    // Silence the console warning from the invalid moment date
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { container } = render(
       <EuiDatePicker selected={moment('invalid')} />
     );
@@ -38,6 +40,8 @@ describe('EuiDatePicker', () => {
     expect(calendar).toBeInTheDocument();
     const selected = document.querySelector('.react-datepicker__day--selected');
     expect(selected).not.toBeInTheDocument();
+
+    jest.restoreAllMocks();
   });
 
   test('compressed', () => {

--- a/packages/eui/src/components/date_picker/date_picker.test.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.test.tsx
@@ -21,6 +21,16 @@ describe('EuiDatePicker', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  it('handles invalid `selected` dates', () => {
+    const { container } = render(
+      <EuiDatePicker selected={moment('invalid')} />
+    );
+    const datepickerInput = container.querySelector('input.euiDatePicker');
+
+    expect(datepickerInput).toHaveValue('Invalid date');
+    expect(datepickerInput).toBeInvalid();
+  });
+
   test('compressed', () => {
     const { container } = render(<EuiDatePicker compressed />);
     // TODO: Should probably be a visual snapshot test

--- a/packages/eui/src/components/date_picker/date_picker.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.tsx
@@ -164,7 +164,7 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
   injectTimes,
   inline,
   inputRef,
-  isInvalid,
+  isInvalid: _isInvalid,
   isLoading,
   locale,
   maxDate,
@@ -192,6 +192,10 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
     'euiDatePicker--inline': inline,
     'euiDatePicker--shadow': inline && shadow,
   });
+
+  // Check for whether the passed `selected` moment date is valid
+  const isInvalid =
+    _isInvalid || (selected?.isValid() === false ? true : undefined);
 
   const numIconsClass = controlOnly
     ? false

--- a/packages/eui/src/components/date_picker/react-datepicker/src/index.js
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/index.js
@@ -83,6 +83,9 @@ function hasPreSelectionChanged(date1, date2) {
 
 function hasSelectionChanged(date1, date2) {
   if (date1 && date2) {
+    if (date1._isValid === false && date2._isValid === false) {
+      return false;
+    }
     return !equals(date1, date2);
   }
 

--- a/packages/eui/src/components/date_picker/react-datepicker/src/index.js
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/index.js
@@ -291,7 +291,7 @@ export default class DatePicker extends React.Component {
     return {
       open: this.props.startOpen || false,
       preventFocus: false,
-      preSelection: this.props.selected
+      preSelection: this.props.selected?._isValid
         ? newDate(this.props.selected)
         : boundedPreSelection,
       // transforming highlighted days (perhaps nested array)
@@ -696,7 +696,7 @@ export default class DatePicker extends React.Component {
         useWeekdaysShort={this.props.useWeekdaysShort}
         formatWeekDay={this.props.formatWeekDay}
         dropdownMode={this.props.dropdownMode}
-        selected={this.props.selected}
+        selected={this.props.selected?._isValid ? this.props.selected : undefined}
         preSelection={this.state.preSelection}
         onSelect={this.handleSelect}
         onWeekSelect={this.props.onWeekSelect}


### PR DESCRIPTION
## Summary

@shahzad31 reported this issue to us in Slack - passing an invalid `moment()` date to the `selected` prop causes a maximum update depth exceeded React error. We should be more gracefully handling and alerting consumers to this issue without just blanket crashing JS.

| Before | After |
|--------|--------|
| <img width="500" alt="" src="https://github.com/elastic/eui/assets/549407/41f9afcf-ef9f-478c-bf18-43f93890c884"> | ![fix](https://github.com/elastic/eui/assets/549407/86db81b6-bf66-4472-9bb2-68fa1d6ab927) | 

## QA

- Go to https://eui.elastic.co/pr_7784/#/forms/date-picker
- [x] Confirm that the first example on the page shows an `Invalid date` value (with danger icon/coloring)
- [x] Confirm that clicking on the invalid date shows the calendar popover without crashing and allows the user to select a new valid date

### General checklist

- [x] Revert [REVERT ME] commit
- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A, bugfix
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A