### PR TITLE
Fix `yarn version` bug with backports

### DIFF
--- a/packages/eui/scripts/release.js
+++ b/packages/eui/scripts/release.js
@@ -141,6 +141,12 @@ const hasStep = (step) => {
 
     // Update version number
     execSync(`yarn version ${versionTarget}`, execOptions);
+    // `yarn version` sometimes has a bug with the suffixed releases (e.g. `-backport.*`)
+    // where it doesn't properly set the version target. Running the command twice in a row
+    // appears to fix the issue for some reason ¯\_(ツ)_/¯
+    if (isSpecialRelease) {
+      execSync(`yarn version ${versionTarget}`, execOptions);
+    }
 
     // Commit version number update
     execSync('git add package.json', execOptions);


### PR DESCRIPTION
## Summary

I noticed this issue in our release script while doing a few backports for 8.16. It likely started when we upgraded from Yarn Classic to Yarn Berry, but I couldn't find a recent bug report in the yarn repo about it.

## QA

- In CLI, run `yarn version v97.3.0-backport.0` - `package.json` should update correctly as expected:
     <img width="332" alt="" src="https://github.com/user-attachments/assets/848753d0-b844-4cb1-b10d-1409d59257fc">
- Now run `yarn version v97.3.0-backport.1` - notice that `package.json` _does not_ update as expected:
     <img width="239" alt="" src="https://github.com/user-attachments/assets/2cdc0215-8573-4602-86fb-b1f425075f0d">
- Rerun `yarn version v97.3.0-backport.1` again and confirm that the second time, package.json is correct for whatever reason 🤷
     <img width="322" alt="" src="https://github.com/user-attachments/assets/1a8f3344-0451-4958-9b10-688e8b1e7904">

### General checklist

N/A, internal/dev only
