### PR TITLE
[EUI+] Implement welcome banner

### DIFF
--- a/packages/website/src/components/homepage/banner/index.tsx
+++ b/packages/website/src/components/homepage/banner/index.tsx
@@ -1,14 +1,28 @@
-import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { css } from '@emotion/react';
+import {
+  EuiCallOut,
+  EuiLink,
+  EuiText,
+  useEuiMemoizedStyles,
+  UseEuiTheme,
+} from '@elastic/eui';
 import { useState } from 'react';
 
 const STORAGE_KEY = 'docs_page_welcome_notification';
 const STORAGE_VALUE_DISMISSED = 'dismissed';
 
+const getStyles = ({ euiTheme }: UseEuiTheme) => ({
+  banner: css`
+    .euiLink {
+      color: ${euiTheme.colors.warningText};
+      text-decoration: underline;
+    }
+  `,
+});
+
 export const HomepageBanner = () => {
   const [isVisible, setVisible] = useState(() => {
     const storageItem = localStorage.getItem(STORAGE_KEY);
-
-    console.log(storageItem);
 
     if (storageItem && storageItem === STORAGE_VALUE_DISMISSED) {
       return false;
@@ -16,6 +30,8 @@ export const HomepageBanner = () => {
 
     return true;
   });
+
+  const styles = useEuiMemoizedStyles(getStyles);
 
   if (!isVisible) return null;
 
@@ -25,21 +41,21 @@ export const HomepageBanner = () => {
   };
 
   return (
-    <EuiCallOut
-      iconType="cheer"
-      title="Welcome to the new EUI docs page!"
-      onDismiss={handleOnDismiss}
-    >
-      If you encounter any issues you can report them{' '}
-      <EuiLink
-        href="https://github.com/elastic/eui/issues"
-        title="EUI issues"
-        target="_blank"
-      >
-        here
-      </EuiLink>{' '}
-      or if you would still like to view the old docs page you can do so{' '}
-      <EuiLink href="https://eui.elastic.co/v95.3.0/">here</EuiLink>.
+    <EuiCallOut color="warning" onDismiss={handleOnDismiss} css={styles.banner}>
+      <EuiText color="warning" size="s">
+        This is a new EUI documentation, and we are still refining it. If you
+        noticed any problems, please{' '}
+        <EuiLink
+          href="https://github.com/elastic/eui/issues"
+          title="EUI issues"
+          target="_blank"
+        >
+          submit an issue here
+        </EuiLink>
+        {'. '}
+        If you would like to view the old docs page you can still do so{' '}
+        <EuiLink href="https://eui.elastic.co/v95.3.0/">here</EuiLink>.
+      </EuiText>
     </EuiCallOut>
   );
 };

--- a/packages/website/src/components/homepage/banner/index.tsx
+++ b/packages/website/src/components/homepage/banner/index.tsx
@@ -43,18 +43,16 @@ export const HomepageBanner = () => {
   return (
     <EuiCallOut color="warning" onDismiss={handleOnDismiss} css={styles.banner}>
       <EuiText color="warning" size="s">
-        This is a new EUI documentation, and we are still refining it. If you
-        noticed any problems, please{' '}
+        Welcome to the new EUI documentation. Enjoy the fresh updates! We are
+        still refining the site, so please{' '}
         <EuiLink
-          href="https://github.com/elastic/eui/issues"
+          href="https://github.com/elastic/eui/issues/new/choose"
           title="EUI issues"
           target="_blank"
         >
-          submit an issue here
+          let us know if you find any issues
         </EuiLink>
         {'. '}
-        If you would like to view the old docs page you can still do so{' '}
-        <EuiLink href="https://eui.elastic.co/v95.3.0/">here</EuiLink>.
       </EuiText>
     </EuiCallOut>
   );

--- a/packages/website/src/components/homepage/banner/index.tsx
+++ b/packages/website/src/components/homepage/banner/index.tsx
@@ -1,0 +1,45 @@
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { useState } from 'react';
+
+const STORAGE_KEY = 'docs_page_welcome_notification';
+const STORAGE_VALUE_DISMISSED = 'dismissed';
+
+export const HomepageBanner = () => {
+  const [isVisible, setVisible] = useState(() => {
+    const storageItem = localStorage.getItem(STORAGE_KEY);
+
+    console.log(storageItem);
+
+    if (storageItem && storageItem === STORAGE_VALUE_DISMISSED) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (!isVisible) return null;
+
+  const handleOnDismiss = () => {
+    localStorage.setItem(STORAGE_KEY, STORAGE_VALUE_DISMISSED);
+    setVisible(false);
+  };
+
+  return (
+    <EuiCallOut
+      iconType="cheer"
+      title="Welcome to the new EUI docs page!"
+      onDismiss={handleOnDismiss}
+    >
+      If you encounter any issues you can report them{' '}
+      <EuiLink
+        href="https://github.com/elastic/eui/issues"
+        title="EUI issues"
+        target="_blank"
+      >
+        here
+      </EuiLink>{' '}
+      or if you would still like to view the old docs page you can do so{' '}
+      <EuiLink href="https://eui.elastic.co/v95.3.0/">here</EuiLink>.
+    </EuiCallOut>
+  );
+};

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -14,6 +14,7 @@ import { useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
 import { HomepageHeader } from '../components/homepage/header';
 import { HomepageUsers } from '../components/homepage/users';
 import { HomepageHighlights } from '../components/homepage/highlights';
+import { HomepageBanner } from '../components/homepage/banner';
 
 const getStyles = ({ euiTheme }: UseEuiTheme) => ({
   main: css`
@@ -52,14 +53,17 @@ export default function Home(): JSX.Element {
   const styles = useEuiMemoizedStyles(getStyles);
 
   return (
-    <Layout title={siteConfig.title} description={siteConfig.tagline}>
-      <main css={styles.main}>
-        <HomepageHeader />
+    <>
+      <HomepageBanner />
+      <Layout title={siteConfig.title} description={siteConfig.tagline}>
+        <main css={styles.main}>
+          <HomepageHeader />
 
-        <HomepageHighlights />
+          <HomepageHighlights />
 
-        <HomepageUsers />
-      </main>
-    </Layout>
+          <HomepageUsers />
+        </main>
+      </Layout>
+    </>
   );
 }

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -8,6 +8,7 @@
 
 import { css } from '@emotion/react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import Layout from '@theme/Layout';
 import { useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
 
@@ -50,11 +51,12 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => ({
 
 export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
+  const isBrowser = useIsBrowser();
   const styles = useEuiMemoizedStyles(getStyles);
 
   return (
     <>
-      <HomepageBanner />
+      {isBrowser && <HomepageBanner />}
       <Layout title={siteConfig.title} description={siteConfig.tagline}>
         <main css={styles.main}>
           <HomepageHeader />


### PR DESCRIPTION
## Summary

This PR implements a welcome banner to highlight the new docs page.

>[!IMPORTANT]
> This PR is currently still a DRAFT as the design and content of the banner needs alignment.

![Screenshot 2024-07-31 at 13 32 02](https://github.com/user-attachments/assets/88c31450-f4c3-456c-b574-121b095a9bb9)

![Screenshot 2024-07-31 at 13 32 05](https://github.com/user-attachments/assets/b4cfc551-92c9-4a8a-ba6e-8cbd1000f1fa)


## QA

- [ ] review the banner in the [new docs page](https://eui.elastic.co/pr_7931/new-docs/)