### PR TITLE
feat: Add support for simplified interactive demo syntax using code blocks

### DIFF
--- a/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch
+++ b/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.js b/dist/index.js
+index 7bcfee33d9cfaa6c5f9d7da40335ec2551f932b6..4c29438cb94412d25aed193f9c86f20ccebb9009 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -168,7 +168,7 @@ var import_sucrase = require("sucrase");
+ var defaultTransforms = ["jsx", "imports"];
+ function transform(opts = {}) {
+   const transforms = Array.isArray(opts.transforms) ? opts.transforms.filter(Boolean) : defaultTransforms;
+-  return (code) => (0, import_sucrase.transform)(code, { transforms }).code;
++  return (code) => (0, import_sucrase.transform)(code, { transforms, jsxPragma: 'jsx' }).code;
+ }
+ 
+ // src/utils/transpile/errorBoundary.tsx
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 44a3fbed4fc0545b75235add7369a262e8ee5220..6cfad17b4ce81553bac1243b7421f5f75ade43fc 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -127,7 +127,7 @@ import { transform as _transform } from "sucrase";
+ var defaultTransforms = ["jsx", "imports"];
+ function transform(opts = {}) {
+   const transforms = Array.isArray(opts.transforms) ? opts.transforms.filter(Boolean) : defaultTransforms;
+-  return (code) => _transform(code, { transforms }).code;
++  return (code) => _transform(code, { transforms, jsxPragma: 'jsx' }).code;
+ }
+ 
+ // src/utils/transpile/errorBoundary.tsx

--- a/packages/docusaurus-theme/package.json
+++ b/packages/docusaurus-theme/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.30.1",
     "prism-react-renderer": "^2.3.1",
     "react-is": "^18.3.1",
-    "react-live": "^4.1.7"
+    "react-live": "patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/docusaurus-theme/src/components/demo/context.ts
+++ b/packages/docusaurus-theme/src/components/demo/context.ts
@@ -2,7 +2,15 @@ import { createContext, useContext } from 'react';
 import { DemoSourceMeta } from './demo';
 
 export interface DemoContextObject {
+  /**
+   * Array of all available sources for this demo instance
+   */
   sources: DemoSourceMeta[];
+
+  /**
+   * Add source to the list of available sources
+   * This should only be used internally when initializing the component!
+   */
   addSource(source: DemoSourceMeta): void;
 }
 

