### PR TITLE
Export EuiFormControlLayoutIcons

### DIFF
--- a/packages/eui/src/components/form/form_control_layout/index.ts
+++ b/packages/eui/src/components/form/form_control_layout/index.ts
@@ -10,3 +10,7 @@ export type { EuiFormControlLayoutProps } from './form_control_layout';
 export { EuiFormControlLayout } from './form_control_layout';
 export type { EuiFormControlLayoutDelimitedProps } from './form_control_layout_delimited';
 export { EuiFormControlLayoutDelimited } from './form_control_layout_delimited';
+export {
+  EuiFormControlLayoutIcons,
+  type EuiFormControlLayoutIconsProps,
+} from './form_control_layout_icons';


### PR DESCRIPTION
## Summary

Required by https://github.com/elastic/kibana/pull/190752

Kibana's unified search query string input was using a direct className to get form control icon styling:

https://github.com/elastic/kibana/blob/74d88580a5e3d24c6421942f2c96a8dfd56d39d1/src/plugins/unified_search/public/query_string_input/query_string_input.tsx#L854-L856

Which will no longer work with its Emotion conversion. I had assumed I could reach into `@elastic/eui/lib/components` directly to import `EuiFormControlLayoutIcons`, but Kibana's optimizer is throwing build errors when I attempt to do so (related to importing EuiIcon 💀)

## QA

N/A

### General checklist

N/A, backport only and a Kibana-only concern