### PR TITLE
[EuiDataGrid] Fix column actions not working for draggable datagrid inside modals

### DIFF
--- a/packages/eui/changelogs/upcoming/8135.md
+++ b/packages/eui/changelogs/upcoming/8135.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+-  Fixed an `EuiDataGrid` bug where column actions where not clickable when `EuiDataGrid` with `columnVisibility.canDragAndDropColumns` was used inside a modal
+

--- a/packages/eui/src-docs/src/views/datagrid/schema_columns/column_dragging.js
+++ b/packages/eui/src-docs/src/views/datagrid/schema_columns/column_dragging.js
@@ -6,6 +6,9 @@ import {
   EuiAvatar,
   EuiToolTip,
   EuiButtonIcon,
+  EuiModal,
+  EuiModalBody,
+  EuiButton,
 } from '../../../../../src/components';
 
 const CustomHeaderCell = ({ title }) => (
@@ -67,21 +70,33 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
+  const [isOpen, setOpen] = useState(false);
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 
   return (
-    <EuiDataGrid
-      aria-label="DataGrid demonstrating column reordering on drag"
-      columns={columns}
-      columnVisibility={{
-        visibleColumns: visibleColumns,
-        setVisibleColumns: setVisibleColumns,
-        canDragAndDropColumns: true,
-      }}
-      rowCount={data.length}
-      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
-    />
+    <>
+      <EuiButton onClick={() => setOpen(!isOpen)}>Toggle modal</EuiButton>
+      {isOpen && (
+        <EuiModal onClose={() => setOpen(false)}>
+          <EuiModalBody>
+            <EuiDataGrid
+              aria-label="DataGrid demonstrating column reordering on drag"
+              columns={columns}
+              columnVisibility={{
+                visibleColumns: visibleColumns,
+                setVisibleColumns: setVisibleColumns,
+                canDragAndDropColumns: true,
+              }}
+              rowCount={data.length}
+              renderCellValue={({ rowIndex, columnId }) =>
+                data[rowIndex][columnId]
+              }
+            />
+          </EuiModalBody>
+        </EuiModal>
+      )}
+    </>
   );
 };

--- a/packages/eui/src-docs/src/views/datagrid/schema_columns/column_dragging.js
+++ b/packages/eui/src-docs/src/views/datagrid/schema_columns/column_dragging.js
@@ -1,44 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { faker } from '@faker-js/faker';
 
