### PR TITLE
[EuiStat] Accessibility - removed `aria-hidden=true` attribute

### DIFF
--- a/packages/eui/changelogs/upcoming/7864.md
+++ b/packages/eui/changelogs/upcoming/7864.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Improved the accessibility experience of `EuiStat` by removing extra `aria-hidden=true` attribute
+

--- a/packages/eui/changelogs/upcoming/7864.md
+++ b/packages/eui/changelogs/upcoming/7864.md
@@ -1,4 +1,3 @@
 **Accessibility**
 
-- Improved the accessibility experience of `EuiStat` by removing extra `aria-hidden=true` attribute
-
+- Improved `EuiStat`'s screen reader accessibility

--- a/packages/eui/src/components/stat/__snapshots__/stat.test.tsx.snap
+++ b/packages/eui/src/components/stat/__snapshots__/stat.test.tsx.snap
@@ -9,14 +9,11 @@ exports[`EuiStat is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -36,14 +33,11 @@ exports[`EuiStat props accent is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-accent"
   >
     title
@@ -63,14 +57,11 @@ exports[`EuiStat props center is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -90,14 +81,11 @@ exports[`EuiStat props danger is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-danger"
   >
     title
@@ -117,14 +105,11 @@ exports[`EuiStat props default is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -144,14 +129,11 @@ exports[`EuiStat props hexcode colors are rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title"
     style="color: rgb(235, 25, 25);"
   >
@@ -172,14 +154,11 @@ exports[`EuiStat props l is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -199,14 +178,11 @@ exports[`EuiStat props left is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -228,14 +204,11 @@ exports[`EuiStat props loading is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default-isLoading"
   >
     --
@@ -255,14 +228,11 @@ exports[`EuiStat props m is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-m-euiStat__title-default"
   >
     title
@@ -282,14 +252,11 @@ exports[`EuiStat props primary is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-primary"
   >
     title
@@ -309,16 +276,13 @@ exports[`EuiStat props render with custom description element 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <div
-      aria-hidden="true"
-    >
+    <div>
       <div>
         description
       </div>
     </div>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title"
     style="color: rgb(235, 25, 25);"
   >
@@ -334,14 +298,11 @@ exports[`EuiStat props render with custom title element 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <div
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     <div>
@@ -358,14 +319,11 @@ exports[`EuiStat props right is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -385,14 +343,11 @@ exports[`EuiStat props s is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-s-euiStat__title-default"
   >
     title
@@ -412,14 +367,11 @@ exports[`EuiStat props subdued is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-subdued"
   >
     title
@@ -439,14 +391,11 @@ exports[`EuiStat props success is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-success"
   >
     title
@@ -464,7 +413,6 @@ exports[`EuiStat props title and description are reversed 1`] = `
   class="euiStat emotion-euiStat-left"
 >
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
@@ -472,9 +420,7 @@ exports[`EuiStat props title and description are reversed 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
@@ -493,14 +439,11 @@ exports[`EuiStat props xs is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-xs-euiStat__title-default"
   >
     title
@@ -520,14 +463,11 @@ exports[`EuiStat props xxs is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-xxs-euiStat__title-default"
   >
     title
@@ -547,14 +487,11 @@ exports[`EuiStat props xxxs is rendered 1`] = `
   <div
     class="euiText euiStat__description emotion-euiText-s"
   >
-    <p
-      aria-hidden="true"
-    >
+    <p>
       description
     </p>
   </div>
   <p
-    aria-hidden="true"
     class="euiTitle euiStat__title emotion-euiTitle-xxxs-euiStat__title-default"
   >
     title

--- a/packages/eui/src/components/stat/__snapshots__/stat.test.tsx.snap
+++ b/packages/eui/src/components/stat/__snapshots__/stat.test.tsx.snap
@@ -18,11 +18,6 @@ exports[`EuiStat is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -41,11 +36,6 @@ exports[`EuiStat props accent is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-accent"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -66,11 +56,6 @@ exports[`EuiStat props center is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -90,11 +75,6 @@ exports[`EuiStat props danger is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -113,11 +93,6 @@ exports[`EuiStat props default is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -139,11 +114,6 @@ exports[`EuiStat props hexcode colors are rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -162,11 +132,6 @@ exports[`EuiStat props l is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -187,11 +152,6 @@ exports[`EuiStat props left is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -209,14 +169,10 @@ exports[`EuiStat props loading is rendered 1`] = `
     </p>
   </div>
   <p
+    aria-label="Statistic is loading"
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-default-isLoading"
   >
     --
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    Statistic is loading
   </p>
 </div>
 `;
@@ -237,11 +193,6 @@ exports[`EuiStat props m is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -260,11 +211,6 @@ exports[`EuiStat props primary is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-primary"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -328,11 +274,6 @@ exports[`EuiStat props right is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -351,11 +292,6 @@ exports[`EuiStat props s is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-s-euiStat__title-default"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -376,11 +312,6 @@ exports[`EuiStat props subdued is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -399,11 +330,6 @@ exports[`EuiStat props success is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-success"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -424,11 +350,6 @@ exports[`EuiStat props title and description are reversed 1`] = `
       description
     </p>
   </div>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    title description
-  </p>
 </div>
 `;
 
@@ -447,11 +368,6 @@ exports[`EuiStat props xs is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-xs-euiStat__title-default"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;
@@ -472,11 +388,6 @@ exports[`EuiStat props xxs is rendered 1`] = `
   >
     title
   </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
-  </p>
 </div>
 `;
 
@@ -495,11 +406,6 @@ exports[`EuiStat props xxxs is rendered 1`] = `
     class="euiTitle euiStat__title emotion-euiTitle-xxxs-euiStat__title-default"
   >
     title
-  </p>
-  <p
-    class="emotion-euiScreenReaderOnly"
-  >
-    description title
   </p>
 </div>
 `;

--- a/packages/eui/src/components/stat/stat.tsx
+++ b/packages/eui/src/components/stat/stat.tsx
@@ -18,8 +18,7 @@ import classNames from 'classnames';
 
 import { EuiText } from '../text';
 import { EuiTitle, EuiTitleSize } from '../title/title';
-import { EuiScreenReaderOnly } from '../accessibility';
-import { EuiI18n } from '../i18n';
+import { useEuiI18n } from '../i18n';
 
 import { useEuiTheme } from '../../services';
 import { euiStatStyles, euiStatTitleStyles } from './stat.styles';
@@ -93,6 +92,11 @@ export const EuiStat: FunctionComponent<
   const cssStyles = [styles.euiStat, styles[textAlign]];
   const classes = classNames('euiStat', className);
 
+  const loadingStatsAriaLabel = useEuiI18n(
+    'euiStat.loadingText',
+    'Statistic is loading'
+  );
+
   const descriptionDisplay = (
     <EuiText size="s" className="euiStat__description">
       {createElement(descriptionElement, {}, description)}
@@ -106,30 +110,20 @@ export const EuiStat: FunctionComponent<
     isNamedTitleColor && titleStyles[titleColor as TitleColor],
     isLoading && titleStyles.isLoading,
   ];
-  const titleChildren = isLoading ? '--' : title;
 
   const titleDisplay = (
-    <EuiTitle size={titleSize} className="euiStat__title" css={titleCssStyles}>
+    <EuiTitle
+      size={titleSize}
+      className="euiStat__title"
+      css={titleCssStyles}
+      aria-label={isLoading ? loadingStatsAriaLabel : undefined}
+    >
       {createElement(
         titleElement,
         isNamedTitleColor ? {} : { style: { color: titleColor } },
-        titleChildren
+        isLoading ? '--' : title
       )}
     </EuiTitle>
-  );
-
-  const screenReader = (
-    <EuiScreenReaderOnly>
-      <p>
-        {isLoading ? (
-          <EuiI18n token="euiStat.loadingText" default="Statistic is loading" />
-        ) : (
-          <Fragment>
-            {reverse ? `${title} ${description}` : `${description} ${title}`}
-          </Fragment>
-        )}
-      </p>
-    </EuiScreenReaderOnly>
   );
 
   const statDisplay = (
@@ -137,9 +131,6 @@ export const EuiStat: FunctionComponent<
       {!reverse && descriptionDisplay}
       {titleDisplay}
       {reverse && descriptionDisplay}
-      {typeof title === 'string' &&
-        typeof description === 'string' &&
-        screenReader}
     </Fragment>
   );
 

--- a/packages/eui/src/components/stat/stat.tsx
+++ b/packages/eui/src/components/stat/stat.tsx
@@ -99,7 +99,7 @@ export const EuiStat: FunctionComponent<
 
   const descriptionDisplay = (
     <EuiText size="s" className="euiStat__description">
-      {createElement(descriptionElement, {}, description)}
+      {createElement(descriptionElement, null, description)}
     </EuiText>
   );
 
@@ -120,7 +120,7 @@ export const EuiStat: FunctionComponent<
     >
       {createElement(
         titleElement,
-        isNamedTitleColor ? {} : { style: { color: titleColor } },
+        isNamedTitleColor ? null : { style: { color: titleColor } },
         isLoading ? '--' : title
       )}
     </EuiTitle>

--- a/packages/eui/src/components/stat/stat.tsx
+++ b/packages/eui/src/components/stat/stat.tsx
@@ -93,13 +93,9 @@ export const EuiStat: FunctionComponent<
   const cssStyles = [styles.euiStat, styles[textAlign]];
   const classes = classNames('euiStat', className);
 
-  const commonProps: HTMLAttributes<Element> = {
-    'aria-hidden': true,
-  };
-
   const descriptionDisplay = (
     <EuiText size="s" className="euiStat__description">
-      {createElement(descriptionElement, commonProps, description)}
+      {createElement(descriptionElement, {}, description)}
     </EuiText>
   );
 
@@ -110,14 +106,15 @@ export const EuiStat: FunctionComponent<
     isNamedTitleColor && titleStyles[titleColor as TitleColor],
     isLoading && titleStyles.isLoading,
   ];
-  const titleProps = isNamedTitleColor
-    ? commonProps
-    : { ...commonProps, style: { color: titleColor } };
   const titleChildren = isLoading ? '--' : title;
 
   const titleDisplay = (
     <EuiTitle size={titleSize} className="euiStat__title" css={titleCssStyles}>
-      {createElement(titleElement, titleProps, titleChildren)}
+      {createElement(
+        titleElement,
+        isNamedTitleColor ? {} : { style: { color: titleColor } },
+        titleChildren
+      )}
     </EuiTitle>
   );
 


### PR DESCRIPTION
Closes: https://github.com/elastic/observability-dev/issues/3630
Closes: https://github.com/elastic/observability-dev/issues/3634
Closes: https://github.com/elastic/observability-dev/issues/3633
Closes: https://github.com/elastic/observability-dev/issues/3632
Closes: https://github.com/elastic/observability-dev/issues/3631

**Summary:**

1. improved the accessibility experience of `EuiStat` by removing extra `aria-hidden=true` attribute
2. removed extra `eui-screen-reader`

<img width="1526" alt="image" src="https://github.com/elastic/eui/assets/20072247/79e234f0-ecad-4479-9f7e-8d4b6524bb12">




