### PR TITLE
POC of honoring cmd+click events in cards to open card links in a new tab

### DIFF
--- a/packages/eui/src-docs/src/views/card/card.tsx
+++ b/packages/eui/src-docs/src/views/card/card.tsx
@@ -17,7 +17,8 @@ const cardNodes = icons.map(function (item, index) {
         title={`Elastic ${item}`}
         isDisabled={item === 'Kibana' ? true : false}
         description="Example of a card's description. Stick to one or two sentences."
-        onClick={() => {}}
+        href="http://www.example.com"
+        onClick={() => {console.log('hi')}}
       />
     </EuiFlexItem>
   );

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -199,7 +199,11 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   let link: HTMLAnchorElement | HTMLButtonElement | null = null;
   const outerOnClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (link && link !== e.target && !link.contains(e.target as Node)) {
-      link.click();
+      // Clone and dispatch event rather than trigger link.click so that links can still be opened in a new tab
+      // with cmd+click, etc.
+      const newEvent = new PointerEvent(e.nativeEvent.type, e.nativeEvent);
+      // Dispatch the cloned event on the new target
+      link.dispatchEvent(newEvent);
     }
   };
 


### PR DESCRIPTION
## Summary

Using an `href` property in an EuiCard will force the EuiCard to render the **title** as an anchor tag:

<img width="674" alt="Screenshot 2024-08-28 at 1 16 49 PM" src="https://github.com/user-attachments/assets/535fbdfb-faff-4729-ac5d-6e8426449a49">


Logic for this is [here](https://github.com/elastic/eui/blob/main/packages/eui/src/components/card/card.tsx#L337).

Clicking on the title of a card using href works like any other link. Nothing special here.

However, when passing an `href` to a card, the expectation is that the entire card is a clickable link, not just the title. For that reason, we add an additional click handler to the entire card, which will manually trigger an click event on our title anchor if anywhere other than the title anchor is clicked.

So basically, if someone clicks on on a card anywhere other than the title, we're going to pretend that they actually clicked on the title, and manually simulate that click event.

That logic is [here](https://github.com/elastic/eui/blob/main/packages/eui/src/components/card/card.tsx#L202).

The problem with this, is that many folks use cmd+click in order to open links in a new tab. This *does work* when clicking directly on the title link, but *does not work* when clicking anywhere else on the card.

<img width="413" alt="Screenshot 2024-08-28 at 1 26 03 PM" src="https://github.com/user-attachments/assets/dea2f8d1-339d-4ce6-9951-51c69bbcabe5">


Here is a codesandbox example: https://c59jqv.csb.app/

This PR resolves this issue. However, I am not sure:
1. How it works cross-browser
2. If it's OK to manually force a PointerEvent (what if the original event was a MouseEvent?)

Opening this up for thoughts and feedback.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