-import {
-  EuiDataGrid,
-  EuiAvatar,
-  EuiToolTip,
-  EuiButtonIcon,
-  EuiModal,
-  EuiModalBody,
-  EuiButton,
-} from '../../../../../src/components';
-
-const CustomHeaderCell = ({ title }) => (
-  <>
-    <span>{title}</span>
-    <EuiToolTip content="tooltip content">
-      <EuiButtonIcon
-        iconType="questionInCircle"
-        aria-label="Additional information"
-        color="primary"
-      />
-    </EuiToolTip>
-  </>
-);
+import { EuiDataGrid, EuiAvatar } from '../../../../../src/components';
 
 const columns = [
   {
     id: 'avatar',
     initialWidth: 40,
     isResizable: false,
-    actions: false,
   },
   {
     id: 'name',
-    displayAsText: 'Name',
-    display: <CustomHeaderCell title="Name" />,
+    initialWidth: 100,
   },
   {
     id: 'email',
-    display: <CustomHeaderCell title="Email" />,
   },
   {
     id: 'city',
@@ -70,33 +46,42 @@ for (let i = 1; i < 5; i++) {
 }
 
 export default () => {
-  const [isOpen, setOpen] = useState(false);
+  const [pagination, setPagination] = useState({ pageIndex: 0 });
+
   const [visibleColumns, setVisibleColumns] = useState(
     columns.map(({ id }) => id)
   );
 
+  const setPageIndex = useCallback(
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    []
+  );
+  const setPageSize = useCallback(
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    []
+  );
+
   return (
-    <>
-      <EuiButton onClick={() => setOpen(!isOpen)}>Toggle modal</EuiButton>
-      {isOpen && (
-        <EuiModal onClose={() => setOpen(false)}>
-          <EuiModalBody>
-            <EuiDataGrid
-              aria-label="DataGrid demonstrating column reordering on drag"
-              columns={columns}
-              columnVisibility={{
-                visibleColumns: visibleColumns,
-                setVisibleColumns: setVisibleColumns,
-                canDragAndDropColumns: true,
-              }}
-              rowCount={data.length}
-              renderCellValue={({ rowIndex, columnId }) =>
-                data[rowIndex][columnId]
-              }
-            />
-          </EuiModalBody>
-        </EuiModal>
-      )}
-    </>
+    <EuiDataGrid
+      aria-label="DataGrid demonstrating column sizing constraints"
+      columns={columns}
+      columnVisibility={{
+        visibleColumns: visibleColumns,
+        setVisibleColumns: setVisibleColumns,
+      }}
+      rowCount={data.length}
+      renderCellValue={({ rowIndex, columnId }) => data[rowIndex][columnId]}
+      pagination={{
+        ...pagination,
+        onChangeItemsPerPage: setPageSize,
+        onChangePage: setPageIndex,
+      }}
+    />
   );
 };

--- a/packages/eui/src/components/datagrid/body/header/draggable_columns.spec.tsx
+++ b/packages/eui/src/components/datagrid/body/header/draggable_columns.spec.tsx
@@ -12,6 +12,7 @@
 
 import React, { useState } from 'react';
 import { EuiDataGrid, EuiDataGridProps } from '../../index';
+import { EuiModal, EuiModalBody } from '../../../modal';
 
 describe('draggable columns', () => {
   const columns = [
@@ -282,6 +283,42 @@ describe('draggable columns', () => {
       });
       cy.get('[data-test-subj=dataGridHeaderCell-a]').should('have.focus');
       cy.get('[data-popover-open]').should('not.exist');
+    });
+  });
+
+  describe('inside a modal', () => {
+    it('should execute column actions on click', () => {
+      cy.realMount(
+        <EuiModal onClose={() => {}}>
+          <EuiModalBody>
+            <StatefulDataGrid />
+          </EuiModalBody>
+        </EuiModal>
+      );
+
+      cy.get('[data-test-subj=dataGridHeaderCell-a]').realHover();
+      cy.wait(50); // wait until actions button transition is progressed enough for the button to be clickable
+      cy.get('[data-test-subj=dataGridHeaderCellActionButton-a]').realClick();
+      cy.get('[data-popover-open]').should('have.focus');
+
+      cy.get(
+        '.euiListGroupItem:last-child .euiListGroupItem__button'
+      ).realClick();
+
+      cy.get('[data-test-subj=dataGridHeaderCell-a]').should(
+        'have.attr',
+        'data-gridcell-column-index',
+        '1'
+      );
+      cy.get('[data-test-subj=dataGridHeaderCell-b]').should(
+        'have.attr',
+        'data-gridcell-column-index',
+        '0'
+      );
+
+      cy.get('[data-test-subj=euiDataGridHeaderColumnActions]').should(
+        'not.exist'
+      );
     });
   });
 });

