### PR TITLE
[DO NOT MERGE] add custom themes for testing purposes

### DIFF
--- a/packages/eui-theme-barcelona/.gitignore
+++ b/packages/eui-theme-barcelona/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+/node_modules
+
+# Production
+/lib
+
+yarn-debug.log*
+yarn-error.log*

--- a/packages/eui-theme-barcelona/README.md
+++ b/packages/eui-theme-barcelona/README.md
@@ -1,0 +1,1 @@
+# `@elastic/eui-theme-barcelona`

--- a/packages/eui-theme-barcelona/package.json
+++ b/packages/eui-theme-barcelona/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@elastic/eui-theme-barcelona",
+  "version": "0.0.1",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elastic/eui.git",
+    "directory": "packages/eui-theme-rainbow"
+  },
+  "private": true,
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  },
+  "peerDependencies": {
+    "@elastic/eui": "^95.10.1"
+  },
+  "main": "lib/index.js",
+  "exports": {
+    "./lib/*": "./lib/*",
+    ".": {
+      "default": "./lib/index.js"
+    }
+  },
+  "files": [
+    "lib/",
+    "README.md"
+  ]
+}

--- a/packages/eui-theme-barcelona/src/index.ts
+++ b/packages/eui-theme-barcelona/src/index.ts
@@ -1,0 +1,28 @@
+import { buildTheme, EuiThemeShape } from '@elastic/eui';
+import { colors } from './variables/_colors';
+import { animation } from './variables/_animation';
+import { breakpoint } from './variables/_breakpoint';
+import { base, size } from './variables/_size';
+import { border } from './variables/_borders';
+import { levels } from './variables/_levels';
+import { font } from './variables/_typography';
+import { focus } from './variables/_states';
+
+export const EUI_THEME_BARCELONA_KEY = 'EUI_THEME_BARCELONA';
+
+export const euiThemeBarcelona: EuiThemeShape = {
+  colors,
+  base,
+  size,
+  border,
+  font,
+  animation,
+  breakpoint,
+  levels,
+  focus,
+};
+
+export const EuiThemeBarcelona = buildTheme(
+  euiThemeBarcelona,
+  EUI_THEME_BARCELONA_KEY,
+);

--- a/packages/eui-theme-barcelona/src/variables/_animation.ts
+++ b/packages/eui-theme-barcelona/src/variables/_animation.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type {
+  _EuiThemeAnimationSpeeds,
+  _EuiThemeAnimationEasings,
+  _EuiThemeAnimation,
+} from '@elastic/eui';
+
+export const animation_speed: _EuiThemeAnimationSpeeds = {
+  extraFast: '90ms',
+  fast: '150ms',
+  normal: '250ms',
+  slow: '350ms',
+  extraSlow: '500ms',
+};
+
+export const animation_ease: _EuiThemeAnimationEasings = {
+  bounce: 'cubic-bezier(.34, 1.61, .7, 1)',
+  resistance: 'cubic-bezier(.694, .0482, .335, 1)',
+};
+
+export const animation: _EuiThemeAnimation = {
+  ...animation_speed,
+  ...animation_ease,
+};

--- a/packages/eui-theme-barcelona/src/variables/_borders.ts
+++ b/packages/eui-theme-barcelona/src/variables/_borders.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { computed, sizeToPixel, type _EuiThemeBorder } from '@elastic/eui';
+
+export const border: _EuiThemeBorder = {
+  color: computed(([lightShade]) => lightShade, ['colors.lightShade']),
+  width: {
+    thin: '1px',
+    thick: '2px',
+  },
+  radius: {
+    medium: computed(sizeToPixel(0.375)),
+    small: computed(sizeToPixel(0.25)),
+  },
+  thin: computed(
+    ([width, color]) => `${width.thin} solid ${color}`,
+    ['border.width', 'border.color']
+  ),
+  thick: computed(
+    ([width, color]) => `${width.thick} solid ${color}`,
+    ['border.width', 'border.color']
+  ),
+  editable: computed(
+    ([width, color]) => `${width.thick} dotted ${color}`,
+    ['border.width', 'border.color']
+  ),
+};

--- a/packages/eui-theme-barcelona/src/variables/_breakpoint.ts
+++ b/packages/eui-theme-barcelona/src/variables/_breakpoint.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { _EuiThemeBreakpoints } from '@elastic/eui';
+
+export const breakpoint: _EuiThemeBreakpoints = {
+  xl: 1200,
+  l: 992,
+  m: 768,
+  s: 575,
+  xs: 0,
+};

