### PR TITLE
Fix stalebot config

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -9,8 +9,8 @@ permissions:
 jobs:
   stale-prs: # close stale PRs after ~3 months
     permissions:
-      issues: write
       pull-requests: write
+      issues: none # this will generate GH actions permissions errors. This is fine; we'd rather the action error than try to parse issues it doesn't need to
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
@@ -28,7 +28,7 @@ jobs:
   stale-issues: # close stale issues after ~1 year
     permissions:
       issues: write
-      pull-requests: write
+      pull-requests: none # this will generate GH actions permissions errors. This is fine; we'd rather the action error than try to parse PRs it doesn't need to
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8
@@ -48,6 +48,7 @@ jobs:
   answered-issues: # close answered issues after 3 days if no response
     permissions:
       issues: write
+      pull-requests: none  # this will generate GH actions permissions errors. This is fine; we'd rather the action error than try to parse PRs it doesn't need to
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
## Summary

Essentially reverts #8059 and leaves more explicit notation as to why we do not want each individual job to have permissions - it's because we have separate jobs for issues vs PRs and separate stale/close durations.

## QA

N/A, dev/internal only