### PR TITLE
[DefaultItemAction] Tooltip now is shown when DefaultItemAction is disabled

### DIFF
--- a/packages/eui/changelogs/upcoming/8134.md
+++ b/packages/eui/changelogs/upcoming/8134.md
@@ -1,0 +1,19 @@
+
+## [Unreleased]
+
+### Added
+- **Wrapper Container for Disabled Items:**
+  - Introduced a higher-level wrapper with `cursor: not-allowed` to properly indicate the disabled status of items.
+  - Added the `default_item_action.styles.ts` file to house additional styles for this and potential future enhancements.
+
+### Removed
+- **Native `title` Option for Disabled Items:**
+  - Removed condition to show tooltip when action item is disabled.
+  - Removed the display of the native `title` attribute when an item is disabled.
+
+### Fixed
+- **`not-allowed` Cursor Behavior:**
+  - Addressed an issue where the `user-select: none` property was overriding the `not-allowed` status. The solution involved applying the cursor style to the wrapper container, ensuring the correct cursor is displayed.
+
+### Visual Improvements
+- Enhanced the disabled state representation with clear visual feedback, including the proper cursor icon and simplified styles.

--- a/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/basic_table.test.tsx.snap
@@ -485,42 +485,50 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           <div
             class="euiTableCellContent emotion-euiTableCellContent-right-wrapText-actions-desktop"
           >
-            <span
-              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            <div
+              class=" icon-wrapper css-1j3nbwz-isDisabled"
             >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                <button
+                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                  type="button"
                 >
                   <span
-                    class="eui-textTruncate euiButtonEmpty__text"
+                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                   >
-                    Edit
+                    <span
+                      class="eui-textTruncate euiButtonEmpty__text"
+                    >
+                      Edit
+                    </span>
                   </span>
-                </span>
-              </button>
-            </span>
-            <span
-              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                </button>
+              </span>
+            </div>
+            <div
+              class=" icon-wrapper css-1j3nbwz-isDisabled"
             >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                <button
+                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                  type="button"
                 >
                   <span
-                    class="eui-textTruncate euiButtonEmpty__text"
+                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                   >
-                    Delete
+                    <span
+                      class="eui-textTruncate euiButtonEmpty__text"
+                    >
+                      Delete
+                    </span>
                   </span>
-                </span>
-              </button>
-            </span>
+                </button>
+              </span>
+            </div>
           </div>
           <span
             aria-hidden="true"
@@ -631,42 +639,50 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           <div
             class="euiTableCellContent emotion-euiTableCellContent-right-wrapText-actions-desktop"
           >
-            <span
-              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            <div
+              class=" icon-wrapper css-1j3nbwz-isDisabled"
             >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                <button
+                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                  type="button"
                 >
                   <span
-                    class="eui-textTruncate euiButtonEmpty__text"
+                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                   >
-                    Edit
+                    <span
+                      class="eui-textTruncate euiButtonEmpty__text"
+                    >
+                      Edit
+                    </span>
                   </span>
-                </span>
-              </button>
-            </span>
-            <span
-              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                </button>
+              </span>
+            </div>
+            <div
+              class=" icon-wrapper css-1j3nbwz-isDisabled"
             >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                <button
+                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                  type="button"
                 >
                   <span
-                    class="eui-textTruncate euiButtonEmpty__text"
+                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                   >
-                    Delete
+                    <span
+                      class="eui-textTruncate euiButtonEmpty__text"
+                    >
+                      Delete
+                    </span>
                   </span>
-                </span>
-              </button>
-            </span>
+                </button>
+              </span>
+            </div>
           </div>
           <span
             aria-hidden="true"
