### PR TITLE
[EuiText] Support component prop

### DIFF
--- a/packages/eui/changelogs/upcoming/7993.md
+++ b/packages/eui/changelogs/upcoming/7993.md
@@ -1,0 +1,3 @@
+- Added `component` prop on `EuiText` and `EuiTextAlign`
+- Updated `component` prop values for `EuiTextColor`
+

--- a/packages/eui/changelogs/upcoming/7993.md
+++ b/packages/eui/changelogs/upcoming/7993.md
@@ -1,3 +1,1 @@
-- Added `component` prop on `EuiText` and `EuiTextAlign`
-- Updated `component` prop values for `EuiTextColor`
-
+- Updated `EuiText`, `EuiTextColor`, and `EuiTextAlign` with a new `component` prop that allows changing the default rendered `<div>` wrapper to a `<span>` or `<p>` tag.

--- a/packages/eui/src/components/text/text.stories.tsx
+++ b/packages/eui/src/components/text/text.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<EuiTextProps> = {
     grow: true,
     color: 'default',
     textAlign: 'left',
+    component: 'div',
   },
 };
 moveStorybookControlsToCategory(meta, ['color'], 'EuiTextColor props');

--- a/packages/eui/src/components/text/text.test.tsx
+++ b/packages/eui/src/components/text/text.test.tsx
@@ -64,5 +64,15 @@ describe('EuiText', () => {
 
       expect(container.firstChild).toMatchSnapshot();
     });
+
+    test('component', () => {
+      const { container } = render(
+        <EuiText {...requiredProps} component="span">
+          Content
+        </EuiText>
+      );
+
+      expect(container.firstChild?.nodeName).toBe('SPAN');
+    });
   });
 });

--- a/packages/eui/src/components/text/text.tsx
+++ b/packages/eui/src/components/text/text.tsx
@@ -6,39 +6,26 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes, CSSProperties } from 'react';
+import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../common';
 
 import { useEuiMemoizedStyles } from '../../services';
+
+import type { SharedTextProps, EuiTextColors, EuiTextAlignment } from './types';
+import { EuiTextColor } from './text_color';
+import { EuiTextAlign } from './text_align';
 import { euiTextStyles } from './text.styles';
-
-import { TextColor, EuiTextColor } from './text_color';
-
-import { EuiTextAlign, TextAlignment } from './text_align';
 
 export const TEXT_SIZES = ['xs', 's', 'm', 'relative'] as const;
 export type TextSize = (typeof TEXT_SIZES)[number];
 
-export type EuiTextProps = CommonProps &
-  Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
-    /**
-     * The HTML element/tag to render.
-     * Use with care when nesting multiple components to ensure valid html.
-     * Block elements can't be nested inside inline elements: `<p>` and `<div>` are not valid inside `<span>`.
-     * Additionally `<div>` is not valid to use inside `<p>`.
-     */
-    component?: 'div' | 'span' | 'p';
-    textAlign?: TextAlignment;
+export type EuiTextProps = SharedTextProps &
+  EuiTextColors &
+  EuiTextAlignment & {
     /**
      * Determines the text size. Choose `relative` to control the `font-size` based on the value of a parent container.
      */
     size?: TextSize;
-    /**
-     * Any of our named colors or a `hex`, `rgb` or `rgba` value.
-     * @default inherit
-     */
-    color?: TextColor | CSSProperties['color'];
     grow?: boolean;
   };
 

--- a/packages/eui/src/components/text/text.tsx
+++ b/packages/eui/src/components/text/text.tsx
@@ -23,7 +23,10 @@ export type TextSize = (typeof TEXT_SIZES)[number];
 export type EuiTextProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
     /**
-     * The HTML element/tag to render
+     * The HTML element/tag to render.
+     * Use with care when nesting multiple components to ensure valid html.
+     * Block elements can't be nested inside inline elements: `<p>` and `<div>` are not valid inside `<span>`.
+     * Additionally `<div>` is not valid to use inside `<p>`.
      */
     component?: 'div' | 'span' | 'p';
     textAlign?: TextAlignment;

--- a/packages/eui/src/components/text/text.tsx
+++ b/packages/eui/src/components/text/text.tsx
@@ -23,7 +23,7 @@ export type TextSize = (typeof TEXT_SIZES)[number];
 export type EuiTextProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
     /**
-     * Determines the root element
+     * The HTML element/tag to render
      */
     component?: 'div' | 'span' | 'p';
     textAlign?: TextAlignment;

