### PR TITLE
[Visual Refresh] Add severity vis colors

### DIFF
--- a/packages/eui-theme-borealis/src/variables/colors/_colors_vis.ts
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_vis.ts
@@ -83,6 +83,22 @@ export const colorVis: _EuiThemeVisColors = {
 
   euiColorVisNeutral0: PRIMITIVE_COLORS.mutedGrey10,
 
+  euiColorSeverity0: PRIMITIVE_COLORS.mutedGrey20,
+  euiColorSeverity1: SEMANTIC_COLORS.shade90,
+  euiColorSeverity2: SEMANTIC_COLORS.shade75,
+  euiColorSeverity3: SEMANTIC_COLORS.shade60,
+  euiColorSeverity4: SEMANTIC_COLORS.shade45,
+  euiColorSeverity5: SEMANTIC_COLORS.shade30,
+  euiColorSeverity6: SEMANTIC_COLORS.warning20,
+  euiColorSeverity7: SEMANTIC_COLORS.warning30,
+  euiColorSeverity8: SEMANTIC_COLORS.danger30,
+  euiColorSeverity9: SEMANTIC_COLORS.danger40,
+  euiColorSeverity10: SEMANTIC_COLORS.danger50,
+  euiColorSeverity11: SEMANTIC_COLORS.danger60,
+  euiColorSeverity12: SEMANTIC_COLORS.danger70,
+  euiColorSeverity13: SEMANTIC_COLORS.danger80,
+  euiColorSeverity14: SEMANTIC_COLORS.danger90,
+
   euiColorVisGrey0: PRIMITIVE_COLORS.blueGrey30,
   euiColorVisGrey1: PRIMITIVE_COLORS.blueGrey60,
   euiColorVisGrey2: PRIMITIVE_COLORS.blueGrey90,

--- a/packages/eui-theme-common/src/global_styling/variables/colors.ts
+++ b/packages/eui-theme-common/src/global_styling/variables/colors.ts
@@ -291,6 +291,22 @@ export type _EuiThemeVisColors = {
 
   euiColorVisNeutral0: string;
 
+  euiColorSeverity0: string;
+  euiColorSeverity1: string;
+  euiColorSeverity2: string;
+  euiColorSeverity3: string;
+  euiColorSeverity4: string;
+  euiColorSeverity5: string;
+  euiColorSeverity6: string;
+  euiColorSeverity7: string;
+  euiColorSeverity8: string;
+  euiColorSeverity9: string;
+  euiColorSeverity10: string;
+  euiColorSeverity11: string;
+  euiColorSeverity12: string;
+  euiColorSeverity13: string;
+  euiColorSeverity14: string;
+
   euiColorVisGrey0: string;
   euiColorVisGrey1: string;
   euiColorVisGrey2: string;

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors_vis.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors_vis.ts
@@ -86,6 +86,22 @@ export const colorVis: _EuiThemeVisColors = {
 
   euiColorVisNeutral0: '#FFFFFF',
 
+  euiColorSeverity0: '#D3DAE6',
+  euiColorSeverity1: '#CC5642',
+  euiColorSeverity2: '#D2634E',
+  euiColorSeverity3: '#D66E5C',
+  euiColorSeverity4: '#DD7B67',
+  euiColorSeverity5: '#E18773',
+  euiColorSeverity6: '#E2907F',
+  euiColorSeverity7: '#E69D8F',
+  euiColorSeverity8: '#D6BF57',
+  euiColorSeverity9: '#DECC79',
+  euiColorSeverity10: '#BECFE3',
+  euiColorSeverity11: '#A6C0DA',
+  euiColorSeverity12: '#90B0D1',
+  euiColorSeverity13: '#78A2C9',
+  euiColorSeverity14: '#6092C0',
+
   euiColorVisGrey0: '#d3dae6',
   euiColorVisGrey1: '#98a2b3',
   euiColorVisGrey2: '#69707d',


### PR DESCRIPTION
## Summary

>[!NOTE]
This PR merges into a feature branch.

This PR introduces new theme tokens for severity colors as part of `euiTheme.colors.vis` as proposed by @gvnmagni 

```ts
euiColorSeverity0
euiColorSeverity1
euiColorSeverity2
euiColorSeverity3
euiColorSeverity4
euiColorSeverity5
euiColorSeverity6
euiColorSeverity7
euiColorSeverity8
euiColorSeverity9
euiColorSeverity10
euiColorSeverity11
euiColorSeverity12
euiColorSeverity13
euiColorSeverity14
```

| Amsterdam | Borealis |
|-------------|---------|
| ![image](https://github.com/user-attachments/assets/4169fced-fa52-4886-a98f-672c9f020417) | ![image](https://github.com/user-attachments/assets/d1fe8463-ba45-458c-9dbd-a059899ca6b7) |

## QA

These new tokens are not used anywhere so far, we introduce them for usage in Kibana.
As long as the CI passes and the token values match the design spec, I think there is no further QA needed.