@@ -777,42 +793,50 @@ exports[`EuiBasicTable renders (kitchen sink) with pagination, selection, sortin
           <div
             class="euiTableCellContent emotion-euiTableCellContent-right-wrapText-actions-desktop"
           >
-            <span
-              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+            <div
+              class=" icon-wrapper css-1j3nbwz-isDisabled"
             >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                <button
+                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                  type="button"
                 >
                   <span
-                    class="eui-textTruncate euiButtonEmpty__text"
+                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                   >
-                    Edit
+                    <span
+                      class="eui-textTruncate euiButtonEmpty__text"
+                    >
+                      Edit
+                    </span>
                   </span>
-                </span>
-              </button>
-            </span>
-            <span
-              class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+                </button>
+              </span>
+            </div>
+            <div
+              class=" icon-wrapper css-1j3nbwz-isDisabled"
             >
-              <button
-                class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-                type="button"
+              <span
+                class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
               >
-                <span
-                  class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+                <button
+                  class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+                  type="button"
                 >
                   <span
-                    class="eui-textTruncate euiButtonEmpty__text"
+                    class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
                   >
-                    Delete
+                    <span
+                      class="eui-textTruncate euiButtonEmpty__text"
+                    >
+                      Delete
+                    </span>
                   </span>
-                </span>
-              </button>
-            </span>
+                </button>
+              </span>
+            </div>
           </div>
           <span
             aria-hidden="true"

--- a/packages/eui/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/default_item_action.test.tsx.snap
@@ -1,51 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DefaultItemAction renders an EuiButtonEmpty when \`type="button" 1`] = `
-<span
-  class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+<div
+  class="undefined icon-wrapper css-1j3nbwz-isDisabled"
 >
-  <button
-    class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-    type="button"
-  >
-    <span
-      class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-    >
-      <span
-        class="eui-textTruncate euiButtonEmpty__text"
-      >
-        action1
-      </span>
-    </span>
-  </button>
-</span>
-`;
-
-exports[`DefaultItemAction renders an EuiButtonIcon with screen reader text when \`type="icon"\` 1`] = `
-<div>
   <span
     class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
   >
     <button
-      aria-labelledby="generated-id"
-      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+      class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
       type="button"
     >
       <span
-        aria-hidden="true"
-        class="euiButtonIcon__icon"
-        color="inherit"
-        data-euiicon-type="trash"
-      />
+        class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+      >
+        <span
+          class="eui-textTruncate euiButtonEmpty__text"
+        >
+          action1
+        </span>
+      </span>
     </button>
   </span>
-  <span
-    class="emotion-euiScreenReaderOnly"
-    id="generated-id"
+</div>
+`;
+
+exports[`DefaultItemAction renders an EuiButtonIcon with screen reader text when \`type="icon"\` 1`] = `
+<div>
+  <div
+    class="undefined icon-wrapper css-1j3nbwz-isDisabled"
   >
-    <span>
-      action1
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+    >
+      <button
+        aria-labelledby="generated-id"
+        class="euiButtonIcon emotion-euiButtonIcon-xs-empty-primary"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="trash"
+        />
+      </button>
     </span>
-  </span>
+    <span
+      class="emotion-euiScreenReaderOnly"
+      id="generated-id"
+    >
+      <span>
+        action1
+      </span>
+    </span>
+  </div>
 </div>
 `;

--- a/packages/eui/src/components/basic_table/__snapshots__/expanded_item_actions.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/expanded_item_actions.test.tsx.snap
@@ -2,45 +2,53 @@
 
 exports[`ExpandedItemActions renders 1`] = `
 <div>
-  <span
-    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+  <div
+    class=" icon-wrapper css-1j3nbwz-isDisabled"
   >
-    <button
-      class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-      type="button"
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
     >
-      <span
-        class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+      <button
+        class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+        type="button"
       >
         <span
-          class="eui-textTruncate euiButtonEmpty__text"
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
         >
-          default1
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            default1
+          </span>
         </span>
-      </span>
-    </button>
-  </span>
+      </button>
+    </span>
+  </div>
   <div
     class=""
   />
-  <span
-    class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+  <div
+    class="euiBasicTableAction-showOnHover icon-wrapper css-1j3nbwz-isDisabled"
   >
-    <a
-      class="euiButtonEmpty euiBasicTableAction-showOnHover emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
-      href="#"
-      rel="noreferrer"
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
     >
-      <span
-        class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+      <a
+        class="euiButtonEmpty euiBasicTableAction-showOnHover emotion-euiButtonDisplay-euiButtonEmpty-s-empty-primary-flush-right"
+        href="#"
+        rel="noreferrer"
       >
         <span
-          class="eui-textTruncate euiButtonEmpty__text"
+          class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
         >
-          showOnHover
+          <span
+            class="eui-textTruncate euiButtonEmpty__text"
+          >
+            showOnHover
+          </span>
         </span>
-      </span>
-    </a>
-  </span>
+      </a>
+    </span>
+  </div>
 </div>
 `;

