### PR TITLE
Updated yearDropdownItemNumber prop description

### DIFF
--- a/packages/eui/src/components/date_picker/react-datepicker/src/index.d.ts
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/index.d.ts
@@ -194,6 +194,10 @@ export interface ReactDatePickerProps {
   value?: string;
   weekLabel?: string;
   withPortal?: boolean;
+  
+  /**
+   * The total number of years to show as options in years selection dropdown
+   */
   yearDropdownItemNumber?: number;
 }
 declare const ReactDatePicker: React.ClassicComponentClass<ReactDatePickerProps>;


### PR DESCRIPTION
## Summary

There was no description for the `yearDropdownItemNumber` prop on [EuiDatePicker](http://localhost:8030/#/forms/date-picker). I added a description. This was prompted by https://github.com/elastic/eui/issues/7869.

<img width="1193" alt="Screenshot 2024-07-16 at 9 24 01 AM" src="https://github.com/user-attachments/assets/d2276bf9-cd84-4adc-943e-e009e2f2d410">

## QA

Make sure the prop description looks good on this page: https://eui.elastic.co/pr_7887/index.html#/forms/date-picker
