### PR TITLE
[BUILD] Support dependency hoisting

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,5 +2,5 @@ nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.2.2.cjs
 
-nmHoistingLimits: workspaces
+nmHoistingLimits: none
 

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -272,5 +272,8 @@
     "eui.d.ts",
     "i18ntokens.json",
     "NOTICE.txt"
-  ]
+  ],
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  }
 }


### PR DESCRIPTION
## Summary

This PR enables dependency hoisting on root level via `nmHoistingLimits: none` in the `.yarnrc.yml`.
This ensures that the `/docusaurus-theme` and `/website` packages resolve shared dependencies properly.

To not break the existing build of the `/eui` package, this package is excluded from the hoisting by setting `"hoistingLimits": "workspaces"` in it's `package.json` which ensures its dependencies are not hoisted beyond its workspace scope.

>[!NOTE]
> This update fixes the issue we encountered with Docusaurus ejected components for EUI+ that were relying on a specific context and were incorrectly using a different instance of the expected provider, resulting in errors like: `Hook useNavbarMobileSidebar is called outside the <NavbarMobileSidebarProvider>. `

![Screenshot 2024-07-18 at 13 52 04](https://github.com/user-attachments/assets/e9eb2f69-233f-4154-92fe-b8c0bc23efc2)


## QA

- [x] checkout this PR `gh pr checkout 7891`  and ensure the usual scripts work
  - `yarn start`
  - `yarn storybook`
  - `yarn build-storybook`
  - `yarn build-docs`
  - `yarn build`
  - `yarn build-pack`
  - `yarn test-ci`
- [x] verify that the [EUI docs](https://eui.elastic.co/pr_7891/#/), [Storybook](https://eui.elastic.co/pr_7891/storybook/index.html) and [EUI+](https://eui.elastic.co/pr_7891/new-docs/) deployments work as expected