### PR TITLE
[EuiDatePicker] Fix clear button appearing when input is disabled

### DIFF
--- a/packages/eui/changelogs/upcoming/8020.md
+++ b/packages/eui/changelogs/upcoming/8020.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDatePicker`'s `onClear` button to not appear when the input is `disabled`

--- a/packages/eui/src/components/date_picker/date_picker.test.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.test.tsx
@@ -47,6 +47,25 @@ describe('EuiDatePicker', () => {
     jest.restoreAllMocks();
   });
 
+  test('onClear', () => {
+    const onClear = () => {};
+    const selected = moment();
+
+    const { queryByLabelText, rerender } = render(
+      <EuiDatePicker onClear={onClear} selected={selected} />
+    );
+    // Should render the clear button
+    expect(queryByLabelText('Clear input')).toBeInTheDocument();
+
+    // Should not render the clear button if the input is disabled
+    rerender(<EuiDatePicker onClear={onClear} selected={selected} disabled />);
+    expect(queryByLabelText('Clear input')).not.toBeInTheDocument();
+
+    // Should not render the clear button if no date is selected
+    rerender(<EuiDatePicker onClear={onClear} />);
+    expect(queryByLabelText('Clear input')).not.toBeInTheDocument();
+  });
+
   test('compressed', () => {
     const { container } = render(<EuiDatePicker compressed />);
     // TODO: Should probably be a visual snapshot test

--- a/packages/eui/src/components/date_picker/date_picker.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.tsx
@@ -320,7 +320,9 @@ export const EuiDatePicker: FunctionComponent<EuiDatePickerProps> = ({
     <span css={cssStyles} className={classes}>
       <EuiFormControlLayout
         icon={optionalIcon}
-        clear={selected && onClear ? { onClick: onClear } : undefined}
+        clear={
+          selected && !disabled && onClear ? { onClick: onClear } : undefined
+        }
         isLoading={isLoading}
         isInvalid={isInvalid}
         isDisabled={disabled}


### PR DESCRIPTION
## Summary

I noticed this minor bug when fixing form control layouts in Kibana (https://github.com/elastic/kibana/pull/192779).

| Before | After |
|--------|--------|
| <img width="484" alt="" src="https://github.com/user-attachments/assets/ec96c69c-8ee0-401c-b6da-8243e86988f7"> | <img width="479" alt="" src="https://github.com/user-attachments/assets/8e1c8689-2deb-43bd-8057-724c9e464e31"> | 

All other clearable inputs (e.g. EuiFieldSearch, EuiFilePicker, EuiColorPicker) hide the clear button when disabled - this component is following suit.

## QA

- Go to https://eui.elastic.co/pr_8020/storybook/?path=/story/forms-euidatepicker--playground&args=disabled:!true
- [x] Confirm the clear button does **not** appear
- Go to https://eui.elastic.co/pr_8020/storybook/?path=/story/forms-euidatepicker--playground
- [x] Confirm the clear button **does** still appear

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md)~ tests**
    ~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A