### PR TITLE
[EuiGlobalStyles]: Support adding partial global styles

### DIFF
--- a/packages/eui/changelogs/upcoming/7839.md
+++ b/packages/eui/changelogs/upcoming/7839.md
@@ -1,0 +1,2 @@
+- Updated `EuiGlobalStyles` to support adding partial styles
+

--- a/packages/eui/src-docs/src/views/provider/provider_example.js
+++ b/packages/eui/src-docs/src/views/provider/provider_example.js
@@ -95,6 +95,43 @@ export const ProviderExample = {
           <EuiCodeBlock language="tsx" fontSize="m" isCopyable>
             {'<EuiProvider globalStyles={false} utilityClasses={false} />'}
           </EuiCodeBlock>
+          <EuiSpacer />
+
+          <p>
+            If you would like to use only a subset of the global styles you can
+            pass a custom instance of <EuiCode>EuiGlobalStyles</EuiCode> to{' '}
+            <EuiCode>globalStyles</EuiCode> with specific style flags disabled.
+            The available props are:
+          </p>
+
+          <ul>
+            <li>
+              <EuiCode>hasReset</EuiCode>
+            </li>
+            <li>
+              <EuiCode>hasFont</EuiCode>
+            </li>
+            <li>
+              <EuiCode>hasBase</EuiCode>
+            </li>
+            <li>
+              <EuiCode>hasColor</EuiCode>
+            </li>
+            <li>
+              <EuiCode>hasLink</EuiCode>
+            </li>
+            <li>
+              <EuiCode>hasFocus</EuiCode>
+            </li>
+            <li>
+              <EuiCode>hasScrollbar</EuiCode>
+            </li>
+          </ul>
+
+          <EuiCodeBlock language="tsx" fontSize="m" isCopyable>
+            {`const CustomStyles = () => <EuiGlobalStyles hasReset={false} />\
+            <EuiProvider globalStyles={CustomStyles} utilityClasses={false} />`}
+          </EuiCodeBlock>
 
           <h3 id="cache-customization">@emotion/cache customization</h3>
           <p>

--- a/packages/eui/src/components/provider/provider.tsx
+++ b/packages/eui/src/components/provider/provider.tsx
@@ -18,10 +18,7 @@ import {
 import { emitEuiProviderWarning } from '../../services/theme/warning';
 import { cache as fallbackCache } from '../../services/emotion/css';
 
-import {
-  EuiGlobalStyles,
-  EuiGlobalStylesProps,
-} from '../../global_styling/reset/global_styles';
+import { EuiGlobalStyles } from '../../global_styling/reset/global_styles';
 import { EuiUtilityClasses } from '../../global_styling/utility/utility';
 import { EuiThemeAmsterdam } from '../../themes';
 
@@ -38,7 +35,6 @@ const isEmotionCacheObject = (
 
 export interface EuiProviderProps<T>
   extends PropsWithChildren,
-    EuiGlobalStylesProps,
     Pick<EuiThemeProviderProps<T>, 'colorMode' | 'modify'> {
   /**
    * Provide a specific EuiTheme; Defaults to EuiThemeAmsterdam;

--- a/packages/eui/src/global_styling/reset/global_styles.tsx
+++ b/packages/eui/src/global_styling/reset/global_styles.tsx
@@ -14,9 +14,27 @@ import { shade, tint, transparentize } from '../../services/color';
 import { useEuiTheme } from '../../services/theme';
 import { resetStyles as reset } from './reset';
 
-export interface EuiGlobalStylesProps {}
+export interface EuiGlobalStylesProps {
+  hasReset?: boolean;
+  hasFontReset?: boolean;
+  hasFont?: boolean;
+  hasBase?: boolean;
+  hasColor?: boolean;
+  hasFocus?: boolean;
+  hasLink?: boolean;
+  hasScrollbar?: boolean;
+}
 
-export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
+export const EuiGlobalStyles = ({
+  hasReset = true,
+  hasFontReset = true,
+  hasFont = true,
+  hasBase = true,
+  hasColor = true,
+  hasFocus = true,
+  hasLink = true,
+  hasScrollbar = true,
+}: EuiGlobalStylesProps) => {
   const euiThemeContext = useEuiTheme();
   const { euiTheme, colorMode } = euiThemeContext;
   const { base, colors, font } = euiTheme;
@@ -51,72 +69,96 @@ export const EuiGlobalStyles = ({}: EuiGlobalStylesProps) => {
    * Final styles
    */
   const styles = css`
-    ${reset}
+    ${hasReset && reset}
 
-    html {
-      ${scrollbarStyles}
-      ${fontReset}
-      text-size-adjust: 100%;
-      font-kerning: normal;
-      ${logicalCSS('height', '100%')}
-      background-color: ${colors.body};
-      color: ${colors.text};
-    }
+    ${hasBase &&
+    css`
+      html {
+        ${hasScrollbar && scrollbarStyles}
+        ${hasFontReset && fontReset}
+        text-size-adjust: 100%;
+        font-kerning: normal;
+        ${logicalCSS('height', '100%')}
+        ${
+          hasColor && {
+            backgroundColor: colors.body,
+            color: colors.text,
+          }
+        }
+    `}
 
-    code,
-    pre,
-    kbd,
-    samp {
-      font-family: ${font.familyCode};
-    }
-
-    input,
-    textarea,
-    select {
-      ${{
-        ...fontReset,
-        fontSize: '1rem', // Inherit from html root
-      }}
-    }
-
-    // Chrome has opinionated select:disabled opacity styles that need to be overridden
-    select:disabled {
-      opacity: 1;
-    }
-
-    button {
-      font-family: ${font.family};
-    }
-
-    em {
-      font-style: italic;
-    }
-
-    strong {
-      font-weight: ${font.weight.bold};
-    }
-
-    *:focus {
-      ${euiFocusRing(euiThemeContext)}
-    }
-
-    // Dark mode's highlighted doesn't work well so lets just set it the same as our focus background
-    ::selection {
-      background: ${transparentize(
-        colors.primary,
-        colorMode === 'LIGHT' ? 0.1 : 0.2
-      )};
-    }
-
-    a {
-      color: ${colors.primaryText};
-
-      &,
-      &:hover,
-      &:focus {
-        text-decoration: none;
+    ${hasFont &&
+    css`
+      code,
+      pre,
+      kbd,
+      samp {
+        font-family: ${font.familyCode};
       }
-    }
+
+      input,
+      textarea,
+      select {
+        ${hasFontReset && {
+          ...fontReset,
+        }}
+        font-size: 1rem; // Inherit from html root
+      }
+    `}
+
+    ${hasBase &&
+    css`
+      // Chrome has opinionated select:disabled opacity styles that need to be overridden
+      select:disabled {
+        opacity: 1;
+      }
+    `}
+
+    ${hasFont &&
+    css`
+      button {
+        font-family: ${font.family};
+      }
+
+      em {
+        font-style: italic;
+      }
+
+      strong {
+        font-weight: ${font.weight.bold};
+      }
+    `}
+
+    ${hasFocus &&
+    css`
+      *:focus {
+        ${euiFocusRing(euiThemeContext)}
+      }
+    `}
+
+    ${hasColor &&
+    css`
+      // Dark mode's highlighted doesn't work well so lets just set it the same as our focus background
+      ::selection {
+        background: ${transparentize(
+          colors.primary,
+          colorMode === 'LIGHT' ? 0.1 : 0.2
+        )};
+      }
+    `}
+
+    ${hasLink &&
+    css`
+      a {
+        ${hasColor && { color: colors.primaryText }}
+
+        &,
+        &:hover,
+        &:focus {
+          text-decoration: none;
+        }
+      }
+    `}
 
     // A few EUI components (e.g. tooltip, combobox) use a portal to render content outside of the DOM hierarchy.
     // The portal content is absolutely positioned relative to the body.


### PR DESCRIPTION
## Summary

relates to #7822

This PR updates `EuiGlobalStyles` to support conditionally enabling/disabling global base styles instead of completely disabling all added styles via `<EuiProvider globalStyles={false} />`
This would allow for a more flexible usage in non-Kibana specific contexts, e.g. EUI+.

The default behavior remains as is (all styles are enabled by default).

The new API allows to disable specific parts of the global styles manually, for example:

```tsx
const CustomStyles = () => <EuiGlobalStyles hasReset={false} />

<EuiProvider globalStyles={CustomStyles} />
```

## QA

- [ ] review the categorization of styles if it makes sense and is logical (there is currently no implementation of this yet to test)

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
    - [ ] ~Updated the **[Figma](https://www.figma.com/community/file/964536385682658129)** library counterpart~
