### PR TITLE
[EUI+] Initial typography and doc content updates

### DIFF
--- a/packages/docusaurus-theme/src/components/call_out/index.tsx
+++ b/packages/docusaurus-theme/src/components/call_out/index.tsx
@@ -1,0 +1,81 @@
+import { css } from '@emotion/react';
+import { EuiText, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
+import { FunctionComponent, PropsWithChildren } from 'react';
+
+type VARIANTS = 'info' | 'tip' | 'note' | 'danger' | 'warning';
+type TEXT_COLORS = 'primaryText' | 'successText' | 'dangerText' | 'warningText';
+
+const VARIANT_TO_COLOR_MAP: Record<
+  VARIANTS,
+  { backgroundVariable: string; colorKey: TEXT_COLORS }
+> = {
+  info: {
+    backgroundVariable: 'var(--eui-background-color-primary)',
+    colorKey: 'primaryText',
+  },
+  note: {
+    backgroundVariable: 'var(--eui-background-color-primary)',
+    colorKey: 'primaryText',
+  },
+  tip: {
+    backgroundVariable: 'var(--eui-background-color-success)',
+    colorKey: 'successText',
+  },
+  danger: {
+    backgroundVariable: 'var(--eui-background-color-danger)',
+    colorKey: 'dangerText',
+  },
+  warning: {
+    backgroundVariable: 'var(--eui-background-color-warning)',
+    colorKey: 'warningText',
+  },
+};
+
+const getStyles = ({ euiTheme }: UseEuiTheme, variant: VARIANTS) => {
+  const colorKey = VARIANT_TO_COLOR_MAP[variant].colorKey;
+  const color = euiTheme.colors[colorKey];
+
+  return {
+    note: css`
+      &:not(:last-of-type) {
+        margin-block-end: ${euiTheme.size.m};
+      }
+
+      .alert {
+        --ifm-alert-background-color: ${VARIANT_TO_COLOR_MAP[variant]
+          .backgroundVariable};
+        --ifm-alert-foreground-color: ${euiTheme.colors.text};
+        --ifm-alert-padding-horizontal: ${euiTheme.size.base};
+        --ifm-alert-padding-vertical: ${euiTheme.size.base};
+        --ifm-alert-border-width: ${euiTheme.border.width.thin};
+        --ifm-alert-border-left-width: ${euiTheme.border.width.thin};
+        --ifm-alert-border-color: ${color};
+
+        [class^='admonitionHeading'] {
+          --ifm-alert-foreground-color: ${color};
+
+          color: var(--ifm-alert-foreground-color);
+        }
+      }
+    `,
+  };
+};
+
+type CallOutProps = PropsWithChildren & {
+  variant: VARIANTS;
+};
+
+export const CallOut: FunctionComponent<CallOutProps> = ({
+  children,
+  variant,
+}) => {
+  const styles = useEuiMemoizedStyles((euiTheme) =>
+    getStyles(euiTheme, variant)
+  );
+
+  return (
+    <EuiText size="s" css={styles.note}>
+      {children}
+    </EuiText>
+  );
+};

--- a/packages/docusaurus-theme/src/components/theme_context/theme_overrides.ts
+++ b/packages/docusaurus-theme/src/components/theme_context/theme_overrides.ts
@@ -6,4 +6,7 @@ export const EuiThemeOverrides: EuiThemeModifications = {
       body: '#fff',
     },
   },