--- a/packages/eui/src/components/text/text.tsx
+++ b/packages/eui/src/components/text/text.tsx
@@ -22,6 +22,10 @@ export type TextSize = (typeof TEXT_SIZES)[number];
 
 export type EuiTextProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'color'> & {
+    /**
+     * Determines the root element
+     */
+    component?: 'div' | 'span' | 'p';
     textAlign?: TextAlignment;
     /**
      * Determines the text size. Choose `relative` to control the `font-size` based on the value of a parent container.
@@ -36,6 +40,7 @@ export type EuiTextProps = CommonProps &
   };
 
 export const EuiText: FunctionComponent<EuiTextProps> = ({
+  component = 'div',
   size = 'm',
   color,
   grow = true,
@@ -52,16 +57,22 @@ export const EuiText: FunctionComponent<EuiTextProps> = ({
   ];
 
   const classes = classNames('euiText', className);
+  const Component = component;
 
   let text = (
-    <div css={cssStyles} className={classes} {...rest}>
+    <Component css={cssStyles} className={classes} {...rest}>
       {children}
-    </div>
+    </Component>
   );
 
   if (color) {
     text = (
-      <EuiTextColor color={color} className={classes} cloneElement>
+      <EuiTextColor
+        component={component}
+        color={color}
+        className={classes}
+        cloneElement
+      >
         {text}
       </EuiTextColor>
     );
@@ -69,7 +80,12 @@ export const EuiText: FunctionComponent<EuiTextProps> = ({
 
   if (textAlign) {
     text = (
-      <EuiTextAlign textAlign={textAlign} className={classes} cloneElement>
+      <EuiTextAlign
+        component={component}
+        textAlign={textAlign}
+        className={classes}
+        cloneElement
+      >
         {text}
       </EuiTextAlign>
     );

--- a/packages/eui/src/components/text/text_align.stories.tsx
+++ b/packages/eui/src/components/text/text_align.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta<EuiTextAlignProps> = {
   args: {
     textAlign: 'left',
     cloneElement: false,
+    component: 'div',
   },
 };
 hideStorybookControls(meta, ['aria-label']);

--- a/packages/eui/src/components/text/text_align.test.tsx
+++ b/packages/eui/src/components/text/text_align.test.tsx
@@ -50,5 +50,15 @@ describe('EuiTextAlign', () => {
 
       shouldRenderCustomStyles(<EuiTextAlign cloneElement textAlign="right" />);
     });
+
+    test('component', () => {
+      const { container } = render(
+        <EuiTextAlign {...requiredProps} component="span">
+          Content
+        </EuiTextAlign>
+      );
+
+      expect(container.firstChild?.nodeName).toBe('SPAN');
+    });
   });
 });

--- a/packages/eui/src/components/text/text_align.tsx
+++ b/packages/eui/src/components/text/text_align.tsx
@@ -22,7 +22,7 @@ export type TextAlignment = (typeof ALIGNMENTS)[number];
 export type EuiTextAlignProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     /**
-     * Determines the root element
+     * The HTML element/tag to render
      */
     component?: 'div' | 'span' | 'p';
     textAlign?: TextAlignment;

--- a/packages/eui/src/components/text/text_align.tsx
+++ b/packages/eui/src/components/text/text_align.tsx
@@ -23,6 +23,9 @@ export type EuiTextAlignProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     /**
      * The HTML element/tag to render
+     * Use with care when nesting multiple components to ensure valid html.
+     * Block elements can't be nested inside inline elements. (<p> and <div> are not valid inside <span>)
+     * Additionally <div> is not valid to use inside <p>.
      */
     component?: 'div' | 'span' | 'p';
     textAlign?: TextAlignment;

--- a/packages/eui/src/components/text/text_align.tsx
+++ b/packages/eui/src/components/text/text_align.tsx
@@ -21,6 +21,10 @@ export type TextAlignment = (typeof ALIGNMENTS)[number];
 
 export type EuiTextAlignProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
+    /**
+     * Determines the root element
+     */
+    component?: 'div' | 'span' | 'p';
     textAlign?: TextAlignment;
     /**
      * Applies text styling to the child element instead of rendering a parent wrapper `div`.
@@ -31,6 +35,7 @@ export type EuiTextAlignProps = CommonProps &
 
 export const EuiTextAlign: FunctionComponent<EuiTextAlignProps> = ({
   children,
+  component: Component = 'div',
   textAlign = 'left',
   cloneElement = false,
   ...rest
@@ -42,6 +47,6 @@ export const EuiTextAlign: FunctionComponent<EuiTextAlignProps> = ({
   if (isValidElement(children) && cloneElement) {
     return cloneElementWithCss(children, props);
   } else {
-    return <div {...props}>{children}</div>;
+    return <Component {...props}>{children}</Component>;
   }
 };

--- a/packages/eui/src/components/text/text_align.tsx
+++ b/packages/eui/src/components/text/text_align.tsx
@@ -6,35 +6,17 @@
  * Side Public License, v 1.
  */
 
-import React, {
-  FunctionComponent,
-  HTMLAttributes,
-  isValidElement,
-} from 'react';
-import { CommonProps } from '../common';
+import React, { FunctionComponent, isValidElement } from 'react';
 import { cloneElementWithCss } from '../../services';
-
+import type { SharedTextProps, CloneElement, EuiTextAlignment } from './types';
 import { euiTextAlignStyles as styles } from './text_align.styles';
 
 export const ALIGNMENTS = ['left', 'right', 'center'] as const;
 export type TextAlignment = (typeof ALIGNMENTS)[number];
 
-export type EuiTextAlignProps = CommonProps &
-  HTMLAttributes<HTMLDivElement> & {
-    /**
-     * The HTML element/tag to render
-     * Use with care when nesting multiple components to ensure valid html.
-     * Block elements can't be nested inside inline elements. (<p> and <div> are not valid inside <span>)
-     * Additionally <div> is not valid to use inside <p>.
-     */
-    component?: 'div' | 'span' | 'p';
-    textAlign?: TextAlignment;
-    /**
-     * Applies text styling to the child element instead of rendering a parent wrapper `div`.
-     * Can only be used when wrapping a *single* child element/tag, and not raw text.
-     */
-    cloneElement?: boolean;
-  };
+export type EuiTextAlignProps = SharedTextProps &
+  CloneElement &
+  EuiTextAlignment;
 
 export const EuiTextAlign: FunctionComponent<EuiTextAlignProps> = ({
   children,

--- a/packages/eui/src/components/text/text_color.test.tsx
+++ b/packages/eui/src/components/text/text_color.test.tsx
@@ -62,5 +62,15 @@ describe('EuiTextColor', () => {
         </EuiTextColor>
       );
     });
+
+    test('component', () => {
+      const { container } = render(
+        <EuiTextColor {...requiredProps} component="span">
+          Content
+        </EuiTextColor>
+      );
+
+      expect(container.firstChild?.nodeName).toBe('SPAN');
+    });
   });
 });

