### PR TITLE
fix(docusaurus-theme): fill Codesandbox icon with currentColor

### DIFF
--- a/packages/docusaurus-theme/src/components/codesandbox_icon/codesandbox_icon.tsx
+++ b/packages/docusaurus-theme/src/components/codesandbox_icon/codesandbox_icon.tsx
@@ -1,7 +1,16 @@
-export const CodeSandboxIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" preserveAspectRatio="xMidYMid"
-       viewBox="-20 0 296 296">
-    <path
-      d="M115.498 261.088v-106.61L23.814 101.73v60.773l41.996 24.347v45.7l49.688 28.54Zm23.814.627 50.605-29.151V185.78l42.269-24.495v-60.011l-92.874 53.621v106.82Zm80.66-180.887-48.817-28.289-42.863 24.872-43.188-24.897-49.252 28.667 91.914 52.882 92.206-53.235ZM0 222.212V74.495L127.987 0 256 74.182v147.797l-128.016 73.744L0 222.212Z" />
+import { HTMLAttributes } from 'react';
+
+type Props = HTMLAttributes<SVGElement>;
+
+export const CodeSandboxIcon = (props: Props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="16"
+    height="16"
+    preserveAspectRatio="xMidYMid"
+    viewBox="-20 0 296 296"
+    {...props}
+  >
+    <path d="M115.498 261.088v-106.61L23.814 101.73v60.773l41.996 24.347v45.7l49.688 28.54Zm23.814.627 50.605-29.151V185.78l42.269-24.495v-60.011l-92.874 53.621v106.82Zm80.66-180.887-48.817-28.289-42.863 24.872-43.188-24.897-49.252 28.667 91.914 52.882 92.206-53.235ZM0 222.212V74.495L127.987 0 256 74.182v147.797l-128.016 73.744L0 222.212Z" />
   </svg>
 );

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -72,7 +72,7 @@ to have version-specific search experience without the need to run
 a search server.
 
 Because the search index is generated in build time, it means that
-searching is not possible when running the development sever.
+searching is not possible when running the development server.
 Please refer to the [Building the website](#building-the-website) section
 to learn how to build the documentation site locally
 and serve it to use local search.


### PR DESCRIPTION
## Summary

The Codesandbox icon in the footer of each example in EUI+ doesn't change the color depending on the theme (dark / light mode).

## QA

1. Open the [new docs](https://eui.elastic.co/pr_8127/new-docs/index.html).
2. Navigate to any component page (e.g. [Accordion](https://eui.elastic.co/pr_8127/new-docs/docs/layout/accordion/)).
3. Notice the component preview. In the footer, there's a Codesandbox icon.
4. Switch themes using the toggle in the top right of the page.
5. Verify that the Codesandbox icon is visible. In light mode it should be black, in dark mode white.

https://github.com/user-attachments/assets/989811da-3fcd-4384-9bc1-d810cea331ca