+  font: {
+    lineHeightMultiplier: 1.75,
+  },
 };

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Danger.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Danger.tsx
@@ -1,0 +1,16 @@
+import OriginalDanger from '@theme-init/Admonition/Type/Danger';
+import type WarningType from '@theme-init/Admonition/Type/Danger';
+import type { WrapperProps } from '@docusaurus/types';
+import { CallOut } from '../../../components/call_out';
+
+type Props = WrapperProps<typeof WarningType>;
+
+const Danger = (props: Props): JSX.Element => {
+  return (
+    <CallOut variant="danger">
+      <OriginalDanger {...props} />
+    </CallOut>
+  );
+};
+
+export default Danger;

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Info.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Info.tsx
@@ -1,0 +1,16 @@
+import OriginalInfo from '@theme-init/Admonition/Type/Info';
+import type InfoType from '@theme-init/Admonition/Type/Info';
+import type { WrapperProps } from '@docusaurus/types';
+import { CallOut } from '../../../components/call_out';
+
+type Props = WrapperProps<typeof InfoType>;
+
+const Note = (props: Props): JSX.Element => {
+  return (
+    <CallOut variant="info">
+      <OriginalInfo {...props} />
+    </CallOut>
+  );
+};
+
+export default Note;

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Note.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Note.tsx
@@ -1,0 +1,16 @@
+import OriginalNote from '@theme-init/Admonition/Type/Note';
+import type NoteType from '@theme-init/Admonition/Type/Note';
+import type { WrapperProps } from '@docusaurus/types';
+import { CallOut } from '../../../components/call_out';
+
+type Props = WrapperProps<typeof NoteType>;
+
+const Note = (props: Props): JSX.Element => {
+  return (
+    <CallOut variant="note">
+      <OriginalNote {...props} />
+    </CallOut>
+  );
+};
+
+export default Note;

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Tip.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Tip.tsx
@@ -1,0 +1,16 @@
+import OriginalTip from '@theme-init/Admonition/Type/Tip';
+import type TipType from '@theme-init/Admonition/Type/Tip';
+import type { WrapperProps } from '@docusaurus/types';
+import { CallOut } from '../../../components/call_out';
+
+type Props = WrapperProps<typeof TipType>;
+
+const Tip = (props: Props): JSX.Element => {
+  return (
+    <CallOut variant="tip">
+      <OriginalTip {...props} />
+    </CallOut>
+  );
+};
+
+export default Tip;

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Warning.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Warning.tsx
@@ -1,0 +1,16 @@
+import OriginalWarning from '@theme-init/Admonition/Type/Warning';
+import type WarningType from '@theme-init/Admonition/Type/Warning';
+import type { WrapperProps } from '@docusaurus/types';
+import { CallOut } from '../../../components/call_out';
+
+type Props = WrapperProps<typeof WarningType>;
+
+const Warning = (props: Props): JSX.Element => {
+  return (
+    <CallOut variant="warning">
+      <OriginalWarning {...props} />
+    </CallOut>
+  );
+};
+
+export default Warning;

--- a/packages/docusaurus-theme/src/theme/DocItem/Content/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,33 @@
+import OriginalContent from '@theme-init/DocItem/Content';
+import type ContentType from '@theme-init/DocItem/Content';
+import type { WrapperProps } from '@docusaurus/types';
+import { useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+type Props = WrapperProps<typeof ContentType>;
+
+const getContentStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    content: css`
+      // required specificity to apply styles
+      .markdown header > h1 {
+        --ifm-h1-font-size: 2.86rem;
+        --ifm-h1-vertical-rhythm-bottom: 1.486;
+      }
+    `,
+  };
+};
+
+/* OriginalContent holds the document title and markdown content
+NOTE: ejecting this results in an error due to using useDoc() hook outside of DocProvider 
+https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/Content/index.tsx */
+const Content = (props: Props): JSX.Element => {
+  const styles = useEuiMemoizedStyles(getContentStyles);
+  return (
+    <div css={styles.content}>
+      <OriginalContent {...props} />
+    </div>
+  );
+};
+
+export default Content;

--- a/packages/docusaurus-theme/src/theme/Footer/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Footer/index.tsx
@@ -1,16 +1,27 @@
 import { css } from '@emotion/react';
-import { EuiText, EuiLink, UseEuiTheme, EuiThemeProvider, useEuiMemoizedStyles } from '@elastic/eui';
+import {
+  EuiText,
+  EuiLink,
+  UseEuiTheme,
+  EuiThemeProvider,
+  useEuiMemoizedStyles,
+} from '@elastic/eui';
 