--- a/packages/eui/src/components/text/text_color.tsx
+++ b/packages/eui/src/components/text/text_color.tsx
@@ -43,6 +43,9 @@ export type EuiTextColorProps = CommonProps &
     color?: TextColor | CSSProperties['color'];
     /**
      * The HTML element/tag to render
+     * Use with care when nesting multiple components to ensure valid html.
+     * Block elements can't be nested inside inline elements. (<p> and <div> are not valid inside <span>)
+     * Additionally <div> is not valid to use inside <p>.
      */
     component?: 'div' | 'span' | 'p';
     /**

--- a/packages/eui/src/components/text/text_color.tsx
+++ b/packages/eui/src/components/text/text_color.tsx
@@ -44,7 +44,7 @@ export type EuiTextColorProps = CommonProps &
     /**
      * Determines the root element
      */
-    component?: 'div' | 'span';
+    component?: 'div' | 'span' | 'p';
     /**
      * Applies text styling to the child element instead of rendering a parent wrapper `span`/`div`.
      * Can only be used when wrapping a *single* child element/tag, and not raw text.
@@ -55,7 +55,7 @@ export type EuiTextColorProps = CommonProps &
 export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
   children,
   color = 'default',
-  component = 'span',
+  component: Component = 'span',
   cloneElement = false,
   style,
   ...rest
@@ -84,7 +84,6 @@ export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
     const childrenStyle = { ...children.props.style, ...euiTextStyle };
     return cloneElementWithCss(children, { ...props, style: childrenStyle });
   } else {
-    const Component = component;
     return <Component {...props}>{children}</Component>;
   }
 };

--- a/packages/eui/src/components/text/text_color.tsx
+++ b/packages/eui/src/components/text/text_color.tsx
@@ -6,16 +6,9 @@
  * Side Public License, v 1.
  */
 
-import React, {
-  FunctionComponent,
-  HTMLAttributes,
-  CSSProperties,
-  isValidElement,
-} from 'react';
-
-import { CommonProps } from '../common';
+import React, { FunctionComponent, isValidElement } from 'react';
 import { useEuiMemoizedStyles, cloneElementWithCss } from '../../services';
