### PR TITLE
Eui theme/borealis align popover arrow styles

### DIFF
--- a/packages/eui/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
+++ b/packages/eui/src/components/basic_table/__snapshots__/collapsed_item_actions.test.tsx.snap
@@ -48,14 +48,18 @@ exports[`CollapsedItemActions custom actions 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: -22px; left: -16px; z-index: 2000;"
+        style="top: -18px; left: -16px; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-left"
-          data-popover-arrow="left"
-          style="left: 0px; top: 10px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="top: 9px; left: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-left"
+            data-popover-arrow="left"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -158,14 +162,18 @@ exports[`CollapsedItemActions default actions 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: -22px; left: -16px; z-index: 2000;"
+        style="top: -18px; left: -16px; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-left"
-          data-popover-arrow="left"
-          style="left: 0px; top: 10px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="top: 9px; left: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-left"
+            data-popover-arrow="left"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/breadcrumbs/__snapshots__/_breadcrumb_content.test.tsx.snap
+++ b/packages/eui/src/components/breadcrumbs/__snapshots__/_breadcrumb_content.test.tsx.snap
@@ -46,14 +46,18 @@ exports[`EuiBreadcrumbContent breadcrumbs with popovers renders with \`popoverCo
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -18px; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
+++ b/packages/eui/src/components/breadcrumbs/__snapshots__/breadcrumb.test.tsx.snap
@@ -61,14 +61,18 @@ exports[`EuiBreadcrumbCollapsed renders a ... breadcrumb with collapsed content 
         data-autofocus="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/code/__snapshots__/code_block_annotations.test.tsx.snap
+++ b/packages/eui/src/components/code/__snapshots__/code_block_annotations.test.tsx.snap
@@ -41,14 +41,18 @@ exports[`EuiCodeBlockAnnotation renders 1`] = `
         data-popover-panel="true"
         data-test-subj="euiCodeBlockAnnotationPopover"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 6001;"
+        style="top: 16px; left: -18px; z-index: 6001;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
@@ -61,14 +61,18 @@ exports[`KibanaCollapsibleNavSolution renders docked icons: popover 1`] = `
   data-popover-open="true"
   data-popover-panel="true"
   role="dialog"
-  style="top: -22px; left: 16px; z-index: 2000;"
+  style="top: -18px; left: 16px; z-index: 2000;"
   tabindex="0"
 >
   <div
-    class="euiPopover__arrow emotion-euiPopoverArrow-right"
-    data-popover-arrow="right"
-    style="left: 0px; top: 10px;"
-  />
+    class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+    style="top: 9px; right: 100%;"
+  >
+    <div
+      class="euiPopover__arrow emotion-euiPopoverArrow-right"
+      data-popover-arrow="right"
+    />
+  </div>
   <p
     class="emotion-euiScreenReaderOnly"
     id="generated-id"
@@ -188,7 +192,7 @@ exports[`KibanaCollapsibleNavSolution renders with a solution switcher: popover 
   data-popover-open="true"
   data-popover-panel="true"
   role="dialog"
-  style="top: 0px; left: -22px; z-index: 2000; inline-size: 0px;"
+  style="top: 0px; left: -18px; z-index: 2000; inline-size: 0px;"
   tabindex="0"
 >
   <p

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_button.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`EuiCollapsedNavButton renders a tooltip around the icon button 1`] = `
     >
       <div
         class="euiToolTip__arrow emotion-euiToolTip__arrow-left"
-        style="left: 0px; top: 4px;"
+        style="top: 3px; left: 100%;"
       />
       <div>
         Nav item

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/__snapshots__/collapsed_nav_popover.test.tsx.snap
@@ -47,14 +47,18 @@ exports[`EuiCollapsedNavPopover renders 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: -22px; left: 16px; z-index: 2000;"
+        style="top: -18px; left: 16px; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-right"
-          data-popover-arrow="right"
-          style="left: 0px; top: 10px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="top: 9px; right: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-right"
+            data-popover-arrow="right"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
+++ b/packages/eui/src/components/color_picker/color_palette_picker/__snapshots__/color_palette_picker.test.tsx.snap
@@ -381,7 +381,7 @@ exports[`EuiColorPalettePicker more props are propagated to each option 1`] = `
         class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-light-isAttached-bottom"
         data-popover-panel="true"
         role="dialog"
-        style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
+        style="top: 0px; left: -18px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
       >
         <div>
           <div

--- a/packages/eui/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/packages/eui/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 0px; left: -22px; z-index: 2000; inline-size: 0px;"
+        style="top: 0px; left: -18px; z-index: 2000; inline-size: 0px;"
       >
         <div>
           <div

--- a/packages/eui/src/components/context_menu/__snapshots__/context_menu_item.test.tsx.snap
+++ b/packages/eui/src/components/context_menu/__snapshots__/context_menu_item.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`EuiContextMenuItem tooltip behavior 1`] = `
       </div>
       <div
         class="euiToolTip__arrow emotion-euiToolTip__arrow-top"
-        style="left: 4px; top: 0px;"
+        style="left: 3px; top: 100%;"
       />
       <div>
         tooltip content

--- a/packages/eui/src/components/datagrid/body/header/__snapshots__/column_actions.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/body/header/__snapshots__/column_actions.test.tsx.snap
@@ -42,14 +42,18 @@ exports[`ColumnActions renders 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 23px; left: -22px; z-index: 2000;"
+        style="top: 23px; left: -18px; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/column_selector.test.tsx.snap
@@ -54,14 +54,18 @@ exports[`useDataGridColumnSelector columnSelector renders a toolbar button/popov
         data-autofocus="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -54,14 +54,18 @@ exports[`DataGridSortingControl renders a toolbar button/popover allowing users 
         data-autofocus="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/display_selector.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/display_selector.test.tsx.snap
@@ -240,14 +240,18 @@ exports[`useDataGridDisplaySelector displaySelector renders a toolbar button/pop
         data-autofocus="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/keyboard_shortcuts.test.tsx.snap
@@ -549,14 +549,18 @@ exports[`useDataGridKeyboardShortcuts [React 18] returns a popover containing a 
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; z-index: 2000;"
+        style="top: 16px; left: -18px; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/form/range/__snapshots__/range.test.tsx.snap
+++ b/packages/eui/src/components/form/range/__snapshots__/range.test.tsx.snap
@@ -454,7 +454,7 @@ exports[`EuiRange props slider should display in popover 1`] = `
         data-popover-panel="true"
         data-test-subj="test"
         role="dialog"
-        style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
+        style="top: 0px; left: -18px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
       >
         <p
           class="emotion-euiScreenReaderOnly"

--- a/packages/eui/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
+++ b/packages/eui/src/components/form/super_select/__snapshots__/super_select.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`EuiSuperSelect renders 1`] = `
         class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-light-isAttached-bottom"
         data-popover-panel="true"
         role="dialog"
-        style="top: 0px; left: -22px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
+        style="top: 0px; left: -18px; will-change: transform, opacity; z-index: 2000; inline-size: 0px;"
       >
         <div>
           <div

--- a/packages/eui/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
+++ b/packages/eui/src/components/popover/__snapshots__/popover.rtl.test.tsx.snap
@@ -44,14 +44,18 @@ exports[`EuiPopover snapshot testing renders with popover contents 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/popover/__snapshots__/popover.test.tsx.snap
+++ b/packages/eui/src/components/popover/__snapshots__/popover.test.tsx.snap
@@ -70,14 +70,17 @@ exports[`EuiPopover props arrowChildren is rendered 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
         >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
           <span />
         </div>
         <p
@@ -122,14 +125,18 @@ exports[`EuiPopover props buffer 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -172,14 +179,18 @@ exports[`EuiPopover props buffer for all sides 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -231,14 +242,18 @@ exports[`EuiPopover props focusTrapProps is rendered 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -290,14 +305,18 @@ exports[`EuiPopover props isOpen renders true 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -340,14 +359,18 @@ exports[`EuiPopover props ownFocus defaults to true 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -388,13 +411,17 @@ exports[`EuiPopover props ownFocus renders false 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <div />
       </div>
     </div>
@@ -431,14 +458,18 @@ exports[`EuiPopover props panelClassName is rendered 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -481,14 +512,18 @@ exports[`EuiPopover props panelPaddingSize is rendered 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -532,14 +567,18 @@ exports[`EuiPopover props panelProps is rendered 1`] = `
         data-popover-panel="true"
         data-test-subj="test subject string"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"
@@ -581,13 +620,17 @@ exports[`EuiPopover props popoverScreenReaderText 1`] = `
         data-popover-open="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: 16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: 16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
-          data-popover-arrow="bottom"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; bottom: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+            data-popover-arrow="bottom"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/popover/popover.tsx
+++ b/packages/eui/src/components/popover/popover.tsx
@@ -543,7 +543,7 @@ export class EuiPopover extends Component<Props, State> {
         ? 16 + offset
         : 8 + offset,
       arrowConfig: this.props.hasArrow
-        ? { arrowWidth: 24, arrowBuffer: 10 }
+        ? { arrowWidth: 16, arrowBuffer: 10 }
         : { arrowWidth: 0, arrowBuffer: 0 },
       returnBoundingBox: this.props.attachToAnchor,
       allowCrossAxis: this.props.repositionToCrossAxis,

--- a/packages/eui/src/components/popover/popover_arrow/__snapshots__/_popover_arrow.test.tsx.snap
+++ b/packages/eui/src/components/popover/popover_arrow/__snapshots__/_popover_arrow.test.tsx.snap
@@ -3,35 +3,51 @@
 exports[`EuiPopoverArrow position bottom is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiPopoverArrow-bottom-euiTestCss"
-  data-popover-arrow="bottom"
+  class="testClass1 testClass2 emotion-euiPopoverArrowWrapper-euiTestCss"
   data-test-subj="test subject string"
-/>
+>
+  <div
+    class="euiPopover__arrow emotion-euiPopoverArrow-bottom"
+    data-popover-arrow="bottom"
+  />
+</div>
 `;
 
 exports[`EuiPopoverArrow position left is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiPopoverArrow-left-euiTestCss"
-  data-popover-arrow="left"
+  class="testClass1 testClass2 emotion-euiPopoverArrowWrapper-euiTestCss"
   data-test-subj="test subject string"
-/>
+>
+  <div
+    class="euiPopover__arrow emotion-euiPopoverArrow-left"
+    data-popover-arrow="left"
+  />
+</div>
 `;
 
 exports[`EuiPopoverArrow position right is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiPopoverArrow-right-euiTestCss"
-  data-popover-arrow="right"
+  class="testClass1 testClass2 emotion-euiPopoverArrowWrapper-euiTestCss"
   data-test-subj="test subject string"
-/>
+>
+  <div
+    class="euiPopover__arrow emotion-euiPopoverArrow-right"
+    data-popover-arrow="right"
+  />
+</div>
 `;
 
 exports[`EuiPopoverArrow position top is rendered 1`] = `
 <div
   aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiPopoverArrow-top-euiTestCss"
-  data-popover-arrow="top"
+  class="testClass1 testClass2 emotion-euiPopoverArrowWrapper-euiTestCss"
   data-test-subj="test subject string"
-/>
+>
+  <div
+    class="euiPopover__arrow emotion-euiPopoverArrow-top"
+    data-popover-arrow="top"
+  />
+</div>
 `;

--- a/packages/eui/src/components/popover/popover_arrow/_popover_arrow.styles.ts
+++ b/packages/eui/src/components/popover/popover_arrow/_popover_arrow.styles.ts
@@ -7,63 +7,31 @@
  */
 
 import { css } from '@emotion/react';
-import { logicalSizeCSS, mathWithUnits } from '../../../global_styling';
+import { logicalSizeCSS } from '../../../global_styling';
+import { _popoverArrowStyles } from '../../../services/popover';
 import { UseEuiTheme } from '../../../services';
 
-export const popoverArrowSize = 'base';
-
 export const euiPopoverArrowStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
+  const { euiTheme, colorMode } = euiThemeContext;
+  const hasBorder = colorMode === 'DARK';
 
-  const arrowColor = 'var(--euiPopoverBackgroundColor)';
-  const borderColor = euiTheme.colors.borderBaseFloating;
-  const arrowSizeBase = euiTheme.size[popoverArrowSize];
-  const arrowSize = mathWithUnits(arrowSizeBase, (x) => x + 3); // calculation to ensure size parity
-
-  const arrowPlusSize = mathWithUnits(arrowSize, (x) => (x / 2 + 1) * -1);
-  const arrowMinusSize = mathWithUnits(arrowSize, (x) => (x / 2 - 1) * -1);
-
-  const adjustedPosition = 'calc(25% - 2px)';
+  const arrowSize = euiTheme.size.base;
+  const arrowStyles = _popoverArrowStyles(euiThemeContext, arrowSize);
 
   return {
+    // Wrapper
+    euiPopoverArrowWrapper: css`
+      position: absolute;
+      ${logicalSizeCSS(arrowSize)}
+    `,
+
     // Base
     euiPopoverArrow: css`
-      position: absolute;
-      ${logicalSizeCSS(arrowSize, arrowSize)}
-      transform-origin: center;
-      border-radius: ${mathWithUnits(
-        euiTheme.border.radius.small,
-        (x) => x / 2
-      )};
-      border: ${euiTheme.border.width.thin} solid transparent;
-      background-color: ${arrowColor};
+      ${arrowStyles._arrowStyles}
+      background-color: var(--euiPopoverBackgroundColor);
+      ${hasBorder ? `border: ${euiTheme.border.thin}` : ''}
     `,
 
-    // POSITIONS
-    top: css`
-      border-block-end-color: ${borderColor};
-      border-inline-end-color: ${borderColor};
-      transform: translate(${adjustedPosition}, ${arrowPlusSize}) rotateZ(45deg);
-    `,
-
-    bottom: css`
-      border-block-start-color: ${borderColor};
-      border-inline-start-color: ${borderColor};
-      transform: translate(${adjustedPosition}, ${arrowMinusSize})
-        rotateZ(45deg);
-    `,
-
-    left: css`
-      border-block-start-color: ${borderColor};
-      border-inline-end-color: ${borderColor};
-      transform: translate(${arrowPlusSize}, ${adjustedPosition}) rotateZ(45deg);
-    `,
-
-    right: css`
-      border-block-end-color: ${borderColor};
-      border-inline-start-color: ${borderColor};
-      transform: translate(${arrowMinusSize}, ${adjustedPosition})
-        rotateZ(45deg);
-    `,
+    ...arrowStyles.positions,
   };
 };

--- a/packages/eui/src/components/popover/popover_arrow/_popover_arrow.tsx
+++ b/packages/eui/src/components/popover/popover_arrow/_popover_arrow.tsx
@@ -7,9 +7,9 @@
  */
 
 import React, { HTMLAttributes, FunctionComponent } from 'react';
+import { useEuiTheme } from '../../../services';
 import { CommonProps } from '../../common';
 import { euiPopoverArrowStyles } from './_popover_arrow.styles';
-import { useEuiTheme } from '../../../services';
 
 export const POSITIONS = ['top', 'left', 'right', 'bottom'] as const;
 export type EuiPopoverArrowPositions = (typeof POSITIONS)[number];
@@ -22,6 +22,7 @@ export type EuiPopoverArrowProps = HTMLAttributes<HTMLDivElement> &
 export const EuiPopoverArrow: FunctionComponent<EuiPopoverArrowProps> = ({
   children,
   position,
+  style,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -30,11 +31,16 @@ export const EuiPopoverArrow: FunctionComponent<EuiPopoverArrowProps> = ({
 
   return (
     <div
-      className="euiPopover__arrow"
-      data-popover-arrow={position}
-      css={cssStyles}
+      className="euiPopover__arrowWrapper"
+      css={styles.euiPopoverArrowWrapper}
+      style={style}
       {...rest}
     >
+      <div
+        className="euiPopover__arrow"
+        data-popover-arrow={position}
+        css={cssStyles}
+      />
       {children}
     </div>
   );

--- a/packages/eui/src/components/popover/popover_panel/_popover_panel.styles.ts
+++ b/packages/eui/src/components/popover/popover_panel/_popover_panel.styles.ts
@@ -40,6 +40,8 @@ export const euiPopoverPanelStyles = (euiThemeContext: UseEuiTheme) => {
     euiTheme.animation.bounce
   } ${mathWithUnits(animationSpeed, (x) => x + 100)}`;
 
+  const hasVisibleBorder = colorMode === 'DARK';
+
   return {
     // Base
     euiPopover__panel: css`
@@ -50,6 +52,8 @@ export const euiPopoverPanelStyles = (euiThemeContext: UseEuiTheme) => {
       pointer-events: none;
       opacity: 0; /* 2 */
       background-color: var(--euiPopoverBackgroundColor); /* 4 */
+      border: ${euiTheme.border.width.thin} solid
+        ${hasVisibleBorder ? euiTheme.border.color : 'transparent'};
 
       ${euiCanAnimate} {
         /* 2 */
@@ -58,16 +62,6 @@ export const euiPopoverPanelStyles = (euiThemeContext: UseEuiTheme) => {
 
       &:focus {
         outline-offset: 0;
-      }
-
-      &::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        border-radius: inherit;
-        border: ${euiTheme.border.width.thin} solid
-          ${euiTheme.colors.borderBaseFloating};
-        pointer-events: none;
       }
     `,
     isOpen: css`

--- a/packages/eui/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
+++ b/packages/eui/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
@@ -557,7 +557,7 @@ exports[`EuiSelectableListItem props tooltip behavior on mouseover 1`] = `
       </div>
       <div
         class="euiToolTip__arrow emotion-euiToolTip__arrow-top"
-        style="left: 4px; top: 0px;"
+        style="left: 3px; top: 100%;"
       />
       <div>
         I am a tooltip!
@@ -637,7 +637,7 @@ exports[`EuiSelectableListItem props tooltip behavior when isFocused 1`] = `
       </div>
       <div
         class="euiToolTip__arrow emotion-euiToolTip__arrow-top"
-        style="left: 4px; top: 0px;"
+        style="left: 3px; top: 100%;"
       />
       <div>
         I am a tooltip!

--- a/packages/eui/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
+++ b/packages/eui/src/components/table/table_pagination/__snapshots__/table_pagination.test.tsx.snap
@@ -209,14 +209,18 @@ exports[`EuiTablePagination renders 1`] = `
         data-autofocus="true"
         data-popover-panel="true"
         role="dialog"
-        style="top: -16px; left: -22px; will-change: transform, opacity; z-index: 2000;"
+        style="top: -16px; left: -18px; will-change: transform, opacity; z-index: 2000;"
         tabindex="0"
       >
         <div
-          class="euiPopover__arrow emotion-euiPopoverArrow-top"
-          data-popover-arrow="top"
-          style="left: 10px; top: 0px;"
-        />
+          class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+          style="left: 9px; top: 100%;"
+        >
+          <div
+            class="euiPopover__arrow emotion-euiPopoverArrow-top"
+            data-popover-arrow="top"
+          />
+        </div>
         <p
           class="emotion-euiScreenReaderOnly"
           id="generated-id"

--- a/packages/eui/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/packages/eui/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`EuiToolTip shows tooltip on mouseover and focus 1`] = `
       </div>
       <div
         class="euiToolTip__arrow emotion-euiToolTip__arrow-top"
-        style="left: 4px; top: 0px;"
+        style="left: 3px; top: 100%;"
       />
       <div>
         content

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -10,7 +10,8 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { enableFunctionToggleControls } from '../../../.storybook/utils';
-import { LOKI_SELECTORS } from '../../../.storybook/loki';
+import { LOKI_SELECTORS, lokiPlayDecorator } from '../../../.storybook/loki';
+import { sleep } from '../../test';
 import { EuiFlexGroup } from '../flex';
 import { EuiButton } from '../button';
 import { EuiToolTip, EuiToolTipProps } from './tool_tip';
@@ -59,16 +60,8 @@ export const Playground: Story = {
     children: <EuiButton autoFocus>Tooltip trigger</EuiButton>,
     content: 'tooltip content',
   },
-  // play: lokiPlayDecorator(async (context) => {
-  //   const { bodyElement, step } = context;
-
-  //   const canvas = within(bodyElement);
-
-  //   await step('show tooltip on click', async () => {
-  //     await userEvent.click(canvas.getByRole('button'));
-  //     await waitFor(() => {
-  //       expect(canvas.getByRole('tooltip')).toBeVisible();
-  //     });
-  //   });
-  // }),
+  play: lokiPlayDecorator(async () => {
+    // Reduce VRT flakiness/screenshots before tooltip is fully visible
+    await sleep(300);
+  }),
 };

--- a/packages/eui/src/components/tool_tip/tool_tip.styles.ts
+++ b/packages/eui/src/components/tool_tip/tool_tip.styles.ts
@@ -7,14 +7,9 @@
  */
 
 import { css, keyframes } from '@emotion/react';
-import {
-  logicalCSS,
-  logicalSizeCSS,
-  euiFontSize,
-  euiCanAnimate,
-  mathWithUnits,
-} from '../../global_styling';
+import { logicalCSS, euiFontSize, euiCanAnimate } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
+import { _popoverArrowStyles } from '../../services/popover';
 import { euiShadow } from '../../themes/amsterdam';
 
 export const euiToolTipBackgroundColor = (euiTheme: UseEuiTheme['euiTheme']) =>
@@ -48,20 +43,21 @@ const euiToolTipAnimationHorizontal = (size: string) => keyframes`
 `;
 
 export const euiToolTipStyles = (euiThemeContext: UseEuiTheme) => {
-  const { euiTheme } = euiThemeContext;
+  const { euiTheme, colorMode } = euiThemeContext;
+
+  const hasVisibleBorder = colorMode === 'DARK';
   const animationTiming = `${euiTheme.animation.slow} ease-out 0s forwards`;
-  // Shift arrow 1px more than half its size to account for border radius
+
   const arrowSize = euiTheme.size.m;
-  const arrowPlusSize = mathWithUnits(arrowSize, (x) => (x / 2 + 1) * -1);
-  const arrowMinusSize = mathWithUnits(arrowSize, (x) => (x / 2 - 1) * -1);
+  const arrowStyles = _popoverArrowStyles(euiThemeContext, arrowSize);
 
   return {
     // Base
     euiToolTip: css`
       ${euiShadow(euiThemeContext)}
-      border-radius: ${euiTheme.border.radius.medium};
       border: ${euiTheme.border.width.thin} solid
-        ${euiTheme.components.tooltipBorderFloating};
+        ${hasVisibleBorder ? euiTheme.border.color : 'transparent'};
+      border-radius: ${euiTheme.border.radius.medium};
       background-color: ${euiToolTipBackgroundColor(euiTheme)};
       color: ${euiTheme.colors.ghost};
       z-index: ${euiTheme.levels.toast};
@@ -107,39 +103,11 @@ export const euiToolTipStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     // Arrow
     euiToolTip__arrow: css`
-      content: '';
-      position: absolute;
-      transform-origin: center;
-      border-radius: ${mathWithUnits(
-        euiTheme.border.radius.small,
-        (x) => x / 2
-      )};
-      border: ${euiTheme.border.width.thin} solid transparent;
-      background-color: ${euiToolTipBackgroundColor(euiTheme)};
-      ${logicalSizeCSS(arrowSize, arrowSize)}
+      ${arrowStyles._arrowStyles}
+      background-color: inherit;
+      border: inherit;
     `,
-    arrowPositions: {
-      top: css`
-        border-block-end-color: ${euiTheme.colors.borderBaseFloating};
-        border-inline-end-color: ${euiTheme.colors.borderBaseFloating};
-        transform: translateY(${arrowPlusSize}) rotateZ(45deg);
-      `,
-      bottom: css`
-        border-block-start-color: ${euiTheme.colors.borderBaseFloating};
-        border-inline-start-color: ${euiTheme.colors.borderBaseFloating};
-        transform: translateY(${arrowMinusSize}) rotateZ(45deg);
-      `,
-      left: css`
-        border-block-start-color: ${euiTheme.colors.borderBaseFloating};
-        border-inline-end-color: ${euiTheme.colors.borderBaseFloating};
-        transform: translateX(${arrowPlusSize}) rotateZ(45deg);
-      `,
-      right: css`
-        border-block-end-color: ${euiTheme.colors.borderBaseFloating};
-        border-inline-start-color: ${euiTheme.colors.borderBaseFloating};
-        transform: translateX(${arrowMinusSize}) rotateZ(45deg);
-      `,
-    },
+    arrowPositions: arrowStyles.positions,
     // Title
     euiToolTip__title: css`
       font-weight: ${euiTheme.font.weight.bold};

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -17,6 +17,7 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../common';
 import { findPopoverPosition, htmlIdGenerator, keys } from '../../services';
+import { type EuiPopoverPosition } from '../../services/popover';
 import { enqueueStateChange } from '../../services/react';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { EuiPortal } from '../portal';
@@ -117,7 +118,7 @@ interface State {
   hasFocus: boolean;
   calculatedPosition: ToolTipPositions;
   toolTipStyles: ToolTipStyles;
-  arrowStyles: undefined | { left: number; top: number };
+  arrowStyles?: Record<EuiPopoverPosition, number | string>;
   id: string;
 }
 

--- a/packages/eui/src/components/tour/__snapshots__/tour_step.test.tsx.snap
+++ b/packages/eui/src/components/tour/__snapshots__/tour_step.test.tsx.snap
@@ -27,13 +27,16 @@ exports[`EuiTourStep renders 1`] = `
           data-popover-open="true"
           data-popover-panel="true"
           role="dialog"
-          style="top: -22px; left: -26px; will-change: transform, opacity; z-index: 2000;"
+          style="top: -18px; left: -26px; will-change: transform, opacity; z-index: 2000;"
         >
           <div
-            class="euiPopover__arrow emotion-euiPopoverArrow-left"
-            data-popover-arrow="left"
-            style="left: 0px; top: 10px;"
+            class="euiPopover__arrowWrapper emotion-euiPopoverArrowWrapper"
+            style="top: 9px; left: 100%;"
           >
+            <div
+              class="euiPopover__arrow emotion-euiPopoverArrow-left"
+              data-popover-arrow="left"
+            />
             <div
               class="euiBeacon euiTour__beacon emotion-euiBeacon-success-euiTourBeacon-isOpen-left"
               style="block-size: 12px; inline-size: 12px;"

--- a/packages/eui/src/components/tour/tour.styles.ts
+++ b/packages/eui/src/components/tour/tour.styles.ts
@@ -10,7 +10,6 @@ import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
 import { logicalCSS, mathWithUnits, euiCanAnimate } from '../../global_styling';
 import { openAnimationTiming } from '../popover/popover_panel/_popover_panel.styles';
-import { popoverArrowSize } from '../popover/popover_arrow/_popover_arrow.styles';
 
 import { _tourFooterBgColor } from './_tour_footer.styles';
 
@@ -24,9 +23,8 @@ export const euiTourStyles = (euiThemeContext: UseEuiTheme) => ({
 });
 
 export const euiTourBeaconStyles = ({ euiTheme }: UseEuiTheme) => {
-  const arrowSize = euiTheme.size[popoverArrowSize];
-  const arrowHalfSize = mathWithUnits(arrowSize, (x) => x / 2);
-  const arrowOffset = mathWithUnits(arrowSize, (x) => x * -2);
+  const beaconSize = euiTheme.size.m;
+  const beaconOffset = mathWithUnits(beaconSize, (x) => x / -2);
 
   return {
     // Base
@@ -45,20 +43,24 @@ export const euiTourBeaconStyles = ({ euiTheme }: UseEuiTheme) => {
     `,
     // Positions
     right: css`
-      ${logicalCSS('top', arrowHalfSize)}
-      ${logicalCSS('left', arrowOffset)}
+      ${logicalCSS('top', '50%')}
+      ${logicalCSS('left', '-50%')}
+      ${logicalCSS('margin-top', beaconOffset)}
     `,
     left: css`
-      ${logicalCSS('top', arrowHalfSize)}
-      ${logicalCSS('left', arrowSize)}
+      ${logicalCSS('top', '50%')}
+      ${logicalCSS('right', '-50%')}
+      ${logicalCSS('margin-top', beaconOffset)}
     `,
     top: css`
-      ${logicalCSS('top', arrowSize)}
-      ${logicalCSS('left', arrowHalfSize)}
+      ${logicalCSS('left', '50%')}
+      ${logicalCSS('bottom', '-50%')}
+      ${logicalCSS('margin-left', beaconOffset)}
     `,
     bottom: css`
-      ${logicalCSS('top', arrowOffset)}
-      ${logicalCSS('left', arrowHalfSize)}
+      ${logicalCSS('left', '50%')}
+      ${logicalCSS('top', '-50%')}
+      ${logicalCSS('margin-left', beaconOffset)}
     `,
   };
 };

--- a/packages/eui/src/services/popover/index.ts
+++ b/packages/eui/src/services/popover/index.ts
@@ -8,4 +8,7 @@
 
 export { calculatePopoverPosition } from './calculate_popover_position';
 export { findPopoverPosition, getElementZIndex } from './popover_positioning';
+
+// Not exported as public APIs
+export { _popoverArrowStyles } from './popover_arrow.styles';
 export type { EuiPopoverPosition } from './types';

--- a/packages/eui/src/services/popover/popover_arrow.styles.ts
+++ b/packages/eui/src/services/popover/popover_arrow.styles.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import {
+  logicalCSS,
+  logicalSizeCSS,
+  mathWithUnits,
+} from '../../global_styling/functions';
+import { UseEuiTheme } from '../../services';
+
+/**
+ * Arrow clipping/transform/positioning CSS shared between EuiPopover and EuiToolTip
+ */
+export const _popoverArrowStyles = (
+  { euiTheme }: UseEuiTheme,
+  arrowSize: string
+) => {
+  const arrowOffset = mathWithUnits(arrowSize, (x) => x / -2);
+
+  const arrowBorderRadius = mathWithUnits(
+    euiTheme.border.radius.small,
+    (x) => x / 2
+  );
+
+  return {
+    _arrowStyles: `
+      position: absolute;
+      ${logicalSizeCSS(arrowSize)}
+      border-radius: ${arrowBorderRadius};
+      /* Use clip-path to ensure that arrows don't overlap into popover content */
+      clip-path: polygon(0 0, 100% 100%, 0 100%);
+      transform-origin: center;
+    `,
+
+    positions: {
+      top: css`
+        ${logicalCSS('margin-top', arrowOffset)}
+        transform: rotate(-45deg);
+      `,
+
+      bottom: css`
+        ${logicalCSS('bottom', 0)}
+        ${logicalCSS('margin-bottom', arrowOffset)}
+        transform: rotate(135deg);
+      `,
+
+      left: css`
+        ${logicalCSS('margin-left', arrowOffset)}
+        transform: rotate(-135deg);
+      `,
+
+      right: css`
+        ${logicalCSS('right', 0)}
+        ${logicalCSS('margin-right', arrowOffset)}
+        transform: rotate(45deg);
+      `,
+    },
+  };
+};

--- a/packages/eui/src/services/popover/popover_positioning.test.ts
+++ b/packages/eui/src/services/popover/popover_positioning.test.ts
@@ -337,8 +337,8 @@ describe('popover_positioning', () => {
           top: 40,
           left: 25,
           arrow: {
-            top: 50,
-            left: 22.5,
+            top: '100%',
+            left: 21.5,
           },
         });
       });
@@ -359,8 +359,8 @@ describe('popover_positioning', () => {
           top: -15,
           left: 37.5,
           arrow: {
-            top: 50,
-            left: 10,
+            top: '100%',
+            left: 9,
           },
         });
       });
@@ -382,8 +382,8 @@ describe('popover_positioning', () => {
           top: -15,
           left: 37.5,
           arrow: {
-            top: 50,
-            left: 10,
+            top: '100%',
+            left: 9,
           },
         });
       });
@@ -406,8 +406,8 @@ describe('popover_positioning', () => {
           top: 50,
           left: 75,
           arrow: {
-            top: 50,
-            left: 22,
+            top: '100%',
+            left: 21,
           },
         });
 
@@ -426,8 +426,8 @@ describe('popover_positioning', () => {
           top: 110,
           left: 25,
           arrow: {
-            top: 0,
-            left: 72,
+            bottom: '100%',
+            left: 71,
           },
         });
       });
@@ -448,8 +448,8 @@ describe('popover_positioning', () => {
           top: -82,
           left: 125,
           arrow: {
-            top: 184,
-            left: 0,
+            top: 183,
+            right: '100%',
           },
         });
       });

--- a/packages/eui/src/services/popover/popover_positioning.ts
+++ b/packages/eui/src/services/popover/popover_positioning.ts
@@ -83,7 +83,7 @@ interface FindPopoverPositionResult {
   left: number;
   position: EuiPopoverPosition;
   fit: number;
-  arrow?: { left: number; top: number };
+  arrow?: Record<EuiPopoverPosition, number | string>;
   anchorBoundingBox?: EuiClientRect;
 }
 
@@ -265,7 +265,7 @@ interface GetPopoverScreenCoordinatesResult {
   top: number;
   left: number;
   fit: number;
-  arrow: { top: number; left: number } | undefined;
+  arrow?: Record<EuiPopoverPosition, number | string>;
 }
 
 /**
@@ -360,14 +360,12 @@ export function getPopoverScreenCoordinates({
   const primaryAxisPositionName =
     dimensionPositionAttribute[primaryAxisDimension]; // "height" -> "top"
 
-  const { primaryAxisPosition, primaryAxisArrowPosition } =
-    getPrimaryAxisPosition({
-      position,
-      offset,
-      popoverBoundingBox,
-      anchorBoundingBox,
-      arrowConfig,
-    });
+  const { primaryAxisPosition } = getPrimaryAxisPosition({
+    position,
+    offset,
+    popoverBoundingBox,
+    anchorBoundingBox,
+  });
 
   const popoverPlacement = {
     [crossAxisFirstSide]: crossAxisPosition,
@@ -401,18 +399,18 @@ export function getPopoverScreenCoordinates({
   );
 
   const arrow = arrowConfig
-    ? {
+    ? ({
         [crossAxisFirstSide]:
-          crossAxisArrowPosition! - popoverPlacement[crossAxisFirstSide],
-        [primaryAxisPositionName]: primaryAxisArrowPosition,
-      }
+          crossAxisArrowPosition! - popoverPlacement[crossAxisFirstSide] - 1, // Account for 1px border thin width
+        [position]: '100%',
+      } as Record<EuiPopoverPosition, number | string>)
     : undefined;
 
   return {
     fit,
     top: popoverPlacement.top,
     left: popoverPlacement.left,
-    arrow: arrow ? { left: arrow.left!, top: arrow.top! } : undefined,
+    arrow,
   };
 }
 
@@ -560,7 +558,6 @@ interface GetPrimaryAxisPositionArgs {
   offset: number;
   popoverBoundingBox: BoundingBox;
   anchorBoundingBox: BoundingBox;
-  arrowConfig?: { arrowWidth: number; arrowBuffer: number };
 }
 
 function getPrimaryAxisPosition({
@@ -568,7 +565,6 @@ function getPrimaryAxisPosition({
   offset,
   popoverBoundingBox,
   anchorBoundingBox,
-  arrowConfig,
 }: GetPrimaryAxisPositionArgs) {
   // if positioning to the top or left, the target position decreases
   // from the anchor's top or left, otherwise the position adds to the anchor's
@@ -591,18 +587,7 @@ function getPrimaryAxisPosition({
     (offset + primaryAxisOffset!) * (isOffsetDecreasing ? -1 : 1);
   const primaryAxisPosition = anchorEdgeOrigin + contentOffset;
 
-  let primaryAxisArrowPosition;
-
-  if (arrowConfig) {
-    primaryAxisArrowPosition = isOffsetDecreasing
-      ? popoverSizeOnPrimaryAxis
-      : 0;
-  }
-
-  return {
-    primaryAxisPosition,
-    primaryAxisArrowPosition,
-  };
+  return { primaryAxisPosition };
 }
 
 /**


### PR DESCRIPTION
## Summary

>[!NOTE]
This PR merges into a feature branch.

This PR introduces changes made in [this PR](https://github.com/elastic/eui/pull/8174) as part of the the High Contrast mode changes to the Borealis feature branch.
This will fix the issue mentioned [here](https://github.com/elastic/eui/pull/8207) and additionally fix an alignment issues of popover arrow and beacon in EuiTour.

_before_
![Screenshot 2024-12-09 at 12 39 56](https://github.com/user-attachments/assets/380a0b98-42d0-46fb-bbda-4ae396c1747d)

![Screenshot 2024-12-09 at 12 35 36](https://github.com/user-attachments/assets/26678578-d118-42e4-905e-d4d7fb08f67f)

_after_
![Screenshot 2024-12-09 at 12 39 19](https://github.com/user-attachments/assets/a29363b6-52fa-4a04-aa93-d1ea1b9791fd)

![Screenshot 2024-12-09 at 12 35 40](https://github.com/user-attachments/assets/e75b4334-de3d-4772-a084-84e9336e54e3)

>[!NOTE]
`EuiTour` color mappings are being updated/fixed in [this PR](https://github.com/elastic/eui/pull/8211).

## QA

- [ ] verify `EuiTour` arrow and beacon positioning match production
