### PR TITLE
[Visual Refresh] Set darker shade for subdued text

### DIFF
--- a/packages/eui-theme-borealis/src/eui_theme_borealis_light.json
+++ b/packages/eui-theme-borealis/src/eui_theme_borealis_light.json
@@ -299,7 +299,7 @@
   "euiColorHighlight": "#E5F3FF",
   "euiTextColor": "#172336",
   "euiTitleColor": "#111C2C",
-  "euiTextSubduedColor": "#5A6D8C",
+  "euiTextSubduedColor": "#516381",
   "euiColorDisabled": "#E3E8F2",
   "euiColorPrimaryText": "#1750BA",
   "euiColorSuccessText": "#09724D",

--- a/packages/eui-theme-borealis/src/variables/colors/_colors_light.scss
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_light.scss
@@ -68,7 +68,7 @@ $euiColorBackgroundFilledText: $euiColorShade90 !default;
 // Texts (legacy)
 $euiTextColor: $euiColorShade135 !default;
 $euiTitleColor: $euiColorShade140 !default;
-$euiTextSubduedColor: $euiColorShade90 !default;
+$euiTextSubduedColor: $euiColorShade95 !default;
 $euiColorDisabled: $euiColorBackgroundBaseDisabled !default;
 $euiColorDisabledText: $euiColorShade70 !default;
 $euiLinkColor: $euiColorPrimary100 !default;
@@ -76,7 +76,7 @@ $euiLinkColor: $euiColorPrimary100 !default;
 // Texts
 $euiColorTextParagraph: $euiColorShade135 !default;
 $euiColorTextHeading: $euiColorShade140 !default;
-$euiColorTextSubdued: $euiColorShade90 !default;
+$euiColorTextSubdued: $euiColorShade95 !default;
 $euiColorTextDisabled: $euiColorShade70 !default;
 $euiColorTextInverse: $euiColorPlainLight !default;
 

--- a/packages/eui-theme-borealis/src/variables/colors/_colors_light.ts
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_light.ts
@@ -55,13 +55,13 @@ export const text_colors: _EuiThemeTextColors = {
   /* Legacy colors */
   text: SEMANTIC_COLORS.shade135,
   title: SEMANTIC_COLORS.shade140,
-  subduedText: SEMANTIC_COLORS.shade90,
+  subduedText: SEMANTIC_COLORS.shade95,
   link: SEMANTIC_COLORS.primary100,
 
   /* New colors */
   textParagraph: SEMANTIC_COLORS.shade135,
   textHeading: SEMANTIC_COLORS.shade140,
-  textSubdued: SEMANTIC_COLORS.shade90,
+  textSubdued: SEMANTIC_COLORS.shade95,
   textDisabled: SEMANTIC_COLORS.shade70,
   textInverse: SEMANTIC_COLORS.plainLight,
 };

--- a/packages/eui/src-docs/src/views/theme/_json/eui_theme_borealis_light.json
+++ b/packages/eui/src-docs/src/views/theme/_json/eui_theme_borealis_light.json
@@ -299,7 +299,7 @@
   "euiColorHighlight": "#E5F3FF",
   "euiTextColor": "#172336",
   "euiTitleColor": "#111C2C",
-  "euiTextSubduedColor": "#5A6D8C",
+  "euiTextSubduedColor": "#516381",
   "euiColorDisabled": "#E3E8F2",
   "euiColorPrimaryText": "#1750BA",
   "euiColorSuccessText": "#09724D",

--- a/packages/eui/src/components/breadcrumbs/_breadcrumb_content.styles.ts
+++ b/packages/eui/src/components/breadcrumbs/_breadcrumb_content.styles.ts
@@ -44,7 +44,7 @@ export const euiBreadcrumbContentStyles = (euiThemeContext: UseEuiTheme) => {
       /* TODO: Remove this ':not()' selector and simply have this be
       baseline CSS once the 'color' prop is removed */
       &:not(.euiLink) {
-        color: ${euiTheme.colors.subduedText};
+        color: ${euiTheme.colors.textSubdued};
       }
     `,
 


### PR DESCRIPTION
Closes https://github.com/elastic/platform-ux-team/issues/563
^ This change stemmed from a contrast check on breadcrumbs.
@ek-so proposed we change the shade for subdued text, globally.

>[!NOTE]
This PR merges into a feature branch.

## Changes

### Color token changes
- updates subdued text with darker shade

### QA notes
Shade95 translates to hex #516381 
- This can be seen on the Colors > Text colors page
- Contrast for the last breadcrumb can be seen on the Header page
- This only impact light mode; contrast on dark mode was sufficient

<img width="420" src="https://github.com/user-attachments/assets/f83de481-f22b-4794-850f-7ee021495c7f" />
