### PR TITLE
[EuiSearchBox][React@18 Legacy Mode] `useLayoutEffect` in `search_box`

### DIFF
--- a/packages/eui/changelogs/upcoming/8047.md
+++ b/packages/eui/changelogs/upcoming/8047.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiSearchBox` skips input when running with React 18 in Legacy Mode
+

--- a/packages/eui/src/components/search_bar/search_box.tsx
+++ b/packages/eui/src/components/search_bar/search_box.tsx
@@ -6,9 +6,8 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, useRef } from 'react';
+import React, { FunctionComponent, useRef, useLayoutEffect } from 'react';
 
-import { useUpdateEffect } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { EuiFieldSearch, EuiFieldSearchProps } from '../form';
 import { EuiInputPopover } from '../popover';
@@ -39,7 +38,7 @@ export const EuiSearchBox: FunctionComponent<EuiSearchBoxProps> = ({
 }) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  useUpdateEffect(() => {
+  useLayoutEffect(() => {
     if (inputRef.current) {
       inputRef.current.value = query;
       inputRef.current.dispatchEvent(new Event('change'));


### PR DESCRIPTION
## Summary

Close https://github.com/elastic/eui/issues/8018

As discussed https://github.com/elastic/eui/issues/8018, while trying to upgade Kibana to React@18 so far we've found a single place where EUI doesn't work nicely with React@18 in legacy mode. 

The workarond we've found is to use `useLayoutEffect` in this component. Hopefull this won't have significant downsides.  

Here is the React issue I filed: `https://github.com/facebook/react/issues/31023`

## QA

I was running Kibana tests with this change and there was no issues discovered 

### General checklist

- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
