### PR TITLE
[EuiFilePicker] update aria-label for `Remove` button

### DIFF
--- a/packages/eui/changelogs/upcoming/7860.md
+++ b/packages/eui/changelogs/upcoming/7860.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Updated the `aria-label` attribute for the `EuiFilePicker` remove file button 

--- a/packages/eui/src/components/form/file_picker/file_picker.tsx
+++ b/packages/eui/src/components/form/file_picker/file_picker.tsx
@@ -144,10 +144,10 @@ export class EuiFilePickerClass extends Component<
 
     return (
       <EuiI18n
-        token="euiFilePicker.removeSelectedFiles"
+        token="euiFilePicker.removeSelectedAriaLabel"
         default="Remove selected files"
       >
-        {(removeSelectedFiles: string) => {
+        {(removeSelectedAriaLabel: string) => {
           const {
             stylesMemoizer,
             id,
@@ -244,7 +244,7 @@ export class EuiFilePickerClass extends Component<
             if (normalFormControl) {
               clearButton = (
                 <EuiFormControlLayoutClearButton
-                  aria-label={removeSelectedFiles}
+                  aria-label={removeSelectedAriaLabel}
                   css={[styles.euiFilePicker__clearButton, rightIconStyles]}
                   className="euiFilePicker__clearButton"
                   onClick={this.removeFiles}
@@ -254,7 +254,7 @@ export class EuiFilePickerClass extends Component<
             } else {
               clearButton = (
                 <EuiButtonEmpty
-                  aria-label={removeSelectedFiles}
+                  aria-label={removeSelectedAriaLabel}
                   css={styles.euiFilePicker__clearButton}
                   className="euiFilePicker__clearButton"
                   size="xs"

--- a/packages/eui/src/components/form/file_picker/file_picker.tsx
+++ b/packages/eui/src/components/form/file_picker/file_picker.tsx
@@ -144,10 +144,10 @@ export class EuiFilePickerClass extends Component<
 
     return (
       <EuiI18n
-        token="euiFilePicker.clearSelectedFiles"
-        default="Clear selected files"
+        token="euiFilePicker.removeSelectedFiles"
+        default="Remove selected files"
       >
-        {(clearSelectedFiles: string) => {
+        {(removeSelectedFiles: string) => {
           const {
             stylesMemoizer,
             id,
@@ -244,7 +244,7 @@ export class EuiFilePickerClass extends Component<
             if (normalFormControl) {
               clearButton = (
                 <EuiFormControlLayoutClearButton
-                  aria-label={clearSelectedFiles}
+                  aria-label={removeSelectedFiles}
                   css={[styles.euiFilePicker__clearButton, rightIconStyles]}
                   className="euiFilePicker__clearButton"
                   onClick={this.removeFiles}
@@ -254,7 +254,7 @@ export class EuiFilePickerClass extends Component<
             } else {
               clearButton = (
                 <EuiButtonEmpty
-                  aria-label={clearSelectedFiles}
+                  aria-label={removeSelectedFiles}
                   css={styles.euiFilePicker__clearButton}
                   className="euiFilePicker__clearButton"
                   size="xs"


### PR DESCRIPTION
Closes: https://github.com/elastic/observability-dev/issues/3641

**Accessibility**

- Updated the `aria-label` attribute for the `EuiFilePicker` remove file button 

**Screen**
<img width="1366" alt="image" src="https://github.com/elastic/eui/assets/20072247/1b022ce1-7def-43ed-b5ac-ba55b7add589">