--- a/packages/docusaurus-theme/src/components/demo/demo.tsx
+++ b/packages/docusaurus-theme/src/components/demo/demo.tsx
@@ -58,7 +58,7 @@ const getDemoStyles = (euiTheme: UseEuiTheme) => ({
 export const Demo = ({
   children,
   scope,
-  isSourceOpen: _isSourceOpen = true,
+  isSourceOpen: _isSourceOpen = false,
   previewPadding,
 }: DemoProps) => {
   const styles = useEuiMemoizedStyles(getDemoStyles);

--- a/packages/docusaurus-theme/src/components/demo/demo.tsx
+++ b/packages/docusaurus-theme/src/components/demo/demo.tsx
@@ -21,6 +21,7 @@ import { DemoSource } from './source';
 import { demoDefaultScope } from './scope';
 import { DemoActionsBar } from './actions_bar';
 import { demoCodeTransformer } from './code_transformer';
+import { DemoPreviewProps } from './preview/preview';
 
 export interface DemoSourceMeta {
   code: string;
@@ -40,6 +41,7 @@ export interface DemoProps extends PropsWithChildren {
    * The default scope exposes all React and EUI exports.
    */
   scope?: Record<string, unknown>;
+  previewPadding?: DemoPreviewProps['padding'];
 }
 
 const getDemoStyles = (euiTheme: UseEuiTheme) => ({
@@ -56,12 +58,13 @@ const getDemoStyles = (euiTheme: UseEuiTheme) => ({
 export const Demo = ({
   children,
   scope,
-  isSourceOpen: _isSourceOpen = true
+  isSourceOpen: _isSourceOpen = true,
+  previewPadding,
 }: DemoProps) => {
   const styles = useEuiMemoizedStyles(getDemoStyles);
   const [sources, setSources] = useState<DemoSourceMeta[]>([]);
   const [isSourceOpen, setIsSourceOpen] = useState<boolean>(_isSourceOpen);
-  const activeSource = sources[0];
+  const activeSource = sources[0] || null;
 
   // liveProviderKey restarts the demo to its initial state
   const [liveProviderKey, setLiveProviderKey] = useState<number>(0);
@@ -101,7 +104,7 @@ export const Demo = ({
           theme={prismThemes.dracula}
           scope={finalScope}
         >
-          <DemoPreview />
+          <DemoPreview padding={previewPadding} />
           <DemoActionsBar
             isSourceOpen={isSourceOpen}
             setSourceOpen={setIsSourceOpen}

--- a/packages/docusaurus-theme/src/components/demo/editor/editor.tsx
+++ b/packages/docusaurus-theme/src/components/demo/editor/editor.tsx
@@ -8,7 +8,7 @@
 
 import { LiveEditor, LiveError } from 'react-live';
 import { css } from '@emotion/react';
-import { useEuiMemoizedStyles, useEuiTheme } from '@elastic/eui';
+import { useEuiMemoizedStyles } from '@elastic/eui';
 
 const getEditorStyles = () => ({
   editor: css`

--- a/packages/docusaurus-theme/src/components/demo/preview/preview.tsx
+++ b/packages/docusaurus-theme/src/components/demo/preview/preview.tsx
@@ -3,11 +3,16 @@ import { LivePreview } from 'react-live';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import ErrorBoundary from '@docusaurus/ErrorBoundary';
 import { ErrorBoundaryErrorMessageFallback } from '@docusaurus/theme-common';
-import { UseEuiTheme, EuiFlexGroup, useEuiTheme } from '@elastic/eui';
+import { UseEuiTheme, useEuiTheme, EuiPaddingSize, euiPaddingSize } from '@elastic/eui';
+import { CSSProperties } from 'react';
+
+export interface DemoPreviewProps {
+  padding?: EuiPaddingSize;
+}
 
 const getPreviewStyles = (euiTheme: UseEuiTheme) => ({
   previewWrapper: css`
-    padding: ${euiTheme.euiTheme.size.l};
+    padding: var(--docs-demo-preview-padding);
     border-radius: var(--docs-demo-border-radius);
   `,
 });
@@ -21,16 +26,21 @@ const PreviewLoader = () => (
   <div>Loading...</div>
 );
 
-export const DemoPreview = () => {
+export const DemoPreview = ({ padding = 'l' }: DemoPreviewProps) => {
   const euiTheme = useEuiTheme();
   const styles = getPreviewStyles(euiTheme);
+  const paddingSize = euiPaddingSize(euiTheme, padding);
+
+  const style = {
+    '--docs-demo-preview-padding': paddingSize,
+  } as CSSProperties;
 
   return (
     <BrowserOnly fallback={<PreviewLoader />}>
       {() => (
         <>
           <ErrorBoundary fallback={(params: any) => <ErrorBoundaryErrorMessageFallback {...params} />}>
-            <div css={styles.previewWrapper}>
+            <div css={styles.previewWrapper} style={style}>
               <LivePreview />
             </div>
           </ErrorBoundary>

--- a/packages/docusaurus-theme/src/components/demo/scope.ts
+++ b/packages/docusaurus-theme/src/components/demo/scope.ts
@@ -4,7 +4,7 @@ import * as EmotionReact from '@emotion/react';
 
 /**
  * A custom client-side require() alternative to inform users it's not available
- * and
+ * in our demo environment
  */
 const clientSideRequire = () => {
   throw new Error('require() is not accessible in the interactive demo environment! All EUI and React exports are available in the global scope for you to use without the need to import them.');

--- a/packages/docusaurus-theme/src/components/demo/scope.ts
+++ b/packages/docusaurus-theme/src/components/demo/scope.ts
@@ -1,5 +1,14 @@
 import React from 'react';
 import * as EUI from '@elastic/eui';
+import * as EmotionReact from '@emotion/react';
+
+/**
+ * A custom client-side require() alternative to inform users it's not available
+ * and
+ */
+const clientSideRequire = () => {
+  throw new Error('require() is not accessible in the interactive demo environment! All EUI and React exports are available in the global scope for you to use without the need to import them.');
+}
 
 export const demoDefaultScope: Record<string, unknown> = {
   // React
@@ -8,4 +17,9 @@ export const demoDefaultScope: Record<string, unknown> = {
 
   // EUI exports
   ...EUI,
+
+  // Emotion
+  ...EmotionReact,
+
+  require: clientSideRequire,
 };

--- a/packages/docusaurus-theme/src/components/demo/source/get_source_from_children.ts
+++ b/packages/docusaurus-theme/src/components/demo/source/get_source_from_children.ts
@@ -12,6 +12,11 @@ export interface SourceMeta {
  * Get source string from given children.
  */
 export const getSourceFromChildren = (children: ReactNode): string | null => {
+  // Direct (non-MDX) usage almost always passes a string
+  if (typeof children === 'string') {
+    return children;
+  }
+
   if (Children.count(children) !== 1 || !isElement(children)) {
     // This should never happen
     return null;

--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -1,0 +1,44 @@
+import React, { isValidElement, type ReactNode } from 'react';
+import { EuiCodeBlock } from '@elastic/eui';
+import type { Props } from '@theme/CodeBlock';
+import { Demo } from '../../components/demo';
+
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+function maybeStringifyChildren(children: ReactNode): ReactNode {
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return children;
+  }
+  // The children is now guaranteed to be one/more plain strings
+  return Array.isArray(children) ? children.join('') : (children as string);
+}
+
+export default function CodeBlock({
+  children: rawChildren,
+  metastring,
+  className,
+  ...props
+}: Props): JSX.Element {
+  const children = maybeStringifyChildren(rawChildren);
+  const language = className?.replace('language-', '') || undefined;
+
+  if (metastring?.startsWith('interactive')) {
+    return <Demo {...props}>{children}</Demo>;
+  }
+
+  return (
+    <EuiCodeBlock
+      {...props}
+      fontSize="m"
+      overflowHeight={450}
+      language={language}
+      isCopyable
+    >
+      {children}
+    </EuiCodeBlock>
+  );
+}

--- a/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import type CodeType from '@theme-init/MDXComponents/Code';
+import CodeBlock from '@theme/CodeBlock';
 import type { WrapperProps } from '@docusaurus/types';
 import { css } from '@emotion/react';
-import {
-  EuiCode,
-  EuiCodeBlock,
-  useEuiMemoizedStyles,
-  UseEuiTheme,
-} from '@elastic/eui';
+import { EuiCode, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
 
 type Props = WrapperProps<typeof CodeType>;
 
@@ -33,15 +29,19 @@ const Code = ({ children, className, ...rest }: Props): JSX.Element => {
       )
     : false;
 
-  return isInlineCode ? (
-    <EuiCode {...rest} language={language} css={styles.code}>
+  if (isInlineCode) {
+    return (
+      <EuiCode {...rest} language={language} css={styles.code}>
+        {children}
+      </EuiCode>
+    );
+  }
+
+  return (
+    <CodeBlock className={className} {...rest}>
       {children}
-    </EuiCode>
-  ) : (
-    <EuiCodeBlock {...rest} fontSize="m" language={language}>
-      {children}
-    </EuiCodeBlock>
-  );
+    </CodeBlock>
+  )
 };
 
 export default Code;

--- a/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
@@ -31,7 +31,12 @@ const Code = ({ children, className, ...rest }: Props): JSX.Element => {
 
   if (isInlineCode) {
     return (
-      <EuiCode {...rest} language={language} css={styles.code}>
+      <EuiCode
+        {...rest}
+        className={className}
+        language={language}
+        css={styles.code}
+      >
         {children}
       </EuiCode>
     );

--- a/packages/docusaurus-theme/src/theme/theme.d.ts
+++ b/packages/docusaurus-theme/src/theme/theme.d.ts
@@ -118,6 +118,31 @@ declare module '@theme-original/EditThisPage' {
   export default function EditThisPage(props: Props): JSX.Element;
 }
 
+// original: https://github.com/facebook/docusaurus/blob/fa743c81defd24e22eae45c81bd79eb8ec2c4ef0/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L364
+declare module '@theme/CodeBlock' {
+  import type { ReactNode } from 'react';
+
+  export interface Props {
+    readonly children: ReactNode;
+    readonly className?: string;
+    readonly metastring?: string;
+    readonly title?: string;
+    readonly language?: string;
+    readonly showLineNumbers?: boolean;
+  }
+
+  export default function CodeBlock(props: Props): JSX.Element;
+}
+
+// original: https://github.com/facebook/docusaurus/blob/8b877d27d4b1bcd5c2ee13dde8332407a1c26447/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L510
+declare module '@theme/MDXComponents/Code' {
+  import type {ComponentProps} from 'react';
+
+  export interface Props extends ComponentProps<'code'> {}
+
+  export default function MDXCode(props: Props): JSX.Element;
+}
+
 // original: https://github.com/facebook/docusaurus/blob/fa743c81defd24e22eae45c81bd79eb8ec2c4ef0/packages/docusaurus-theme-classic/src/theme-classic.d.ts#L563
 declare module '@theme-original/DocSidebar' {
   import type { PropSidebarItem } from '@docusaurus/plugin-content-docs';

--- a/packages/website/docs/02_components/navigation/button/overview.mdx
+++ b/packages/website/docs/02_components/navigation/button/overview.mdx
@@ -20,421 +20,413 @@ The most standard button component is **EuiButton** which comes in two styles an
 
 When using colors other than `primary`, be sure that either the words or an icon also represents the status. For instance, don't rely on color alone to represent dangerous actions but use words like "Delete" not "Confirm". The `text` and `accent` colors should be used sparingly as they can easily be confused with other states like disabled and danger.
 
-<Demo>
-  ```tsx
-  import React from 'react';
-  import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+```tsx interactive
+import React from 'react';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
-  const buttons = [
-    'primary',
-    'success',
-    'warning',
-    'danger',
-    'text',
-    'accent',
-    'disabled',
-  ];
+const buttons = [
+  'primary',
+  'success',
+  'warning',
+  'danger',
+  'text',
+  'accent',
+  'disabled',
+];
 
-  export default () => (
-    <div>
-      {buttons.map((value) => (
-        <>
-          <EuiFlexGroup
-            key={value}
-            gutterSize="s"
-            alignItems="center"
-            responsive={false}
-            wrap
-          >
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color={value !== 'disabled' ? value : undefined}
-                isDisabled={value === 'disabled' ? true : false}
-                onClick={() => {}}
-              >
-                {value.charAt(0).toUpperCase() + value.slice(1)}
-              </EuiButton>
-            </EuiFlexItem>
+export default () => (
+  <div>
+    {buttons.map((value) => (
+      <>
+        <EuiFlexGroup
+          key={value}
+          gutterSize="s"
+          alignItems="center"
+          responsive={false}
+          wrap
+        >
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              color={value !== 'disabled' ? value : undefined}
+              isDisabled={value === 'disabled' ? true : false}
+              onClick={() => {}}
+            >
+              {value.charAt(0).toUpperCase() + value.slice(1)}
+            </EuiButton>
+          </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color={value !== 'disabled' ? value : undefined}
-                isDisabled={value === 'disabled' ? true : false}
-                fill
-                onClick={() => {}}
-              >
-                Filled
-              </EuiButton>
-            </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              color={value !== 'disabled' ? value : undefined}
+              isDisabled={value === 'disabled' ? true : false}
+              fill
+              onClick={() => {}}
+            >
+              Filled
+            </EuiButton>
+          </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color={value !== 'disabled' ? value : undefined}
-                isDisabled={value === 'disabled' ? true : false}
-                size="s"
-                onClick={() => {}}
-              >
-                Small
-              </EuiButton>
-            </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              color={value !== 'disabled' ? value : undefined}
+              isDisabled={value === 'disabled' ? true : false}
+              size="s"
+              onClick={() => {}}
+            >
+              Small
+            </EuiButton>
+          </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiButton
-                color={value !== 'disabled' ? value : undefined}
-                isDisabled={value === 'disabled' ? true : false}
-                size="s"
-                fill
-                onClick={() => {}}
-              >
-                Small and filled
-              </EuiButton>
-            </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              color={value !== 'disabled' ? value : undefined}
+              isDisabled={value === 'disabled' ? true : false}
+              size="s"
+              fill
+              onClick={() => {}}
+            >
+              Small and filled
+            </EuiButton>
+          </EuiFlexItem>
 
-            <EuiFlexItem grow={true}>
-              <EuiButton
-                color={value !== 'disabled' ? value : undefined}
-                isDisabled={value === 'disabled' ? true : false}
-                fullWidth
-                onClick={() => {}}
-              >
-                Full width
-              </EuiButton>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="s" />
-        </>
-      ))}
-    </div>
-  );
-  ```
-</Demo>
+          <EuiFlexItem grow={true}>
+            <EuiButton
+              color={value !== 'disabled' ? value : undefined}
+              isDisabled={value === 'disabled' ? true : false}
+              fullWidth
+              onClick={() => {}}
+            >
+              Full width
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="s" />
+      </>
+    ))}
+  </div>
+);
+```
 
 ## Empty button
 
 Use **EuiButtonEmpty** when you want to reduce the importance of the button, but still want to align it to the rest of the buttons. It is also the only button component that supports down to size `xs`.
 
-<Demo>
-  ```tsx
-  import React from 'react';
-  import {
-    EuiButtonEmpty,
-    EuiFlexGroup,
-    EuiFlexItem,
-    EuiSpacer,
-  } from '@elastic/eui';
+```tsx interactive
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+} from '@elastic/eui';
 
-  const buttons = ['primary', 'success', 'warning', 'danger', 'text', 'disabled'];
+const buttons = ['primary', 'success', 'warning', 'danger', 'text', 'disabled'];
 
-  export default () => (
-    <div>
-      {buttons.map((value) => (
-        <>
-          <EuiFlexGroup
-            key={value}
-            responsive={false}
-            gutterSize="s"
-            alignItems="center"
-          >
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                isDisabled={value === 'disabled' ? true : false}
-                color={value !== 'disabled' ? value : 'primary'}
-                onClick={() => {}}
-              >
-                {value.charAt(0).toUpperCase() + value.slice(1)}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
+export default () => (
+  <div>
+    {buttons.map((value) => (
+      <>
+        <EuiFlexGroup
+          key={value}
+          responsive={false}
+          gutterSize="s"
+          alignItems="center"
+        >
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              isDisabled={value === 'disabled' ? true : false}
+              color={value !== 'disabled' ? value : 'primary'}
+              onClick={() => {}}
+            >
+              {value.charAt(0).toUpperCase() + value.slice(1)}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                size="s"
-                isDisabled={value === 'disabled' ? true : false}
-                color={value !== 'disabled' ? value : 'primary'}
-                onClick={() => {}}
-              >
-                Small
-              </EuiButtonEmpty>
-            </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              isDisabled={value === 'disabled' ? true : false}
+              color={value !== 'disabled' ? value : 'primary'}
+              onClick={() => {}}
+            >
+              Small
+            </EuiButtonEmpty>
+          </EuiFlexItem>
 
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                size="xs"
-                isDisabled={value === 'disabled' ? true : false}
-                color={value !== 'disabled' ? value : 'primary'}
-                onClick={() => {}}
-              >
-                Extra small
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="s" />
-        </>
-      ))}
-    </div>
-  );
-  ```
-</Demo>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              isDisabled={value === 'disabled' ? true : false}
+              color={value !== 'disabled' ? value : 'primary'}
+              onClick={() => {}}
+            >
+              Extra small
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiSpacer size="s" />
+      </>
+    ))}
+  </div>
+);
+```
 
 ## Flush empty button
 
 When aligning **EuiButtonEmpty** components to the left or the right, you should make sure they’re flush with the edge of their container, so that they’re horizontally aligned with the other content in the container.
 
-<Demo>
-  ```tsx
-  import React from 'react';
-  import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+```tsx interactive
+import React from 'react';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
-  export default () => (
-    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty flush="left">Flush left</EuiButtonEmpty>
-      </EuiFlexItem>
+export default () => (
+  <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty flush="left">Flush left</EuiButtonEmpty>
+    </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty flush="right">Flush right</EuiButtonEmpty>
-      </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty flush="right">Flush right</EuiButtonEmpty>
+    </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty flush="both">Flush both</EuiButtonEmpty>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-  ```
-</Demo>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty flush="both">Flush both</EuiButtonEmpty>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+);
+```
 
 ## Buttons with icons
 
 All button components accept an `iconType` which must be an acceptable [**EuiIcon**](#/display/icons) type. Multi-color icons like app icons will be converted to single color. Icons can be displayed on the opposite side by passing `iconSide="right"`.
 
-<Demo>
-  ```tsx
-  import React from 'react';
-  import {
-    EuiButton,
-    EuiFlexGroup,
-    EuiFlexItem,
-    EuiButtonEmpty,
-    EuiSpacer,
-  } from '@elastic/eui';
+```tsx interactive
+import React from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  EuiSpacer,
+} from '@elastic/eui';
 
-  export default () => (
-    <div>
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => {}} iconType="heart">
-            Primary
-          </EuiButton>
-        </EuiFlexItem>
+export default () => (
+  <div>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton onClick={() => {}} iconType="heart">
+          Primary
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton fill iconType="lensApp" onClick={() => {}}>
-            Filled
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton fill iconType="lensApp" onClick={() => {}}>
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton iconType="heart" size="s" onClick={() => {}}>
-            Small
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton iconType="heart" size="s" onClick={() => {}}>
+          Small
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton iconType="lensApp" size="s" fill onClick={() => {}}>
-            Small and filled
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton iconType="lensApp" size="s" fill onClick={() => {}}>
+          Small and filled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={true}>
-          <EuiButton fullWidth iconType="lensApp" onClick={() => {}}>
-            Full width
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={true}>
+        <EuiButton fullWidth iconType="lensApp" onClick={() => {}}>
+          Full width
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
+    <EuiSpacer size="s" />
 
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={() => {}} iconType="lensApp">
-            Empty button
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty onClick={() => {}} iconType="lensApp">
+          Empty button
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={() => {}} iconType="lensApp" size="s">
-            Small empty
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty onClick={() => {}} iconType="lensApp" size="s">
+          Small empty
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty onClick={() => {}} iconType="lensApp" size="xs">
-            Extra small empty
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty onClick={() => {}} iconType="lensApp" size="xs">
+          Extra small empty
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
+    <EuiSpacer size="s" />
 
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButton iconSide="right" onClick={() => {}} iconType="arrowDown">
-            Icon right
-          </EuiButton>
-        </EuiFlexItem>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton iconSide="right" onClick={() => {}} iconType="arrowDown">
+          Icon right
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            iconSide="right"
-            fill
-            iconType="arrowDown"
-            onClick={() => {}}
-          >
-            Filled
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          fill
+          iconType="arrowDown"
+          onClick={() => {}}
+        >
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            iconSide="right"
-            iconType="arrowDown"
-            size="s"
-            onClick={() => {}}
-          >
-            Small
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          iconType="arrowDown"
+          size="s"
+          onClick={() => {}}
+        >
+          Small
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            iconSide="right"
-            iconType="arrowDown"
-            size="s"
-            fill
-            onClick={() => {}}
-          >
-            Small and filled
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconSide="right"
+          iconType="arrowDown"
+          size="s"
+          fill
+          onClick={() => {}}
+        >
+          Small and filled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={true}>
-          <EuiButton
-            fullWidth
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={() => {}}
-          >
-            Full width
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={true}>
+        <EuiButton
+          fullWidth
+          iconSide="right"
+          iconType="arrowDown"
+          onClick={() => {}}
+        >
+          Full width
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
+    <EuiSpacer size="s" />
 
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            iconSide="right"
-            onClick={() => {}}
-            iconType="arrowDown"
-          >
-            Icon right
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          iconSide="right"
+          onClick={() => {}}
+          iconType="arrowDown"
+        >
+          Icon right
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            iconSide="right"
-            onClick={() => {}}
-            iconType="arrowDown"
-            size="s"
-          >
-            Small empty
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          iconSide="right"
+          onClick={() => {}}
+          iconType="arrowDown"
+          size="s"
+        >
+          Small empty
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            iconSide="right"
-            onClick={() => {}}
-            iconType="arrowDown"
-            size="xs"
-          >
-            Extra small empty
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          iconSide="right"
+          onClick={() => {}}
+          iconType="arrowDown"
+          size="xs"
+        >
+          Extra small empty
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
+    <EuiSpacer size="s" />
 
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButton onClick={() => {}} iconType="heart" isDisabled>
-            Disabled
-          </EuiButton>
-        </EuiFlexItem>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton onClick={() => {}} iconType="heart" isDisabled>
+          Disabled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton fill iconType="lensApp" onClick={() => {}} isDisabled>
-            Filled
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton fill iconType="lensApp" onClick={() => {}} isDisabled>
+          Filled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton iconType="heart" size="s" onClick={() => {}} isDisabled>
-            Small
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton iconType="heart" size="s" onClick={() => {}} isDisabled>
+          Small
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButton
-            iconType="lensApp"
-            size="s"
-            fill
-            onClick={() => {}}
-            isDisabled
-          >
-            Small and filled
-          </EuiButton>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          iconType="lensApp"
+          size="s"
+          fill
+          onClick={() => {}}
+          isDisabled
+        >
+          Small and filled
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={true}>
-          <EuiButton fullWidth iconType="lensApp" onClick={() => {}} isDisabled>
-            Full width
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={true}>
+        <EuiButton fullWidth iconType="lensApp" onClick={() => {}} isDisabled>
+          Full width
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
+    <EuiSpacer size="s" />
 
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            isDisabled
-            color="text"
-            onClick={() => {}}
-            iconType="dashboardApp"
-          >
-            Disabled app icon
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          isDisabled
+          color="text"
+          onClick={() => {}}
+          iconType="dashboardApp"
+        >
+          Disabled app icon
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            isDisabled
-            color="text"
-            onClick={() => {}}
-            iconType="arrowDown"
-            iconSide="right"
-            size="xs"
-          >
-            Disabled icon right
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </div>
-  );
-  ```
-</Demo>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty
+          isDisabled
+          color="text"
+          onClick={() => {}}
+          iconType="arrowDown"
+          iconSide="right"
+          size="xs"
+        >
+          Disabled icon right
+        </EuiButtonEmpty>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </div>
+);
+```
 
 ## Icon buttons
 
@@ -448,140 +440,138 @@ An **EuiButtonIcon** is a button that only contains an icon (no text). Use the `
 
 :::
 
-<Demo>
-  ```tsx
-  import React from 'react';
-  import {
-    EuiButtonIcon,
-    EuiFlexGroup,
-    EuiFlexItem,
-    EuiSpacer,
-    EuiTitle,
-    EuiCode,
-  } from '@elastic/eui';
+```tsx interactive
+import React from 'react';
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiTitle,
+  EuiCode,
+} from '@elastic/eui';
 
-  const colors = ['primary', 'success', 'warning', 'danger', 'text', 'accent'];
+const colors = ['primary', 'success', 'warning', 'danger', 'text', 'accent'];
 
-  export default () => (
-    <>
-      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-        {colors.map((color) => (
-          <EuiFlexItem key={color} grow={false}>
-            <EuiButtonIcon
-              color={color}
-              onClick={() => {}}
-              iconType="help"
-              aria-label="Help"
-            />
-          </EuiFlexItem>
-        ))}
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <EuiTitle size="xxs">
-        <h3>
-          Display (<EuiCode>empty</EuiCode>, <EuiCode>base</EuiCode>,{' '}
-          <EuiCode>fill</EuiCode>)
-        </h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon iconType="arrowRight" aria-label="Next" />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon display="base" iconType="arrowRight" aria-label="Next" />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon display="fill" iconType="arrowRight" aria-label="Next" />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <EuiTitle size="xxs">
-        <h3>Disabled </h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon iconType="arrowRight" isDisabled aria-label="Next" />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
+export default () => (
+  <>
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+      {colors.map((color) => (
+        <EuiFlexItem key={color} grow={false}>
           <EuiButtonIcon
-            display="base"
-            iconType="arrowRight"
-            isDisabled
-            aria-label="Next"
+            color={color}
+            onClick={() => {}}
+            iconType="help"
+            aria-label="Help"
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="arrowRight"
-            display="fill"
-            disabled
-            aria-label="Next"
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <EuiTitle size="xxs">
-        <h3>
-          Size (<EuiCode>xs</EuiCode>, <EuiCode>s</EuiCode>, <EuiCode>m</EuiCode>)
-        </h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon display="base" iconType="arrowRight" aria-label="Next" />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            display="base"
-            iconType="arrowRight"
-            size="s"
-            aria-label="Next"
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            display="base"
-            iconType="arrowRight"
-            iconSize="l"
-            size="m"
-            aria-label="Next"
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="m" />
-      <EuiTitle size="xxs">
-        <h3>All icons types inherit button color</h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon iconType="heart" aria-label="Heart" color="accent" />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="dashboardApp"
-            aria-label="Dashboard"
-            color="success"
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            display="base"
-            iconType="trash"
-            aria-label="Delete"
-            color="danger"
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon display="base" iconType="lensApp" aria-label="Lens" />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
-  );
-  ```
-</Demo>
+      ))}
+    </EuiFlexGroup>
+    <EuiSpacer size="m" />
+    <EuiTitle size="xxs">
+      <h3>
+        Display (<EuiCode>empty</EuiCode>, <EuiCode>base</EuiCode>,{' '}
+        <EuiCode>fill</EuiCode>)
+      </h3>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon iconType="arrowRight" aria-label="Next" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon display="base" iconType="arrowRight" aria-label="Next" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon display="fill" iconType="arrowRight" aria-label="Next" />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer size="m" />
+    <EuiTitle size="xxs">
+      <h3>Disabled </h3>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon iconType="arrowRight" isDisabled aria-label="Next" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          display="base"
+          iconType="arrowRight"
+          isDisabled
+          aria-label="Next"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          iconType="arrowRight"
+          display="fill"
+          disabled
+          aria-label="Next"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer size="m" />
+    <EuiTitle size="xxs">
+      <h3>
+        Size (<EuiCode>xs</EuiCode>, <EuiCode>s</EuiCode>, <EuiCode>m</EuiCode>)
+      </h3>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon display="base" iconType="arrowRight" aria-label="Next" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          display="base"
+          iconType="arrowRight"
+          size="s"
+          aria-label="Next"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          display="base"
+          iconType="arrowRight"
+          iconSize="l"
+          size="m"
+          aria-label="Next"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+    <EuiSpacer size="m" />
+    <EuiTitle size="xxs">
+      <h3>All icons types inherit button color</h3>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon iconType="heart" aria-label="Heart" color="accent" />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          iconType="dashboardApp"
+          aria-label="Dashboard"
+          color="success"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          display="base"
+          iconType="trash"
+          aria-label="Delete"
+          color="danger"
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon display="base" iconType="lensApp" aria-label="Lens" />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </>
+);
+```
 
 ## Buttons as links
 
@@ -593,117 +583,113 @@ it is not usually recommended. For more specific information on how to integrate
 If you are creating a purely text-based link, like the one in the previous paragraph,
 use [**EuiLink**](#/navigation/link) instead.
 
-<Demo>
-  ```tsx
-  import React, { Fragment } from 'react';
-  import {
-    EuiButton,
-    EuiButtonEmpty,
-    EuiButtonIcon,
-    EuiFlexGroup,
-    EuiFlexItem,
-    EuiSpacer,
+```tsx interactive
+import React, { Fragment } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
 } from '@elastic/eui';
 
-  export default () => (
-    <Fragment>
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButton href="#/navigation/button">Link to elastic.co</EuiButton>
-        </EuiFlexItem>
+export default () => (
+  <Fragment>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton href="#/navigation/button">Link to elastic.co</EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty href="#/navigation/button">
-            Link to elastic.co
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty href="#/navigation/button">
+          Link to elastic.co
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            href="#/navigation/button"
-            iconType="link"
-            aria-label="This is a link"
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          href="#/navigation/button"
+          iconType="link"
+          aria-label="This is a link"
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
 
-      <EuiSpacer size="s" />
+    <EuiSpacer size="s" />
 
-      <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-        <EuiFlexItem grow={false}>
-          <EuiButton href="#/navigation/button" isDisabled>
-            Disabled link
-          </EuiButton>
-        </EuiFlexItem>
+    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiButton href="#/navigation/button" isDisabled>
+          Disabled link
+        </EuiButton>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty href="#/navigation/button" isDisabled>
-            Disabled empty link
-          </EuiButtonEmpty>
-        </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButtonEmpty href="#/navigation/button" isDisabled>
+          Disabled empty link
+        </EuiButtonEmpty>
+      </EuiFlexItem>
 
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            href="#/navigation/button"
-            iconType="link"
-            aria-label="This is a link"
-            isDisabled
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </Fragment>
-  );
-  ```
-</Demo>
+      <EuiFlexItem grow={false}>
+        <EuiButtonIcon
+          href="#/navigation/button"
+          iconType="link"
+          aria-label="This is a link"
+          isDisabled
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </Fragment>
+);
+```
 
 ## Loading state
 
 Setting the `isLoading` prop to true will add the loading spinner or swap the existing icon for the loading spinner
 and set the button to disabled. It is good practice to also rename the button to "Loading…".
 
-<Demo>
-  ```tsx
-  import React from 'react';
-  import {
-    EuiButton,
-    EuiFlexGroup,
-    EuiFlexItem,
-    EuiButtonEmpty,
-  } from '@elastic/eui';
+```tsx interactive
+import React from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+} from '@elastic/eui';
 
-  export default () => (
-    <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
-      <EuiFlexItem grow={false}>
-        <EuiButton isLoading={true}>Loading&hellip;</EuiButton>
-      </EuiFlexItem>
+export default () => (
+  <EuiFlexGroup responsive={false} wrap gutterSize="s" alignItems="center">
+    <EuiFlexItem grow={false}>
+      <EuiButton isLoading={true}>Loading&hellip;</EuiButton>
+    </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiButton fill size="s" isLoading={true}>
-          Loading&hellip;
-        </EuiButton>
-      </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButton fill size="s" isLoading={true}>
+        Loading&hellip;
+      </EuiButton>
+    </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiButton fill isLoading={true} iconType="check" iconSide="right">
-          Loading&hellip;
-        </EuiButton>
-      </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButton fill isLoading={true} iconType="check" iconSide="right">
+        Loading&hellip;
+      </EuiButton>
+    </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty onClick={() => {}} isLoading>
-          Loading&hellip;
-        </EuiButtonEmpty>
-      </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty onClick={() => {}} isLoading>
+        Loading&hellip;
+      </EuiButtonEmpty>
+    </EuiFlexItem>
 
-      <EuiFlexItem grow={false}>
-        <EuiButtonEmpty size="xs" onClick={() => {}} isLoading iconSide="right">
-          Loading&hellip;
-        </EuiButtonEmpty>
-      </EuiFlexItem>
-  </EuiFlexGroup>
-  );
-  ```
-</Demo>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty size="xs" onClick={() => {}} isLoading iconSide="right">
+        Loading&hellip;
+      </EuiButtonEmpty>
+    </EuiFlexItem>
+</EuiFlexGroup>
+);
+```
 
 ## Split buttons
 
@@ -711,80 +697,78 @@ EUI [does not support](https://github.com/elastic/eui/issues/4171) split buttons
 we recommend using separate buttons for the main and overflow actions. You can achieve this by simply using
 the `display` and `size` props **EuiButtonIcon** to match that of the primary action button.
 
-<Demo isSourceOpen={false}>
-  ```tsx
-  import React, { useState } from 'react';
-  import {
-    EuiButton,
-    EuiButtonIcon,
-    EuiFlexGroup,
-    EuiFlexItem,
-    EuiContextMenuPanel,
-    EuiContextMenuItem,
-    EuiPopover,
-    useGeneratedHtmlId,
-  } from '@elastic/eui';
+```tsx interactive
+import React, { useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiContextMenuPanel,
+  EuiContextMenuItem,
+  EuiPopover,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 
-  export default () => {
-    const [isPopoverOpen, setPopover] = useState(false);
-    const splitButtonPopoverId = useGeneratedHtmlId({
-      prefix: 'splitButtonPopover',
-    });
+export default () => {
+  const [isPopoverOpen, setPopover] = useState(false);
+  const splitButtonPopoverId = useGeneratedHtmlId({
+    prefix: 'splitButtonPopover',
+  });
 
-    const onButtonClick = () => {
-      setPopover(!isPopoverOpen);
-    };
-
-    const closePopover = () => {
-      setPopover(false);
-    };
-
-    const items = [
-      <EuiContextMenuItem key="copy" icon="copy" onClick={closePopover}>
-        Copy
-      </EuiContextMenuItem>,
-      <EuiContextMenuItem key="edit" icon="pencil" onClick={closePopover}>
-        Edit
-      </EuiContextMenuItem>,
-      <EuiContextMenuItem key="share" icon="share" onClick={closePopover}>
-        Share
-      </EuiContextMenuItem>,
-    ];
-
-    return (
-      <>
-        <EuiFlexGroup responsive={false} gutterSize="xs" alignItems="center">
-          <EuiFlexItem grow={false}>
-            <EuiButton size="s" iconType="calendar">
-              Last 15 min
-            </EuiButton>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              id={splitButtonPopoverId}
-              button={
-                <EuiButtonIcon
-                  display="base"
-                  size="s"
-                  iconType="boxesVertical"
-                  aria-label="More"
-                  onClick={onButtonClick}
-                />
-              }
-              isOpen={isPopoverOpen}
-              closePopover={closePopover}
-              panelPaddingSize="none"
-              anchorPosition="downLeft"
-            >
-              <EuiContextMenuPanel size="s" items={items} />
-            </EuiPopover>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </>
-    );
+  const onButtonClick = () => {
+    setPopover(!isPopoverOpen);
   };
-  ```
-</Demo>
+
+  const closePopover = () => {
+    setPopover(false);
+  };
+
+  const items = [
+    <EuiContextMenuItem key="copy" icon="copy" onClick={closePopover}>
+      Copy
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem key="edit" icon="pencil" onClick={closePopover}>
+      Edit
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem key="share" icon="share" onClick={closePopover}>
+      Share
+    </EuiContextMenuItem>,
+  ];
+
+  return (
+    <>
+      <EuiFlexGroup responsive={false} gutterSize="xs" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton size="s" iconType="calendar">
+            Last 15 min
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            id={splitButtonPopoverId}
+            button={
+              <EuiButtonIcon
+                display="base"
+                size="s"
+                iconType="boxesVertical"
+                aria-label="More"
+                onClick={onButtonClick}
+              />
+            }
+            isOpen={isPopoverOpen}
+            closePopover={closePopover}
+            panelPaddingSize="none"
+            anchorPosition="downLeft"
+          >
+            <EuiContextMenuPanel size="s" items={items} />
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};
+```
 
 ## Toggle buttons
 
@@ -795,38 +779,36 @@ Though there are two **exclusive** situations to consider.
 1.  If your button changes its readable **text**, via children or `aria-label`,
 then there is no additional accessibility concern.
 
-<Demo isSourceOpen={false}>
-  ```tsx
-  import React, { useState } from 'react';
-  import { EuiButton, EuiButtonIcon } from '@elastic/eui';
+```tsx interactive
+import React, { useState } from 'react';
+import { EuiButton, EuiButtonIcon } from '@elastic/eui';
 
-  export default () => {
-    const [toggle0On, setToggle0On] = useState(false);
-    const [toggle1On, setToggle1On] = useState(true);
+export default () => {
+  const [toggle0On, setToggle0On] = useState(false);
+  const [toggle1On, setToggle1On] = useState(true);
 
-    return (
-      <>
-        <EuiButton
-          onClick={() => {
-            setToggle0On((isOn) => !isOn);
-          }}
-        >
-          {toggle0On ? 'Hey there good lookin' : 'Toggle me'}
-        </EuiButton>
-        &emsp;
-        <EuiButtonIcon
-          title={toggle1On ? 'Play' : 'Pause'}
-          aria-label={toggle1On ? 'Play' : 'Pause'}
-          iconType={toggle1On ? 'play' : 'pause'}
-          onClick={() => {
-            setToggle1On((isOn) => !isOn);
-          }}
-        />
-      </>
-    );
-  };
-  ```
-</Demo>
+  return (
+    <>
+      <EuiButton
+        onClick={() => {
+          setToggle0On((isOn) => !isOn);
+        }}
+      >
+        {toggle0On ? 'Hey there good lookin' : 'Toggle me'}
+      </EuiButton>
+      &emsp;
+      <EuiButtonIcon
+        title={toggle1On ? 'Play' : 'Pause'}
+        aria-label={toggle1On ? 'Play' : 'Pause'}
+        iconType={toggle1On ? 'play' : 'pause'}
+        onClick={() => {
+          setToggle1On((isOn) => !isOn);
+        }}
+      />
+    </>
+  );
+};
+```
 
 2.  If your button only changes the **visual** appearance, you must add `aria-pressed` passing a boolean
 for the on and off states. All EUI button types provide a helper prop for this called `isSelected`.
@@ -837,45 +819,43 @@ Do not add `aria-pressed` or `isSelected` if you also change the readable text.
 
 :::
 
-<Demo isSourceOpen={false}>
-  ```tsx
-  import React, { useState } from 'react';
-  import { EuiButton, EuiButtonIcon } from '@elastic/eui';
+```tsx interactive
+import React, { useState } from 'react';
+import { EuiButton, EuiButtonIcon } from '@elastic/eui';
 
-  export default () => {
-    const [toggle2On, setToggle2On] = useState(true);
-    const [toggle3On, setToggle3On] = useState(false);
+export default () => {
+  const [toggle2On, setToggle2On] = useState(true);
+  const [toggle3On, setToggle3On] = useState(false);
 
-    return (
-      <>
-        <EuiButton
-          isSelected={toggle2On}
-          fill={toggle2On}
-          iconType={toggle2On ? 'starFilledSpace' : 'starPlusEmpty'}
-          onClick={() => {
-            setToggle2On((isOn) => !isOn);
-          }}
-        >
-          Toggle me
-        </EuiButton>
-        &emsp;
-        <EuiButtonIcon
-          display={toggle3On ? 'base' : 'empty'}
-          size="m"
-          aria-label="Autosave"
-          title="Autosave"
-          iconType="save"
-          aria-pressed={toggle3On}
-          color={toggle3On ? 'primary' : 'text'}
-          onClick={() => {
-            setToggle3On((isOn) => !isOn);
-          }}
-        />
-      </>
-    );
-  };
-  ```
-</Demo>
+  return (
+    <>
+      <EuiButton
+        isSelected={toggle2On}
+        fill={toggle2On}
+        iconType={toggle2On ? 'starFilledSpace' : 'starPlusEmpty'}
+        onClick={() => {
+          setToggle2On((isOn) => !isOn);
+        }}
+      >
+        Toggle me
+      </EuiButton>
+      &emsp;
+      <EuiButtonIcon
+        display={toggle3On ? 'base' : 'empty'}
+        size="m"
+        aria-label="Autosave"
+        title="Autosave"
+        iconType="save"
+        aria-pressed={toggle3On}
+        color={toggle3On ? 'primary' : 'text'}
+        onClick={() => {
+          setToggle3On((isOn) => !isOn);
+        }}
+      />
+    </>
+  );
+};
+```
 
 ## Button groups
 
@@ -889,245 +869,241 @@ This is only for accessibility, however, so it will be visibly hidden.
 
 :::
 
-<Demo isSourceOpen={false}>
-  ```tsx
-  import React, { useState, Fragment } from 'react';
-  import {
-    EuiButtonGroup,
-    EuiSpacer,
-    EuiTitle,
-    useGeneratedHtmlId,
-  } from '@elastic/eui';
+```tsx interactive
+import React, { useState, Fragment } from 'react';
+import {
+  EuiButtonGroup,
+  EuiSpacer,
+  EuiTitle,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 
-  export default () => {
-    const basicButtonGroupPrefix = useGeneratedHtmlId({
-      prefix: 'basicButtonGroup',
-    });
-    const multiSelectButtonGroupPrefix = useGeneratedHtmlId({
-      prefix: 'multiSelectButtonGroup',
-    });
-    const disabledButtonGroupPrefix = useGeneratedHtmlId({
-      prefix: 'disabledButtonGroup',
-    });
+export default () => {
+  const basicButtonGroupPrefix = useGeneratedHtmlId({
+    prefix: 'basicButtonGroup',
+  });
+  const multiSelectButtonGroupPrefix = useGeneratedHtmlId({
+    prefix: 'multiSelectButtonGroup',
+  });
+  const disabledButtonGroupPrefix = useGeneratedHtmlId({
+    prefix: 'disabledButtonGroup',
+  });
 
-    const toggleButtons = [
-      {
-        id: `${basicButtonGroupPrefix}__0`,
-        label: 'Option one',
-      },
-      {
-        id: `${basicButtonGroupPrefix}__1`,
-        label: 'Option two is selected by default',
-      },
-      {
-        id: `${basicButtonGroupPrefix}__2`,
-        label: 'Option three',
-      },
-    ];
+  const toggleButtons = [
+    {
+      id: `${basicButtonGroupPrefix}__0`,
+      label: 'Option one',
+    },
+    {
+      id: `${basicButtonGroupPrefix}__1`,
+      label: 'Option two is selected by default',
+    },
+    {
+      id: `${basicButtonGroupPrefix}__2`,
+      label: 'Option three',
+    },
+  ];
 
-    const toggleButtonsDisabled = [
-      {
-        id: `${disabledButtonGroupPrefix}__0`,
-        label: 'Option one',
-      },
-      {
-        id: `${disabledButtonGroupPrefix}__1`,
-        label: 'Option two is selected by default',
-      },
-      {
-        id: `${disabledButtonGroupPrefix}__2`,
-        label: 'Option three',
-      },
-    ];
+  const toggleButtonsDisabled = [
+    {
+      id: `${disabledButtonGroupPrefix}__0`,
+      label: 'Option one',
+    },
+    {
+      id: `${disabledButtonGroupPrefix}__1`,
+      label: 'Option two is selected by default',
+    },
+    {
+      id: `${disabledButtonGroupPrefix}__2`,
+      label: 'Option three',
+    },
+  ];
 
-    const toggleButtonsMulti = [
-      {
-        id: `${multiSelectButtonGroupPrefix}__0`,
-        label: 'Option 1',
-      },
-      {
-        id: `${multiSelectButtonGroupPrefix}__1`,
-        label: 'Option 2 is selected by default',
-      },
-      {
-        id: `${multiSelectButtonGroupPrefix}__2`,
-        label: 'Option 3',
-      },
-    ];
+  const toggleButtonsMulti = [
+    {
+      id: `${multiSelectButtonGroupPrefix}__0`,
+      label: 'Option 1',
+    },
+    {
+      id: `${multiSelectButtonGroupPrefix}__1`,
+      label: 'Option 2 is selected by default',
+    },
+    {
+      id: `${multiSelectButtonGroupPrefix}__2`,
+      label: 'Option 3',
+    },
+  ];
 
-    const [toggleIdSelected, setToggleIdSelected] = useState(
-      `${basicButtonGroupPrefix}__1`
-    );
-    const [toggleIdDisabled, setToggleIdDisabled] = useState(
-      `${disabledButtonGroupPrefix}__1`
-    );
-    const [toggleIdToSelectedMap, setToggleIdToSelectedMap] = useState({
-      [`${multiSelectButtonGroupPrefix}__1`]: true,
-    });
+  const [toggleIdSelected, setToggleIdSelected] = useState(
+    `${basicButtonGroupPrefix}__1`
+  );
+  const [toggleIdDisabled, setToggleIdDisabled] = useState(
+    `${disabledButtonGroupPrefix}__1`
+  );
+  const [toggleIdToSelectedMap, setToggleIdToSelectedMap] = useState({
+    [`${multiSelectButtonGroupPrefix}__1`]: true,
+  });
 
-    const onChange = (optionId) => {
-      setToggleIdSelected(optionId);
-    };
-
-    const onChangeDisabled = (optionId) => {
-      setToggleIdDisabled(optionId);
-    };
-
-    const onChangeMulti = (optionId) => {
-      const newToggleIdToSelectedMap = {
-        ...toggleIdToSelectedMap,
-        ...{
-          [optionId]: !toggleIdToSelectedMap[optionId],
-        },
-      };
-      setToggleIdToSelectedMap(newToggleIdToSelectedMap);
-    };
-
-    return (
-      <Fragment>
-        <EuiButtonGroup
-          legend="This is a basic group"
-          options={toggleButtons}
-          idSelected={toggleIdSelected}
-          onChange={(id) => onChange(id)}
-        />
-        <EuiSpacer size="m" />
-        <EuiTitle size="xxs">
-          <h3>Primary &amp; multi select</h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiButtonGroup
-          legend="This is a primary group"
-          options={toggleButtonsMulti}
-          idToSelectedMap={toggleIdToSelectedMap}
-          onChange={(id) => onChangeMulti(id)}
-          color="primary"
-          type="multi"
-        />
-        <EuiSpacer size="m" />
-        <EuiTitle size="xxs">
-          <h3>Disabled &amp; full width</h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiButtonGroup
-          legend="This is a disabled group"
-          options={toggleButtonsDisabled}
-          idSelected={toggleIdDisabled}
-          onChange={(id) => onChangeDisabled(id)}
-          buttonSize="m"
-          isDisabled
-          isFullWidth
-        />
-      </Fragment>
-    );
+  const onChange = (optionId) => {
+    setToggleIdSelected(optionId);
   };
-  ```
-</Demo>
+
+  const onChangeDisabled = (optionId) => {
+    setToggleIdDisabled(optionId);
+  };
+
+  const onChangeMulti = (optionId) => {
+    const newToggleIdToSelectedMap = {
+      ...toggleIdToSelectedMap,
+      ...{
+        [optionId]: !toggleIdToSelectedMap[optionId],
+      },
+    };
+    setToggleIdToSelectedMap(newToggleIdToSelectedMap);
+  };
+
+  return (
+    <Fragment>
+      <EuiButtonGroup
+        legend="This is a basic group"
+        options={toggleButtons}
+        idSelected={toggleIdSelected}
+        onChange={(id) => onChange(id)}
+      />
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>Primary &amp; multi select</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiButtonGroup
+        legend="This is a primary group"
+        options={toggleButtonsMulti}
+        idToSelectedMap={toggleIdToSelectedMap}
+        onChange={(id) => onChangeMulti(id)}
+        color="primary"
+        type="multi"
+      />
+      <EuiSpacer size="m" />
+      <EuiTitle size="xxs">
+        <h3>Disabled &amp; full width</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <EuiButtonGroup
+        legend="This is a disabled group"
+        options={toggleButtonsDisabled}
+        idSelected={toggleIdDisabled}
+        onChange={(id) => onChangeDisabled(id)}
+        buttonSize="m"
+        isDisabled
+        isFullWidth
+      />
+    </Fragment>
+  );
+};
+```
 
 ### Icon only button groups
 
 If you're just displaying a group of icons, add the prop `isIconOnly`.
 
-<Demo isSourceOpen={false}>
-  ```tsx
-  import React, { useState, Fragment } from 'react';
-  import { EuiButtonGroup, htmlIdGenerator } from '@elastic/eui';
+```tsx interactive
+import React, { useState, Fragment } from 'react';
+import { EuiButtonGroup, htmlIdGenerator } from '@elastic/eui';
 
-  const idPrefix3 = htmlIdGenerator()();
+const idPrefix3 = htmlIdGenerator()();
 
-  export default () => {
-    const toggleButtonsIcons = [
-      {
-        id: `${idPrefix3}0`,
-        label: 'Align left',
-        iconType: 'editorAlignLeft',
-      },
-      {
-        id: `${idPrefix3}1`,
-        label: 'Align center',
-        iconType: 'editorAlignCenter',
-      },
-      {
-        id: `${idPrefix3}2`,
-        label: 'Align right',
-        iconType: 'editorAlignRight',
-        isDisabled: true,
-      },
-    ];
+export default () => {
+  const toggleButtonsIcons = [
+    {
+      id: `${idPrefix3}0`,
+      label: 'Align left',
+      iconType: 'editorAlignLeft',
+    },
+    {
+      id: `${idPrefix3}1`,
+      label: 'Align center',
+      iconType: 'editorAlignCenter',
+    },
+    {
+      id: `${idPrefix3}2`,
+      label: 'Align right',
+      iconType: 'editorAlignRight',
+      isDisabled: true,
+    },
+  ];
 
-    const toggleButtonsIconsMulti = [
-      {
-        id: `${idPrefix3}3`,
-        label: 'Bold',
-        name: 'bold',
-        iconType: 'editorBold',
-      },
-      {
-        id: `${idPrefix3}4`,
-        label: 'Italic',
-        name: 'italic',
-        iconType: 'editorItalic',
-        isDisabled: true,
-      },
-      {
-        id: `${idPrefix3}5`,
-        label: 'Underline',
-        name: 'underline',
-        iconType: 'editorUnderline',
-      },
-      {
-        id: `${idPrefix3}6`,
-        label: 'Strikethrough',
-        name: 'strikethrough',
-        iconType: 'editorStrike',
-      },
-    ];
+  const toggleButtonsIconsMulti = [
+    {
+      id: `${idPrefix3}3`,
+      label: 'Bold',
+      name: 'bold',
+      iconType: 'editorBold',
+    },
+    {
+      id: `${idPrefix3}4`,
+      label: 'Italic',
+      name: 'italic',
+      iconType: 'editorItalic',
+      isDisabled: true,
+    },
+    {
+      id: `${idPrefix3}5`,
+      label: 'Underline',
+      name: 'underline',
+      iconType: 'editorUnderline',
+    },
+    {
+      id: `${idPrefix3}6`,
+      label: 'Strikethrough',
+      name: 'strikethrough',
+      iconType: 'editorStrike',
+    },
+  ];
 
-    const [toggleIconIdSelected, setToggleIconIdSelected] = useState(
-      `${idPrefix3}1`
-    );
-    const [toggleIconIdToSelectedMap, setToggleIconIdToSelectedMap] = useState(
-      {}
-    );
+  const [toggleIconIdSelected, setToggleIconIdSelected] = useState(
+    `${idPrefix3}1`
+  );
+  const [toggleIconIdToSelectedMap, setToggleIconIdToSelectedMap] = useState(
+    {}
+  );
 
-    const onChangeIcons = (optionId) => {
-      setToggleIconIdSelected(optionId);
-    };
-
-    const onChangeIconsMulti = (optionId) => {
-      const newToggleIconIdToSelectedMap = {
-        ...toggleIconIdToSelectedMap,
-        ...{
-          [optionId]: !toggleIconIdToSelectedMap[optionId],
-        },
-      };
-
-      setToggleIconIdToSelectedMap(newToggleIconIdToSelectedMap);
-    };
-
-    return (
-      <Fragment>
-        <EuiButtonGroup
-          legend="Text align"
-          options={toggleButtonsIcons}
-          idSelected={toggleIconIdSelected}
-          onChange={(id) => onChangeIcons(id)}
-          isIconOnly
-        />
-        &nbsp;&nbsp;
-        <EuiButtonGroup
-          legend="Text style"
-          options={toggleButtonsIconsMulti}
-          idToSelectedMap={toggleIconIdToSelectedMap}
-          onChange={(id) => onChangeIconsMulti(id)}
-          type="multi"
-          isIconOnly
-        />
-      </Fragment>
-    );
+  const onChangeIcons = (optionId) => {
+    setToggleIconIdSelected(optionId);
   };
-  ```
-</Demo>
+
+  const onChangeIconsMulti = (optionId) => {
+    const newToggleIconIdToSelectedMap = {
+      ...toggleIconIdToSelectedMap,
+      ...{
+        [optionId]: !toggleIconIdToSelectedMap[optionId],
+      },
+    };
+
+    setToggleIconIdToSelectedMap(newToggleIconIdToSelectedMap);
+  };
+
+  return (
+    <Fragment>
+      <EuiButtonGroup
+        legend="Text align"
+        options={toggleButtonsIcons}
+        idSelected={toggleIconIdSelected}
+        onChange={(id) => onChangeIcons(id)}
+        isIconOnly
+      />
+      &nbsp;&nbsp;
+      <EuiButtonGroup
+        legend="Text style"
+        options={toggleButtonsIconsMulti}
+        idToSelectedMap={toggleIconIdToSelectedMap}
+        onChange={(id) => onChangeIconsMulti(id)}
+        type="multi"
+        isIconOnly
+      />
+    </Fragment>
+  );
+};
+```
 
 ### Button groups in forms
 
@@ -1137,112 +1113,110 @@ Compressed groups should always be `fullWidth` so they line up nicely in their s
 For a more detailed example of how to integrate with forms,
 see the ["Complex example"](#/forms/compressed-forms#complex-example) on the compressed forms page.
 
-<Demo isSourceOpen={false}>
-  ```tsx
-  import React, { useState } from 'react';
-  import {
-    EuiButtonGroup,
-    EuiSpacer,
-    EuiPanel,
-    useGeneratedHtmlId,
-  } from '@elastic/eui';
+```tsx interactive
+import React, { useState } from 'react';
+import {
+  EuiButtonGroup,
+  EuiSpacer,
+  EuiPanel,
+  useGeneratedHtmlId,
+} from '@elastic/eui';
 
-  export default () => {
-    const compressedToggleButtonGroupPrefix = useGeneratedHtmlId({
-      prefix: 'compressedToggleButtonGroup',
-    });
-    const multiSelectButtonGroupPrefix = useGeneratedHtmlId({
-      prefix: 'multiSelectButtonGroup',
-    });
+export default () => {
+  const compressedToggleButtonGroupPrefix = useGeneratedHtmlId({
+    prefix: 'compressedToggleButtonGroup',
+  });
+  const multiSelectButtonGroupPrefix = useGeneratedHtmlId({
+    prefix: 'multiSelectButtonGroup',
+  });
 
-    const toggleButtonsCompressed = [
-      {
-        id: `${compressedToggleButtonGroupPrefix}__0`,
-        label: 'fine',
-      },
-      {
-        id: `${compressedToggleButtonGroupPrefix}__1`,
-        label: 'rough',
-      },
-      {
-        id: `${compressedToggleButtonGroupPrefix}__2`,
-        label: 'coarse',
-      },
-    ];
+  const toggleButtonsCompressed = [
+    {
+      id: `${compressedToggleButtonGroupPrefix}__0`,
+      label: 'fine',
+    },
+    {
+      id: `${compressedToggleButtonGroupPrefix}__1`,
+      label: 'rough',
+    },
+    {
+      id: `${compressedToggleButtonGroupPrefix}__2`,
+      label: 'coarse',
+    },
+  ];
 
-    const toggleButtonsIconsMulti = [
-      {
-        id: `${multiSelectButtonGroupPrefix}__0`,
-        label: 'Bold',
-        name: 'bold',
-        iconType: 'editorBold',
-      },
-      {
-        id: `${multiSelectButtonGroupPrefix}__1`,
-        label: 'Italic',
-        name: 'italic',
-        iconType: 'editorItalic',
-        isDisabled: true,
-      },
-      {
-        id: `${multiSelectButtonGroupPrefix}__2`,
-        label: 'Underline',
-        name: 'underline',
-        iconType: 'editorUnderline',
-      },
-      {
-        id: `${multiSelectButtonGroupPrefix}__3`,
-        label: 'Strikethrough',
-        name: 'strikethrough',
-        iconType: 'editorStrike',
-      },
-    ];
+  const toggleButtonsIconsMulti = [
+    {
+      id: `${multiSelectButtonGroupPrefix}__0`,
+      label: 'Bold',
+      name: 'bold',
+      iconType: 'editorBold',
+    },
+    {
+      id: `${multiSelectButtonGroupPrefix}__1`,
+      label: 'Italic',
+      name: 'italic',
+      iconType: 'editorItalic',
+      isDisabled: true,
+    },
+    {
+      id: `${multiSelectButtonGroupPrefix}__2`,
+      label: 'Underline',
+      name: 'underline',
+      iconType: 'editorUnderline',
+    },
+    {
+      id: `${multiSelectButtonGroupPrefix}__3`,
+      label: 'Strikethrough',
+      name: 'strikethrough',
+      iconType: 'editorStrike',
+    },
+  ];
 
-    const [toggleIconIdToSelectedMapIcon, setToggleIconIdToSelectedMapIcon] =
-      useState({});
-    const [toggleCompressedIdSelected, setToggleCompressedIdSelected] = useState(
-      `${compressedToggleButtonGroupPrefix}__1`
-    );
+  const [toggleIconIdToSelectedMapIcon, setToggleIconIdToSelectedMapIcon] =
+    useState({});
+  const [toggleCompressedIdSelected, setToggleCompressedIdSelected] = useState(
+    `${compressedToggleButtonGroupPrefix}__1`
+  );
 
-    const onChangeCompressed = (optionId) => {
-      setToggleCompressedIdSelected(optionId);
-    };
-
-    const onChangeIconsMultiIcons = (optionId) => {
-      const newToggleIconIdToSelectedMapIcon = {
-        ...toggleIconIdToSelectedMapIcon,
-        ...{
-          [optionId]: !toggleIconIdToSelectedMapIcon[optionId],
-        },
-      };
-
-      setToggleIconIdToSelectedMapIcon(newToggleIconIdToSelectedMapIcon);
-    };
-
-    return (
-      <EuiPanel hasBorder style={{ maxWidth: 300 }}>
-        <EuiButtonGroup
-          name="coarsness"
-          legend="This is a basic group"
-          options={toggleButtonsCompressed}
-          idSelected={toggleCompressedIdSelected}
-          onChange={(id) => onChangeCompressed(id)}
-          buttonSize="compressed"
-          isFullWidth
-        />
-        <EuiSpacer />
-        <EuiButtonGroup
-          legend="Text style"
-          className="eui-displayInlineBlock"
-          options={toggleButtonsIconsMulti}
-          idToSelectedMap={toggleIconIdToSelectedMapIcon}
-          onChange={(id) => onChangeIconsMultiIcons(id)}
-          type="multi"
-          buttonSize="compressed"
-          isIconOnly
-        />
-      </EuiPanel>
-    );
+  const onChangeCompressed = (optionId) => {
+    setToggleCompressedIdSelected(optionId);
   };
-  ```
-</Demo>
+
+  const onChangeIconsMultiIcons = (optionId) => {
+    const newToggleIconIdToSelectedMapIcon = {
+      ...toggleIconIdToSelectedMapIcon,
+      ...{
+        [optionId]: !toggleIconIdToSelectedMapIcon[optionId],
+      },
+    };
+
+    setToggleIconIdToSelectedMapIcon(newToggleIconIdToSelectedMapIcon);
+  };
+
+  return (
+    <EuiPanel hasBorder style={{ maxWidth: 300 }}>
+      <EuiButtonGroup
+        name="coarsness"
+        legend="This is a basic group"
+        options={toggleButtonsCompressed}
+        idSelected={toggleCompressedIdSelected}
+        onChange={(id) => onChangeCompressed(id)}
+        buttonSize="compressed"
+        isFullWidth
+      />
+      <EuiSpacer />
+      <EuiButtonGroup
+        legend="Text style"
+        className="eui-displayInlineBlock"
+        options={toggleButtonsIconsMulti}
+        idToSelectedMap={toggleIconIdToSelectedMapIcon}
+        onChange={(id) => onChangeIconsMultiIcons(id)}
+        type="multi"
+        buttonSize="compressed"
+        isIconOnly
+      />
+    </EuiPanel>
+  );
+};
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -5703,7 +5703,7 @@ __metadata:
     moment: "npm:^2.30.1"
     prism-react-renderer: "npm:^2.3.1"
     react-is: "npm:^18.3.1"
-    react-live: "npm:^4.1.7"
+    react-live: "patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch"
     typescript: "npm:~5.4.5"
   peerDependencies:
     react: ^18.0.0
@@ -31278,7 +31278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-live@npm:^4.1.7":
+"react-live@npm:4.1.7":
   version: 4.1.7
   resolution: "react-live@npm:4.1.7"
   dependencies:
@@ -31289,6 +31289,20 @@ __metadata:
     react: ">=18.0.0"
     react-dom: ">=18.0.0"
   checksum: 10c0/728a51cb0b92774076e4592f9b3cbc2af4afac1da549dbb55723728324bdc1968d3f7b268b5dd92929dcc9d3aa1fd1265f7e912b5ee6fd4fe9b5b77898b50237
+  languageName: node
+  linkType: hard
+
+"react-live@patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch":
+  version: 4.1.7
+  resolution: "react-live@patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch::version=4.1.7&hash=33c21c"
+  dependencies:
+    prism-react-renderer: "npm:^2.0.6"
+    sucrase: "npm:^3.31.0"
+    use-editable: "npm:^2.3.3"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
+  checksum: 10c0/f26c208a9d2e885a1c0a0a3eae8126ac6e772e37507a53d36f802bc993449f8765dff621d51cfba681c68de4da9aad5f01c2fb1c2df716d27c96ccd94cacf188
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/7899.

This PR adds support for creating interactive component examples without the need to wrap code blocks with `<Demo>` in MDX. Now we can define simple interactive examples like this (ignore `//` at the beginning of each line):

```markdown
// ```tsx interactive
// <EuiButton>Button</EuiButton>
// ```
```

An added benefit to that is greatly increased Github preview readability

## QA

- [ ] Open EUI+ button docs and confirm the interactive examples render correctly