### PR TITLE
[High Contrast Mode] Allow forced high contrast themes to also force color mode

### DIFF
--- a/packages/eui/changelogs/upcoming/8036.md
+++ b/packages/eui/changelogs/upcoming/8036.md
@@ -1,3 +1,4 @@
 - Updated `EuiProvider` `and `EuiThemeProvider` with a new `highContrastMode`
   - This prop allows toggling a higher contrast visual style that primarily affects borders and shadows
-  - On `EuiProvider`, if the `highContrastMode` prop is not passed, this setting will inherit from the user's OS/system light/dark mode setting
+  - On `EuiProvider`, if the `highContrastMode` prop is not passed, this setting will inherit from the user's OS/system settings
+  - If the user is using a forced colors mode (e.g. Windows' high contrast themes), this system setting will take precedence over any `highContrastMode` or `colorMode` props passed

--- a/packages/eui/src-docs/src/components/guide_theme_selector/guide_theme_selector.tsx
+++ b/packages/eui/src-docs/src/components/guide_theme_selector/guide_theme_selector.tsx
@@ -18,9 +18,17 @@ import {
 export const GuideThemeSelector = () => {
   const context = useContext(ThemeContext);
   const euiThemeContext = useEuiTheme();
-  const colorMode = context.colorMode ?? euiThemeContext.colorMode;
+
+  const isForced = euiThemeContext.highContrastMode === 'forced';
+  const colorMode =
+    context.colorMode && !isForced
+      ? context.colorMode
+      : euiThemeContext.colorMode;
   const highContrastMode =
-    context.highContrastMode ?? euiThemeContext.highContrastMode;
+    context.colorMode && !isForced
+      ? context.highContrastMode
+      : euiThemeContext.highContrastMode;
+
   const currentTheme: EUI_THEME =
     EUI_THEMES.find((theme) => theme.value === context.theme) || EUI_THEMES[0];
 
@@ -51,12 +59,14 @@ export const GuideThemeSelector = () => {
         context.setContext({
           colorMode: e.target.checked ? 'DARK' : 'LIGHT',
         }),
+      disabled: isForced,
     },
     {
       label: 'High contrast',
       checked: !!highContrastMode,
       onChange: (e: EuiSwitchEvent) =>
         context.setContext({ highContrastMode: e.target.checked }),
+      disabled: isForced,
     },
     location.host.includes('803') && {
       label: 'i18n testing',
@@ -102,6 +112,7 @@ export const GuideThemeSelector = () => {
               label={item.label}
               checked={item.checked}
               onChange={item.onChange}
+              disabled={item.disabled}
             />
           </div>
         ) : null

--- a/packages/eui/src-docs/src/views/theme/high_contrast_mode/high_contrast_mode_example.js
+++ b/packages/eui/src-docs/src/views/theme/high_contrast_mode/high_contrast_mode_example.js
@@ -78,8 +78,9 @@ export const HighContrastModeExample = {
           <p>
             Since this is done at a level that EUI can do nothing about, if
             forced colors mode is detected by <strong>EuiProvider</strong>, EUI
-            will ignore any passed <EuiCode>highContrastMode</EuiCode> prop, as
-            this user choice and system setting takes precedence.
+            will ignore any passed <EuiCode>highContrastMode</EuiCode> or{' '}
+            <EuiCode>colorMode</EuiCode> props, as this user choice and system
+            setting takes precedence.
           </p>
           <EuiCallOut>
             To quickly test your application in forced colors mode without

--- a/packages/eui/src/services/theme/provider.test.tsx
+++ b/packages/eui/src/services/theme/provider.test.tsx
@@ -67,6 +67,25 @@ describe('EuiThemeProvider', () => {
         '#000'
       );
     });
+
+    it('detects if color mode is forced from the system and overrides any props', () => {
+      (useWindowMediaMatcher as jest.Mock).mockImplementation((media) => {
+        if (media === '(prefers-color-scheme: dark)') return true;
+        if (media === '(forced-colors: active)') return true;
+      });
+
+      const { getByText } = render(
+        <EuiSystemDefaultsProvider>
+          <EuiThemeProvider colorMode="light">
+            <div css={({ euiTheme }) => ({ color: euiTheme.colors.fullShade })}>
+              Forced dark mode
+            </div>
+          </EuiThemeProvider>
+        </EuiSystemDefaultsProvider>
+      );
+
+      expect(getByText('Forced dark mode')).toHaveStyleRule('color', '#FFF');
+    });
   });
 
   describe('highContrastMode', () => {

--- a/packages/eui/src/services/theme/provider.tsx
+++ b/packages/eui/src/services/theme/provider.tsx
@@ -88,7 +88,7 @@ export const EuiThemeProvider = <T extends {} = {}>({
   const parentTheme = useContext(EuiThemeContext);
 
   // If the user has an OS-wide high contrast theme applied, it will ignore EUI's
-  // colors and light/dark mode. We should respect that use the system setting
+  // colors and light/dark mode. We should respect the user's system setting
   const isForced = parentHighContrastMode === 'forced';
 
   // To reduce the number of window resize listeners, only render a

--- a/packages/eui/src/services/theme/provider.tsx
+++ b/packages/eui/src/services/theme/provider.tsx
@@ -87,8 +87,9 @@ export const EuiThemeProvider = <T extends {} = {}>({
   const parentHighContrastMode = useContext(EuiHighContrastModeContext);
   const parentTheme = useContext(EuiThemeContext);
 
-  const [system, setSystem] = useState(_system || parentSystem);
-  const prevSystemKey = useRef(system.key);
+  // If the user has an OS-wide high contrast theme applied, it will ignore EUI's
+  // colors and light/dark mode. We should respect that use the system setting
+  const isForced = parentHighContrastMode === 'forced';
 
   // To reduce the number of window resize listeners, only render a
   // CurrentEuiBreakpointProvider for the top level parent theme, or for
@@ -98,6 +99,9 @@ export const EuiThemeProvider = <T extends {} = {}>({
       ? CurrentEuiBreakpointProvider
       : Fragment;
   }, [isGlobalTheme, _modifications]);
+
+  const [system, setSystem] = useState(_system || parentSystem);
+  const prevSystemKey = useRef(system.key);
 
   const [modifications, setModifications] = useState<EuiThemeModifications>(
     mergeDeep(parentModifications, _modifications)
@@ -110,11 +114,11 @@ export const EuiThemeProvider = <T extends {} = {}>({
   const prevColorMode = useRef(colorMode);
 
   const highContrastMode: EuiThemeHighContrastMode = useMemo(() => {
-    if (parentHighContrastMode === 'forced') return 'forced'; // System forced high contrast mode will always supercede application settings
+    if (isForced) return 'forced'; // System forced high contrast mode will always supercede application settings
     if (_highContrastMode === true) return 'preferred'; // Convert the boolean prop to our internal enum
     if (_highContrastMode === false) return false; // Allow `false` prop to override user/system preference
     return parentHighContrastMode; // Fall back to the parent/system setting
-  }, [_highContrastMode, parentHighContrastMode]);
+  }, [_highContrastMode, parentHighContrastMode, isForced]);
   const prevHighContrastMode = useRef(highContrastMode);
 
   const modificationsWithHighContrast = useHighContrastModifications({

--- a/packages/eui/src/services/theme/provider.tsx
+++ b/packages/eui/src/services/theme/provider.tsx
@@ -109,7 +109,7 @@ export const EuiThemeProvider = <T extends {} = {}>({
   const prevModifications = useRef(modifications);
 
   const [colorMode, setColorMode] = useState<EuiThemeColorModeStandard>(
-    getColorMode(_colorMode, parentColorMode)
+    getColorMode(_colorMode, parentColorMode, isForced)
   );
   const prevColorMode = useRef(colorMode);
 
@@ -169,13 +169,13 @@ export const EuiThemeProvider = <T extends {} = {}>({
   }, [_modifications, parentModifications]);
 
   useEffect(() => {
-    const newColorMode = getColorMode(_colorMode, parentColorMode);
+    const newColorMode = getColorMode(_colorMode, parentColorMode, isForced);
     if (!isEqual(newColorMode, prevColorMode.current)) {
       setColorMode(newColorMode);
       prevColorMode.current = newColorMode;
       isParentTheme.current = false;
     }
-  }, [_colorMode, parentColorMode]);
+  }, [_colorMode, parentColorMode, isForced]);
 
   useEffect(() => {
     if (prevHighContrastMode.current !== highContrastMode) {

--- a/packages/eui/src/services/theme/utils.test.ts
+++ b/packages/eui/src/services/theme/utils.test.ts
@@ -35,6 +35,9 @@ describe('getColorMode', () => {
   it('uses `parentMode` as fallback', () => {
     expect(getColorMode(undefined, 'DARK')).toEqual('DARK');
   });
+  it('uses `parentMode` (the system OS setting) if isForced is true', () => {
+    expect(getColorMode('LIGHT', 'DARK', true)).toEqual('DARK');
+  });
   it("understands 'INVERSE'", () => {
     expect(getColorMode('INVERSE', 'DARK')).toEqual('LIGHT');
     expect(getColorMode('INVERSE', 'LIGHT')).toEqual('DARK');

--- a/packages/eui/src/services/theme/utils.ts
+++ b/packages/eui/src/services/theme/utils.ts
@@ -44,9 +44,10 @@ export const isInverseColorMode = (
  */
 export const getColorMode = (
   colorMode?: EuiThemeColorMode,
-  parentColorMode?: EuiThemeColorModeStandard
+  parentColorMode?: EuiThemeColorModeStandard,
+  isForced?: boolean
 ): EuiThemeColorModeStandard => {
-  if (colorMode == null) {
+  if (isForced || colorMode == null) {
     return parentColorMode || DEFAULT_COLOR_MODE;
   }
   const mode = colorMode.toUpperCase() as

--- a/packages/website/docs/components/theming/high_contrast_mode.mdx
+++ b/packages/website/docs/components/theming/high_contrast_mode.mdx
@@ -72,7 +72,7 @@ export default () => {
 
 Please note that some OSes and browsers have something called [forced colors mode](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors), which overrides **all** colors, backgrounds, borders, and shadows. An example of this is Windows High Contrast modes.
 
-Since this is done at a level that EUI can do nothing about, if forced colors mode is detected by **EuiProvider**, EUI will ignore *any* passed `highContrastMode` prop, as this user choice and system setting takes precedence.
+Since this is done at a level that EUI can do nothing about, if forced colors mode is detected by **EuiProvider**, EUI will ignore *any* passed `highContrastMode` or `colorMode` prop, as this user choice and system setting takes precedence.
 
 :::tip
 To quickly test your application in forced colors mode without switching OS themes, you can [use Chrome or Edge's devtools to emulate forced-colors mode](https://devtoolstips.org/tips/en/emulate-forced-colors/).


### PR DESCRIPTION
## Summary

> [!note]
> This PR merges into a feature branch.

The impetus for this PR stems from this earlier conversation: https://github.com/elastic/eui/pull/8193#discussion_r1866168485

Essentially, our use of `forced-color-adjust: none` can cause visibility issues with `fullShade/emptyShade`, if we don't respect high contrast themes that force light/dark mode.

At this point, we need to treat forced colors/high contrast themes as superceding any application setting (since they do in reality) - hence this architectural change.

## QA

- Go to https://eui.elastic.co/pr_8200/#/theming/high-contrast-mode
- Use Chrome/Edge devtools > rendering to emulate both forced colors and prefers color scheme media queries
  <img src="https://github.com/user-attachments/assets/f443ad3d-f55b-47d1-a516-b609851ad293" alt="" width="400">
- [x] Confirm that toggling the color scheme correctly updates the color mode, and that EUI's theme switcher toggles in the nav are unable to be toggled

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    ~- [ ] Checked in **mobile**~
    ~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    ~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    ~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    ~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests~**
    ~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist - N/A