### PR TITLE
[EuiCollapsibleNavBeta] Allow consumer to control the collapsed state

### DIFF
--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -42,7 +42,6 @@ const meta: Meta<EuiCollapsibleNavBetaProps> = {
     // Component defaults
     side: 'left',
     initialIsCollapsed: false,
-    isCollapsed: false,
     width: 248,
   },
 };

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.stories.tsx
@@ -42,6 +42,7 @@ const meta: Meta<EuiCollapsibleNavBetaProps> = {
     // Component defaults
     side: 'left',
     initialIsCollapsed: false,
+    isCollapsed: false,
     width: 248,
   },
 };

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.test.tsx
@@ -64,6 +64,47 @@ describe('EuiCollapsibleNavBeta', () => {
     expect(onCollapseToggle).toHaveBeenLastCalledWith(true);
   });
 
+  it('lets the consumer control the collapsed state', () => {
+    const spyOnCollapseToggle = jest.fn();
+
+    const Parent = () => {
+      const [isCollapsed, setIsCollapsed] = React.useState(false);
+      const onCollapseToggle = (isCollapsed: boolean) => {
+        spyOnCollapseToggle(isCollapsed);
+        setIsCollapsed(isCollapsed);
+      };
+
+      return (
+        <>
+          <button
+            onClick={() => setIsCollapsed(!isCollapsed)}
+            data-test-subj="parentToggleCollapse"
+          >
+            Toggle
+          </button>
+          <EuiCollapsibleNavBeta
+            isCollapsed={isCollapsed}
+            onCollapseToggle={onCollapseToggle}
+            data-test-subj="nav"
+          >
+            Nav content
+          </EuiCollapsibleNavBeta>
+        </>
+      );
+    };
+    const { getByTestSubject } = render(<Parent />);
+
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '248px' }); // initially expanded
+
+    fireEvent.click(getByTestSubject('parentToggleCollapse')); // collapse the nav from the parent
+    expect(spyOnCollapseToggle).not.toHaveBeenCalled();
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '48px' }); // collapsed from the parent
+
+    fireEvent.click(getByTestSubject('euiCollapsibleNavButton')); // expand from the child
+    expect(spyOnCollapseToggle).toHaveBeenLastCalledWith(false);
+    expect(getByTestSubject('nav')).toHaveStyle({ 'inline-size': '248px' }); // expanded from the child
+  });
+
   describe('responsive behavior', () => {
     const mockWindowResize = (width: number) => {
       window.innerWidth = width;

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_beta.tsx
@@ -51,6 +51,11 @@ export type EuiCollapsibleNavBetaProps = CommonProps &
      */
     initialIsCollapsed?: boolean;
     /**
+     * Whether the navigation flyout should be collapsed or expanded. If set, the collapsed state
+     * is **controlled** by the parent component. This prop superseeds `initialIsCollapsed`.
+     */
+    isCollapsed?: boolean;
+    /**
      * Optional callback that fires when the user toggles the nav between
      * collapsed and uncollapsed states
      */
@@ -87,6 +92,7 @@ const _EuiCollapsibleNavBeta: FunctionComponent<EuiCollapsibleNavBetaProps> = ({
   children,
   className,
   initialIsCollapsed = false,
+  isCollapsed: propsIsCollapsed,
   onCollapseToggle,
   width: _width = 248,
   side = 'left',
@@ -99,16 +105,29 @@ const _EuiCollapsibleNavBeta: FunctionComponent<EuiCollapsibleNavBetaProps> = ({
   /**
    * Collapsed state
    */
-  const [isCollapsed, setIsCollapsed] = useState(initialIsCollapsed);
-  const toggleCollapsed = useCallback(
-    () =>
-      setIsCollapsed((isCollapsed) => {
-        onCollapseToggle?.(!isCollapsed);
-        return !isCollapsed;
-      }),
-    [onCollapseToggle]
-  );
-  const onClose = useCallback(() => setIsCollapsed(true), []);
+  const [stateIsCollapsed, setIsCollapsed] = useState(initialIsCollapsed);
+  const isCollapsedControlled = propsIsCollapsed !== undefined;
+  const isCollapsed = isCollapsedControlled
+    ? propsIsCollapsed
+    : stateIsCollapsed;
+
+  const toggleCollapsed = useCallback(() => {
+    if (isCollapsedControlled) {
+      onCollapseToggle?.(!isCollapsed);
+    } else {
+      setIsCollapsed((prev) => {
+        onCollapseToggle?.(!prev);
+        return !prev;
+      });
+    }
+  }, [isCollapsed, isCollapsedControlled, onCollapseToggle]);
+
+  const onClose = useCallback(() => {
+    setIsCollapsed(true);
+    if (isCollapsedControlled) {
+      onCollapseToggle?.(true);
+    }
+  }, [isCollapsedControlled, onCollapseToggle]);
 
   /**
    * Responsive behavior


### PR DESCRIPTION
In this PR I've updated the `EuiCollapsibleNavBeta` component to allow consumers to control the collapsed state of the navigation with a `isCollapsed` prop.

If the prop is not set, the collapsed state is controlled by the component (same as before this PR). If it is set, it is the parent that controls the state.
