### PR TITLE
[EuiCodeBlock] Improve accessibility of expandable code blocks

### DIFF
--- a/packages/eui/changelogs/upcoming/8195.md
+++ b/packages/eui/changelogs/upcoming/8195.md
@@ -2,6 +2,6 @@
 
 - Improved the accessibility of `EuiCodeBlock`s by
   - adding screen reader only labels
-  - adding `role="dialog` on in fullscreen mode
+  - adding `role="dialog"` on in fullscreen mode
   - ensuring focus is returned on closing fullscreen mode
 

--- a/packages/eui/changelogs/upcoming/8195.md
+++ b/packages/eui/changelogs/upcoming/8195.md
@@ -1,0 +1,7 @@
+**Accessibility**
+
+- Improved the accessibility of `EuiCodeBlock`s by
+  - adding screen reader only labels
+  - adding `role="dialog` on in fullscreen mode
+  - ensuring focus is returned on closing fullscreen mode
+

--- a/packages/eui/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/packages/eui/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -63,6 +63,25 @@ exports[`EuiCodeBlock renders a code block 1`] = `
     class="euiCodeBlock__pre emotion-euiCodeBlock__pre-preWrap-padding"
     tabindex="-1"
   >
+    <span
+      aria-hidden="true"
+      class="euiScreenReaderOnly"
+      data-tabular-copy-marker="no-copy"
+    >
+      ✄𐘗
+    </span>
+    <div
+      class="emotion-euiScreenReaderOnly"
+    >
+      text code block:
+    </div>
+    <span
+      aria-hidden="true"
+      class="euiScreenReaderOnly"
+      data-tabular-copy-marker="no-copy"
+    >
+      ✄𐘗
+    </span>
     <code
       aria-label="aria-label"
       class="euiCodeBlock__code emotion-euiCodeBlock__code"

--- a/packages/eui/src/components/code/code_block.test.tsx
+++ b/packages/eui/src/components/code/code_block.test.tsx
@@ -194,13 +194,13 @@ describe('EuiCodeBlock', () => {
 
         userEvent.keyboard('{enter}');
 
-        waitFor(() =>
+        waitFor(() => {
           expect(
             baseElement.querySelector('.euiCodeBlockFullScreen')
-          ).not.toBeInTheDocument()
-        );
+          ).not.toBeInTheDocument();
 
-        waitFor(() => expect(getByLabelText('Expand')).toHaveFocus());
+          expect(getByLabelText('Expand')).toHaveFocus();
+        });
       });
     });
 

--- a/packages/eui/src/components/code/code_block.test.tsx
+++ b/packages/eui/src/components/code/code_block.test.tsx
@@ -7,7 +7,8 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { requiredProps } from '../../test/required_props';
 import { render } from '../../test/rtl';
@@ -147,7 +148,63 @@ describe('EuiCodeBlock', () => {
       ).toBeInTheDocument();
     });
 
-    it('closes fullscreen mode when the Escape key is pressed', () => {
+    describe('keyboard navigation', () => {
+      it('correctly navigates fullscreen with keyboard', () => {
+        const { getByLabelText, baseElement } = render(
+          <EuiCodeBlock
+            {...requiredProps}
+            language="javascript"
+            overflowHeight={300}
+          >
+            const value = &quot;hello&quot;
+          </EuiCodeBlock>
+        );
+
+        (baseElement.querySelector(
+          '.euiCodeBlock__pre'
+        ) as HTMLPreElement)!.focus(); // start on focusable code block element
+
+        expect(getByLabelText('Expand')).toBeInTheDocument();
+
+        userEvent.keyboard('{tab}');
+
+        waitFor(() => expect(getByLabelText('Expand')).toHaveFocus());
+
+        userEvent.keyboard('{enter}');
+
+        waitFor(() =>
+          expect(
+            baseElement.querySelector('.euiCodeBlockFullScreen')
+          ).toBeInTheDocument()
+        );
+
+        userEvent.keyboard('{tab}');
+
+        waitFor(() =>
+          expect(
+            baseElement.querySelector(
+              '.euiCodeBlockFullScreen .euiCodeBlock__pre'
+            )
+          ).toHaveFocus()
+        );
+
+        userEvent.keyboard('{tab}');
+
+        waitFor(() => expect(getByLabelText('Collapse')).toHaveFocus());
+
+        userEvent.keyboard('{enter}');
+
+        waitFor(() =>
+          expect(
+            baseElement.querySelector('.euiCodeBlockFullScreen')
+          ).not.toBeInTheDocument()
+        );
+
+        waitFor(() => expect(getByLabelText('Expand')).toHaveFocus());
+      });
+    });
+
+    it('closes fullscreen mode when the escape key is pressed', () => {
       const { getByLabelText, baseElement } = render(
         <EuiCodeBlock
           {...requiredProps}
@@ -169,6 +226,8 @@ describe('EuiCodeBlock', () => {
       expect(
         baseElement.querySelector('.euiCodeBlockFullScreen')
       ).not.toBeInTheDocument();
+
+      waitFor(() => expect(getByLabelText('Expand')).toHaveFocus());
     });
   });
 

--- a/packages/eui/src/components/code/code_block.tsx
+++ b/packages/eui/src/components/code/code_block.tsx
@@ -37,6 +37,8 @@ import {
   euiCodeBlockPreStyles,
   euiCodeBlockCodeStyles,
 } from './code_block.styles';
+import { EuiScreenReaderOnly } from '../accessibility';
+import { useEuiI18n } from '../i18n';
 
 // Based on observed line height for non-virtualized code blocks
 const fontSizeToRowHeightMap = {
@@ -235,7 +237,6 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
             : preStyles.whiteSpace.preWrap.controlsOffset.xl),
       ],
       tabIndex: 0,
-      onKeyDown,
     };
 
     return [preProps, preFullscreenProps];
@@ -245,7 +246,6 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
     isVirtualized,
     hasControls,
     paddingSize,
-    onKeyDown,
     tabIndex,
   ]);
 
@@ -264,6 +264,21 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
     };
   }, [codeStyles, language, isVirtualized, rest]);
 
+  const codeBlockLabel = useEuiI18n(
+    'euiCodeBlock.label',
+    '{language} code block:',
+    {
+      language,
+    }
+  );
+  // pre tags don't accept aria-label without an
+  // appropriate role, we add a SR only text instead
+  const codeBlockLabelElement = (
+    <EuiScreenReaderOnly>
+      <div>{codeBlockLabel}</div>
+    </EuiScreenReaderOnly>
+  );
+
   return (
     <div
       css={cssStyles}
@@ -280,6 +295,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
         />
       ) : (
         <pre {...preProps} ref={combinedRef} style={overflowHeightStyles}>
+          {codeBlockLabelElement}
           <code {...codeProps}>{content}</code>
         </pre>
       )}
@@ -289,7 +305,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
       />
 
       {isFullScreen && (
-        <EuiCodeBlockFullScreenWrapper>
+        <EuiCodeBlockFullScreenWrapper onClose={onKeyDown}>
           {isVirtualized ? (
             <EuiCodeBlockVirtualized
               data={data}
@@ -299,6 +315,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
             />
           ) : (
             <pre {...preFullscreenProps}>
+              {codeBlockLabelElement}
               <code {...codeProps}>{content}</code>
             </pre>
           )}

--- a/packages/eui/src/components/code/code_block.tsx
+++ b/packages/eui/src/components/code/code_block.tsx
@@ -14,6 +14,7 @@ import {
   useCombinedRefs,
   useEuiTheme,
   useEuiMemoizedStyles,
+  tabularCopyMarkers,
 } from '../../services';
 import { ExclusiveUnion } from '../common';
 import {
@@ -274,9 +275,13 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   // pre tags don't accept aria-label without an
   // appropriate role, we add a SR only text instead
   const codeBlockLabelElement = (
-    <EuiScreenReaderOnly>
-      <div>{codeBlockLabel}</div>
-    </EuiScreenReaderOnly>
+    <>
+      {tabularCopyMarkers.hiddenNoCopyBoundary}
+      <EuiScreenReaderOnly>
+        <div>{codeBlockLabel}</div>
+      </EuiScreenReaderOnly>
+      {tabularCopyMarkers.hiddenNoCopyBoundary}
+    </>
   );
 
   return (

--- a/packages/eui/src/components/code/code_block_copy.tsx
+++ b/packages/eui/src/components/code/code_block_copy.tsx
@@ -7,6 +7,8 @@
  */
 
 import React, { ReactNode, useMemo } from 'react';
+
+import { noCopyBoundsRegex } from '../../services';
 import { useInnerText } from '../inner_text';
 import { EuiCopy } from '../copy';
 import { useEuiI18n } from '../i18n';
@@ -28,17 +30,23 @@ export const useCopy = ({
   children: ReactNode;
 }) => {
   const [innerTextRef, _innerText] = useInnerText('');
-  const innerText = useMemo(
-    () =>
+  const innerText = useMemo(() => {
+    if (!_innerText) return;
+
+    return (
       _innerText
+        // remove text that should not be copied (e.g. screen reader instructions)
+        ?.replace(noCopyBoundsRegex, '')
         // Normalize line terminations to match native JS format
         ?.replace(NEW_LINE_REGEX_GLOBAL, '\n')
+        // remove initial line break (if there was hidden content removed)
+        ?.replace(/^\n/, '')
         // Reduce two or more consecutive new line characters to a single one
         // This is needed primarily because of how syntax highlighting
         // generated DOM elements affect `innerText` output.
-        .replace(/\n{2,}/g, '\n') || '',
-    [_innerText]
-  );
+        ?.replace(/\n{2,}/g, '\n') || ''
+    );
+  }, [_innerText]);
   const textToCopy = isVirtualized ? `${children}` : innerText; // Virtualized code blocks do not have inner text
 
   const showCopyButton = isCopyable && textToCopy;

--- a/packages/eui/src/components/code/code_block_full_screen.tsx
+++ b/packages/eui/src/components/code/code_block_full_screen.tsx
@@ -13,6 +13,7 @@ import React, {
   useCallback,
   useMemo,
   PropsWithChildren,
+  useRef,
 } from 'react';
 import { keys, useEuiMemoizedStyles } from '../../services';
 import { useEuiI18n } from '../i18n';
@@ -20,6 +21,7 @@ import { EuiButtonIcon } from '../button';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiOverlayMask } from '../overlay_mask';
 import { euiCodeBlockStyles } from './code_block.styles';
+import { EuiDelayRender } from '../delay_render';
 
 /**
  * Hook that returns fullscreen-related state/logic/utils
@@ -29,13 +31,26 @@ export const useFullScreen = ({
 }: {
   overflowHeight?: number | string;
 }) => {
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+
   const showFullScreenButton = !!overflowHeight;
 
   const [isFullScreen, setIsFullScreen] = useState(false);
 
+  const returnFocus = () => {
+    // uses timeout to ensure focus is placed after potential other updates happen
+    setTimeout(() => {
+      toggleButtonRef.current?.focus();
+    });
+  };
+
   const toggleFullScreen = useCallback(() => {
     setIsFullScreen((isFullScreen) => !isFullScreen);
-  }, []);
+
+    if (isFullScreen) {
+      returnFocus();
+    }
+  }, [isFullScreen]);
 
   const onKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
     if (event.key === keys.ESCAPE) {
@@ -48,6 +63,8 @@ export const useFullScreen = ({
         event.preventDefault();
         event.stopPropagation();
         setIsFullScreen(false);
+
+        returnFocus();
       }
     }
   }, []);
@@ -61,14 +78,25 @@ export const useFullScreen = ({
   );
 
   const fullScreenButton = useMemo(() => {
-    return showFullScreenButton ? (
+    const button = (
       <EuiButtonIcon
+        buttonRef={toggleButtonRef}
         className="euiCodeBlock__fullScreenButton"
         onClick={toggleFullScreen}
         iconType={isFullScreen ? 'fullScreenExit' : 'fullScreen'}
         color="text"
         aria-label={isFullScreen ? fullscreenCollapse : fullscreenExpand}
       />
+    );
+
+    return showFullScreenButton ? (
+      isFullScreen ? (
+        // use delay to prevent label being updated in non-fullscreen state before fullscreen is opened
+        // otherwise this causes screen readers to read the collapse label before anything else (as the button was focused when opening)
+        <EuiDelayRender delay={10}>{button}</EuiDelayRender>
+      ) : (
+        button
+      )
     ) : null;
   }, [
     showFullScreenButton,
@@ -89,8 +117,10 @@ export const useFullScreen = ({
  * Portalled full screen wrapper
  */
 export const EuiCodeBlockFullScreenWrapper: FunctionComponent<
-  PropsWithChildren
-> = ({ children }) => {
+  PropsWithChildren & {
+    onClose: (event: React.KeyboardEvent<HTMLElement>) => void;
+  }
+> = ({ children, onClose }) => {
   const styles = useEuiMemoizedStyles(euiCodeBlockStyles);
   const cssStyles = [
     styles.euiCodeBlock,
@@ -98,10 +128,28 @@ export const EuiCodeBlockFullScreenWrapper: FunctionComponent<
     styles.isFullScreen,
   ];
 
+  const ariaLabel = useEuiI18n(
+    'euiCodeBlockFullScreen.ariaLabel',
+    'Expanded code block'
+  );
+
+  // the fullscreen element is fullscreen and has a focus trap, mark it as dialog
+  // to ensure expected semantic definition and behavior for screen readers
+  const dialogProps = {
+    role: 'dialog',
+    'aria-modal': true,
+    'aria-label': ariaLabel,
+    onKeyDown: onClose,
+  };
+
   return (
     <EuiOverlayMask>
       <EuiFocusTrap scrollLock preventScrollOnFocus clickOutsideDisables={true}>
-        <div className="euiCodeBlockFullScreen" css={cssStyles}>
+        <div
+          className="euiCodeBlockFullScreen"
+          css={cssStyles}
+          {...dialogProps}
+        >
           {children}
         </div>
       </EuiFocusTrap>

--- a/packages/eui/src/components/code/code_block_full_screen.tsx
+++ b/packages/eui/src/components/code/code_block_full_screen.tsx
@@ -133,8 +133,6 @@ export const EuiCodeBlockFullScreenWrapper: FunctionComponent<
     'Expanded code block'
   );
 
-  // the fullscreen element is fullscreen and has a focus trap, mark it as dialog
-  // to ensure expected semantic definition and behavior for screen readers
   const dialogProps = {
     role: 'dialog',
     'aria-modal': true,

--- a/packages/eui/src/services/copy/index.ts
+++ b/packages/eui/src/services/copy/index.ts
@@ -9,5 +9,6 @@
 export { copyToClipboard } from './copy_to_clipboard';
 export {
   tabularCopyMarkers,
+  noCopyBoundsRegex,
   OverrideCopiedTabularContent,
 } from './tabular_copy';

--- a/packages/eui/src/services/copy/tabular_copy.tsx
+++ b/packages/eui/src/services/copy/tabular_copy.tsx
@@ -22,7 +22,7 @@ export const CHARS = {
   NO_COPY_BOUND: '✄𐘗',
 };
 // This regex finds all content between two bounds
-const noCopyBoundsRegex = new RegExp(
+export const noCopyBoundsRegex = new RegExp(
   `${CHARS.NO_COPY_BOUND}[^${CHARS.NO_COPY_BOUND}]*${CHARS.NO_COPY_BOUND}`,
   'gs'
 );


### PR DESCRIPTION
## Summary

closes #8175.

This PR aims to improve the accessibility of the `EuiCodeBlock` component, especially the expandable/fullscreen functionality.

### Accessibility issues
1. focusable code blocks did not have any semantic information (the code block is focusable when a `height` is set to provide scrolling via arrow keys - similar to a listbox pattern)
2. entering fullscreen mode (expanded code block) did not announce the change to screen reader users
3. closing the fullscreen mode via the collapse button did not return the focus to the toggle button

### Changes
> 1. focusable code blocks did not have any semantic information

`<pre>` elements don't have any semantic information (without adding a specific `role`) and hence also don't support `aria-label` to add additional semantic information directly. `<code>` elements [don't accept `aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/structural_roles) and similar attributes either.

