### PR TITLE
github-actions: add missing permissions

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   stale-prs: # close stale PRs after ~3 months
     permissions:
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +28,7 @@ jobs:
   stale-issues: # close stale issues after ~1 year
     permissions:
       issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
## Summary

Fixes the required permissions for the GitHub actions in charge of managing the stale issues or PRs

There are some missing permissions and some error annotations in the GitHub workflow:

<img width="931" alt="image" src="https://github.com/user-attachments/assets/31da2422-3ef0-465e-a64d-a212b69faca6">

I discovered these errors as part of the CICD Observability for GitHub actions that we enabled some time ago and with some alerting when searching for `Resource not accessible by integration`

<img width="697" alt="image" src="https://github.com/user-attachments/assets/fe20d5e9-f68c-449b-ba13-0e24a65fa078">

<img width="1242" alt="image" src="https://github.com/user-attachments/assets/861876ce-66c3-4081-bbd2-0198e81a94f4">



For further details please see https://github.com/actions/stale/issues/840

## QA

N/A, internal only