### PR TITLE
[Cypress] Add static colorMode for test environment

### DIFF
--- a/packages/eui/cypress/support/setup/mount.tsx
+++ b/packages/eui/cypress/support/setup/mount.tsx
@@ -29,7 +29,7 @@ const mountCommand = (
   options: MountOptions = {}
 ): ReturnType<typeof mount> => {
   const { providerProps } = options;
-  return cypressMount(<EuiProvider {...providerProps}>{children}</EuiProvider>);
+  return cypressMount(<EuiProvider {...providerProps} colorMode="LIGHT">{children}</EuiProvider>);
 };
 
 // Export only the type to not confuse code-completion tools

--- a/packages/eui/cypress/support/setup/mount.tsx
+++ b/packages/eui/cypress/support/setup/mount.tsx
@@ -29,7 +29,11 @@ const mountCommand = (
   options: MountOptions = {}
 ): ReturnType<typeof mount> => {
   const { providerProps } = options;
-  return cypressMount(<EuiProvider {...providerProps} colorMode="LIGHT">{children}</EuiProvider>);
+  return cypressMount(
+    <EuiProvider colorMode="LIGHT" {...providerProps}>
+      {children}
+    </EuiProvider>
+  );
 };
 
 // Export only the type to not confuse code-completion tools


### PR DESCRIPTION
## Summary

In this [previous PR](https://github.com/elastic/eui/pull/8026) we removed the default `colorMode` on **EuiProvider** in favor of listening to system settings.
This causes issues in testing environments because our tests assert on LIGHT mode (e.g. color values). Tests will fail when the system setting is set to DARK mode because of this.

### Changes

- adds static `colorMode="light"` on the wrapping **EuiProvider** for cypress tests

## QA

- [x] CI passes
- [x] verify system settings have no affect on tests:
  - checkout this PR
  - set the local system setting for color mode to "dark"
  - run `yarn test-cypress-dev` and run the test for `data_grid_cell.styles.spec.ts`
  - verify the test does not fail