### PR TITLE
fix(website): add missing props tables

### DIFF
--- a/packages/website/docs/components/editors_and_syntax/code.mdx
+++ b/packages/website/docs/components/editors_and_syntax/code.mdx
@@ -1912,3 +1912,10 @@ export default () => {
 };
 
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/code';
+
+<PropTable definition={docgen.EuiCode} />
+<PropTable definition={docgen.EuiCodeBlock} />

--- a/packages/website/docs/components/editors_and_syntax/markdown_editor.mdx
+++ b/packages/website/docs/components/editors_and_syntax/markdown_editor.mdx
@@ -442,3 +442,9 @@ export default () => {
 };
 
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/markdown_editor';
+
+<PropTable definition={docgen.EuiMarkdownEditor} />

--- a/packages/website/docs/components/editors_and_syntax/markdown_format.mdx
+++ b/packages/website/docs/components/editors_and_syntax/markdown_format.mdx
@@ -415,3 +415,9 @@ import classNames from 'classnames';
   };
   ```
 </Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/markdown_editor';
+
+<PropTable definition={docgen.EuiMarkdownFormat} />

--- a/packages/website/docs/components/forms/auto_refresh.mdx
+++ b/packages/website/docs/components/forms/auto_refresh.mdx
@@ -99,3 +99,11 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/date_picker/auto_refresh';
+
+<PropTable definition={docgen.EuiAutoRefresh} />
+<PropTable definition={docgen.EuiAutoRefreshButton} />
+<PropTable definition={docgen.EuiRefreshInterval} />

--- a/packages/website/docs/components/forms/color_selection.mdx
+++ b/packages/website/docs/components/forms/color_selection.mdx
@@ -760,3 +760,10 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/color_picker';
+
+<PropTable definition={docgen.EuiColorPicker} />
+<PropTable definition={docgen.EuiColorPalettePicker} />

--- a/packages/website/docs/components/forms/combo_box.mdx
+++ b/packages/website/docs/components/forms/combo_box.mdx
@@ -2021,3 +2021,9 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/combo_box';
+
+<PropTable definition={docgen.EuiComboBox} />

--- a/packages/website/docs/components/forms/date_picker.mdx
+++ b/packages/website/docs/components/forms/date_picker.mdx
@@ -675,3 +675,10 @@ import { css } from '@emotion/css';
   };
   ```
 </Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/date_picker';
+
+<PropTable definition={docgen.EuiDatePicker} />
+<PropTable definition={docgen.EuiDatePickerRange} />

--- a/packages/website/docs/components/forms/expression.mdx
+++ b/packages/website/docs/components/forms/expression.mdx
@@ -616,3 +616,9 @@ export default () => (
   </div>
 );
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/expression';
+
+<PropTable definition={docgen.EuiExpression} />

--- a/packages/website/docs/components/forms/filter_group.mdx
+++ b/packages/website/docs/components/forms/filter_group.mdx
@@ -297,3 +297,10 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/filter_group';
+
+<PropTable definition={docgen.EuiFilterGroup} />
+<PropTable definition={docgen.EuiFilterButton} />

--- a/packages/website/docs/components/forms/form_controls/overview.mdx
+++ b/packages/website/docs/components/forms/form_controls/overview.mdx
@@ -966,3 +966,15 @@ export default () => (
   </div>
 );
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/form';
+
+<PropTable definition={docgen.EuiFieldText} />
+<PropTable definition={docgen.EuiFieldSearch} />
+<PropTable definition={docgen.EuiFieldNumber} />
+<PropTable definition={docgen.EuiFieldPassword} />
+<PropTable definition={docgen.EuiSelect} />
+<PropTable definition={docgen.EuiTextArea} />
+<PropTable definition={docgen.EuiFilePicker} />

--- a/packages/website/docs/components/forms/form_layouts/overview.mdx
+++ b/packages/website/docs/components/forms/form_layouts/overview.mdx
@@ -901,3 +901,11 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/form';
+
+<PropTable definition={docgen.EuiForm} />
+<PropTable definition={docgen.EuiFormRow} />
+<PropTable definition={docgen.EuiDescribedFormGroup} />

--- a/packages/website/docs/components/forms/form_validation/overview.mdx
+++ b/packages/website/docs/components/forms/form_validation/overview.mdx
@@ -80,3 +80,10 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/form';
+
+<PropTable definition={docgen.EuiForm} />
+<PropTable definition={docgen.EuiFormRow} />

--- a/packages/website/docs/components/forms/inline_edit.mdx
+++ b/packages/website/docs/components/forms/inline_edit.mdx
@@ -402,3 +402,10 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/inline_edit';
+
+<PropTable definition={docgen.EuiInlineEditText} />
+<PropTable definition={docgen.EuiInlineEditTitle} />

--- a/packages/website/docs/components/forms/range_sliders.mdx
+++ b/packages/website/docs/components/forms/range_sliders.mdx
@@ -707,3 +707,10 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/form';
+
+<PropTable definition={docgen.EuiRange} />
+<PropTable definition={docgen.EuiDualRange} />

--- a/packages/website/docs/components/forms/search_bar.mdx
+++ b/packages/website/docs/components/forms/search_bar.mdx
@@ -1061,3 +1061,10 @@ export default () => {
 };
 
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/search_bar';
+
+<PropTable definition={docgen.EuiSearchBar} />
+<PropTable definition={docgen.EuiSearchBarFilters} />

--- a/packages/website/docs/components/forms/selectable.mdx
+++ b/packages/website/docs/components/forms/selectable.mdx
@@ -1121,3 +1121,10 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/selectable';
+
+<PropTable definition={docgen.EuiSelectable} />
+<PropTable definition={docgen.EuiSelectableMessage} />

