### PR TITLE
[FIX] Prevent Storybook code-snippet errors crashing the story preview

### DIFF
--- a/packages/eui/.storybook/addons/code-snippet/constants.ts
+++ b/packages/eui/.storybook/addons/code-snippet/constants.ts
@@ -43,6 +43,6 @@ export const PRESERVED_FALSE_VALUE_PROPS = new Set(['grow']);
 
 /** ERRORS */
 export const ADDON_ERROR =
-  'An error occurred in the EUI Storybook `code-snippet` addon. Returning the Story without code snippet.';
+  'An error occurred in the EUI Storybook `code-snippet` addon. Returning the story without code snippet.';
 export const CODE_FORMATTING_ERROR =
   'An error occurred and no formatted code was provided. Falling back to pre-formatted code.';

--- a/packages/eui/.storybook/addons/code-snippet/constants.ts
+++ b/packages/eui/.storybook/addons/code-snippet/constants.ts
@@ -40,3 +40,9 @@ export const EXCLUDED_PROPS = new Set([
 ]);
 // props with 'false' value that should not be removed but shown in the code snippet
 export const PRESERVED_FALSE_VALUE_PROPS = new Set(['grow']);
+
+/** ERRORS */
+export const ADDON_ERROR =
+  'An error occurred in the EUI Storybook `code-snippet` addon. Returning the Story without code snippet.';
+export const CODE_FORMATTING_ERROR =
+  'An error occurred and no formatted code was provided. Falling back to pre-formatted code.';

--- a/packages/eui/.storybook/addons/code-snippet/decorators/jsx_decorator.tsx
+++ b/packages/eui/.storybook/addons/code-snippet/decorators/jsx_decorator.tsx
@@ -15,7 +15,10 @@ import type {
   ArgsStoryFn,
   PartialStoryFn,
 } from '@storybook/types';
-import { addons, useEffect, useCallback } from '@storybook/preview-api';
+import {
+  addons,
+  useEffect as useStorybookEffect,
+} from '@storybook/preview-api';
 import { logger } from '@storybook/client-logger';
 
 import { useEuiTheme } from '../../../../src/services';
@@ -64,45 +67,43 @@ export const customJsxDecorator = (
   let jsx = '';
   let error: AddonError | false = false;
 
-  // using Storybook Channel events to send the code string
-  // to the addon panel to output.
-  // This uses Storybook useCallback hook not the React one
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const emitChannel = useCallback(
-    (jsx: string, skip: boolean, shouldSkip = false, error?: AddonError) => {
-      const { id, unmappedArgs } = context;
-      if (skip || shouldSkip) {
-        channel.emit(EVENTS.SNIPPET_RENDERED, {
-          id,
-          source: '',
-          error: false,
-          args: unmappedArgs,
-        });
-      } else if (error) {
-        channel.emit(EVENTS.SNIPPET_RENDERED, {
-          id,
-          source: '',
-          error,
-          args: unmappedArgs,
-        });
-      } else {
-        channel.emit(EVENTS.SNIPPET_RENDERED, {
-          id,
-          source: jsx,
-          error: false,
-          args: unmappedArgs,
-        });
-      }
-    },
-    [context, channel]
-  );
+  const emitChannel = (
+    jsx: string,
+    skip: boolean,
+    shouldSkip = false,
+    error?: AddonError
+  ) => {
+    const { id, unmappedArgs } = context;
+    if (skip || shouldSkip) {
+      channel.emit(EVENTS.SNIPPET_RENDERED, {
+        id,
+        source: '',
+        error: false,
+        args: unmappedArgs,
+      });
+    } else if (error) {
+      channel.emit(EVENTS.SNIPPET_RENDERED, {
+        id,
+        source: '',
+        error,
+        args: unmappedArgs,
+      });
+    } else {
+      channel.emit(EVENTS.SNIPPET_RENDERED, {
+        id,
+        source: jsx,
+        error: false,
+        args: unmappedArgs,
+      });
+    }
+  };
 
   // disabling this rule as this is how Storybook handles it
   // they export their own hook wrappers and have the eslint rule disabled completely
   // https://github.com/storybookjs/storybook/blob/2bff7a1c156bbd42ab381f84b8a55a07694e7e53/code/renderers/react/src/docs/jsxDecorator.tsx#L233
   // https://github.com/storybookjs/storybook/blob/4c1d585ca07db5097f01a84bc6a4092ada33629b/code/lib/preview-api/src/modules/addons/hooks.ts#L474
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  useEffect(() => {
+  useStorybookEffect(() => {
     if (error) {
       emitChannel(jsx, skip, false, error);
     } else if (jsx !== '' && !error) {
@@ -220,7 +221,6 @@ export const customJsxDecorator = (
     logger.error(ADDON_ERROR, err);
 
     error = { reason: ADDON_ERROR, body: err as Error };
-    jsx = '';
   }
 
   // return story from decorator to be rendered

--- a/packages/eui/.storybook/addons/code-snippet/types.ts
+++ b/packages/eui/.storybook/addons/code-snippet/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export type AddonError = {
+  reason: string;
+  body: Error;
+};


### PR DESCRIPTION
## Summary

This PR adds an additional `try/catch` wrapper on the main functionality of the Storybook `code-snippet` addon to prevent any potential errors in the code snippet from crashing the Storybook preview and making local development impossible. The addon will return no code snippet if an error occurred and log the error to the console.

This does not actually affect any story currently but would be an issue if code is changed/added to a version that the code snippet doesn't support yet. E.g. the functionality to resolve the Emotion `css` prop is currently not fully supporting all cases, and can break otherwise.

## QA

There is not actual way to QA this in the existing Storybook