### PR TITLE
[FIX] prevent errors around fewer/more hooks in Storybook

### DIFF
--- a/packages/eui/.storybook/addons/code-snippet/decorators/utils.ts
+++ b/packages/eui/.storybook/addons/code-snippet/decorators/utils.ts
@@ -330,15 +330,17 @@ export const getDefaultPropsfromDocgenInfo = (
 ): Record<string, any> | undefined => {
   if (typeof component.type === 'string') return;
 
+  if (!isStoryComponent(component, context)) return;
+
   // determine the story element first
   // this is required because the story might be wrapped and
   // only the story element has the required docgenInfo
-  let storyComponent: ReactElementWithDocgenInfo | undefined =
+  const storyComponent: ReactElementWithDocgenInfo | undefined =
     getStoryComponent(component, context);
 
   if (!storyComponent) return;
 
-  let propsInfo =
+  const propsInfo =
     isEmotionComponent(storyComponent) &&
     typeof storyComponent.props?.[EMOTION_TYPE_KEY] !== 'string'
       ? storyComponent.props?.[EMOTION_TYPE_KEY]?.__docgenInfo.props


### PR DESCRIPTION
## Summary

After merging the [Storybook code-snippet addon](https://github.com/elastic/eui/pull/7716) feature and right after the [EUIColorPicker Emotion conversion](https://github.com/elastic/eui/pull/7859) updates, an issue emerged in the `code-snippet` where Storybook previews render an error due to fewer rendered (conditional) hooks. (see an affected component [here](https://eui.elastic.co/storybook/index.html?path=/story/forms-euicolorpicker-euicolorpicker--playground))

This is due to the functionality within the `code-snippet` addon that checks for the story's defaultProps and has to evaluate components where needed to get to the right react element (recursively checking children until the story element is found).

This can be fixed (and optimized) by making sure we only check for the default props for the story element. It's not needed to check for other elements, as they won't have default props and are not relevant to the code snippet.

## QA

- [ ] open the [affected story](https://eui.elastic.co/pr_7870/storybook/?path=/story/forms-euicolorpicker-euicolorpicker--playground) in Storybook and verify the error is gone and the story and its code snippet render as expected