-
+import type { SharedTextProps, CloneElement, EuiTextColors } from './types';
 import { euiTextColorStyles } from './text_color.styles';
 
 export const COLORS = [
@@ -32,28 +25,7 @@ export type TextColor = (typeof COLORS)[number];
 export const _isNamedColor = (color: any): color is TextColor =>
   COLORS.includes(color);
 
-export type EuiTextColorProps = CommonProps &
-  Omit<
-    HTMLAttributes<HTMLDivElement> & HTMLAttributes<HTMLSpanElement>,
-    'color'
-  > & {
-    /**
-     * Any of our named colors or a `hex`, `rgb` or `rgba` value.
-     */
-    color?: TextColor | CSSProperties['color'];
-    /**
-     * The HTML element/tag to render
-     * Use with care when nesting multiple components to ensure valid html.
-     * Block elements can't be nested inside inline elements. (<p> and <div> are not valid inside <span>)
-     * Additionally <div> is not valid to use inside <p>.
-     */
-    component?: 'div' | 'span' | 'p';
-    /**
-     * Applies text styling to the child element instead of rendering a parent wrapper `span`/`div`.
-     * Can only be used when wrapping a *single* child element/tag, and not raw text.
-     */
-    cloneElement?: boolean;
-  };
+export type EuiTextColorProps = SharedTextProps & CloneElement & EuiTextColors;
 
 export const EuiTextColor: FunctionComponent<EuiTextColorProps> = ({
   children,

--- a/packages/eui/src/components/text/text_color.tsx
+++ b/packages/eui/src/components/text/text_color.tsx
@@ -42,7 +42,7 @@ export type EuiTextColorProps = CommonProps &
      */
     color?: TextColor | CSSProperties['color'];
     /**
-     * Determines the root element
+     * The HTML element/tag to render
      */
     component?: 'div' | 'span' | 'p';
     /**

--- a/packages/eui/src/components/text/types.ts
+++ b/packages/eui/src/components/text/types.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { HTMLAttributes, CSSProperties } from 'react';
+import type { CommonProps } from '../common';
+
+import type { TextColor } from './text_color';
+import type { TextAlignment } from './text_align';
+
+export type SharedTextProps = CommonProps &
+  Omit<HTMLAttributes<HTMLElement>, 'color'> & {
+    /**
+     * The HTML element/tag to render.
+     * Use with care when nesting multiple components to ensure valid XHTML:
+     * - `<div>` and other block tags are not valid to use inside `<p>`. If using the `<p>` tag, we recommend passing strings/text only.
+     * - `<span>` is valid to be nested in any tag, and can have any tag nested within it.
+     */
+    component?: 'div' | 'span' | 'p';
+  };
+
+export type CloneElement = {
+  /**
+   * Applies text styling to the child element instead of rendering a parent wrapper.
+   * Can only be used when wrapping a *single* child element/tag, and not raw text.
+   */
+  cloneElement?: boolean;
+};
+
+export type EuiTextColors = {
+  /**
+   * Any of our named colors or a `hex`, `rgb` or `rgba` value.
+   * @default inherit
+   */
+  color?: TextColor | CSSProperties['color'];
+};
+
+export type EuiTextAlignment = {
+  /**
+   * Applies horizontal text alignment
+   * @default left
+   */
+  textAlign?: TextAlignment;
+};


### PR DESCRIPTION
## Summary

closes #7975 

This PR adds support for a `component` prop on `EuiText` and related components `EuiTextColor` and `EuiTextAlign` to support rendering different root elements. Currently `EuiText` always outputs a `div` element, which results in invalid html issues where `EuiText` is not the wrapper but used in a composition where the div would be a child of a `p` for example.

## Changes
- adds prop `component` with values `p`, `div` and `span` (default value stays `div` for parity) for `EuiText` and `EuiTextAlign`
- updates `component` prop on `EuiText` to match the same values as for the other two text components

## QA

- [ ] review the related stories and check the DOM output when changing the value for `component` prop
 - [EuiText](https://eui.elastic.co/pr_7993/storybook/index.html?path=/story/display-euitext-euitext--playground)
 - [EuiTextColor](https://eui.elastic.co/pr_7993/storybook/index.html?path=/story/display-euitext-euitextcolor--playground)
 - [EuiTextAlign](https://eui.elastic.co/pr_7993/storybook/index.html?path=/story/display-euitext-euitextalign--playground)

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
