### PR TITLE
fix: `refreshMinInterval` for use in `EuiQuickSelectPopover`

### DIFF
--- a/packages/eui/changelogs/upcoming/7905.md
+++ b/packages/eui/changelogs/upcoming/7905.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed usage of `refreshMinInterval` with `EuiSuperDatePicker`, passing interval to `EuiQuickSelectPopover` https://github.com/elastic/eui/pull/7905
+

--- a/packages/eui/changelogs/upcoming/7905.md
+++ b/packages/eui/changelogs/upcoming/7905.md
@@ -1,4 +1,3 @@
 **Bug fixes**
 
-- Fixed usage of `refreshMinInterval` with `EuiSuperDatePicker`, passing interval to `EuiQuickSelectPopover` https://github.com/elastic/eui/pull/7905
-
+- Fixed `EuiSuperDatePicker` not correctly passing `refreshMinInterval` from the quick select popover

--- a/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
@@ -58,8 +58,8 @@ export interface EuiQuickSelectPopoverProps {
   isDisabled: boolean;
   isPaused: boolean;
   recentlyUsedRanges: DurationRange[];
-  refreshInterval: number;
-  minInterval?: Milliseconds;
+  refreshInterval: Milliseconds;
+  refreshMinInterval?: Milliseconds;
   intervalUnits?: RefreshUnitsOptions;
   start: string;
   timeOptions: TimeOptions;
@@ -139,7 +139,7 @@ export const EuiQuickSelectPanels: FunctionComponent<
   customQuickSelectRender,
   isPaused,
   refreshInterval,
-  minInterval,
+  refreshMinInterval,
   intervalUnits,
   applyRefreshInterval,
   applyTime,
@@ -176,7 +176,7 @@ export const EuiQuickSelectPanels: FunctionComponent<
       onRefreshChange={applyRefreshInterval}
       isPaused={isPaused}
       refreshInterval={refreshInterval}
-      minInterval={minInterval}
+      minInterval={refreshMinInterval}
       intervalUnits={intervalUnits}
     />
   );

--- a/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
@@ -34,6 +34,7 @@ import {
   ApplyTime,
   QuickSelect,
   QuickSelectPanel,
+  Milliseconds,
 } from '../../types';
 
 export type CustomQuickSelectRenderOptions = {
@@ -58,6 +59,7 @@ export interface EuiQuickSelectPopoverProps {
   isPaused: boolean;
   recentlyUsedRanges: DurationRange[];
   refreshInterval: number;
+  minInterval?: Milliseconds;
   intervalUnits?: RefreshUnitsOptions;
   start: string;
   timeOptions: TimeOptions;
@@ -137,6 +139,7 @@ export const EuiQuickSelectPanels: FunctionComponent<
   customQuickSelectRender,
   isPaused,
   refreshInterval,
+  minInterval,
   intervalUnits,
   applyRefreshInterval,
   applyTime,
@@ -173,6 +176,7 @@ export const EuiQuickSelectPanels: FunctionComponent<
       onRefreshChange={applyRefreshInterval}
       isPaused={isPaused}
       refreshInterval={refreshInterval}
+      minInterval={minInterval}
       intervalUnits={intervalUnits}
     />
   );

--- a/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -457,6 +457,7 @@ export class EuiSuperDatePickerInternal extends Component<
       onRefreshChange,
       recentlyUsedRanges,
       refreshInterval,
+      refreshMinInterval,
       refreshIntervalUnits,
       isPaused,
       isDisabled,
@@ -477,6 +478,7 @@ export class EuiSuperDatePickerInternal extends Component<
         isPaused={isPaused}
         recentlyUsedRanges={recentlyUsedRanges}
         refreshInterval={refreshInterval}
+        minInterval={refreshMinInterval}
         intervalUnits={refreshIntervalUnits}
         start={start}
         timeOptions={timeOptions}

--- a/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -478,7 +478,7 @@ export class EuiSuperDatePickerInternal extends Component<
         isPaused={isPaused}
         recentlyUsedRanges={recentlyUsedRanges}
         refreshInterval={refreshInterval}
-        minInterval={refreshMinInterval}
+        refreshMinInterval={refreshMinInterval}
         intervalUnits={refreshIntervalUnits}
         start={start}
         timeOptions={timeOptions}


### PR DESCRIPTION
## Summary

Following the addition of the new `refreshMinInterval` prop to `EuiSuperDatePicker` in #7516, we missed passing this prop to `EuiQuickSelectPopover`

#### Before

Notice changing the interval from `EuiAutoRefreshButton` properly validates against the `minInterval`. But when changing the interval from within `EuiQuickSelectPopover`, the validation is skipped.

![Zight Recording 2024-07-22 at 05 02 40 PM](https://github.com/user-attachments/assets/3ca76688-6482-4a5a-9dd0-6526b7808f20)

#### After

![Zight Recording 2024-07-22 at 05 01 27 PM](https://github.com/user-attachments/assets/cdf1df4d-ae14-4a43-9a4e-bf75411b8c57)

Related to https://github.com/elastic/kibana/pull/188881

### General checklist

- Code quality checklist
    - ~[ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~ - Skipped, just a basic prop pass
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.