### PR TITLE
[EuiFieldSearch] update clear button `aria-label`

### DIFF
--- a/packages/eui/changelogs/upcoming/7970.md
+++ b/packages/eui/changelogs/upcoming/7970.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Updated the `aria-label` attribute for the `EuiFieldSearch` clear button

--- a/packages/eui/src/components/form/field_search/field_search.tsx
+++ b/packages/eui/src/components/form/field_search/field_search.tsx
@@ -8,6 +8,7 @@
 
 import React, { Component, InputHTMLAttributes, KeyboardEvent } from 'react';
 import classNames from 'classnames';
+import { EuiI18n } from '../../i18n';
 
 import { Browser } from '../../../services/browser';
 import { CommonProps } from '../../common';
@@ -256,36 +257,47 @@ export class EuiFieldSearchClass extends Component<
     ];
 
     return (
-      <EuiFormControlLayout
-        icon="search"
-        fullWidth={fullWidth}
-        isLoading={isLoading}
-        isInvalid={isInvalid}
-        isDisabled={disabled}
-        clear={
-          isClearable
-            ? { onClick: this.onClear, 'data-test-subj': 'clearSearchButton' }
-            : undefined
-        }
-        compressed={compressed}
-        append={append}
-        prepend={prepend}
+      <EuiI18n
+        token="euiFieldSearch.clearSearchButtonLabel"
+        default="Clear search input"
       >
-        <EuiValidatableControl isInvalid={isInvalid}>
-          <input
-            type="search"
-            id={id}
-            name={name}
-            placeholder={placeholder}
-            className={classes}
-            css={cssStyles}
-            onKeyUp={(e) => this.onKeyUp(e, incremental, onSearch)}
-            disabled={disabled}
-            ref={this.setRef}
-            {...rest}
-          />
-        </EuiValidatableControl>
-      </EuiFormControlLayout>
+        {(clearSearchButtonLabel: string) => (
+          <EuiFormControlLayout
+            icon="search"
+            fullWidth={fullWidth}
+            isLoading={isLoading}
+            isInvalid={isInvalid}
+            isDisabled={disabled}
+            clear={
+              isClearable
+                ? {
+                    onClick: this.onClear,
+                    'aria-label': clearSearchButtonLabel,
+                    'data-test-subj': 'clearSearchButton',
+                  }
+                : undefined
+            }
+            compressed={compressed}
+            append={append}
+            prepend={prepend}
+          >
+            <EuiValidatableControl isInvalid={isInvalid}>
+              <input
+                type="search"
+                id={id}
+                name={name}
+                placeholder={placeholder}
+                className={classes}
+                css={cssStyles}
+                onKeyUp={(e) => this.onKeyUp(e, incremental, onSearch)}
+                disabled={disabled}
+                ref={this.setRef}
+                {...rest}
+              />
+            </EuiValidatableControl>
+          </EuiFormControlLayout>
+        )}
+      </EuiI18n>
     );
   }
 }

--- a/packages/eui/src/components/form/field_search/field_search.tsx
+++ b/packages/eui/src/components/form/field_search/field_search.tsx
@@ -8,15 +8,15 @@
 
 import React, { Component, InputHTMLAttributes, KeyboardEvent } from 'react';
 import classNames from 'classnames';
-import { EuiI18n } from '../../i18n';
 
-import { Browser } from '../../../services/browser';
-import { CommonProps } from '../../common';
 import {
   keys,
   withEuiStylesMemoizer,
   WithEuiStylesMemoizerProps,
 } from '../../../services';
+import { Browser } from '../../../services/browser';
+import { CommonProps } from '../../common';
+import { EuiI18n } from '../../i18n';
 
 import {
   EuiFormControlLayout,

--- a/packages/eui/src/components/search_bar/__snapshots__/search_bar.test.tsx.snap
+++ b/packages/eui/src/components/search_bar/__snapshots__/search_bar.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`SearchBar render - provided query, filters 1`] = `
           class="euiFormControlLayoutIcons emotion-euiFormControlLayoutIcons-absolute-right"
         >
           <button
-            aria-label="Clear input"
+            aria-label="Clear search input"
             class="euiFormControlLayoutClearButton emotion-euiFormControlLayoutClearButton"
             data-test-subj="clearSearchButton"
             type="button"

--- a/packages/eui/src/components/selectable/__snapshots__/selectable.test.tsx.snap
+++ b/packages/eui/src/components/selectable/__snapshots__/selectable.test.tsx.snap
@@ -385,7 +385,7 @@ exports[`EuiSelectable search value supports inheriting initialSearchValue from 
         class="euiFormControlLayoutIcons emotion-euiFormControlLayoutIcons-absolute-right"
       >
         <button
-          aria-label="Clear input"
+          aria-label="Clear search input"
           class="euiFormControlLayoutClearButton emotion-euiFormControlLayoutClearButton"
           data-test-subj="clearSearchButton"
           type="button"

--- a/packages/eui/src/components/selectable/selectable_search/__snapshots__/selectable_search.test.tsx.snap
+++ b/packages/eui/src/components/selectable/selectable_search/__snapshots__/selectable_search.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`EuiSelectableSearch renders placeholder, value, name, and other remaini
       class="euiFormControlLayoutIcons emotion-euiFormControlLayoutIcons-absolute-right"
     >
       <button
-        aria-label="Clear input"
+        aria-label="Clear search input"
         class="euiFormControlLayoutClearButton emotion-euiFormControlLayoutClearButton"
         data-test-subj="clearSearchButton"
         type="button"


### PR DESCRIPTION
## Description: 

This pull request addresses issue [#138](https://github.com/elastic/observability-accessibility/issues/138) by updating the `aria-label` attribute of the clear button. The previous label, `Clear input` has been enhanced to `Clear search input` to provide more specific context for users who rely on screen readers. This change improves accessibility by making the button's function clearer, ensuring that all users have a more intuitive experience.

## Key Changes:

1. Updated the `aria-label` attribute from `Clear input` to `Clear search input` to enhance clarity for screen reader users.

## Screen: 
<img width="1378" alt="image" src="https://github.com/user-attachments/assets/a22edee4-785d-4a69-ace7-53ded11b52ef">

fyi: @dave-gus and @1Copenut 