### PR TITLE
Updated callout example

### DIFF
--- a/packages/eui/src-docs/src/views/call_out/warning.tsx
+++ b/packages/eui/src-docs/src/views/call_out/warning.tsx
@@ -8,7 +8,7 @@ export default () => (
       Here be dragons. Don&rsquo;t wanna mess with no dragons. And{' '}
       <EuiLink href="#">here&rsquo;s a link</EuiLink>.
     </p>
-    <EuiButton href="#" color="warning">
+    <EuiButton href="#" color="warning" fill>
       Link button
     </EuiButton>
   </EuiCallOut>


### PR DESCRIPTION
I updated the callout example to use a primary button rather than a secondary button, to provide better contrast.

I don't think this is a pattern we want to inadvertently encourage via our docs.

https://eui.elastic.co/#/display/callout

Before:
<img width="1007" alt="Screenshot 2024-08-23 at 3 00 48 PM" src="https://github.com/user-attachments/assets/ba705669-3aaa-4eda-951d-c71c5c5db43d">

After:
<img width="1019" alt="Screenshot 2024-08-23 at 3 00 26 PM" src="https://github.com/user-attachments/assets/8ca5e8ab-f77e-41e8-a4ea-03ab1a0ac66f">


