### PR TITLE
feat(beta_badge): support warning color value

### DIFF
--- a/packages/eui/changelogs/upcoming/8177.md
+++ b/packages/eui/changelogs/upcoming/8177.md
@@ -1,0 +1,1 @@
+- Added a new color variant of the EuiBetaBadge component: `warning`. It can be set using the `color` prop: `<EuiBetaBadge color="warning" />`.

--- a/packages/eui/changelogs/upcoming/8177.md
+++ b/packages/eui/changelogs/upcoming/8177.md
@@ -1,1 +1,1 @@
-- Added a new color variant of the EuiBetaBadge component: `warning`. It can be set using the `color` prop: `<EuiBetaBadge color="warning" />`.
+- Updated `EuiBetaBadge` with a new `warning` color variant

--- a/packages/eui/src-docs/src/views/badge/beta_badge.tsx
+++ b/packages/eui/src-docs/src/views/badge/beta_badge.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 
 import { EuiBetaBadge, EuiSpacer, EuiTitle } from '../../../../src/components';
 
-const colors = ['hollow', 'accent', 'subdued'] as const;
+const colors = ['hollow', 'accent', 'subdued', 'warning'] as const;
 
 export default () => (
   <>

--- a/packages/eui/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
+++ b/packages/eui/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
@@ -68,6 +68,17 @@ exports[`EuiBetaBadge props color subdued is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiBetaBadge props color warning is rendered 1`] = `
+<span>
+  <span
+    class="euiBetaBadge emotion-euiBetaBadge-warning-m-baseline"
+    title="Beta"
+  >
+    Beta
+  </span>
+</span>
+`;
+
 exports[`EuiBetaBadge props iconType 1`] = `
 <span>
   <span

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -49,6 +49,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       box-shadow: inset 0 0 0 ${euiTheme.border.width.thin}
         ${badgeColors.hollow.borderColor};
     `,
+    warning: css(badgeColors.warning),
     // Font sizes
     m: css`
       font-size: ${euiFontSizeFromScale('xs', euiTheme)};

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
@@ -22,7 +22,7 @@ import { EuiIcon, IconType } from '../../icon';
 
 import { euiBetaBadgeStyles } from './beta_badge.styles';
 
-export const COLORS = ['accent', 'subdued', 'hollow'] as const;
+export const COLORS = ['accent', 'subdued', 'hollow', 'warning'] as const;
 export type BetaBadgeColor = (typeof COLORS)[number];
 
 export const SIZES = ['s', 'm'] as const;
@@ -109,7 +109,7 @@ type BadgeProps = {
    */
   title?: string;
   /**
-   * Accepts accent, subdued and hollow.
+   * Accepts accent, subdued, hollow and warning.
    */
   color?: BetaBadgeColor;
   size?: BetaBadgeSize;

--- a/packages/website/docs/components/display/badge.mdx
+++ b/packages/website/docs/components/display/badge.mdx
@@ -323,7 +323,7 @@ import React from 'react';
 import { EuiBetaBadge, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { css } from '@emotion/react';
 
-const colors = ['hollow', 'accent', 'subdued'] as const;
+const colors = ['hollow', 'accent', 'subdued', 'warning'] as const;
 
 export default () => (
   <>


### PR DESCRIPTION
## Summary

I added a "warning" value to the color prop, updated both documentation websites and updated snapshot tests.

![Screenshot 2024-11-22 at 12 00 48](https://github.com/user-attachments/assets/95614add-33fb-403c-8ecf-8e14e299b436)
![Screenshot 2024-11-22 at 12 00 56](https://github.com/user-attachments/assets/672d133e-3167-414b-bc3f-817d62df3aa4)

In the new docs, the warning beta badge doesn't display as expected even after rebuilding dependencies. Not sure if it's a problem with the Docasaurus theme?

![Screenshot 2024-11-22 at 12 01 53](https://github.com/user-attachments/assets/fbb122b0-807c-43fc-8840-f56e9fa584fb)

closes #8138

## QA

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [ ] ~Checked in **mobile**~ (not applicable)
    - [x] Checked in **Chrome**, **Safari**, ~**Edge**, and **Firefox**~
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~ (not applicable)
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~ (not applicable)
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~ (not applicable)
- Designer checklist
  - [x] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_ https://github.com/elastic/platform-ux-team/issues/533
