### PR TITLE
[EUI+]: Connect Docusaurus color mode toggle with EUI theme

### DIFF
--- a/packages/docusaurus-theme/src/components/theme_context/index.tsx
+++ b/packages/docusaurus-theme/src/components/theme_context/index.tsx
@@ -1,0 +1,45 @@
+import {
+  createContext,
+  FunctionComponent,
+  PropsWithChildren,
+  useState,
+} from 'react';
+import { EUI_THEMES, EuiProvider, EuiThemeColorMode } from '@elastic/eui';
+
+import { EuiThemeOverrides } from './theme_overrides';
+
+const EUI_THEME_NAMES = EUI_THEMES.map(
+  ({ value }) => value
+) as EuiThemeColorMode[];
+
+const defaultState = {
+  theme: EUI_THEME_NAMES[0],
+  changeTheme: (themeValue: EuiThemeColorMode) => {},
+};
+
+export const AppThemeContext = createContext(defaultState);
+
+export const AppThemeProvider: FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
+  const savedTheme: EuiThemeColorMode | undefined =
+    (localStorage.getItem('theme') as EuiThemeColorMode) ?? defaultState.theme;
+  const [theme, setTheme] = useState<EuiThemeColorMode>(savedTheme);
+
+  return (
+    <AppThemeContext.Provider
+      value={{
+        theme,
+        changeTheme: setTheme,
+      }}
+    >
+      <EuiProvider
+        globalStyles={false}
+        modify={EuiThemeOverrides}
+        colorMode={theme}
+      >
+        {children}
+      </EuiProvider>
+    </AppThemeContext.Provider>
+  );
+};

--- a/packages/docusaurus-theme/src/components/theme_context/theme_overrides.ts
+++ b/packages/docusaurus-theme/src/components/theme_context/theme_overrides.ts
@@ -1,0 +1,9 @@
+import { EuiThemeModifications } from '@elastic/eui';
+
+export const EuiThemeOverrides: EuiThemeModifications = {
+  colors: {
+    LIGHT: {
+      body: '#fff',
+    },
+  },
+};

--- a/packages/docusaurus-theme/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme/src/theme/ColorModeToggle/index.tsx
@@ -1,0 +1,36 @@
+import { useContext, useEffect } from 'react';
+import OriginalColorModeToggle from '@theme-init/ColorModeToggle';
+import type ColorModeToggleType from '@theme-init/ColorModeToggle';
+import type { WrapperProps } from '@docusaurus/types';
+import { EuiThemeColorMode } from '@elastic/eui';
+
+import { AppThemeContext } from '../../components/theme_context';
+
+type Props = WrapperProps<typeof ColorModeToggleType>;
+
+export default function ColorModeToggle({
+  value,
+  onChange,
+  ...rest
+}: Props): JSX.Element {
+  const { theme, changeTheme } = useContext(AppThemeContext);
+
+  useEffect(() => {
+    changeTheme(value);
+  }, []);
+
+  const handleOnChange = (themeName: EuiThemeColorMode) => {
+    changeTheme(themeName);
+    onChange?.(themeName);
+  };
+
+  return (
+    <>
+      <OriginalColorModeToggle
+        value={theme}
+        onChange={handleOnChange}
+        {...rest}
+      />
+    </>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/Root.styles.ts
+++ b/packages/docusaurus-theme/src/theme/Root.styles.ts
@@ -1,0 +1,18 @@
+import { UseEuiTheme } from '@elastic/eui';
+
+// override docusaurus variables as needed
+export const getGlobalStyles = ({ euiTheme }: UseEuiTheme) => {
+  const { colors } = euiTheme;
+
+  // overriding Docusaurus variables:
+  // since EUI handles the token value updates, we can override both
+  // color modes at the same time (Docusaurus separates based on `data-theme`)
+  return `
+      :root,
+      [data-theme='dark']:root {  
+        // base
+        --ifm-background-color: ${colors.body};
+        --ifm-font-color-base: ${colors.text};
+      }
+  `;
+};

--- a/packages/docusaurus-theme/src/theme/Root.tsx
+++ b/packages/docusaurus-theme/src/theme/Root.tsx
@@ -6,15 +6,25 @@
  * Side Public License, v 1.
  */
 
+import { FunctionComponent, PropsWithChildren } from 'react';
 import { Props } from '@theme/Root';
+import { Global } from '@emotion/react';
 import { _EuiThemeFontScale, useEuiTheme } from '@elastic/eui';
 import '@elastic/eui/dist/eui_theme_light.css';
-import { FunctionComponent, PropsWithChildren } from 'react';
 
 import { AppThemeProvider } from '../components/theme_context';
+import { getGlobalStyles } from './Root.styles';
 
 const _Root: FunctionComponent<PropsWithChildren> = ({ children }) => {
-  return <>{children}</>;
+  const euiTheme = useEuiTheme();
+  const styles = getGlobalStyles(euiTheme);
+
+  return (
+    <>
+      <Global styles={styles} />
+      {children}
+    </>
+  );
 };
 
 // Wrap docusaurus root component with <EuiProvider>

--- a/packages/docusaurus-theme/src/theme/Root.tsx
+++ b/packages/docusaurus-theme/src/theme/Root.tsx
@@ -6,16 +6,25 @@
  * Side Public License, v 1.
  */
 
-import { EuiProvider } from '@elastic/eui';
 import { Props } from '@theme/Root';
+import { _EuiThemeFontScale, useEuiTheme } from '@elastic/eui';
 import '@elastic/eui/dist/eui_theme_light.css';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+import { AppThemeProvider } from '../components/theme_context';
+
+const _Root: FunctionComponent<PropsWithChildren> = ({ children }) => {
+  return <>{children}</>;
+};
 
 // Wrap docusaurus root component with <EuiProvider>
 // See https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root
-const Root = ({ children }: Props) => (
-  <EuiProvider globalStyles={false}>
-    {children}
-  </EuiProvider>
-);
+const Root = ({ children }: Props) => {
+  return (
+    <AppThemeProvider>
+      <_Root>{children}</_Root>
+    </AppThemeProvider>
+  );
+};
 
 export default Root;

--- a/packages/docusaurus-theme/tsconfig.json
+++ b/packages/docusaurus-theme/tsconfig.json
@@ -3,7 +3,7 @@
   "references": [{"path": "./tsconfig.client.json"}],
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "dom"],
     "declaration": true,
     "sourceMap": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

relates to #7822

This PR connects the Docusaurus `ColorModeToggle` with the `colorMode` passed to the `EuiProvider` providing the theme to the app. 

### Changes

- adds `AppThemeContext` and `AppThemeProvider` to handle the app theme
- swizzles (wrap) Docusaurus' `ColorModeToggle` and connects it with the theme provider state
- adds an initial `EuiThemeOverrides` object to handle EUI theme overrides (sets app background-color to `#fff`)

## QA

- [ ] checkout this PR `gh pr checkout xxxx`, build the theme in `/packages/docusaurus-theme` with `yarn build` and run the EUI+ docs page in `packages/website` with `yarn start`
  - [ ] verify that the app background color is `#fff`
  - [ ] verify that the app background-color and text color update on clicking the color mode toggle button (see the css variable values in the devTools, these should use EUI values not Docusaurus ones)