### PR TITLE
[EuiThemeProvider] Allow nested `modify.breakpoint` overrides

### DIFF
--- a/packages/eui/changelogs/upcoming/7862.md
+++ b/packages/eui/changelogs/upcoming/7862.md
@@ -1,0 +1,1 @@
+- Updated `EuiThemeProvider`s to allow modifying/setting custom `breakpoint`s in nested usage (as opposed to only at the top `EuiProvider` level)

--- a/packages/eui/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
+++ b/packages/eui/src-docs/src/views/theme/breakpoints/_breakpoints_js.tsx
@@ -217,7 +217,8 @@ export const CustomBreakpointsJS = () => {
         <>
           <p>
             Theme breakpoints can be overriden or added via{' '}
-            <EuiCode>EuiProvider</EuiCode>&apos;s <EuiCode>modify</EuiCode>{' '}
+            <EuiCode>EuiProvider</EuiCode>&apos;s or{' '}
+            <EuiCode>EuiThemeProvider</EuiCode>&apos;s <EuiCode>modify</EuiCode>{' '}
             prop.
           </p>
           <p>
@@ -232,7 +233,7 @@ export const CustomBreakpointsJS = () => {
           Current custom breakpoint: <strong>{currentBreakpoint}</strong>
         </p>
       }
-      snippet={`<EuiProvider
+      snippet={`<EuiThemeProvider
   modify={{
     breakpoint: {
       xxs: 0,
@@ -246,7 +247,7 @@ export const CustomBreakpointsJS = () => {
   }}
 >
   <App />
-</EuiProvider>
+</EuiThemeProvider>
 `}
       snippetLanguage="js"
     />

--- a/packages/eui/src-docs/src/views/theme/breakpoints/breakpoints.tsx
+++ b/packages/eui/src-docs/src/views/theme/breakpoints/breakpoints.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from 'react';
-import { EuiSpacer, EuiText, EuiProvider } from '../../../../../src';
+import { EuiSpacer, EuiText, EuiThemeProvider } from '../../../../../src';
 
 import { GuideSection } from '../../../components/guide_section/guide_section';
 import { ThemeContext } from '../../../components/with_theme';
@@ -51,7 +51,7 @@ export default () => {
       <GuideSection color="transparent">{valuesContent}</GuideSection>
 
       {currentLanguage.includes('js') && (
-        <EuiProvider modify={{ breakpoint: CUSTOM_BREAKPOINTS }}>
+        <EuiThemeProvider modify={{ breakpoint: CUSTOM_BREAKPOINTS }}>
           <GuideSection color="subdued">
             <EuiText grow={false}>
               <h2 id={breakpointSections[1].id}>
@@ -70,7 +70,7 @@ export default () => {
           </GuideSection>
 
           <GuideSection color="transparent">{valuesContent}</GuideSection>
-        </EuiProvider>
+        </EuiThemeProvider>
       )}
     </>
   );

--- a/packages/eui/src/components/provider/provider.tsx
+++ b/packages/eui/src/components/provider/provider.tsx
@@ -13,7 +13,6 @@ import {
   EuiThemeProvider,
   EuiThemeProviderProps,
   EuiThemeSystem,
-  CurrentEuiBreakpointProvider,
 } from '../../services';
 import { emitEuiProviderWarning } from '../../services/theme/warning';
 import { cache as fallbackCache } from '../../services/emotion/css';
@@ -146,9 +145,7 @@ export const EuiProvider = <T extends {} = {}>({
             </>
           )}
           <EuiComponentDefaultsProvider componentDefaults={componentDefaults}>
-            <CurrentEuiBreakpointProvider>
-              {children}
-            </CurrentEuiBreakpointProvider>
+            {children}
           </EuiComponentDefaultsProvider>
         </EuiThemeProvider>
       </EuiCacheProvider>

--- a/packages/eui/src/services/breakpoint/current_breakpoint.tsx
+++ b/packages/eui/src/services/breakpoint/current_breakpoint.tsx
@@ -21,7 +21,7 @@ import {
   _EuiThemeBreakpoint,
   _EuiThemeBreakpoints,
 } from '../../global_styling/variables/breakpoint';
-import { useEuiTheme } from '../theme';
+import { useEuiTheme } from '../theme/hooks';
 import { throttle } from '../throttle';
 import { sortMapByLargeToSmallValues } from './_sorting';
 

--- a/packages/eui/src/services/breakpoint/current_breakpoint.tsx
+++ b/packages/eui/src/services/breakpoint/current_breakpoint.tsx
@@ -31,8 +31,10 @@ export const CurrentEuiBreakpointContext =
   createContext<CurrentEuiBreakpoint>(undefined);
 
 /**
- * Top level provider (nested within EuiProvider) which provides a single
- * resize listener that returns the current breakpoint based on window width
+ * Returns the current breakpoint based on window width.
+ * Typically only called by the top-level `EuiProvider` (to reduce the number
+ * of window resize listeners on the page). Also conditionally called if a
+ * nested `EuiThemeProvider` defines a `modify.breakpoint` override
  */
 export const CurrentEuiBreakpointProvider: FunctionComponent<
   PropsWithChildren

--- a/packages/eui/src/services/theme/provider.test.tsx
+++ b/packages/eui/src/services/theme/provider.test.tsx
@@ -11,6 +11,7 @@ import { render } from '@testing-library/react'; // Note - don't use the EUI cus
 import { css } from '@emotion/react';
 
 import { EuiProvider } from '../../components/provider';
+import { useCurrentEuiBreakpoint } from '../breakpoint';
 import { EuiNestedThemeContext } from './context';
 import { EuiThemeProvider } from './provider';
 
@@ -72,6 +73,33 @@ describe('EuiThemeProvider', () => {
       );
 
       expect(getByText('Modified')).toHaveStyleRule('color', 'hotpink');
+    });
+
+    it('sets a conditional CurrentEuiBreakpointProvider if modify.breakpoint is passed', () => {
+      window.innerWidth = 2500;
+      const customBreakpoints = { xxl: 2000 };
+      const PrintCurrentBreakpoint = () => <>{useCurrentEuiBreakpoint()}</>;
+
+      const { container, rerender } = render(
+        <EuiThemeProvider modify={{ breakpoint: customBreakpoints }}>
+          <PrintCurrentBreakpoint />
+        </EuiThemeProvider>
+      );
+
+      expect(container.textContent).toEqual('xxl');
+
+      // Does nothing if no modify.breakpoint is passed
+      const eventListenerSpy = jest.spyOn(window, 'addEventListener');
+      rerender(
+        <EuiThemeProvider>
+          <PrintCurrentBreakpoint />
+        </EuiThemeProvider>
+      );
+      expect(eventListenerSpy).not.toHaveBeenCalledWith('resize');
+      expect(container.textContent).toEqual('xl');
+
+      // Reset window width to jsdom's default
+      window.innerWidth = 1024;
     });
   });
 

--- a/packages/eui/src/services/theme/provider.tsx
+++ b/packages/eui/src/services/theme/provider.tsx
@@ -83,10 +83,13 @@ export const EuiThemeProvider = <T extends {} = {}>({
   const prevSystemKey = useRef(system.key);
 
   // To reduce the number of window resize listeners, only render a
-  // CurrentEuiBreakpointProvider if modified breakpoint overrides are passed
+  // CurrentEuiBreakpointProvider for the top level parent theme, or for
+  // nested themes only if modified breakpoint overrides are passed
   const EuiConditionalBreakpointProvider = useMemo(() => {
-    return _modifications?.breakpoint ? CurrentEuiBreakpointProvider : Fragment;
-  }, [_modifications]);
+    return isGlobalTheme || _modifications?.breakpoint
+      ? CurrentEuiBreakpointProvider
+      : Fragment;
+  }, [isGlobalTheme, _modifications]);
 
   const [modifications, setModifications] = useState<EuiThemeModifications>(
     mergeDeep(parentModifications, _modifications)

--- a/packages/eui/src/services/theme/provider.tsx
+++ b/packages/eui/src/services/theme/provider.tsx
@@ -23,7 +23,7 @@ import isEqual from 'lodash/isEqual';
 import type { CommonProps } from '../../components/common';
 import { cloneElementWithCss } from '../emotion';
 import { css, cx } from '../emotion/css';
-import { CurrentEuiBreakpointProvider } from '../breakpoint';
+import { CurrentEuiBreakpointProvider } from '../breakpoint/current_breakpoint';
 
 import {
   EuiSystemContext,

--- a/packages/eui/src/services/theme/provider.tsx
+++ b/packages/eui/src/services/theme/provider.tsx
@@ -15,6 +15,7 @@ import React, {
   useCallback,
   PropsWithChildren,
   HTMLAttributes,
+  Fragment,
 } from 'react';
 import { Global, type CSSObject } from '@emotion/react';
 import isEqual from 'lodash/isEqual';
@@ -22,6 +23,7 @@ import isEqual from 'lodash/isEqual';
 import type { CommonProps } from '../../components/common';
 import { cloneElementWithCss } from '../emotion';
 import { css, cx } from '../emotion/css';
+import { CurrentEuiBreakpointProvider } from '../breakpoint';
 
 import {
   EuiSystemContext,
@@ -79,6 +81,12 @@ export const EuiThemeProvider = <T extends {} = {}>({
 
   const [system, setSystem] = useState(_system || parentSystem);
   const prevSystemKey = useRef(system.key);
+
+  // To reduce the number of window resize listeners, only render a
+  // CurrentEuiBreakpointProvider if modified breakpoint overrides are passed
+  const EuiConditionalBreakpointProvider = useMemo(() => {
+    return _modifications?.breakpoint ? CurrentEuiBreakpointProvider : Fragment;
+  }, [_modifications]);
 
   const [modifications, setModifications] = useState<EuiThemeModifications>(
     mergeDeep(parentModifications, _modifications)
@@ -232,7 +240,9 @@ export const EuiThemeProvider = <T extends {} = {}>({
               <EuiNestedThemeContext.Provider value={nestedThemeContext}>
                 <EuiThemeMemoizedStylesProvider>
                   <EuiEmotionThemeProvider>
-                    {renderedChildren}
+                    <EuiConditionalBreakpointProvider>
+                      {renderedChildren}
+                    </EuiConditionalBreakpointProvider>
                   </EuiEmotionThemeProvider>
                 </EuiThemeMemoizedStylesProvider>
               </EuiNestedThemeContext.Provider>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7829

I originally started this work hoping it would be a quick fix/workaround solution to the broken docs example, but I quickly realized that `EuiThemeProvider` needed to be updated to handle `modify={{ breakpoint }}` overrides because it was currently not doing anything with that configuration.

We've also recently seen some dialogue in Slack with Fleet about needing to set custom breakpoints for certain screens/views/flyouts as opposed to entire plugins, so this work would strongly facilitate the ability to do that (currently difficult or not possible).

> [!NOTE]
> **Not addressed in this PR:**
> "I would still consider adding guidelines to flyout in our design system. it's important so when designers use 1200 version, they know what design principles to follow"
> "[...] We document _how_ to customize our breakpoints but not _when_ to or when not to"

## QA

- Go to https://eui.elastic.co/pr_7862/#/theming/breakpoints/values#custom-values
- Open your browser devtools and responsive mode
- Set the browser width to 2501px wide (or more)
- [x] Confirm the `xxl` breakpoint is shown in both the example and in the table:

<img width="959" alt="" src="https://github.com/elastic/eui/assets/549407/16c8ea0c-eb61-4143-86f3-684af0a959bb">

<img width="1410" alt="" src="https://github.com/elastic/eui/assets/549407/fe5a5aba-8d4f-404e-82b4-993cd56e7221">

### General checklist

- Browser QA
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    ~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
    ~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A