To address this a screen-reader only text was added inside the element to be read with the content. This includes the `language` prop of the code block to increase context.

```
// example for language="html"

html code block:
<p>
  <!-- Hello world -->
</p>
```

> 2. entering fullscreen mode (expanded code block) did not announce the change to screen reader users

The fullscreen wrapper was not semantically marked and therefore did not provide any information about context change. The container is fullscreen and it has a focus trap, therefore it should be semantically defined as a dialog. Additionally this allows to apply an `aria-label` to the element, providing context on opening the dialog.

This will result in the following experience:

- user opens dialog (expands code block)
> screen reader output: "Expanded code bock, dialog"
> depending on setting the screen reader might read the content of the dialog
- the code block is focused
> screen reader reads: `html code block: <p> ... `
- `ArrowUp/Down` keys navigate the code block content line by line (screen reader browse modes)
- `Escape` key anywhere in the dialog closes the dialog and returns the focus to the expand button
- clicking the collapse button or pressing `Enter` key on it closes the dialog and returns the focus to the expand button


> 3. closing the fullscreen mode via the collapse button did not return the focus to the toggle button

This PR adds a small change to the toggle functionality to ensure the focus is returned to the expand button when closing the fullscreen dialog.

## Testing

__NVDA__

https://github.com/user-attachments/assets/22694abf-7438-434a-8289-9062ecc3b3ab

