### PR TITLE
[EuiDataGrid] Vertically center toolbar `additionalControls` items

### DIFF
--- a/packages/eui/changelogs/upcoming/8085.md
+++ b/packages/eui/changelogs/upcoming/8085.md
@@ -1,0 +1,1 @@
+- Updated `EuiDataGrid` to vertically center all `toolbarVisibility.additionalControls` nodes

--- a/packages/eui/src/components/datagrid/controls/data_grid_toolbar.styles.ts
+++ b/packages/eui/src/components/datagrid/controls/data_grid_toolbar.styles.ts
@@ -26,6 +26,7 @@ export const euiDataGridToolbarStyles = ({ euiTheme }: UseEuiTheme) => {
     euiDataGrid__rightControls: css`
       display: flex;
       justify-content: flex-end;
+      align-items: center;
       flex-wrap: wrap;
       column-gap: ${euiTheme.size.s};
       ${logicalCSS('padding-right', euiTheme.size.xs)}
@@ -38,6 +39,7 @@ export const euiDataGridToolbarStyles = ({ euiTheme }: UseEuiTheme) => {
     euiDataGrid__leftControls: css`
       display: flex;
       flex-wrap: wrap;
+      align-items: center;
       gap: ${euiTheme.size.xxs};
     `,
   };


### PR DESCRIPTION
## Summary

I recently noticed that the alerts table toolbar in security has items that were not vertically centered. I created fixes for that in Kibana but I think the actual fix would be to add `align-items: center;` to the actual wrapper classes, hence this PR. [[Kibana PR]](https://github.com/elastic/kibana/pull/196804)

Alerts table before:

<img width="1265" alt="Screenshot 2024-10-18 at 09 47 53" src="https://github.com/user-attachments/assets/ddd28535-7fc9-4631-808f-7e4d81b5d270">

Alerts table after:

<img width="1274" alt="Screenshot 2024-10-18 at 09 47 14" src="https://github.com/user-attachments/assets/93a24d04-0687-4534-9882-11a9dd84a276">

TODO:
- [ ] Revert https://github.com/elastic/kibana/pull/196804 when this PR makes it into an EUI update in Kibana