### PR TITLE
feat(tabs): traverse tabs with arrow keys

### DIFF
--- a/packages/eui/changelogs/upcoming/8116.md
+++ b/packages/eui/changelogs/upcoming/8116.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Improved the accessibility experience of tabs (EuiTab, EuiTabs): tab group is a tab stop and tabs can be traversed with arrow keys.
+

--- a/packages/eui/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/packages/eui/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -342,6 +342,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           aria-selected="true"
           class="euiTab euiTab-isSelected emotion-euiTab-selected"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <span
@@ -354,6 +355,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           aria-selected="false"
           class="euiTab emotion-euiTab"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <span

--- a/packages/eui/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/packages/eui/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -300,6 +300,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
         aria-selected="true"
         class="euiTab euiTab-isSelected emotion-euiTab-selected"
         role="tab"
+        tabindex="0"
         type="button"
       >
         <span
@@ -312,6 +313,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
         aria-selected="false"
         class="euiTab emotion-euiTab"
         role="tab"
+        tabindex="-1"
         type="button"
       >
         <span
@@ -557,6 +559,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           aria-selected="true"
           class="euiTab euiTab-isSelected emotion-euiTab-selected"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <span
@@ -569,6 +572,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           aria-selected="false"
           class="euiTab emotion-euiTab"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <span
@@ -608,6 +612,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           aria-selected="true"
           class="euiTab euiTab-isSelected emotion-euiTab-selected"
           role="tab"
+          tabindex="0"
           type="button"
         >
           <span
@@ -620,6 +625,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           aria-selected="false"
           class="euiTab emotion-euiTab"
           role="tab"
+          tabindex="-1"
           type="button"
         >
           <span

--- a/packages/eui/src/components/tabs/__snapshots__/tab.test.tsx.snap
+++ b/packages/eui/src/components/tabs/__snapshots__/tab.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EuiTab props append is rendered 1`] = `
   aria-selected="false"
   class="euiTab emotion-euiTab"
   role="tab"
+  tabindex="-1"
   type="button"
 >
   <span
@@ -26,6 +27,7 @@ exports[`EuiTab props disabled and selected 1`] = `
   class="euiTab euiTab-isSelected emotion-euiTab-disabled-selected"
   disabled=""
   role="tab"
+  tabindex="0"
   type="button"
 >
   <span
@@ -42,6 +44,7 @@ exports[`EuiTab props disabled is rendered 1`] = `
   class="euiTab emotion-euiTab-disabled"
   disabled=""
   role="tab"
+  tabindex="-1"
   type="button"
 >
   <span
@@ -61,6 +64,7 @@ exports[`EuiTab props href renders anchor 1`] = `
   href="/baz/bing"
   rel="noreferrer"
   role="tab"
+  tabindex="-1"
 >
   <span
     class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
@@ -75,6 +79,7 @@ exports[`EuiTab props isSelected is rendered 1`] = `
   aria-selected="true"
   class="euiTab euiTab-isSelected emotion-euiTab-selected"
   role="tab"
+  tabindex="0"
   type="button"
 >
   <span
@@ -92,6 +97,7 @@ exports[`EuiTab props onClick renders button 1`] = `
   class="euiTab testClass1 testClass2 emotion-euiTab-euiTestCss"
   data-test-subj="test subject string"
   role="tab"
+  tabindex="-1"
   type="button"
 >
   <span
@@ -107,6 +113,7 @@ exports[`EuiTab props prepend is rendered 1`] = `
   aria-selected="false"
   class="euiTab emotion-euiTab"
   role="tab"
+  tabindex="-1"
   type="button"
 >
   <span

--- a/packages/eui/src/components/tabs/__snapshots__/tabs.test.tsx.snap
+++ b/packages/eui/src/components/tabs/__snapshots__/tabs.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`EuiTabs props expand passes down to EuiTab children 1`] = `
     aria-selected="false"
     class="euiTab emotion-euiTab-expanded"
     role="tab"
+    tabindex="-1"
     type="button"
   >
     <span
@@ -29,6 +30,7 @@ exports[`EuiTabs props size l renders and passes down to EuiTab children 1`] = `
     aria-selected="false"
     class="euiTab emotion-euiTab"
     role="tab"
