### PR TITLE
[Visual Refresh] Remove support for accentSecondary badges

### DIFF
--- a/packages/eui/src-docs/src/views/badge/beta_badge.tsx
+++ b/packages/eui/src-docs/src/views/badge/beta_badge.tsx
@@ -3,13 +3,7 @@ import { css } from '@emotion/react';
 
 import { EuiBetaBadge, EuiSpacer, EuiTitle } from '../../../../src/components';
 
-const colors = [
-  'hollow',
-  'accent',
-  'accentSecondary',
-  'subdued',
-  'warning',
-] as const;
+const colors = ['hollow', 'accent', 'subdued', 'warning'] as const;
 
 export default () => (
   <>

--- a/packages/eui/src/components/badge/__snapshots__/badge.test.tsx.snap
+++ b/packages/eui/src/components/badge/__snapshots__/badge.test.tsx.snap
@@ -175,23 +175,6 @@ exports[`EuiBadge props color accent is rendered 1`] = `
 </span>
 `;
 
-exports[`EuiBadge props color accentSecondary is rendered 1`] = `
-<span
-  class="euiBadge emotion-euiBadge-accentSecondary"
-  title="Content"
->
-  <span
-    class="euiBadge__content emotion-euiBadge__content"
-  >
-    <span
-      class="euiBadge__text emotion-euiBadge__text"
-    >
-      Content
-    </span>
-  </span>
-</span>
-`;
-
 exports[`EuiBadge props color accepts hex 1`] = `
 <span
   class="euiBadge emotion-euiBadge"
@@ -417,24 +400,6 @@ exports[`EuiBadge props style is rendered 1`] = `
 exports[`EuiBadge props style is rendered with accent 1`] = `
 <span
   class="euiBadge emotion-euiBadge-accent"
-  style="border: 4px solid tomato;"
-  title="Content"
->
-  <span
-    class="euiBadge__content emotion-euiBadge__content"
-  >
-    <span
-      class="euiBadge__text emotion-euiBadge__text"
-    >
-      Content
-    </span>
-  </span>
-</span>
-`;
-
-exports[`EuiBadge props style is rendered with accentSecondary 1`] = `
-<span
-  class="euiBadge emotion-euiBadge-accentSecondary"
   style="border: 4px solid tomato;"
   title="Content"
 >

--- a/packages/eui/src/components/badge/badge.styles.ts
+++ b/packages/eui/src/components/badge/badge.styles.ts
@@ -106,7 +106,6 @@ export const euiBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     primary: css(setBadgeColorVars(badgeColors.primary)),
     accent: css(setBadgeColorVars(badgeColors.accent)),
-    accentSecondary: css(setBadgeColorVars(badgeColors.accentSecondary)),
     warning: css(setBadgeColorVars(badgeColors.warning)),
     danger: css(setBadgeColorVars(badgeColors.danger)),
     success: css(setBadgeColorVars(badgeColors.success)),

--- a/packages/eui/src/components/badge/badge.tsx
+++ b/packages/eui/src/components/badge/badge.tsx
@@ -40,7 +40,6 @@ export const COLORS = [
   'primary',
   'success',
   'accent',
-  'accentSecondary',
   'warning',
   'danger',
 ] as const;

--- a/packages/eui/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
+++ b/packages/eui/src/components/badge/beta_badge/__snapshots__/beta_badge.test.tsx.snap
@@ -46,17 +46,6 @@ exports[`EuiBetaBadge props color accent is rendered 1`] = `
 </span>
 `;
 
-exports[`EuiBetaBadge props color accentSecondary is rendered 1`] = `
-<span>
-  <span
-    class="euiBetaBadge emotion-euiBetaBadge-accentSecondary-m-baseline"
-    title="Beta"
-  >
-    Beta
-  </span>
-</span>
-`;
-
 exports[`EuiBetaBadge props color hollow is rendered 1`] = `
 <span>
   <span

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -46,9 +46,6 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     accent: hasVisColorAdjustment
       ? css(badgeColors.accentText)
       : css(badgeColors.accent),
-    accentSecondary: hasVisColorAdjustment
-      ? css(badgeColors.accentSecondaryText)
-      : css(badgeColors.accentSecondary),
     subdued: css(badgeColors.subdued),
     hollow: css`
       color: ${badgeColors.hollow.color};

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
@@ -22,13 +22,7 @@ import { EuiIcon, IconType } from '../../icon';
 
 import { euiBetaBadgeStyles } from './beta_badge.styles';
 
-export const COLORS = [
-  'accent',
-  'accentSecondary',
-  'subdued',
-  'hollow',
-  'warning',
-] as const;
+export const COLORS = ['accent', 'subdued', 'hollow', 'warning'] as const;
 export type BetaBadgeColor = (typeof COLORS)[number];
 
 export const SIZES = ['s', 'm'] as const;

--- a/packages/eui/src/components/badge/notification_badge/__snapshots__/badge_notification.test.tsx.snap
+++ b/packages/eui/src/components/badge/notification_badge/__snapshots__/badge_notification.test.tsx.snap
@@ -18,14 +18,6 @@ exports[`EuiNotificationBadge props color accent is rendered 1`] = `
 </span>
 `;
 
-exports[`EuiNotificationBadge props color accentSecondary is rendered 1`] = `
-<span
-  class="euiNotificationBadge emotion-euiNotificationBadge-s-accentSecondary"
->
-  5
-</span>
-`;
-
 exports[`EuiNotificationBadge props color subdued is rendered 1`] = `
 <span
   class="euiNotificationBadge emotion-euiNotificationBadge-s-subdued"

--- a/packages/eui/src/components/badge/notification_badge/badge_notification.styles.ts
+++ b/packages/eui/src/components/badge/notification_badge/badge_notification.styles.ts
@@ -55,7 +55,6 @@ export const euiNotificationBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     // Colors
     accent: css(badgeColors.accentText),
-    accentSecondary: css(badgeColors.accentSecondaryText),
     success: css(badgeColors.success),
     subdued: css(badgeColors.subdued),
   };

--- a/packages/eui/src/components/badge/notification_badge/badge_notification.tsx
+++ b/packages/eui/src/components/badge/notification_badge/badge_notification.tsx
@@ -14,12 +14,7 @@ import { CommonProps } from '../../common';
 
 import { euiNotificationBadgeStyles } from './badge_notification.styles';
 
-export const COLORS = [
-  'accent',
-  'accentSecondary',
-  'subdued',
-  'success',
-] as const;
+export const COLORS = ['accent', 'subdued', 'success'] as const;
 export type BadgeNotificationColor = (typeof COLORS)[number];
 
 export const SIZES = ['s', 'm'] as const;


### PR DESCRIPTION
## Summary

>[!NOTE]
This PR merges into a feature branch.

This PR removes support for the `accentSecondary` variant of badges.
This was initially added while `accentSecondary` was still being considered a regular usage, but latest design discussions are moving away from `accentSecondary` as a color for e.g. Buttons and [Badges](https://www.figma.com/design/FHys7gLzyvD1gc9DrJM6D8/%5BVR%5D-Elastic-UI-New-Library-%5BTEST%5D?node-id=6259-60641&t=VycQ1C4s2TIR5MYt-4).

To proactively prevent further usage of it, we're removing it again.
This change was discussed with @ek-so.

## QA

- [x] confirm that EuiBadge, EuiNotificationBadge and EuiBetaBadge don't support `accentSecondary` variants