### PR TITLE
[EuiBasicTable] Support indeterminate checkboxes in header row

### DIFF
--- a/packages/eui/changelogs/upcoming/7817.md
+++ b/packages/eui/changelogs/upcoming/7817.md
@@ -1,0 +1,1 @@
+- Updated `EuiBasicTable` and `EuiInMemoryTable`s with `selection` - the header row checkbox will now render an indeterminate state if some (but not all) rows are selected

--- a/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
                 aria-label="Select all rows"
                 class="euiCheckbox__input"
                 data-test-subj="checkboxSelectAll"
-                id="_selection_column-checkbox_generated-id_desktop"
+                id="_selection_column-checkbox_generated-id"
                 title="Select all rows"
                 type="checkbox"
               />

--- a/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
                 class="euiCheckbox__input"
                 data-test-subj="checkboxSelectAll"
                 id="_selection_column-checkbox_generated-id_desktop"
+                title="Select all rows"
                 type="checkbox"
               />
               <div

--- a/packages/eui/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -10,7 +10,8 @@ exports[`EuiInMemoryTable behavior mobile header 1`] = `
     <input
       aria-label="Select all rows"
       class="euiCheckbox__input"
-      id="_selection_column-checkbox_generated-id_mobile"
+      data-test-subj="checkboxSelectAll"
+      id="_selection_column-checkbox_generated-id"
       title="Select all rows"
       type="checkbox"
     />
@@ -19,7 +20,7 @@ exports[`EuiInMemoryTable behavior mobile header 1`] = `
     />
     <label
       class="euiCheckbox__label"
-      for="_selection_column-checkbox_generated-id_mobile"
+      for="_selection_column-checkbox_generated-id"
     >
       Select all rows
     </label>

