### PR TITLE
Chromium workaround for CSS mask-image bug

### DIFF
--- a/packages/eui/changelogs/upcoming/7855.md
+++ b/packages/eui/changelogs/upcoming/7855.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a Chrome/Edge CSS `mask-image` bug that was affecting scroll overflow shadow utilties

--- a/packages/eui/src-docs/src/views/modal/modal.tsx
+++ b/packages/eui/src-docs/src/views/modal/modal.tsx
@@ -4,13 +4,135 @@ import {
   EuiButton,
   EuiModal,
   EuiModalBody,
-  EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
-  EuiCodeBlock,
-  EuiSpacer,
-  useGeneratedHtmlId,
-} from '../../../../src';
+  EuiHealth,
+  EuiLink,
+  EuiInMemoryTable,
+} from '../../../../src/components';
+
+import _times from 'lodash/times';
+
+const firstNames = [
+  'Very long first name that will wrap or be truncated',
+  'Another very long first name which will wrap or be truncated',
+  'Clinton',
+  'Igor',
+  undefined,
+  'Drew',
+  null,
+  'Rashid',
+  undefined,
+  'John',
+];
+
+const lastNames = [
+  'Very long last name that will wrap or be truncated',
+  'Another very long last name which will wrap or be truncated',
+  'Gormley',
+  'Motov',
+  'Minarik',
+  'Raines',
+  'Král',
+  'Khan',
+  'Sissel',
+  'Dorlus',
+];
+
+const github = [
+  'martijnvg',
+  'elissaw',
+  'clintongormley',
+  'imotov',
+  'karmi',
+  'drewr',
+  'HonzaKral',
+  'rashidkpc',
+  'jordansissel',
+  'silne30',
+];
+
+const createUsers = () => {
+  return _times(20, (index) => {
+    return {
+      id: index,
+      firstName: index < 10 ? firstNames[index] : firstNames[index - 10],
+      lastName: index < 10 ? lastNames[index] : lastNames[index - 10],
+      github: index < 10 ? github[index] : github[index - 10],
+      dateOfBirth: new Date(
+        1980,
+        Math.floor(Math.random() * 12),
+        Math.floor(Math.random() * 27) + 1
+      ),
+      nationality: 'nationality',
+      online: index % 2 === 0,
+    };
+  });
+};
+
+export const Table = () => {
+  const columns = [
+    {
+      field: 'firstName',
+      name: 'First Name',
+      sortable: true,
+      truncateText: true,
+    },
+    {
+      field: 'lastName',
+      name: 'Last Name',
+      truncateText: true,
+    },
+    {
+      field: 'github',
+      name: 'Github',
+      render: (username: string) => (
+        <EuiLink href={`https://github.com/${username}`} target="_blank">
+          {username}
+        </EuiLink>
+      ),
+    },
+    {
+      field: 'dateOfBirth',
+      name: 'Date of Birth',
+      dataType: 'string',
+      render: () => `hello`,
+      sortable: true,
+    },
+    {
+      field: 'nationality',
+      name: 'Nationality',
+    },
+    {
+      field: 'online',
+      name: 'Online',
+      dataType: 'boolean',
+      render: (online: boolean) => {
+        const color = online ? 'success' : 'danger';
+        const label = online ? 'Online' : 'Offline';
+        return <EuiHealth color={color}>{label}</EuiHealth>;
+      },
+      sortable: true,
+    },
+  ];
+
+  const sorting = {
+    sort: {
+      field: 'dateOfBirth',
+      direction: 'desc',
+    },
+  } as const;
+
+  return (
+    <EuiInMemoryTable
+      tableCaption="Demo of EuiInMemoryTable"
+      items={createUsers()}
+      columns={columns as any}
+      pagination={true}
+      sorting={sorting}
+    />
+  );
+};
 
 export default () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -18,49 +140,28 @@ export default () => {
   const closeModal = () => setIsModalVisible(false);
   const showModal = () => setIsModalVisible(true);
 
-  const modalTitleId = useGeneratedHtmlId();
+  let modal;
+
+  if (isModalVisible) {
+    modal = (
+      <EuiModal onClose={closeModal}>
+        <EuiModalHeader>
+          <EuiModalHeaderTitle>
+            <h1>title</h1>
+          </EuiModalHeaderTitle>
+        </EuiModalHeader>
+
+        <EuiModalBody>
+          <Table />
+        </EuiModalBody>
+      </EuiModal>
+    );
+  }
 
   return (
-    <>
+    <div>
       <EuiButton onClick={showModal}>Show modal</EuiButton>
-
-      {isModalVisible && (
-        <EuiModal aria-labelledby={modalTitleId} onClose={closeModal}>
-          <EuiModalHeader>
-            <EuiModalHeaderTitle id={modalTitleId}>
-              Modal title
-            </EuiModalHeaderTitle>
-          </EuiModalHeader>
-
-          <EuiModalBody>
-            This modal has the following setup:
-            <EuiSpacer />
-            <EuiCodeBlock language="html" isCopyable>
-              {`<EuiModal aria-labelledby={titleId} onClose={closeModal}>
-  <EuiModalHeader>
-    <EuiModalHeaderTitle title={titleId}><!-- Modal title --></EuiModalHeaderTitle>
-  </EuiModalHeader>
-
-  <EuiModalBody>
-    <!-- Modal body -->
-  </EuiModalBody>
-
-  <EuiModalFooter>
-    <EuiButton onClick={closeModal} fill>
-      Close
-    </EuiButton>
-  </EuiModalFooter>
-</EuiModal>`}
-            </EuiCodeBlock>
-          </EuiModalBody>
-
-          <EuiModalFooter>
-            <EuiButton onClick={closeModal} fill>
-              Close
-            </EuiButton>
-          </EuiModalFooter>
-        </EuiModal>
-      )}
-    </>
+      {modal}
+    </div>
   );
 };

