### PR TITLE
[EuiCheckbox] Remove `type`/`inList` prop

### DIFF
--- a/packages/eui/changelogs/upcoming/7814.md
+++ b/packages/eui/changelogs/upcoming/7814.md
@@ -1,0 +1,3 @@
+**Breaking changes**
+
+- Removed `type="inList"` from `EuiCheckbox`. Simply omit passing a `label` prop to render this style of checkbox

--- a/packages/eui/src-docs/src/views/tables/custom/custom.tsx
+++ b/packages/eui/src-docs/src/views/tables/custom/custom.tsx
@@ -494,7 +494,6 @@ export default class extends Component<{}, State> {
         title="Select all rows"
         checked={this.areAllItemsSelected()}
         onChange={this.toggleAll.bind(this)}
-        type={mobile ? undefined : 'inList'}
       />
     );
   };
@@ -572,7 +571,6 @@ export default class extends Component<{}, State> {
                 id={`${item.id}-checkbox`}
                 checked={this.isItemSelected(item.id)}
                 onChange={this.toggleItem.bind(this, item.id)}
-                type="inList"
                 title="Select this row"
                 aria-label="Select this row"
               />

--- a/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             class="euiTableCellContent"
           >
             <div
-              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
+              class="euiCheckbox euiCheckbox--noLabel emotion-euiCheckbox"
             >
               <input
                 aria-label="Select all rows"
@@ -268,7 +268,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             class="euiTableCellContent"
           >
             <div
-              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
+              class="euiCheckbox euiCheckbox--noLabel emotion-euiCheckbox"
             >
               <input
                 aria-label="Select row 1"
@@ -374,7 +374,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             class="euiTableCellContent"
           >
             <div
-              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
+              class="euiCheckbox euiCheckbox--noLabel emotion-euiCheckbox"
             >
               <input
                 aria-label="Select row 2"
@@ -480,7 +480,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
             class="euiTableCellContent"
           >
             <div
-              class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
+              class="euiCheckbox euiCheckbox--noLabel emotion-euiCheckbox"
             >
               <input
                 aria-label="Select row 3"

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -703,7 +703,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
         {(selectAllRows: string) => (
           <EuiCheckbox
             id={this.selectAllIdGenerator(isMobile ? 'mobile' : 'desktop')}
-            type={isMobile ? undefined : 'inList'}
             checked={checked}
             disabled={disabled}
             onChange={onChange}
@@ -1114,7 +1113,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
           {(selectThisRow: string) => (
             <EuiCheckbox
               id={`${this.tableId}${key}-checkbox`}
-              type="inList"
               disabled={disabled}
               checked={checked}
               onChange={onChange}

--- a/packages/eui/src/components/form/checkbox/__snapshots__/checkbox.test.tsx.snap
+++ b/packages/eui/src/components/form/checkbox/__snapshots__/checkbox.test.tsx.snap
@@ -94,18 +94,3 @@ exports[`EuiCheckbox props labelProps is rendered 1`] = `
   </label>
 </div>
 `;
-
-exports[`EuiCheckbox props type inList is rendered 1`] = `
-<div
-  class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel emotion-euiCheckbox"
->
-  <input
-    class="euiCheckbox__input"
-    id="id"
-    type="checkbox"
-  />
-  <div
-    class="euiCheckbox__square"
-  />
-</div>
-`;

--- a/packages/eui/src/components/form/checkbox/_checkbox.scss
+++ b/packages/eui/src/components/form/checkbox/_checkbox.scss
@@ -99,7 +99,6 @@
     }
   }
 
-  &.euiCheckbox--inList,
   &.euiCheckbox--noLabel {
     min-height: $euiCheckBoxSize;
     min-width: $euiCheckBoxSize;

--- a/packages/eui/src/components/form/checkbox/checkbox.stories.tsx
+++ b/packages/eui/src/components/form/checkbox/checkbox.stories.tsx
@@ -12,18 +12,11 @@ import {
   disableStorybookControls,
   enableFunctionToggleControls,
 } from '../../../../.storybook/utils';
-import { EuiCheckbox, EuiCheckboxProps, TYPES } from './checkbox';
+import { EuiCheckbox, EuiCheckboxProps } from './checkbox';
 
 const meta: Meta<EuiCheckboxProps> = {
   title: 'Forms/EuiCheckbox',
   component: EuiCheckbox,
-  argTypes: {
-    label: { control: 'text' },
-    type: {
-      control: 'radio',
-      options: [undefined, ...TYPES],
-    },
-  },
   args: {
     checked: false,
     compressed: false,

--- a/packages/eui/src/components/form/checkbox/checkbox.test.tsx
+++ b/packages/eui/src/components/form/checkbox/checkbox.test.tsx
@@ -15,7 +15,7 @@ import {
 import { shouldRenderCustomStyles } from '../../../test/internal';
 import { render } from '../../../test/rtl';
 
-import { EuiCheckbox, TYPES } from './checkbox';
+import { EuiCheckbox } from './checkbox';
 
 beforeAll(startThrowingReactWarnings);
 afterAll(stopThrowingReactWarnings);
@@ -77,17 +77,6 @@ describe('EuiCheckbox', () => {
       );
 
       expect(container.firstChild).toMatchSnapshot();
-    });
-    describe('type', () => {
-      TYPES.forEach((value) => {
-        test(`${value} is rendered`, () => {
-          const { container } = render(
-            <EuiCheckbox {...checkboxRequiredProps} type={value} />
-          );
-
-          expect(container.firstChild).toMatchSnapshot();
-        });
-      });
     });
 
     describe('disabled', () => {

--- a/packages/eui/src/components/form/checkbox/checkbox.tsx
+++ b/packages/eui/src/components/form/checkbox/checkbox.tsx
@@ -19,15 +19,7 @@ import { css } from '@emotion/react';
 import classNames from 'classnames';
 
 import { useCombinedRefs } from '../../../services';
-import { keysOf, CommonProps } from '../../common';
-
-const typeToClassNameMap = {
-  inList: 'euiCheckbox--inList',
-};
-
-export const TYPES = keysOf(typeToClassNameMap);
-
-export type EuiCheckboxType = keyof typeof typeToClassNameMap;
+import { CommonProps } from '../../common';
 
 export interface EuiCheckboxProps
   extends CommonProps,
@@ -37,7 +29,6 @@ export interface EuiCheckboxProps
   onChange: ChangeEventHandler<HTMLInputElement>; // overriding to make it required
   inputRef?: (element: HTMLInputElement) => void;
   label?: ReactNode;
-  type?: EuiCheckboxType;
   disabled?: boolean;
   /**
    * when `true` creates a shorter height checkbox row
@@ -67,7 +58,6 @@ export const EuiCheckbox: FunctionComponent<EuiCheckboxProps> = ({
 }) => {
   const classes = classNames(
     'euiCheckbox',
-    type && typeToClassNameMap[type],
     {
       'euiCheckbox--noLabel': !label,
       'euiCheckbox--compressed': compressed,

--- a/packages/eui/src/components/form/radio/_radio.scss
+++ b/packages/eui/src/components/form/radio/_radio.scss
@@ -71,7 +71,6 @@
     }
   }
 
-  &.euiRadio--inList,
   &.euiRadio--noLabel {
     min-height: $euiRadioSize;
     min-width: $euiRadioSize;


### PR DESCRIPTION
## Summary

> [!NOTE]
> This PR **is** merging into main and not a feature branch - I wanted the breaking `type inList` change in at the same time as our other June deprecations

### Checkbox `type` breaking change

- Discussed in https://github.com/elastic/eui/pull/7781#discussion_r1619783789
- Related Kibana PR removing usages: https://github.com/elastic/kibana/pull/184881

## QA

- [x] [EuiTable selection checkboxes](https://eui.elastic.co/pr_7814/#/tabular-content/tables#build-a-custom-table-from-individual-components) render as before with no visual regressions

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
    - ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - N/A, not documented
    - [x] Props have proper **autodocs** ~(using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist - N/A, tests should pass as before
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist - N/A