### PR TITLE
[A11y] [Table] Improvements to Screen Reader Functionality for Sortable Table Header Buttons

### DIFF
--- a/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -286,6 +286,11 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
                 your name
               </span>
               <span
+                class="emotion-euiScreenReaderOnly"
+              >
+                Sorted ascending. Click to sort descending
+              </span>
+              <span
                 class="euiTableSortIcon"
                 data-euiicon-type="sortUp"
               />

--- a/packages/eui/src/components/basic_table/basic_table.test.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.test.tsx
@@ -350,7 +350,8 @@ describe('EuiBasicTable', () => {
     expect(
       container.querySelector('[aria-sort="ascending"] .euiTableCellContent')
         ?.textContent
-    ).toEqual('Name');
+      // Using toMatch because the text includes screen reader only text.
+    ).toMatch('Name');
   });
 
   test('with sortable columns and sorting disabled', () => {

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -797,6 +797,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
             : undefined;
           sorting.onSort = this.resolveColumnOnSort(column);
           sorting.readOnly = this.props.sorting.readOnly || readOnly;
+          sorting.allowNeutralSort = this.props.sorting.allowNeutralSort;
         }
         headers.push(
           <EuiTableHeaderCell

--- a/packages/eui/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
+++ b/packages/eui/src/components/table/__snapshots__/table_header_cell.test.tsx.snap
@@ -139,6 +139,11 @@ exports[`EuiTableHeaderCell sorting renders a button with onSort 1`] = `
               Test
             </span>
             <span
+              class="emotion-euiScreenReaderOnly"
+            >
+              Sorted descending. Click to unsort
+            </span>
+            <span
               class="euiTableSortIcon"
               data-euiicon-type="sortDown"
             />
@@ -233,6 +238,11 @@ exports[`EuiTableHeaderCell sorting renders with a sortable icon if \`onSort\` i
               title="Test"
             >
               Test
+            </span>
+            <span
+              class="emotion-euiScreenReaderOnly"
+            >
+              Unsorted. Click to sort ascending
             </span>
             <span
               class="euiTableSortIcon euiTableSortIcon--sortable"

--- a/packages/eui/src/components/table/table_header_cell.tsx
+++ b/packages/eui/src/components/table/table_header_cell.tsx
@@ -11,6 +11,7 @@ import React, {
   HTMLAttributes,
   ThHTMLAttributes,
   ReactNode,
+  useMemo,
 } from 'react';
 import classNames from 'classnames';
 
@@ -66,27 +67,47 @@ const SortScreenReaderText = ({
   isSortAscending: boolean | undefined;
   allowNeutralSort: boolean | undefined;
 }) => {
-  if (!isSorted) {
-    return useEuiI18n(
-      'euiTableHeaderCell.unsorted',
-      'Unsorted. Click to sort ascending'
-    );
-  }
-  if (isSortAscending) {
-    return useEuiI18n(
-      'euiTableHeaderCell.sortedAscending',
-      'Sorted ascending. Click to sort descending'
-    );
-  }
-  if (allowNeutralSort === false) {
-    return useEuiI18n(
-      'euiTableHeaderCell.sortedDescending',
-      'Sorted descending. Click to sort ascending'
-    );
-  }
-  return useEuiI18n(
+  const unsortedText = useEuiI18n(
+    'euiTableHeaderCell.unsorted',
+    'Unsorted. Click to sort ascending'
+  );
+  const sortedAscendingText = useEuiI18n(
+    'euiTableHeaderCell.sortedAscending',
+    'Sorted ascending. Click to sort descending'
+  );
+  const sortedDescendingText = useEuiI18n(
+    'euiTableHeaderCell.sortedDescending',
+    'Sorted descending. Click to sort ascending'
+  );
+  const sortedDescendingUnsortText = useEuiI18n(
     'euiTableHeaderCell.sortedDescendingUnsort',
     'Sorted descending. Click to unsort'
+  );
+  const text = useMemo(() => {
+    if (!isSorted) {
+      return unsortedText;
+    }
+    if (isSortAscending) {
+      return sortedAscendingText;
+    }
+    if (allowNeutralSort === false) {
+      return sortedDescendingText;
+    }
+    return sortedDescendingUnsortText;
+  }, [
+    isSorted,
+    isSortAscending,
+    allowNeutralSort,
+    unsortedText,
+    sortedAscendingText,
+    sortedDescendingText,
+    sortedDescendingUnsortText,
+  ]);
+
+  return (
+    <EuiScreenReaderOnly>
+      <span>{text}</span>
+    </EuiScreenReaderOnly>
   );
 };
 
@@ -140,11 +161,7 @@ const CellContents = ({
           <span>{description}</span>
         </EuiScreenReaderOnly>
       )}
-      {sortScreenReaderText && (
-        <EuiScreenReaderOnly>
-          <span>{sortScreenReaderText}</span>
-        </EuiScreenReaderOnly>
-      )}
+      {sortScreenReaderText}
       {isSorted ? (
         <EuiIcon
           className="euiTableSortIcon"

--- a/packages/eui/src/components/table/table_header_cell.tsx
+++ b/packages/eui/src/components/table/table_header_cell.tsx
@@ -19,7 +19,7 @@ import {
   HorizontalAlignment,
   LEFT_ALIGNMENT,
 } from '../../services';
-import { EuiI18n } from '../i18n';
+import { EuiI18n, useEuiI18n } from '../i18n';
 import { EuiScreenReaderOnly } from '../accessibility';
 import { CommonProps, NoArgCallback } from '../common';
 import { EuiIcon } from '../icon';
@@ -54,7 +54,41 @@ export type EuiTableHeaderCellProps = CommonProps &
      * Used by EuiBasicTable to render hidden copy markers
      */
     append?: ReactNode;
+    allowNeutralSort?: boolean;
   };
+
+const SortScreenReaderText = ({
+  isSorted,
+  isSortAscending,
+  allowNeutralSort,
+}: {
+  isSorted: boolean | undefined;
+  isSortAscending: boolean | undefined;
+  allowNeutralSort: boolean | undefined;
+}) => {
+  if (!isSorted) {
+    return useEuiI18n(
+      'euiTableHeaderCell.unsorted',
+      'Unsorted. Click to sort ascending'
+    );
+  }
+  if (isSortAscending) {
+    return useEuiI18n(
+      'euiTableHeaderCell.sortedAscending',
+      'Sorted ascending. Click to sort descending'
+    );
+  }
+  if (allowNeutralSort === false) {
+    return useEuiI18n(
+      'euiTableHeaderCell.sortedDescending',
+      'Sorted descending. Click to sort ascending'
+    );
+  }
+  return useEuiI18n(
+    'euiTableHeaderCell.sortedDescendingUnsort',
+    'Sorted descending. Click to unsort'
+  );
+};
 
 const CellContents = ({
   className,
@@ -64,6 +98,7 @@ const CellContents = ({
   canSort,
   isSorted,
   isSortAscending,
+  sortScreenReaderText,
 }: {
   className?: string;
   align: HorizontalAlignment;
@@ -72,6 +107,7 @@ const CellContents = ({
   canSort?: boolean;
   isSorted: EuiTableHeaderCellProps['isSorted'];
   isSortAscending?: EuiTableHeaderCellProps['isSortAscending'];
+  sortScreenReaderText?: ReactNode;
 }) => {
   return (
     <EuiTableCellContent
@@ -102,6 +138,11 @@ const CellContents = ({
       {description && (
         <EuiScreenReaderOnly>
           <span>{description}</span>
+        </EuiScreenReaderOnly>
+      )}
+      {sortScreenReaderText && (
+        <EuiScreenReaderOnly>
+          <span>{sortScreenReaderText}</span>
         </EuiScreenReaderOnly>
       )}
       {isSorted ? (
@@ -136,6 +177,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
   readOnly,
   description,
   append,
+  allowNeutralSort,
   ...rest
 }) => {
   const styles = useEuiMemoizedStyles(euiTableHeaderFooterCellStyles);
@@ -159,6 +201,14 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
     ariaSortValue = 'none';
   }
 
+  const sortScreenReaderText = canSort ? (
+    <SortScreenReaderText
+      isSorted={isSorted}
+      isSortAscending={isSortAscending}
+      allowNeutralSort={allowNeutralSort}
+    />
+  ) : undefined;
+
   const cellContentsProps = {
     css: styles.euiTableHeaderCell__content,
     align,
@@ -167,6 +217,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
     isSorted,
     isSortAscending,
     children,
+    sortScreenReaderText,
   };
 
   return (


### PR DESCRIPTION
## Summary

Related to: [#8087](https://github.com/elastic/eui/issues/8087)
Improved screen reader functionality for sortable table headers.
It now also includes the sorting state.
Updated test snapshots to ensure all tests pass.
