### PR TITLE
[EuiDataGrid] Fix header actions button causing cell height changes

### DIFF
--- a/packages/eui/changelogs/upcoming/7999.md
+++ b/packages/eui/changelogs/upcoming/7999.md
@@ -1,4 +1,4 @@
 **Bug fixes**
 
-- Fixed a visual bug in `EuiDataGrid` where the header cell height increased when the actions button became visible
+- Fixed a visual bug in compact density `EuiDataGrid`s, where the header cell height would increase when the actions button became visible
 

--- a/packages/eui/changelogs/upcoming/7999.md
+++ b/packages/eui/changelogs/upcoming/7999.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed a visual bug in `EuiDataGrid` where the header cell height increased when the actions button became visible
+

--- a/packages/eui/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/packages/eui/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -91,6 +91,8 @@
     .euiPopover-isOpen {
       .euiDataGridHeaderCell__button {
         padding: $euiSizeXS;
+        // balance out additional button target size in header height, prevents increased header cell height
+        margin: -$euiSizeXS 0;
       }
 
       .euiDataGridHeaderCell__icon {

--- a/packages/eui/src/components/datagrid/body/header/_data_grid_header_row.scss
+++ b/packages/eui/src/components/datagrid/body/header/_data_grid_header_row.scss
@@ -92,7 +92,7 @@
       .euiDataGridHeaderCell__button {
         padding: $euiSizeXS;
         // balance out additional button target size in header height, prevents increased header cell height
-        margin: -$euiSizeXS 0;
+        margin-block: -$euiSizeXS;
       }
 
       .euiDataGridHeaderCell__icon {


### PR DESCRIPTION
## Summary

This PR fixes an issue that was introducede with this previously merged [PR](https://github.com/elastic/eui/pull/7898) that updated `EuiDataGrid` header cells to support interactive content. As part of that PR the size of the actions button was increased via `padding` to satisfy the min. target size accessibility requirements.

This causes the header cells to increase in height when the actions button is visible on hover/focus for small cell fontSize/lineHeight settings.

## Changes

- adds negative margin for the action button that is equivalent the added padding to ensure the button still uses the same vertical space

## Screenshots

_issue_

https://github.com/user-attachments/assets/33d779de-5289-4e2e-9373-fc705687814c

_fixed_

https://github.com/user-attachments/assets/27180c31-dfa2-460b-b097-5bf63c6e507f


## QA

- [x] ensure the header cell does not increase in size when the action button is visible for a small fontSize/lineHeight variant
  - open the [datagrid playground story](https://eui.elastic.co/pr_7999/#/tabular-content/data-grid)
  - change the `gridStyle` prop:
    - change `fontSize` to `"s"`
    - add the key `"lineHeight"` and set its value to `"1.6em"` (1.6em is the value used on Kibana)

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
