### PR TITLE
build: update release script for yarn berry

### DIFF
--- a/packages/eui/scripts/release.js
+++ b/packages/eui/scripts/release.js
@@ -133,8 +133,15 @@ const hasStep = (step) => {
     updateChangelog(changelog, versionTarget);
     execSync('git commit -m "Updated changelog" -n');
 
-    // update package.json version, git commit, git tag
-    execSync(`yarn version --new-version ${versionTarget} --version-tag-prefix=v --version-git-tag=true --version-commit-hooks=false`, execOptions);
+    // Update version number
+    execSync(`yarn version ${versionTarget}`, execOptions);
+
+    // Commit version number update
+    execSync('git add package.json', execOptions);
+    execSync(`git commit --no-verify -m "${versionTarget}"`, execOptions);
+
+    // Create a tag
+    execSync(`git tag -a -m "v${versionTarget}" "v${versionTarget}"`, execOptions);
   }
 
   if (hasStep('tag') && !isDryRun) {

--- a/packages/eui/scripts/release.js
+++ b/packages/eui/scripts/release.js
@@ -139,12 +139,12 @@ const hasStep = (step) => {
     // Commit version number update
     execSync('git add package.json', execOptions);
     execSync(`git commit --no-verify -m "${versionTarget}"`, execOptions);
-
-    // Create a tag
-    execSync(`git tag -a -m "v${versionTarget}" "v${versionTarget}"`, execOptions);
   }
 
   if (hasStep('tag') && !isDryRun) {
+    // Create a tag
+    execSync(`git tag -a -m "v${versionTarget}" "v${versionTarget}"`, execOptions);
+
     // Skip prepush test hook on all pushes - we should have already tested previously,
     // or we skipped the test step for a reason
     if (isSpecialRelease) {


### PR DESCRIPTION
## Summary

Yarn Berry doesn't commit or tag created versions. This updates our release script to commit and tag the updated `package.json` the same way Yarn Classic [did](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/version.js#L190).

## QA

- [x] Confirm the updated script executes commands that make sense. Test each command locally if needed