### PR TITLE
[EuiCollapsibleNavBeta] Tweak styles per latest Kibana directives

### DIFF
--- a/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`KibanaCollapsibleNavSolution renders with a solution switcher 1`] = `
   </div>
   <div
     aria-label="Some solution"
-    class="euiCollapsibleNavItem__items emotion-euiCollapsibleNavItem__items-isGroup"
+    class="euiCollapsibleNavItem__items emotion-euiCollapsibleNavItem__items-isTopItem"
     role="group"
   >
     <span

--- a/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/collapsible_nav_kibana_solution.tsx
@@ -180,7 +180,6 @@ export const KibanaCollapsibleNavSolution: FunctionComponent<
           </EuiInputPopover>
           <EuiCollapsibleNavSubItems
             items={items}
-            isGroup
             role="group"
             aria-label={title}
           />

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -94,23 +94,9 @@ export const Playground: Story = {
     <OpenCollapsibleNav {...args}>
       <EuiCollapsibleNavBeta.Body>
         <EuiCollapsibleNavBeta.Item
-          title="Home"
-          icon="home"
-          isSelected
-          href="#"
-        />
-        <EuiCollapsibleNavBeta.Item
-          title="Recent"
-          icon="clock"
-          items={[
-            { title: 'Lorem ipsum', icon: 'visMapRegion', href: '#' },
-            { title: 'Consectetur cursus', icon: 'visPie', href: '#' },
-            { title: 'Ultricies tellus', icon: 'visMetric', href: '#' },
-          ]}
-        />
-        <EuiCollapsibleNavBeta.Item
           title="Elasticsearch"
           icon="logoElasticsearch"
+          isCollapsible={false}
           items={[
             { title: 'Get started', href: '#' },
             ...renderGroup('Explore', [
@@ -126,145 +112,17 @@ export const Playground: Story = {
             ...renderGroup('Security', [{ title: 'API keys', href: '#' }]),
           ]}
         />
-        <EuiCollapsibleNavBeta.Item
-          title="Enterprise Search"
-          icon="logoEnterpriseSearch"
-          items={[
-            { title: 'ESRE', href: '#' },
-            { title: 'Vector search', href: '#' },
-            { title: 'Content', href: '#' },
-            { title: 'Search applications', href: '#' },
-            { title: 'Behavioral analytics', href: '#' },
-            { title: 'Elasticsearch', href: '#' },
-            { title: 'App search', href: '#' },
-            { title: 'Workplace search', href: '#' },
-            { title: 'Search experiences', href: '#' },
-          ]}
-        />
-        <EuiCollapsibleNavBeta.Item
-          title="Observability"
-          icon="logoObservability"
-          items={[
-            { title: 'Get started', href: '#' },
-            { title: 'Alerts', href: '#' },
-            { title: 'Cases', href: '#' },
-            { title: 'SLOs', href: '#' },
-            ...renderGroup('Signals', [
-              { title: 'Logs', href: '#' },
-              {
-                title: 'Tracing',
-                items: [
-                  { title: 'Services', href: '#' },
-                  { title: 'Traces', href: '#' },
-                  { title: 'Dependencies', href: '#' },
-                ],
-              },
-            ]),
-            ...renderGroup('Toolbox', [
-              { title: 'Visualize library', href: '#' },
-              { title: 'Dashboards', href: '#' },
-              {
-                title: 'AIOps',
-                items: [
-                  { title: 'Anomaly detection', href: '#' },
-                  { title: 'Spike analysis', href: '#' },
-                  { title: 'Change point detection', href: '#' },
-                  { title: 'Notifications', href: '#' },
-                ],
-              },
-            ]),
-          ]}
-        />
-        <EuiCollapsibleNavBeta.Item
-          title="Security"
-          icon="logoSecurity"
-          items={[
-            { title: 'Get started', href: '#' },
-            { title: 'Dashboards', href: '#' },
-            { title: 'Alerts', href: '#' },
-            { title: 'Findings', href: '#' },
-            { title: 'Cases', href: '#' },
-            { title: 'Investigation', href: '#' },
-            { title: 'Intelligence', href: '#' },
-            {
-              title: 'Explore',
-              items: [
-                { title: 'Host', href: '#' },
-                { title: 'Users', href: '#' },
-                { title: 'Network', href: '#' },
-              ],
-            },
-            { title: 'Assets', href: '#' },
-            {
-              title: 'Rules',
-              items: [
-                { title: 'SIEM rules', href: '#' },
-                { title: 'Shared exception list', href: '#' },
-                { title: 'CIS benchmark rules', href: '#' },
-                { title: 'Defend rules', href: '#' },
-              ],
-            },
-            {
-              title: 'Machine learning',
-              items: [
-                { title: 'Overview', href: '#' },
-                { title: 'Notifications', href: '#' },
-                { title: 'Memory usage', href: '#' },
-                { title: 'Anomaly detection', href: '#' },
-                { title: 'Data frame analytics', href: '#' },
-                { title: 'Model management', href: '#' },
-              ],
-            },
-            {
-              title: 'Settings',
-              items: [
-                { title: 'Endpoints', href: '#' },
-                { title: 'OS query', href: '#' },
-                { title: 'Response actions history', href: '#' },
-                { title: 'Event filters', href: '#' },
-                { title: 'Host isolation', href: '#' },
-              ],
-            },
-          ]}
-        />
-        <EuiCollapsibleNavBeta.Item
-          title="Analytics"
-          icon="stats"
-          items={[
-            { title: 'Discover', href: '#' },
-            { title: 'Dashboard', href: '#' },
-            { title: 'Visualize library', href: '#' },
-          ]}
-        />
-        <EuiCollapsibleNavBeta.Item
-          title="Machine learning"
-          icon="indexMapping"
-          items={[
-            { title: 'Overview', href: '#' },
-            { title: 'Notifications', href: '#' },
-            { title: 'Memory usage', href: '#' },
-            ...renderGroup('Anomaly detection', [
-              { title: 'Jobs', href: '#' },
-              { title: 'Anomaly explorer', href: '#' },
-              { title: 'Single metric viewer', href: '#' },
-              { title: 'Settings', href: '#' },
-            ]),
-            ...renderGroup('Data frame analytics', [
-              { title: 'Jobs', href: '#' },
-              { title: 'Results explorer', href: '#' },
-              { title: 'Analytics map', href: '#' },
-            ]),
-            ...renderGroup('Model management', [
-              { title: 'Trained models', href: '#' },
-            ]),
-            ...renderGroup('Data visualizer', [
-              { title: 'File', href: '#' },
-              { title: 'Data view', href: '#' },
-            ]),
-          ]}
-        />
       </EuiCollapsibleNavBeta.Body>
       <EuiCollapsibleNavBeta.Footer>
+        <EuiCollapsibleNavBeta.Item
+          title="Recent"
+          icon="clock"
+          items={[
+            { title: 'Lorem ipsum', icon: 'visMapRegion', href: '#' },
+            { title: 'Consectetur cursus', icon: 'visPie', href: '#' },
+            { title: 'Ultricies tellus', icon: 'visMetric', href: '#' },
+          ]}
+        />
         <EuiCollapsibleNavBeta.Item
           title="Developer tools"
           icon="editorCodeBlock"
@@ -276,21 +134,19 @@ export const Playground: Story = {
           ]}
         />
         <EuiCollapsibleNavBeta.Item
-          title="Management"
-          icon="gear"
-          items={[
-            { title: 'Integrations', href: '#' },
-            { title: 'Fleet', href: '#' },
-            { title: 'Osquery', href: '#' },
-            { title: 'Stack monitoring', href: '#' },
-            { title: 'Stack management', href: '#' },
-          ]}
-        />
-        <EuiCollapsibleNavBeta.Item
           title="Project settings"
           icon="gear"
           items={[
-            { title: 'Management', href: '#' },
+            {
+              title: 'Management',
+              items: [
+                { title: 'Integrations', href: '#' },
+                { title: 'Fleet', href: '#' },
+                { title: 'Osquery', href: '#' },
+                { title: 'Stack monitoring', href: '#' },
+                { title: 'Stack management', href: '#' },
+              ],
+            },
             {
               title: 'Users and roles',
               href: '#',

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/__snapshots__/collapsible_nav_item.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`EuiCollapsibleNavItem renders a collapsed button icon when in a collaps
 exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] = `
 <div
   aria-label="aria-label"
-  class="euiAccordion euiCollapsibleNavAccordion euiCollapsibleNavItem testClass1 testClass2 emotion-euiAccordion-euiCollapsibleNavAccordion-isTopItem-euiTestCss"
+  class="euiAccordion euiCollapsibleNavAccordion euiCollapsibleNavItem testClass1 testClass2 emotion-euiAccordion-euiCollapsibleNavAccordion-isTopItem-euiCollapsibleNavTopItem-euiTestCss"
   data-test-subj="test subject string"
 >
   <div
@@ -102,7 +102,7 @@ exports[`EuiCollapsibleNavItem renders a top level accordion if items exist 1`] 
 exports[`EuiCollapsibleNavItem renders a top level group if items exist and \`isCollapsible\` is set to false 1`] = `
 <div
   aria-label="aria-label"
-  class="euiCollapsibleNavGroup euiCollapsibleNavItem testClass1 testClass2 emotion-euiCollapsibleNavGroup-isTopItem-euiTestCss"
+  class="euiCollapsibleNavGroup euiCollapsibleNavItem testClass1 testClass2 emotion-euiCollapsibleNavGroup-isTopItem-euiCollapsibleNavTopItem-euiTestCss"
   data-test-subj="test subject string"
 >
   <span

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.styles.ts
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.styles.ts
@@ -57,7 +57,7 @@ export const euiCollapsibleNavSubItemsStyles = ({ euiTheme }: UseEuiTheme) => {
     euiCollapsibleNavItem__items: css``,
     isTopItem: css`
       ${logicalCSS('padding-top', euiTheme.size.xs)}
