### PR TITLE
[EUI+] Implement Breadcrumbs design changes

### DIFF
--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/Home/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/Home/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import { translate } from '@docusaurus/Translate';
+import { EuiIcon, useEuiMemoizedStyles } from '@elastic/eui';
+
+import { getItemStyles } from '../item.styles';
+
+export default function HomeBreadcrumbItem(): JSX.Element {
+  const homeHref = useBaseUrl('/');
+
+  const styles = useEuiMemoizedStyles(getItemStyles);
+
+  return (
+    <li className="breadcrumbs__item" css={styles.item}>
+      <Link
+        aria-label={translate({
+          id: 'theme.docs.breadcrumbs.home',
+          message: 'Home page',
+          description: 'The ARIA label for the home page in the breadcrumbs',
+        })}
+        className="breadcrumbs__link"
+        href={homeHref}
+      >
+        EUI+
+      </Link>
+      <EuiIcon type="arrowRight" size="s" css={styles.icon} />
+    </li>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/Home/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/Home/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from '@emotion/react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { translate } from '@docusaurus/Translate';
@@ -23,7 +22,7 @@ export default function HomeBreadcrumbItem(): JSX.Element {
         className="breadcrumbs__link"
         href={homeHref}
       >
-        EUI+
+        EUI
       </Link>
       <EuiIcon type="arrowRight" size="s" css={styles.icon} />
     </li>

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/item.styles.ts
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/item.styles.ts
@@ -1,0 +1,39 @@
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '@elastic/eui';
+
+export const getItemStyles = ({ euiTheme }: UseEuiTheme) => ({
+  item: css`
+    --ifm-breadcrumb-item-background: transparent;
+    --ifm-breadcrumb-item-background-active: transparent;
+
+    // overwrite global styles
+    &.breadcrumbs__item:not(:last-child):after {
+      content: none;
+    }
+
+    .breadcrumbs__link {
+      padding: 0 ${euiTheme.size.m};
+      font-size: var(--eui-font-size-xs);
+      line-height: var(--eui-line-height-m);
+    }
+
+    &.breadcrumbs__item:first-child .breadcrumbs__link {
+      padding-inline-start: 0;
+    }
+
+    a.breadcrumbs__link {
+      color: ${euiTheme.colors.link};
+      font-weight: ${euiTheme.font.weight.bold};
+      text-decoration: underline;
+    }
+
+    &.breadcrumbs__item--active .breadcrumbs__link {
+      color: ${euiTheme.colors.text};
+    }
+  `,
+  icon: css`
+    block-size: ${euiTheme.size.s};
+    inline-size: ${euiTheme.size.s};
+    fill: ${euiTheme.colors.text};
+  `,
+});

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/item.styles.ts
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/item.styles.ts
@@ -17,10 +17,6 @@ export const getItemStyles = ({ euiTheme }: UseEuiTheme) => ({
       line-height: var(--eui-line-height-m);
     }
 
-    &.breadcrumbs__item:first-child .breadcrumbs__link {
-      padding-inline-start: 0;
-    }
-
     a.breadcrumbs__link {
       color: ${euiTheme.colors.link};
       font-weight: ${euiTheme.font.weight.bold};

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/index.tsx
@@ -14,11 +14,14 @@ import HomeBreadcrumbItem from './Items/Home';
 import { getItemStyles } from './Items/item.styles';
 
 // converted from css modules to Emotion
-const styles = {
+const getStyles = ({ euiTheme }: UseEuiTheme) => ({
   breadcrumbsContainer: css`
     --ifm-breadcrumb-size-multiplier: 0.8;
+
+    // align breadcrumb items with content
+    margin-inline-start: -${euiTheme.size.m};
   `,
-};
+});
 
 // TODO move to design system folder
 function BreadcrumbsItemLink({
@@ -87,6 +90,8 @@ function BreadcrumbsItem({
 export default function DocBreadcrumbs(): JSX.Element | null {
   const breadcrumbs = useSidebarBreadcrumbs();
   const homePageRoute = useHomePageRoute();
+
+  const styles = useEuiMemoizedStyles(getStyles);
 
   if (!breadcrumbs) {
     return null;

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,133 @@
+import React, { type ReactNode } from 'react';
+import clsx from 'clsx';
+import { css } from '@emotion/react';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import {
+  useSidebarBreadcrumbs,
+  useHomePageRoute,
+} from '@docusaurus/theme-common/internal';
+import Link from '@docusaurus/Link';
+import { translate } from '@docusaurus/Translate';
+import { EuiIcon, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
+
+import HomeBreadcrumbItem from './Items/Home';
+import { getItemStyles } from './Items/item.styles';
+
+// converted from css modules to Emotion
+const styles = {
+  breadcrumbsContainer: css`
+    --ifm-breadcrumb-size-multiplier: 0.8;
+  `,
+};
+
+// TODO move to design system folder
+function BreadcrumbsItemLink({
+  children,
+  href,
+  isLast,
+}: {
+  children: ReactNode;
+  href: string | undefined;
+  isLast: boolean;
+}): JSX.Element {
+  const className = 'breadcrumbs__link';
+  if (isLast) {
+    return (
+      <span className={className} itemProp="name">
+        {children}
+      </span>
+    );
+  }
+  return href ? (
+    <Link className={className} href={href} itemProp="item">
+      <span itemProp="name">{children}</span>
+    </Link>
+  ) : (
+    // TODO Google search console doesn't like breadcrumb items without href.
+    // The schema doesn't seem to require `id` for each `item`, although Google
+    // insist to infer one, even if it's invalid. Removing `itemProp="item
+    // name"` for now, since I don't know how to properly fix it.
+    // See https://github.com/facebook/docusaurus/issues/7241
+    <span className={className}>{children}</span>
+  );
+}
+
+function BreadcrumbsItem({
+  children,
+  active,
+  index,
+  addMicrodata,
+}: {
+  children: ReactNode;
+  active?: boolean;
+  index: number;
+  addMicrodata: boolean;
+}): JSX.Element {
+  const styles = useEuiMemoizedStyles(getItemStyles);
+
+  return (
+    <li
+      {...(addMicrodata && {
+        itemScope: true,
+        itemProp: 'itemListElement',
+        itemType: 'https://schema.org/ListItem',
+      })}
+      className={clsx('breadcrumbs__item', {
+        'breadcrumbs__item--active': active,
+      })}
+      css={styles.item}
+    >
+      {children}
+      <meta itemProp="position" content={String(index + 1)} />
+      {!active && <EuiIcon type="arrowRight" css={styles.icon} />}
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs(): JSX.Element | null {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  return (
+    <nav
+      className={clsx(ThemeClassNames.docs.docBreadcrumbs)}
+      aria-label={translate({
+        id: 'theme.docs.breadcrumbs.navAriaLabel',
+        message: 'Breadcrumbs',
+        description: 'The ARIA label for the breadcrumbs',
+      })}
+      css={styles.breadcrumbsContainer}
+    >
+      <ul
+        className="breadcrumbs"
+        itemScope
+        itemType="https://schema.org/BreadcrumbList"
+      >
+        {homePageRoute && <HomeBreadcrumbItem />}
+        {breadcrumbs.map((item, idx) => {
+          const isLast = idx === breadcrumbs.length - 1;
+          const href =
+            item.type === 'category' && item.linkUnlisted
+              ? undefined
+              : item.href;
+          return (
+            <BreadcrumbsItem
+              key={idx}
+              active={isLast}
+              index={idx}
+              addMicrodata={!!href}
+            >
+              <BreadcrumbsItemLink href={href} isLast={isLast}>
+                {item.label}
+              </BreadcrumbsItemLink>
+            </BreadcrumbsItem>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
@@ -3,13 +3,13 @@ import { css } from '@emotion/react';
 import { useWindowSize } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/theme-common/internal';
 import DocItemPaginator from '@theme-original/DocItem/Paginator';
-import DocVersionBanner from '@theme-original/DocVersionBanner';
-import DocVersionBadge from '@theme-original/DocVersionBadge';
-import DocBreadcrumbs from '@theme-original/DocBreadcrumbs';
 import Unlisted from '@theme-original/Unlisted';
 import * as Props from '@theme-original/DocItem/Layout';
 import { EuiHorizontalRule } from '@elastic/eui';
 
+import DocVersionBanner from '../../DocVersionBanner';
+import DocVersionBadge from '../../DocVersionBadge';
+import DocBreadcrumbs from '../../DocBreadcrumbs';
 import DocItemContent from '../Content';
 import DocItemTOCMobile from '../TOC/Mobile';
 import DocItemTOCDesktop from '../TOC/Desktop';

--- a/packages/docusaurus-theme/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { HtmlClassNameProvider } from '@docusaurus/theme-common';
 import { DocProvider } from '@docusaurus/theme-common/internal';
-import DocItemMetadata from '@theme-original/DocItem/Metadata';
 import type { Props } from '@theme/DocItem';
 
+import DocItemMetadata from './Metadata';
 import DocItemLayout from './Layout';
 
 export default function DocItem(props: Props): JSX.Element {

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/Main/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/Main/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import clsx from 'clsx';
+import { css } from '@emotion/react';
+import { useDocsSidebar } from '@docusaurus/theme-common/internal';
+import type { Props } from '@theme-original/DocRoot/Layout/Main';
+
+// converted from css modules to Emotion
+const styles = {
+  docMainContainer: css`
+    display: flex;
+    width: 100%;
+
+    @media (min-width: 997px) {
+      flex-grow: 1;
+      max-width: calc(100% - var(--doc-sidebar-width));
+    }
+  `,
+  docMainContainerEnhanced: css`
+    @media (min-width: 997px) {
+      max-width: calc(100% - var(--doc-sidebar-hidden-width));
+    }
+  `,
+  docItemWrapperEnhanced: css`
+    @media (min-width: 997px) {
+      max-width: calc(
+        var(--ifm-container-width) + var(--doc-sidebar-width)
+      ) !important;
+    }
+  `,
+};
+
+export default function DocRootLayoutMain({
+  hiddenSidebarContainer,
+  children,
+}: any): JSX.Element {
+  const sidebar = useDocsSidebar();
+  return (
+    <main
+      className={clsx(styles.docMainContainer)}
+      css={[
+        styles.docMainContainer,
+        (hiddenSidebarContainer || !sidebar) && styles.docMainContainerEnhanced,
+      ]}
+    >
+      <div
+        className="container padding-top--md padding-bottom--lg"
+        css={[hiddenSidebarContainer && styles.docItemWrapperEnhanced]}
+      >
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/Sidebar/ExpandButton/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { translate } from '@docusaurus/Translate';
+import IconArrow from '@theme-original/Icon/Arrow';
+
+import type { Props } from '@theme-original/DocRoot/Layout/Sidebar/ExpandButton';
+
+// converted from css modules to Emotion
+const styles = {
+  expandButton: css`
+    @media (min-width: 997px) {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background-color var(--ifm-transition-fast) ease;
+      background-color: var(--docusaurus-collapse-button-bg);
+
+      &:hover,
+      &:focus {
+        background-color: var(--docusaurus-collapse-button-bg-hover);
+      }
+    }
+  `,
+  expandButtonIcon: css`
+    transform: rotate(0);
+  `,
+};
+
+export default function DocRootLayoutSidebarExpandButton({
+  toggleSidebar,
+}: Props): JSX.Element {
+  return (
+    <div
+      css={styles.expandButton}
+      title={translate({
+        id: 'theme.docs.sidebar.expandButtonTitle',
+        message: 'Expand sidebar',
+        description:
+          'The ARIA label and title attribute for expand button of doc sidebar',
+      })}
+      aria-label={translate({
+        id: 'theme.docs.sidebar.expandButtonAriaLabel',
+        message: 'Expand sidebar',
+        description:
+          'The ARIA label and title attribute for expand button of doc sidebar',
+      })}
+      tabIndex={0}
+      role="button"
+      onKeyDown={toggleSidebar}
+      onClick={toggleSidebar}
+    >
+      <IconArrow css={styles.expandButtonIcon} />
+    </div>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/index.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import { useDocsSidebar } from '@docusaurus/theme-common/internal';
+import BackToTopButton from '@theme-original/BackToTopButton';
+import type { Props } from '@theme-original/DocRoot/Layout';
+
+import DocRootLayoutSidebar from './Sidebar';
+import DocRootLayoutMain from './Main';
+
+// converted from css modules to Emotion
+const styles = {
+  docRoot: css`
+    display: flex;
+    width: 100%;
+  `,
+  docsWrapper: css`
+    display: flex;
+    flex: 1 0 auto;
+  `,
+};
+
+export default function DocRootLayout({ children }: Props): JSX.Element {
+  const sidebar = useDocsSidebar();
+  const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
+  return (
+    <div css={styles.docsWrapper}>
+      <BackToTopButton />
+      <div css={styles.docRoot}>
+        {sidebar && (
+          <DocRootLayoutSidebar
+            sidebar={sidebar.items}
+            hiddenSidebarContainer={hiddenSidebarContainer}
+            setHiddenSidebarContainer={setHiddenSidebarContainer}
+          />
+        )}
+        <DocRootLayoutMain hiddenSidebarContainer={hiddenSidebarContainer}>
+          {children}
+        </DocRootLayoutMain>
+      </div>
+    </div>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocRoot/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  HtmlClassNameProvider,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {
+  DocsSidebarProvider,
+  useDocRootMetadata,
+} from '@docusaurus/theme-common/internal';
+import DocRootLayout from '@theme-original/DocRoot/Layout';
+import NotFoundContent from '@theme-original/NotFound/Content';
+import type { Props } from '@theme-original/DocRoot';
+
+export default function DocRoot(props: Props): JSX.Element {
+  const currentDocRouteMetadata = useDocRootMetadata(props);
+  if (!currentDocRouteMetadata) {
+    // We only render the not found content to avoid a double layout
+    // see https://github.com/facebook/docusaurus/pull/7966#pullrequestreview-1077276692
+    return <NotFoundContent />;
+  }
+  const { docElement, sidebarName, sidebarItems } = currentDocRouteMetadata;
+  return (
+    <HtmlClassNameProvider className={clsx(ThemeClassNames.page.docsDocPage)}>
+      <DocsSidebarProvider name={sidebarName} items={sidebarItems}>
+        <DocRootLayout>{docElement}</DocRootLayout>
+      </DocsSidebarProvider>
+    </HtmlClassNameProvider>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/DocVersionBadge/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocVersionBadge/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDocsVersion } from '@docusaurus/theme-common/internal';
+import type { Props } from '@theme-original/DocVersionBadge';
+
+export default function DocVersionBadge({
+  className,
+}: Props): JSX.Element | null {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.badge) {
+    return (
+      <span
+        className={clsx(
+          className,
+          ThemeClassNames.docs.docVersionBadge,
+          'badge badge--secondary'
+        )}
+      >
+        <Translate
+          id="theme.docs.versionBadge.label"
+          values={{ versionLabel: versionMetadata.label }}
+        >
+          {'Version: {versionLabel}'}
+        </Translate>
+      </span>
+    );
+  }
+  return null;
+}

--- a/packages/docusaurus-theme/src/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocVersionBanner/index.tsx
@@ -1,0 +1,176 @@
+import React, { type ComponentType } from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+  type GlobalVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/theme-common/internal';
+import type { Props } from '@theme-original/DocVersionBanner';
+import type {
+  VersionBanner,
+  PropVersionMetadata,
+} from '@docusaurus/plugin-content-docs';
+
+type BannerLabelComponentProps = {
+  siteTitle: string;
+  versionMetadata: PropVersionMetadata;
+};
+
+function UnreleasedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id="theme.docs.versions.unreleasedVersionLabel"
+      description="The label used to tell the user that he's browsing an unreleased doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}
+    >
+      {
+        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+      }
+    </Translate>
+  );
+}
+
+function UnmaintainedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabel"
+      description="The label used to tell the user that he's browsing an unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}
+    >
+      {
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+      }
+    </Translate>
+  );
+}
+
+const BannerLabelComponents: {
+  [banner in VersionBanner]: ComponentType<BannerLabelComponentProps>;
+} = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+
+function BannerLabel(props: BannerLabelComponentProps) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner!];
+  return <BannerLabelComponent {...props} />;
+}
+
+function LatestVersionSuggestionLabel({
+  versionLabel,
+  to,
+  onClick,
+}: {
+  to: string;
+  onClick: () => void;
+  versionLabel: string;
+}) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel"
+      description="The label used to tell the user to check the latest version"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel"
+                description="The label used for the latest version suggestion link label"
+              >
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}
+    >
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+
+function DocVersionBannerEnabled({
+  className,
+  versionMetadata,
+}: Props & {
+  versionMetadata: PropVersionMetadata;
+}): JSX.Element {
+  const {
+    siteConfig: { title: siteTitle },
+  } = useDocusaurusContext();
+  const { pluginId } = useActivePlugin({ failfast: true })!;
+
+  const getVersionMainDoc = (version: GlobalVersion) =>
+    version.docs.find((doc) => doc.id === version.mainDocId)!;
+
+  const { savePreferredVersionName } = useDocsPreferredVersion(pluginId);
+
+  const { latestDocSuggestion, latestVersionSuggestion } =
+    useDocVersionSuggestions(pluginId);
+
+  // Try to link to same doc in latest version (not always possible), falling
+  // back to main doc of latest version
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md'
+      )}
+      role="alert"
+    >
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className="margin-top--md">
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function DocVersionBanner({
+  className,
+}: Props): JSX.Element | null {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}

--- a/packages/docusaurus-theme/src/theme/DocVersionRoot/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocVersionRoot/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { HtmlClassNameProvider, PageMetadata } from '@docusaurus/theme-common';
+import {
+  docVersionSearchTag,
+  DocsVersionProvider,
+} from '@docusaurus/theme-common/internal';
+import renderRoutes from '@docusaurus/renderRoutes';
+import SearchMetadata from '@theme-original/SearchMetadata';
+
+import type { Props } from '@theme-original/DocVersionRoot';
+
+function DocVersionRootMetadata(props: any): JSX.Element {
+  const { version } = props;
+  return (
+    <>
+      <SearchMetadata
+        version={version.version}
+        tag={docVersionSearchTag(version.pluginId, version.version)}
+      />
+      <PageMetadata>
+        {version.noIndex && <meta name="robots" content="noindex, nofollow" />}
+      </PageMetadata>
+    </>
+  );
+}
+
+function DocVersionRootContent(props: any): JSX.Element {
+  const { version, route } = props;
+  return (
+    <HtmlClassNameProvider className={version.className}>
+      <DocsVersionProvider version={version}>
+        {renderRoutes(route.routes!)}
+      </DocsVersionProvider>
+    </HtmlClassNameProvider>
+  );
+}
+export default function DocVersionRoot(props: any): JSX.Element {
+  return (
+    <>
+      <DocVersionRootMetadata {...props} />
+      <DocVersionRootContent {...props} />
+    </>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/theme.d.ts
+++ b/packages/docusaurus-theme/src/theme/theme.d.ts
@@ -4,6 +4,82 @@
 // NOTE: when using swizzle --wrap there is the approach to do the following:
 // type Props = WrapperProps<typeof NameOfComponent> but it will result in `any` type
 
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-plugin-content-docs/src/plugin-content-docs.d.ts#L635
+declare module '@theme-original/DocRoot' {
+  import type { RouteConfigComponentProps } from 'react-router-config';
+  import type { Required } from 'utility-types';
+
+  export interface Props extends Required<RouteConfigComponentProps, 'route'> {}
+
+  export default function DocRoot(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L510
+declare module '@theme-original/DocRoot/Layout' {
+  import type { ReactNode } from 'react';
+
+  export interface Props {
+    readonly children: ReactNode;
+  }
+
+  export default function DocRootLayout(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L543
+declare module '@theme-original/DocRoot/Layout/Main' {
+  import type { ReactNode } from 'react';
+
+  export interface Props {
+    readonly hiddenSidebarContainer: boolean;
+    readonly children: ReactNode;
+  }
+
+  export default function DocRootLayoutMain(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L520
+declare module '@theme-original/DocRoot/Layout/Sidebar' {
+  import type { Dispatch, SetStateAction } from 'react';
+  import type { PropSidebar } from '@docusaurus/plugin-content-docs';
+
+  export interface Props {
+    readonly sidebar: PropSidebar;
+    readonly hiddenSidebarContainer: boolean;
+    readonly setHiddenSidebarContainer: Dispatch<SetStateAction<boolean>>;
+  }
+
+  export default function DocRootLayoutSidebar(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L533
+declare module '@theme-original/DocRoot/Layout/Sidebar/ExpandButton' {
+  export interface Props {
+    toggleSidebar: () => void;
+  }
+
+  export default function DocRootLayoutSidebarExpandButton(
+    props: Props
+  ): JSX.Element;
+}
+
+// original" https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L672
+declare module '@theme-original/DocVersionBanner' {
+  export interface Props {
+    readonly className?: string;
+  }
+
+  export default function DocVersionBanner(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L680
+declare module '@theme-original/DocVersionBadge' {
+  export interface Props {
+    readonly className?: string;
+  }
+
+  export default function DocVersionBadge(props: Props): JSX.Element;
+}
+
 // original: https://github.com/facebook/docusaurus/blob/d2bb74a8fd4ee92fc7ff806657dbb35de1de845f/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L560
 declare module '@theme-original/DocItem/Content' {
   export interface Props {


### PR DESCRIPTION
## Summary

closes #7882 

### Changes

- ejects more Docusaurus components to ensure nested ejected components work (they need to shared the same context)
  - this is a bit of a snowball because the higher up we need to eject the more we need to eject with it if the components use provider hooks
- adds ejected breadcrumbs components and updates styles to align with current initial [design](https://www.figma.com/design/g5Vk0k2DgeQPCPBoWmun2U/EUI%2B-docs?node-id=20-37183&m=dev)

### Screenshots

![Screenshot 2024-07-12 at 14 06 35](https://github.com/user-attachments/assets/8d7cd1cd-3db9-48fb-a20d-7a197cc335ab)

![Screenshot 2024-07-12 at 14 06 30](https://github.com/user-attachments/assets/d15507b3-38b2-43e1-8e77-bb611a19291a)

![Screenshot 2024-07-12 at 14 27 04](https://github.com/user-attachments/assets/9f3bd2ee-656b-4231-9fc5-c6a9a450b232)

## QA

- [x] open the [deployed EUI+ website](https://eui.elastic.co/pr_7885/new-docs/docs/guidelines/getting-started/) and review the changes and verify they fullfill the current initial [design](https://www.figma.com/design/g5Vk0k2DgeQPCPBoWmun2U/EUI%2B-docs?node-id=20-37154&m=dev).
