### PR TITLE
docs: fix broken imports in color utilities

### DIFF
--- a/packages/website/docs/components/theming/colors/utilities/use_eui_background_color_css_preview.tsx
+++ b/packages/website/docs/components/theming/colors/utilities/use_eui_background_color_css_preview.tsx
@@ -1,5 +1,4 @@
-import { useEuiBackgroundColorCSS, useEuiPaddingCSS } from '@elastic/eui';
-import { useEuiBackgroundColor } from '@elastic/eui/src/global_styling/mixins/_color';
+import { useEuiBackgroundColorCSS, useEuiPaddingCSS, useEuiBackgroundColor } from '@elastic/eui';
 
 export const UseEuiBackgroundColorCSSPreview = () => {
   const accentStyles = useEuiBackgroundColorCSS().accent;

--- a/packages/website/docs/components/theming/colors/utilities/use_eui_background_color_preview.tsx
+++ b/packages/website/docs/components/theming/colors/utilities/use_eui_background_color_preview.tsx
@@ -1,6 +1,5 @@
-import { useEuiBackgroundColor } from '@elastic/eui/src/global_styling/mixins/_color';
+import { useEuiBackgroundColor, useEuiPaddingCSS } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useEuiPaddingCSS } from '@elastic/eui/src/global_styling/mixins/_padding';
 
 export const UseEuiBackgroundColorPreview = () => {
   return (

--- a/packages/website/docs/components/theming/colors/utilities/use_eui_background_color_table.tsx
+++ b/packages/website/docs/components/theming/colors/utilities/use_eui_background_color_table.tsx
@@ -5,9 +5,9 @@ import {
   EuiSpacer,
   EuiButtonGroup,
   useEuiTheme,
+  euiBackgroundColor,
 } from '@elastic/eui';
 import { ColorsTable } from '../colors_table';
-import { euiBackgroundColor } from '@elastic/eui/src/global_styling/mixins/_color';
 
 const colors = [
   'transparent',


### PR DESCRIPTION
## Summary

This replaces the auto-suggested imports from `@elastic/eui/src` with the correct `@elastic/eui` ones and fixes the new docs site builds.

## QA

- [x] Confirm the "Build and deploy new documentation website" is passing
- [x] Confirm the `/new-docs/docs/theming/colors/utilities/` docs are rendering as expected