--- a/packages/eui-theme-barcelona/src/variables/_colors.ts
+++ b/packages/eui-theme-barcelona/src/variables/_colors.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  computed,
+  makeHighContrastColor,
+  makeDisabledContrastColor,
+  shade,
+  tint,
+  type _EuiThemeColors,
+  type _EuiThemeBrandColors,
+  type _EuiThemeBrandTextColors,
+  type _EuiThemeShadeColors,
+  type _EuiThemeSpecialColors,
+  type _EuiThemeTextColors,
+  type _EuiThemeColorsMode,
+} from '@elastic/eui';
+
+/*
+ * LIGHT THEME
+ * Only split up in the light theme to access the keys by section in the docs
+ */
+
+export const brand_colors: _EuiThemeBrandColors = {
+  primary: '#07C',
+  accent: '#F04E98',
+  success: '#00BFB3',
+  warning: '#FEC514',
+  danger: '#BD271E',
+};
+
+export const brand_text_colors: _EuiThemeBrandTextColors = {
+  primaryText: computed(makeHighContrastColor('colors.primary')),
+  accentText: computed(makeHighContrastColor('colors.accent')),
+  successText: computed(makeHighContrastColor('colors.success')),
+  warningText: computed(makeHighContrastColor('colors.warning')),
+  dangerText: computed(makeHighContrastColor('colors.danger')),
+};
+
+export const shade_colors: _EuiThemeShadeColors = {
+  emptyShade: '#FFF',
+  lightestShade: '#F1F4FA',
+  lightShade: '#D3DAE6',
+  mediumShade: '#98A2B3',
+  darkShade: '#69707D',
+  darkestShade: '#343741',
+  fullShade: '#000',
+};
+
+export const special_colors: _EuiThemeSpecialColors = {
+  body: computed(
+    ([lightestShade]) => tint(lightestShade, 0.4),
+    ['colors.lightestShade']
+  ),
+  highlight: computed(([warning]) => tint(warning, 0.9), ['colors.warning']),
+  disabled: '#ABB4C4',
+  disabledText: computed(makeDisabledContrastColor('colors.disabled')),
+  shadow: computed(({ colors }) => colors.ink),
+};
+
+export const text_colors: _EuiThemeTextColors = {
+  text: computed(([darkestShade]) => darkestShade, ['colors.darkestShade']),
+  title: computed(([text]) => shade(text, 0.5), ['colors.text']),
+  subduedText: computed(makeHighContrastColor('colors.darkShade')),
+  link: computed(([primaryText]) => primaryText, ['colors.primaryText']),
+};
+
+export const light_colors: _EuiThemeColorsMode = {
+  ...brand_colors,
+  ...shade_colors,
+  ...special_colors,
+  // Need to come after special colors so they can react to `body`
+  ...brand_text_colors,
+  ...text_colors,
+};
+
+/*
+ * DARK THEME
+ */
+
+export const dark_shades: _EuiThemeShadeColors = {
+  emptyShade: '#1D1E24',
+  lightestShade: '#25262E',
+  lightShade: '#343741',
+  mediumShade: '#535966',
+  darkShade: '#98A2B3',
+  darkestShade: '#D4DAE5',
+  fullShade: '#FFF',
+};
+
+export const dark_colors_ams: _EuiThemeColorsMode = {
+  // Brand
+  primary: '#36A2EF',
+  accent: '#F68FBE',
+  success: '#7DDED8',
+  warning: '#F3D371',
+  danger: '#F86B63',
+
+  // Shades
+  ...dark_shades,
+
+  // Special
+  body: computed(
+    ([lightestShade]) => shade(lightestShade, 0.45),
+    ['colors.lightestShade']
+  ),
+  highlight: '#2E2D25',
+  disabled: '#515761',
+  disabledText: computed(makeDisabledContrastColor('colors.disabled')),
+  shadow: computed(({ colors }) => colors.ink),
+
+  // Need to come after special colors so they can react to `body`
+  ...brand_text_colors,
+
+  // Text
+  text: '#DFE5EF',
+  title: computed(([text]) => text, ['colors.text']),
+  subduedText: computed(makeHighContrastColor('colors.mediumShade')),
+  link: computed(([primaryText]) => primaryText, ['colors.primaryText']),
+};
+
+/*
+ * FULL
+ */
+
+export const colors: _EuiThemeColors = {
+  ghost: '#FFF',
+  ink: '#000',
+  LIGHT: light_colors,
+  DARK: dark_colors_ams,
+};

