### PR TITLE
June deprecations

### DIFF
--- a/packages/eui/changelogs/upcoming/7808.md
+++ b/packages/eui/changelogs/upcoming/7808.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- Removed deprecated `euiPalettePositive` and `euiPaletteNegative`. Use `euiPaletteGreen` and `euiPaletteRed` instead

--- a/packages/eui/src-docs/src/views/flyout/flyout_example.js
+++ b/packages/eui/src-docs/src/views/flyout/flyout_example.js
@@ -402,7 +402,6 @@ export const FlyoutExample = {
     },
     {
       title: 'Resizable flyouts',
-      isBeta: true,
       source: [
         {
           type: GuideSectionTypes.JS,

--- a/packages/eui/src/services/color/eui_palettes.ts
+++ b/packages/eui/src/services/color/eui_palettes.ts
@@ -203,10 +203,6 @@ export const euiPaletteRed = function (steps: number): EuiPalette {
 
   return euiPalette(['white', redColor], steps);
 };
-/**
- * @deprecated - use `euiPaletteRed` instead
- */
-export const euiPaletteNegative = euiPaletteRed;
 
 export const euiPaletteGreen = function (steps: number): EuiPalette {
   if (steps === 1) {
@@ -215,10 +211,6 @@ export const euiPaletteGreen = function (steps: number): EuiPalette {
 
   return euiPalette(['white', greenColor], steps);
 };
-/**
- * @deprecated - use `euiPaletteGreen` instead
- */
-export const euiPalettePositive = euiPaletteGreen;
 
 export const euiPaletteCool = function (steps: number): EuiPalette {
   if (steps === 1) {

--- a/packages/eui/src/services/color/index.ts
+++ b/packages/eui/src/services/color/index.ts
@@ -33,8 +33,6 @@ export {
   euiPaletteComplementary,
   euiPaletteRed,
   euiPaletteGreen,
-  euiPaletteNegative,
-  euiPalettePositive,
   euiPaletteCool,
   euiPaletteWarm,
   euiPaletteGray,

--- a/packages/eui/src/services/index.ts
+++ b/packages/eui/src/services/index.ts
@@ -40,8 +40,6 @@ export {
   euiPaletteGray,
   euiPaletteRed,
   euiPaletteGreen,
-  euiPalettePositive,
-  euiPaletteNegative,
   euiPaletteWarm,
   getSteppedGradient,
   hexToHsv,


### PR DESCRIPTION
## Summary

See https://github.com/elastic/eui/issues/1469

- Removes beta status on **EuiFlyoutResizable**
- Removes `euiPalettePositive` and `euiPaletteNegative` (https://github.com/elastic/eui/pull/7570)

## QA

- [x] https://eui.elastic.co/pr_7808/#/layout/flyout#resizable-flyouts no longer has a beta badge in its heading title or side nav

### General checklist

- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)