### PR TITLE
[EuiButtonDisplay] Fix missing text-align CSS

### DIFF
--- a/packages/eui/src/components/button/button_display/_button_display.styles.ts
+++ b/packages/eui/src/components/button/button_display/_button_display.styles.ts
@@ -11,7 +11,7 @@ import {
   euiFontSize,
   logicalCSS,
   logicalShorthandCSS,
-  logicalTextAlignStyle,
+  logicalTextAlignCSS,
 } from '../../../global_styling';
 import { euiButtonSizeMap } from '../../../themes/amsterdam/global_styling/mixins';
 import { EuiButtonDisplaySizes } from './_button_display';
@@ -23,7 +23,7 @@ export const euiButtonBaseCSS = () => {
     display: inline-block;
     appearance: none;
     cursor: pointer;
-    ${logicalTextAlignStyle('center')};
+    ${logicalTextAlignCSS('center')};
     white-space: nowrap;
     ${logicalCSS('max-width', '100%')};
     vertical-align: middle;


### PR DESCRIPTION
## Summary

> [!note]
> This doesn't fundamentally affect any actual visuals, because flex CSS was already handling centering button content for us. But it's nice not to have buggy CSS-in-JS in our codebase 😅 

This was missed during EuiButton's original Emotion conversion. Just for funsies, I'm going to dive into what was causing the bug:

- Our `logical*Style` utilities output **objects** of CSS key/values, e.g. `{ color: red }`

- Our `logical*CSS` utilities output **strings** of CSS, e.g. `'color: red;'`

- Emotion CSS that uses the ``` css`` ``` template literal can parse **both**.

- Regular template literals (``` `` ```), like the one being used in `euiButtonBaseCSS` (to avoid generating an extra emotion label, presumably), **cannot** parse objects, only strings. So the previous code was generating this:
    <img width="584" alt="" src="https://github.com/user-attachments/assets/f649cb20-b911-4f5f-aa54-d04bd1e73a77">
    Huge thank you/shout out to @tsullivan for logging and noticing this bug!

- Changing our internal EUI code to use the string output instead of object output solves the issue. We now have `text-align: center` in our CSS again, where it was previously missing.
    <img width="299" alt="" src="https://github.com/user-attachments/assets/e012bfbd-4ebc-405c-9d94-41b1881291bf">

- Bonus: another approach I could have tried to resolve this was potentially using the ``` css`` ``` template literal and renaming the util to `_euiButtonBaseCSS`. Emotion generally seems to respect and not add extra classNames to underscore-prefixed utilities, although this is not _always_ the case.

## QA

- [x] Go to https://eui.elastic.co/pr_8057/#/navigation/button and confirm `text-align: center` is now present on our buttons, where it is not on [prod](https://eui.elastic.co/#/navigation/button)

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA - N/A
- Code quality checklist - N/A, styles only
- Release checklist
    - ~[ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.~ I'm opting to skip a changelog for this since it's an internal-only component / tech debt and doesn't affect any consumers or end-users.
- Designer checklist - N/A