### PR TITLE
[headerLinks] horizontally center mobileList button

### DIFF
--- a/packages/eui/src/components/header/header_links/header_links.styles.ts
+++ b/packages/eui/src/components/header/header_links/header_links.styles.ts
@@ -39,6 +39,9 @@ export const euiHeaderLinksStyles = ({ euiTheme }: UseEuiTheme) => {
       `,
     },
     euiHeaderLinks__mobileList: css`
+      display: flex;
+      flex-direction: column;
+
       .euiHeaderLink {
         display: block;
         ${logicalCSS('width', '100%')}


### PR DESCRIPTION
## Summary

Hi, folks! 👋🏻
As part of Papercuts project, I've been working on the [[Dashboard] Center Save top nav button for small viewport](https://github.com/elastic/kibana/issues/180093) Kibana issue. While working on this, I noticed that in the **HeaderLinks pop-up** on mobile, the **`Save`** button is left-aligned in different areas across Kibana. 

For example, in Analytics Dashboards:

![Screenshot 2024-11-06 at 21 24 07](https://github.com/user-attachments/assets/59ca112c-ab85-4754-ad4d-caf7a9a1c02b)

This made me think that perhaps we could make the button span the entire width of the modal, like so:

![Screenshot 2024-11-06 at 21 32 04](https://github.com/user-attachments/assets/a8231899-b41f-42b9-a1df-08995afa1c88)

What do you think? I'd love to hear your thoughts, as it's possible this is intentional and designed to be this way. 😁 

In this PR, I am sharing the lines of code I added as a reference, but there may be other ways to implement this.

### General checklist


- Browser QA
    - [x ] Checked in both **light and dark** modes
    - [x ] Checked in **mobile**
    - [x ] Checked in **Chrome**, **Safari**, and **Firefox**
