### PR TITLE
[EuiBetaBadge] Improved the accessibility experience of EuiBetaBadge component

### DIFF
--- a/packages/eui/changelogs/upcoming/7805.md
+++ b/packages/eui/changelogs/upcoming/7805.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Improved the accessibility experience of EuiBetaBadge component

--- a/packages/eui/changelogs/upcoming/7805.md
+++ b/packages/eui/changelogs/upcoming/7805.md
@@ -1,3 +1,3 @@
 **Accessibility**
 
-- Improved the accessibility experience of EuiBetaBadge component
+- Improved the accessibility experience of `EuiBetaBadge`

--- a/packages/eui/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
+++ b/packages/eui/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
@@ -124,7 +124,6 @@ exports[`EuiBetaBadge props tooltip and anchorProps are rendered 1`] = `
 >
   <span
     class="euiBetaBadge emotion-euiBetaBadge-hollow-m-baseline"
-    role="button"
     tabindex="0"
   >
     Beta

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
@@ -234,7 +234,6 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
             tabIndex={0}
             css={cssStyles}
             className={classes}
-            role="button"
             {...rest}
           >
             {icon || label}

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
@@ -230,12 +230,7 @@ export const EuiBetaBadge: FunctionComponent<EuiBetaBadgeProps> = ({
           title={title || label}
           anchorProps={anchorProps}
         >
-          <span
-            tabIndex={0}
-            css={cssStyles}
-            className={classes}
-            {...rest}
-          >
+          <span tabIndex={0} css={cssStyles} className={classes} {...rest}>
             {icon || label}
           </span>
         </EuiToolTip>


### PR DESCRIPTION
Closes: https://github.com/elastic/eui/issues/7791

## Summary

Remove `role=button` for cases when the user doesn't provide an `onClick` or `href` attribute. In that mode, the component only shows the tooltip