--- a/packages/eui/src/components/basic_table/basic_table.styles.ts
+++ b/packages/eui/src/components/basic_table/basic_table.styles.ts
@@ -57,3 +57,7 @@ export const euiBasicTableBodyLoading = ({ euiTheme }: UseEuiTheme) => css`
 export const safariLoadingWorkaround = css`
   position: relative;
 `;
+
+export const iconButtonWrapper = css`
+  cursor: not-allowed;
+`;

--- a/packages/eui/src/components/basic_table/default_item_action.styles.ts
+++ b/packages/eui/src/components/basic_table/default_item_action.styles.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+
+export const euiIconButtonWrapperStyles = () => {
+  return {
+    isDisabled: css`
+      cursor: not-allowed;
+    `,
+  };
+};

--- a/packages/eui/src/components/basic_table/default_item_action.tsx
+++ b/packages/eui/src/components/basic_table/default_item_action.tsx
@@ -22,6 +22,8 @@ import {
   DefaultItemAction as Action,
   callWithItemIfFunction,
 } from './action_types';
+import { useEuiMemoizedStyles } from '../../services';
+import { euiIconButtonWrapperStyles } from './default_item_action.styles';
 
 export interface DefaultItemActionProps<T extends object> {
   action: Action<T>;
@@ -65,6 +67,9 @@ export const DefaultItemAction = <T extends object>({
   let ariaLabelledBy: ReactNode;
   let button;
 
+  const styles = useEuiMemoizedStyles(euiIconButtonWrapperStyles);
+  const cssStyles = [styles.isDisabled];
+
   if (action.type === 'icon') {
     if (!icon) {
       throw new Error(`Cannot render item action [${action.name}]. It is configured to render as an icon but no
@@ -81,9 +86,6 @@ export const DefaultItemAction = <T extends object>({
         href={href}
         target={action.target}
         data-test-subj={dataTestSubj}
-        // If action is disabled, the normal tooltip can't show - attempt to
-        // provide some amount of affordance with a browser title tooltip
-        title={!enabled ? tooltipContent : undefined}
       />
     );
     // actionContent (action.name) is a ReactNode and must be rendered
@@ -112,19 +114,14 @@ export const DefaultItemAction = <T extends object>({
     );
   }
 
-  return enabled ? (
-    <>
+  return (
+    <div css={cssStyles} className={`${className} icon-wrapper`}>
       <EuiToolTip content={tooltipContent} delay="long">
         {button}
       </EuiToolTip>
       {/* SR text has to be rendered outside the tooltip,
       otherwise EuiToolTip's own aria-labelledby won't properly clone */}
       {ariaLabelledBy}
-    </>
-  ) : (
-    <>
-      {button}
-      {ariaLabelledBy}
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary

This PR provides:

- A simple implementation to solve the issue #8134.
- A workaround to the "not-allowed" status on the action.
- Behavior is the same as enabled. 

## About implementation

- Removed the option to show a native `title` when the item is disabled.
![image](https://github.com/user-attachments/assets/0ad67aff-fcd3-46a5-b70f-1057671a7cc2)

- Implemented a wrapper container to show the status `not-allowed` when it's disable. This workaround arose because when disabled, the `user-select: none` property overrode the `not-allowed` status, preventing the corresponding icon from being displayed. So, the solution was to apply the `cursor: not-allowed`, to a higher level wrapper.

![image](https://github.com/user-attachments/assets/f45464d1-6a04-44c3-b8bf-3055fd254964)

- A `default_item_action.styles.ts` file was added to include all the aditional styles to this new wrapper (and many more in the future if necessary for this component).

![image](https://github.com/user-attachments/assets/6caee52f-9280-44f0-817a-86287132f700)

Here's a short video with the visible changes implemented:


https://github.com/user-attachments/assets/8e2e95a9-2d96-4212-abed-7a8e0866cf05


## QA

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox** (And Opera and Brave)
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