--- a/packages/eui/src/components/datagrid/body/header/draggable_columns.tsx
+++ b/packages/eui/src/components/datagrid/body/header/draggable_columns.tsx
@@ -132,16 +132,24 @@ export const DraggableColumn: FunctionComponent<{
     const { setFocusedCell } = useContext(DataGridFocusContext);
     const handleOnMouseDown: MouseEventHandler = useCallback(
       (e) => {
-        const openFocusTrap = document.querySelector(
+        const openFocusTraps = document.querySelectorAll(
           '[data-focus-lock-disabled="false"]'
         );
-        if (
-          !!openFocusTrap && // If a focus trap is open somewhere on the page
-          !openFocusTrap.contains(e.target as Node) && // & the focus trap doesn't belong to this header
-          e.target !== actionsPopoverToggle // & we're not closing the actions popover toggle
-        ) {
+        const validOpenFocusTraps = [...openFocusTraps].filter(
+          (focusTrap) =>
+            !focusTrap.querySelector('.euiModal') && // if it's not a modal
+            !focusTrap.contains(e.target as Node) // & if it doesn't contain the target
+        );
+
+        const shouldDispatchEvent = validOpenFocusTraps.some(
+          (focusTrap) =>
+            !!focusTrap && // If there is a focus trap is open
+            e.target !== actionsPopoverToggle // & we're not closing the actions popover toggle
+        );
+
+        if (shouldDispatchEvent) {
           // Trick the focus trap lib into registering an outside click -
-          // the drag/drop lib otherwise otherwise prevents the event 💀
+          // the drag/drop lib otherwise prevents the event 💀
           document.dispatchEvent(new MouseEvent('mousedown'));
         }
         setTimeout(() => {

--- a/packages/eui/src/components/datagrid/body/header/draggable_columns.tsx
+++ b/packages/eui/src/components/datagrid/body/header/draggable_columns.tsx
@@ -136,14 +136,13 @@ export const DraggableColumn: FunctionComponent<{
           '[data-focus-lock-disabled="false"]'
         );
         const validOpenFocusTraps = [...openFocusTraps].filter(
-          (focusTrap) =>
-            !focusTrap.querySelector('.euiModal') && // if it's not a modal
-            !focusTrap.contains(e.target as Node) // & if it doesn't contain the target
+          (focusTrap) => !focusTrap.contains(e.currentTarget as Node) // remove containing focus traps (e.g. modals or flyouts)
         );
 
         const shouldDispatchEvent = validOpenFocusTraps.some(
           (focusTrap) =>
-            !!focusTrap && // If there is a focus trap is open
+            !!focusTrap && // If there is a focus trap open
+            !focusTrap.contains(e.target as Node) && // & if it doesn't contain the target
             e.target !== actionsPopoverToggle // & we're not closing the actions popover toggle
         );
 


### PR DESCRIPTION
## Summary

closes #8119 

This PR fixes an issue for `EuiDataGrid` with `columnVisibility.canDragAndDropColumns` enabled and used inside `EuiModal` where the column actions would not be clickable.

This was caused by a custom "blur"/"clickAway" event being fired (added [here](https://github.com/elastic/eui/pull/8015/commits/96f325ed7e534b201209f910a73f0efed24d0afa#diff-27ccea893ced8c90d7c620365b116fb988720f4c4a0311bf748f529e7ac637cfR172)) because the [selector](https://github.com/elastic/eui/pull/8015/commits/96f325ed7e534b201209f910a73f0efed24d0afa#diff-27ccea893ced8c90d7c620365b116fb988720f4c4a0311bf748f529e7ac637cfR162) for this condition was selecting the modal focus trap instead of the column action one.

## Changes

- updates the condition to check for all focus traps and exclude modal focus traps that contain the datagrid
- adds a regression test for this scenario

_before_

https://github.com/user-attachments/assets/fd8a4b50-7a44-4b4b-a83e-96c93f655f89

_after_

https://github.com/user-attachments/assets/652863d7-ef81-4dd3-89b0-fb4720a9ecf6

## TODO

- [ ] revert [testing example commit](https://github.com/elastic/eui/pull/8135/commits/1f94aaf51311e8c6b61c29cbe6e8041485c86e36) after review

## QA

- [x] the added cypress test passed
- [ ] verify expected behavior using [this testing example](https://eui.elastic.co/pr_8135/#/tabular-content/data-grid-schema-columns#draggable-columns) (click the button to open the modal with the datagrid inside)
- generally ensure the `EuiDataGrid` with draggable columns still works as expected

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