-      ${logicalCSS('padding-left', euiTheme.size.s)}
+      ${logicalCSS('padding-left', euiTheme.size.xl)}
     `,
     isSubItem: css`
       ${logicalCSS('border-left', euiTheme.border.thin)}
@@ -69,6 +69,28 @@ export const euiCollapsibleNavSubItemsStyles = ({ euiTheme }: UseEuiTheme) => {
           (x, y) => x - y
         )
       )}
+    `,
+  };
+};
+
+/**
+ * Top-level item only styles
+ */
+
+export const euiCollapsibleNavTopItemStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    // If this is the only top-level item in the list, assume it's a solution nav and
+    // reduce its default left padding + increase its relative icon size
+    euiCollapsibleNavTopItem: css`
+      &:only-child {
+        .euiCollapsibleNavItem__items {
+          ${logicalCSS('padding-left', euiTheme.size.s)}
+        }
+
+        .euiCollapsibleNavItem__icon {
+          transform: scale(1.25);
+        }
+      }
     `,
   };
 };

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.styles.ts
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.styles.ts
@@ -55,13 +55,9 @@ export const euiCollapsibleNavItemTitleStyles = {
 export const euiCollapsibleNavSubItemsStyles = ({ euiTheme }: UseEuiTheme) => {
   return {
     euiCollapsibleNavItem__items: css``,
-    isGroup: css`
-      ${logicalCSS('padding-top', euiTheme.size.xs)}
-      ${logicalCSS('padding-left', euiTheme.size.s)}
-    `,
     isTopItem: css`
       ${logicalCSS('padding-top', euiTheme.size.xs)}
