### PR TITLE
Re-add more of a README to `packages/eui/`

### DIFF
--- a/packages/eui/README.md
+++ b/packages/eui/README.md
@@ -1,1 +1,18 @@
-## See [the top-level repo README](../../#readme) and [wiki](../../wiki) for more information on consuming and contributing to EUI.
+<img src="https://repository-images.githubusercontent.com/107422373/b6180480-a1d7-11eb-8a3c-902086232aa7" alt="" />
+
+# Elastic UI Framework
+
+**The Elastic UI Framework is a collection of React UI components for quickly building user interfaces at Elastic.**
+
+## Resources
+
+- Check out our [full documentation site](https://eui.elastic.co), which contains many examples of components in the EUI framework aesthetic, and how to use them in your products.
+- [Our FAQ](https://github.com/elastic/eui#frequently-asked-questions) covers common usage questions — for other general questions regarding EUI, check out the [Discussions tab](https://github.com/elastic/eui/discussions).
+- For technical instructions and guidelines on usage and development, please [refer to our wiki](https://github.com/elastic/eui/tree/main/wiki).
+
+## License
+
+[Dual-licensed under Elastic v2 and Server Side Public License, v1][license]. See Elastic's [licensing FAQ][licensing-faq] for details.
+
+[license]: LICENSE.txt
+[licensing-faq]: https://www.elastic.co/pricing/faq/licensing#im-using-eui-or-elastic-charts-in-my-application-outside-of-kibana-how-does-this-affect-me

--- a/packages/eui/README.md
+++ b/packages/eui/README.md
@@ -1,3 +1,4 @@
+<!-- Note: this README is what renders to our published NPM package, and should remain nice-looking & have useful links without repeating too much information from the top-level README -->
 <img src="https://repository-images.githubusercontent.com/107422373/b6180480-a1d7-11eb-8a3c-902086232aa7" alt="" />
 
 # Elastic UI Framework


### PR DESCRIPTION
## Summary

I pruned the duplicate READMEs in #8029 (between `/` and `/packages/eui/` without realizing that `/packages/eui/` is what determines what renders in https://www.npmjs.com/package/@elastic/eui, so we now have a very sad looking NPM package 🤦 

I've brought back some of the higher level content with links without going so far as to duplicate the FAQ and more detailed docs/copy from the root README.

## QA

- https://github.com/elastic/eui/blob/f75285ffd17aa119a700276828b0101782601b94/packages/eui/README.md

### General checklist

N/A, internal only