### PR TITLE
[Docs] Fix EuiMarkdownEditor plugin example polluting other examples

### DIFF
--- a/packages/eui/src-docs/src/views/markdown_editor/markdown_link_validation.js
+++ b/packages/eui/src-docs/src/views/markdown_editor/markdown_link_validation.js
@@ -6,15 +6,18 @@ import {
   EuiMarkdownFormat,
 } from '../../../../src/components';
 
-// find the validation plugin and configure it to only allow https: and mailto: links
-const parsingPlugins = getDefaultEuiMarkdownParsingPlugins();
-parsingPlugins.find(([plugin, config]) => {
-  const isValidationPlugin = plugin === euiMarkdownLinkValidator;
-  if (isValidationPlugin) {
-    config.allowProtocols = ['https:', 'mailto:'];
-  }
-  return isValidationPlugin;
-});
+const parsingPlugins = [
+  // Exclude the default validation plugin, we're configuring our own that excludes `http` as a protocol
+  ...getDefaultEuiMarkdownParsingPlugins({
+    exclude: ['linkValidator'],
+  }),
+  [
+    euiMarkdownLinkValidator,
+    {
+      allowProtocols: ['https:', 'mailto:'],
+    },
+  ],
+];
 
 const markdown = `**Standalone links**
 https://example.com

--- a/packages/eui/src-docs/src/views/markdown_editor/markdown_plugin_example.js
+++ b/packages/eui/src-docs/src/views/markdown_editor/markdown_plugin_example.js
@@ -327,28 +327,24 @@ export const MarkdownPluginExample = {
         </Fragment>
       ),
       snippet: [
-        `// change what link protocols are allowed
-const parsingPlugins = getDefaultEuiMarkdownParsingPlugins();
-parsingPlugins.find(([plugin, config]) => {
-  const isValidationPlugin = plugin === euiMarkdownLinkValidator;
-  if (isValidationPlugin) {
-    config.allowProtocols = ['https:', 'mailto:'];
-  }
-  return isValidationPlugin;
-});`,
-        `// filter out the link validation plugin
-const parsingPlugins = getDefaultEuiMarkdownParsingPlugins().filter(([plugin]) => {
-  return plugin !== euiMarkdownLinkValidator;
-});`,
-        `// disable relative urls
-const parsingPlugins = getDefaultEuiMarkdownParsingPlugins();
-parsingPlugins.find(([plugin, config]) => {
-  const isValidationPlugin = plugin === euiMarkdownLinkValidator;
-  if (isValidationPlugin) {
-    config.allowRelative = false;
-  }
-  return isValidationPlugin;
-});`,
+        `// customize what link protocols are allowed
+const parsingPlugins = [
+  ...getDefaultEuiMarkdownParsingPlugins({
+    // Exclude the default validation plugin - we're configuring our own
+    exclude: ['linkValidator'],
+  }),
+  [
+    euiMarkdownLinkValidator,
+    {
+      // Customize what link protocols are allowed
+      allowProtocols: ['https:', 'mailto:'],
+    },
+  ]
+];
+
+// Pass the customized parsing plugins to your markdown component
+<EuiMarkdownFormat parsingPlugins={parsingPlugins} />
+`,
       ],
       demo: <LinkValidation />,
     },


### PR DESCRIPTION
## Summary

The previous example code was polluting the default link validator plugin, leading to https://eui.elastic.co/v94.2.0/#/editors-syntax/markdown-format#link-validation-for-security incorrectly not parsing `http` links. This PR fixes the example to use the new `exclude` configs we added in #7676, and is overall a significantly cleaner approach in any case.

## QA

- [ ] Confirm https://eui.elastic.co/pr_7929/#/editors-syntax/markdown-plugins#link-validation-security still does not have working `http` links
- [ ] Confirm https://eui.elastic.co/pr_7929/#/editors-syntax/markdown-format#link-validation-for-security has all working links, including `http` ones

### General checklist

N/A, docs only change