### PR TITLE
[EUI+] Implement document content styles

### DIFF
--- a/packages/docusaurus-theme/package.json
+++ b/packages/docusaurus-theme/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.4.0",
     "@docusaurus/module-type-aliases": "^3.4.0",
+    "@docusaurus/theme-common": "^3.4.0",
     "@docusaurus/utils-validation": "^3.4.0",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "94.5.0",

--- a/packages/docusaurus-theme/src/theme/DocItem/Footer/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import clsx from 'clsx';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import TagsListInline from '@theme-original/TagsListInline';
+
+import EditMetaRow from '@theme-original/EditMetaRow';
+
+export default function DocItemFooter(): JSX.Element | null {
+  const { metadata } = useDoc();
+  const { editUrl, lastUpdatedAt, lastUpdatedBy, tags } = metadata;
+
+  const canDisplayTagsRow = tags.length > 0;
+  const canDisplayEditMetaRow = !!(editUrl || lastUpdatedAt || lastUpdatedBy);
+
+  const canDisplayFooter = canDisplayTagsRow || canDisplayEditMetaRow;
+
+  if (!canDisplayFooter) {
+    return null;
+  }
+
+  return (
+    <footer
+      className={clsx(ThemeClassNames.docs.docFooter, 'docusaurus-mt-lg')}
+    >
+      {canDisplayTagsRow && (
+        <div
+          className={clsx(
+            'row margin-top--sm',
+            ThemeClassNames.docs.docFooterTagsRow
+          )}
+        >
+          <div className="col">
+            <TagsListInline tags={tags} />
+          </div>
+        </div>
+      )}
+      {canDisplayEditMetaRow && (
+        <EditMetaRow
+          className={clsx(
+            'margin-top--sm',
+            ThemeClassNames.docs.docFooterEditMetaRow
+          )}
+          editUrl={editUrl}
+          lastUpdatedAt={lastUpdatedAt}
+          lastUpdatedBy={lastUpdatedBy}
+        />
+      )}
+    </footer>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
@@ -8,6 +8,7 @@ import DocVersionBadge from '@theme-original/DocVersionBadge';
 import DocBreadcrumbs from '@theme-original/DocBreadcrumbs';
 import Unlisted from '@theme-original/Unlisted';
 import * as Props from '@theme-original/DocItem/Layout';
+import { EuiHorizontalRule } from '@elastic/eui';
 
 import DocItemContent from '../Content';
 import DocItemTOCMobile from '../TOC/Mobile';
@@ -71,6 +72,7 @@ export default function DocItemLayout({ children }: typeof Props): JSX.Element {
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
           </article>
+          <EuiHorizontalRule margin="xl" />
           <DocItemPaginator />
         </div>
       </div>

--- a/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { useWindowSize } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import DocItemPaginator from '@theme-original/DocItem/Paginator';
+import DocVersionBanner from '@theme-original/DocVersionBanner';
+import DocVersionBadge from '@theme-original/DocVersionBadge';
+import DocBreadcrumbs from '@theme-original/DocBreadcrumbs';
+import Unlisted from '@theme-original/Unlisted';
+import * as Props from '@theme-original/DocItem/Layout';
+
+import DocItemContent from '../Content';
+import DocItemTOCMobile from '../TOC/Mobile';
+import DocItemTOCDesktop from '../TOC/Desktop';
+import DocItemFooter from '../Footer';
+
+// converted from css modules to emotion
+const layoutStyles = {
+  docItemContainer: css`
+    & header + *,
+    & article > *:first-child {
+      margin-top: 0;
+    }
+  `,
+  docItemCol: css`
+    @media (min-width: 997px) {
+      max-width: 75% !important;
+    }
+  `,
+};
+
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const { frontMatter, toc } = useDoc();
+  const windowSize = useWindowSize();
+
+  const hidden = frontMatter.hide_table_of_contents ?? false;
+  const canRender = !hidden && toc.length > 0;
+
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+
+export default function DocItemLayout({ children }: typeof Props): JSX.Element {
+  const docTOC = useDocTOC();
+  const {
+    metadata: { unlisted },
+  } = useDoc();
+  return (
+    <div className="row">
+      <div className="col" css={layoutStyles.docItemCol}>
+        {unlisted && <Unlisted />}
+        <DocVersionBanner />
+        <div css={layoutStyles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/Metadata/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Metadata/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import {PageMetadata} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/theme-common/internal';
+
+export default function DocItemMetadata(): JSX.Element {
+  const {metadata, frontMatter, assets} = useDoc();
+  return (
+    <PageMetadata
+      title={metadata.title}
+      description={metadata.description}
+      keywords={frontMatter.keywords}
+      image={assets.image ?? frontMatter.image}
+    />
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/Paginator/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Paginator/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import DocPaginator from '@theme-original/DocPaginator';
+
+/**
+ * This extra component is needed, because <DocPaginator> should remain generic.
+ * DocPaginator is used in non-docs contexts too: generated-index pages...
+ */
+export default function DocItemPaginator(): JSX.Element {
+  const { metadata } = useDoc();
+  return <DocPaginator previous={metadata.previous} next={metadata.next} />;
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/TOC/Desktop/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/TOC/Desktop/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+
+import TOC from '@theme-original/TOC';
+
+export default function DocItemTOCDesktop(): JSX.Element {
+  const { toc, frontMatter } = useDoc();
+  return (
+    <TOC
+      toc={toc}
+      minHeadingLevel={frontMatter.toc_min_heading_level}
+      maxHeadingLevel={frontMatter.toc_max_heading_level}
+      className={ThemeClassNames.docs.docTocDesktop}
+    />
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+
+import TOCCollapsible from '@theme-original/TOCCollapsible';
+
+// converted from css modules to emotion
+const tocStyles = {
+  tocMobile: css`
+    @media (min-width: 997px) {
+      /* Prevent hydration FOUC, as the mobile TOC needs to be server-rendered */
+      display: none;
+    }
+
+    @media print {
+      display: none;
+    }
+  `,
+};
+
+export default function DocItemTOCMobile(): JSX.Element {
+  const { toc, frontMatter } = useDoc();
+  return (
+    <TOCCollapsible
+      toc={toc}
+      minHeadingLevel={frontMatter.toc_min_heading_level}
+      maxHeadingLevel={frontMatter.toc_max_heading_level}
+      className={ThemeClassNames.docs.docTocMobile}
+      css={tocStyles.tocMobile}
+    />
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { HtmlClassNameProvider } from '@docusaurus/theme-common';
+import { DocProvider } from '@docusaurus/theme-common/internal';
+import DocItemMetadata from '@theme-original/DocItem/Metadata';
+import type { Props } from '@theme/DocItem';
+
+import DocItemLayout from './Layout';
+
+export default function DocItem(props: Props): JSX.Element {
+  const docHtmlClassName = `docs-doc-id-${props.content.metadata.id}`;
+  const MDXComponent = props.content;
+  return (
+    <DocProvider content={props.content}>
+      <HtmlClassNameProvider className={docHtmlClassName}>
+        <DocItemMetadata />
+        <DocItemLayout>
+          <MDXComponent />
+        </DocItemLayout>
+      </HtmlClassNameProvider>
+    </DocProvider>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocPaginator/index.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+import Translate, { translate } from '@docusaurus/Translate';
+import PaginatorNavLink from '@theme-original/PaginatorNavLink';
+import type { Props } from '@theme-original/DocPaginator';
+
+const styles = {
+  pagination: css`
+    // docusaurus reset, we add spacing via the
+    // horizontal rule in Layout instead
+    margin-top: 0;
+  `,
+};
+
+export default function DocPaginator(props: Props): JSX.Element {
+  const { previous, next } = props;
+  return (
+    <nav
+      className="pagination-nav docusaurus-mt-lg"
+      css={styles.pagination}
+      aria-label={translate({
+        id: 'theme.docs.paginator.navAriaLabel',
+        message: 'Docs pages',
+        description: 'The ARIA label for the docs pagination',
+      })}
+    >
+      {previous && (
+        <PaginatorNavLink
+          {...previous}
+          subLabel={
+            <Translate
+              id="theme.docs.paginator.previous"
+              description="The label used to navigate to the previous doc"
+            >
+              Previous
+            </Translate>
+          }
+        />
+      )}
+      {next && (
+        <PaginatorNavLink
+          {...next}
+          subLabel={
+            <Translate
+              id="theme.docs.paginator.next"
+              description="The label used to navigate to the next doc"
+            >
+              Next
+            </Translate>
+          }
+          isNext
+        />
+      )}
+    </nav>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/EditThisPage/index.tsx
+++ b/packages/docusaurus-theme/src/theme/EditThisPage/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import Translate from '@docusaurus/Translate';
+import type { Props } from '@theme-original/EditThisPage';
+import { EuiButton, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
+// @ts-ignore - eui only has module declarations for '@elastic/eui/src/themes/amsterdam/global_styling/mixins/button'
+// but importing from /src results in "Module not found" error
+import { euiButtonColor } from '@elastic/eui/lib/themes/amsterdam/global_styling/mixins/button';
+
+const getStyles = (theme: UseEuiTheme) => {
+  const { euiTheme } = theme;
+  const buttonColor = euiButtonColor(theme, 'primary');
+  console.log(buttonColor);
+  return {
+    editPage: css`
+      // overriding Docusaurus link hover styles to preserve button styles
+      --ifm-link-hover-color: ${buttonColor.color};
+
+      border: ${euiTheme.border.thin};
+      border-color: ${euiTheme.colors.primary};
+    `,
+  };
+};
+
+export default function EditThisPage({ editUrl, ...rest }: Props): JSX.Element {
+  const styles = useEuiMemoizedStyles(getStyles);
+
+  return (
+    <EuiButton
+      {...rest}
+      href={editUrl}
+      iconType="pencil"
+      color="primary"
+      css={styles.editPage}
+    >
+      <Translate
+        id="theme.common.editThisPage"
+        description="The link label to edit the current page"
+      >
+        Edit this page
+      </Translate>
+    </EuiButton>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/PaginatorNavLink/index.tsx
+++ b/packages/docusaurus-theme/src/theme/PaginatorNavLink/index.tsx
@@ -1,0 +1,63 @@
+import clsx from 'clsx';
+import { css } from '@emotion/react';
+import Link from '@docusaurus/Link';
+import type { Props } from '@theme-original/PaginatorNavLink';
+import { useEuiMemoizedStyles, UseEuiTheme, EuiIcon } from '@elastic/eui';
+
+const getStyles = ({ euiTheme }: UseEuiTheme) => {
+  return {
+    link: css`
+      --ifm-pagination-nav-color-hover: ${euiTheme.colors.primary};
+
+      border: ${euiTheme.border.thin};
+
+      .pagination-nav__label {
+        display: flex;
+        align-items: center;
+
+        font-size: var(--eui-font-size-m);
+        line-height: var(--eui-line-height-l);
+      }
+
+      &.pagination-nav__link--next .pagination-nav__label {
+        justify-content: flex-end;
+      }
+
+      .pagination-nav__label::before,
+      .pagination-nav__label::after {
+        content: '';
+      }
+
+      .pagination-nav__sublabel {
+        margin-block-end: ${euiTheme.size.xs};
+        font-size: var(--eui-font-size-s);
+        line-height: var(--eui-line-height-l);
+      }
+    `,
+  };
+};
+
+export default function PaginatorNavLink(props: Props): JSX.Element {
+  const { permalink, title, subLabel, isNext } = props;
+  const isPrev = !isNext;
+  const styles = useEuiMemoizedStyles(getStyles);
+
+  return (
+    <Link
+      className={clsx(
+        'pagination-nav__link',
+        isNext ? 'pagination-nav__link--next' : 'pagination-nav__link--prev'
+      )}
+      css={styles.link}
+      to={permalink}
+    >
+      {subLabel && <div className="pagination-nav__sublabel">{subLabel}</div>}
+
+      <div className="pagination-nav__label">
+        {isPrev && <EuiIcon type="arrowLeft" />}
+        {title}
+        {isNext && <EuiIcon type="arrowRight" />}
+      </div>
+    </Link>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/Root.styles.ts
+++ b/packages/docusaurus-theme/src/theme/Root.styles.ts
@@ -1,10 +1,13 @@
 import {
+  euiFontSizeFromScale,
   euiLineHeightFromBaseline,
   useEuiBackgroundColor,
   UseEuiTheme,
 } from '@elastic/eui';
 
 // override docusaurus variables as needed
+// NOTE: we use define variables with style calculations here
+// on the global level to reduce how often they are called
 export const getGlobalStyles = ({ euiTheme }: UseEuiTheme) => {
   const { font, base, colors, size } = euiTheme;
   const fontBodyScale = font.scale[font.body.scale];
@@ -16,7 +19,16 @@ export const getGlobalStyles = ({ euiTheme }: UseEuiTheme) => {
     fontWeight: font.weight[font.body.weight],
   };
 
-  const lineHeightL = '1.75rem';
+  const fontSizeXXL = euiFontSizeFromScale('xxl', euiTheme);
+  const fontSizeXL = euiFontSizeFromScale('xl', euiTheme);
+  const fontSizeL = euiFontSizeFromScale('l', euiTheme);
+  const fontSizeM = euiFontSizeFromScale('m', euiTheme);
+  const fontSizeS = euiFontSizeFromScale('s', euiTheme);
+  const fontSizeXS = euiFontSizeFromScale('xs', euiTheme);
+  const fontSizeXXS = euiFontSizeFromScale('xxs', euiTheme);
+
+  const lineHeightXL = '1.75rem';
+  const lineHeightL = '1.5rem';
   const lineHeightM = euiLineHeightFromBaseline('s', euiTheme);
   const lineHeightS = euiLineHeightFromBaseline('xs', euiTheme);
   const lineHeightXS = '1.33rem';
@@ -34,18 +46,31 @@ export const getGlobalStyles = ({ euiTheme }: UseEuiTheme) => {
         /* Docusaurus theme variables */
         --ifm-background-color: ${colors.body};
         --ifm-font-color-base: ${colors.text};
+        --ifm-link-color: ${colors.link};
+        --ifm-link-hover-color: ${colors.link};
       }
 
       :root {
         /* EUI theme variables */
-        --eui-line-height-base: ${lineHeightL};
+        --eui-font-size-base: ${fontBase.fontSize};
+        --eui-font-size-xxl: ${fontSizeXXL};
+        --eui-font-size-xl: ${fontSizeXL};
+        --eui-font-size-l: ${fontSizeL};
+        --eui-font-size-m: ${fontSizeM};
+        --eui-font-size-s: ${fontSizeS};
+        --eui-font-size-xs: ${fontSizeXS};
+        --eui-font-size-xxs: ${fontSizeXXS};
+
+        --eui-line-height-base: ${lineHeightXL};
+        --eui-line-height-xl: ${lineHeightXL};
+        --eui-line-height-l: ${lineHeightL};
         --eui-line-height-m: ${lineHeightM};
         --eui-line-height-s: ${lineHeightS};
         --eui-line-height-xs: ${lineHeightXS};
 
         /* Docusaurus theme variables */
         --ifm-font-family-base: ${fontBase.fontFamily};
-        --ifm-font-size-base: ${fontBase.fontSize};
+        --ifm-font-size-base: var(--eui-font-size-base);
         --ifm-font-weight-base: ${fontBase.fontWeight};
         --ifm-line-height-base: var(--eui-line-height-base);
 

--- a/packages/docusaurus-theme/src/theme/theme.d.ts
+++ b/packages/docusaurus-theme/src/theme/theme.d.ts
@@ -1,0 +1,43 @@
+// Prop types are declared for @theme scope in @docusaurus/theme-classic
+// but when using swizzle --eject the type import is not available.
+// we re-declare the needed types here to ensure type checking
+// NOTE: when using swizzle --wrap there is the approach to do the following:
+// type Props = WrapperProps<typeof NameOfComponent> but it will result in `any` type
+
+// original: https://github.com/facebook/docusaurus/blob/d2bb74a8fd4ee92fc7ff806657dbb35de1de845f/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L560
+declare module '@theme-original/DocItem/Content' {
+  export interface Props {
+    readonly children: JSX.Element;
+  }
+}
+
+// original: https://github.com/facebook/docusaurus/blob/d2bb74a8fd4ee92fc7ff806657dbb35de1de845f/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L554
+declare module '@theme-original/DocPaginator' {
+  import type { PropNavigation } from '@docusaurus/plugin-content-docs';
+
+  export interface Props extends PropNavigation {}
+
+  export default function DocPaginator(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/d2bb74a8fd4ee92fc7ff806657dbb35de1de845f/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L1252
+declare module '@theme-original/PaginatorNavLink' {
+  import type { ReactNode } from 'react';
+  import type { PropNavigationLink } from '@docusaurus/plugin-content-docs';
+
+  export interface Props extends Omit<PropNavigationLink, 'title'> {
+    readonly title: ReactNode;
+    readonly subLabel?: JSX.Element;
+    readonly isNext?: boolean;
+  }
+
+  export default function PaginatorNavLink(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/fa743c81defd24e22eae45c81bd79eb8ec2c4ef0/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L702
+declare module '@theme-original/EditThisPage' {
+  export interface Props {
+    readonly editUrl: string;
+  }
+  export default function EditThisPage(props: Props): JSX.Element;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,7 +5477,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.4.0":
+"@docusaurus/theme-common@npm:3.4.0, @docusaurus/theme-common@npm:^3.4.0":
   version: 3.4.0
   resolution: "@docusaurus/theme-common@npm:3.4.0"
   dependencies:
@@ -5691,6 +5691,7 @@ __metadata:
   dependencies:
     "@docusaurus/core": "npm:^3.4.0"
     "@docusaurus/module-type-aliases": "npm:^3.4.0"
+    "@docusaurus/theme-common": "npm:^3.4.0"
     "@docusaurus/types": "npm:^3.4.0"
     "@docusaurus/utils-validation": "npm:^3.4.0"
     "@elastic/datemath": "npm:^5.0.3"


### PR DESCRIPTION
## Summary

closes #7844 

This PR updates the styles for the documentation page content elements:

- Layout
- Pagination
- EditThisPage

>[!NOTE]
> It was required to eject all components for `DocItem` to ensure the components work as expected. Otherwise components that require a specific context would fail.

![Screenshot 2024-07-03 at 18 11 18](https://github.com/elastic/eui/assets/44670957/b7d2c87e-15fc-4b01-a5c2-0868a47cbd19)
![Screenshot 2024-07-03 at 18 11 27](https://github.com/elastic/eui/assets/44670957/878136a9-cf5d-45c5-92c8-409b7329539d)


## QA

- [ ] review the EUI+ documentation page and verify it aligns with the current [design](https://www.figma.com/design/g5Vk0k2DgeQPCPBoWmun2U/EUI%2B-docs?node-id=19-143036&m=dev).