### PR TITLE
[Eui+] Fix docusaurus containerId for local environment

### DIFF
--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -50,9 +50,9 @@ const config: Config = {
           showReadingTime: true,
           editUrl: 'https://github.com/elastic/eui/tree/main/website/',
         },
-        googleTagManager: {
+        googleTagManager: googleTagManagerId && {
           containerId: googleTagManagerId,
-        }
+        },
       } satisfies Preset.Options,
     ],
   ],
@@ -103,6 +103,12 @@ const config: Config = {
           label: 'GitHub',
           position: 'right',
           component: 'github',
+        },
+        {
+          href: 'https://www.figma.com/community/file/964536385682658129',
+          label: 'Figma',
+          position: 'right',
+          component: 'figma',
         },
       ],
     },


### PR DESCRIPTION
## Summary

This PR ensures that Docusaurus can run locally as expected when no GTM `containerId` is available. This is a small update to the changes done in [this PR](https://github.com/elastic/eui/pull/7933).

This affects both dev environment and production build BUT **locally** only.
There is no issue with the production build in CI as the `containerId` is provided in the pipeline from the vault.

## QA

- [ ] checkout the PR and verify the website can be run locally without error
  - `gh pr checkout 7938`
  - go to `/packages/website`
  - install all local dependencies `yarn workspaces foreach -Rpti --from @elastic/eui-website run build` 
  - start the local dev environment `yarn start`
  - build production locally and run it: `yarn build && yarn serve`