### PR TITLE
fix: Simplify EuiFlex generic types

### DIFF
--- a/packages/eui/changelogs/upcoming/7792.md
+++ b/packages/eui/changelogs/upcoming/7792.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFlexGroup` and `EuiFlexItem` types to correctly accept global attribute props and simplify type resolution when used with `styled()`-like wrappers

--- a/packages/eui/scripts/dtsgenerator.js
+++ b/packages/eui/scripts/dtsgenerator.js
@@ -106,6 +106,7 @@ const generator = dtsGenerator({
 // 2. replace any import("src/...") declarations to import("@elastic/eui/src/...")
 // 3. replace any import("./...") declarations to import("@elastic/eui/src/...)
 // 4. generate & add EuiTokenObject
+// 5. Fix React.ElementType being incorrectly expanded to React.ElementType<any, keyof React.JSX.IntrinsicElements>
 generator.then(() => {
   const defsFilePath = path.resolve(baseDir, 'eui.d.ts');
 
@@ -155,6 +156,10 @@ generator.then(() => {
         }
       ) // end 3.
       .replace(/$/, `\n\n${buildEuiTokensObject()}`) // 4.
+      .replaceAll(
+        'React.ElementType<any, keyof React.JSX.IntrinsicElements>',
+        'React.ElementType'
+      ) // 5.
   );
 });
 

--- a/packages/eui/src/components/flex/flex_group.tsx
+++ b/packages/eui/src/components/flex/flex_group.tsx
@@ -8,11 +8,12 @@
 
 import React, {
   ComponentPropsWithoutRef,
-  ComponentType,
   ElementType,
   ForwardedRef,
   forwardRef,
+  FunctionComponent,
   PropsWithChildren,
+  ReactElement,
   Ref,
 } from 'react';
 import classNames from 'classnames';
@@ -51,9 +52,7 @@ export const DIRECTIONS = [
 ] as const;
 type FlexGroupDirection = (typeof DIRECTIONS)[number];
 
-type ComponentPropType = ElementType<CommonProps>;
-
-export type EuiFlexGroupProps<TComponent extends ComponentPropType = 'div'> =
+export type EuiFlexGroupProps<TComponent extends ElementType = 'div'> =
   PropsWithChildren &
     CommonProps &
     ComponentPropsWithoutRef<TComponent> & {
@@ -83,7 +82,7 @@ export type EuiFlexGroupProps<TComponent extends ComponentPropType = 'div'> =
       wrap?: boolean;
     };
 
-const EuiFlexGroupInternal = <TComponent extends ComponentPropType>(
+const EuiFlexGroupInternal = <TComponent extends ElementType>(
   {
     className,
     component = 'div' as TComponent,
@@ -96,7 +95,7 @@ const EuiFlexGroupInternal = <TComponent extends ComponentPropType>(
     ...rest
   }: EuiFlexGroupProps<TComponent>,
   ref: ForwardedRef<TComponent>
-) => {
+): ReactElement<EuiFlexGroupProps<TComponent>, TComponent> => {
   const styles = useEuiMemoizedStyles(euiFlexGroupStyles);
   const cssStyles = [
     styles.euiFlexGroup,
@@ -110,10 +109,11 @@ const EuiFlexGroupInternal = <TComponent extends ComponentPropType>(
 
   const classes = classNames('euiFlexGroup', className);
 
-  // Cast the resolved component prop type to ComponentType to help TS
-  // process multiple infers and the overall type complexity.
-  // This might not be needed in TypeScript 5
-  const Component = component as ComponentType<CommonProps & typeof rest>;
+  // Cast `component` to FunctionComponent to simplify its type.
+  // Note that FunctionComponent type is used here for purely typing
+  // convenience since we specify the return type above, and function
+  // components don't support `ref`s, but that doesn't matter in this case.
+  const Component = component as FunctionComponent<CommonProps & typeof rest>;
 
   return <Component {...rest} ref={ref} className={classes} css={cssStyles} />;
 };
@@ -121,12 +121,12 @@ const EuiFlexGroupInternal = <TComponent extends ComponentPropType>(
 // Cast forwardRef return type to work with the generic TComponent type
 // and not fallback to implicit any typing
 export const EuiFlexGroup = forwardRef(EuiFlexGroupInternal) as (<
-  TComponent extends ComponentPropType = 'div',
-  TComponentRef = ReturnType<typeof EuiFlexGroupInternal>
+  TComponent extends ElementType = 'div',
+  TComponentRef = ReactElement<any, TComponent>
 >(
   props: EuiFlexGroupProps<TComponent> & {
     ref?: Ref<TComponentRef>;
   }
-) => ReturnType<typeof EuiFlexGroupInternal>) & { displayName?: string };
+) => ReactElement) & { displayName?: string };
 
 EuiFlexGroup.displayName = 'EuiFlexGroup';


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/eui/issues/7783

This PR optimizes types used in `EuiFlexItem` and `EuiFlexGroup` to be resolved faster and more reliably.

We recently found out that the introduction of https://github.com/elastic/eui/pull/7688 caused a significant increase in type-checking times in Kibana. The reason wasn't clear at first, but profiling `tsc` and running type checking with various type simplifications highlighted the primary error. The generic typing of these two components isn't at fault. It's actually the type inferencing and distributive conditionals used multiple times in the type resolution path and EUI types being combined into a single big `eui.d.ts` all added to the type checking execution time.

This PR addresses all of these by simplifying these types and fixes a bug where some global attributes (e.g., `title`) weren't recognized as a proper argument.

This PR shouldn't introduce any breaking changes since the new types can be considered less strict / looser.

## QA

1. Checkout latest Kibana main and run `yarn kbn bootstrap` and `time node scripts/type_check --clean-cache`
2. Checkout this branch, build EUI and link it locally to kibana. Run `yarn kbn bootstrap --no-validate` and `time node scripts/type_check --clean-cache` again to confirm reduced type checking times

### General checklist

- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