+    tabindex="-1"
     type="button"
   >
     <span
@@ -49,6 +51,7 @@ exports[`EuiTabs props size m renders and passes down to EuiTab children 1`] = `
     aria-selected="false"
     class="euiTab emotion-euiTab"
     role="tab"
+    tabindex="-1"
     type="button"
   >
     <span
@@ -69,6 +72,7 @@ exports[`EuiTabs props size s renders and passes down to EuiTab children 1`] = `
     aria-selected="false"
     class="euiTab emotion-euiTab"
     role="tab"
+    tabindex="-1"
     type="button"
   >
     <span
@@ -89,6 +93,7 @@ exports[`EuiTabs props size xl renders and passes down to EuiTab children 1`] = 
     aria-selected="false"
     class="euiTab emotion-euiTab"
     role="tab"
+    tabindex="-1"
     type="button"
   >
     <span

--- a/packages/eui/src/components/tabs/tab.tsx
+++ b/packages/eui/src/components/tabs/tab.tsx
@@ -100,6 +100,7 @@ export const EuiTab: FunctionComponent<Props> = ({
       <a
         role="tab"
         aria-selected={!!isSelected}
+        tabIndex={isSelected ? 0 : -1}
         className={classes}
         css={cssTabStyles}
         href={href}
@@ -123,6 +124,7 @@ export const EuiTab: FunctionComponent<Props> = ({
     <button
       role="tab"
       aria-selected={!!isSelected}
+      tabIndex={isSelected ? 0 : -1}
       type="button"
       className={classes}
       css={cssTabStyles}

--- a/packages/eui/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
+++ b/packages/eui/src/components/tabs/tabbed_content/__snapshots__/tabbed_content.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
       class="euiTab euiTab-isSelected emotion-euiTab-selected"
       id="es"
       role="tab"
+      tabindex="0"
       type="button"
     >
       <span
@@ -31,6 +32,7 @@ exports[`EuiTabbedContent is rendered with required props and tabs 1`] = `
       data-test-subj="kibanaTab"
       id="kibana"
       role="tab"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -76,6 +78,7 @@ exports[`EuiTabbedContent props autoFocus initial is rendered 1`] = `
       class="euiTab euiTab-isSelected emotion-euiTab-selected"
       id="es"
       role="tab"
+      tabindex="0"
       type="button"
     >
       <span
@@ -91,6 +94,7 @@ exports[`EuiTabbedContent props autoFocus initial is rendered 1`] = `
       data-test-subj="kibanaTab"
       id="kibana"
       role="tab"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -136,6 +140,7 @@ exports[`EuiTabbedContent props autoFocus selected is rendered 1`] = `
       class="euiTab euiTab-isSelected emotion-euiTab-selected"
       id="es"
       role="tab"
+      tabindex="0"
       type="button"
     >
       <span
@@ -151,6 +156,7 @@ exports[`EuiTabbedContent props autoFocus selected is rendered 1`] = `
       data-test-subj="kibanaTab"
       id="kibana"
       role="tab"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -196,6 +202,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
       class="euiTab emotion-euiTab"
       id="es"
       role="tab"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -211,6 +218,7 @@ exports[`EuiTabbedContent props initialSelectedTab renders a selected tab 1`] = 
       data-test-subj="kibanaTab"
       id="kibana"
       role="tab"
+      tabindex="0"
       type="button"
     >
       <span
@@ -256,6 +264,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
       class="euiTab emotion-euiTab"
       id="es"
       role="tab"
+      tabindex="-1"
       type="button"
     >
       <span
@@ -271,6 +280,7 @@ exports[`EuiTabbedContent props selectedTab renders a selected tab 1`] = `
       data-test-subj="kibanaTab"
       id="kibana"
       role="tab"
+      tabindex="0"
       type="button"
     >
       <span
@@ -316,6 +326,7 @@ exports[`EuiTabbedContent props size can be small 1`] = `
       class="euiTab euiTab-isSelected emotion-euiTab-selected"
       id="es"
       role="tab"
+      tabindex="0"
       type="button"
     >
       <span
@@ -331,6 +342,7 @@ exports[`EuiTabbedContent props size can be small 1`] = `
       data-test-subj="kibanaTab"
       id="kibana"
       role="tab"
+      tabindex="-1"
       type="button"
     >
       <span

--- a/packages/eui/src/components/tabs/tabs.spec.tsx
+++ b/packages/eui/src/components/tabs/tabs.spec.tsx
@@ -88,16 +88,33 @@ const tabs = [
 
 const tabsSecond = [
   {
-    id: 'hello',
-    name: 'New tab 1',
-    content: <p>Hello</p>,
+    id: 'apple',
+    name: 'Apple',
+    content: <p>Apple</p>,
   },
   {
-    id: 'world',
-    name: 'New tab 2',
-    content: <p>World</p>,
+    id: 'banana',
+    name: 'Banana',
+    content: <p>Banana</p>,
+  },
+  {
+    id: 'pear',
+    name: 'Pear',
+    content: <p>Pear</p>,
+    disabled: true,
   },
 ];
+
+const TabbedContent = () => {
+  const tabProps: EuiTabbedContentProps = {
+    tabs: tabs,
+    initialSelectedTab: tabs[1],
+    autoFocus: 'selected',
+    onTabClick: () => {},
+  };
+
+  return <EuiTabbedContent {...tabProps} />;
+};
 
 const DynamicTabbedContent = () => {
   const [items, setItems] = useState(tabs);
@@ -110,10 +127,10 @@ const DynamicTabbedContent = () => {
   );
 };
 
-const TabbedContent = () => {
+const TabbedContentWithDisabledTabs = () => {
   const tabProps: EuiTabbedContentProps = {
-    tabs: tabs,
-    initialSelectedTab: tabs[1],
+    tabs: tabsSecond,
+    initialSelectedTab: tabsSecond[0],
     autoFocus: 'selected',
     onTabClick: () => {},
   };
@@ -173,16 +190,36 @@ describe('EuiTabs', () => {
       // assert that the focus was reset
       cy.realPress('Tab');
       cy.realPress('ArrowRight');
-      cy.focused().should('have.text', 'New tab 2');
+      cy.focused().should('have.text', 'Banana');
       // press ArrowRight to navigate to the first tab and assert it is focused
       cy.realPress('ArrowRight');
-      cy.focused().should('have.text', 'New tab 1');
+      cy.focused().should('have.text', 'Apple');
       // press ArrowRight to navigate back to the second tab and assert it is focused
       cy.realPress('ArrowRight');
-      cy.focused().should('have.text', 'New tab 2');
+      cy.focused().should('have.text', 'Banana');
       // press ArrowLeft to navigate back to the first tab and verify it is focused
       cy.realPress('ArrowLeft');
-      cy.focused().should('have.text', 'New tab 1');
+      cy.focused().should('have.text', 'Apple');
+    });
+
+    it('should skip disabled tabs', () => {
+      cy.mount(<TabbedContentWithDisabledTabs />);
+
+      // focus the first tab and assert it is focused
+      cy.realPress('Tab');
+      cy.focused().should('have.text', 'Apple');
+
+      // press ArrowRight to navigate to the second tab and assert it is focused
+      cy.realPress('ArrowRight');
+      cy.focused().should('have.text', 'Banana');
+
+      // press ArrowRight to navigate to the first tab because the third tab is disabled
+      cy.realPress('ArrowRight');
+      cy.focused().should('have.text', 'Apple');
+
+      // press ArrowLeft to navigate back to the second tab, skipping the third tab and assert it is focused
+      cy.realPress('ArrowLeft');
+      cy.focused().should('have.text', 'Banana');
     });
   });
 });

--- a/packages/eui/src/components/tabs/tabs.spec.tsx
+++ b/packages/eui/src/components/tabs/tabs.spec.tsx
@@ -114,13 +114,22 @@ describe('EuiTabs', () => {
     it('handles keypress events', () => {
       cy.realMount(<TabbedContent />);
       cy.realPress('Tab');
-      cy.realPress(['Shift', 'Tab']);
+      cy.realPress('ArrowLeft');
+      // on enter, should select the first tab
       cy.realPress('Enter');
       cy.get('div[role="tabpanel"]').first().should('exist');
       cy.get('div[role="tabpanel"]').should('have.length', 1);
       cy.focused().should('have.text', 'Cobalt');
-      cy.repeatRealPress('Tab', 3);
+      // on arrow right, should navigate to the next tab
+      cy.repeatRealPress('ArrowRight', 3);
       cy.focused().should('have.text', 'Monosodium Glutamate');
+      // on arrow right, should loop back to the first tab
+      cy.repeatRealPress('ArrowRight', 1);
+      cy.focused().should('have.text', 'Cobalt');
+      // on arrow left, should loop back to the last tab
+      cy.repeatRealPress('ArrowLeft', 1);
+      cy.focused().should('have.text', 'Monosodium Glutamate');
+      // on enter, should select the last tab
       cy.realPress('Enter');
       cy.get('div[role="tabpanel"]').last().should('exist');
       cy.get('div[role="tabpanel"]').should('have.length', 1);

--- a/packages/eui/src/components/tabs/tabs.tsx
+++ b/packages/eui/src/components/tabs/tabs.tsx
@@ -80,10 +80,12 @@ export const EuiTabs = forwardRef<EuiTabRef, EuiTabsProps>(
       );
 
       if (event.key === keys.ARROW_LEFT) {
-        const previousIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        const previousIndex =
+          (currentIndex === 0 ? tabs.length : currentIndex) - 1;
         tabs[previousIndex].focus();
       } else if (event.key === keys.ARROW_RIGHT) {
-        const nextIndex = (currentIndex + 1) % tabs.length;
+        const nextIndex =
+          currentIndex === tabs.length - 1 ? 0 : currentIndex + 1;
         tabs[nextIndex].focus();
       }
     };

--- a/packages/eui/src/components/tabs/tabs.tsx
+++ b/packages/eui/src/components/tabs/tabs.tsx
@@ -9,11 +9,12 @@
 import React, {
   forwardRef,
   HTMLAttributes,
+  KeyboardEventHandler,
   PropsWithChildren,
   ReactNode,
 } from 'react';
 import classNames from 'classnames';
-import { useEuiMemoizedStyles } from '../../services';
+import { keys, useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
 import { euiTabsStyles } from './tabs.styles';
 import { EuiTabsContext } from './tabs_context';
@@ -67,11 +68,32 @@ export const EuiTabs = forwardRef<EuiTabRef, EuiTabsProps>(
       bottomBorder && styles.bottomBorder,
     ];
 
+    const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+      const tablist = event.currentTarget;
+      const tabs = tablist?.querySelectorAll<HTMLButtonElement>(
+        '[role="tab"]:not(:disabled, [inert])'
+      );
+      if (!tabs?.length) return;
+
+      const currentIndex = Array.from(tabs).findIndex((tab) =>
+        tab.matches(':focus')
+      );
+
+      if (event.key === keys.ARROW_LEFT) {
+        const previousIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        tabs[previousIndex].focus();
+      } else if (event.key === keys.ARROW_RIGHT) {
+        const nextIndex = (currentIndex + 1) % tabs.length;
+        tabs[nextIndex].focus();
+      }
+    };
+
     return (
       <div
         ref={ref}
         className={classes}
         css={cssStyles}
+        onKeyDown={handleKeyDown}
         {...(children && { role: 'tablist' })}
         {...rest}
       >


### PR DESCRIPTION
## Summary

Both the [WCAG](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) and [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) specifications for tabs specify that they should be within a tab group and traversed via arrow keys.

https://github.com/user-attachments/assets/00716ddb-542d-4139-b8e6-442223a915e3

I've noticed there are 2 ways the tabs are used:

1. either with **EuiTabbedContent** (that provides a `tabpanel`; **EuiTabs** and **EuiTab** accessible from the same level),
2. or using **EuiTabs** + **EuiTab** directly (composition through children prop).

I decided to put the logic inside **EuiTabs** as its the common point between the 2 use cases and it makes sense for that wrapper to traverse the nodes within and manipulate the DOM (as opposed to traversing them inside EuiTab from the `parentElement` or handling in **EuiTabbedContent**).

closes #8005

## QA

I tested the changes in the Storybook, the docs and against Kibana (the provided use case: Main Menu > Management > Dev Tools) with VoiceOver.

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, ~**Edge**, and **Firefox**~
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~ (not applicable)
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
