### PR TITLE
fix: keep arrow below popover content

### DIFF
--- a/packages/eui/src/components/popover/popover_arrow/_popover_arrow.styles.ts
+++ b/packages/eui/src/components/popover/popover_arrow/_popover_arrow.styles.ts
@@ -22,6 +22,7 @@ export const euiPopoverArrowStyles = (euiThemeContext: UseEuiTheme) => {
     // Base
     euiPopoverArrow: css`
       position: absolute;
+      z-index: -1; // keep arrow below content
       ${logicalSizeCSS(0, 0)}
 
       /* This part of the arrow matches the panel. */


### PR DESCRIPTION
## Summary

Adds a `z-index` of `-1` to popover arrow to prevent stacking on top of popover content.

This issue was noticed in the Lens color mapping UI where we set `panelPaddingSize="none"`, see code [here](https://github.com/elastic/kibana/blob/5145d76fb1159b7a574eafaacbcf57e51cf00273/packages/kbn-coloring/src/shared_components/color_mapping/components/color_picker/color_swatch.tsx#L72-L163). We are not applying any special styles that I can tell but the arrow shows on top of the content, you can see this better when a background color is applied, see below...

![Zight Recording 2024-12-05 at 02 27 02 PM](https://github.com/user-attachments/assets/81fa8a29-44f3-4f52-ab75-68645f55abca)

I was not able to reproduce this in eui docs but another improvement with this change that I did see is the focus state of the popover.

| | Before | After |
|-|--------|--------|
| Chrome | ![Popover - Elastic UI Framework 2024-12-05 at 2 55 55 PM](https://github.com/user-attachments/assets/c5a47d1c-b765-45ce-bbb1-de7d5e72f91c) | ![Popover - Elastic UI Framework 2024-12-05 at 2 56 12 PM](https://github.com/user-attachments/assets/048c0926-364d-48e3-a982-10ab049df292) |
| Firefox | ![firefox-before](https://github.com/user-attachments/assets/a2afaa1b-68c0-4e02-b58e-88484e149389) | ![firefox-after](https://github.com/user-attachments/assets/b16afeff-b53d-4433-bca6-17f456eff950) |

Notice how the arrow slightly occludes the border.

Maybe there is a better solution or issues with this one, open to alternatives.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
