### PR TITLE
[Docs] Update Unsplash image URLs to point at picsum.photos instead

### DIFF
--- a/packages/eui/src-docs/src/views/avatar/avatar.js
+++ b/packages/eui/src-docs/src/views/avatar/avatar.js
@@ -16,28 +16,12 @@ export default () => (
       <h2>With image</h2>
     </EuiTitle>
     <EuiSpacer />
-    <EuiAvatar
-      size="s"
-      name="Cat"
-      imageUrl="https://source.unsplash.com/64x64/?cat"
-    />
+    <EuiAvatar size="s" name="Cat" imageUrl="https://picsum.photos/id/40/64" />
     &emsp;
-    <EuiAvatar
-      size="m"
-      name="Cat"
-      imageUrl="https://source.unsplash.com/64x64/?cat"
-    />
+    <EuiAvatar size="m" name="Cat" imageUrl="https://picsum.photos/id/40/64" />
     &emsp;
-    <EuiAvatar
-      size="l"
-      name="Cat"
-      imageUrl="https://source.unsplash.com/64x64/?cat"
-    />
+    <EuiAvatar size="l" name="Cat" imageUrl="https://picsum.photos/id/40/64" />
     &emsp;
-    <EuiAvatar
-      size="xl"
-      name="Cat"
-      imageUrl="https://source.unsplash.com/64x64/?cat"
-    />
+    <EuiAvatar size="xl" name="Cat" imageUrl="https://picsum.photos/id/40/64" />
   </div>
 );

