### PR TITLE
Poc/code connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 !.yarn/sdks
 !.yarn/versions
 yarn-error.log
+
+# Environment variables
+.env

--- a/packages/eui/.storybook/main.ts
+++ b/packages/eui/.storybook/main.ts
@@ -30,6 +30,7 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-webpack5-compiler-babel',
+    '@storybook/addon-designs',
   ],
   framework: {
     name: '@storybook/react-webpack5',
@@ -50,6 +51,15 @@ const config: StorybookConfig = {
       ...config,
       resolve: {
         ...config.resolve,
+        fallback: {
+          ...config.resolve?.fallback,
+          console: false, // used by @figma/code-connect
+          child_process: false, // used by @figma/code-connect
+          os: false, // used by dotenv
+          // not necessary for the browser environment (Storybook), therefore doesn't need a polyfill;
+          // the change is required only for the purposes of Code Connect investigation, otherwise
+          // Webpack gets confused; likely this won't get merged
+        },
         alias: {
           ...config.resolve?.alias,
           // we need to resolve to the modules file as otherwise

--- a/packages/eui/figma.config.json
+++ b/packages/eui/figma.config.json
@@ -1,0 +1,12 @@
+{
+  "codeConnect": {
+    "parser": "react",
+    "include": ["/**/*.{tsx,jsx}"],
+    "importPaths": {
+      "src/components/*": "@elastic/eui"
+    },
+    "documentUrlSubstitutions": {
+      "node-id": "https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id"
+    }
+  }
+}

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -44,7 +44,8 @@
     "release-rc": "node ./scripts/release.js --type=prerelease",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "pre-push": "yarn test-staged"
+    "pre-push": "yarn test-staged",
+    "figma": "dotenv -- figma connect"
   },
   "repository": {
     "type": "git",
@@ -110,6 +111,7 @@
     "@emotion/jest": "^11.11.0",
     "@emotion/react": "^11.11.0",
     "@faker-js/faker": "^8.0.2",
+    "@figma/code-connect": "^1.1.4",
     "@loki/create-async-callback": "^0.35.0",
     "@loki/is-loki-running": "^0.35.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
@@ -174,6 +176,7 @@
     "cypress-plugin-tab": "^1.0.5",
     "cypress-real-events": "^1.7.0",
     "dedent": "^0.7.0",
+    "dotenv-cli": "^7.4.2",
     "dts-generator": "^3.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.7",

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -115,6 +115,7 @@
     "@loki/create-async-callback": "^0.35.0",
     "@loki/is-loki-running": "^0.35.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
+    "@storybook/addon-designs": "^8.0.3",
     "@storybook/addon-essentials": "^8.0.5",
     "@storybook/addon-interactions": "^8.0.5",
     "@storybook/addon-links": "^8.0.5",

--- a/packages/eui/src/components/badge/badge.figma.tsx
+++ b/packages/eui/src/components/badge/badge.figma.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// eslint-disable-next-line
+// @ts-nocheck
+
+/**
+ * `iconType` expects an enum member, a string or ComponentType
+ * `iconSide` expects "left" or "right" or undefined
+ *
+ * I cannot use `as const` to narrow down the type because the value is serialized, so the code snippet would be
+ * `iconSide={'left' as const}`
+ *
+ * figma.instance returns a a JSX.Element, not ComponentType or string. The code is not executed so it doesn't matter.
+ *
+ * `props` must be an object literal so we cannot use assertion there either.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiBadge } from './badge';
+
+figma.connect(EuiBadge, 'node-id=31918-390303', {
+  props: {
+    children: figma.boolean('Icon only', {
+      true: undefined,
+      false: figma.string('Text'),
+    }),
+    color: figma.enum('Color', {
+      Default: undefined,
+      Hollow: 'hollow',
+      Primary: 'primary',
+      Accent: 'accent',
+      Success: 'success',
+      Danger: 'danger',
+      Warning: 'warning',
+    }),
+    isDisabled: figma.boolean('Disabled'),
+    iconType: figma.boolean('Icon only', {
+      true: figma.instance('⮑ Icon'),
+      false: figma.boolean('Icon left', {
+        true: figma.instance('⮑ Icon left'),
+        false: figma.boolean('Icon right', {
+          true: figma.instance('⮑ Icon right'),
+          false: undefined,
+        }),
+      }),
+    }),
+    iconSide: figma.boolean('Icon left', {
+      true: 'left',
+      false: figma.boolean('Icon right', {
+        true: 'right',
+        false: undefined,
+      }),
+    }),
+  },
+  example: ({ children, ...props }) => (
+    <EuiBadge {...props}>{children}</EuiBadge>
+  ),
+});

--- a/packages/eui/src/components/badge/badge.stories.tsx
+++ b/packages/eui/src/components/badge/badge.stories.tsx
@@ -6,25 +6,12 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EuiBadge, EuiBadgeProps, COLORS } from './badge';
 
-const meta: Meta<EuiBadgeProps> = {
-  title: 'Display/EuiBadge/EuiBadge',
-  component: EuiBadge,
-  argTypes: {
-    iconType: { control: 'text' },
-  },
-  args: {
-    // Component defaults
-    iconSide: 'left',
-    isDisabled: false,
-    color: 'default',
-  },
-};
-
-export default meta;
 type Story = StoryObj<EuiBadgeProps>;
 
 export const Playground: Story = {
@@ -37,6 +24,9 @@ export const Playground: Story = {
       options: COLORS,
     },
   },
+  render: ({ children, ...args }: EuiBadgeProps) => (
+    <EuiBadge {...args}>{children}</EuiBadge>
+  ),
 };
 
 export const CustomColors: Story = {
@@ -50,3 +40,59 @@ export const CustomColors: Story = {
     color: '#0000FF',
   },
 };
+
+const meta: Meta<EuiBadgeProps> = {
+  title: 'Display/EuiBadge/EuiBadge',
+  component: EuiBadge,
+  argTypes: {
+    iconType: { control: 'text' },
+  },
+  args: {
+    // Component defaults
+    iconSide: 'left',
+    isDisabled: false,
+    color: 'default',
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31918-390303&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        children: figma.boolean('Icon only', {
+          true: undefined,
+          false: figma.string('Text'),
+        }),
+        color: figma.enum('Color', {
+          Default: undefined,
+          Hollow: 'hollow',
+          Primary: 'primary',
+          Accent: 'accent',
+          Success: 'success',
+          Danger: 'danger',
+          Warning: 'warning',
+        }),
+        isDisabled: figma.boolean('Disabled'),
+        iconType: figma.boolean('Icon only', {
+          true: figma.instance('⮑ Icon'),
+          false: figma.boolean('Icon left', {
+            true: figma.instance('⮑ Icon left'),
+            false: figma.boolean('Icon right', {
+              true: figma.instance('⮑ Icon right'),
+              false: undefined,
+            }),
+          }),
+        }),
+        iconSide: figma.boolean('Icon left', {
+          true: 'left',
+          false: figma.boolean('Icon right', {
+            true: 'right',
+            false: undefined,
+          }),
+        }),
+      },
+    },
+  },
+};
+
+export default meta;

--- a/packages/eui/src/components/button/button.figma.tsx
+++ b/packages/eui/src/components/button/button.figma.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// eslint-disable-next-line
+// @ts-nocheck
+
+/**
+ * `iconType` expects an enum member, a string or ComponentType
+ * `iconSide` expects "left" or "right" or undefined
+ *
+ * I cannot use `as const` to narrow down the type below because the value is serialized,
+ * so the code snippet would be `iconSide={'left' as const}`,
+ * and figma.instance is a JSX.Element, not ComponentType or string but it's a conflict between
+ * Code Connect API and the icon implementation (it's not render props pattern). I don't think there's an alternative,
+ * at the same time it doesn't matter much because Figma files are not executed, they're parsed as string.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiButton } from './button';
+import { EuiButtonEmpty } from './button_empty';
+
+/* Example: reusing the same props across multiple component connections */
+const sharedProps = {
+  children: figma.boolean('Icon only', {
+    true: undefined,
+    false: figma.textContent('Text'),
+  }),
+  color: figma.enum('Color', {
+    'Primary*': undefined,
+    Neutral: 'text',
+    Success: 'success',
+    Warning: 'warning',
+    Danger: 'danger',
+    Accent: 'accent',
+  }),
+  isDisabled: figma.boolean('Disabled'),
+  isLoading: figma.boolean('Loading'),
+  iconType: figma.boolean('Icon only', {
+    true: figma.instance('⮑ Icon'),
+    false: figma.boolean('Icon left', {
+      true: figma.instance('⮑ Icon left'),
+      false: figma.boolean('Icon right', {
+        true: figma.instance('⮑ Icon right'),
+        false: undefined,
+      }),
+    }),
+  }),
+  iconSide: figma.boolean('Icon left', {
+    true: 'left',
+    false: figma.boolean('Icon right', {
+      true: 'right',
+      false: figma.boolean('Loading', {
+        true: figma.boolean('Left spinner', {
+          true: 'left',
+          false: figma.boolean('Right spinner', {
+            true: 'right',
+            false: undefined,
+          }),
+        }),
+        false: undefined,
+      }),
+    }),
+  }),
+  size: figma.enum('Size', {
+    'Medium*': undefined,
+    Small: 's',
+    // Discrepancy between Figma and EUI
+    // 'Extra Small': 'extra-small',
+  }),
+};
+
+/* Basic example */
+figma.connect(EuiButton, 'node-id=31735-391399', {
+  props: {
+    ...sharedProps,
+    fill: figma.enum('Style', {
+      'Default*': undefined,
+      Filled: true,
+    }),
+  },
+  example: ({ children, ...props }) => (
+    <EuiButton onClick={() => {}} {...props}>
+      {children}
+    </EuiButton>
+  ),
+});
+
+/* Example: Self-closing tags example (doesn't work, error: The Figma Variant "Icon only" does not have an option for true) */
+/* figma.connect(EuiButton, 'node-id=31735-391399', {
+  variant: { 'Icon only': true },
+  props: sharedProps,
+  example: (props) => (
+    <EuiButton aria-label="Meaningful label" onClick={() => {}} {...props} />
+  ),
+}); */
+
+/* Example: Figma variant being a separate component in code */
+figma.connect(EuiButtonEmpty, 'node-id=31735-391399', {
+  variant: { Style: 'Empty' },
+  props: sharedProps,
+  example: ({ children, ...props }) => (
+    <EuiButtonEmpty onClick={() => {}} {...props}>
+      {children}
+    </EuiButtonEmpty>
+  ),
+});

--- a/packages/eui/src/components/button/button.stories.tsx
+++ b/packages/eui/src/components/button/button.stories.tsx
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import {
@@ -14,6 +16,18 @@ import {
 } from '../../../.storybook/utils';
 
 import { EuiButton, Props as EuiButtonProps } from './button';
+
+type Story = StoryObj<EuiButtonProps>;
+
+export const Playground: Story = {
+  args: {
+    children: 'Button',
+  },
+  render: ({ children, ...args }: EuiButtonProps) => (
+    <EuiButton {...args}>{children}</EuiButton>
+  ),
+};
+disableStorybookControls(Playground, ['buttonRef']);
 
 const meta: Meta<EuiButtonProps> = {
   title: 'Navigation/EuiButton',
@@ -37,15 +51,66 @@ const meta: Meta<EuiButtonProps> = {
     isLoading: false,
     isSelected: false,
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31735-391399&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        children: figma.boolean('Icon only', {
+          true: undefined,
+          false: figma.textContent('Text'),
+        }),
+        color: figma.enum('Color', {
+          'Primary*': undefined,
+          Neutral: 'text',
+          Success: 'success',
+          Warning: 'warning',
+          Danger: 'danger',
+          Accent: 'accent',
+        }),
+        fill: figma.enum('Style', {
+          'Default*': undefined,
+          Filled: true,
+        }),
+        isDisabled: figma.boolean('Disabled'),
+        isLoading: figma.boolean('Loading'),
+        iconType: figma.boolean('Icon only', {
+          true: figma.instance('⮑ Icon'),
+          false: figma.boolean('Icon left', {
+            true: figma.instance('⮑ Icon left'),
+            false: figma.boolean('Icon right', {
+              true: figma.instance('⮑ Icon right'),
+              false: undefined,
+            }),
+          }),
+        }),
+        iconSide: figma.boolean('Icon left', {
+          true: 'left',
+          false: figma.boolean('Icon right', {
+            true: 'right',
+            false: figma.boolean('Loading', {
+              true: figma.boolean('Left spinner', {
+                true: 'left',
+                false: figma.boolean('Right spinner', {
+                  true: 'right',
+                  false: undefined,
+                }),
+              }),
+              false: undefined,
+            }),
+          }),
+        }),
+        size: figma.enum('Size', {
+          'Medium*': undefined,
+          Small: 's',
+          // Discrepancy between Figma and EUI
+          // 'Extra Small': 'extra-small',
+        }),
+      },
+    },
+  },
 };
 enableFunctionToggleControls(meta, ['onClick']);
 
 export default meta;
-type Story = StoryObj<EuiButtonProps>;
-
-export const Playground: Story = {
-  args: {
-    children: 'Button',
-  },
-};
-disableStorybookControls(Playground, ['buttonRef']);

--- a/packages/eui/src/components/button/button_empty/button_empty.stories.tsx
+++ b/packages/eui/src/components/button/button_empty/button_empty.stories.tsx
@@ -6,10 +6,25 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
+
 import { disableStorybookControls } from '../../../../.storybook/utils';
 
 import { EuiButtonEmpty, EuiButtonEmptyProps } from './button_empty';
+
+type Story = StoryObj<EuiButtonEmptyProps>;
+
+export const Playground: Story = {
+  args: {
+    children: 'Tertiary action',
+  },
+  render: ({ children, ...args }: EuiButtonEmptyProps) => (
+    <EuiButtonEmpty {...args}>{children}</EuiButtonEmpty>
+  ),
+};
+disableStorybookControls(Playground, ['buttonRef']);
 
 const meta: Meta<EuiButtonEmptyProps> = {
   title: 'Navigation/EuiButtonEmpty',
@@ -32,14 +47,61 @@ const meta: Meta<EuiButtonEmptyProps> = {
     isLoading: false,
     isSelected: false,
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31735-391399&node-type=frame&m=dev',
+      examples: [{ example: Playground, variant: { Style: 'Empty' } }],
+      props: {
+        children: figma.boolean('Icon only', {
+          true: undefined,
+          false: figma.textContent('Text'),
+        }),
+        color: figma.enum('Color', {
+          'Primary*': 'primary',
+          Neutral: 'text',
+          Success: 'success',
+          Warning: 'warning',
+          Danger: 'danger',
+          Accent: 'accent',
+        }),
+        iconType: figma.boolean('Icon only', {
+          true: figma.instance('⮑ Icon'),
+          false: figma.boolean('Icon left', {
+            true: figma.instance('⮑ Icon left'),
+            false: figma.boolean('Icon right', {
+              true: figma.instance('⮑ Icon right'),
+              false: undefined,
+            }),
+          }),
+        }),
+        iconSide: figma.boolean('Icon left', {
+          true: 'left',
+          false: figma.boolean('Icon right', {
+            true: 'right',
+            false: figma.boolean('Loading', {
+              true: figma.boolean('Left spinner', {
+                true: 'left',
+                false: figma.boolean('Right spinner', {
+                  true: 'right',
+                  false: undefined,
+                }),
+              }),
+              false: undefined,
+            }),
+          }),
+        }),
+        isDisabled: figma.boolean('Disabled'),
+        isLoading: figma.boolean('Loading'),
+        size: figma.enum('Size', {
+          'Medium*': 'm',
+          Small: 's',
+          // TODO: document discrepancy between Figma and EUI
+          // 'Extra Small': 'extra-small',
+        }),
+      },
+    },
+  },
 };
 
 export default meta;
-type Story = StoryObj<EuiButtonEmptyProps>;
-
-export const Playground: Story = {
-  args: {
-    children: 'Tertiary action',
-  },
-};
-disableStorybookControls(Playground, ['buttonRef']);

--- a/packages/eui/src/components/button/button_group/button_group.figma.tsx
+++ b/packages/eui/src/components/button/button_group/button_group.figma.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiButtonGroup } from './button_group';
+
+figma.connect(EuiButtonGroup, 'node-id=31735-392753', {
+  props: {
+    buttonSize: figma.enum('Size', {
+      'Small*': undefined,
+      Medium: 'm',
+      Compressed: 'compressed',
+    }),
+    color: figma.enum('Color', {
+      'Neutral*': undefined,
+      Primary: 'primary',
+      // Discrepancy between Figma and EUI
+      // Lack of "accent", "success", "warning", "danger" in Figma
+    }),
+    isDisabled: figma.boolean('Disabled'),
+    isFullWidth: figma.boolean('Full width'),
+    isIconOnly: figma.boolean('Icon only'),
+  },
+  example: (props) => (
+    <EuiButtonGroup
+      type="single"
+      idSelected="0"
+      legend="Legend"
+      onChange={() => {}}
+      options={[
+        { id: '0', label: 'Button' },
+        { id: '1', label: 'Button' },
+        { id: '2', label: 'Button' },
+      ]}
+      {...props}
+    />
+  ),
+});

--- a/packages/eui/src/components/call_out/call_out.figma.tsx
+++ b/packages/eui/src/components/call_out/call_out.figma.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// eslint-disable-next-line
+// @ts-nocheck
+
+/**
+ * `iconType` expects an enum member, a string or ComponentType
+ *
+ * figma.instance is a JSX.Element, not ComponentType or string but it's a conflict between
+ * Code Connect API and the icon implementation (it's not render props pattern). I don't think there's an alternative,
+ * at the same time it doesn't matter much because Figma files are not executed, they're parsed as string.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiCallOut } from './call_out';
+
+figma.connect(EuiCallOut, 'node-id=32350-392160', {
+  props: {
+    children: figma.nestedProps('Children', {
+      text: figma.children('Callout text'),
+    }),
+    color: figma.enum('Color', {
+      Success: 'success',
+      Danger: 'danger',
+      Warning: 'warning',
+      Primary: 'primary',
+    }),
+    iconType: figma.boolean('⮑ Icon', {
+      true: figma.instance('⮑ Icon glyph'),
+      false: undefined,
+    }),
+    onDismiss: figma.boolean('Dismiss', {
+      true: () => {},
+      false: undefined,
+    }),
+    size: figma.enum('Size', {
+      Medium: 'm',
+      Small: 's',
+    }),
+    title: figma.boolean('Title', {
+      true: figma.nestedProps('Callout title', {
+        text: figma.string('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+  },
+  example: ({ children, title, ...props }) => (
+    <EuiCallOut title={title.text} {...props}>
+      {children.text}
+    </EuiCallOut>
+  ),
+});

--- a/packages/eui/src/components/call_out/call_out.stories.tsx
+++ b/packages/eui/src/components/call_out/call_out.stories.tsx
@@ -6,9 +6,39 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EuiCallOut, EuiCallOutProps } from './call_out';
+
+type Story = StoryObj<EuiCallOutProps>;
+
+// It's hard to align component props with Figma property mapping
+/* type Story = StoryObj<
+  EuiCallOutProps & {
+    title: { text: string };
+    children: { text: string };
+  }
+>; */
+
+export const Playground: Story = {
+  args: {
+    title: 'Callout title',
+    children: 'Callout text',
+  },
+  render: ({ children, title, ...props }) => (
+    <EuiCallOut title={title} {...props}>
+      {children}
+    </EuiCallOut>
+  ),
+  // This would have to be the render function with nested properties:
+  /* render: ({ children, title, ...props }) => (
+    <EuiCallOut title={title.text} {...props}>
+      {children.text}
+    </EuiCallOut>
+  ), */
+};
 
 const meta: Meta<EuiCallOutProps> = {
   title: 'Display/EuiCallOut',
@@ -22,14 +52,38 @@ const meta: Meta<EuiCallOutProps> = {
     heading: 'p',
     size: 'm',
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=32350-392160&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        children: figma.instance('Children'),
+        color: figma.enum('Color', {
+          Success: 'success',
+          Danger: 'danger',
+          Warning: 'warning',
+          Primary: 'primary',
+        }),
+        iconType: figma.boolean('⮑ Icon', {
+          true: figma.instance('⮑ Icon glyph'),
+          false: undefined,
+        }),
+        onDismiss: figma.boolean('Dismiss', {
+          true: () => {},
+          false: undefined,
+        }),
+        size: figma.enum('Size', {
+          Medium: 'm',
+          Small: 's',
+        }),
+        // This has to differ from the standalone Figma config to align with Storybook
+        title: figma.boolean('Title', {
+          true: 'Title',
+        }),
+      },
+    },
+  },
 };
 
 export default meta;
