### PR TITLE
feat(website): setup google tag manager

### DIFF
--- a/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
@@ -28,8 +28,10 @@ yarn
 
 echo "+++ :yarn: Building @elastic/eui-website and its local dependencies"
 
+analytics_vault="secret/ci/elastic-eui/analytics"
 # Pass base url to docusaurus. It must have a leading and trailing slash included.
 export DOCS_BASE_URL="/${bucket_directory}"
+export DOCS_GOOGLE_TAG_MANAGER_ID="$(retry 5 vault read -field=google_tag_manager_id "${analytics_vault}")"
 
 yarn workspaces foreach -Rpt --from @elastic/eui-website run build
 

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -11,6 +11,7 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const baseUrl = process.env.DOCS_BASE_URL || '/';
+const googleTagManagerId = process.env.DOCS_GOOGLE_TAG_MANAGER_ID || undefined;
 
 const config: Config = {
   title: 'Elastic UI Framework',
@@ -49,6 +50,9 @@ const config: Config = {
           showReadingTime: true,
           editUrl: 'https://github.com/elastic/eui/tree/main/website/',
         },
+        googleTagManager: {
+          containerId: googleTagManagerId,
+        }
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui-private/issues/108

This PR adds Google Tag Manager integration to the new documentation site.

# QA

- [x] Go to the [PR preview](https://eui.elastic.co/pr_7933/new-docs/), open DevTools and ensure the GTM script is fetched