### PR TITLE
[EuiSearchBar][FieldValueSelectionFilter] Fix `autoClose: false` to always be respected regardless of `multiSelect`

### DIFF
--- a/packages/eui/changelogs/upcoming/7806.md
+++ b/packages/eui/changelogs/upcoming/7806.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSearchBar`'s filter configs to always respect `autoClose: false`

--- a/packages/eui/src-docs/src/views/search_bar/props_info.js
+++ b/packages/eui/src-docs/src/views/search_bar/props_info.js
@@ -279,7 +279,7 @@ export const propsInfo = {
         },
         autoClose: {
           description:
-            'Should the dropdown close after the user selects a value. Ignored if multiSelect is true.',
+            'Should the dropdown close after the user selects a value. If not explicitly passed, will auto-close for single selection and remain open for multi-selection.',
           required: false,
           defaultValue: { value: 'true' },
           type: { name: 'boolean' },

--- a/packages/eui/src/components/search_bar/filters/field_value_selection_filter.spec.tsx
+++ b/packages/eui/src/components/search_bar/filters/field_value_selection_filter.spec.tsx
@@ -225,6 +225,119 @@ describe('FieldValueSelectionFilter', () => {
     });
   });
 
+  describe('auto-close testing', () => {
+    const FieldValueSelectionFilterWithState = ({
+      autoClose,
+      multiSelect,
+    }: {
+      autoClose: undefined | boolean;
+      multiSelect: 'or' | boolean;
+    }) => {
+      const [query, setQuery] = useState(Query.parse(''));
+      const onChange = (newQuery: Query) => setQuery(newQuery);
+
+      const props: FieldValueSelectionFilterProps = {
+        ...requiredProps,
+        index: 0,
+        onChange,
+        query,
+        config: {
+          type: 'field_value_selection',
+          field: 'tag',
+          name: 'Tag',
+          multiSelect,
+          autoClose,
+          options: staticOptions,
+        },
+      };
+
+      return <FieldValueSelectionFilter {...props} />;
+    };
+    const selectFilter = () => {
+      // Open popover
+      cy.get('button').click();
+      cy.get('.euiPopover__panel').should('exist');
+
+      // Select filter option
+      cy.get('li[role="option"][title="feature"]')
+        .should('have.attr', 'aria-checked', 'false')
+        .click();
+    };
+
+    describe('undefined', () => {
+      it('multi select: does not close popover', () => {
+        cy.mount(
+          <FieldValueSelectionFilterWithState
+            autoClose={undefined}
+            multiSelect={true}
+          />
+        );
+        selectFilter();
+        cy.get('.euiPopover__panel').should('exist');
+      });
+
+      it('single select: closes popover', () => {
+        cy.mount(
+          <FieldValueSelectionFilterWithState
+            autoClose={undefined}
+            multiSelect={false}
+          />
+        );
+        selectFilter();
+        cy.get('.euiPopover__panel').should('not.exist');
+      });
+    });
+
+    describe('false', () => {
+      it('multi select: never closes popover', () => {
+        cy.mount(
+          <FieldValueSelectionFilterWithState
+            autoClose={false}
+            multiSelect={true}
+          />
+        );
+        selectFilter();
+        cy.get('.euiPopover__panel').should('exist');
+      });
+
+      it('single select: never closes popover', () => {
+        cy.mount(
+          <FieldValueSelectionFilterWithState
+            autoClose={false}
+            multiSelect={false}
+          />
+        );
+        selectFilter();
+        cy.get('.euiPopover__panel').should('exist');
+      });
+    });
+
+    describe('true', () => {
+      it('multi select: always closes popover', () => {
+        cy.mount(
+          <FieldValueSelectionFilterWithState
+            autoClose={true}
+            multiSelect={true}
+          />
+        );
+        selectFilter();
+        cy.get('.euiPopover__panel').should('not.exist');
+      });
+
+      it('single select: always closes popover', () => {
+        cy.mount(
+          <FieldValueSelectionFilterWithState
+            autoClose={true}
+            multiSelect={false}
+          />
+        );
+
+        selectFilter();
+        cy.get('.euiPopover__panel').should('not.exist');
+      });
+    });
+  });
+
   it('has inactive filters, field is global', () => {
     const props: FieldValueSelectionFilterProps = {
       ...requiredProps,


### PR DESCRIPTION
## Summary

closes #2259

## QA

- N/A - I'm leaning towards the written  Cypress tests being thorough enough to suffice, but LMK if you disagree!

### General checklist

- Browser QA - N/A, JS logic change only
- Docs site QA - N/A
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A