### PR TITLE
[EuiHeaderLinks] Add `xxs` gutterSize

### DIFF
--- a/packages/eui/changelogs/upcoming/8079.md
+++ b/packages/eui/changelogs/upcoming/8079.md
@@ -1,0 +1,1 @@
+- Updated `EuiHeaderLinks` with a new `xxs` gutter size

--- a/packages/eui/src/components/header/header_links/__snapshots__/header_links.test.tsx.snap
+++ b/packages/eui/src/components/header/header_links/__snapshots__/header_links.test.tsx.snap
@@ -44,6 +44,17 @@ exports[`EuiHeaderLinks gutterSize xs is rendered 1`] = `
 </nav>
 `;
 
+exports[`EuiHeaderLinks gutterSize xxs is rendered 1`] = `
+<nav
+  aria-label="App menu"
+  class="euiHeaderLinks emotion-euiHeaderLinks"
+>
+  <div
+    class="euiHeaderLinks__list emotion-euiHeaderLinks__list-xxs-EuiHeaderLinks"
+  />
+</nav>
+`;
+
 exports[`EuiHeaderLinks is rendered 1`] = `
 <nav
   aria-label="aria-label"

--- a/packages/eui/src/components/header/header_links/header_links.styles.ts
+++ b/packages/eui/src/components/header/header_links/header_links.styles.ts
@@ -22,6 +22,9 @@ export const euiHeaderLinksStyles = ({ euiTheme }: UseEuiTheme) => {
       align-items: center;
     `,
     gutterSizes: {
+      xxs: css`
+        gap: ${euiTheme.size.xs};
+      `,
       xs: css`
         gap: ${euiTheme.size.s};
       `,

--- a/packages/eui/src/components/header/header_links/header_links.tsx
+++ b/packages/eui/src/components/header/header_links/header_links.tsx
@@ -31,7 +31,7 @@ import { EuiHideFor, EuiShowFor } from '../../responsive';
 
 import { euiHeaderLinksStyles } from './header_links.styles';
 
-export const GUTTER_SIZES = ['xs', 's', 'm', 'l'] as const;
+export const GUTTER_SIZES = ['xxs', 'xs', 's', 'm', 'l'] as const;
 type EuiHeaderLinksGutterSize = (typeof GUTTER_SIZES)[number];
 
 type EuiHeaderLinksPopoverButtonProps =


### PR DESCRIPTION
## Summary

Will be used in Kibana for a scalable app menu bar related to One Discover

## QA

- https://eui.elastic.co/pr_8079/storybook/?path=/story/layout-euiheader-euiheaderlinks--playground&args=gutterSize:xxs

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked in both **light and dark** modes~
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    ~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