-type Story = StoryObj<EuiCallOutProps>;
-
-export const Playground: Story = {
-  args: {
-    title: 'Callout title',
-    children: 'Callout text',
-  },
-};

--- a/packages/eui/src/components/combo_box/combo_box.figma.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.figma.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiComboBox } from './combo_box';
+import { EuiFormRow } from '../form';
+
+figma.connect(EuiComboBox, 'node-id=15883-161301', {
+  props: {
+    ariaLabel: figma.boolean('Label', {
+      true: undefined,
+      false: 'Meaningful label',
+    }),
+    compressed: figma.boolean('Compressed'),
+    error: figma.nestedProps('📦Form Row / Error text', {
+      text: figma.textContent('Text'),
+    }),
+    helpText: figma.boolean('Help text', {
+      true: figma.nestedProps('📦 Form Row / Help text', {
+        text: figma.textContent('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+    isDisabled: figma.enum('State', {
+      Disabled: true,
+    }),
+    isInvalid: figma.enum('State', {
+      Invalid: true,
+    }),
+    label: figma.boolean('Label', {
+      true: figma.nestedProps('📦 Form Row / Label', {
+        text: figma.textContent('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+  },
+  example: ({ ariaLabel, error, helpText, isInvalid, label, ...props }) => (
+    <EuiFormRow
+      error={error.text}
+      helpText={helpText.text}
+      isInvalid={isInvalid}
+      label={label.text}
+    >
+      <EuiComboBox
+        aria-label={ariaLabel}
+        options={[
+          { label: 'Item 1' },
+          { label: 'Item 2' },
+          { label: 'Item 3' },
+          { label: 'Item 4', disabled: true },
+          { label: 'Item 5' },
+        ]}
+        selectedOptions={[{ label: 'Item 1' }, { label: 'Item 2' }]}
+        onChange={() => {}}
+        isInvalid={isInvalid}
+        {...props}
+      />
+    </EuiFormRow>
+  ),
+});

--- a/packages/eui/src/components/form/field_text/field_text.figma.tsx
+++ b/packages/eui/src/components/form/field_text/field_text.figma.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiFieldText } from './field_text';
+import { EuiFormRow } from '../form_row';
+
+figma.connect(EuiFieldText, 'node-id=13676-796', {
+  props: {
+    ariaLabel: figma.boolean('Label', {
+      true: undefined,
+      false: 'Meaningful label',
+    }),
+    compressed: figma.boolean('Compressed'),
+    error: figma.nestedProps('📦Form Row / Error text', {
+      text: figma.textContent('Text'),
+    }),
+    helpText: figma.boolean('Help text', {
+      true: figma.nestedProps('📦 Form Row / Help text', {
+        text: figma.textContent('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+    isDisabled: figma.enum('State', {
+      Disabled: true,
+    }),
+    isInvalid: figma.enum('State', {
+      Invalid: true,
+    }),
+    label: figma.boolean('Label', {
+      true: figma.nestedProps('📦 Form Row / Label', {
+        text: figma.textContent('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+  },
+  example: ({ ariaLabel, error, helpText, isInvalid, label, ...props }) => (
+    <EuiFormRow
+      error={error.text}
+      helpText={helpText.text}
+      isInvalid={isInvalid}
+      label={label.text}
+    >
+      <EuiFieldText
+        aria-label={ariaLabel}
+        value={''}
+        onChange={() => {}}
+        isInvalid={isInvalid}
+        {...props}
+      />
+    </EuiFormRow>
+  ),
+});

--- a/packages/eui/src/components/form/field_text/field_text.stories.tsx
+++ b/packages/eui/src/components/form/field_text/field_text.stories.tsx
@@ -7,45 +7,46 @@
  */
 
 import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
+
 import {
   disableStorybookControls,
   moveStorybookControlsToCategory,
 } from '../../../../.storybook/utils';
+import { EuiFormRow } from '../form_row';
 
 import { EuiFieldText, EuiFieldTextProps } from './field_text';
 
-const meta: Meta<EuiFieldTextProps> = {
-  title: 'Forms/EuiFieldText',
-  component: EuiFieldText,
-  argTypes: {
-    // For quicker/easier QA
-    icon: { control: 'text' },
-    prepend: { control: 'text' },
-    append: { control: 'text' },
-    value: { control: 'text' },
-  },
-  args: {
-    // Component defaults
-    compressed: false,
-    fullWidth: false,
-    isInvalid: false,
-    isLoading: false,
-    disabled: false,
-    readOnly: false,
-    controlOnly: false,
-    // Added for easier testing
-    placeholder: 'EuiFieldText',
-    id: '',
-    name: '',
-  },
+// We need to add some args to make the snippet fully accurate
+// Here, args do not map 1:1 to props
+type Story = StoryObj<
+  EuiFieldTextProps & {
+    ariaLabel: string;
+    error: { text?: string };
+    helpText: { text?: string };
+    label: { text?: string };
+  }
+>;
+
+export const Playground: Story = {
+  render: ({ ariaLabel, error, helpText, isInvalid, label, ...props }) => (
+    <EuiFormRow
+      error={error.text}
+      helpText={helpText.text}
+      isInvalid={isInvalid}
+      label={label.text}
+    >
+      <EuiFieldText
+        aria-label={ariaLabel}
+        value={''}
+        onChange={() => {}}
+        isInvalid={isInvalid}
+        {...props}
+      />
+    </EuiFormRow>
+  ),
 };
-
-export default meta;
-type Story = StoryObj<EuiFieldTextProps>;
-disableStorybookControls(meta, ['inputRef']);
-
-export const Playground: Story = {};
 
 export const IconShape: Story = {
   parameters: {
@@ -98,3 +99,71 @@ export const AutoFill: Story = {
     name: 'autofill-test',
   },
 };
+
+const meta: Meta<EuiFieldTextProps> = {
+  title: 'Forms/EuiFieldText',
+  component: EuiFieldText,
+  argTypes: {
+    // For quicker/easier QA
+    icon: { control: 'text' },
+    prepend: { control: 'text' },
+    append: { control: 'text' },
+    value: { control: 'text' },
+  },
+  args: {
+    // Component defaults
+    compressed: false,
+    fullWidth: false,
+    isInvalid: false,
+    isLoading: false,
+    disabled: false,
+    readOnly: false,
+    controlOnly: false,
+    // Added for easier testing
+    placeholder: 'EuiFieldText',
+    id: '',
+    name: '',
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=13676-796&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        ariaLabel: figma.boolean('Label', {
+          true: undefined,
+          false: 'Meaningful label',
+        }),
+        compressed: figma.boolean('Compressed'),
+        error: figma.nestedProps('📦Form Row / Error text', {
+          text: figma.textContent('Text'),
+        }),
+        helpText: figma.boolean('Help text', {
+          true: figma.nestedProps('📦 Form Row / Help text', {
+            text: figma.textContent('Text'),
+          }),
+          false: {
+            text: undefined,
+          },
+        }),
+        isDisabled: figma.enum('State', {
+          Disabled: true,
+        }),
+        isInvalid: figma.enum('State', {
+          Invalid: true,
+        }),
+        label: figma.boolean('Label', {
+          true: figma.nestedProps('📦 Form Row / Label', {
+            text: figma.textContent('Text'),
+          }),
+          false: {
+            text: undefined,
+          },
+        }),
+      },
+    },
+  },
+};
+
+export default meta;
+disableStorybookControls(meta, ['inputRef']);

--- a/packages/eui/src/components/form/select/select.figma.tsx
+++ b/packages/eui/src/components/form/select/select.figma.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiSelect } from './select';
+import { EuiFormRow } from '../form_row';
+
+figma.connect(EuiSelect, 'node-id=15883-129716', {
+  props: {
+    ariaLabel: figma.boolean('Label', {
+      true: undefined,
+      false: 'Meaningful label',
+    }),
+    compressed: figma.boolean('Compressed'),
+    error: figma.nestedProps('📦Form Row / Error text', {
+      text: figma.textContent('Text'),
+    }),
+    helpText: figma.boolean('Help text', {
+      true: figma.nestedProps('📦 Form Row / Help text', {
+        text: figma.textContent('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+    isDisabled: figma.enum('State', {
+      Disabled: true,
+    }),
+    isInvalid: figma.enum('State', {
+      Invalid: true,
+    }),
+    label: figma.boolean('Label', {
+      true: figma.nestedProps('📦 Form Row / Label', {
+        text: figma.textContent('Text'),
+      }),
+      false: {
+        text: undefined,
+      },
+    }),
+  },
+  example: ({ ariaLabel, error, helpText, isInvalid, label, ...props }) => (
+    <EuiFormRow
+      error={error.text}
+      helpText={helpText.text}
+      isInvalid={isInvalid}
+      label={label.text}
+    >
+      <EuiSelect
+        aria-label={ariaLabel}
+        options={[
+          { value: 'option-1', text: 'Option 1' },
+          { value: 'option-2', text: 'Option 2' },
+          { value: 'option-3', text: 'Option 3' },
+        ]}
+        value="option-1"
+        onChange={() => {}}
+        isInvalid={isInvalid}
+        {...props}
+      />
+    </EuiFormRow>
+  ),
+});

--- a/packages/eui/src/components/form/select/select.stories.tsx
+++ b/packages/eui/src/components/form/select/select.stories.tsx
@@ -8,14 +8,68 @@
 
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import figma from '@figma/code-connect';
 
 import {
   disableStorybookControls,
   enableFunctionToggleControls,
 } from '../../../../.storybook/utils';
 import { EuiIcon } from '../../icon';
+import { EuiFormRow } from '../form_row';
 
 import { EuiSelect, EuiSelectProps } from './select';
+
+// We need to add story-specific arguments (that do not map directly to component props)
+type Story = StoryObj<
+  EuiSelectProps & {
+    ariaLabel: string;
+    error: { text?: string };
+    helpText: { text?: string };
+    label: { text?: string };
+  }
+>;
+
+export const Playground: Story = {
+  args: {
+    defaultValue: 'option-2',
+    options: [
+      { value: 'option-1', text: 'Option 1' },
+      { value: 'option-2', text: 'Option 2' },
+      { value: 'option-3', text: 'Option 3' },
+    ],
+  },
+  // Each prop has to be explicitly defined to be present in the Code Connect code snippet
+  // but if it's not available in the Figma mapping, the parsing will fail if we add it as an explicit story arg
+  render: ({
+    ariaLabel,
+    error,
+    helpText,
+    isInvalid,
+    label,
+    /* options - this will fail parsing */
+    ...props
+  }) => (
+    <EuiFormRow
+      error={error.text}
+      helpText={helpText.text}
+      isInvalid={isInvalid}
+      label={label.text}
+    >
+      <EuiSelect
+        aria-label={ariaLabel}
+        value="option-1"
+        options={[
+          { value: 'option-1', text: 'Option 1' },
+          { value: 'option-2', text: 'Option 2' },
+          { value: 'option-3', text: 'Option 3' },
+        ]}
+        onChange={() => {}}
+        isInvalid={isInvalid}
+        {...props}
+      />
+    </EuiFormRow>
+  ),
+};
 
 const meta: Meta<EuiSelectProps> = {
   title: 'Forms/EuiSelect',
@@ -24,6 +78,43 @@ const meta: Meta<EuiSelectProps> = {
     controls: {
       // Excude onMouseUp from controls, as it's not a terribly useful prop to document
       exclude: ['onMouseUp'],
+    },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=15883-129716&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        ariaLabel: figma.boolean('Label', {
+          true: undefined,
+          false: 'Meaningful label',
+        }),
+        compressed: figma.boolean('Compressed'),
+        error: figma.nestedProps('📦Form Row / Error text', {
+          text: figma.textContent('Text'),
+        }),
+        helpText: figma.boolean('Help text', {
+          true: figma.nestedProps('📦 Form Row / Help text', {
+            text: figma.textContent('Text'),
+          }),
+          false: {
+            text: undefined,
+          },
+        }),
+        isDisabled: figma.enum('State', {
+          Disabled: true,
+        }),
+        isInvalid: figma.enum('State', {
+          Invalid: true,
+        }),
+        label: figma.boolean('Label', {
+          true: figma.nestedProps('📦 Form Row / Label', {
+            text: figma.textContent('Text'),
+          }),
+          false: {
+            text: undefined,
+          },
+        }),
+      },
     },
   },
   argTypes: {
@@ -63,15 +154,3 @@ enableFunctionToggleControls(meta, ['onChange']);
 disableStorybookControls(meta, ['inputRef']);
 
 export default meta;
-type Story = StoryObj<EuiSelectProps>;
-
-export const Playground: Story = {
-  args: {
-    defaultValue: 'option-2',
-    options: [
-      { value: 'option-1', text: 'Option 1' },
-      { value: 'option-2', text: 'Option 2' },
-      { value: 'option-3', text: 'Option 3' },
-    ],
-  },
-};

--- a/packages/eui/src/components/icon/icon.figma.tsx
+++ b/packages/eui/src/components/icon/icon.figma.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// eslint-disable-next-line
+// @ts-nocheck
+
+/**
+ * `type` expects an enum member, a string or ComponentType
+ *
+ * figma.instance is a JSX.Element, not ComponentType or string but it's a conflict between
+ * Code Connect API and the icon implementation (it's not render props pattern). I don't think there's an alternative,
+ * at the same time it doesn't matter much because Figma files are not executed, they're parsed as string.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiIcon } from './icon';
+
+figma.connect(EuiIcon, 'node-id=31572-393323', {
+  props: {
+    type: figma.instance('Type'),
+    size: figma.enum('Size', {
+      'Small - 12px': 's',
+      'Medium* - 16px': 'm',
+      'Large - 24px': 'l',
+      'X-Large - 32px': 'xl',
+      'XX-Large - 40px': 'xxl',
+      Size6: 'original',
+    }),
+  },
+  example: (props) => <EuiIcon {...props} />,
+});

--- a/packages/eui/src/components/icon/icon.stories.tsx
+++ b/packages/eui/src/components/icon/icon.stories.tsx
@@ -6,9 +6,17 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EuiIcon, EuiIconProps } from './icon';
+
+type Story = StoryObj<EuiIconProps>;
+
+export const Playground: Story = {
+  render: (props) => <EuiIcon {...props} />,
+};
 
 const meta: Meta<EuiIconProps> = {
   title: 'Display/EuiIcon',
@@ -21,9 +29,24 @@ const meta: Meta<EuiIconProps> = {
     type: 'accessibility',
     size: 'm',
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31572-393323&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        type: figma.instance('Type'),
+        size: figma.enum('Size', {
+          'Small - 12px': 's',
+          'Medium* - 16px': 'm',
+          'Large - 24px': 'l',
+          'X-Large - 32px': 'xl',
+          'XX-Large - 40px': 'xxl',
+          Size6: 'original',
+        }),
+      },
+    },
+  },
 };
 
 export default meta;
-type Story = StoryObj<EuiIconProps>;
-
-export const Playground: Story = {};

--- a/packages/eui/src/components/panel/panel.figma.tsx
+++ b/packages/eui/src/components/panel/panel.figma.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiPanel } from './panel';
+
+const sharedProps = {
+  borderRadius: figma.boolean('Border radius', {
+    true: 'm',
+    false: 'none',
+  }),
+  color: figma.enum('Color', {
+    'Plain*': undefined,
+    Subdued: 'subdued',
+    Primary: 'primary',
+    Success: 'success',
+    Warning: 'warning',
+    Danger: 'danger',
+    Accent: 'accent',
+    Transparent: 'transparent',
+  }),
+  children: figma.instance('Content'),
+  hasBorder: figma.boolean('Border'),
+  paddingSize: figma.enum('Padding size', {
+    None: 'none',
+    Small: 's',
+    'Medium*': undefined,
+    Large: 'l',
+  }),
+};
+
+figma.connect(EuiPanel, 'node-id=32642-391756', {
+  // variant: { Shadow: true },
+  props: sharedProps,
+  example: ({ children, ...props }) => (
+    <EuiPanel {...props}>{children}</EuiPanel>
+  ),
+});
+
+/* Example: Self-closing tags example (doesn't work, error: The Figma Variant "Shadow" does not have an option for true) */
+/* figma.connect(EuiPanel, 'node-id=32642-391756', {
+  variant: { Shadow: false },
+  props: sharedProps,
+  example: ({ children, ...props }) => (
+    <EuiPanel hasShadow={false} {...props}>
+      {children}
+    </EuiPanel>
+  ),
+}); */

--- a/packages/eui/src/components/panel/panel.stories.tsx
+++ b/packages/eui/src/components/panel/panel.stories.tsx
@@ -6,13 +6,27 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import figma from '@figma/code-connect';
 
 import {
   disableStorybookControls,
   enableFunctionToggleControls,
 } from '../../../.storybook/utils';
+
 import { EuiPanel, EuiPanelProps } from './panel';
+
+type Story = StoryObj<EuiPanelProps>;
+
+export const Playground: Story = {
+  args: {
+    children: 'Panel content',
+  },
+  render: ({ children, ...props }: EuiPanelProps) => (
+    <EuiPanel {...props}>{children}</EuiPanel>
+  ),
+};
 
 const meta: Meta<EuiPanelProps> = {
   title: 'Layout/EuiPanel',
@@ -33,15 +47,39 @@ const meta: Meta<EuiPanelProps> = {
     hasBorder: false,
     grow: true,
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=32642-391756&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        borderRadius: figma.boolean('Border radius', {
+          true: 'm',
+          false: 'none',
+        }),
+        color: figma.enum('Color', {
+          'Plain*': undefined,
+          Subdued: 'subdued',
+          Primary: 'primary',
+          Success: 'success',
+          Warning: 'warning',
+          Danger: 'danger',
+          Accent: 'accent',
+          Transparent: 'transparent',
+        }),
+        children: figma.instance('Content'),
+        hasBorder: figma.boolean('Border'),
+        paddingSize: figma.enum('Padding size', {
+          None: 'none',
+          Small: 's',
+          'Medium*': undefined,
+          Large: 'l',
+        }),
+      },
+    },
+  },
 };
 enableFunctionToggleControls(meta, ['onClick']);
 disableStorybookControls(meta, ['panelRef']);
 
 export default meta;
-type Story = StoryObj<EuiPanelProps>;
-
-export const Playground: Story = {
-  args: {
-    children: 'Panel content',
-  },
-};

--- a/packages/eui/src/components/text/text.figma.tsx
+++ b/packages/eui/src/components/text/text.figma.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiText } from './text';
+
+figma.connect(EuiText, 'node-id=32296-391647', {
+  props: {
+    children: figma.string('Text'),
+    size: figma.enum('Size', {
+      Medium: 'm',
+      Small: 's',
+      'X-Small': 'xs',
+    }),
+  },
+  example: ({ children, ...props }) => <EuiText {...props}>{children}</EuiText>,
+});

--- a/packages/eui/src/components/text/text.stories.tsx
+++ b/packages/eui/src/components/text/text.stories.tsx
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
 import { faker } from '@faker-js/faker';
 
@@ -13,6 +15,17 @@ faker.seed(42);
 
 import { moveStorybookControlsToCategory } from '../../../.storybook/utils';
 import { EuiText, EuiTextProps } from './text';
+
+type Story = StoryObj<EuiTextProps>;
+
+export const Playground: Story = {
+  args: {
+    children: faker.lorem.sentences(3),
+  },
+  render: ({ children, ...args }: EuiTextProps) => (
+    <EuiText {...args}>{children}</EuiText>
+  ),
+};
 
 const meta: Meta<EuiTextProps> = {
   title: 'Display/EuiText/EuiText',
@@ -27,15 +40,23 @@ const meta: Meta<EuiTextProps> = {
     textAlign: 'left',
     component: 'div',
   },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=32296-391647&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        children: figma.string('Text'),
+        size: figma.enum('Size', {
+          Medium: 'm',
+          Small: 's',
+          'X-Small': 'xs',
+        }),
+      },
+    },
+  },
 };
 moveStorybookControlsToCategory(meta, ['color'], 'EuiTextColor props');
 moveStorybookControlsToCategory(meta, ['textAlign'], 'EuiTextAlign props');
 
 export default meta;
-type Story = StoryObj<EuiTextProps>;
-
-export const Playground: Story = {
-  args: {
-    children: faker.lorem.sentences(3),
-  },
-};

--- a/packages/eui/src/components/tool_tip/tool_tip.figma.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.figma.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+import { EuiToolTip } from './tool_tip';
+
+figma.connect(EuiToolTip, 'node-id=32039-390707', {
+  props: {
+    content: figma.string('Description'),
+    position: figma.enum('Direction', {
+      '12:00 ↑': 'bottom',
+      '11:00': 'bottom',
+      '10:00': 'right',
+      '8:00': 'right',
+      '7:00': 'top',
+      '6:00 ↓': 'top',
+      '5:00': 'top',
+      '4:00': 'left',
+      '3:00 →': 'left',
+      '2:00': 'left',
+      '1::00': 'bottom',
+      '9:00 ←': 'right',
+    }),
+    title: figma.boolean('Title', {
+      true: figma.string('⮑ Title'),
+      false: undefined,
+    }),
+  },
+  example: (props) => <EuiToolTip {...props} />,
+});

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -7,13 +7,39 @@
  */
 
 import React from 'react';
+import figma from '@figma/code-connect';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { enableFunctionToggleControls } from '../../../.storybook/utils';
 import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { EuiFlexGroup } from '../flex';
 import { EuiButton } from '../button';
+
 import { EuiToolTip, EuiToolTipProps } from './tool_tip';
+
+type Story = StoryObj<EuiToolTipProps>;
+
+export const Playground: Story = {
+  args: {
+    // using autoFocus here as small trick to ensure showing the tooltip on load (e.g. for VRT)
+    // TODO: uncomment loki play() interactions and remove autoFocus once #7747 is merged
+    children: <EuiButton autoFocus>Tooltip trigger</EuiButton>,
+    content: 'tooltip content',
+  },
+  render: (props) => <EuiToolTip {...props} />,
+  // play: lokiPlayDecorator(async (context) => {
+  //   const { bodyElement, step } = context;
+
+  //   const canvas = within(bodyElement);
+
+  //   await step('show tooltip on click', async () => {
+  //     await userEvent.click(canvas.getByRole('button'));
+  //     await waitFor(() => {
+  //       expect(canvas.getByRole('tooltip')).toBeVisible();
+  //     });
+  //   });
+  // }),
+};
 
 const meta: Meta<EuiToolTipProps> = {
   title: 'Display/EuiToolTip',
@@ -22,6 +48,32 @@ const meta: Meta<EuiToolTipProps> = {
     layout: 'fullscreen',
     loki: {
       chromeSelector: LOKI_SELECTORS.portal,
+    },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=32039-390707&node-type=frame&m=dev',
+      examples: [Playground],
+      props: {
+        content: figma.string('Description'),
+        position: figma.enum('Direction', {
+          '12:00 ↑': 'bottom',
+          '11:00': 'bottom',
+          '10:00': 'right',
+          '8:00': 'right',
+          '7:00': 'top',
+          '6:00 ↓': 'top',
+          '5:00': 'top',
+          '4:00': 'left',
+          '3:00 →': 'left',
+          '2:00': 'left',
+          '1::00': 'bottom',
+          '9:00 ←': 'right',
+        }),
+        title: figma.boolean('Title', {
+          true: figma.string('⮑ Title'),
+          false: undefined,
+        }),
+      },
     },
   },
   decorators: [
@@ -50,25 +102,3 @@ const meta: Meta<EuiToolTipProps> = {
 enableFunctionToggleControls(meta, ['onMouseOut']);
 
 export default meta;
-type Story = StoryObj<EuiToolTipProps>;
-
-export const Playground: Story = {
-  args: {
-    // using autoFocus here as small trick to ensure showing the tooltip on load (e.g. for VRT)
-    // TODO: uncomment loki play() interactions and remove autoFocus once #7747 is merged
-    children: <EuiButton autoFocus>Tooltip trigger</EuiButton>,
-    content: 'tooltip content',
-  },
-  // play: lokiPlayDecorator(async (context) => {
-  //   const { bodyElement, step } = context;
-
-  //   const canvas = within(bodyElement);
-
-  //   await step('show tooltip on click', async () => {
-  //     await userEvent.click(canvas.getByRole('button'));
-  //     await waitFor(() => {
-  //       expect(canvas.getByRole('tooltip')).toBeVisible();
-  //     });
-  //   });
-  // }),
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5858,6 +5858,7 @@ __metadata:
     "@emotion/jest": "npm:^11.11.0"
     "@emotion/react": "npm:^11.11.0"
     "@faker-js/faker": "npm:^8.0.2"
+    "@figma/code-connect": "npm:^1.1.4"
     "@hello-pangea/dnd": "npm:^16.6.0"
     "@loki/create-async-callback": "npm:^0.35.0"
     "@loki/is-loki-running": "npm:^0.35.0"
@@ -5929,6 +5930,7 @@ __metadata:
     cypress-plugin-tab: "npm:^1.0.5"
     cypress-real-events: "npm:^1.7.0"
     dedent: "npm:^0.7.0"
+    dotenv-cli: "npm:^7.4.2"
     dts-generator: "npm:^3.0.0"
     enzyme: "npm:^3.11.0"
     enzyme-adapter-react-16: "npm:^1.15.7"
@@ -6501,6 +6503,42 @@ __metadata:
   bin:
     osnap: bin/osnap
   checksum: 10c0/436c6a26f644c1a9d8f5e699b1303b3ef160828391d6850aca469e98c706e5a0105588695f5fd71db8750b7b4355a23fa91421c72c786abe6f4ad15a4a0872f4
+  languageName: node
+  linkType: hard
+
+"@figma/code-connect@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@figma/code-connect@npm:1.1.4"
+  dependencies:
+    "@babel/core": "npm:^7.24.7"
+    "@babel/generator": "npm:^7.24.7"
+    "@babel/parser": "npm:^7.24.7"
+    "@babel/types": "npm:^7.24.7"
+    "@storybook/csf-tools": "npm:^7.6.7"
+    axios: "npm:^1.7.4"
+    boxen: "npm:5.1.1"
+    chalk: "npm:^4.1.2"
+    commander: "npm:^11.1.0"
+    compare-versions: "npm:^6.1.0"
+    cross-spawn: "npm:^7.0.3"
+    dotenv: "npm:^16.3.1"
+    fast-fuzzy: "npm:^1.12.0"
+    find-up: "npm:^5.0.0"
+    glob: "npm:^10.3.10"
+    jsdom: "npm:^24.1.1"
+    lodash: "npm:^4.17.21"
+    minimatch: "npm:^9.0.3"
+    ora: "npm:^5.4.1"
+    parse5: "npm:^7.1.2"
+    prettier: "npm:^2.8.8"
+    prompts: "npm:^2.4.2"
+    strip-ansi: "npm:^6.0.0"
+    typescript: "npm:5.4.2"
+    zod: "npm:^3.23.6"
+    zod-validation-error: "npm:^3.2.0"
+  bin:
+    figma: bin/figma
+  checksum: 10c0/41b5bb197aea0b737feeeb0a8860827f534499a7f680cdc7be73304c295a8520771274c923bcd41290d7d0596e304a332c31e12e7a2e08d0b33c5cc2629a5416
   languageName: node
   linkType: hard
 
@@ -8168,6 +8206,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:7.6.20":
+  version: 7.6.20
+  resolution: "@storybook/channels@npm:7.6.20"
+  dependencies:
+    "@storybook/client-logger": "npm:7.6.20"
+    "@storybook/core-events": "npm:7.6.20"
+    "@storybook/global": "npm:^5.0.0"
+    qs: "npm:^6.10.0"
+    telejson: "npm:^7.2.0"
+    tiny-invariant: "npm:^1.3.1"
+  checksum: 10c0/5aaa3e06a27750ffc48be6a5375dc286e1de5ae6c54f8318338afa2bbea68e37842f8eb17ce509c5587af173289640e78a4bbec3f234be9395bd08a0e1820308
+  languageName: node
+  linkType: hard
+
 "@storybook/channels@npm:8.0.6":
   version: 8.0.6
   resolution: "@storybook/channels@npm:8.0.6"
@@ -8238,6 +8290,15 @@ __metadata:
     getstorybook: ./bin/index.js
     sb: ./bin/index.js
   checksum: 10c0/ffd84438efb0eb34a49a1a21845ab78ca974d4227dcaba34abb6f64a04e41150841ff123d0dc2db07499fdf23aff0250cbffc0a9c563da25fd86094d3219f4f0
+  languageName: node
+  linkType: hard
+
+"@storybook/client-logger@npm:7.6.20":
+  version: 7.6.20
+  resolution: "@storybook/client-logger@npm:7.6.20"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+  checksum: 10c0/cd1a9cb0a484a1585d5b4a918b20335ba8bd6655ae0051ba30c729b75678bafca62b8ef124fecd5c5883debf41d93a1827cf7bdf08df666f64de3cc15864be54
   languageName: node
   linkType: hard
 
@@ -8335,6 +8396,15 @@ __metadata:
     ts-dedent: "npm:^2.0.0"
     util: "npm:^0.12.4"
   checksum: 10c0/2079364e6b4371605f2962316f4027c35a3ded4a15523de67c2585c6df3e2b1d2043ae9bd8bbda3908a86bbae688842c0a5a1f6be83e5ebff66847a3104631c7
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:7.6.20":
+  version: 7.6.20
+  resolution: "@storybook/core-events@npm:7.6.20"
+  dependencies:
+    ts-dedent: "npm:^2.0.0"
+  checksum: 10c0/4ee2cc7ca6d7cae579befab640bfe1e8b30243305f73e7d731e40aa1295ff5fc1b6c61561929d2e4db315f7c4f5b3cfdf0ddc3746b3660d34b0dd3911a55d4ad
   languageName: node
   linkType: hard
 
@@ -8445,6 +8515,23 @@ __metadata:
     recast: "npm:^0.23.5"
     ts-dedent: "npm:^2.0.0"
   checksum: 10c0/6474196925b1946afec701882e32ef7d70f33197900d94a7c0ffc4da7076516c0cab011f9a23e2dd7c086b8e10e9fa75349b48b59a777866b661f46c5d99af14
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-tools@npm:^7.6.7":
+  version: 7.6.20
+  resolution: "@storybook/csf-tools@npm:7.6.20"
+  dependencies:
+    "@babel/generator": "npm:^7.23.0"
+    "@babel/parser": "npm:^7.23.0"
+    "@babel/traverse": "npm:^7.23.2"
+    "@babel/types": "npm:^7.23.0"
+    "@storybook/csf": "npm:^0.1.2"
+    "@storybook/types": "npm:7.6.20"
+    fs-extra: "npm:^11.1.0"
+    recast: "npm:^0.23.1"
+    ts-dedent: "npm:^2.0.0"
+  checksum: 10c0/f1dd3bf645b4828c8e88ce65db9ebcfc074368e7e818f0c656bc41d5f5e1b1fd435a8a4b488907025a58c200f805e20c7fb7673feac2dad5d62d2e0917387d94
   languageName: node
   linkType: hard
 
@@ -8846,6 +8933,18 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/13bf3c940ce2ff27088d9147d22cd45f53de5251e8d41cc170d2f569cd6ba30aa1a4574494a15774c82f501889709accff370b9131a5d973243528160d7a0d50
+  languageName: node
+  linkType: hard
+
+"@storybook/types@npm:7.6.20":
+  version: 7.6.20
+  resolution: "@storybook/types@npm:7.6.20"
+  dependencies:
+    "@storybook/channels": "npm:7.6.20"
+    "@types/babel__core": "npm:^7.0.0"
+    "@types/express": "npm:^4.7.0"
+    file-system-cache: "npm:2.3.0"
+  checksum: 10c0/148ba54a43a247291d43e06585688279a6ea52ea0e227bab3f28d589adb02b5f436862e49a6c943940da81204662bcfc87922f61011518a554b0d3c83b0293aa
   languageName: node
   linkType: hard
 
@@ -9354,7 +9453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.18.0":
+"@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.18.0":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
@@ -12483,6 +12582,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.7.4":
+  version: 1.7.7
+  resolution: "axios@npm:1.7.7"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/4499efc89e86b0b49ffddc018798de05fab26e3bf57913818266be73279a6418c3ce8f9e934c7d2d707ab8c095e837fc6c90608fb7715b94d357720b5f568af7
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^3.1.1":
   version: 3.2.1
   resolution: "axobject-query@npm:3.2.1"
@@ -12969,6 +13079,22 @@ __metadata:
   version: 3.0.1
   resolution: "boolean@npm:3.0.1"
   checksum: 10c0/e07406095260ae09002c17fd2e43c7e63b743d29aa8e4a110e4435f0f5d53d79c5e57879bff69e4a87c9645c9774f6b94713b078c21d236d73c710a1da3984fc
+  languageName: node
+  linkType: hard
+
+"boxen@npm:5.1.1":
+  version: 5.1.1
+  resolution: "boxen@npm:5.1.1"
+  dependencies:
+    ansi-align: "npm:^3.0.0"
+    camelcase: "npm:^6.2.0"
+    chalk: "npm:^4.1.0"
+    cli-boxes: "npm:^2.2.1"
+    string-width: "npm:^4.2.2"
+    type-fest: "npm:^0.20.2"
+    widest-line: "npm:^3.1.0"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10c0/4b8631b6794c80464d0c4ef78cd0e56257edd8cc4e6debf45fcc8ea4d20b069743d3fa78c9da7c9eee7e6a55fd43b22a0ecfc821c978d4f85b047dbaa9e72821
   languageName: node
   linkType: hard
 
@@ -14741,6 +14867,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "commander@npm:11.1.0"
+  checksum: 10c0/13cc6ac875e48780250f723fb81c1c1178d35c5decb1abb1b628b3177af08a8554e76b2c0f29de72d69eef7c864d12613272a71fabef8047922bc622ab75a179
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0, commander@npm:^2.9.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -14822,6 +14955,13 @@ __metadata:
   version: 1.0.1
   resolution: "commondir@npm:1.0.1"
   checksum: 10c0/33a124960e471c25ee19280c9ce31ccc19574b566dc514fe4f4ca4c34fa8b0b57cf437671f5de380e11353ea9426213fca17687dd2ef03134fea2dbc53809fd6
+  languageName: node
+  linkType: hard
+
+"compare-versions@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "compare-versions@npm:6.1.1"
+  checksum: 10c0/415205c7627f9e4f358f571266422980c9fe2d99086be0c9a48008ef7c771f32b0fbe8e97a441ffedc3910872f917a0675fe0fe3c3b6d331cda6d8690be06338
   languageName: node
   linkType: hard
 
@@ -16990,6 +17130,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-cli@npm:^7.4.2":
+  version: 7.4.2
+  resolution: "dotenv-cli@npm:7.4.2"
+  dependencies:
+    cross-spawn: "npm:^7.0.3"
+    dotenv: "npm:^16.3.0"
+    dotenv-expand: "npm:^10.0.0"
+    minimist: "npm:^1.2.6"
+  bin:
+    dotenv: cli.js
+  checksum: 10c0/7841bfaa78975aa6b51e529bf5795e062bc6e595021d1931427bb55a6f75e1775d944f4dd91bef8accbbd539c466bfee48fa804e0f6b3a1bcf18ae7de0d64bed
+  languageName: node
+  linkType: hard
+
 "dotenv-expand@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv-expand@npm:10.0.0"
@@ -17004,7 +17158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.2":
+"dotenv@npm:^16.0.2, dotenv@npm:^16.3.0, dotenv@npm:^16.3.1":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 10c0/48d92870076832af0418b13acd6e5a5a3e83bb00df690d9812e94b24aff62b88ade955ac99a05501305b8dc8f1b0ee7638b18493deb6fe93d680e5220936292f
@@ -18842,6 +18996,15 @@ __metadata:
   version: 1.2.0
   resolution: "fast-diff@npm:1.2.0"
   checksum: 10c0/2fbcb23957fb0bc920832a94ba627b860400f9cce45e1594e931dabf62e858369a58c6c2603e2ecc4f7679580f710b5b5b6e698a355a9a9bfcfd93c06c7c4350
+  languageName: node
+  linkType: hard
+
+"fast-fuzzy@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "fast-fuzzy@npm:1.12.0"
+  dependencies:
+    graphemesplit: "npm:^2.4.1"
+  checksum: 10c0/c4adb03b21472b655414c9cb4680f217790ae641a9974148f55f7778da9a2cac26325996073b1082f76da5ab0f11f845122a6f717a5a99329c17e12ba625f3d6
   languageName: node
   linkType: hard
 
@@ -20693,6 +20856,16 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: 10c0/e951259d8cd2e0d196c72ec711add7115d42eb9a8146c8eeda5b8d3ac91e5dd816b9cd68920726d9fd4490368e7ed86e9c423f40db87e2d8dfafa00fa17c3a31
+  languageName: node
+  linkType: hard
+
+"graphemesplit@npm:^2.4.1":
+  version: 2.4.4
+  resolution: "graphemesplit@npm:2.4.4"
+  dependencies:
+    js-base64: "npm:^3.6.0"
+    unicode-trie: "npm:^2.0.0"
+  checksum: 10c0/8c1ba90b97b5a71ded869bfa0282013ff8c182f679706aaac90c111bcd7d504ed3867ce7f11221496ec18ea71e793976e66b16f9e988ac22652e928a9e8e5890
   languageName: node
   linkType: hard
 
@@ -24234,6 +24407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-base64@npm:^3.6.0":
+  version: 3.7.7
+  resolution: "js-base64@npm:3.7.7"
+  checksum: 10c0/3c905a7e78b601e4751b5e710edd0d6d045ce2d23eb84c9df03515371e1b291edc72808dc91e081cb9855aef6758292a2407006f4608ec3705373dd8baf2f80f
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -26839,6 +27019,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^9.0.3":
+  version: 9.0.5
+  resolution: "minimatch@npm:9.0.5"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.4":
   version: 9.0.4
   resolution: "minimatch@npm:9.0.4"
@@ -28824,7 +29013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pako@npm:~0.2.0":
+"pako@npm:^0.2.5, pako@npm:~0.2.0":
   version: 0.2.9
   resolution: "pako@npm:0.2.9"
   checksum: 10c0/79c1806ebcf325b60ae599e4d7227c2e346d7b829dc20f5cf24cef07c934079dc3a61c5b3c8278a2f7a190c4a613e343ea11e5302dbe252efd11712df4b6b041
@@ -32065,6 +32254,19 @@ __metadata:
   version: 1.5.0
   resolution: "reading-time@npm:1.5.0"
   checksum: 10c0/0f730852fd4fb99e5f78c5b0cf36ab8c3fa15db96f87d9563843f6fd07a47864273ade539ebb184b785b728cde81a70283aa2d9b80cba5ca03b81868be03cabc
+  languageName: node
+  linkType: hard
+
+"recast@npm:^0.23.1":
+  version: 0.23.9
+  resolution: "recast@npm:0.23.9"
+  dependencies:
+    ast-types: "npm:^0.16.1"
+    esprima: "npm:~4.0.0"
+    source-map: "npm:~0.6.1"
+    tiny-invariant: "npm:^1.3.3"
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/65d6e780351f0180ea4fe5c9593ac18805bf2b79977f5bedbbbf26f6d9b619ed0f6992c1bf9e06dd40fca1aea727ad6d62463cfb5d3a33342ee5a6e486305fe5
   languageName: node
   linkType: hard
 
@@ -35930,6 +36132,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-inflate@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "tiny-inflate@npm:1.0.3"
+  checksum: 10c0/fab687537254f6ec44c9a2e880048fe70da3542aba28f73cda3e74c95cabf342a339372f2a6c032e322324f01accc03ca26c04ba2bad9b3eb8cf3ee99bba7f9b
+  languageName: node
+  linkType: hard
+
 "tiny-invariant@npm:^1.0.2, tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1":
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
@@ -36582,6 +36791,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.4.2":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/583ff68cafb0c076695f72d61df6feee71689568179fb0d3a4834dac343df6b6ed7cf7b6f6c801fa52d43cd1d324e2f2d8ae4497b09f9e6cfe3d80a6d6c9ca52
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -36599,6 +36818,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/b1912ff8dcae3c5a8739dc5a3f12422d3bf5f8a6a5642b1d537ee18873de0bb7346e83c7de3b146291e93f6493ac9843c7bbbbb12ec6393b8e07a0a2dc88550f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/fcf6658073d07283910d9a0e04b1d5d0ebc822c04dbb7abdd74c3151c7aa92fcddbac7d799404e358197222006ccdc4c0db219d223d2ee4ccd9e2b01333b49be
   languageName: node
   linkType: hard
 
@@ -36746,6 +36975,16 @@ __metadata:
   version: 2.0.0
   resolution: "unicode-property-aliases-ecmascript@npm:2.0.0"
   checksum: 10c0/db7f7ae188ce1a59b133a2c97021aebe30acc18a55f41074d126dcce5ac9d789dbd3ce7947e391b23db27f969251037b6ae05871d036aaa6cc0a6510c429aa1c
+  languageName: node
+  linkType: hard
+
+"unicode-trie@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "unicode-trie@npm:2.0.0"
+  dependencies:
+    pako: "npm:^0.2.5"
+    tiny-inflate: "npm:^1.0.0"
+  checksum: 10c0/2422368645249f315640a1c9e9506046aa7738fc9c5d59e15c207cdd6ec66101c35b0b9f75dc3ac28fe7be19aaf1efc898bbea074fa1e8e295ef736aeb7904bb
   languageName: node
   linkType: hard
 
@@ -39193,6 +39432,22 @@ __metadata:
   bin:
     yosay: cli.js
   checksum: 10c0/985973d2c153b9402d009e36d5661a33d5d2e4c4309495e60d1b54e711a7fc5ca9c2c75b920f6fe6f00c6cf50d3d787fabfd2faab5d768f2821e3d79acd27018
+  languageName: node
+  linkType: hard
+
+"zod-validation-error@npm:^3.2.0":
+  version: 3.4.0
+  resolution: "zod-validation-error@npm:3.4.0"
+  peerDependencies:
+    zod: ^3.18.0
+  checksum: 10c0/aaadb0e65c834aacb12fa088663d52d9f4224b5fe6958f09b039f4ab74145fda381c8a7d470bfddf7ddd9bbb5fdfbb52739cd66958ce6d388c256a44094d1fba
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.6":
+  version: 3.23.8
+  resolution: "zod@npm:3.23.8"
+  checksum: 10c0/8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5863,6 +5863,7 @@ __metadata:
     "@loki/create-async-callback": "npm:^0.35.0"
     "@loki/is-loki-running": "npm:^0.35.0"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.3"
+    "@storybook/addon-designs": "npm:^8.0.3"
     "@storybook/addon-essentials": "npm:^8.0.5"
     "@storybook/addon-interactions": "npm:^8.0.5"
     "@storybook/addon-links": "npm:^8.0.5"
@@ -6542,6 +6543,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@figspec/components@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "@figspec/components@npm:1.0.3"
+  dependencies:
+    lit: "npm:^2.1.3"
+  checksum: 10c0/78f5ee600ea1d15af7848b9fc601063acd537f49deb08aa16b95d3452c3a5783352e142c970f9a7375817099f2f54c3f9b42911f21c44ce6dab72eab20e6e20a
+  languageName: node
+  linkType: hard
+
+"@figspec/react@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@figspec/react@npm:1.0.3"
+  dependencies:
+    "@figspec/components": "npm:^1.0.1"
+    "@lit-labs/react": "npm:^1.0.2"
+  peerDependencies:
+    react: ^16.14.0 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/d5bbb79e106f522f5b867d0f55de01391edd1011e3f5d5a966ac07a5fca75f499d1d4d40a6186cf0afdc4fc4b49d808eb5d4fcbaf1784401a1ace2865dbc19be
+  languageName: node
+  linkType: hard
+
 "@fisker/parse-srcset@npm:1.0.2":
   version: 1.0.2
   resolution: "@fisker/parse-srcset@npm:1.0.2"
@@ -7071,6 +7093,29 @@ __metadata:
   version: 2.0.4
   resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
   checksum: 10c0/3b0d8844d1d47c0a5ed7267c2964886adad3a642b85d06f95c148eeefd80cdabbd6aa0d63ccde8239967a2e9b6bb734a16bd57e1fda3d16bf56d50a7e7ec131b
+  languageName: node
+  linkType: hard
+
+"@lit-labs/react@npm:^1.0.2":
+  version: 1.2.1
+  resolution: "@lit-labs/react@npm:1.2.1"
+  checksum: 10c0/c92364101348400a06c3eb45a6384ca7d47c32765fdcad892827b360d0bad6cef7916f9a17744f2f471a5da3d7d73750767b885fc1521cd5e5e724badb71f014
+  languageName: node
+  linkType: hard
+
+"@lit-labs/ssr-dom-shim@npm:^1.0.0, @lit-labs/ssr-dom-shim@npm:^1.1.0":
+  version: 1.2.1
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.2.1"
+  checksum: 10c0/75cecf2cc4c1a089c6984d9f45b8264e3b4947b4ebed96aef7eb201bd6b3f26caeaafedf457884ac38d4f2d99cddaf94a4b2414c02c61fbf1f64c0a0dade11f4
+  languageName: node
+  linkType: hard
+
+"@lit/reactive-element@npm:^1.3.0, @lit/reactive-element@npm:^1.6.0":
+  version: 1.6.3
+  resolution: "@lit/reactive-element@npm:1.6.3"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.0.0"
+  checksum: 10c0/10f1d25e24e32feb21c4c6f9e11d062901241602e12c4ecf746b3138f87fed4d8394194645514d5c1bfd5f33f3fd56ee8ef41344e2cb4413c40fe4961ec9d419
   languageName: node
   linkType: hard
 
@@ -7961,6 +8006,32 @@ __metadata:
     lodash: "npm:^4.17.21"
     ts-dedent: "npm:^2.0.0"
   checksum: 10c0/d57bb74e50a9e4c4830c7891e0789528f4b8aeb8b43fea407853ca296fd68a52de1b37e8276fcc490ef182ff3282acd690ff4d7c5e7e42656183617960879897
+  languageName: node
+  linkType: hard
+
+"@storybook/addon-designs@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "@storybook/addon-designs@npm:8.0.3"
+  dependencies:
+    "@figspec/react": "npm:^1.0.0"
+  peerDependencies:
+    "@storybook/blocks": ^8.0.0
+    "@storybook/components": ^8.0.0
+    "@storybook/theming": ^8.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@storybook/blocks":
+      optional: true
+    "@storybook/components":
+      optional: true
+    "@storybook/theming":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/a865b0d5b48de07443ca8e9e5f3de10df17e956bd3c09abd83eff91de6199151cb35e2c2d0b0a06d5c2c87162f51912d177501f7f872a4e3ea694fc49c30b3e9
   languageName: node
   linkType: hard
 
@@ -10454,6 +10525,13 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^2.0.2":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
   languageName: node
   linkType: hard
 
@@ -25011,6 +25089,37 @@ __metadata:
   peerDependencies:
     enquirer: ">= 2.3.0 < 3"
   checksum: 10c0/fa241f93fb8e694575e208e1c0dfe920539a6ca135a928344a20a783918d8437b0682661dc88b743e4f9bc27f4ea6a29b2268e86ca13514ece3ea80a00564230
+  languageName: node
+  linkType: hard
+
+"lit-element@npm:^3.3.0":
+  version: 3.3.3
+  resolution: "lit-element@npm:3.3.3"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.1.0"
+    "@lit/reactive-element": "npm:^1.3.0"
+    lit-html: "npm:^2.8.0"
+  checksum: 10c0/f44c12fa3423a4e9ca5b84651410687e14646bb270ac258325e6905affac64a575f041f8440377e7ebaefa3910b6f0d6b8b1e902cb1aa5d0849b3fdfbf4fb3b6
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "lit-html@npm:2.8.0"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.2"
+  checksum: 10c0/90057dee050803823ac884c1355b0213ab8c05fbe2ec63943c694b61aade5d36272068f3925f45a312835e504f9c9784738ef797009f0a756a750351eafb52d5
+  languageName: node
+  linkType: hard
+
+"lit@npm:^2.1.3":
+  version: 2.8.0
+  resolution: "lit@npm:2.8.0"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.6.0"
+    lit-element: "npm:^3.3.0"
+    lit-html: "npm:^2.8.0"
+  checksum: 10c0/bf33c26b1937ee204aed1adbfa4b3d43a284e85aad8ea9763c7865365917426eded4e5888158b4136095ea42054812561fe272862b61775f1198fad3588b071f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Code Connect

Auto-generated code snippets with mapped properties between Figma and code.

## Table of content

- [Scope](#scope)
- [Summary](#summary)
- [Demo](#demo)
- [Conclusions](#conclusions)
   * [Benefits](#benefits)
   * [Limitations](#limitations)
   * [Storybook](#storybook)
   * [Typography](#typography)
   * [Icons](#icons)
   * [Component Insights](#component-insights)
      + [Buttons (EuiButton, EuiButtonEmpty, EuiButtonGroup)](#buttons-euibutton-euibuttonempty-euibuttongroup)
      + [EuiPanel](#euipanel)
      + [EuiBadge](#euibadge)
      + [EuiCallOut](#euicallout)
      + [EuiToolTip](#euitooltip)
      + [EuiFieldText](#euifieldtext)
      + [EuiComboBox](#euicombobox)
      + [EuiSelect](#euiselect)
- [Sources](#sources)

## Scope

The purpose of this investigation was to:

- see how Figma's Dev Mode Code Connect integrates with EUI to improve design-to-code workflows,
- define the most used components to be integrated as the first iteration,
- identify potential technical challenges, compatibility issues, and benefits of this integration,
- provide a recommendation on whether or not to proceed with using Code Connect for EUI projects.

For the purpose of the investigation, I used the EUI usage metrics to define the most common components (this excludes Cloud UI) which provide enough complexity:

1. EuiButton (1,606), EuiButtonEmpty (1,274)
2. EuiButtonGroup (122)
3. EuiPanel (1,050)
4. EuiToolTip (1,140)
5. EuiCallOut (990)
6. EuiBadge (605)
7. EuiFieldText (454)
8. EuiComboBox (314)
9. EuiSelect (304)

There are some components that are used often but are less complex and their auto-generated code snippets might not be as useful for investigation purposes:

- EuiSpacer (5,399)
- EuiHorizontalRule (480)
- EuiText (3,364), EuiTitle (1,549), EuiLink (1,549)
- EuiIcon (1,241), EuiButtonIcon (785)

## Summary

It is technically feasible to integrate Code Connect. It will significantly speed up feature development, onboard new developers quicker, minimize confusion regarding component usage, provide the space to advise best practices and highlight all discrepancies between the design and code implementation.

On the other hand, the integration will depend on the designers using the official main components and not detaching instances, and it will be fragile to any big (like the Visual Refresh initiative) or small (renaming a Figma property) Figma component library changes and a chore to set up and maintain (for the EUI development team).

Most of the tricky use cases can be handled without much issue (e.g. a variant in Figma being a separate component in the code) and some, while possible, require a lot of work (e.g. integrating icons). Storybook integration in its current form is poorly configurable, creates conflicts between Figma property mapping, React component props and story arguments, and has bugs (e.g. code snippet of nested components not hydrated). It would be recommended to use standalone Figma files with greater flexibility at the cost of more maintenance.

To bring benefit to all front-end / full-stack engineers, Dev Mode seats have to be provided to all.

## Considerations

- Requires a Dev Mode seat to use. Dev Mode is under investigation and if it does not prove to be of high value compared to its price, we might not end up buying the licenses, rendering Code Connect unusable.
- We are working on a new component library file in Figma. Therefore, we cannot reap the full benefits of Code Connect straight away. Why?
	- If we decide to integrate the current EUI library, we will make a chore for components that will become deprecated / removed once the Visual Refresh initiative ends and designers start using the new library
	- If we decide to integrate the new EUI library, we might lose component instance links for most of the library, i.e. code snippets will not be propagated across all product designs. Only the new designs that use the new library components will have auto-generated snippets.
- With the current icons and typography setup, and the on-going cleanup initiative, it will be hard to integrate them with Code Connect in an effective and maintainable way. More on this below in the [Typography](#typography) and [Icons](#icons) sections. Both are topics to be tackled in more detail once the decision on Dev Mode and Code Connect is made.
- *"Code Connect files are not executed. While they're written using real components from your codebase, the Figma CLI essentially treats code snippets as strings. This means you can use, for example, hooks without needing to mock data. However, this also means that logical operators such as ternaries or conditionals will be output verbatim in your example code rather than executed to show the result. You also won't be able to dynamically construct `figma.connect` calls in a for-loop, as an example."* source: [https://github.com/figma/code-connect/blob/main/docs/react.md#basic-setup](https://github.com/figma/code-connect/blob/main/docs/react.md#basic-setup)

## Demo

Short video demo [here](https://drive.google.com/file/d/19Gnh_gMDFBzCaWV6K0nE_5IE66ixc2a5/view?usp=sharing).
Figma file [here](https://www.figma.com/design/XCL1Qt4XgPibqH1NbcVDs7/Dumb-functionality?node-id=0-1&m=dev).

**Note:** For most of these cases, the integration could be even better.

## Conclusions

### Benefits

- As shown in the demo above, developers can look for how to implement a component instance in the EUI documentation, in the Storybook, in the component source code or in the existing feature implementation. All of those options require experience with the library and / or time and focus. Auto-generated code snippets significantly reduce the time to develop a functionality because they're readily available. They may also provide a head-start to onboarding developers.
- As shown by the [Component Insights](#component-insights) section, Code Connect can be a great exercise to evaluate and assert the parity between Figma design and code implementation.
- The code snippets can showcase usage with companion hooks, encourage best practices and influence code quality, and overall application accessibility (e.g. using `aria-label` when "Icon only" property is toggled).

### Limitations

- Dedicated integration files (*\*.figma.tsx*) are another file to maintain while keeping the Figma integration in Storybook files means less configuration capabilities (at the moment) and busier stories files.
- Resolving any type errors that do not cause runtime issues so can be "ignored" are tricky to resolve. TypeScript expressions like type assertion (`as Y`, e.g. `as const` to narrow down the type) and `@ts-ignore` or `@ts-expect-error` comment annotations will be shown in the code snippet because the examples are not executed but resolved as a string.
- Figma doesn't always rehydrate code snippets with other component instances. Sometimes, even when a component is integrated, it will display the purple badge instead of that component's code snippet (see _EuiPanel_).
- For Storybook, component instances are not populated at all, i.e. if a component is used in an instance swap or as children, and is integrated, the parent component still displays the purple badge instead of component's code snippet (see _EuiPanel_).
- Code Connect doesn't consider Prettier and ESLint configuration, e.g. semicolons are missing. https://github.com/figma/code-connect/issues/152
- There are no usage analytics implemented yet. https://github.com/figma/code-connect/issues/144
- Whenever there are some nested components, several imports will be added. Right now, there's no possibility to merge them into one import statement. https://github.com/figma/code-connect/issues/69
- There's no possibility to connect multiple stories to multiple components in Figma (story-level connection). https://github.com/figma/code-connect/issues/35
  
### Storybook

- Requires a "render" function to be defined. Most component stories do not define it leading to additional chore to be made.
```tsx
// component.stories.tsx
  
export const Playground: Story = {
	render: ({ children, ...props }) => (
		<EuiCallOut {...props}>{children}</EuiCallOut>
	),
};
```

- Requires a separate "parameters" config object with a props mapping, regardless of explicit or implicit controls. Furthermore, there can be annoying discrepancies between Figma properties (in the code), component props and Storybook args.
```tsx
// component.stories.tsx

export const Playground = () => {
	// 3. Notice how here we get:
	// "ariaLabel" from Code Connect mapping (it can only be camelCase), and
	// "aria-label" from Storybook args (either inferred or explicitly defined)
	render: ({ ariaLabel, label, ...args }) => (
		<EuiComboBox aria-label={ariaLabel} label={label} {...args} />
	),
	// SOLUTION: We have to rename Storybook arg to "ariaLabel"
	// and we lose the 1:1 mapping of props to Storybook args.
};

const meta = {
	argTypes: {
		// control types
		'aria-label': { control: 'text' }, // This would become "ariaLabel".
		label: { control: 'text' },
		...
	},
	args: {
		// default values
		'aria-label': 'Aria Label', // This would become "ariaLabel".
		label: 'Label', // 2. Notice how in SB the label is a string value!
		...
	},
	parameters: {
		design: {
			type: 'figma',
			// We cannot leverage URL replacement from global config
			// as in the standalone configuration (*.figma.tsx files).
			url: 'https://www.figma.com/design/{project}/{file}?node-id={id}',
			examples: [Playground],
			props: {
				// 1. Cannot write `aria-label`, otherwise parsing fails;
				// Notice how "Label" in Figma is a boolean value!
				ariaLabel: figma.boolean('Label', {
					true: undefined,
					false: 'Aria Label',
				}),
				label: figma.boolean('Label', {
					true: 'Label',
					false: undefined
				}),
				...
			}
		},
	},
};

export default meta;
```

- Another example of the awkward Storybook integration is *EuiButtonGroup* (button-group.stories.tsx) which has 2 component wrappers: *StatefulEuiButtonGroupSingle* and *StatefulEuiButtonGroupMulti*. In order for these components to display correct names in the code snippet, they have to be renamed to EuiButtonGroup. But both cannot be named that way.
  Additional problem is that for the sake of showcasing in Storybook, the wrappers add state logic. This state logic, abstracted in the wrappers, is not explicitly defined in the render function that Code Connect uses for code snippet generation. Therefore, important props are missing (like `onChange` and `idSelected`) from the code snippet:
!["Screenshot 2024-10-09 at 17 09 56"](https://github.com/user-attachments/assets/3bf476af-2a25-4d3c-8438-71645bad6104)

- If the original component is renamed within the story or a wrapper is created and used for the render functions, there's no way to change it for the code snippet. The only way to mitigate this is to rename the original component when importing and name the wrapper as the original component.
```tsx
// Current stories code:
const StatefulComboBox = (props: EuiComboBoxProps<{}>) => {
	...
}

// Code snippet:
<StatefulComboBox
	aria-label="Meaningful label"
	compressed
/>

// Solution:
import { EuiComboBox as ComboBox } from './combo_box';

const EuiComboBox = (props: EuiComboBoxProps<{}>) => {
	...
}
```

- [Storybook Designs add-on](https://github.com/storybookjs/addon-designs) configuration capabilities are poor, e.g. we cannot add an import `import { Component } from '@elastic/eui';` (there's an [issue](https://github.com/figma/code-connect/issues/142) open for this; on the other hand, developers can rely on auto-import) or resolve the "url" based on global configuration to avoid repetition (on the other hand, there can be a util function that returns the whole Figma URL or a constant to use within a template literal but copy-pasting a link from Figma is quick and easy so it might be a redundant abstraction).
![Screenshot 2024-10-08 at 19 28 57](https://github.com/user-attachments/assets/7ac396cc-e97d-4a98-aead-878a4186735b)
![image](https://github.com/user-attachments/assets/33479407-45d0-4b1f-84df-e0d89207f7b1)

- Storybook supports [variant restrictions](https://github.com/figma/code-connect/blob/main/docs/react.md#variant-restrictions). In the case of standalone `*.figma.tsx` files, all subcomponents can be integrated within the same file. In the case of Storybook integration, usually each component has a separate `*.stories.tsx` file, i.e. the relationship between Figma components and code components will now be scattered across different stories, even though in Figma it's the same component. Furthermore, reusing property mapping would be tricky. We'd need to extract `sharedProps` constant to separate file to be reusable by all stories.
**Example:** *EuiButton* and *EuiButtonEmpty*. Figma's Button style "empty" maps to a separate component in the code - *EuiButtonEmpty*. That component has a separate stories file. Therefore, from the level of *EuiButton* stories file we do not know about this subcomponent and may believe that we just haven't implemented the style for "empty". This might as well turn out to not be an issue. Take a look at:
	- _EuiButton_ and _EuiButtonEmpty_: [button.figma.tsx](https://github.com/elastic/eui/blob/poc/code-connect/packages/eui/src/components/button/button.figma.tsx)
	- _EuiButton_: [button.stories.tsx](https://github.com/elastic/eui/blob/poc/code-connect/packages/eui/src/components/button/button.stories.tsx)
	- _EuiButtonEmpty_: [button_empty.stories.tsx](https://github.com/elastic/eui/blob/poc/code-connect/packages/eui/src/components/button/button_empty/button_empty.stories.tsx)

- I'm only adding "Playground" story to the "examples" set but there can be multiple stories, each representing a different use case (as per Storybook snippet in [Variant restrictions](https://github.com/figma/code-connect/blob/main/docs/react.md#variant-restrictions)):
```tsx
export default {
  component: Button,
  parameters: {
    design: {
      type: 'figma',
      url: 'https://...',
      examples: [
        { example: PrimaryButtonStory, variant: { Type: 'Primary' } },
        { example: SecondaryButtonStory, variant: { Type: 'Secondary' } },
        { example: DangerButtonStory, variant: { Type: 'Danger' } },
      ],
    },
  },
}

export function PrimaryButtonStory() {
  return <PrimaryButton />
}

export function SecondaryButtonStory() {
  return <SecondaryButton />
}

export function DangerButtonStory() {
  return <DangerButton />
}
```

- Thanks to integrating Code Connect through the [Storybook Designs add-on](https://github.com/storybookjs/addon-designs), we are receiving [Figma component embed panel](https://storybookjs.github.io/addon-designs/?path=/story/docs-figma-examples--embed-file) out-of-the-box. This might prove useful for when working inside the sandboxing environment.

### Typography

Typography integration depends on whether the Figma library uses text styles (optionally with typography variables) or a component with [instance swap](https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances). In the latter case, integration is possible because code implementation is based on the usage of typography components (e.g. *EuiText* and *EuiTitle*). But most of the time, the former is true because it's easier to manage by the designers.

Whatever the case, the EUI Figma library will support both ways. We can integrate typography components easily and display accurate code snippets for them. We cannot map in any way text styles.

For an example, see _EuiPanel_ integration.

There's an [issue](https://github.com/figma/code-connect/issues/146) open for this topic in Code Connect GH repo.

### Icons

Each icon (glyph) is a separate component in Figma. For the purposes of this explanation, let's call them [atomic icon components](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=12956-45237&node-type=frame&m=dev). They are used as an instance swap in all components, including an [Icon component](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31572-393323&node-type=frame&m=dev) which is used as a standalone icon. This provides a unique challenge because most EUI components in the code, e.g. *EuiButton*, receive an icon name / source / SVG element in the `iconType` prop, and not the *EuiIcon* component instance:
```tsx
// 🟢 It's this:
<EuiButton iconType="accessibility">Hello</EuiButton>

// 🔴 and NOT this:
<EuiButton icon={<EuiIcon type="accessibility" />}>Hello</EuiButton>
```
and that's the reverse approach to the Figma component library:
![Screenshot 2024-10-08 at 14 20 09](https://github.com/user-attachments/assets/01e9d4d6-fa40-41c6-841f-91aab40136e5)
![Screenshot 2024-10-08 at 14 18 57](https://github.com/user-attachments/assets/836f62a9-910e-463d-be91-055755cdef83)

which results in a weird-ish code snippet being generated when [figma.instance](https://github.com/figma/code-connect/blob/main/docs/react.md#instances) is used (no better alternative):
![Screenshot 2024-10-08 at 14 36 20](https://github.com/user-attachments/assets/b047ea5c-d3e6-4b0d-ba19-6effe12b47fc)

where this "Icon" is a Figma component reference. Upon copying the code snippet to the clipboard, here's what we get:
```tsx
<EuiButton
    onClick={() => {}}
    color="primary"
    iconType={/* Icon right */} // this isn't the icon we set, we have to manually change it to desired icon name
    iconSide="right"
    size="m"
>
    Add element
</EuiButton>
```

If I connected the chosen icon component (say "accessibility") in Figma to _EuiIcon_ component, then Figma would hydrate the _EuiButton_ code snippet with the _EuiIcon_ code snippet of the accessibility icon instance swap, resulting in:
```tsx
<EuiButton icon={<EuiIcon type="accessibility" />}>Hello</EuiButton>
```

Circling to the beginning, that's not how the Button is designed to be used (with render props).
  
The [Icon component](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31572-393323&node-type=frame&m=dev) is easily integrated because it's used as a standalone component and not an instance swap:

![Screenshot 2024-10-08 at 14 24 23](https://github.com/user-attachments/assets/3420f8e9-2bfc-4eb3-a045-a073593affdb)

On the other hand, the [atomic icon components](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=12956-45237&node-type=frame&m=dev) are used as swappable instances in its "Type" property. In theory, those should be mapped to a string, resulting in the following code snippet:
```tsx
import { EuiIcon } from "@elastic/eui"

<EuiIcon
    type="accessibility"
    size="m"
/>
```

Unfortunately, this is not possible and will result in "accessibility" being a comment upon copying and pasting because it's treated as an unlinked React component:
```tsx
<EuiIcon
    type={/* accessibility */}
    size="m"
/>
```

One solution would be to, instead of integrating atomic icon components, integrate all icon instance swaps with the _EuiButton_. That is not sustainable in the long run. Imagine integrating all components that consume an icon the number of times there are icons in the library.

It is recommended to create a script that pulls icons from a Figma file and generates *icons.figma.tsx* with appropriate integrations. You can read more about it [here](https://github.com/figma/code-connect/blob/main/cli/scripts/README.md).

There are some issues on the topic in Code Connect GH repo:
- https://github.com/figma/code-connect/issues/145
- https://github.com/figma/code-connect/issues/13

### Component Insights

#### EuiButton, EuiButtonEmpty

[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31735-391399&node-type=frame&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/navigation/button) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/button)

https://github.com/user-attachments/assets/0fded1ce-8e65-48d0-adca-4d3d37e7dd6f

- The size "Extra Small" is not implemented in the component library.
- The style "Empty" is a separate component - *EuiButtonEmpty* - seemingly the same, worth investigating if it can be merged.

#### EuiButtonGroup

[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=31735-391399&node-type=frame&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/navigation/button) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/button)

https://github.com/user-attachments/assets/7510be9e-9971-43db-80cd-c15bfed48ed9

- In Figma, there are no styles: "Accent" | "Success" | "Warning" | "Danger" but they are implemented in code.

#### EuiPanel
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=13420-851&node-type=canvas&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/layout/panel) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/panel)

https://github.com/user-attachments/assets/b16317ed-34f8-4108-8dc4-3b70e7b66f56

- Because `false` values are resolved to no prop passed, we cannot replicate `hasShadow={true}` interface in the integration. A workaround are variant restrictions (as explained [here](https://github.com/figma/code-connect/issues/155#issuecomment-2353096836)), unfortunately Code Connect throws an error: "The Figma Variant "Shadow" does not have an option for true". For now, I skipped `hasShadow` prop altogether.

#### EuiBadge
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=12804-44450&node-type=canvas&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/display/badge) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/badge)

https://github.com/user-attachments/assets/49875e8c-38e0-4b46-b839-69097b8c1695

- In Figma, we can define both the left and the right icon at the same time. In code, there are component props `iconType` and `iconSide`, and we can only ever have one icon at a time.

#### EuiCallOut
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=32350-392160&node-type=frame&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/display/callout) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/call_out)

https://github.com/user-attachments/assets/52df14dd-b2a5-45e2-bfe2-303bc70fd78b

- Primary and secondary buttons in the content are not controlled through the component. Furthermore, there is no story or a documentation entry that explains how to achieve that result.

#### EuiToolTip
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=13494-22214&node-type=canvas&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/display/tooltip) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/tool_tip)

https://github.com/user-attachments/assets/88f292a7-a481-4147-80ec-44c10a285e1f

#### EuiFieldText
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=13676-796&node-type=frame&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/forms/form-controls#text-field) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/form/field_text)

https://github.com/user-attachments/assets/101fa22f-f8af-41e3-8c2c-221e2891d981

- It wasn't clear to me how to map "Column display". It doesn't seem to be controlled by the _EuiFieldText_ or _EuiFormRow_ (unless with`display` prop).

#### EuiComboBox
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=15883-161301&node-type=frame&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/forms/combo-box) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/combo_box)

https://github.com/user-attachments/assets/0aa265df-ef76-4cf8-9f91-4050d501acdb

- It wasn't clear to me how to map "Column display". It doesn't seem to be controlled by the _EuiComboBox_ or _EuiFormRow_ (unless with`display` prop).

#### EuiSelect
[Figma](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=15883-129716&node-type=frame&m=dev) | [Docs](https://eui.elastic.co/v95.10.1/#/forms/form-controls#select) | [Code](https://github.com/elastic/eui/tree/main/packages/eui/src/components/form/select)

https://github.com/user-attachments/assets/deb19445-9d92-46ee-b216-f88780f46cb2

- It wasn't clear to me how to map "Column display". It doesn't seem to be controlled by the _EuiSelect_ or _EuiFormRow_ (unless with`display` prop).

## Sources

- [The Right Code for Your Design System](https://www.figma.com/blog/introducing-code-connect/) @Figma
- [Framework: Creating a more connected design system with Code Connect](https://www.youtube.com/watch?v=5GVNfbltrQg) @YouTube
- [Config 2024: Drive design system adoption with Code Connect](https://www.youtube.com/watch?v=RvFSyxAWriw) @YouTube
- [Code Connect - React](https://github.com/figma/code-connect/blob/main/docs/react.md) @GitHub
- [Code Connect - Icons](https://github.com/figma/code-connect/blob/main/cli/scripts/README.md) @GitHub
- [Swap components and instances](https://help.figma.com/hc/en-us/articles/360039150413-Swap-components-and-instances) @Figma
- [EUI Metrics](https://my-deployment-49bd8c.kb.us-central1.gcp.cloud.es.io:9243/app/dashboards#/view/33ed796c-63e5-448e-ad09-002d7c342595?_g=(filters:!())) - I used it to understand the component usage and define the most used components with enough complexity to explore limitations and capabilities of Code Connect integration.
- [EUI Documentation](https://eui.elastic.co/v95.10.1/#/) - I used the current EUI Docs as the new ones haven't been released yet.
- [Elastic UI Figma Library](https://www.figma.com/design/RzfYLj2xmH9K7gQtbSKygn/Elastic-UI?node-id=5202-1) - I used the current Figma library for investigation as the new one is actively being worked on, resulting in frequent changes and (possibly) breaking Code Connect integration.