### PR TITLE
fix(tool_tip): stop propagation on escape key down

### DIFF
--- a/packages/eui/changelogs/upcoming/8140.md
+++ b/packages/eui/changelogs/upcoming/8140.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- When the tooltips components (`EuiTooltip`, `EuiIconTip`) are used inside components that handle the Escape key (like `EuiFlyout` or `EuiModal`), pressing the Escape key will now only close the tooltip and not the entire wrapping component.

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -15,6 +15,8 @@ import React, { useState } from 'react';
 import { EuiGlobalToastList } from '../toast';
 import { EuiHeader } from '../header';
 import { EuiFlyout } from './flyout';
+import { EuiToolTip } from '../tool_tip';
+import { EuiButton } from '../button';
 
 const childrenDefault = (
   <>
@@ -89,6 +91,46 @@ describe('EuiFlyout', () => {
       cy.realPress('Escape').then(() => {
         expect(cy.get('[data-test-subj="flyoutSpec"]').should('not.exist'));
       });
+    });
+  });
+
+  describe('Close behavior: overlay elements as children', () => {
+    it('closes the flyout when the EuiToolTip is not focused', () => {
+      cy.mount(
+        <Flyout>
+          <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
+            <EuiButton data-test-subj="tool_tip_trigger">
+              Show tooltip
+            </EuiButton>
+          </EuiToolTip>
+        </Flyout>
+      );
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="flyoutSpec"]').should('not.exist');
+    });
+
+    it('does not close the flyout when the tooltip is shown but closes the tooltip', () => {
+      cy.mount(
+        <Flyout
+          children={
+            <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
+              <EuiButton data-test-subj="tool_tip_trigger">
+                Show tooltip
+              </EuiButton>
+            </EuiToolTip>
+          }
+        ></Flyout>
+      );
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+
+      cy.repeatRealPress('Tab', 2);
+      cy.get('[data-test-subj="tool_tip"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+      cy.get('[data-test-subj="flyoutSpec"]').should('exist');
     });
   });
 

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -15,8 +15,6 @@ import React, { useState } from 'react';
 import { EuiGlobalToastList } from '../toast';
 import { EuiHeader } from '../header';
 import { EuiFlyout } from './flyout';
-import { EuiToolTip } from '../tool_tip';
-import { EuiButton } from '../button';
 
 const childrenDefault = (
   <>
@@ -91,46 +89,6 @@ describe('EuiFlyout', () => {
       cy.realPress('Escape').then(() => {
         expect(cy.get('[data-test-subj="flyoutSpec"]').should('not.exist'));
       });
-    });
-  });
-
-  describe('Close behavior: overlay elements as children', () => {
-    it('closes the flyout when the EuiToolTip is not focused', () => {
-      cy.mount(
-        <Flyout>
-          <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
-            <EuiButton data-test-subj="tool_tip_trigger">
-              Show tooltip
-            </EuiButton>
-          </EuiToolTip>
-        </Flyout>
-      );
-      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
-
-      cy.realPress('Escape');
-      cy.get('[data-test-subj="flyoutSpec"]').should('not.exist');
-    });
-
-    it('does not close the flyout when the tooltip is shown but closes the tooltip', () => {
-      cy.mount(
-        <Flyout
-          children={
-            <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
-              <EuiButton data-test-subj="tool_tip_trigger">
-                Show tooltip
-              </EuiButton>
-            </EuiToolTip>
-          }
-        ></Flyout>
-      );
-      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
-
-      cy.repeatRealPress('Tab', 2);
-      cy.get('[data-test-subj="tool_tip"]').should('exist');
-
-      cy.realPress('Escape');
-      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
-      cy.get('[data-test-subj="flyoutSpec"]').should('exist');
     });
   });
 

--- a/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
@@ -10,9 +10,12 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../cypress/support" />
 
-import React from 'react';
+import React, { ComponentProps, useState } from 'react';
 
