### PR TITLE
[EuiDatePicker] Fix `inline` rendering + add `append`/`prepend` support

### DIFF
--- a/packages/eui/changelogs/upcoming/7987.md
+++ b/packages/eui/changelogs/upcoming/7987.md
@@ -1,0 +1,5 @@
+- Updated `EuiDatePicker` to support `append` and `prepend` nodes in its form control layout
+
+**Bug fixes**
+
+- Fixed border rendering bug with inline `EuiDatePicker`s with `shadow={false}`

--- a/packages/eui/src-docs/src/views/date_picker/states.js
+++ b/packages/eui/src-docs/src/views/date_picker/states.js
@@ -21,8 +21,8 @@ export default () => {
 
   return (
     /* DisplayToggles wrapper for Docs only */
-    <div>
-      <DisplayToggles>
+    <>
+      <DisplayToggles canPrepend={true} canAppend={true}>
         <EuiDatePicker
           showTimeSelect
           selected={startDate}
@@ -52,6 +52,6 @@ export default () => {
           placeholder="Example of an error"
         />
       </EuiFormRow>
-    </div>
+    </>
   );
 };

--- a/packages/eui/src/components/date_picker/date_picker.stories.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.stories.tsx
@@ -100,6 +100,8 @@ const meta: Meta<EuiDatePickerProps> = {
     isInvalid: false,
     isLoading: false,
     placeholder: '',
+    append: '',
+    prepend: '',
     // manually adding non-resolved prop types (extended from react-date-picker)
     calendarClassName: '',
     customInput: undefined,

--- a/packages/eui/src/components/date_picker/date_picker.styles.ts
+++ b/packages/eui/src/components/date_picker/date_picker.styles.ts
@@ -31,7 +31,7 @@ export const euiDatePickerStyles = (euiThemeContext: UseEuiTheme) => {
         .euiFormControlLayout {
           ${logicalCSS('height', 'auto')}
           ${logicalCSS('width', 'fit-content')}
-          box-shadow: none;
+          border: none;
           padding: 0;
         }
 

--- a/packages/eui/src/components/date_picker/date_picker.styles.ts
+++ b/packages/eui/src/components/date_picker/date_picker.styles.ts
@@ -75,5 +75,14 @@ export const euiDatePickerStyles = (euiThemeContext: UseEuiTheme) => {
         }
       `,
     },
+
+    inGroup: css`
+      .euiFormControlLayout__childrenWrapper {
+        .euiPopover,
+        .react-datepicker__input-container {
+          ${logicalCSS('height', '100%')}
+        }
+      }
+    `,
   };
 };

--- a/packages/eui/src/components/date_picker/date_picker.test.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.test.tsx
@@ -53,6 +53,29 @@ describe('EuiDatePicker', () => {
     expect(container.innerHTML).toContain('-compressed');
   });
 
+  test('append/prepend', () => {
+    const { container, rerender } = render(
+      <EuiDatePicker append="hello" prepend="world" />
+    );
+    const getAppend = () =>
+      container.querySelector('.euiFormControlLayout__append');
+    const getPrepend = () =>
+      container.querySelector('.euiFormControlLayout__prepend');
+
+    expect(getAppend()).toHaveTextContent('hello');
+    expect(getPrepend()).toHaveTextContent('world');
+
+    // Does not render if controlOnly
+    rerender(<EuiDatePicker append="hello" prepend="world" controlOnly />);
+    expect(getAppend()).not.toBeInTheDocument();
+    expect(getPrepend()).not.toBeInTheDocument();
+
+    // Does not render if inline
+    rerender(<EuiDatePicker append="hello" prepend="world" inline />);
+    expect(getAppend()).not.toBeInTheDocument();
+    expect(getPrepend()).not.toBeInTheDocument();
+  });
+
   // TODO: These tests/snapshots don't really do anything in Jest without
   // the corresponding popover opening. Should be switched to an E2E test instead
   describe.skip('popoverPlacement', () => {

--- a/packages/eui/src/components/date_picker/date_picker.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.tsx
@@ -325,17 +325,17 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
         isInvalid={isInvalid}
         isDisabled={disabled}
         readOnly={readOnly}
-        {...(!inline
+        {...(inline
           ? {
+              isDelimited: true,
+              iconsPosition: 'static',
+            }
+          : {
               fullWidth,
               compressed,
               append,
               prepend,
               css: (append || prepend) && styles.inGroup,
-            }
-          : {
-              isDelimited: true,
-              iconsPosition: 'static',
             })}
       >
         {control}

--- a/packages/eui/src/components/date_picker/date_picker.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.tsx
@@ -22,7 +22,11 @@ import { useCombinedRefs, useEuiMemoizedStyles } from '../../services';
 import { EuiI18nConsumer } from '../context';
 import { CommonProps } from '../common';
 import { PopoverAnchorPosition } from '../popover';
-import { EuiFormControlLayout, useEuiValidatableControl } from '../form';
+import {
+  EuiFormControlLayout,
+  EuiFormControlLayoutProps,
+  useEuiValidatableControl,
+} from '../form';
 import { EuiFormControlLayoutIconsProps } from '../form/form_control_layout/form_control_layout_icons';
 
 import { ReactDatePicker, ReactDatePickerProps } from './react-datepicker';
@@ -139,8 +143,25 @@ interface EuiExtendedDatePickerProps
   popoverPlacement?: PopoverAnchorPosition;
 
   /**
+   * Creates an input group with element(s) coming before the input.
+   * `string` | `ReactElement` or an array of these
+   *
+   * Ignored if `inline` or `controlOnly` are true.
+   */
+  append?: EuiFormControlLayoutProps['append'];
+  /**
+   * Creates an input group with element(s) coming before the input.
+   * `string` | `ReactElement` or an array of these
+   *
+   * Ignored if `inline` or `controlOnly` are true.
+   */
+  prepend?: EuiFormControlLayoutProps['prepend'];
+
+  /**
    * Completely removes form control layout wrapper and ignores
-   * iconType. Best used inside EuiFormControlLayoutDelimited.
+   * `iconType`, `prepend`, and `append`.
+   *
+   * Best used inside EuiFormControlLayoutDelimited.
    */
   controlOnly?: boolean;
 }
@@ -149,6 +170,7 @@ export type EuiDatePickerProps = CommonProps & EuiExtendedDatePickerProps;
 
 export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
   adjustDateOnChange = true,
+  append,
   calendarClassName,
   className,
   compressed,
@@ -177,6 +199,7 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
   placeholder,
   popperClassName,
   popoverPlacement = 'downLeft',
+  prepend,
   readOnly,
   selected,
   shadow = true,
@@ -297,15 +320,23 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
     <span css={cssStyles} className={classes}>
       <EuiFormControlLayout
         icon={optionalIcon}
-        fullWidth={!inline && fullWidth}
-        compressed={!inline && compressed}
         clear={selected && onClear ? { onClick: onClear } : undefined}
         isLoading={isLoading}
         isInvalid={isInvalid}
         isDisabled={disabled}
         readOnly={readOnly}
-        isDelimited={inline} // Styling shortcut for inline calendars
-        iconsPosition={inline ? 'static' : undefined}
+        {...(!inline
+          ? {
+              fullWidth,
+              compressed,
+              append,
+              prepend,
+              css: (append || prepend) && styles.inGroup,
+            }
+          : {
+              isDelimited: true,
+              iconsPosition: 'static',
+            })}
       >
         {control}
       </EuiFormControlLayout>

--- a/packages/eui/src/components/date_picker/date_picker_range.styles.ts
+++ b/packages/eui/src/components/date_picker/date_picker_range.styles.ts
@@ -58,7 +58,7 @@ export const euiDatePickerRangeInlineStyles = (
         ${logicalCSS('height', 'auto')}
         ${logicalCSS('width', 'fit-content')}
         ${logicalCSS('max-width', '100%')}
-        box-shadow: none;
+        border: none;
         padding: 0;
 
         .euiFormControlLayout__childrenWrapper {


### PR DESCRIPTION
## Summary

I discovered an inline EuiDatePicker border regression while investigating #5958, and I also discovered some very incorrect usages of `EuiFormControlLayout` while grepping for the component in Kibana.

Adding `append`/`prepend` nodes to EuiDatePicker will help with a significant amount of those use cases, as people were using the layout wrapper just for appending/prepending info to the date picker input.

## QA

- Go to https://eui.elastic.co/pr_7987/#/forms/date-picker#date-picker-inline
- [x] Both inline date pickers should not have a border when the `Show shadow` switch is toggled

| Before | After |
|--------|--------|
| <img width="456" alt="" src="https://github.com/user-attachments/assets/aaa462a8-d1ea-4fb2-a119-0aba436199f9"> | <img width="449" alt="" src="https://github.com/user-attachments/assets/be6b8b9e-1e09-4fc4-a1a7-5850d59e3b3c"> | 

- Go to https://eui.elastic.co/pr_7987/#/forms/date-picker#date-picker-states or https://eui.elastic.co/pr_7987/storybook/?path=/story/forms-euidatepicker--playground
- [x] Toggling the append/prepend display should render side nodes as expected, e.g.
  <img width="485" alt="" src="https://github.com/user-attachments/assets/5fc0103a-88ab-4eac-930b-ef902e0e4478">



### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Updated **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md)~ tests**
    ~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~ 
- Designer checklist - N/A