### PR TITLE
[EuiFlyoutResizable] Do not extend resize click area past flyout for flyouts with no overlays

### DIFF
--- a/packages/eui/changelogs/upcoming/8010.md
+++ b/packages/eui/changelogs/upcoming/8010.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed push `EuiFlyoutResizable`s to not potentially block scrollbars on outside content

--- a/packages/eui/src/components/flyout/flyout_resizable.stories.tsx
+++ b/packages/eui/src/components/flyout/flyout_resizable.stories.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { moveStorybookControlsToCategory } from '../../../.storybook/utils';
 
 import { EuiText } from '../text';
@@ -18,7 +19,6 @@ import {
   EuiFlyoutResizable,
   EuiFlyoutResizableProps,
 } from './flyout_resizable';
-import { LOKI_SELECTORS } from '../../../.storybook/loki';
 
 const meta: Meta<EuiFlyoutResizableProps> = {
   title: 'Layout/EuiFlyout/EuiFlyoutResizable',
@@ -57,7 +57,6 @@ moveStorybookControlsToCategory(
     'closeButtonProps',
     'focusTrapProps',
     'includeFixedHeadersInFocusTrap',
-    'ownFocus',
     'maskProps',
     'pushAnimation',
     'pushMinBreakpoint',

--- a/packages/eui/src/components/flyout/flyout_resizable.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_resizable.styles.ts
@@ -25,10 +25,21 @@ export const euiFlyoutResizableButtonStyles = ({ euiTheme }: UseEuiTheme) => ({
   },
   push: {
     left: css`
-      ${logicalCSS('right', `-${euiTheme.border.width.thin}`)}
+      ${logicalCSS('right', `-${euiTheme.border.width.thick}`)}
     `,
     right: css`
-      ${logicalCSS('left', `-${euiTheme.border.width.thin}`)}
+      ${logicalCSS('left', `-${euiTheme.border.width.thick}`)}
+    `,
+  },
+  noOverlay: {
+    noOverlay: css`
+      margin-inline: 0;
+    `,
+    left: css`
+      justify-content: flex-end;
+    `,
+    right: css`
+      justify-content: flex-start;
     `,
   },
 });

--- a/packages/eui/src/components/flyout/flyout_resizable.tsx
+++ b/packages/eui/src/components/flyout/flyout_resizable.tsx
@@ -40,13 +40,21 @@ export const EuiFlyoutResizable = forwardRef(
       onResize,
       side = 'right',
       type = 'overlay',
+      ownFocus = true,
       children,
       ...rest
     }: EuiFlyoutResizableProps,
     ref
   ) => {
+    const hasOverlay = type === 'overlay' && ownFocus;
+
     const styles = useEuiMemoizedStyles(euiFlyoutResizableButtonStyles);
-    const cssStyles = [styles.euiFlyoutResizableButton, styles[type][side]];
+    const cssStyles = [
+      styles.euiFlyoutResizableButton,
+      styles[type][side],
+      !hasOverlay && styles.noOverlay.noOverlay,
+      !hasOverlay && styles.noOverlay[side],
+    ];
 
     const getFlyoutMinMaxWidth = useCallback(
       (width: number) => {
@@ -169,6 +177,7 @@ export const EuiFlyoutResizable = forwardRef(
         maxWidth={maxWidth}
         side={side}
         type={type}
+        ownFocus={ownFocus}
         ref={setRefs}
       >
         <EuiResizableButton


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/7988

This PR fixes the scenario where the content to the left of the resizable flyout has a scrollbar (or any other clickable element that butts up against the flyout), and the placement of the resize border/indicator button prevents the thing it's overlaying from being clicked:

| Before | After |
|--------|--------|
| <img width="336" alt="" src="https://github.com/user-attachments/assets/e22e1b5b-c9a3-4dfe-9ed3-7d3ba2870d35"> | <img width="322" alt="" src="https://github.com/user-attachments/assets/5818b837-da10-44ce-8443-847f5adf88d2"> | 

FYI that I kept the centered styling on flyouts with overlay masks, because those overlays will close the entire flyout on outside click which feels super disruptive - I felt the extra space there would be more beneficial UX-wise to help minimize that for users who attempt to resize and are a few pixels off.

## QA

- Go to https://eui.elastic.co/pr_8010/storybook/?path=/story/layout-euiflyout-euiflyoutresizable--playground
- [x] Confirm the resize indicator is still centered on the border and overlays over the mask by default
- Change the `ownFocus` control to `false`
- [x] Confirm the resize indicator is now contained within the flyout only
- Change the flyout `type` to `push`
- [x] Confirm the resize indicator is still contained within the flyout only

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
    ~- [ ] Checked in **mobile**~
- Docs site QA - N/A
- Code quality checklist
    ~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)** - Looking into this, but Loki doesn't play well with focus/click events
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