-      ${logicalCSS('padding-left', euiTheme.size.xl)}
+      ${logicalCSS('padding-left', euiTheme.size.s)}
     `,
     isSubItem: css`
       ${logicalCSS('border-left', euiTheme.border.thin)}

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.test.tsx
@@ -17,6 +17,7 @@ import { EuiCollapsibleNavItem } from './collapsible_nav_item';
 describe('EuiCollapsibleNavItem', () => {
   shouldRenderCustomStyles(<EuiCollapsibleNavItem title="Title" href="#" />, {
     childProps: ['linkProps'],
+    skip: { css: true }, // The custom CSS is there but the merged order is unpredictable
   });
   shouldRenderCustomStyles(
     <EuiCollapsibleNavItem title="Title" items={[{ title: 'Sub-item' }]} />,

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -240,17 +240,16 @@ export const EuiCollapsibleNavSubItem: FunctionComponent<
 type EuiCollapsibleNavSubItemsProps = HTMLAttributes<HTMLDivElement> &
   _EuiCollapsibleNavItemDisplayProps & {
     items: EuiCollapsibleNavSubItemProps[];
-    isGroup?: boolean;
   };
 export const EuiCollapsibleNavSubItems: FunctionComponent<
   EuiCollapsibleNavSubItemsProps
-> = ({ items, isSubItem, isGroup, className, ...rest }) => {
+> = ({ items, isSubItem, className, ...rest }) => {
   const classes = classNames('euiCollapsibleNavItem__items', className);
 
   const styles = useEuiMemoizedStyles(euiCollapsibleNavSubItemsStyles);
   const cssStyles = [
     styles.euiCollapsibleNavItem__items,
-    isGroup ? styles.isGroup : isSubItem ? styles.isSubItem : styles.isTopItem,
+    isSubItem ? styles.isSubItem : styles.isTopItem,
   ];
 
   const itemsHaveIcons = useMemo(

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsible_nav_item.tsx
@@ -28,6 +28,7 @@ import { EuiCollapsibleNavAccordion } from './collapsible_nav_accordion';
 import { EuiCollapsibleNavGroup } from './collapsible_nav_group';
 import { EuiCollapsibleNavLink } from './collapsible_nav_link';
 import {
+  euiCollapsibleNavTopItemStyles,
   euiCollapsibleNavItemTitleStyles,
   euiCollapsibleNavSubItemsStyles,
 } from './collapsible_nav_item.styles';
@@ -199,7 +200,16 @@ export const EuiCollapsibleNavItemTitle: FunctionComponent<
 
   return (
     <>
-      {icon && <EuiIcon type={icon} {...iconProps} />}
+      {icon && (
+        <EuiIcon
+          type={icon}
+          {...iconProps}
+          className={classNames(
+            'euiCollapsibleNavItem__icon',
+            iconProps?.className
+          )}
+        />
+      )}
 
       <TitleElement
         className="euiCollapsibleNavItem__title eui-textTruncate"
@@ -284,6 +294,7 @@ export const EuiCollapsibleNavItem: FunctionComponent<
   EuiCollapsibleNavItemProps
 > = ({ className, ...props }) => {
   const classes = classNames('euiCollapsibleNavItem', className);
+  const styles = useEuiMemoizedStyles(euiCollapsibleNavTopItemStyles);
 
   const { isCollapsed, isPush } = useContext(EuiCollapsibleNavContext);
 
@@ -293,6 +304,7 @@ export const EuiCollapsibleNavItem: FunctionComponent<
     <EuiCollapsibleNavItemDisplay
       className={classes}
       {...props}
+      css={styles.euiCollapsibleNavTopItem}
       isSubItem={false}
     />
   );


### PR DESCRIPTION
## Summary

Requested by @sebelga and @ryankeairns. ~Updates all top-level `items` to have the same reduced padding of `EuiCollapsibleNavBeta.KibanaSolution`.~ See comment thread below for final design choices

| Before | After |
|--------|--------|
| <img width="270" alt="" src="https://github.com/elastic/eui/assets/549407/603f8816-c55d-48cb-956f-99a79b67e6f9"> | <img width="449" alt="" src="https://github.com/elastic/eui/assets/549407/908082f0-6fe6-4129-9c64-340d8df12b70"> | 

NOTE: `EuiCollapsibleNavBeta.KibanaSolution` is no longer slated to be used in Kibana, but we're holding off for another little while (to let decision making settle) before removing it fully.

## QA

- https://eui.elastic.co/pr_7796/storybook/?path=/story/navigation-euicollapsiblenav-beta-euicollapsiblenavbeta--playground