--- a/packages/eui-theme-barcelona/src/variables/_levels.ts
+++ b/packages/eui-theme-barcelona/src/variables/_levels.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { _EuiThemeLevels } from '@elastic/eui';
+
+export const levels: _EuiThemeLevels = {
+  toast: 9000,
+  modal: 8000,
+  mask: 6000,
+  navigation: 6000,
+  menu: 2000,
+  header: 1000,
+  flyout: 1000,
+  maskBelowHeader: 1000,
+  content: 0,
+};

--- a/packages/eui-theme-barcelona/src/variables/_size.ts
+++ b/packages/eui-theme-barcelona/src/variables/_size.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  computed,
+  sizeToPixel,
+  type _EuiThemeBase,
+  type _EuiThemeSizes,
+} from '@elastic/eui';
+
+export const base: _EuiThemeBase = 16;
+
+export const size: _EuiThemeSizes = {
+  xxs: computed(sizeToPixel(0.125)),
+  xs: computed(sizeToPixel(0.25)),
+  s: computed(sizeToPixel(0.5)),
+  m: computed(sizeToPixel(0.75)),
+  base: computed(sizeToPixel()),
+  l: computed(sizeToPixel(1.5)),
+  xl: computed(sizeToPixel(2)),
+  xxl: computed(sizeToPixel(2.5)),
+  xxxl: computed(sizeToPixel(3)),
+  xxxxl: computed(sizeToPixel(4)),
+};

--- a/packages/eui-theme-barcelona/src/variables/_states.ts
+++ b/packages/eui-theme-barcelona/src/variables/_states.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  computed,
+  transparentize,
+  sizeToPixel,
+  type _EuiThemeFocus,
+} from '@elastic/eui';
+
+export const focus: _EuiThemeFocus = {
+  // Focus ring
+  color: 'currentColor',
+  width: computed(sizeToPixel(0.125)),
+  // Focus background
+  transparency: { LIGHT: 0.1, DARK: 0.2 },
+  backgroundColor: computed(({ colors, focus }) =>
+    transparentize(colors.primary, focus.transparency)
+  ),
+};

--- a/packages/eui-theme-barcelona/src/variables/_typography.ts
+++ b/packages/eui-theme-barcelona/src/variables/_typography.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  computed,
+  type _EuiThemeFont,
+  type _EuiThemeFontBase,
+  type _EuiThemeFontScales,
+  type _EuiThemeFontWeights,
+} from '@elastic/eui';
+
+// Typographic scale -- loosely based on Major Third (1.250)
+export const fontScale: _EuiThemeFontScales = {
+  xxxs: 0.5625, // 9px
+  xxs: 0.6875, // 11px
+  xs: 0.75, // 12px
+  s: 0.875, // 14px
+  m: 1, // 16px
+  l: 1.25, // 20px
+  xl: 1.5, // 24px
+  xxl: 1.875, // 30px
+};
+
+// Families & base font settings
+export const fontBase: _EuiThemeFontBase = {
+  family: "'Inter', BlinkMacSystemFont, Helvetica, Arial, sans-serif",
+  familyCode: "'Roboto Mono', Menlo, Courier, monospace",
+  familySerif: 'Georgia, Times, Times New Roman, serif',
+
+  // Careful using ligatures. Code editors like ACE will often error because of width calculations
+  featureSettings: "'calt' 1, 'kern' 1, 'liga' 1",
+  defaultUnits: 'rem',
+
+  baseline: computed(([base]) => base / 4, ['base']),
+  lineHeightMultiplier: 1.5,
+};
+
+export const fontWeight: _EuiThemeFontWeights = {
+  light: 300,
+  regular: 400,
+  medium: 450,
+  semiBold: 500,
+  bold: 600,
+};
+
+export const font: _EuiThemeFont = {
+  ...fontBase,
+  scale: fontScale,
+  weight: fontWeight,
+  body: {
+    scale: 's',
+    weight: 'regular',
+  },
+  title: {
+    weight: 'bold',
+  },
+};

