### PR TITLE
ci: add buildkite step to build new docs website

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
@@ -10,6 +10,6 @@ steps:
     label: ":docusaurus: Build and deploy new documentation website"
     agents:
       provider: gcp
-      machineType: "n2-standard-1"
+      machineType: "n2-standard-2"
       image: "family/eui-ubuntu-2204"
     if: build.branch != "main"

--- a/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
@@ -1,7 +1,15 @@
 ## 🏠/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
 
 steps:
-  - agents:
+  - command: .buildkite/scripts/pipelines/pipeline_deploy_docs.sh
+    label: ":newspaper: Build and deploy EUI documentation website"
+    agents:
       provider: "gcp"
-    command: .buildkite/scripts/pipelines/pipeline_deploy_docs.sh
     if: build.branch != "main" # We don't want to deploy docs on main, only on manual release
+  - command: .buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+    label: ":docusaurus: Build and deploy new documentation website"
+    agents:
+      provider: gcp
+      machineType: "n2-standard-1"
+      image: "family/eui-ubuntu-2204"
+    if: build.branch != "main"

--- a/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test_and_deploy.yml
@@ -9,8 +9,11 @@ steps:
   - trigger: "eui-pull-request-deploy-docs"
     label: ":newspaper: EUI pull request deploy docs"
     build:
+      message: "${BUILDKITE_MESSAGE}"
       branch: "${BUILDKITE_BRANCH}"
       commit: "${BUILDKITE_COMMIT}"
       env:
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         GIT_BRANCH: "${BUILDKITE_BRANCH}"
         GIT_PULL_REQUEST_ID: "${BUILDKITE_PULL_REQUEST}"

--- a/.buildkite/pipelines/pipeline_release_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_release_deploy_docs.yml
@@ -8,3 +8,9 @@ steps:
       GIT_BRANCH: "${BUILDKITE_BRANCH}"
       GIT_PULL_REQUEST_ID: "${BUILDKITE_PULL_REQUEST}"
       GIT_TAG: "${BUILDKITE_TAG}"
+  - command: .buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+    label: ":docusaurus: Build and deploy new documentation website"
+    agents:
+      provider: gcp
+      machineType: "n2-standard-1"
+      image: "family/eui-ubuntu-2204"

--- a/.buildkite/pipelines/pipeline_release_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_release_deploy_docs.yml
@@ -8,9 +8,3 @@ steps:
       GIT_BRANCH: "${BUILDKITE_BRANCH}"
       GIT_PULL_REQUEST_ID: "${BUILDKITE_PULL_REQUEST}"
       GIT_TAG: "${BUILDKITE_TAG}"
-  - command: .buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
-    label: ":docusaurus: Build and deploy new documentation website"
-    agents:
-      provider: gcp
-      machineType: "n2-standard-1"
-      image: "family/eui-ubuntu-2204"

--- a/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
@@ -1,0 +1,20 @@
+#!/bun/bash
+# Build and deploy new documentation website
+
+set -eo pipefail
+
+# include utils
+source .buildkite/scripts/common/utils.sh
+
+echo "+++ :yarn: Installing dependencies"
+yarn
+
+echo "+++ :yarn: Building @elastic/eui-website and its local dependencies"
+yarn workspaces foreach -Rpt --from @elastic/eui-website run build
+
+echo "+++ Configuring environment for website deployment"
+
+# See if gsutil and gcloud are installed by default
+
+echo "gsutil version: $(gsutil version)"
+echo "gcloud version: $(gcloud version)"

--- a/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
@@ -1,4 +1,4 @@
-#!/bun/bash
+#!/bin/bash
 # Build and deploy new documentation website
 
 set -eo pipefail

--- a/packages/docusaurus-theme/src/components/theme_context/index.tsx
+++ b/packages/docusaurus-theme/src/components/theme_context/index.tsx
@@ -4,6 +4,7 @@ import {
   PropsWithChildren,
   useState,
 } from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import { EUI_THEMES, EuiProvider, EuiThemeColorMode } from '@elastic/eui';
 
 import { EuiThemeOverrides } from './theme_overrides';
@@ -13,7 +14,7 @@ const EUI_THEME_NAMES = EUI_THEMES.map(
 ) as EuiThemeColorMode[];
 
 const defaultState = {
-  theme: EUI_THEME_NAMES[0],
+  theme: EUI_THEME_NAMES[0] as EuiThemeColorMode,
   changeTheme: (themeValue: EuiThemeColorMode) => {},
 };
 
@@ -22,9 +23,14 @@ export const AppThemeContext = createContext(defaultState);
 export const AppThemeProvider: FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
-  const savedTheme: EuiThemeColorMode | undefined =
-    (localStorage.getItem('theme') as EuiThemeColorMode) ?? defaultState.theme;
-  const [theme, setTheme] = useState<EuiThemeColorMode>(savedTheme);
+  const isBrowser = useIsBrowser();
+  const [theme, setTheme] = useState<EuiThemeColorMode>(() => {
+    if (isBrowser) {
+      return localStorage.getItem('theme') as EuiThemeColorMode ?? defaultState.theme;
+    }
+
+    return defaultState.theme;
+  });
 
   return (
     <AppThemeContext.Provider

--- a/packages/eui/scripts/deploy/deploy_docs
+++ b/packages/eui/scripts/deploy/deploy_docs
@@ -58,7 +58,8 @@ post_comment_to_gh()
     printf '\nAdding comment to GitHub Pull Request: %i\n' "${GIT_PULL_REQUEST_ID}"
     comment="Preview staging links for this PR:
 - Docs site: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/
-- Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook"
+- Storybook: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/storybook
+- New docs: https://eui.elastic.co/pr_${GIT_PULL_REQUEST_ID}/new-docs"
 
     curl \
       --silent \


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui-private/issues/93.

This adds a script to build and deploy the new documentation website to the existing PR deploy pipeline.

## QA

- [x] Confirm the new documentation website is being deployed and linked in the `kibanamachine` comment
- [x] Confirm the bash script looks correct
