### PR TITLE
Explicitly support EUI Icons in EuiContextMenuItemIcon type definition

### DIFF
--- a/packages/eui/changelogs/upcoming/7804.md
+++ b/packages/eui/changelogs/upcoming/7804.md
@@ -1,1 +1,1 @@
-- Modify `EuiContextMenuItemIcon` type definition to explicitly define support for EuiIcon's icon definition (i.e `IconType`)
+- Updated `EuiContextMenuItemIcon`'s type definition to explicitly define support for `EuiIcon`'s `IconType`

--- a/packages/eui/changelogs/upcoming/7804.md
+++ b/packages/eui/changelogs/upcoming/7804.md
@@ -1,0 +1,1 @@
+- Modify `EuiContextMenuItemIcon` type definition to explicitly define support for EuiIcon's icon definition (i.e `IconType`)

--- a/packages/eui/src/components/context_menu/context_menu_item.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.tsx
@@ -25,12 +25,12 @@ import {
 } from '../../services';
 import { validateHref } from '../../services/security/href_validator';
 import { CommonProps, keysOf } from '../common';
-import { EuiIcon } from '../icon';
+import { EuiIcon, type IconType } from '../icon';
 import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 
 import { euiContextMenuItemStyles } from './context_menu_item.styles';
 
-export type EuiContextMenuItemIcon = ReactElement<any> | string | HTMLElement;
+export type EuiContextMenuItemIcon = IconType | ReactElement<any>;
 
 export type EuiContextMenuItemLayoutAlignment = 'center' | 'top' | 'bottom';
 
@@ -124,7 +124,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
       />
     ) : (
       // Assume it's already an instance of an icon.
-      cloneElementWithCss(icon as ReactElement, {
+      cloneElementWithCss(icon, {
         css: styles.euiContextMenu__icon,
       })
     ));

--- a/packages/eui/src/components/context_menu/context_menu_item.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.tsx
@@ -30,7 +30,7 @@ import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 
 import { euiContextMenuItemStyles } from './context_menu_item.styles';
 
-export type EuiContextMenuItemIcon = IconType | ReactElement<any>;
+export type EuiContextMenuItemIcon = IconType | ReactElement<any> | HTMLElement;
 
 export type EuiContextMenuItemLayoutAlignment = 'center' | 'top' | 'bottom';
 


### PR DESCRIPTION
## Summary

This PR includes changes to the type definition for `EuiContextMenuItemIcon` so that support for valid EUI `IconType` is explicit.

This change would be transparent to the end user, and is more a DX improvement.