--- a/packages/eui/src/components/modal/modal.styles.ts
+++ b/packages/eui/src/components/modal/modal.styles.ts
@@ -31,8 +31,7 @@ export const euiModalStyles = (euiThemeContext: UseEuiTheme) => {
       z-index: ${euiTheme.levels.modal};
       min-inline-size: ${euiFormVariables(euiThemeContext).maxWidth};
       max-inline-size: calc(100vw - ${euiTheme.size.base});
-      /* TODO: Consider restoring this once https://bugs.chromium.org/p/chromium/issues/detail?id=1229700 is resolved */
-      /* overflow: hidden; Ensure long, non-breaking text doesn't expand beyond the modal bounds */
+      overflow: hidden; /* Ensure long, non-breaking text doesn't expand beyond the modal bounds */
 
       ${euiCanAnimate} {
         animation: ${euiAnimSlideInUp(euiTheme.size.xxl)}

--- a/packages/eui/src/global_styling/mixins/_helpers.ts
+++ b/packages/eui/src/global_styling/mixins/_helpers.ts
@@ -113,10 +113,18 @@ const euiOverflowShadowStyles = (
     }
   }
 
+  // Chrome+Edge has a very bizarre edge case bug where `mask-image` stops working
+  // This workaround forces a stacking context on the scrolling container, which
+  // hopefully addresses the bug. @see:
+  // - https://issues.chromium.org/issues/40778541
+  // - https://github.com/elastic/kibana/issues/180828
+  // - https://github.com/elastic/eui/pull/6343#issuecomment-1302732021
+  const chromiumMaskWorkaround = 'transform: translateZ(0);';
+
   if (direction === 'y') {
-    return `mask-image: linear-gradient(to bottom, ${gradient});`;
+    return `mask-image: linear-gradient(to bottom, ${gradient}); ${chromiumMaskWorkaround}`;
   } else {
-    return `mask-image: linear-gradient(to right, ${gradient});`;
+    return `mask-image: linear-gradient(to right, ${gradient}); ${chromiumMaskWorkaround}`;
   }
 };
 

--- a/packages/eui/src/global_styling/mixins/_shadow.scss
+++ b/packages/eui/src/global_styling/mixins/_shadow.scss
@@ -100,4 +100,9 @@
   } @else {
     @warn "euiOverflowShadow() expects direction to be 'y' or 'x' but got '#{$direction}'";
   }
+
+  // Chrome+Edge has a very bizarre edge case bug where `mask-image` stops working
+  // This workaround forces a stacking context on the scrolling container, which
+  // hopefully addresses the bug. @see https://github.com/elastic/eui/pull/7855
+  transform: translateZ(0);
 }

--- a/packages/eui/src/global_styling/utility/__snapshots__/utility.test.ts.snap
+++ b/packages/eui/src/global_styling/utility/__snapshots__/utility.test.ts.snap
@@ -182,7 +182,7 @@ exports[`global utility styles generates static global styles 1`] = `
   , 
   rgb(255,0,0) calc(100% - 8px),
   rgba(255,0,0,0.1) 100%
-  );
+  ); transform: translateZ(0);
 ;}
 .eui-xScrollWithShadows{
   
@@ -221,7 +221,7 @@ exports[`global utility styles generates static global styles 1`] = `
   , 
   rgb(255,0,0) calc(100% - 8px),
   rgba(255,0,0,0.1) 100%
-  );
+  ); transform: translateZ(0);
 ;}[class*='eui-showFor']{display:none!important;}
       .eui-hideFor--xl {
         @media only screen and (min-width: 1200px) {


### PR DESCRIPTION
## Summary

This bug was originally addressed in https://github.com/elastic/eui/issues/6328 / https://github.com/elastic/eui/pull/6343, but it turns out that it's affecting more components than just EuiModal (at least EuiFlyout as well - see https://github.com/elastic/kibana/issues/180828). The browser-level bug in question is being tracked in https://issues.chromium.org/issues/40778541.

The amazing @kqualters-elastic helped us look into the issue and came up with an excellent workaround. Chromium appears to be not correctly applying a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) to `mask-image`s with linear gradients and certain other children/properties. Using `transform: translateZ(0)` forces that stacking context and fixes the bug.

NOTE: `will-change: transform` and `position: relative` also works around the bug, but I deemed them to potentially have outsized side effects compared to translateZ.

| Broken | Fixed |
|--------|--------|
| <img width="525" alt="" src="https://github.com/elastic/eui/assets/549407/929375fe-efb2-42fb-b3b5-787950318dac"> | <img width="527" alt="" src="https://github.com/elastic/eui/assets/549407/29a8e7a4-e380-43fe-82a8-cf578ff14586"> | 

## QA

- Open Chrome or Edge and go to https://eui.elastic.co/pr_7855/#/layout/modal (bug does not affect Firefox or Safari)
- Click the `Show Modal` button
- [x] Confirm the modal body content does not have a red overlay
- Open your browser devtools and inspect `.euiModalBody__overflow`
- [x] Hide/uncheck the `transform: translateZ(0)` CSS and confirm that it _does_ have a red overlay without the workaround CSS

### General checklist

- [ ] Revert `REVERT ME` commit
- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A, CSS only
- Code quality checklist - N/A, CSS only
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A