### PR TITLE
chore(website): use workspace version of eui

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -19,7 +19,7 @@
     "@docusaurus/preset-classic": "^3.5.2",
     "@elastic/charts": "^68.0.2",
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "97.2.0",
+    "@elastic/eui": "workspace:^",
     "@elastic/eui-docgen": "workspace:^",
     "@elastic/eui-docusaurus-theme": "workspace:^",
     "@emotion/css": "^11.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4650,7 +4650,7 @@ __metadata:
     "@docusaurus/types": "npm:^3.5.2"
     "@elastic/charts": "npm:^68.0.2"
     "@elastic/datemath": "npm:^5.0.3"
-    "@elastic/eui": "npm:97.2.0"
+    "@elastic/eui": "workspace:^"
     "@elastic/eui-docgen": "workspace:^"
     "@elastic/eui-docusaurus-theme": "workspace:^"
     "@emotion/css": "npm:^11.11.2"
@@ -4727,7 +4727,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@elastic/eui@workspace:packages/eui":
+"@elastic/eui@workspace:^, @elastic/eui@workspace:packages/eui":
   version: 0.0.0-use.local
   resolution: "@elastic/eui@workspace:packages/eui"
   dependencies:


### PR DESCRIPTION
## Summary

When working with the new docs page, local changes to the EUI library are not reflected. That's because `website` package doesn't use workspace version of `eui`. 

**For context:** [Slack](https://elastic.slack.com/archives/C04UK0RDL2J/p1732293051350609)

## QA

### Test path

1. Run `yarn` to install deps.
2. Run `yarn workspaces foreach -Rpti --from @elastic/eui-website run build` to build all local dependency packages.
3. Run `yarn workspace @elastic/eui-website start` to run the new docs website.
4. Choose any component doc page. Change that component's source code (e.g. color).
5. Run `yarn workspace @elastic/eui build` and reload the page. The changes should be visible.

![Screenshot 2024-11-22 at 22 00 14](https://github.com/user-attachments/assets/580c3c77-6d5a-4396-a740-b4452f595a76)
(context: https://github.com/elastic/eui/pull/8177)
