### PR TITLE
feat: add code transformer to `<Demo>` component

### DIFF
--- a/packages/docusaurus-theme/src/components/demo/code_transformer.ts
+++ b/packages/docusaurus-theme/src/components/demo/code_transformer.ts
@@ -1,0 +1,36 @@
+const IMPORT_REGEX = /^import [^'"]* from ['"]([^.'"\n ][^'"\n ]*)['"];?/gm;
+const DEFAULT_EXPORT_REGEX = /export default /;
+const COMPONENT_ONLY_REGEX = /^\(?</;
+
+/**
+ * Transforms input JS/TS source code to a react-live compatible syntax.
+ * react-live uses the surcase library to transform input source code into
+ * browser-readable JavaScript.
+ *
+ * While surcase does support CommonJS and ESM import/export statements,
+ * it's not trivial to expose our internal React and EUI exports through it
+ * and because we already control the execution scope of the interactive demos
+ * it isn't really necessary to implement a smart `require()` replacement.
+ *
+ * Returning an IIFE is necessary when the source code is more than just
+ * a JSX component definition (e.g. it contains a variable definition
+ * or `export default` statement).
+ *
+ * @see {@link https://github.com/alangpierce/sucrase}
+ * @see {@link https://github.com/FormidableLabs/react-live/blob/master/packages/react-live/src/utils/transpile/index.ts}
+ */
+export const demoCodeTransformer = (code: string) => {
+  // Remove ESM imports
+  code = code.replace(IMPORT_REGEX, '');
+
+  // Handle ESM default exports
+  code = code.replace(DEFAULT_EXPORT_REGEX, 'return ');
+
+  // If the demo is JSX only return as-is
+  if (COMPONENT_ONLY_REGEX.test(code)) {
+    return code;
+  }
+
+  // If the demo is more than just JSX wrap in an immediately invoked function expression
+  return `(() => { ${code} })()`;
+}

--- a/packages/docusaurus-theme/src/components/demo/demo.tsx
+++ b/packages/docusaurus-theme/src/components/demo/demo.tsx
@@ -10,6 +10,7 @@ import { DemoPreview } from './preview';
 import { DemoSource } from './source';
 import { demoScope } from './scope';
 import { DemoActionsBar } from './actions_bar';
+import { demoCodeTransformer } from './code_transformer';
 
 export interface DemoSourceMeta {
   code: string;
@@ -20,8 +21,6 @@ export interface DemoSourceMeta {
 export interface DemoProps extends PropsWithChildren {
   isSourceOpen?: boolean;
 }
-
-const transformCode = (code: string) => code;
 
 const getDemoStyles = (euiTheme: UseEuiTheme) => ({
   demo: css`
@@ -69,7 +68,7 @@ export const Demo = ({
         <LiveProvider
           key={liveProviderKey}
           code={activeSource?.code || ''}
-          transformCode={transformCode}
+          transformCode={demoCodeTransformer}
           theme={prismThemes.dracula}
           scope={demoScope}
         >

--- a/packages/docusaurus-theme/src/components/demo/demo.tsx
+++ b/packages/docusaurus-theme/src/components/demo/demo.tsx
@@ -1,14 +1,24 @@
-import { Children, PropsWithChildren, useCallback, useState } from 'react';
+import {
+  Children,
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { isElement } from 'react-is';
 import { LiveProvider } from 'react-live';
 import { themes as prismThemes } from 'prism-react-renderer';
-import { useEuiMemoizedStyles, copyToClipboard, UseEuiTheme } from '@elastic/eui';
+import {
+  useEuiMemoizedStyles,
+  copyToClipboard,
+  UseEuiTheme,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { DemoContext, DemoContextObject } from './context';
 import { DemoEditor } from './editor';
 import { DemoPreview } from './preview';
 import { DemoSource } from './source';
-import { demoScope } from './scope';
+import { demoDefaultScope } from './scope';
 import { DemoActionsBar } from './actions_bar';
 import { demoCodeTransformer } from './code_transformer';
 
@@ -19,7 +29,17 @@ export interface DemoSourceMeta {
 }
 
 export interface DemoProps extends PropsWithChildren {
+  /**
+   * Whether the source code editor is open by default
+   */
   isSourceOpen?: boolean;
+  /**
+   * Allows to extend the default scope of the rendered demo and pass additional
+   * properties available within the demo.
+   *
+   * The default scope exposes all React and EUI exports.
+   */
+  scope?: Record<string, unknown>;
 }
 
 const getDemoStyles = (euiTheme: UseEuiTheme) => ({
@@ -35,6 +55,7 @@ const getDemoStyles = (euiTheme: UseEuiTheme) => ({
 
 export const Demo = ({
   children,
+  scope,
   isSourceOpen: _isSourceOpen = true
 }: DemoProps) => {
   const styles = useEuiMemoizedStyles(getDemoStyles);
@@ -45,9 +66,17 @@ export const Demo = ({
   // liveProviderKey restarts the demo to its initial state
   const [liveProviderKey, setLiveProviderKey] = useState<number>(0);
 
-  const addSource = useCallback<DemoContextObject['addSource']>((source: DemoSourceMeta) => {
-    setSources((sources) => ([...sources, source]));
-  }, []);
+  const finalScope = useMemo(() => ({
+    ...demoDefaultScope,
+    ...scope,
+  }), [scope]);
+
+  const addSource = useCallback<DemoContextObject['addSource']>(
+    (source: DemoSourceMeta) => {
+      setSources((sources) => ([...sources, source]));
+    },
+    [],
+  );
 
   const onClickCopyToClipboard = useCallback(() => {
     copyToClipboard(activeSource?.code || '');
@@ -70,7 +99,7 @@ export const Demo = ({
           code={activeSource?.code || ''}
           transformCode={demoCodeTransformer}
           theme={prismThemes.dracula}
-          scope={demoScope}
+          scope={finalScope}
         >
           <DemoPreview />
           <DemoActionsBar

--- a/packages/docusaurus-theme/src/components/demo/editor/editor.tsx
+++ b/packages/docusaurus-theme/src/components/demo/editor/editor.tsx
@@ -17,6 +17,8 @@ const getEditorStyles = () => ({
 
     & .prism-code {
       border-radius: 0 0 calc(var(--docs-demo-border-radius) - 1px) calc(var(--docs-demo-border-radius) - 1px);
+      max-height: 450px;
+      overflow: auto;
     }
   `,
   error: css`

--- a/packages/docusaurus-theme/src/components/demo/preview/preview.tsx
+++ b/packages/docusaurus-theme/src/components/demo/preview/preview.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { LiveError, LivePreview } from 'react-live';
+import { LivePreview } from 'react-live';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import { ErrorBoundaryErrorMessageFallback } from '@docusaurus/theme-common';
@@ -30,9 +30,9 @@ export const DemoPreview = () => {
       {() => (
         <>
           <ErrorBoundary fallback={(params: any) => <ErrorBoundaryErrorMessageFallback {...params} />}>
-            <EuiFlexGroup css={styles.previewWrapper} alignItems="center" justifyContent="center">
+            <div css={styles.previewWrapper}>
               <LivePreview />
-            </EuiFlexGroup>
+            </div>
           </ErrorBoundary>
         </>
       )}

--- a/packages/docusaurus-theme/src/components/demo/scope.ts
+++ b/packages/docusaurus-theme/src/components/demo/scope.ts
@@ -1,8 +1,11 @@
 import React from 'react';
 import * as EUI from '@elastic/eui';
 
-export const demoScope: Record<string, unknown> = {
+export const demoDefaultScope: Record<string, unknown> = {
+  // React
   React,
   ...React,
+
+  // EUI exports
   ...EUI,
 };

--- a/packages/website/docs/02_components/navigation/button/overview.mdx
+++ b/packages/website/docs/02_components/navigation/button/overview.mdx
@@ -22,7 +22,90 @@ When using colors other than `primary`, be sure that either the words or an icon
 
 <Demo>
   ```tsx
-  <EuiButton>Button</EuiButton>
+  import React from 'react';
+  import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+
+  const buttons = [
+    'primary',
+    'success',
+    'warning',
+    'danger',
+    'text',
+    'accent',
+    'disabled',
+  ];
+
+  export default () => (
+    <div>
+      {buttons.map((value) => (
+        <>
+          <EuiFlexGroup
+            key={value}
+            gutterSize="s"
+            alignItems="center"
+            responsive={false}
+            wrap
+          >
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color={value !== 'disabled' ? value : undefined}
+                isDisabled={value === 'disabled' ? true : false}
+                onClick={() => {}}
+              >
+                {value.charAt(0).toUpperCase() + value.slice(1)}
+              </EuiButton>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color={value !== 'disabled' ? value : undefined}
+                isDisabled={value === 'disabled' ? true : false}
+                fill
+                onClick={() => {}}
+              >
+                Filled
+              </EuiButton>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color={value !== 'disabled' ? value : undefined}
+                isDisabled={value === 'disabled' ? true : false}
+                size="s"
+                onClick={() => {}}
+              >
+                Small
+              </EuiButton>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color={value !== 'disabled' ? value : undefined}
+                isDisabled={value === 'disabled' ? true : false}
+                size="s"
+                fill
+                onClick={() => {}}
+              >
+                Small and filled
+              </EuiButton>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={true}>
+              <EuiButton
+                color={value !== 'disabled' ? value : undefined}
+                isDisabled={value === 'disabled' ? true : false}
+                fullWidth
+                onClick={() => {}}
+              >
+                Full width
+              </EuiButton>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="s" />
+        </>
+      ))}
+    </div>
+  );
   ```
 </Demo>
 
@@ -32,7 +115,63 @@ Use **EuiButtonEmpty** when you want to reduce the importance of the button, but
 
 <Demo>
   ```tsx
-  <EuiButtonEmpty>ButtonEmpty</EuiButtonEmpty>
+  import React from 'react';
+  import {
+    EuiButtonEmpty,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiSpacer,
+  } from '@elastic/eui';
+
+  const buttons = ['primary', 'success', 'warning', 'danger', 'text', 'disabled'];
+
+  export default () => (
+    <div>
+      {buttons.map((value) => (
+        <>
+          <EuiFlexGroup
+            key={value}
+            responsive={false}
+            gutterSize="s"
+            alignItems="center"
+          >
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                isDisabled={value === 'disabled' ? true : false}
+                color={value !== 'disabled' ? value : 'primary'}
+                onClick={() => {}}
+              >
+                {value.charAt(0).toUpperCase() + value.slice(1)}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="s"
+                isDisabled={value === 'disabled' ? true : false}
+                color={value !== 'disabled' ? value : 'primary'}
+                onClick={() => {}}
+              >
+                Small
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="xs"
+                isDisabled={value === 'disabled' ? true : false}
+                color={value !== 'disabled' ? value : 'primary'}
+                onClick={() => {}}
+              >
+                Extra small
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="s" />
+        </>
+      ))}
+    </div>
+  );
   ```
 </Demo>
 
@@ -40,9 +179,262 @@ Use **EuiButtonEmpty** when you want to reduce the importance of the button, but
 
 When aligning **EuiButtonEmpty** components to the left or the right, you should make sure they’re flush with the edge of their container, so that they’re horizontally aligned with the other content in the container.
 
+<Demo>
+  ```tsx
+  import React from 'react';
+  import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+  export default () => (
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty flush="left">Flush left</EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty flush="right">Flush right</EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty flush="both">Flush both</EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+  ```
+</Demo>
+
 ## Buttons with icons
 
 All button components accept an `iconType` which must be an acceptable [**EuiIcon**](#/display/icons) type. Multi-color icons like app icons will be converted to single color. Icons can be displayed on the opposite side by passing `iconSide="right"`.
+
+<Demo>
+  ```tsx
+  import React from 'react';
+  import {
+    EuiButton,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiButtonEmpty,
+    EuiSpacer,
+  } from '@elastic/eui';
+
+  export default () => (
+    <div>
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={() => {}} iconType="heart">
+            Primary
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton fill iconType="lensApp" onClick={() => {}}>
+            Filled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton iconType="heart" size="s" onClick={() => {}}>
+            Small
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton iconType="lensApp" size="s" fill onClick={() => {}}>
+            Small and filled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={true}>
+          <EuiButton fullWidth iconType="lensApp" onClick={() => {}}>
+            Full width
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={() => {}} iconType="lensApp">
+            Empty button
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={() => {}} iconType="lensApp" size="s">
+            Small empty
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty onClick={() => {}} iconType="lensApp" size="xs">
+            Extra small empty
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton iconSide="right" onClick={() => {}} iconType="arrowDown">
+            Icon right
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            iconSide="right"
+            fill
+            iconType="arrowDown"
+            onClick={() => {}}
+          >
+            Filled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            iconSide="right"
+            iconType="arrowDown"
+            size="s"
+            onClick={() => {}}
+          >
+            Small
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            iconSide="right"
+            iconType="arrowDown"
+            size="s"
+            fill
+            onClick={() => {}}
+          >
+            Small and filled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={true}>
+          <EuiButton
+            fullWidth
+            iconSide="right"
+            iconType="arrowDown"
+            onClick={() => {}}
+          >
+            Full width
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            iconSide="right"
+            onClick={() => {}}
+            iconType="arrowDown"
+          >
+            Icon right
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            iconSide="right"
+            onClick={() => {}}
+            iconType="arrowDown"
+            size="s"
+          >
+            Small empty
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            iconSide="right"
+            onClick={() => {}}
+            iconType="arrowDown"
+            size="xs"
+          >
+            Extra small empty
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={() => {}} iconType="heart" isDisabled>
+            Disabled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton fill iconType="lensApp" onClick={() => {}} isDisabled>
+            Filled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton iconType="heart" size="s" onClick={() => {}} isDisabled>
+            Small
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            iconType="lensApp"
+            size="s"
+            fill
+            onClick={() => {}}
+            isDisabled
+          >
+            Small and filled
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={true}>
+          <EuiButton fullWidth iconType="lensApp" onClick={() => {}} isDisabled>
+            Full width
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            isDisabled
+            color="text"
+            onClick={() => {}}
+            iconType="dashboardApp"
+          >
+            Disabled app icon
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            isDisabled
+            color="text"
+            onClick={() => {}}
+            iconType="arrowDown"
+            iconSide="right"
+            size="xs"
+          >
+            Disabled icon right
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  );
+  ```
+</Demo>
 
 ## Icon buttons
 
@@ -56,6 +448,141 @@ An **EuiButtonIcon** is a button that only contains an icon (no text). Use the `
 
 :::
 
+<Demo>
+  ```tsx
+  import React from 'react';
+  import {
+    EuiButtonIcon,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiSpacer,
+    EuiTitle,
+    EuiCode,
+  } from '@elastic/eui';
+
+  const colors = ['primary', 'success', 'warning', 'danger', 'text', 'accent'];
+
+  export default () => (
+    <>
+      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+        {colors.map((color) => (
+          <EuiFlexItem key={color} grow={false}>
+            <EuiButtonIcon
+              color={color}
+              onClick={() => {}}
+              iconType="help"
+              aria-label="Help"
+            />
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>
+          Display (<EuiCode>empty</EuiCode>, <EuiCode>base</EuiCode>,{' '}
+          <EuiCode>fill</EuiCode>)
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon iconType="arrowRight" aria-label="Next" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon display="base" iconType="arrowRight" aria-label="Next" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon display="fill" iconType="arrowRight" aria-label="Next" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>Disabled </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon iconType="arrowRight" isDisabled aria-label="Next" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            display="base"
+            iconType="arrowRight"
+            isDisabled
+            aria-label="Next"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            iconType="arrowRight"
+            display="fill"
+            disabled
+            aria-label="Next"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>
+          Size (<EuiCode>xs</EuiCode>, <EuiCode>s</EuiCode>, <EuiCode>m</EuiCode>)
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon display="base" iconType="arrowRight" aria-label="Next" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            display="base"
+            iconType="arrowRight"
+            size="s"
+            aria-label="Next"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            display="base"
+            iconType="arrowRight"
+            iconSize="l"
+            size="m"
+            aria-label="Next"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>All icons types inherit button color</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon iconType="heart" aria-label="Heart" color="accent" />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            iconType="dashboardApp"
+            aria-label="Dashboard"
+            color="success"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            display="base"
+            iconType="trash"
+            aria-label="Delete"
+            color="danger"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon display="base" iconType="lensApp" aria-label="Lens" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+  ```
+</Demo>
+
 ## Buttons as links
 
 Every button component accepts either an `href` (rendered as an `<a>`) or an `onClick` (rendered as a `<button>`).
@@ -66,16 +593,198 @@ it is not usually recommended. For more specific information on how to integrate
 If you are creating a purely text-based link, like the one in the previous paragraph,
 use [**EuiLink**](#/navigation/link) instead.
 
+<Demo>
+  ```tsx
+  import React, { Fragment } from 'react';
+  import {
+    EuiButton,
+    EuiButtonEmpty,
+    EuiButtonIcon,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiSpacer,
+} from '@elastic/eui';
+
+  export default () => (
+    <Fragment>
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton href="#/navigation/button">Link to elastic.co</EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty href="#/navigation/button">
+            Link to elastic.co
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            href="#/navigation/button"
+            iconType="link"
+            aria-label="This is a link"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="s" />
+
+      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton href="#/navigation/button" isDisabled>
+            Disabled link
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty href="#/navigation/button" isDisabled>
+            Disabled empty link
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <EuiButtonIcon
+            href="#/navigation/button"
+            iconType="link"
+            aria-label="This is a link"
+            isDisabled
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </Fragment>
+  );
+  ```
+</Demo>
+
 ## Loading state
 
 Setting the `isLoading` prop to true will add the loading spinner or swap the existing icon for the loading spinner
 and set the button to disabled. It is good practice to also rename the button to "Loading…".
+
+<Demo>
+  ```tsx
+  import React from 'react';
+  import {
+    EuiButton,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiButtonEmpty,
+  } from '@elastic/eui';
+
+  export default () => (
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton isLoading={true}>Loading&hellip;</EuiButton>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButton fill size="s" isLoading={true}>
+          Loading&hellip;
+        </EuiButton>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButton fill isLoading={true} iconType="check" iconSide="right">
+          Loading&hellip;
+        </EuiButton>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty onClick={() => {}} isLoading>
+          Loading&hellip;
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty size="xs" onClick={() => {}} isLoading iconSide="right">
+          Loading&hellip;
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+  </EuiFlexGroup>
+  );
+  ```
+</Demo>
 
 ## Split buttons
 
 EUI [does not support](https://github.com/elastic/eui/issues/4171) split buttons specifically. Instead,
 we recommend using separate buttons for the main and overflow actions. You can achieve this by simply using
 the `display` and `size` props **EuiButtonIcon** to match that of the primary action button.
+
+<Demo isSourceOpen={false}>
+  ```tsx
+  import React, { useState } from 'react';
+  import {
+    EuiButton,
+    EuiButtonIcon,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiContextMenuPanel,
+    EuiContextMenuItem,
+    EuiPopover,
+    useGeneratedHtmlId,
+  } from '@elastic/eui';
+
+  export default () => {
+    const [isPopoverOpen, setPopover] = useState(false);
+    const splitButtonPopoverId = useGeneratedHtmlId({
+      prefix: 'splitButtonPopover',
+    });
+
+    const onButtonClick = () => {
+      setPopover(!isPopoverOpen);
+    };
+
+    const closePopover = () => {
+      setPopover(false);
+    };
+
+    const items = [
+      <EuiContextMenuItem key="copy" icon="copy" onClick={closePopover}>
+        Copy
+      </EuiContextMenuItem>,
+      <EuiContextMenuItem key="edit" icon="pencil" onClick={closePopover}>
+        Edit
+      </EuiContextMenuItem>,
+      <EuiContextMenuItem key="share" icon="share" onClick={closePopover}>
+        Share
+      </EuiContextMenuItem>,
+    ];
+
+    return (
+      <>
+        <EuiFlexGroup responsive={false} gutterSize="xs" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButton size="s" iconType="calendar">
+              Last 15 min
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiPopover
+              id={splitButtonPopoverId}
+              button={
+                <EuiButtonIcon
+                  display="base"
+                  size="s"
+                  iconType="boxesVertical"
+                  aria-label="More"
+                  onClick={onButtonClick}
+                />
+              }
+              isOpen={isPopoverOpen}
+              closePopover={closePopover}
+              panelPaddingSize="none"
+              anchorPosition="downLeft"
+            >
+              <EuiContextMenuPanel size="s" items={items} />
+            </EuiPopover>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    );
+  };
+  ```
+</Demo>
 
 ## Toggle buttons
 
@@ -86,6 +795,39 @@ Though there are two **exclusive** situations to consider.
 1.  If your button changes its readable **text**, via children or `aria-label`,
 then there is no additional accessibility concern.
 
+<Demo isSourceOpen={false}>
+  ```tsx
+  import React, { useState } from 'react';
+  import { EuiButton, EuiButtonIcon } from '@elastic/eui';
+
+  export default () => {
+    const [toggle0On, setToggle0On] = useState(false);
+    const [toggle1On, setToggle1On] = useState(true);
+
+    return (
+      <>
+        <EuiButton
+          onClick={() => {
+            setToggle0On((isOn) => !isOn);
+          }}
+        >
+          {toggle0On ? 'Hey there good lookin' : 'Toggle me'}
+        </EuiButton>
+        &emsp;
+        <EuiButtonIcon
+          title={toggle1On ? 'Play' : 'Pause'}
+          aria-label={toggle1On ? 'Play' : 'Pause'}
+          iconType={toggle1On ? 'play' : 'pause'}
+          onClick={() => {
+            setToggle1On((isOn) => !isOn);
+          }}
+        />
+      </>
+    );
+  };
+  ```
+</Demo>
+
 2.  If your button only changes the **visual** appearance, you must add `aria-pressed` passing a boolean
 for the on and off states. All EUI button types provide a helper prop for this called `isSelected`.
 
@@ -94,6 +836,46 @@ for the on and off states. All EUI button types provide a helper prop for this c
 Do not add `aria-pressed` or `isSelected` if you also change the readable text.
 
 :::
+
+<Demo isSourceOpen={false}>
+  ```tsx
+  import React, { useState } from 'react';
+  import { EuiButton, EuiButtonIcon } from '@elastic/eui';
+
+  export default () => {
+    const [toggle2On, setToggle2On] = useState(true);
+    const [toggle3On, setToggle3On] = useState(false);
+
+    return (
+      <>
+        <EuiButton
+          isSelected={toggle2On}
+          fill={toggle2On}
+          iconType={toggle2On ? 'starFilledSpace' : 'starPlusEmpty'}
+          onClick={() => {
+            setToggle2On((isOn) => !isOn);
+          }}
+        >
+          Toggle me
+        </EuiButton>
+        &emsp;
+        <EuiButtonIcon
+          display={toggle3On ? 'base' : 'empty'}
+          size="m"
+          aria-label="Autosave"
+          title="Autosave"
+          iconType="save"
+          aria-pressed={toggle3On}
+          color={toggle3On ? 'primary' : 'text'}
+          onClick={() => {
+            setToggle3On((isOn) => !isOn);
+          }}
+        />
+      </>
+    );
+  };
+  ```
+</Demo>
 
 ## Button groups
 
@@ -107,9 +889,245 @@ This is only for accessibility, however, so it will be visibly hidden.
 
 :::
 
+<Demo isSourceOpen={false}>
+  ```tsx
+  import React, { useState, Fragment } from 'react';
+  import {
+    EuiButtonGroup,
+    EuiSpacer,
+    EuiTitle,
+    useGeneratedHtmlId,
+  } from '@elastic/eui';
+
+  export default () => {
+    const basicButtonGroupPrefix = useGeneratedHtmlId({
+      prefix: 'basicButtonGroup',
+    });
+    const multiSelectButtonGroupPrefix = useGeneratedHtmlId({
+      prefix: 'multiSelectButtonGroup',
+    });
+    const disabledButtonGroupPrefix = useGeneratedHtmlId({
+      prefix: 'disabledButtonGroup',
+    });
+
+    const toggleButtons = [
+      {
+        id: `${basicButtonGroupPrefix}__0`,
+        label: 'Option one',
+      },
+      {
+        id: `${basicButtonGroupPrefix}__1`,
+        label: 'Option two is selected by default',
+      },
+      {
+        id: `${basicButtonGroupPrefix}__2`,
+        label: 'Option three',
+      },
+    ];
+
+    const toggleButtonsDisabled = [
+      {
+        id: `${disabledButtonGroupPrefix}__0`,
+        label: 'Option one',
+      },
+      {
+        id: `${disabledButtonGroupPrefix}__1`,
+        label: 'Option two is selected by default',
+      },
+      {
+        id: `${disabledButtonGroupPrefix}__2`,
+        label: 'Option three',
+      },
+    ];
+
+    const toggleButtonsMulti = [
+      {
+        id: `${multiSelectButtonGroupPrefix}__0`,
+        label: 'Option 1',
+      },
+      {
+        id: `${multiSelectButtonGroupPrefix}__1`,
+        label: 'Option 2 is selected by default',
+      },
+      {
+        id: `${multiSelectButtonGroupPrefix}__2`,
+        label: 'Option 3',
+      },
+    ];
+
+    const [toggleIdSelected, setToggleIdSelected] = useState(
+      `${basicButtonGroupPrefix}__1`
+    );
+    const [toggleIdDisabled, setToggleIdDisabled] = useState(
+      `${disabledButtonGroupPrefix}__1`
+    );
+    const [toggleIdToSelectedMap, setToggleIdToSelectedMap] = useState({
+      [`${multiSelectButtonGroupPrefix}__1`]: true,
+    });
+
+    const onChange = (optionId) => {
+      setToggleIdSelected(optionId);
+    };
+
+    const onChangeDisabled = (optionId) => {
+      setToggleIdDisabled(optionId);
+    };
+
+    const onChangeMulti = (optionId) => {
+      const newToggleIdToSelectedMap = {
+        ...toggleIdToSelectedMap,
+        ...{
+          [optionId]: !toggleIdToSelectedMap[optionId],
+        },
+      };
+      setToggleIdToSelectedMap(newToggleIdToSelectedMap);
+    };
+
+    return (
+      <Fragment>
+        <EuiButtonGroup
+          legend="This is a basic group"
+          options={toggleButtons}
+          idSelected={toggleIdSelected}
+          onChange={(id) => onChange(id)}
+        />
+        <EuiSpacer size="m" />
+        <EuiTitle size="xxs">
+          <h3>Primary &amp; multi select</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiButtonGroup
+          legend="This is a primary group"
+          options={toggleButtonsMulti}
+          idToSelectedMap={toggleIdToSelectedMap}
+          onChange={(id) => onChangeMulti(id)}
+          color="primary"
+          type="multi"
+        />
+        <EuiSpacer size="m" />
+        <EuiTitle size="xxs">
+          <h3>Disabled &amp; full width</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiButtonGroup
+          legend="This is a disabled group"
+          options={toggleButtonsDisabled}
+          idSelected={toggleIdDisabled}
+          onChange={(id) => onChangeDisabled(id)}
+          buttonSize="m"
+          isDisabled
+          isFullWidth
+        />
+      </Fragment>
+    );
+  };
+  ```
+</Demo>
+
 ### Icon only button groups
 
 If you're just displaying a group of icons, add the prop `isIconOnly`.
+
+<Demo isSourceOpen={false}>
+  ```tsx
+  import React, { useState, Fragment } from 'react';
+  import { EuiButtonGroup, htmlIdGenerator } from '@elastic/eui';
+
+  const idPrefix3 = htmlIdGenerator()();
+
+  export default () => {
+    const toggleButtonsIcons = [
+      {
+        id: `${idPrefix3}0`,
+        label: 'Align left',
+        iconType: 'editorAlignLeft',
+      },
+      {
+        id: `${idPrefix3}1`,
+        label: 'Align center',
+        iconType: 'editorAlignCenter',
+      },
+      {
+        id: `${idPrefix3}2`,
+        label: 'Align right',
+        iconType: 'editorAlignRight',
+        isDisabled: true,
+      },
+    ];
+
+    const toggleButtonsIconsMulti = [
+      {
+        id: `${idPrefix3}3`,
+        label: 'Bold',
+        name: 'bold',
+        iconType: 'editorBold',
+      },
+      {
+        id: `${idPrefix3}4`,
+        label: 'Italic',
+        name: 'italic',
+        iconType: 'editorItalic',
+        isDisabled: true,
+      },
+      {
+        id: `${idPrefix3}5`,
+        label: 'Underline',
+        name: 'underline',
+        iconType: 'editorUnderline',
+      },
+      {
+        id: `${idPrefix3}6`,
+        label: 'Strikethrough',
+        name: 'strikethrough',
+        iconType: 'editorStrike',
+      },
+    ];
+
+    const [toggleIconIdSelected, setToggleIconIdSelected] = useState(
+      `${idPrefix3}1`
+    );
+    const [toggleIconIdToSelectedMap, setToggleIconIdToSelectedMap] = useState(
+      {}
+    );
+
+    const onChangeIcons = (optionId) => {
+      setToggleIconIdSelected(optionId);
+    };
+
+    const onChangeIconsMulti = (optionId) => {
+      const newToggleIconIdToSelectedMap = {
+        ...toggleIconIdToSelectedMap,
+        ...{
+          [optionId]: !toggleIconIdToSelectedMap[optionId],
+        },
+      };
+
+      setToggleIconIdToSelectedMap(newToggleIconIdToSelectedMap);
+    };
+
+    return (
+      <Fragment>
+        <EuiButtonGroup
+          legend="Text align"
+          options={toggleButtonsIcons}
+          idSelected={toggleIconIdSelected}
+          onChange={(id) => onChangeIcons(id)}
+          isIconOnly
+        />
+        &nbsp;&nbsp;
+        <EuiButtonGroup
+          legend="Text style"
+          options={toggleButtonsIconsMulti}
+          idToSelectedMap={toggleIconIdToSelectedMap}
+          onChange={(id) => onChangeIconsMulti(id)}
+          type="multi"
+          isIconOnly
+        />
+      </Fragment>
+    );
+  };
+  ```
+</Demo>
 
 ### Button groups in forms
 
@@ -118,3 +1136,113 @@ Compressed groups should always be `fullWidth` so they line up nicely in their s
 
 For a more detailed example of how to integrate with forms,
 see the ["Complex example"](#/forms/compressed-forms#complex-example) on the compressed forms page.
+
+<Demo isSourceOpen={false}>
+  ```tsx
+  import React, { useState } from 'react';
+  import {
+    EuiButtonGroup,
+    EuiSpacer,
+    EuiPanel,
+    useGeneratedHtmlId,
+  } from '@elastic/eui';
+
+  export default () => {
+    const compressedToggleButtonGroupPrefix = useGeneratedHtmlId({
+      prefix: 'compressedToggleButtonGroup',
+    });
+    const multiSelectButtonGroupPrefix = useGeneratedHtmlId({
+      prefix: 'multiSelectButtonGroup',
+    });
+
+    const toggleButtonsCompressed = [
+      {
+        id: `${compressedToggleButtonGroupPrefix}__0`,
+        label: 'fine',
+      },
+      {
+        id: `${compressedToggleButtonGroupPrefix}__1`,
+        label: 'rough',
+      },
+      {
+        id: `${compressedToggleButtonGroupPrefix}__2`,
+        label: 'coarse',
+      },
+    ];
+
+    const toggleButtonsIconsMulti = [
+      {
+        id: `${multiSelectButtonGroupPrefix}__0`,
+        label: 'Bold',
+        name: 'bold',
+        iconType: 'editorBold',
+      },
+      {
+        id: `${multiSelectButtonGroupPrefix}__1`,
+        label: 'Italic',
+        name: 'italic',
+        iconType: 'editorItalic',
+        isDisabled: true,
+      },
+      {
+        id: `${multiSelectButtonGroupPrefix}__2`,
+        label: 'Underline',
+        name: 'underline',
+        iconType: 'editorUnderline',
+      },
+      {
+        id: `${multiSelectButtonGroupPrefix}__3`,
+        label: 'Strikethrough',
+        name: 'strikethrough',
+        iconType: 'editorStrike',
+      },
+    ];
+
+    const [toggleIconIdToSelectedMapIcon, setToggleIconIdToSelectedMapIcon] =
+      useState({});
+    const [toggleCompressedIdSelected, setToggleCompressedIdSelected] = useState(
+      `${compressedToggleButtonGroupPrefix}__1`
+    );
+
+    const onChangeCompressed = (optionId) => {
+      setToggleCompressedIdSelected(optionId);
+    };
+
+    const onChangeIconsMultiIcons = (optionId) => {
+      const newToggleIconIdToSelectedMapIcon = {
+        ...toggleIconIdToSelectedMapIcon,
+        ...{
+          [optionId]: !toggleIconIdToSelectedMapIcon[optionId],
+        },
+      };
+
+      setToggleIconIdToSelectedMapIcon(newToggleIconIdToSelectedMapIcon);
+    };
+
+    return (
+      <EuiPanel hasBorder style={{ maxWidth: 300 }}>
+        <EuiButtonGroup
+          name="coarsness"
+          legend="This is a basic group"
+          options={toggleButtonsCompressed}
+          idSelected={toggleCompressedIdSelected}
+          onChange={(id) => onChangeCompressed(id)}
+          buttonSize="compressed"
+          isFullWidth
+        />
+        <EuiSpacer />
+        <EuiButtonGroup
+          legend="Text style"
+          className="eui-displayInlineBlock"
+          options={toggleButtonsIconsMulti}
+          idToSelectedMap={toggleIconIdToSelectedMapIcon}
+          onChange={(id) => onChangeIconsMultiIcons(id)}
+          type="multi"
+          buttonSize="compressed"
+          isIconOnly
+        />
+      </EuiPanel>
+    );
+  };
+  ```
+</Demo>


### PR DESCRIPTION
## Summary

Resolves #7866.

This adds a custom code transformer to our `<Demo>` component that makes the existing component examples work with `react-live`. The major factor was that `react-live` only supports code that's just a JSX component or render function declaration. There's no way to define variables outside of the render function or have import/export statements.

The new code transformer removes any import statements because all externals should always come from the `scope`, and wraps the source code in an IIFE to support defining variables and functions outside of the render function as we often do in our examples.

## QA

- [x] Open built [PR preview](https://eui.elastic.co/pr_7894/new-docs/docs/components/button/) and confirm that the EuiButton examples work as intended