### PR TITLE
[EuiSwitch] Re-add `pointer-events: none` to switch button children

### DIFF
--- a/packages/eui/src/components/form/switch/switch.styles.ts
+++ b/packages/eui/src/components/form/switch/switch.styles.ts
@@ -160,6 +160,7 @@ const bodyStyles = ({ colorMode }: UseEuiTheme, { colors }: EuiSwitchVars) => {
       inset: 0;
       overflow: hidden;
       border-radius: inherit;
+      pointer-events: none; /* Required for Kibana's Selenium driver to be able to click switches in FTR tests */
     `,
     on: css`
       background-color: ${colors.on};
@@ -242,6 +243,7 @@ const thumbStyles = ({ euiTheme }: UseEuiTheme, switchVars: EuiSwitchVars) => {
       ${logicalCSS('width', 'fit-content')}
       ${logicalCSS('height', '100%')}
       border-radius: 50%;
+      pointer-events: none; /* Required for Kibana's Selenium driver to be able to click switches in FTR tests */
 
       ${euiCanAnimate} {
         transition-property: inset-inline-start, transform, background-color,


### PR DESCRIPTION
## Summary

This is blocking/causing FTR failures in https://github.com/elastic/kibana/pull/190752 😬 It has no effect on actual browsers/productions, just on Selenium 💀 

## QA

- [ ] [EuiSwitch](https://eui.elastic.co/pr_7974/#/forms/selection-controls#switch) is still clickable/interactive

### General checklist

N/A, skipping because it doesn't affect end-users or consumers, just Kibana, and we have another item in the changelog queue to release from