-const ELASTIC_LICENSE_URL = "https://github.com/elastic/eui/blob/main/licenses/ELASTIC-LICENSE-2.0.md";
-const SSPL_LICENSE_URL = "https://github.com/elastic/eui/blob/main/licenses/SSPL-LICENSE.md";
+const ELASTIC_LICENSE_URL =
+  'https://github.com/elastic/eui/blob/main/licenses/ELASTIC-LICENSE-2.0.md';
+const SSPL_LICENSE_URL =
+  'https://github.com/elastic/eui/blob/main/licenses/SSPL-LICENSE.md';
 
 const getFooterStyles = ({ euiTheme }: UseEuiTheme) => {
   return {
     root: css`
-      background: #1C1E23; // Color not available in EUI
+      background: #1c1e23; // Color not available in EUI
       border-radius: ${euiTheme.size.s} ${euiTheme.size.s} 0 0;
       padding: ${euiTheme.size.l};
       text-align: center;
+    `,
+    text: css`
+      line-height: var(--eui-line-height-s);
     `,
     heart: css`
       color: ${euiTheme.colors.accent};
@@ -22,22 +33,21 @@ const Footer = () => {
   const styles = useEuiMemoizedStyles(getFooterStyles);
 
   return (
-    <EuiThemeProvider colorMode="inverse">
+    <EuiThemeProvider colorMode="dark">
       <footer css={styles.root}>
-        <EuiText textAlign="center" size="s">
-          EUI is dual-licensed under {' '}
-          <EuiLink href={ELASTIC_LICENSE_URL}>
-            Elastic License 2.0
-          </EuiLink>
+        <EuiText textAlign="center" size="s" css={styles.text}>
+          EUI is dual-licensed under{' '}
+          <EuiLink href={ELASTIC_LICENSE_URL}>Elastic License 2.0</EuiLink>
           {' and '}
           <EuiLink href={SSPL_LICENSE_URL}>
             Server Side Public License, v 1
           </EuiLink>
           {' | '}
-          Crafted with <span role="img" aria-label="love" css={styles.heart}>❤</span> by{' '}
-          <EuiLink href="https://elastic.co">
-            Elastic
-          </EuiLink>
+          Crafted with{' '}
+          <span role="img" aria-label="love" css={styles.heart}>
+            ❤
+          </span>{' '}
+          by <EuiLink href="https://elastic.co">Elastic</EuiLink>
         </EuiText>
       </footer>
     </EuiThemeProvider>

--- a/packages/docusaurus-theme/src/theme/MDXComponents/A.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/A.tsx
@@ -1,0 +1,22 @@
+import type AType from '@theme-init/MDXComponents/A';
+import type { WrapperProps } from '@docusaurus/types';
+import { css } from '@emotion/react';
+import { EuiLink, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
+
+type Props = WrapperProps<typeof AType>;
+
+const getStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    link: css`
+      text-decoration: underline;
+    `,
+  };
+};
+
+const A = (props: Props): JSX.Element => {
+  const styles = useEuiMemoizedStyles(getStyles);
+
+  return <EuiLink {...props} css={styles.link} />;
+};
+
+export default A;

--- a/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import type CodeType from '@theme-init/MDXComponents/Code';
+import type { WrapperProps } from '@docusaurus/types';
+import { css } from '@emotion/react';
+import {
+  EuiCode,
+  EuiCodeBlock,
+  useEuiMemoizedStyles,
+  UseEuiTheme,
+} from '@elastic/eui';
+
+type Props = WrapperProps<typeof CodeType>;
+
+const getStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    code: css`
+      // reset docusaurus code styles
+      border: none;
+      vertical-align: initial;
+    `,
+  };
+};
+
+const Code = ({ children, className, ...rest }: Props): JSX.Element => {
+  const styles = useEuiMemoizedStyles(getStyles);
+  const language = className?.startsWith('language-')
+    ? className.replace('language-', '')
+    : undefined;
+
+  const isInlineCode = children
+    ? React.Children.toArray(children).every(
+        (el) => typeof el === 'string' && !el.includes('\n')
+      )
+    : false;
+
+  return isInlineCode ? (
+    <EuiCode {...rest} language={language} css={styles.code}>
+      {children}
+    </EuiCode>
+  ) : (
+    <EuiCodeBlock {...rest} fontSize="m" language={language}>
+      {children}
+    </EuiCodeBlock>
+  );
+};
+
+export default Code;

--- a/packages/docusaurus-theme/src/theme/MDXComponents/Heading.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Heading.tsx
@@ -1,0 +1,29 @@
+import OriginalHeading from '@theme-init/MDXComponents/Heading';
+import type HeadingType from '@theme-init/MDXComponents/Heading';
+import type { WrapperProps } from '@docusaurus/types';
+import { EuiTitle, EuiTitleSize } from '@elastic/eui';
+import { FunctionComponent } from 'react';
+
+type Props = WrapperProps<typeof HeadingType>;
+
+const SIZE_TO_LEVEL_MAP: Record<string, EuiTitleSize> = {
+  h6: 'xxxs',
+  h5: 'xxs',
+  h4: 'xs',
+  h3: 's',
+  h2: 'm',
+  h1: 'l',
+};
+
+const Heading: FunctionComponent<Omit<Props, 'as'> & { as: string }> = ({
+  as,
+  ...rest
+}): JSX.Element => {
+  return (
+    <EuiTitle size={SIZE_TO_LEVEL_MAP[as]}>
+      <OriginalHeading as={as} {...rest} />
+    </EuiTitle>
+  );
+};
+
+export default Heading;

--- a/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
@@ -1,0 +1,35 @@
+import OriginalMDXContent from '@theme-init/MDXContent';
+import type MDXContentType from '@theme-init/MDXContent';
+import type { WrapperProps } from '@docusaurus/types';
+import { css } from '@emotion/react';
+import { EuiText, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
+
+type Props = WrapperProps<typeof MDXContentType>;
+
+const getStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    text: css`
+      p {
+        margin-block-end: ${euiTheme.size.xl};
+      }
+
+      ul,
+      ol {
+        margin-inline-start: 0;
+        margin-block-end: ${euiTheme.size.xl};
+      }
+    `,
+  };
+};
+
+const MDXContent = (props: Props): JSX.Element => {
+  const styles = useEuiMemoizedStyles(getStyles);
+
+  return (
+    <EuiText size="m" css={styles.text}>
+      <OriginalMDXContent {...props} />
+    </EuiText>
+  );
+};
+
+export default MDXContent;

--- a/packages/docusaurus-theme/src/theme/Root.styles.ts
+++ b/packages/docusaurus-theme/src/theme/Root.styles.ts
@@ -1,18 +1,72 @@
-import { UseEuiTheme } from '@elastic/eui';
+import {
+  euiLineHeightFromBaseline,
+  useEuiBackgroundColor,
+  UseEuiTheme,
+} from '@elastic/eui';
 
 // override docusaurus variables as needed
 export const getGlobalStyles = ({ euiTheme }: UseEuiTheme) => {
-  const { colors } = euiTheme;
+  const { font, base, colors, size } = euiTheme;
+  const fontBodyScale = font.scale[font.body.scale];
+  const fontBase = {
+    fontFamily: font.family,
+    fontSize: `${
+      font.defaultUnits === 'px' ? fontBodyScale * base : fontBodyScale
+    }${font.defaultUnits}`,
+    fontWeight: font.weight[font.body.weight],
+  };
 
-  // overriding Docusaurus variables:
-  // since EUI handles the token value updates, we can override both
-  // color modes at the same time (Docusaurus separates based on `data-theme`)
+  const lineHeightL = '1.75rem';
+  const lineHeightM = euiLineHeightFromBaseline('s', euiTheme);
+  const lineHeightS = euiLineHeightFromBaseline('xs', euiTheme);
+  const lineHeightXS = '1.33rem';
+
   return `
+      // color theme related variables
       :root,
-      [data-theme='dark']:root {  
-        // base
+      [data-theme='dark']:root {
+        /* EUI theme variables */
+        --eui-background-color-primary: ${useEuiBackgroundColor('primary')};
+        --eui-background-color-success: ${useEuiBackgroundColor('success')};
+        --eui-background-color-danger: ${useEuiBackgroundColor('danger')};
+        --eui-background-color-warning: ${useEuiBackgroundColor('warning')};
+  
+        /* Docusaurus theme variables */
         --ifm-background-color: ${colors.body};
         --ifm-font-color-base: ${colors.text};
+      }
+
+      :root {
+        /* EUI theme variables */
+        --eui-line-height-base: ${lineHeightL};
+        --eui-line-height-m: ${lineHeightM};
+        --eui-line-height-s: ${lineHeightS};
+        --eui-line-height-xs: ${lineHeightXS};
+
+        /* Docusaurus theme variables */
+        --ifm-font-family-base: ${fontBase.fontFamily};
+        --ifm-font-size-base: ${fontBase.fontSize};
+        --ifm-font-weight-base: ${fontBase.fontWeight};
+        --ifm-line-height-base: var(--eui-line-height-base);
+
+      }
+
+      /* base styles & resets */
+      h1, h2, h3, h4, h5, h6 {
+        margin-block-start: ${size.l};
+        margin-block-end: ${size.m};
+        
+        font-weight: ${font.weight.bold};
+      }
+
+      button {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        color: inherit;
+        border-radius: 0;
+        font-size: inherit;
       }
   `;
 };

--- a/packages/docusaurus-theme/src/theme/Root.tsx
+++ b/packages/docusaurus-theme/src/theme/Root.tsx
@@ -7,6 +7,7 @@
  */
 
 import { FunctionComponent, PropsWithChildren } from 'react';
+import Head from '@docusaurus/Head';
 import { Props } from '@theme/Root';
 import { Global } from '@emotion/react';
 import { _EuiThemeFontScale, useEuiTheme } from '@elastic/eui';
@@ -21,6 +22,12 @@ const _Root: FunctionComponent<PropsWithChildren> = ({ children }) => {
 
   return (
     <>
+      <Head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&family=Roboto+Mono:ital,wght@0,400..700;1,400..700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
       <Global styles={styles} />
       {children}
     </>

--- a/packages/website/docs/01_guidelines/testing/introduction.mdx
+++ b/packages/website/docs/01_guidelines/testing/introduction.mdx
@@ -4,10 +4,10 @@ slug: /guidelines/testing
 id: testing-introduction
 ---
 
-<p style={{ fontSize: '22px' }}>
+<div style={{ fontSize: '22px' }}>
   Learn how we test our code internally and how you should test integration with EUI components to ensure
   good test coverage and easy maintainability.
-</p>
+</div>
 
 ## How we test our components
 

--- a/packages/website/docs/01_guidelines/testing/recommendations.mdx
+++ b/packages/website/docs/01_guidelines/testing/recommendations.mdx
@@ -3,9 +3,9 @@ title: Testing recommendations
 sidebar_label: Recommendations
 ---
 
-<p style={{ fontSize: '22px' }}>
+<div style={{ fontSize: '22px' }}>
   Our general set of do's and don'ts for testing components and views.
-</p>
+</div>
 
 ## Choose the right selectors
 


### PR DESCRIPTION
## Summary

closes: #7795 
relates to #7822 

>[!IMPORTANT]
> ~Parts of this PR (anything related to the ColorModeToggle) was added as a separate PR [here](https://github.com/elastic/eui/pull/7846) but kept in this PR as well for testing purposes. That previous PR for ColorModeToggle should be reviewed and merged before this one.~ Update: The PR was merged and this PR rebased.

This PR updates the base global styles for the new EUI+ docs and additionally adds the first style updates for doc content components.

### Changes:

- swizzles `MDXContent` (wrap) and updates it to use `EuiText` + custom EUI+ adjustments to ensure markdown content styling (text, lists etc)
- swizzles `DocItem/Content` (wrap) and adds custom styles for the document heading
- swizzles `MDXComponents/A` and `MDXComponents/Code` (wrap) and uses Eui components instead (`EuiLink` and `EuiCode`/`EuiCodeBlock`)
- swizzles `MDXComponents/Heading` and uses a wrapping `EuiText` to apply EUI heading styles
- adds a custom EUI+ `CallOut` component and uses it to wrap Docusaurus admonition components (Note, Info, Tip, Warning, Danger) and apply custom styles
- updates swizzled `Footer` component theme to ensure static dark theme (independent from global `colorMode`)

![Screenshot 2024-06-25 at 11 56 55](https://github.com/elastic/eui/assets/44670957/4be1bc34-a79d-4f4e-b823-605729b81deb)

![Screenshot 2024-06-25 at 11 57 08](https://github.com/elastic/eui/assets/44670957/1f4926af-9e67-4d98-9a0a-15c3c515d2bb)

## QA

- [ ] checkout this PR `gh pr checkout 7848`, build the theme in `/packages/docusaurus-theme` with `yarn build` and run the EUI+ docs page in `packages/website` with `yarn start`
  - [ ] review docs pages and styles and verify that they look as currently expected based on initial designs ([link](https://www.figma.com/file/g5Vk0k2DgeQPCPBoWmun2U/EUI%2B-docs?type=design&node-id=19-143558&mode=design&t=tPY9scfTdppfpKYA-0))