### PR TITLE
ci: update github PAT token secret path

### DIFF
--- a/.buildkite/scripts/lifecycle/pre_command.sh
+++ b/.buildkite/scripts/lifecycle/pre_command.sh
@@ -7,14 +7,14 @@ echo '[SOURCE]: Buildkite dependencies'
 source .buildkite/scripts/common/utils.sh
 
 echo '[INSTALL]: Non-exported variables'
-GITHUB_ACCOUNT=secret/ci/elastic-eui/kibanamachine
+GITHUB_ACCOUNT=secret/ci/elastic-eui/github_machine_user
 VAULT_ACCOUNT=secret/ci/elastic-eui/bekitzur-kibana-service-account
 
 echo '[INSTALL]: Exported variables'
 GCE_ACCOUNT=$(retry 5 vault read -field=value $VAULT_ACCOUNT)
 export GCE_ACCOUNT
 
-GITHUB_TOKEN=$(retry 5 vault read -field=github_token $GITHUB_ACCOUNT)
+GITHUB_TOKEN=$(retry 5 vault read -field=kibanamachine_token $GITHUB_ACCOUNT)
 export GITHUB_TOKEN
 
 DOCKER_BASE_IMAGE=docker.elastic.co/eui/ci:6.6


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui-private/issues/122

This updates the path for where the Github PAT is stored in our vault. The updated path is already used in other places but wasn't used in the `pre_command` hook.

# QA

- [x] Confirm `kibanamachine` adds a comment when CI for this PR passes