### PR TITLE
[EuiDataGrid] Allow `column.initialWidth`+`onColumnResize` to be used to control column widths

### DIFF
--- a/packages/eui/changelogs/upcoming/8082.md
+++ b/packages/eui/changelogs/upcoming/8082.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an `EuiDataGrid` regression from [#8015](https://github.com/elastic/eui/pull/8015) to allow `onColumnResize` to control columns' `initialWidth`s again

--- a/packages/eui/src/components/datagrid/data_grid_types.ts
+++ b/packages/eui/src/components/datagrid/data_grid_types.ts
@@ -349,6 +349,10 @@ export type CommonGridProps = CommonProps &
     sorting?: EuiDataGridSorting;
     /**
      * A callback for when a column's size changes. Callback receives `{ columnId: string, width: number }`.
+     *
+     * When an `onColumnResize` function is passed, `columns[].initialWidth` behaves like a
+     * controlled (rather than uncontrolled) prop, and can be used to completely manage column
+     * widths even after initial mount.
      */
     onColumnResize?: EuiDataGridOnColumnResizeHandler;
     /**

--- a/packages/eui/src/components/datagrid/utils/col_widths.test.ts
+++ b/packages/eui/src/components/datagrid/utils/col_widths.test.ts
@@ -88,7 +88,6 @@ describe('useColumnWidths', () => {
     columns: [{ id: 'b', initialWidth: 75 }, { id: 'c' }],
     trailingControlColumns: [{ id: 'd', width: 25 }] as any,
     defaultColumnWidth: 150,
-    onColumnResize: jest.fn(),
   };
 
   describe('columnWidths', () => {
@@ -136,16 +135,36 @@ describe('useColumnWidths', () => {
         });
         expect(result.current.columnWidths).toEqual({ b: 150 });
       });
+
+      it('does override user resized column widths if `onColumnResize` is passed', () => {
+        const controlledWidthsArgs = {
+          ...args,
+          onColumnResize: jest.fn(),
+        };
+        const { rerender, result } = renderHook(useColumnWidths, {
+          initialProps: controlledWidthsArgs,
+        });
+
+        renderHookAct(() => result.current.setColumnWidth('b', 150));
+        rerender({
+          ...controlledWidthsArgs,
+          columns: [{ id: 'b', initialWidth: 100 }],
+        });
+        expect(result.current.columnWidths).toEqual({ b: 100 });
+      });
     });
   });
 
   describe('setColumnWidth', () => {
     it("sets a single column's width in the columnWidths map", () => {
-      const { result } = renderHook(() => useColumnWidths(args));
+      const onColumnResize = jest.fn();
+      const { result } = renderHook(() =>
+        useColumnWidths({ ...args, onColumnResize })
+      );
 
       renderHookAct(() => result.current.setColumnWidth('c', 125));
       expect(result.current.columnWidths).toEqual({ b: 75, c: 125 });
-      expect(args.onColumnResize).toHaveBeenCalledWith({
+      expect(onColumnResize).toHaveBeenCalledWith({
         columnId: 'c',
         width: 125,
       });

--- a/packages/eui/src/components/datagrid/utils/col_widths.ts
+++ b/packages/eui/src/components/datagrid/utils/col_widths.ts
@@ -79,19 +79,25 @@ export const useColumnWidths = ({
   setColumnWidth: (columnId: string, width: number) => void;
   getColumnWidth: (index: number) => number;
 } => {
+  const hasOnColumnResize = !!onColumnResize;
   const getInitialWidths = useCallback(
     (prevColumnWidths?: EuiDataGridColumnWidths) => {
       const columnWidths = { ...prevColumnWidths };
       columns
         .filter(doesColumnHaveAnInitialWidth)
         .forEach(({ id, initialWidth }) => {
-          if (columnWidths[id] == null) {
+          // Several Kibana datagrids are using `onColumnResize` and `column.initialWidth`
+          // to fully control column widths. Sadly, we didn't do a good job documenting
+          // the intent of this prop and how controlled it is, so for now we'll assume
+          // that any datagrid passing `onColumnResize` is controlling its column widths
+          // and should override any internal column width state set by user resizing
+          if (hasOnColumnResize || columnWidths[id] == null) {
             columnWidths[id] = initialWidth!;
           }
         });
       return columnWidths;
     },
-    [columns]
+    [columns, hasOnColumnResize]
   );
 
   // Passes initializer function for performance, so computing only runs once on init


### PR DESCRIPTION
## Summary

This partially reverts the column width cache/state storage we added in https://github.com/elastic/eui/pull/8015#discussion_r1788889926 and https://github.com/elastic/eui/pull/8015#discussion_r1793977545.

It turns out Kibana is using `onColumnResize` way more than I had realized, and `initialWidth` (which I had assumed to be mostly used for uncontrolled usage, as its naming is similar to `defaultValue`) is being used fairly heavily in combination with `onColumnResize` to control column widths on update.

This PR allows for that controlled usage while still maintaining uncontrolled in-memory user resized column widths for datagrids that do not have a `onColumnResize` callback passed.

## QA

- (Regression testing) Go to https://eui.elastic.co/pr_8082/storybook/?path=/story/tabular-content-euidatagrid--draggable-columns
- Resize a column and then drag it, and confirm that the reordered column(s) maintains its resized width

### General checklist

- Browser QA - N/A, API vs UI-facing change
- Docs site QA - N/A, we don't really appear to document `onColumnResize` thoroughly anywhere 🫠 
    ~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    ~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
    ~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A