### PR TITLE
[Visual Refresh] Fix theme package builds

### DIFF
--- a/packages/eui-theme-borealis/.babelrc.js
+++ b/packages/eui-theme-borealis/.babelrc.js
@@ -1,0 +1,27 @@
+module.exports = {
+  // We need to preserve comments as they are used by webpack for
+  // naming chunks during code-splitting. The compression step during
+  // bundling will remove them later.
+  comments: true,
+
+  presets: [
+    [
+      '@babel/env',
+      {
+        // `targets` property set via `.browserslistrc`
+        useBuiltIns: process.env.NO_COREJS_POLYFILL ? false : 'usage',
+        corejs: !process.env.NO_COREJS_POLYFILL ? '3.6' : undefined,
+        modules: process.env.BABEL_MODULES
+          ? process.env.BABEL_MODULES === 'false'
+            ? false
+            : process.env.BABEL_MODULES
+          : 'commonjs', // babel's default is commonjs
+      },
+    ],
+    ['@babel/react', { runtime: 'classic' }],
+    [
+      '@babel/typescript',
+      { isTSX: true, allExtensions: true, allowDeclareFields: true },
+    ],
+  ],
+};

--- a/packages/eui-theme-borealis/package.json
+++ b/packages/eui-theme-borealis/package.json
@@ -5,7 +5,11 @@
   "license": "SEE LICENSE IN LICENSE.txt",
   "scripts": {
     "build:workspaces": "yarn workspaces foreach -Rti --from @elastic/eui-theme-borealis --exclude @elastic/eui-theme-borealis run build",
-    "build": "tsc",
+    "build:clean": "rimraf lib/",
+    "build": "yarn build:clean && yarn build:compile && yarn build:compile:cjs && yarn build:types",
+    "build:compile": "tsc --project ./tsconfig.json",
+    "build:compile:cjs": "NODE_ENV=production NO_COREJS_POLYFILL=true babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx --source-maps=true",
+    "build:types": "NODE_ENV=production tsc --project tsconfig.types.json",
     "build-pack": "yarn build && npm pack",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-sass",
     "lint-es": "eslint --cache src/**/*.ts --max-warnings 0",
@@ -20,6 +24,11 @@
   },
   "private": true,
   "devDependencies": {
+    "@babel/cli": "^7.21.5",
+    "@babel/core": "^7.21.8",
+    "@babel/preset-env": "^7.21.5",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.5",
     "@elastic/eui-theme-common": "workspace:^",
     "@types/jest": "^29.5.12",
     "@types/prettier": "2.7.3",
@@ -33,6 +42,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.7.0",
     "prettier": "^2.8.8",
+    "rimraf": "^6.0.1",
     "stylelint": "^15.7.0",
     "stylelint-config-prettier-scss": "^1.0.0",
     "stylelint-config-standard": "^33.0.0",
@@ -42,11 +52,13 @@
   "peerDependencies": {
     "@elastic/eui-theme-common": "0.0.1"
   },
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "exports": {
     "./lib/*": "./lib/*",
     ".": {
-      "default": "./lib/index.js"
+      "require": "./lib/cjs/index.js",
+      "import": "./lib/esm/index.js",
+      "default": "./lib/cjs/index.js"
     }
   },
   "files": [

--- a/packages/eui-theme-borealis/tsconfig.cjs.json
+++ b/packages/eui-theme-borealis/tsconfig.cjs.json
@@ -2,11 +2,11 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib/esm",
-    "target": "ES2020",
-    "module": "ESNext",
+    "outDir": "lib/cjs",
+    "target": "es6",
+    "module": "CommonJS",
     "lib": [
-      "ESNext",
+      "es6",
       "DOM"
     ],
     "moduleResolution": "Node",
@@ -17,10 +17,11 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "tsBuildInfoFile": "lib/esm/.tsbuildinfo"
+    "tsBuildInfoFile": "lib/cjs/.tsbuildinfo",
+    "importHelpers": false,
   },
   "include": [
-    "src",
+    "src"
   ],
   "exclude": [
     "node_modules"

--- a/packages/eui-theme-borealis/tsconfig.types.json
+++ b/packages/eui-theme-borealis/tsconfig.types.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.cjs.json",
+    "compilerOptions": {
+        "outDir": "lib/cjs",
+        "declaration": true,
+        "declarationMap": true,
+        "isolatedModules": false,
+        "noEmit": false,
+        "allowJs": false,
+        "emitDeclarationOnly": true
+    },
+    "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/eui-theme-common/package.json
+++ b/packages/eui-theme-common/package.json
@@ -7,7 +7,7 @@
     "build:clean": "rimraf lib/",
     "build": "yarn build:clean && yarn build:compile && yarn build:compile:cjs && yarn build:types",
     "build:compile": "tsc --project ./tsconfig.json",
-    "build:compile:cjs": "NODE_ENV=production babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx --source-maps",
+    "build:compile:cjs": "NODE_ENV=production NO_COREJS_POLYFILL=true babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx --source-maps=true",
     "build:types": "NODE_ENV=production tsc --project tsconfig.types.json",
     "build-pack": "yarn build && npm pack",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-sass",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5785,6 +5785,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis"
   dependencies:
+    "@babel/cli": "npm:^7.21.5"
+    "@babel/core": "npm:^7.21.8"
+    "@babel/preset-env": "npm:^7.21.5"
+    "@babel/preset-react": "npm:^7.18.6"
+    "@babel/preset-typescript": "npm:^7.21.5"
     "@elastic/eui-theme-common": "workspace:^"
     "@types/jest": "npm:^29.5.12"
     "@types/prettier": "npm:2.7.3"
@@ -5798,6 +5803,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.1"
     jest: "npm:^29.7.0"
     prettier: "npm:^2.8.8"
+    rimraf: "npm:^6.0.1"
     stylelint: "npm:^15.7.0"
     stylelint-config-prettier-scss: "npm:^1.0.0"
     stylelint-config-standard: "npm:^33.0.0"


### PR DESCRIPTION
## Summary

This PR updates the builds for the new theme packages that ensure Kibana CI runs as expected:

- ensure core-js polyfills are handled as expected
- align `eui-theme-borealis` package build with `eui-theme-common` build to ensure both esm and cjs packages are available

## QA

- [x] CI builds 
- [x] Kibana CI doesn't run into errors of missing modules or import statements ([before](https://buildkite.com/elastic/kibana-pull-request/builds/248620#0192fdfe-c28c-4028-8782-a9e1b97a15ca), [after](https://buildkite.com/elastic/kibana-pull-request/builds/248666))