--- a/packages/eui-theme-barcelona/tsconfig.json
+++ b/packages/eui-theme-barcelona/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ESNext", "DOM"],
+    "declaration": true,
+    "sourceMap": true,
+    "noEmitHelpers": true,
+    "incremental": true,
+    "tsBuildInfoFile": "lib/.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "lib",
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "Node",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/eui-theme-rainbow/.gitignore
+++ b/packages/eui-theme-rainbow/.gitignore
@@ -1,0 +1,8 @@
+# Dependencies
+/node_modules
+
+# Production
+/lib
+
+yarn-debug.log*
+yarn-error.log*

--- a/packages/eui-theme-rainbow/README.md
+++ b/packages/eui-theme-rainbow/README.md
@@ -1,0 +1,2 @@
+# `@elastic/eui-theme-rainbow`
+

--- a/packages/eui-theme-rainbow/package.json
+++ b/packages/eui-theme-rainbow/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@elastic/eui-theme-rainbow",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tkajtoch/eui.git",
+    "directory": "packages/eui-theme-rainbow"
+  },
+  "private": true,
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  },
+  "peerDependencies": {
+    "@elastic/eui": "^95.10.1"
+  },
+  "main": "lib/index.js",
+  "exports": {
+    "./lib/*": "./lib/*",
+    ".": {
+      "default": "./lib/index.js"
+    }
+  },
+  "files": [
+    "lib/",
+    "README.md"
+  ]
+}

--- a/packages/eui-theme-rainbow/src/index.ts
+++ b/packages/eui-theme-rainbow/src/index.ts
@@ -1,0 +1,28 @@
+import { buildTheme, EuiThemeShape } from '@elastic/eui';
+import { colors } from './variables/_colors';
+import { animation } from './variables/_animation';
+import { breakpoint } from './variables/_breakpoint';
+import { base, size } from './variables/_size';
+import { border } from './variables/_borders';
+import { levels } from './variables/_levels';
+import { font } from './variables/_typography';
+import { focus } from './variables/_states';
+
+export const EUI_THEME_RAINBOW_KEY = 'EUI_THEME_RAINBOW';
+
+export const euiThemeRainbow: EuiThemeShape = {
+  colors,
+  base,
+  size,
+  border,
+  font,
+  animation,
+  breakpoint,
+  levels,
+  focus,
+};
+
+export const EuiThemeRainbow = buildTheme(
+  euiThemeRainbow,
+  EUI_THEME_RAINBOW_KEY,
+);

--- a/packages/eui-theme-rainbow/src/variables/_animation.ts
+++ b/packages/eui-theme-rainbow/src/variables/_animation.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type {
+  _EuiThemeAnimationSpeeds,
+  _EuiThemeAnimationEasings,
+  _EuiThemeAnimation,
+} from '@elastic/eui';
+
+export const animation_speed: _EuiThemeAnimationSpeeds = {
+  extraFast: '90ms',
+  fast: '150ms',
+  normal: '250ms',
+  slow: '350ms',
+  extraSlow: '500ms',
+};
+
+export const animation_ease: _EuiThemeAnimationEasings = {
+  bounce: 'cubic-bezier(.34, 1.61, .7, 1)',
+  resistance: 'cubic-bezier(.694, .0482, .335, 1)',
+};
+
+export const animation: _EuiThemeAnimation = {
+  ...animation_speed,
+  ...animation_ease,
+};

--- a/packages/eui-theme-rainbow/src/variables/_borders.ts
+++ b/packages/eui-theme-rainbow/src/variables/_borders.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { computed, sizeToPixel, type _EuiThemeBorder } from '@elastic/eui';
+
+export const border: _EuiThemeBorder = {
+  color: computed(([lightShade]) => lightShade, ['colors.lightShade']),
+  width: {
+    thin: '2px',
+    thick: '4px',
+  },
+  radius: {
+    medium: computed(sizeToPixel(0.75)),
+    small: computed(sizeToPixel(0.5)),
+  },
+  thin: computed(
+    ([width, color]) => `${width.thin} solid ${color}`,
+    ['border.width', 'border.color']
+  ),
+  thick: computed(
+    ([width, color]) => `${width.thick} solid ${color}`,
+    ['border.width', 'border.color']
+  ),
+  editable: computed(
+    ([width, color]) => `${width.thick} dotted ${color}`,
+    ['border.width', 'border.color']
+  ),
+};

--- a/packages/eui-theme-rainbow/src/variables/_breakpoint.ts
+++ b/packages/eui-theme-rainbow/src/variables/_breakpoint.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { _EuiThemeBreakpoints } from '@elastic/eui';
+
+export const breakpoint: _EuiThemeBreakpoints = {
+  xl: 1200,
+  l: 992,
+  m: 768,
+  s: 575,
+  xs: 0,
+};

