### PR TITLE
[EuiEmptyPrompt] Fix styles to work correctly with custom larger breakpoints

### DIFF
--- a/packages/eui/changelogs/upcoming/7935.md
+++ b/packages/eui/changelogs/upcoming/7935.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiEmptyPrompt` to correctly collapse and expand responsively when used with custom breakpoints larger than the default `xl` breakpoint

--- a/packages/eui/src/components/empty_prompt/empty_prompt.stories.tsx
+++ b/packages/eui/src/components/empty_prompt/empty_prompt.stories.tsx
@@ -17,6 +17,7 @@ import { EuiImage } from '../image';
 import { EuiPageTemplate } from '../page_template';
 
 import { EuiEmptyPrompt, EuiEmptyPromptProps } from './empty_prompt';
+import { EuiThemeProvider } from '../../services';
 
 const meta: Meta<EuiEmptyPromptProps> = {
   title: 'Display/EuiEmptyPrompt',
@@ -61,9 +62,11 @@ export const Playground: Story = {
 
 export const PageTemplate: Story = {
   render: ({ ...args }) => (
-    <EuiPageTemplate minHeight="0">
-      <EuiPageTemplate.EmptyPrompt {...args} />
-    </EuiPageTemplate>
+    <EuiThemeProvider modify={{ breakpoint: { xxl: 2000 } }}>
+      <EuiPageTemplate minHeight="0">
+        <EuiPageTemplate.EmptyPrompt {...args} />
+      </EuiPageTemplate>
+    </EuiThemeProvider>
   ),
   args: {
     title: <h2>Create your first visualization</h2>,

--- a/packages/eui/src/components/empty_prompt/empty_prompt.styles.ts
+++ b/packages/eui/src/components/empty_prompt/empty_prompt.styles.ts
@@ -8,7 +8,7 @@
 
 import { css } from '@emotion/react';
 import {
-  euiBreakpoint,
+  euiMinBreakpoint,
   euiPaddingSize,
   euiBorderColor,
   logicalCSS,
@@ -45,14 +45,14 @@ export const euiEmptyPromptStyles = (euiThemeContext: UseEuiTheme) => {
       text-align: center;
       margin: auto;
 
-      ${euiBreakpoint(euiThemeContext, ['l', 'xl'])} {
+      ${euiMinBreakpoint(euiThemeContext, 'l')} {
         /* the width becomes as wide as necessary to contain all of its contents */
         ${logicalCSS('max-width', 'max-content')}
       }
     `,
     vertical: css``,
     horizontal: css`
-      ${euiBreakpoint(euiThemeContext, ['l', 'xl'])} {
+      ${euiMinBreakpoint(euiThemeContext, 'l')} {
         justify-content: flex-start;
         text-align: start;
       }
@@ -68,7 +68,7 @@ export const euiEmptyPromptStyles = (euiThemeContext: UseEuiTheme) => {
       horizontal: css`
         align-items: center;
 
-        ${euiBreakpoint(euiThemeContext, ['l', 'xl'])} {
+        ${euiMinBreakpoint(euiThemeContext, 'l')} {
           flex-direction: row-reverse;
         }
       `,
@@ -83,7 +83,7 @@ export const euiEmptyPromptStyles = (euiThemeContext: UseEuiTheme) => {
         margin: auto;
       `,
       horizontal: css`
-        ${euiBreakpoint(euiThemeContext, ['l', 'xl'])} {
+        ${euiMinBreakpoint(euiThemeContext, 'l')} {
           padding-block: ${euiTheme.size.l};
           padding-inline: 0;
         }
@@ -105,7 +105,7 @@ export const euiEmptyPromptStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('margin-bottom', euiTheme.size.base)}
       `,
       horizontal: css`
-        ${euiBreakpoint(euiThemeContext, ['l', 'xl'])} {
+        ${euiMinBreakpoint(euiThemeContext, 'l')} {
           ${logicalCSS('min-width', '40%')}
           ${logicalCSS('max-width', '50%')}
 
@@ -123,7 +123,7 @@ export const euiEmptyPromptStyles = (euiThemeContext: UseEuiTheme) => {
       euiEmptyPrompt__actions: css``,
       vertical: css``,
       horizontal: css`
-        ${euiBreakpoint(euiThemeContext, ['l', 'xl'])} {
+        ${euiMinBreakpoint(euiThemeContext, 'l')} {
           justify-content: flex-start;
         }
       `,


### PR DESCRIPTION
## Summary

@kpatticha reported an issue in APM  where EuiEmptyPrompt stops displaying with desktop/larger styles. This is because APM uses a custom `xxl: 1600` breakpoint, and EuiEmptyPrompt's styles previously used an `euiBreakpoint('l', 'xl')` which was not accounting for larger breakpoints.

Switching the component to `euiMinBreakpoint` resolves the issue for consumers with custom larger breakpoints.

## QA

- Go to https://eui.elastic.co/pr_7935/storybook/?path=/story/display-euiemptyprompt--page-template
- Inspect `.euiEmptyPrompt__main` in devtools
- [x] Confirm that the `flex-direction: row-reverse` CSS is correctly wrapped in `@media only screen and (min-width: 992px)`, and not a min+max width media query

### General checklist

- [ ] Revert [REVERT ME] commit
- Browser QA
    - [x] Checked in **mobile**
    ~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
    ~- [ ] Checked in both **light and dark** modes~
- Docs site QA - N/A
- Code quality checklist - N/A, CSS only change
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A