### PR TITLE
[Visual Refresh] Fix transparent color variable definitions

### DIFF
--- a/packages/eui-theme-borealis/src/variables/_components.ts
+++ b/packages/eui-theme-borealis/src/variables/_components.ts
@@ -73,8 +73,8 @@ const component_colors: _EuiThemeComponentColors = {
   collapsibleNavGroupBackgroundDark:
     dark_background_colors.backgroundBaseSubdued,
 
-  dataGridBorderColor: border_colors.borderBasePlain,
-  dataGridVerticalLineBorderColor: border_colors.borderBasePlain,
+  dataGridBorderColor: border_colors.borderBaseSubdued,
+  dataGridVerticalLineBorderColor: border_colors.borderBaseSubdued,
   dataGridRowBackgroundStriped: background_colors.backgroundBaseSubdued,
   dataGridRowBackgroundHover: background_colors.backgroundBaseInteractiveHover,
   dataGridRowBackgroundSelect:
@@ -209,7 +209,8 @@ export const components: _EuiThemeComponents = {
     collapsibleNavGroupBackgroundDark:
       dark_background_colors.backgroundBaseSubdued,
 
-    dataGridVerticalLineBorderColor: dark_border_colors.borderBasePlain,
+    dataGridBorderColor: dark_border_colors.borderBaseSubdued,
+    dataGridVerticalLineBorderColor: dark_border_colors.borderBaseSubdued,
     dataGridRowBackgroundStriped: dark_background_colors.backgroundBaseSubdued,
     dataGridRowBackgroundHover:
       dark_background_colors.backgroundBaseInteractiveHover,

--- a/packages/eui-theme-borealis/src/variables/colors/_semantic_colors.ts
+++ b/packages/eui-theme-borealis/src/variables/colors/_semantic_colors.ts
@@ -148,51 +148,53 @@ const _semantic_colors = {
   shade145: PRIMITIVE_COLORS.blueGrey145,
 };
 
-const plainLightRGB = chroma(_semantic_colors.plainLight);
-const primary70RGB = chroma(_semantic_colors.primary70);
-const primary100RGB = chroma(_semantic_colors.primary100);
-const accent70RGB = chroma(_semantic_colors.accent70);
-const accentSecondary70RGB = chroma(_semantic_colors.accentSecondary70);
-const success70RGB = chroma(_semantic_colors.success70);
-const warning40RGB = chroma(_semantic_colors.warning40);
-const danger70RGB = chroma(_semantic_colors.danger70);
-const shade100RGB = chroma(_semantic_colors.shade100);
-const shade120RGB = chroma(_semantic_colors.shade120);
+const plainLightRGB = chroma(_semantic_colors.plainLight).rgb().join();
+const primary70RGB = chroma(_semantic_colors.primary70).rgb().join();
+const primary100RGB = chroma(_semantic_colors.primary100).rgb().join();
+const accent70RGB = chroma(_semantic_colors.accent70).rgb().join();
+const accentSecondary70RGB = chroma(_semantic_colors.accentSecondary70)
+  .rgb()
+  .join();
+const success70RGB = chroma(_semantic_colors.success70).rgb().join();
+const warning40RGB = chroma(_semantic_colors.warning40).rgb().join();
+const danger70RGB = chroma(_semantic_colors.danger70).rgb().join();
+const shade100RGB = chroma(_semantic_colors.shade100).rgb().join();
+const shade120RGB = chroma(_semantic_colors.shade120).rgb().join();
 
 const _semantic_alpha_colors = {
-  plainLightAlpha8: `rgba(${chroma(plainLightRGB)}, 0.08)`,
-  plainLightAlpha12: `rgba(${chroma(plainLightRGB)}, 0.12)`,
-  plainLightAlpha16: `rgba(${chroma(plainLightRGB)}, 0.16)`,
-  plainLightAlpha32: `rgba(${chroma(plainLightRGB)}, 0.32)`,
+  plainLightAlpha8: `rgba(${plainLightRGB}, 0.08)`,
+  plainLightAlpha12: `rgba(${plainLightRGB}, 0.12)`,
+  plainLightAlpha16: `rgba(${plainLightRGB}, 0.16)`,
+  plainLightAlpha32: `rgba(${plainLightRGB}, 0.32)`,
 
-  primary70Alpha12: `rgba(${chroma(primary70RGB)}, 0.12)`,
-  primary70Alpha16: `rgba(${chroma(primary70RGB)}, 0.16)`,
+  primary70Alpha12: `rgba(${primary70RGB}, 0.12)`,
+  primary70Alpha16: `rgba(${primary70RGB}, 0.16)`,
 
-  primary100Alpha4: `rgba(${chroma(primary100RGB)}, 0.04)`,
-  primary100Alpha8: `rgba(${chroma(primary100RGB)}, 0.08)`,
-  primary100Alpha12: `rgba(${chroma(primary100RGB)}, 0.12)`,
+  primary100Alpha4: `rgba(${primary100RGB}, 0.04)`,
+  primary100Alpha8: `rgba(${primary100RGB}, 0.08)`,
+  primary100Alpha12: `rgba(${primary100RGB}, 0.12)`,
 
-  accent70Alpha12: `rgba(${chroma(accent70RGB)}, 0.12)`,
-  accent70Alpha16: `rgba(${chroma(accent70RGB)}, 0.16)`,
+  accent70Alpha12: `rgba(${accent70RGB}, 0.12)`,
+  accent70Alpha16: `rgba(${accent70RGB}, 0.16)`,
 
-  accentSecondary70Alpha12: `rgba(${chroma(accentSecondary70RGB)}, 0.12)`,
-  accentSecondary70Alpha16: `rgba(${chroma(accentSecondary70RGB)}, 0.16)`,
+  accentSecondary70Alpha12: `rgba(${accentSecondary70RGB}, 0.12)`,
+  accentSecondary70Alpha16: `rgba(${accentSecondary70RGB}, 0.16)`,
 
-  success70Alpha12: `rgba(${chroma(success70RGB)}, 0.12)`,
-  success70Alpha16: `rgba(${chroma(success70RGB)}, 0.16)`,
+  success70Alpha12: `rgba(${success70RGB}, 0.12)`,
+  success70Alpha16: `rgba(${success70RGB}, 0.16)`,
 
-  warning40Alpha12: `rgba(${chroma(warning40RGB)}, 0.12)`,
-  warning40Alpha24: `rgba(${chroma(warning40RGB)}, 0.24)`,
+  warning40Alpha12: `rgba(${warning40RGB}, 0.12)`,
+  warning40Alpha24: `rgba(${warning40RGB}, 0.24)`,
 
-  danger70Alpha12: `rgba(${chroma(danger70RGB)}, 0.12)`,
-  danger70Alpha16: `rgba(${chroma(danger70RGB)}, 0.16)`,
+  danger70Alpha12: `rgba(${danger70RGB}, 0.12)`,
+  danger70Alpha16: `rgba(${danger70RGB}, 0.16)`,
 
-  shade100Alpha4: `rgba(${chroma(shade100RGB)}, 0.04)`,
-  shade100Alpha16: `rgba(${chroma(shade100RGB)}, 0.16)`,
-  shade100Alpha24: `rgba(${chroma(shade100RGB)}, 0.24)`,
-  shade100Alpha70: `rgba(${chroma(shade100RGB)}, 0.7)`,
+  shade100Alpha4: `rgba(${shade100RGB}, 0.04)`,
+  shade100Alpha16: `rgba(${shade100RGB}, 0.16)`,
+  shade100Alpha24: `rgba(${shade100RGB}, 0.24)`,
+  shade100Alpha70: `rgba(${shade100RGB}, 0.7)`,
 
-  shade120Alpha70: `rgba(${chroma(shade120RGB)}, 0.7)`,
+  shade120Alpha70: `rgba(${shade120RGB}, 0.7)`,
 };
 
 export const SEMANTIC_COLORS = {


### PR DESCRIPTION
## Summary

>[!IMPORTANT]
This PR merges into a feature branch

This PR fixes the values for transparent colors calculated using `chroma` as added [here](https://github.com/elastic/eui/pull/8211).

The usage was not correct and still returned a hex code, which does not work as value used in `rgba()`.
I complete missed that 😭 

Additionally it reverts a change of the EuiDatagrid border color from `plain` to `subdued`.

## QA

- ensure that transparent colors are output properly in Borealis, e.g. here for the following examples:
  - [x] [EuiModal](https://eui.elastic.co/pr_8249/storybook/index.html?path=/story/layout-euimodal-euimodal--playground&globals=theme:EUI_THEME_BOREALIS) and [EuiFlyout](https://eui.elastic.co/pr_8249/storybook/index.html?path=/story/layout-euiflyout-euiflyout--playground&globals=theme:EUI_THEME_BOREALIS) have a grey overlay mask
  - [x] [EuiTable](https://eui.elastic.co/pr_8249/storybook/index.html?path=/story/tabular-content-euibasictable--playground&globals=theme:EUI_THEME_BOREALIS) row hover is applied
  - [x] [Skeleton](https://eui.elastic.co/pr_8249/storybook/index.html?path=/story/display-euiskeletonloading-euiskeletontext--playground&globals=theme:EUI_THEME_BOREALIS) components are visible
- verify [EuiDataGrid](https://eui.elastic.co/pr_8249/storybook/index.html?path=/story/tabular-content-euidatagrid--playground) uses `borderBasePlain` borders in Borealis