--- a/packages/eui-theme-rainbow/src/variables/_colors.ts
+++ b/packages/eui-theme-rainbow/src/variables/_colors.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { type _EuiThemeColors } from '@elastic/eui';
+
+export const colors: _EuiThemeColors = {
+  ghost: '#FFF',
+  ink: '#000',
+  LIGHT: {
+    primary: '#00ff6a',
+    accent: '#00ff6a',
+    success: '#00ff6a',
+    warning: '#00ff6a',
+    danger: '#00ff6a',
+    emptyShade: '#ebfff3',
+    lightestShade: '#daede2',
+    lightShade: '#c1d2c8',
+    mediumShade: '#a6c5b3',
+    darkShade: '#61806e',
+    darkestShade: '#325842',
+    fullShade: '#002811',
+    body: '#f0f7f3',
+    highlight: '#ddffeb',
+    disabled: '#929e97',
+    disabledText: '#5b6961',
+    shadow: '#000',
+    primaryText: '#007731',
+    accentText: '#007731',
+    successText: '#007731',
+    warningText: '#007731',
+    dangerText: '#007731',
+    text: '#325842',
+    title: '#061b0f',
+    subduedText: '#536e5f',
+    link: '#007731',
+  },
+  DARK: {
+    primary: '#00ff6a',
+    accent: '#00ff6a',
+    success: '#00ff6a',
+    warning: '#00ff6a',
+    danger: '#00ff6a',
+    emptyShade: '#ebfff3',
+    lightestShade: '#daede2',
+    lightShade: '#c1d2c8',
+    mediumShade: '#a6c5b3',
+    darkShade: '#61806e',
+    darkestShade: '#325842',
+    fullShade: '#002811',
+    body: '#f0f7f3',
+    highlight: '#ddffeb',
+    disabled: '#929e97',
+    disabledText: '#5b6961',
+    shadow: '#000',
+    primaryText: '#007731',
+    accentText: '#007731',
+    successText: '#007731',
+    warningText: '#007731',
+    dangerText: '#007731',
+    text: '#325842',
+    title: '#061b0f',
+    subduedText: '#536e5f',
+    link: '#007731',
+  },
+};

--- a/packages/eui-theme-rainbow/src/variables/_levels.ts
+++ b/packages/eui-theme-rainbow/src/variables/_levels.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { _EuiThemeLevels } from '@elastic/eui';
+
+export const levels: _EuiThemeLevels = {
+  toast: 9000,
+  modal: 8000,
+  mask: 6000,
+  navigation: 6000,
+  menu: 2000,
+  header: 1000,
+  flyout: 1000,
+  maskBelowHeader: 1000,
+  content: 0,
+};

--- a/packages/eui-theme-rainbow/src/variables/_size.ts
+++ b/packages/eui-theme-rainbow/src/variables/_size.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  computed,
+  sizeToPixel,
+  type _EuiThemeBase,
+  type _EuiThemeSizes,
+} from '@elastic/eui';
+
+export const base: _EuiThemeBase = 14;
+
+export const size: _EuiThemeSizes = {
+  xxs: computed(sizeToPixel(0.125)),
+  xs: computed(sizeToPixel(0.25)),
+  s: computed(sizeToPixel(0.5)),
+  m: computed(sizeToPixel(0.75)),
+  base: computed(sizeToPixel()),
+  l: computed(sizeToPixel(1.5)),
+  xl: computed(sizeToPixel(2)),
+  xxl: computed(sizeToPixel(2.5)),
+  xxxl: computed(sizeToPixel(3)),
+  xxxxl: computed(sizeToPixel(4)),
+};

--- a/packages/eui-theme-rainbow/src/variables/_states.ts
+++ b/packages/eui-theme-rainbow/src/variables/_states.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { computed, transparentize, sizeToPixel, type _EuiThemeFocus } from '@elastic/eui';
+
+export const focus: _EuiThemeFocus = {
+  // Focus ring
+  color: 'currentColor',
+  width: computed(sizeToPixel(0.125)),
+  // Focus background
+  transparency: { LIGHT: 0.1, DARK: 0.2 },
+  backgroundColor: computed(({ colors, focus }) =>
+    transparentize(colors.primary, focus.transparency)
+  ),
+};

