### PR TITLE
[Visual Refresh] Fix euiColorFullShade Sass variable mapping

### DIFF
--- a/packages/eui-theme-borealis/src/variables/colors/_colors_light.scss
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_light.scss
@@ -25,7 +25,7 @@ $euiColorLightShade: $euiColorShade30 !default;
 $euiColorMediumShade: $euiColorShade60 !default;
 $euiColorDarkShade: $euiColorShade90 !default;
 $euiColorDarkestShade: $euiColorShade120 !default;
-$euiColorFullShade: $euiColorPlainLight !default;
+$euiColorFullShade: $euiColorPlainDark !default;
 
 // Backgrounds
 $euiPageBackgroundColor: $euiColorShade10 !default; // deprecated


### PR DESCRIPTION
## Summary

>[!NOTE]
This PR merges into a feature branch.

This PR fixes a wrong Sass variable mapping. `euiColorFullShade` in light color mode should be mapped to `euiColorPlainDark` as it's the darkest (legacy) shade. It having been mapped to `euiColorPlainLight` (which is white) was a mistake, likely due to copying.

## QA

There is no actual output of this in EUI. The EUI docs [here](https://eui.elastic.co/pr_8178/#/theming/colors/values#shades) use the legacy JSON tokens as output.