### PR TITLE
fix: patch `@types/jsdom` to work with TypeScript 4.x

### DIFF
--- a/.yarn/patches/@types-jsdom-npm-20.0.1-5bb899e006.patch
+++ b/.yarn/patches/@types-jsdom-npm-20.0.1-5bb899e006.patch
@@ -1,0 +1,14 @@
+diff --git a/base.d.ts b/base.d.ts
+index 67d7514cc700338442c49cb1fcdf868d5ef3bf67..ec12157f934136844ff5973811022fd3563fed09 100755
+--- a/base.d.ts
++++ b/base.d.ts
+@@ -191,7 +191,9 @@ declare module "jsdom" {
+ 
+         /* ECMAScript Globals */
+         globalThis: DOMWindow;
++        // @ts-ignore This fails on TypeScript 4.x
+         readonly ["Infinity"]: number;
++        // @ts-ignore This fails on TypeScript 4.x
+         readonly ["NaN"]: number;
+         readonly undefined: undefined;
+ 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@types/react": "^18",
     "react-focus-lock": "2.9.5",
     "@babel/core": "^7.21.8",
-    "jsdom": "24.1.0"
+    "jsdom": "24.1.0",
+    "@types/jsdom@npm:^20.0.0": "patch:@types/jsdom@npm%3A20.0.1#~/.yarn/patches/@types-jsdom-npm-20.0.1-5bb899e006.patch"
   },
   "packageManager": "yarn@4.2.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9764,7 +9764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:^20.0.0":
+"@types/jsdom@npm:20.0.1":
   version: 20.0.1
   resolution: "@types/jsdom@npm:20.0.1"
   dependencies:
@@ -9772,6 +9772,17 @@ __metadata:
     "@types/tough-cookie": "npm:*"
     parse5: "npm:^7.0.0"
   checksum: 10c0/3d4b2a3eab145674ee6da482607c5e48977869109f0f62560bf91ae1a792c9e847ac7c6aaf243ed2e97333cb3c51aef314ffa54a19ef174b8f9592dfcb836b25
+  languageName: node
+  linkType: hard
+
+"@types/jsdom@patch:@types/jsdom@npm%3A20.0.1#~/.yarn/patches/@types-jsdom-npm-20.0.1-5bb899e006.patch":
+  version: 20.0.1
+  resolution: "@types/jsdom@patch:@types/jsdom@npm%3A20.0.1#~/.yarn/patches/@types-jsdom-npm-20.0.1-5bb899e006.patch::version=20.0.1&hash=3b81c8"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/tough-cookie": "npm:*"
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/bdb44ea3ddfea29cf75e318096c0180f73c3dff9290068ef6859fa0f1c660335e754836003a4d93ac1ac627c837b566561c1f155ea68d9dc721e174dba3b30a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This fixes a recently introduced issue in https://github.com/elastic/eui/pull/7821, causing EUI to fail to build. The upgraded `@types/jsdom` used by Jest v29 is incompatible with TypeScript 4 and it needs to be [patched](https://github.com/microsoft/vscode-jupyter/pull/7987/files) in order to work properly.

## QA

- [ ] Confirm EUI is building with no type errors by running `yarn workspace @elastic/eui build`