### PR TITLE
[EuiDataGrid] Revert column width changes

### DIFF
--- a/packages/eui/changelogs/upcoming/8086.md
+++ b/packages/eui/changelogs/upcoming/8086.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Reverted an `EuiDataGrid` regression from [#8015](https://github.com/elastic/eui/pull/8015) which prevented overriding column widths via columns's `initialWidth`s

--- a/packages/eui/src/components/datagrid/utils/col_widths.test.ts
+++ b/packages/eui/src/components/datagrid/utils/col_widths.test.ts
@@ -99,43 +99,16 @@ describe('useColumnWidths', () => {
       expect(columnWidths).toEqual({ b: 75 });
     });
 
-    describe('when `columns` updates', () => {
-      it('adds new `initialWidth`s', () => {
-        const { rerender, result } = renderHook(useColumnWidths, {
-          initialProps: args,
-        });
-        rerender({
-          ...args,
-          columns: [{ id: 'f', initialWidth: 100 }],
-        });
-
-        expect(result.current.columnWidths).toEqual({ b: 75, f: 100 });
+    it('recomputes column widths on columns change', () => {
+      const { rerender, result } = renderHook(useColumnWidths, {
+        initialProps: args,
+      });
+      rerender({
+        ...args,
+        columns: [{ id: 'c', initialWidth: 125 }],
       });
 
-      it('does not remove column widths that have been hidden', () => {
-        const { rerender, result } = renderHook(useColumnWidths, {
-          initialProps: args,
-        });
-
-        rerender({
-          ...args,
-          columns: [{ id: 'c' }],
-        });
-        expect(result.current.columnWidths).toEqual({ b: 75 });
-      });
-
-      it('does not override column widths that have already been set by manual user resize', () => {
-        const { rerender, result } = renderHook(useColumnWidths, {
-          initialProps: args,
-        });
-
-        renderHookAct(() => result.current.setColumnWidth('b', 150));
-        rerender({
-          ...args,
-          columns: [...args.columns],
-        });
-        expect(result.current.columnWidths).toEqual({ b: 150 });
-      });
+      expect(result.current.columnWidths).toEqual({ c: 125 });
     });
   });
 

--- a/packages/eui/src/components/datagrid/utils/col_widths.ts
+++ b/packages/eui/src/components/datagrid/utils/col_widths.ts
@@ -79,20 +79,13 @@ export const useColumnWidths = ({
   setColumnWidth: (columnId: string, width: number) => void;
   getColumnWidth: (index: number) => number;
 } => {
-  const getInitialWidths = useCallback(
-    (prevColumnWidths?: EuiDataGridColumnWidths) => {
-      const columnWidths = { ...prevColumnWidths };
-      columns
-        .filter(doesColumnHaveAnInitialWidth)
-        .forEach(({ id, initialWidth }) => {
-          if (columnWidths[id] == null) {
-            columnWidths[id] = initialWidth!;
-          }
-        });
-      return columnWidths;
-    },
-    [columns]
-  );
+  const getInitialWidths = useCallback(() => {
+    return columns
+      .filter(doesColumnHaveAnInitialWidth)
+      .reduce<EuiDataGridColumnWidths>((initialWidths, column) => {
+        return { ...initialWidths, [column.id]: column.initialWidth! };
+      }, {});
+  }, [columns]);
 
   // Passes initializer function for performance, so computing only runs once on init
   // @see https://react.dev/reference/react/useState#examples-initializer
@@ -101,7 +94,7 @@ export const useColumnWidths = ({
 
   useUpdateEffect(() => {
     setColumnWidths(getInitialWidths);
-  }, [columns]);
+  }, [getInitialWidths]);
 
   const setColumnWidth = useCallback(
     (columnId: string, width: number) => {

--- a/packages/eui/src/components/datagrid/utils/col_widths.ts
+++ b/packages/eui/src/components/datagrid/utils/col_widths.ts
@@ -79,7 +79,7 @@ export const useColumnWidths = ({
   setColumnWidth: (columnId: string, width: number) => void;
   getColumnWidth: (index: number) => number;
 } => {
-  const getInitialWidths = useCallback(() => {
+  const computeColumnWidths = useCallback(() => {
     return columns
       .filter(doesColumnHaveAnInitialWidth)
       .reduce<EuiDataGridColumnWidths>((initialWidths, column) => {
@@ -90,11 +90,11 @@ export const useColumnWidths = ({
   // Passes initializer function for performance, so computing only runs once on init
   // @see https://react.dev/reference/react/useState#examples-initializer
   const [columnWidths, setColumnWidths] =
-    useState<EuiDataGridColumnWidths>(getInitialWidths);
+    useState<EuiDataGridColumnWidths>(computeColumnWidths);
 
   useUpdateEffect(() => {
-    setColumnWidths(getInitialWidths);
-  }, [getInitialWidths]);
+    setColumnWidths(computeColumnWidths());
+  }, [computeColumnWidths]);
 
   const setColumnWidth = useCallback(
     (columnId: string, width: number) => {


### PR DESCRIPTION
## Summary

This PR reverts [changes done in this PR](https://github.com/elastic/eui/pull/8015/commits/fb3ff84f90b8a41e05a81ede5e3c60ac56e38c98) to store column widths after resize. While the change works for uncontrolled `EuiDataGrid`s, it currently does not allow for controlled usages to override saved widths anymore.
This is an issue in Kibana where column widths can be reset. 

We decided to revert the change for now and address it separately, as the issue was not specific to the [draggable column update](https://github.com/elastic/eui/pull/8015) but existed before.

## QA

- [x] test that the revert fixes the issue on Kibana (tested with a local package: both manual test and unit tests work again as expected)