![Screenshot 2024-11-28 at 15 37 58](https://github.com/user-attachments/assets/d266a4a3-afbb-484f-aa0a-a8be821cc68c)


__JAWS__

https://github.com/user-attachments/assets/4285810d-991a-4908-8a4e-dc5b30a9b27c

![Screenshot 2024-11-28 at 15 36 31](https://github.com/user-attachments/assets/038c98a2-b42c-424a-bb25-34a3e4edb39c)


## QA

- open the [EuiCodeBlock story](https://eui.elastic.co/pr_8195/storybook/index.html?path=/story/editors-syntax-euicodeblock--playground) and set the `overflowHeight` control to `50` to reduce the height and enable the expandable code block

#generic
- [ ] verify the code block can be navigated entirely by keyboard
- [ ] verify there is no regression ([Storybook](https://eui.elastic.co/pr_8195/storybook/index.html?path=/story/editors-syntax-euicodeblock--playground), [EUI docs](https://eui.elastic.co/pr_8195/#/editors-syntax/code#code-block)) in functionality with production ([Storybook](https://eui.elastic.co/storybook/index.html?path=/story/editors-syntax-euicodeblock--playground), [EUI docs](https://eui.elastic.co/#/editors-syntax/code#code-block))
- [ ] verify that copying the code of a code block does not include the screen reader only label

#a11y
- [ ] verify the component provides sufficient semantic context and focus management
  - [ ] verify the code block screen-reader only label is read, announcing it as code block of a specific type (depending on `language` prop)
  - [ ] verify the fullscreen element is a dialog and aria-label is read on opening (reading "Expanded code block, dialog")
  - [ ] verify dialog content can be navigated and closed with screen reader navigation and default keyboard navigation

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles]~(https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