-import { EuiButton } from '../../components';
+import { EuiButton } from '../button';
+import { EuiFlyout } from '../flyout';
+import { EuiModal } from '../modal';
+import { EuiPopover } from '../popover';
 import { EuiToolTip } from './tool_tip';
 
 describe('EuiToolTip', () => {
@@ -46,19 +49,6 @@ describe('EuiToolTip', () => {
     cy.get('[data-test-subj="tooltip"]').should('not.exist');
   });
 
-  it('hides the tooltip on Escape key down', () => {
-    cy.realMount(
-      <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
-        <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
-      </EuiToolTip>
-    );
-    cy.realPress('Tab');
-    cy.get('[data-test-subj="tooltip"]').should('exist');
-
-    cy.realPress('Escape');
-    cy.get('[data-test-subj="tooltip"]').should('not.exist');
-  });
-
   it('does not show multiple tooltips if one tooltip toggle is focused and another tooltip toggle is hovered', () => {
     cy.mount(
       <>
@@ -79,5 +69,145 @@ describe('EuiToolTip', () => {
     cy.get('[data-test-subj="toggleToolTipB"]').trigger('mouseover');
     cy.contains('Tooltip B').should('exist');
     cy.contains('Tooltip A').should('not.exist');
+  });
+
+  describe('Escape key', () => {
+    it('hides the tooltip when rendered by itself', () => {
+      cy.realMount(
+        <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
+          <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
+        </EuiToolTip>
+      );
+      cy.realPress('Tab');
+      cy.get('[data-test-subj="tooltip"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="tooltip"]').should('not.exist');
+    });
+
+    it('hides the tooltip when rendered by EuiFlyout', () => {
+      const Flyout = (
+        props: Omit<ComponentProps<typeof EuiFlyout>, 'onClose'>
+      ) => {
+        const [isOpen, setIsOpen] = useState(true);
+
+        return isOpen ? (
+          <EuiFlyout
+            {...props}
+            data-test-subj="flyout"
+            onClose={() => setIsOpen(false)}
+          />
+        ) : null;
+      };
+
+      cy.realMount(
+        <Flyout>
+          <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
+            <EuiButton data-test-subj="tool_tip_trigger">
+              Show tooltip
+            </EuiButton>
+          </EuiToolTip>
+        </Flyout>
+      );
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+
+      cy.repeatRealPress('Tab', 2);
+      cy.get('[data-test-subj="tool_tip"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+      cy.get('[data-test-subj="flyout"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="flyout"]').should('not.exist');
+    });
+
+    it('hides the tooltip when rendered by EuiModal', () => {
+      const Modal = (
+        props: Omit<ComponentProps<typeof EuiModal>, 'onClose'>
+      ) => {
+        const [isOpen, setIsOpen] = useState(true);
+
+        return isOpen ? (
+          <EuiModal
+            {...props}
+            data-test-subj="modal"
+            onClose={() => setIsOpen(false)}
+          />
+        ) : null;
+      };
+
+      cy.realMount(
+        <Modal>
+          <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
+            <EuiButton data-test-subj="tool_tip_trigger">
+              Show tooltip
+            </EuiButton>
+          </EuiToolTip>
+        </Modal>
+      );
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+
+      cy.repeatRealPress('Tab', 2);
+      cy.get('[data-test-subj="tool_tip"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+      cy.get('[data-test-subj="modal"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="modal"]').should('not.exist');
+    });
+
+    it('hides the tooltip when rendered by EuiPopover', () => {
+      const Popover = (
+        props: Omit<
+          ComponentProps<typeof EuiPopover>,
+          'closePopover' | 'button'
+        >
+      ) => {
+        const [isOpen, setIsOpen] = useState(true);
+
+        return (
+          <EuiPopover
+            {...props}
+            button={
+              <EuiButton
+                onClick={() => setIsOpen(true)}
+                data-test-subj="popover_toggle"
+              >
+                Show popover
+              </EuiButton>
+            }
+            panelProps={{ 'data-test-subj': 'popover' }}
+            isOpen={isOpen}
+            closePopover={() => setIsOpen(false)}
+          >
+            {props.children}
+          </EuiPopover>
+        );
+      };
+
+      cy.realMount(
+        <Popover>
+          <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
+            <EuiButton data-test-subj="tool_tip_trigger">
+              Show tooltip
+            </EuiButton>
+          </EuiToolTip>
+        </Popover>
+      );
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+
+      cy.realPress('Tab');
+      cy.get('[data-test-subj="tool_tip"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="tool_tip"]').should('not.exist');
+      cy.get('[data-test-subj="popover"]').should('exist');
+
+      cy.realPress('Escape');
+      cy.get('[data-test-subj="popover"]').should('not.exist');
+    });
   });
 });

--- a/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
@@ -73,7 +73,7 @@ describe('EuiToolTip', () => {
 
   describe('Escape key', () => {
     it('hides the tooltip when rendered by itself', () => {
-      cy.realMount(
+      cy.mount(
         <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
           <EuiButton data-test-subj="toggleToolTip">Show tooltip</EuiButton>
         </EuiToolTip>
@@ -100,7 +100,7 @@ describe('EuiToolTip', () => {
         ) : null;
       };
 
-      cy.realMount(
+      cy.mount(
         <Flyout>
           <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
             <EuiButton data-test-subj="tool_tip_trigger">
@@ -111,7 +111,7 @@ describe('EuiToolTip', () => {
       );
       cy.get('[data-test-subj="tool_tip"]').should('not.exist');
 
-      cy.repeatRealPress('Tab', 2);
+      cy.get('[data-test-subj="tool_tip_trigger"]').focus();
       cy.get('[data-test-subj="tool_tip"]').should('exist');
 
       cy.realPress('Escape');
@@ -137,7 +137,7 @@ describe('EuiToolTip', () => {
         ) : null;
       };
 
-      cy.realMount(
+      cy.mount(
         <Modal>
           <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
             <EuiButton data-test-subj="tool_tip_trigger">
@@ -148,7 +148,7 @@ describe('EuiToolTip', () => {
       );
       cy.get('[data-test-subj="tool_tip"]').should('not.exist');
 
-      cy.repeatRealPress('Tab', 2);
+      cy.get('[data-test-subj="tool_tip_trigger"]').focus();
       cy.get('[data-test-subj="tool_tip"]').should('exist');
 
       cy.realPress('Escape');
@@ -188,7 +188,7 @@ describe('EuiToolTip', () => {
         );
       };
 
-      cy.realMount(
+      cy.mount(
         <Popover>
           <EuiToolTip content="Tooltip text here" data-test-subj="tool_tip">
             <EuiButton data-test-subj="tool_tip_trigger">
@@ -199,7 +199,7 @@ describe('EuiToolTip', () => {
       );
       cy.get('[data-test-subj="tool_tip"]').should('not.exist');
 
-      cy.realPress('Tab');
+      cy.get('[data-test-subj="tool_tip_trigger"]').focus();
       cy.get('[data-test-subj="tool_tip"]').should('exist');
 
       cy.realPress('Escape');

--- a/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
@@ -111,7 +111,9 @@ describe('EuiToolTip', () => {
       );
       cy.get('[data-test-subj="tool_tip"]').should('not.exist');
 
-      cy.get('[data-test-subj="tool_tip_trigger"]').focus();
+      cy.get('[data-test-subj="flyout"]').focus();
+
+      cy.repeatRealPress('Tab', 2);
       cy.get('[data-test-subj="tool_tip"]').should('exist');
 
       cy.realPress('Escape');
@@ -148,7 +150,9 @@ describe('EuiToolTip', () => {
       );
       cy.get('[data-test-subj="tool_tip"]').should('not.exist');
 
-      cy.get('[data-test-subj="tool_tip_trigger"]').focus();
+      cy.get('[data-test-subj="modal"]').focus();
+
+      cy.repeatRealPress('Tab', 2);
       cy.get('[data-test-subj="tool_tip"]').should('exist');
 
       cy.realPress('Escape');
@@ -199,7 +203,9 @@ describe('EuiToolTip', () => {
       );
       cy.get('[data-test-subj="tool_tip"]').should('not.exist');
 
-      cy.get('[data-test-subj="tool_tip_trigger"]').focus();
+      cy.get('[data-test-subj="popover"]').focus();
+
+      cy.realPress('Tab');
       cy.get('[data-test-subj="tool_tip"]').should('exist');
 
       cy.realPress('Escape');

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -280,6 +280,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
 
   onEscapeKey = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     if (event.key === keys.ESCAPE) {
+      event.stopPropagation();
       this.setState({ hasFocus: false }); // Allows mousing over back into the tooltip to work correctly
       this.hideToolTip();
     }

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -280,7 +280,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
 
   onEscapeKey = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     if (event.key === keys.ESCAPE) {
-      event.stopPropagation();
+      if (this.state.visible) event.stopPropagation();
       this.setState({ hasFocus: false }); // Allows mousing over back into the tooltip to work correctly
       this.hideToolTip();
     }


### PR DESCRIPTION
## Summary

When we have `EuiIconTip` (consequently, `EuiTooltip`) within `EuiFlyout` and with the tooltip open we click "Escape" key, the flyout gets closed. The reason is, the escape keydown event is propagated from the tooltip and captured by the flyout as its parent. Simple `event.stopPropagation()` inside `EuiTooltip` seemed to do the trick.

closes #8130

## QA

**Test path:**

1. Run Storybook locally: `yarn storybook`.
2. Find the component `EuiFlyout`.
3. Close the flyout with the escape key.
4. Change the `EuiFlyoutBody` to contain a `EuiToolTip` as children.
5. Focus the tooltip and close it with the Escape key. The flyout should not close, the tooltip - yes.
6. With the tooltip closed, click Escape key again to close the flyout.

https://github.com/user-attachments/assets/34b833bd-9c62-4f9c-9810-844222f6d193

### Manual QA of other focus-trap elements

#### EuiModal

https://github.com/user-attachments/assets/b968c2b4-d219-41a8-9116-b04daa356400

#### EuiPopover

https://github.com/user-attachments/assets/8b1be95d-13de-4677-b403-e1820e6fc1da

#### EuiDataGrid fullscreen

https://github.com/user-attachments/assets/50d30f2d-c61e-4211-a30b-c843f27ef0a0

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~ (not applicable)
    - [ ] ~Checked in **mobile**~ (not applicable)
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ (not applicable)
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~ (not applicable)
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~ (not applicable)
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~ (not applicable)
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
