### PR TITLE
Fix EUI+ search not indexing heading elements

### DIFF
--- a/packages/docusaurus-theme/src/theme/DocItem/Content/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Content/index.tsx
@@ -51,7 +51,7 @@ export default function DocItemContent({ children }: Props): JSX.Element {
   const styles = useEuiMemoizedStyles(getContentStyles);
 
   return (
-    <div className={clsx(ThemeClassNames.docs.docMarkdown)}>
+    <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
       {syntheticTitle && (
         <>
           <header css={styles.header}>

--- a/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
@@ -13,7 +13,7 @@ import type { WrapperProps } from '@docusaurus/types';
 type Props = WrapperProps<typeof MDXContentType>;
 
 const MDXContent = (props: Props): JSX.Element => (
-  <div data-search-children="">
+  <div data-search-children={true}>
     <OriginalMDXContent {...props} />
   </div>
 );

--- a/packages/website/src/components/homepage/header/index.tsx
+++ b/packages/website/src/components/homepage/header/index.tsx
@@ -59,7 +59,7 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
       --hero-decor-fill-brand-poppy: #ff957d;
 
       position: relative;
-      overflow: hidden;
+      overflow: hidden auto;
       display: flex;
       flex-direction: column;
       justify-content: center;

--- a/packages/website/src/components/homepage/header/index.tsx
+++ b/packages/website/src/components/homepage/header/index.tsx
@@ -59,7 +59,6 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
       --hero-decor-fill-brand-poppy: #ff957d;
 
       position: relative;
-      overflow: hidden auto;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -178,6 +177,14 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     decor: {
+      wrapper: css`
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        overflow: hidden;
+      `,
       decor: css`
         position: absolute;
         top: 0;
@@ -216,11 +223,13 @@ export function HomepageHeader() {
 
   return (
     <header className={clsx('hero hero--primary')} css={styles.hero}>
-      <div css={[styles.decor.decor, styles.decor.left]}>
-        <DecorLeft />
-      </div>
-      <div css={[styles.decor.decor, styles.decor.right]}>
-        <DecorRight />
+      <div css={styles.decor.wrapper}>
+        <div css={[styles.decor.decor, styles.decor.left]}>
+          <DecorLeft />
+        </div>
+        <div css={[styles.decor.decor, styles.decor.right]}>
+          <DecorRight />
+        </div>
       </div>
       <HomepageContainer>
         <div css={styles.left}>


### PR DESCRIPTION
## Summary

This PR fixes EUI+ search by re-adding the necessary `markdown` class name to `DocItemContent` and setting the `data-search-children` attribute to a truthy value to allow proper heading recognition.

## QA

- [ ] Confirm the search bar shows results when searching by heading names such as `Installation` (Getting started page) or `Basic button` (Button page) - this PR's base is set to a commit with no components sidebar visible. This is expected