--- a/packages/eui-theme-rainbow/src/variables/_typography.ts
+++ b/packages/eui-theme-rainbow/src/variables/_typography.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  computed,
+  type _EuiThemeFont,
+  type _EuiThemeFontBase,
+  type _EuiThemeFontScales,
+  type _EuiThemeFontWeights,
+} from '@elastic/eui';
+
+// Typographic scale -- loosely based on Major Third (1.250)
+export const fontScale: _EuiThemeFontScales = {
+  xxxs: 0.5625,
+  xxs: 0.6875,
+  xs: 0.75,
+  s: 0.875,
+  m: 1,
+  l: 1.375,
+  xl: 1.6875,
+  xxl: 2.125,
+};
+
+// Families & base font settings
+export const fontBase: _EuiThemeFontBase = {
+  family: "'Comic Sans MS', 'Inter', BlinkMacSystemFont, Helvetica, Arial, sans-serif",
+  familyCode: "'Comic Sans MS', 'Roboto Mono', Menlo, Courier, monospace",
+  familySerif: "'Comic Sans MS', Georgia, Times, Times New Roman, serif",
+
+  // Careful using ligatures. Code editors like ACE will often error because of width calculations
+  featureSettings: "",
+  defaultUnits: 'rem',
+
+  baseline: computed(([base]) => base / 4, ['base']),
+  lineHeightMultiplier: 1.25,
+};
+
+export const fontWeight: _EuiThemeFontWeights = {
+  light: 400,
+  regular: 400,
+  medium: 400,
+  semiBold: 700,
+  bold: 700,
+};
+
+export const font: _EuiThemeFont = {
+  ...fontBase,
+  scale: fontScale,
+  weight: fontWeight,
+  body: {
+    scale: 's',
+    weight: 'regular',
+  },
+  title: {
+    weight: 'bold',
+  },
+};

--- a/packages/eui-theme-rainbow/tsconfig.json
+++ b/packages/eui-theme-rainbow/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ESNext", "DOM"],
+    "declaration": true,
+    "sourceMap": true,
+    "noEmitHelpers": true,
+    "incremental": true,
+    "tsBuildInfoFile": "lib/.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "lib",
+    "esModuleInterop": true,
+    "strict": true,
+    "moduleResolution": "Node",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5748,6 +5748,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@elastic/eui-theme-barcelona@workspace:packages/eui-theme-barcelona":
+  version: 0.0.0-use.local
+  resolution: "@elastic/eui-theme-barcelona@workspace:packages/eui-theme-barcelona"
+  dependencies:
+    typescript: "npm:^5.6.2"
+  peerDependencies:
+    "@elastic/eui": ^95.10.1
+  languageName: unknown
+  linkType: soft
+
+"@elastic/eui-theme-rainbow@workspace:packages/eui-theme-rainbow":
+  version: 0.0.0-use.local
+  resolution: "@elastic/eui-theme-rainbow@workspace:packages/eui-theme-rainbow"
+  dependencies:
+    typescript: "npm:^5.6.2"
+  peerDependencies:
+    "@elastic/eui": ^95.10.1
+  languageName: unknown
+  linkType: soft
+
 "@elastic/eui-website@workspace:packages/website":
   version: 0.0.0-use.local
   resolution: "@elastic/eui-website@workspace:packages/website"
@@ -36582,6 +36602,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "typescript@npm:5.6.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/3ed8297a8c7c56b7fec282532503d1ac795239d06e7c4966b42d4330c6cf433a170b53bcf93a130a7f14ccc5235de5560df4f1045eb7f3550b46ebed16d3c5e5
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -36599,6 +36629,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/b1912ff8dcae3c5a8739dc5a3f12422d3bf5f8a6a5642b1d537ee18873de0bb7346e83c7de3b146291e93f6493ac9843c7bbbbb12ec6393b8e07a0a2dc88550f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>":
+  version: 5.6.2
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=b45daf"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/e6c1662e4852e22fe4bbdca471dca3e3edc74f6f1df043135c44a18a7902037023ccb0abdfb754595ca9028df8920f2f8492c00fc3cbb4309079aae8b7de71cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds custom theme packages for testing purposes, which are used in the https://github.com/elastic/kibana/pull/192708 PR.

The Barcelona theme is a copy of the Amsterdam theme with slight typography changes coming from https://github.com/elastic/eui/pull/7942, and the rainbow theme is a green Comic Sans _chaos_ created purely to see parts of Kibana that are not using our theme variables.