### PR TITLE
fix(date-picker-range): make inputs take the whole available space

### DIFF
--- a/packages/eui/changelogs/upcoming/8061.md
+++ b/packages/eui/changelogs/upcoming/8061.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed inputs not taking the whole width when passing `fullWidth` as `true` to EuiDatePickerRange component
+

--- a/packages/eui/src/components/date_picker/date_picker_range.styles.ts
+++ b/packages/eui/src/components/date_picker/date_picker_range.styles.ts
@@ -19,6 +19,11 @@ export const euiDatePickerRangeStyles = {
     .euiDatePicker {
       ${logicalCSS('height', '100%')}
     }
+
+    /* Needed for the fullWidth prop: makes inputs take the whole available space */
+    .euiPopover {
+      flex: 1;
+    }
   `,
 };
 


### PR DESCRIPTION
## Summary

Between the latest [v95.10.1](https://eui.elastic.co/v95.10.1/#/forms/date-picker#date-picker-range) and [v95.7.0](https://eui.elastic.co/v95.7.0/#/forms/date-picker#date-picker-range) the `fullWidth` prop stopped working as expected.

**Current behaviour:**

https://github.com/user-attachments/assets/7686b997-b2b1-495f-b892-b4d78cf89eae

**Expected behaviour:** 

https://github.com/user-attachments/assets/bc90b5ba-7844-48dd-a7d5-d441f5b03624

Because both controls (the start and end date) are within a flex parent, we can use `flex: 1` to make them take all the available space equally. I added a comment to highlight that it's important for `fullWidth` functionality because it's not applied conditionally based on the `fullWidth` value.

## QA

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, ~**Edge**~, and ~**Firefox**~
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
