### PR TITLE
[EuiComment] Fix typing to accurately reflect `...rest` spread

### DIFF
--- a/packages/eui/changelogs/upcoming/8089.md
+++ b/packages/eui/changelogs/upcoming/8089.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComment`'s typing to correctly reflect all accepted props

--- a/packages/eui/src/components/comment_list/comment.tsx
+++ b/packages/eui/src/components/comment_list/comment.tsx
@@ -8,7 +8,7 @@
 
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
-import { EuiTimelineItem } from '../timeline';
+import { EuiTimelineItem, EuiTimelineItemProps } from '../timeline';
 import { EuiCommentEvent, EuiCommentEventProps } from './comment_event';
 import {
   EuiCommentTimeline,
@@ -17,7 +17,8 @@ import {
 
 export interface EuiCommentProps
   extends EuiCommentEventProps,
-    EuiCommentTimelineProps {}
+    EuiCommentTimelineProps,
+    Omit<EuiTimelineItemProps, 'children' | 'icon' | 'iconAriaLabel'> {}
 
 export const EuiComment: FunctionComponent<EuiCommentProps> = ({
   children,


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8090

@jpcarey pinged us to let us know that `<EuiComment id="...">` was being incorrectly flagged via types, when in fact the component passes all attributes down to the HTMLElement node. I've fixed the typing of component to correctly reflect that / extend to all valid & accepted props.

| Before | After |
|--------|--------|
| <img width="538" alt="" src="https://github.com/user-attachments/assets/280be951-160c-445e-aa93-41d3708cb31e"> | <img width="521" alt="" src="https://github.com/user-attachments/assets/8db15476-f1be-4819-9bcf-b5822a17e106"> | 

## QA

- Go to https://eui.elastic.co/pr_8089/#/display/comment-list#comment
- Click the `Props` tab
- [ ] Confirm that the **EuiComment** props table now extends HTMLElement

### General checklist

- Browser QA - N/A
- Docs site QA
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist - N/A
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A