### PR TITLE
[EuiContextMenuPanel] Allow consumers to disable initial focus via `initialFocusedItemIndex={-1}`

### DIFF
--- a/packages/eui/changelogs/upcoming/8101.md
+++ b/packages/eui/changelogs/upcoming/8101.md
@@ -1,0 +1,1 @@
+- Updated `EuiContextMenuPanel` to allow disabling initial focus via `initialFocusedItemIndex={-1}`

--- a/packages/eui/src/components/context_menu/context_menu_panel.spec.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_panel.spec.tsx
@@ -231,6 +231,52 @@ describe('EuiContextMenuPanel', () => {
         cy.focused().should('have.attr', 'data-test-subj', 'popoverToggle');
       });
     });
+
+    describe('disabling auto focus', () => {
+      it('does not focus anything if initialFocusedItemIndex is set to -1', () => {
+        cy.mount(
+          <EuiContextMenuPanel initialFocusedItemIndex={-1}>
+            {children}
+          </EuiContextMenuPanel>
+        );
+        cy.focused().should('not.exist');
+      });
+
+      it('does not focus the back button if it exists', () => {
+        cy.mount(
+          <EuiContextMenuPanel
+            initialFocusedItemIndex={-1}
+            onClose={() => {}}
+            title="Test"
+            items={items}
+          />
+        );
+        cy.focused().should('not.exist');
+      });
+
+      it('still allows for manually tabbing to the panel and using up/down key navigation', () => {
+        cy.realMount(
+          <EuiContextMenuPanel initialFocusedItemIndex={-1} items={items} />
+        );
+        cy.realPress('Tab');
+        cy.focused().should('have.attr', 'data-test-subj', 'itemA');
+        cy.realPress('{downarrow}');
+        cy.focused().should('have.attr', 'data-test-subj', 'itemB');
+      });
+
+      it('other children with `autoFocus` should take focus', () => {
+        cy.mount(
+          <EuiContextMenuPanel
+            initialFocusedItemIndex={-1}
+            items={[
+              ...items,
+              <input type="text" value="Auto focus test" autoFocus />,
+            ]}
+          />
+        );
+        cy.focused().should('have.value', 'Auto focus test');
+      });
+    });
   });
 
   describe('Keyboard navigation of items', () => {

--- a/packages/eui/src/components/context_menu/context_menu_panel.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_panel.tsx
@@ -46,6 +46,12 @@ export type EuiContextMenuPanelProps = PropsWithChildren &
     HTMLAttributes<HTMLDivElement>,
     'onKeyDown' | 'tabIndex' | 'onAnimationEnd' | 'title'
   > & {
+    /**
+     * Determines the initially focused menu item for keyboard and screen reader users.
+     *
+     * Can be set to `-1` to prevent autofocus (an uncommon case that must have
+     * keyboard accessibility accounted for manually if used)
+     */
     initialFocusedItemIndex?: number;
     items?: ReactElement[];
     onClose?: NoArgCallback<void>;
@@ -99,7 +105,9 @@ export class EuiContextMenuPanelClass extends Component<
       },
       menuItems: [],
       focusedItemIndex:
-        props.onClose && props.initialFocusedItemIndex != null
+        props.onClose &&
+        props.initialFocusedItemIndex != null &&
+        props.initialFocusedItemIndex !== -1
           ? props.initialFocusedItemIndex + 1 // Account for panel title back button
           : props.initialFocusedItemIndex,
       currentHeight: undefined,
@@ -255,6 +263,13 @@ export class EuiContextMenuPanelClass extends Component<
       // Initial focus has already been handled, no need to continue and potentially hijack/focus fight
       if (this.state.tookInitialFocus) {
         return;
+      }
+
+      // `initialFocusedItemIndex={-1}` should only be used when preventing initial item focus is desired
+      if (this.state.focusedItemIndex === -1) {
+        // Resetting the focusedItemIndex to 0 allows keyboard up/down behavior to
+        // still work correctly later if the panel is manually tabbed into
+        return this.setState({ tookInitialFocus: true, focusedItemIndex: 0 });
       }
 
       // If an item should be focused, focus it (if it exists)


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8094

This functionality allows consumers with, e.g. inputs (or other custom items that they may want to receive auto focus) to disable `EuiContextMenuPanel`'s initial focus logic via setting the index to `-1`.

## QA

Storybook arg testing:
- [`initialFocusedItemIndex={-1}`](https://eui.elastic.co/pr_8101/storybook/iframe.html?args=initialFocusedItemIndex:-1&showSnippet=undefined&id=navigation-euicontextmenu-euicontextmenupanel--playground&viewMode=story) should not focus anything
- [`initialFocusedItemIndex={0}`](https://eui.elastic.co/pr_8101/storybook/iframe.html?args=initialFocusedItemIndex:0&showSnippet=undefined&id=navigation-euicontextmenu-euicontextmenupanel--playground&viewMode=story) should focus the first context menu item on page load
- [`initialFocusedItemIndex={1}`](https://eui.elastic.co/pr_8101/storybook/iframe.html?args=initialFocusedItemIndex:1&showSnippet=undefined&id=navigation-euicontextmenu-euicontextmenupanel--playground&viewMode=story)  should focus the second context menu item on page load

### General checklist

- Browser QA
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - ~[ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ - Deliberately skipped adding an example as we don't really want to document this edge case, and this feature is more of an escape hatch
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) ~and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.