--- a/packages/eui/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/in_memory_table.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`EuiInMemoryTable behavior mobile header 1`] = `
       aria-label="Select all rows"
       class="euiCheckbox__input"
       id="_selection_column-checkbox_generated-id_mobile"
+      title="Select all rows"
       type="checkbox"
     />
     <div

--- a/packages/eui/src/components/basic_table/basic_table.test.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 import { render, screen } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
@@ -460,6 +461,72 @@ describe('EuiBasicTable', () => {
 
       expect(onSelectionChange).toHaveBeenCalledWith([]);
       expect(container.querySelectorAll('[checked]')).toHaveLength(0);
+    });
+
+    describe('header checkbox', () => {
+      it('selects all rows', () => {
+        const props: EuiBasicTableProps<BasicItem> = {
+          items: basicItems,
+          columns: basicColumns,
+          itemId: 'id',
+          selection: {
+            onSelectionChange: () => {},
+            initialSelected: [],
+          },
+        };
+        const { getByTestSubject } = render(<EuiBasicTable {...props} />);
+        expect(getByTestSubject('checkboxSelectAll')).not.toBeChecked();
+
+        fireEvent.click(getByTestSubject('checkboxSelectAll'));
+
+        expect(getByTestSubject('checkboxSelectAll')).toBeChecked();
+        expect(getCheckboxAt(1)).toBeChecked();
+        expect(getCheckboxAt(2)).toBeChecked();
+        expect(getCheckboxAt(3)).toBeChecked();
+      });
+
+      it('deselects all rows', () => {
+        const props: EuiBasicTableProps<BasicItem> = {
+          items: basicItems,
+          columns: basicColumns,
+          itemId: 'id',
+          selection: {
+            onSelectionChange: () => {},
+            initialSelected: basicItems,
+          },
+        };
+        const { getByTestSubject } = render(<EuiBasicTable {...props} />);
+        expect(getByTestSubject('checkboxSelectAll')).toBeChecked();
+
+        fireEvent.click(getByTestSubject('checkboxSelectAll'));
+
+        expect(getByTestSubject('checkboxSelectAll')).not.toBeChecked();
+        expect(getCheckboxAt(1)).not.toBeChecked();
+        expect(getCheckboxAt(2)).not.toBeChecked();
+        expect(getCheckboxAt(3)).not.toBeChecked();
+      });
+
+      it('renders an indeterminate header checkbox if some but not all rows are selected', () => {
+        const props: EuiBasicTableProps<BasicItem> = {
+          items: basicItems,
+          columns: basicColumns,
+          itemId: 'id',
+          selection: {
+            onSelectionChange: () => {},
+            initialSelected: [],
+          },
+        };
+        const { getByTestSubject } = render(<EuiBasicTable {...props} />);
+        expect(getByTestSubject('checkboxSelectAll')).not.toBeChecked();
+
+        fireEvent.click(getCheckboxAt(1));
+        expect(getCheckboxAt(1)).toBeChecked();
+        expect(getByTestSubject('checkboxSelectAll')).toBePartiallyChecked();
+
+        // Should deselect all rows on indeterminate click
+        fireEvent.click(getByTestSubject('checkboxSelectAll'));
+        expect(getCheckboxAt(1)).not.toBeChecked();
+      });
     });
   });
 

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -711,13 +711,12 @@ export class EuiBasicTable<T extends object = any> extends Component<
       >
         {([selectAllRows, deselectRows]: string[]) => (
           <EuiCheckbox
-            id={this.selectAllIdGenerator(isMobile ? 'mobile' : 'desktop')}
+            id={this.selectAllIdGenerator()}
             checked={checked}
             indeterminate={indeterminate}
             disabled={disabled}
             onChange={onChange}
-            // Only add data-test-subj to one of the checkboxes
-            data-test-subj={isMobile ? undefined : 'checkboxSelectAll'}
+            data-test-subj="checkboxSelectAll"
             aria-label={checked || indeterminate ? deselectRows : selectAllRows}
             title={checked || indeterminate ? deselectRows : selectAllRows}
             label={isMobile ? selectAllRows : null}

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -688,10 +688,16 @@ export class EuiBasicTable<T extends object = any> extends Component<
       selectableItems.length > 0 &&
       this.state.selection.length === selectableItems.length;
 
+    const indeterminate =
+      !checked &&
+      this.state.selection &&
+      selectableItems.length > 0 &&
+      this.state.selection.length > 0;
+
     const disabled = selectableItems.length === 0;
 
     const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (event.target.checked) {
+      if (event.target.checked && !indeterminate) {
         this.changeSelection(selectableItems);
       } else {
         this.changeSelection([]);
@@ -699,16 +705,21 @@ export class EuiBasicTable<T extends object = any> extends Component<
     };
 
     return (
-      <EuiI18n token="euiBasicTable.selectAllRows" default="Select all rows">
-        {(selectAllRows: string) => (
+      <EuiI18n
+        tokens={['euiBasicTable.selectAllRows', 'euiBasicTable.deselectRows']}
+        defaults={['Select all rows', 'Deselect rows']}
+      >
+        {([selectAllRows, deselectRows]: string[]) => (
           <EuiCheckbox
             id={this.selectAllIdGenerator(isMobile ? 'mobile' : 'desktop')}
             checked={checked}
+            indeterminate={indeterminate}
             disabled={disabled}
             onChange={onChange}
             // Only add data-test-subj to one of the checkboxes
             data-test-subj={isMobile ? undefined : 'checkboxSelectAll'}
-            aria-label={selectAllRows}
+            aria-label={checked || indeterminate ? deselectRows : selectAllRows}
+            title={checked || indeterminate ? deselectRows : selectAllRows}
             label={isMobile ? selectAllRows : null}
           />
         )}


### PR DESCRIPTION
## Summary

| Before | After |
|--------|--------|
| ![before](https://github.com/elastic/eui/assets/549407/3e9af24f-62c8-47c9-a9f3-2d4b0f8541fc) | ![after](https://github.com/elastic/eui/assets/549407/22a04b5a-af74-48dc-a488-029f0bb1ca28) |

I implemented this kind of on a whim while looking at our indeterminate EuiCheckboxes in https://github.com/elastic/eui/pull/7814, and realizing we don't really utilize them 👀  UX is based off of Gmail's select all behavior.

## QA

- [EuiBasicTable](https://eui.elastic.co/pr_7817/#/tabular-content/tables#adding-selection-to-a-table)'s header checkbox selection:
  - [x] Shows an indeterminate checkbox whenever 1 or more (but less than all rows) are selected
  - [x] Still shows a regular check if all rows are selected
  - [x] Deselects all rows on click, if either checked or indeterminate
  - [x] Shows a `title` & `aria-label` that accurately reflects the deselect/select all UX

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A