### PR TITLE
[Visual Refresh] Update Typography scale

### DIFF
--- a/packages/eui-theme-borealis/src/variables/_font_weight.scss
+++ b/packages/eui-theme-borealis/src/variables/_font_weight.scss
@@ -1,0 +1,10 @@
+// Separated out to its own file for easy import into docs
+
+// Font weights
+$euiFontWeightLight:        300 !default;
+$euiFontWeightRegular:      400 !default;
+$euiFontWeightMedium:       450 !default;
+$euiFontWeightSemiBold:     500 !default;
+$euiFontWeightBold:         600 !default;
+$euiCodeFontWeightRegular:  400 !default;
+$euiCodeFontWeightBold:     600 !default;

--- a/packages/eui-theme-borealis/src/variables/_index.scss
+++ b/packages/eui-theme-borealis/src/variables/_index.scss
@@ -4,4 +4,5 @@
 
 @import 'buttons';
 @import 'page';
+@import 'font_weight';
 @import 'typography';

--- a/packages/eui-theme-borealis/src/variables/_typography.scss
+++ b/packages/eui-theme-borealis/src/variables/_typography.scss
@@ -1,23 +1,23 @@
 // Finally start using the non-beta version of Inter
 $euiFontFamily: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !default;
 
-// Font sizes -- scale is loosely based on Major Third (1.250) with a base of 14px
+// Font sizes -- scale is loosely based on Minor Third (1.200) with a base of 14px
 // Base list is an altered scale based on 16px to match the resulted values below
 $euiTextScale:    2.125, 1.6875, 1.375, 1.125, 1, .875, .75 !default;
 
 $euiFontSize:     $euiSize - 2; // 14px
 
-$euiFontSizeXS:   floor($euiFontSize * .86);  // 12px // h6
-$euiFontSizeS:    floor($euiFontSize * 1);    // 14px // h5 --> Now the same as the base $euiFontSize
-$euiFontSizeM:     ceil($euiFontSize * 1.14); // 16px // h4
-$euiFontSizeL:     ceil($euiFontSize * 1.57); // 22px // h3
-$euiFontSizeXL:   floor($euiFontSize * 1.93); // 27px // h2
-$euiFontSizeXXL:  floor($euiFontSize * 2.43); // 34px // h1
+$euiFontSizeXS:   floor($euiFontSize * .86);   // 12px // h6
+$euiFontSizeS:    floor($euiFontSize * 1);     // 14px // h5
+$euiFontSizeM:     ceil($euiFontSize * 1.14);  // 16px // h4
+$euiFontSizeL:    floor($euiFontSize * 1.44);  // 20px // h3
+$euiFontSizeXL:   floor($euiFontSize * 1.728); // 24px // h2
+$euiFontSizeXXL:   ceil($euiFontSize * 2.074); // 30px // h1
 
 $euiBodyLineHeight: 1.142857143 !default; // 16px from a 14px base font size to ensure it aligns to our 16px grid
 
 $euiCodeFontWeightRegular: 400;
-$euiCodeFontWeightBold: 700;
+$euiCodeFontWeightBold: 600;
 
 // Normally functions are imported before variables in `_index.scss` files
 // But because they need to consume some typography variables they need to live here

--- a/packages/eui-theme-borealis/src/variables/_typography.ts
+++ b/packages/eui-theme-borealis/src/variables/_typography.ts
@@ -14,16 +14,16 @@ import {
   type _EuiThemeFontWeights,
 } from '@elastic/eui-theme-common';
 
-// Typographic scale -- loosely based on Major Third (1.250)
+// Typographic scale -- loosely based on Major Third (1.200)
 export const fontScale: _EuiThemeFontScales = {
-  xxxs: 0.5625,
-  xxs: 0.6875,
-  xs: 0.75,
-  s: 0.875,
-  m: 1,
-  l: 1.375,
-  xl: 1.6875,
-  xxl: 2.125,
+  xxxs: 0.5625, // 9px
+  xxs: 0.6875, // 11px
+  xs: 0.75, // 12px
+  s: 0.875, // 14px
+  m: 1, // 16px
+  l: 1.25, // 20px
+  xl: 1.5, // 24px
+  xxl: 1.875, // 30px
 };
 
 // Families & base font settings
@@ -43,9 +43,9 @@ export const fontBase: _EuiThemeFontBase = {
 export const fontWeight: _EuiThemeFontWeights = {
   light: 300,
   regular: 400,
-  medium: 500,
-  semiBold: 600,
-  bold: 700,
+  medium: 450,
+  semiBold: 500,
+  bold: 600,
 };
 
 export const font: _EuiThemeFont = {


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui-private/issues/129

This PR adds updates to the typography scale for the new theme. These changes are directly taken from this [PR](https://github.com/elastic/eui/pull/7942) that proposed the changes.

>[!IMPORTANT]
This PR merges into a feature branch.

>[!NOTE]
Changes to the legacy JSON tokens will be done separately as part of this [task](https://github.com/elastic/eui-private/issues/138).

## QA

>[!NOTE]
 This PR does not use the new theme yet in the docs, but the changes can be seen on this testing [PR](https://eui.elastic.co/pr_8083/index.html#/theming/typography/values)

- [ ] compare docs font sizes for `l`, `xl` and `xxl` with [production](https://eui.elastic.co/#/theming/typography/values#font-scale) (they should be smaller now)
- [ ] compare font weights for `medium`, `semibold` and `bold` with [production](https://eui.elastic.co/#/theming/typography/values#font-weight) (they should be less bold now)
