### PR TITLE
[EuiSelectableTemplateSitewide] Fix border bug in Kibana when used in dark-themed EuiHeaders

### DIFF
--- a/packages/eui/changelogs/upcoming/8100.md
+++ b/packages/eui/changelogs/upcoming/8100.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSelectableTemplateSitewide`s within dark-themed `EuiHeader`s missing input borders

--- a/packages/eui/src/components/header/header.stories.tsx
+++ b/packages/eui/src/components/header/header.stories.tsx
@@ -124,7 +124,7 @@ export const DarkThemeWithSitewideSearch: Story = {
               },
             ]}
             searchProps={{
-              append: '⌘K',
+              // append: '⌘K',
               compressed: true,
             }}
             popoverButton={

--- a/packages/eui/src/components/header/header.stories.tsx
+++ b/packages/eui/src/components/header/header.stories.tsx
@@ -124,7 +124,7 @@ export const DarkThemeWithSitewideSearch: Story = {
               },
             ]}
             searchProps={{
-              // append: '⌘K',
+              append: '⌘K',
               compressed: true,
             }}
             popoverButton={

--- a/packages/eui/src/components/header/header.styles.ts
+++ b/packages/eui/src/components/header/header.styles.ts
@@ -126,6 +126,13 @@ const euiHeaderDarkStyles = (euiThemeContext: UseEuiTheme) => {
         box-shadow: inset 0 0 0 ${euiTheme.border.width.thin} ${
     selectableSitewide.borderColor
   };
+        ${
+          // hide the focus underline in light mode - the search input showing a white background
+          // on focus is sufficient indicator
+          colorMode !== 'DARK'
+            ? `&:focus { --euiFormControlStateColor: transparent; }`
+            : ''
+        }
       }
 
       &--group {

--- a/packages/eui/src/components/header/header.styles.ts
+++ b/packages/eui/src/components/header/header.styles.ts
@@ -122,8 +122,18 @@ const euiHeaderDarkStyles = (euiThemeContext: UseEuiTheme) => {
     .euiSelectableTemplateSitewide .euiFormControlLayout {
       background-color: transparent;
 
+      input {
+        box-shadow: inset 0 0 0 ${euiTheme.border.width.thin} ${
+    selectableSitewide.borderColor
+  };
+      }
+
       &--group {
         border-color: ${selectableSitewide.borderColor};
+
+        input {
+          box-shadow: none;
+        }
       }
 
       &:not(:focus-within) {

--- a/packages/eui/src/components/header/header.styles.ts
+++ b/packages/eui/src/components/header/header.styles.ts
@@ -126,13 +126,6 @@ const euiHeaderDarkStyles = (euiThemeContext: UseEuiTheme) => {
         box-shadow: inset 0 0 0 ${euiTheme.border.width.thin} ${
     selectableSitewide.borderColor
   };
-        ${
-          // hide the focus underline in light mode - the search input showing a white background
-          // on focus is sufficient indicator
-          colorMode !== 'DARK'
-            ? `&:focus { --euiFormControlStateColor: transparent; }`
-            : ''
-        }
       }
 
       &--group {

--- a/packages/eui/src/components/header/header.styles.ts
+++ b/packages/eui/src/components/header/header.styles.ts
@@ -80,6 +80,16 @@ const euiHeaderDarkStyles = (euiThemeContext: UseEuiTheme) => {
       ? shade(euiTheme.colors.lightestShade, 0.5)
       : shade(euiTheme.colors.darkestShade, 0.28);
 
+  // Specific color overrides for EuiSelectableTemplateSitewide
+  const selectableSitewide = {
+    color: euiTheme.colors.ghost,
+    borderColor: transparentize(euiTheme.colors.ghost, 0.3),
+    placeholderColor: makeHighContrastColor(
+      controlPlaceholderText,
+      8
+    )(backgroundColor),
+  };
+
   return `
     background-color: ${backgroundColor};
 
@@ -113,20 +123,17 @@ const euiHeaderDarkStyles = (euiThemeContext: UseEuiTheme) => {
       background-color: transparent;
 
       &--group {
-        border-color: ${transparentize(euiTheme.colors.ghost, 0.3)};
+        border-color: ${selectableSitewide.borderColor};
       }
 
       &:not(:focus-within) {
         /* Increase contrast of filled text to be more than placeholder text */
-        color: ${euiTheme.colors.ghost};
+        color: ${selectableSitewide.color};
 
         input {
           /* Increase contrast of placeholder text */
           &::placeholder {
-            color: ${makeHighContrastColor(
-              controlPlaceholderText,
-              8
-            )(backgroundColor)};
+            color: ${selectableSitewide.placeholderColor};
           }
 
           /* Inherit color from form control layout */


### PR DESCRIPTION
## Summary

This bug is reproducible in local Kibana by typing and searching for "api keys" and then clicking the result - the border goes away because the `append` label is not being passed:

![bug](https://github.com/user-attachments/assets/2aa9e828-4c03-4129-a606-2d1054ff87fa)

| Before | After |
|--------|--------|
| <img width="723" alt="" src="https://github.com/user-attachments/assets/6d04a0e0-7bb1-46c1-981f-d624d4c68e2c"> | <img width="716" alt="" src="https://github.com/user-attachments/assets/971251a0-0f0f-459f-b2bd-c4f53b3d5dec"> | 

Note: I regression-tested that append labels still look as before visually via VRT.

## QA

- Go to https://eui.elastic.co/pr_8100/storybook/?path=/story/layout-euiheader-euiheader--dark-theme-with-sitewide-search
- [x] Confirm that the search input has a border around it

### General checklist

- [x] Revert [REVERT ME] commit
- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA - N/A
- Code quality checklist
    ~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [x] Ran **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A