--- a/packages/website/docs/components/forms/selection_controls/overview.mdx
+++ b/packages/website/docs/components/forms/selection_controls/overview.mdx
@@ -397,3 +397,14 @@ export default () => (
   </EuiFormFieldset>
 );
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/form';
+
+<PropTable definition={docgen.EuiCheckbox} />
+<PropTable definition={docgen.EuiCheckboxGroup} />
+<PropTable definition={docgen.EuiRadio} />
+<PropTable definition={docgen.EuiRadioGroup} />
+<PropTable definition={docgen.EuiSwitch} />
+<PropTable definition={docgen.EuiFormFieldset} />

--- a/packages/website/docs/components/forms/super_select.mdx
+++ b/packages/website/docs/components/forms/super_select.mdx
@@ -191,3 +191,9 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/form';
+
+<PropTable definition={docgen.EuiSuperSelect} />

--- a/packages/website/docs/components/navigation/pagination/overview.mdx
+++ b/packages/website/docs/components/navigation/pagination/overview.mdx
@@ -278,8 +278,9 @@ export default () => {
 
 ## Props
 
-import docgen from '@elastic/eui-docgen/dist/components/pagination';
+import paginationDocgen from '@elastic/eui-docgen/dist/components/pagination';
+import tableDocgen from '@elastic/eui-docgen/dist/components/table';
 
-<PropTable definition={docgen.EuiPagination} />
-
-<PropTable definition={docgen.EuiPaginationButton} />
+<PropTable definition={paginationDocgen.EuiPagination} />
+<PropTable definition={paginationDocgen.EuiPaginationButton} />
+<PropTable definition={tableDocgen.EuiTablePagination} />

--- a/packages/website/docs/components/navigation/tree_view.mdx
+++ b/packages/website/docs/components/navigation/tree_view.mdx
@@ -193,6 +193,8 @@ export default () => {
 
 ## Props
 
-import docgen from '@elastic/eui-docgen/dist/components/tree_view';
+import treeViewDocgen from '@elastic/eui-docgen/dist/components/tree_view';
+import treeViewItemDocgen from '@elastic/eui-docgen/dist/components/tree_view/tree_view_item';
 
-<PropTable definition={docgen.EuiTreeView} />
+<PropTable definition={treeViewDocgen.EuiTreeView} />
+<PropTable definition={treeViewItemDocgen.EuiTreeViewItem} />

--- a/packages/website/docs/components/tabular_content/in_memory_tables.mdx
+++ b/packages/website/docs/components/tabular_content/in_memory_tables.mdx
@@ -1024,3 +1024,9 @@ export default () => {
 };
 
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/basic_table';
+
+<PropTable definition={docgen.EuiInMemoryTable} />

--- a/packages/website/docs/components/tabular_content/tables.mdx
+++ b/packages/website/docs/components/tabular_content/tables.mdx
@@ -2989,3 +2989,24 @@ export default class extends Component<{}, State> {
 }
 
 ```
+
+## Props
+
+import basicTableDocgen from '@elastic/eui-docgen/dist/components/basic_table';
+import tableDocgen from '@elastic/eui-docgen/dist/components/table';
+
+<PropTable definition={basicTableDocgen.EuiBasicTable} />
+<PropTable definition={tableDocgen.EuiTable} />
+<PropTable definition={tableDocgen.EuiTableBody} />
+<PropTable definition={tableDocgen.EuiTableFooter} />
+<PropTable definition={tableDocgen.EuiTableFooterCell} />
+<PropTable definition={tableDocgen.EuiTableHeader} />
+<PropTable definition={tableDocgen.EuiTableHeaderCell} />
+<PropTable definition={tableDocgen.EuiTableHeaderCellCheckbox} />
+<PropTable definition={tableDocgen.EuiTablePagination} />
+<PropTable definition={tableDocgen.EuiTableRow} />
+<PropTable definition={tableDocgen.EuiTableRowCell} />
+<PropTable definition={tableDocgen.EuiTableRowCellCheckbox} />
+<PropTable definition={tableDocgen.EuiTableSortMobile} />
+<PropTable definition={tableDocgen.EuiTableSortMobileItem} />
+<PropTable definition={tableDocgen.EuiTableHeaderMobile} />

--- a/packages/website/docs/components/templates/page_template/overview.mdx
+++ b/packages/website/docs/components/templates/page_template/overview.mdx
@@ -273,3 +273,9 @@ export default ({
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/page_template';
+
+<PropTable definition={docgen.EuiPageTemplate} />

--- a/packages/website/docs/components/templates/sitewide_search.mdx
+++ b/packages/website/docs/components/templates/sitewide_search.mdx
@@ -433,3 +433,9 @@ import { SitewideOption } from './sitewide_option';
 :::note
 The demo shows how you can temporarily replace the icon for a subset of options to display a short list of recently viewed options.
 :::
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/selectable';
+
+<PropTable definition={docgen.EuiSelectableTemplateSitewide} />

--- a/packages/website/docs/components/templates/super_date_picker.mdx
+++ b/packages/website/docs/components/templates/super_date_picker.mdx
@@ -805,3 +805,9 @@ export default () => {
   );
 };
 ```
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/date_picker';
+
+<PropTable definition={docgen.EuiSuperDatePicker} />


### PR DESCRIPTION
## Summary

I added missing props tables to EUI+ pages. Check the issue for the whole list: [#139](https://github.com/elastic/eui-private/issues/139)

![Screenshot 2024-11-11 at 11 14 26](https://github.com/user-attachments/assets/84ee1300-e0c4-474a-8a0e-2fa2af7396ec)

If you notice any more let me know, I can add them as part of this PR.

## QA

Use the staging link from the comment below. Cross-reference with the list in the issue ☝🏻 