--- a/packages/eui/src-docs/src/views/avatar/avatar_disabled.js
+++ b/packages/eui/src-docs/src/views/avatar/avatar_disabled.js
@@ -25,7 +25,7 @@ export default () => (
     <EuiAvatar
       size="m"
       name="Cat"
-      imageUrl="https://source.unsplash.com/64x64/?cat"
+      imageUrl="https://picsum.photos/id/40/64"
       isDisabled={true}
     />
     &emsp;

--- a/packages/eui/src-docs/src/views/avatar/avatar_example.js
+++ b/packages/eui/src-docs/src/views/avatar/avatar_example.js
@@ -10,7 +10,7 @@ const avatarSource = require('!!raw-loader!./avatar');
 const avatarSnippet = [
   `<EuiAvatar name="Raphael" />
 `,
-  `<EuiAvatar size="s" name="Cat" imageUrl="https://source.unsplash.com/64x64/?cat" />
+  `<EuiAvatar size="s" name="Cat" imageUrl="https://picsum.photos/id/40/64" />
 `,
   '<EuiAvatar name="Leonardo" color="#BD10E0" />',
 ];

--- a/packages/eui/src-docs/src/views/card/card_example.js
+++ b/packages/eui/src-docs/src/views/card/card_example.js
@@ -184,7 +184,7 @@ export const CardExample = {
       },
       snippet: `<EuiCard
   textAlign="left"
-  image="https://source.unsplash.com/400x200/?Nature"
+  image="https://picsum.photos/400/200"
   title="title"
   description="description"
   onClick={handleClick}

--- a/packages/eui/src-docs/src/views/card/card_image.tsx
+++ b/packages/eui/src-docs/src/views/card/card_image.tsx
@@ -15,10 +15,7 @@ export default () => (
         textAlign="left"
         image={
           <div>
-            <img
-              src="https://source.unsplash.com/400x200/?Nature"
-              alt="Nature"
-            />
+            <img src="https://picsum.photos/id/13/400/200" alt="Nature" />
           </div>
         }
         title="Elastic in Nature"
@@ -35,7 +32,7 @@ export default () => (
     <EuiFlexItem>
       <EuiCard
         textAlign="left"
-        image="https://source.unsplash.com/400x200/?Water"
+        image="https://picsum.photos/400/200"
         title="Elastic in Water"
         description="Example of a card's description. Stick to one or two sentences."
         isDisabled
@@ -45,7 +42,7 @@ export default () => (
       <EuiCard
         textAlign="left"
         href="https://elastic.github.io/eui/"
-        image="https://source.unsplash.com/400x200/?City"
+        image="https://picsum.photos/id/57/400/200"
         icon={<EuiIcon size="xxl" type="logoBeats" />}
         title={'Beats in the City'}
         description="This card has an href and should be a link."

--- a/packages/eui/src-docs/src/views/comment/comment_avatar.tsx
+++ b/packages/eui/src-docs/src/views/comment/comment_avatar.tsx
@@ -36,13 +36,10 @@ export default () => (
 
     <EuiComment
       username="cat"
-      timelineAvatarAriaLabel="Beatiful cat"
+      timelineAvatarAriaLabel="Beautiful cat"
       event="is using a custom avatar"
       timelineAvatar={
-        <EuiAvatar
-          name="cat"
-          imageUrl="https://source.unsplash.com/64x64/?cat"
-        />
+        <EuiAvatar name="Cat" imageUrl="https://picsum.photos/id/40/64" />
       }
     >
       <EuiText size="s">

--- a/packages/eui/src-docs/src/views/datagrid/cells_popovers/cell_popover_rendercellpopover.tsx
+++ b/packages/eui/src-docs/src/views/datagrid/cells_popovers/cell_popover_rendercellpopover.tsx
@@ -100,7 +100,7 @@ const RenderCellPopover = (props: EuiDataGridCellPopoverElementProps) => {
             hasShadow
             caption={caption}
             alt="Random Star Wars image"
-            url="https://source.unsplash.com/600x600/?starwars"
+            url="https://picsum.photos/id/35/600"
           />
         ) : (
           <EuiImage
@@ -109,7 +109,7 @@ const RenderCellPopover = (props: EuiDataGridCellPopoverElementProps) => {
             hasShadow
             caption={caption}
             alt="Random Star Trek image"
-            url="https://source.unsplash.com/600x600/?startrek"
+            url="https://picsum.photos/id/120/600"
           />
         )}
       </>

--- a/packages/eui/src-docs/src/views/image/playground.js
+++ b/packages/eui/src-docs/src/views/image/playground.js
@@ -21,7 +21,7 @@ export default () => {
     },
     defaultValue: 'original',
   };
-  propsToUse.src.value = 'https://source.unsplash.com/100x100/?Nature';
+  propsToUse.src.value = 'https://picsum.photos/100';
   propsToUse.alt.value = 'image_alt';
 
   return {

--- a/packages/eui/src-docs/src/views/page_header/playground.js
+++ b/packages/eui/src-docs/src/views/page_header/playground.js
@@ -1,9 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-import React from 'react';
 import { PropTypes } from 'react-view';
 import {
-  EuiPageTemplate,
   EuiPageHeader,
   EuiButton,
   EuiTabs,
@@ -42,10 +38,6 @@ const rightSideItems = `[
   <EuiButton fill>Button 1</EuiButton>,
   <EuiButton>Button 2</EuiButton>,
 ]`;
-
-// TODO: Try later to build a toggle that allows switching between different types of content to pass
-// const rightSideItems =
-//   '[<EuiImage url="https://source.unsplash.com/400x200/?Water" height="200" />]';
 
 export const pageHeaderConfig = () => {
   const docgenInfo = Array.isArray(EuiPageHeader.__docgenInfo)


### PR DESCRIPTION
## Summary

Unsplash recently deprecated their source API, so we're moving onto Lorem Picsum instead (which we were already using in `EuiImage` docs I believe).

## QA

- https://eui.elastic.co/pr_7851/#/display/avatar
- https://eui.elastic.co/pr_7851/#/display/comment-list#timeline-avatar
- https://eui.elastic.co/pr_7851/#/display/card#images
- https://eui.elastic.co/pr_7851/#/tabular-content/data-grid-cells-popovers#completely-customizing-cell-popover-rendering

### General checklist

- [x] Confirm images show up