### PR TITLE
[Visual Refresh] Update `EuiToken` colors

### DIFF
--- a/packages/eui/src/components/token/token.styles.ts
+++ b/packages/eui/src/components/token/token.styles.ts
@@ -49,7 +49,7 @@ const getTokenColor = (
     : euiTheme.colors.darkShade;
 
   const backgroundLightColor = isDarkMode
-    ? shade(iconColor, 0.7)
+    ? shade(iconColor, 0.9)
     : tint(iconColor, 0.9);
 
   const getIconVisColor = (
@@ -68,12 +68,12 @@ const getTokenColor = (
   const lightColor = hasVisColorAdjustment
     ? makeHighContrastColor(iconColor)(backgroundLightColor)
     : isVizColor
-    ? getIconVisColor(euiTheme, color)
+    ? shade(getIconVisColor(euiTheme, color), .3)
     : iconColor;
 
   const boxShadowColor = isDarkMode
     ? shade(iconColor, 0.6)
-    : tint(iconColor, 0.7);
+    : tint(iconColor, 0.2);
 
   const darkColor = isColorDark(...chroma(backgroundDarkColor).rgb())
     ? euiTheme.colors.ghost

--- a/packages/eui/src/components/token/token.styles.ts
+++ b/packages/eui/src/components/token/token.styles.ts
@@ -68,7 +68,7 @@ const getTokenColor = (
   const lightColor = hasVisColorAdjustment
     ? makeHighContrastColor(iconColor)(backgroundLightColor)
     : isVizColor
-    ? shade(getIconVisColor(euiTheme, color), .3)
+    ? shade(getIconVisColor(euiTheme, color), 0.3)
     : iconColor;
 
   const boxShadowColor = isDarkMode

--- a/packages/eui/src/components/token/token_map.ts
+++ b/packages/eui/src/components/token/token_map.ts
@@ -310,8 +310,8 @@ export const TOKEN_MAP_BOREALIS: {
   [mapType in EuiTokenMapType]: Omit<TokenProps, 'iconType'>;
 } = {
   tokenAlias: {
-    shape: 'circle',
-    color: 'euiColorVis1',
+    shape: 'square',
+    color: 'euiColorVis0',
   },
   tokenAnnotation: {
     shape: 'square',
@@ -319,15 +319,15 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenArray: {
     shape: 'square',
-    color: 'euiColorVis3',
+    color: 'euiColorVis4',
   },
   tokenBinary: {
     shape: 'square',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenBoolean: {
     shape: 'square',
-    color: 'euiColorVis3',
+    color: 'euiColorVis4',
   },
   tokenClass: {
     shape: 'circle',
@@ -343,7 +343,7 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenDate: {
     shape: 'square',
-    color: 'euiColorVis9',
+    color: 'euiColorVis8',
   },
   tokenDimension: {
     shape: 'square',
@@ -351,19 +351,19 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenElement: {
     shape: 'square',
-    color: 'euiColorVis1',
+    color: 'euiColorVis0',
   },
   tokenEnum: {
     shape: 'circle',
-    color: 'euiColorVis1',
+    color: 'euiColorVis0',
   },
   tokenEnumMember: {
     shape: 'square',
-    color: 'euiColorVis3',
+    color: 'euiColorVis4',
   },
   tokenEvent: {
     shape: 'circle',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenException: {
     shape: 'circle',
@@ -379,7 +379,7 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenFlattened: {
     shape: 'square',
-    color: 'euiColorVis3',
+    color: 'euiColorVis4',
   },
   tokenFunction: {
     shape: 'circle',
@@ -391,7 +391,7 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenHistogram: {
     shape: 'square',
-    color: 'euiColorVis9',
+    color: 'euiColorVis0',
   },
   tokenInterface: {
     shape: 'circle',
@@ -427,7 +427,7 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenModule: {
     shape: 'square',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenNamespace: {
     shape: 'square',
@@ -447,11 +447,11 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenObject: {
     shape: 'circle',
-    color: 'euiColorVis1',
+    color: 'euiColorVis0',
   },
   tokenOperator: {
     shape: 'circle',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenPackage: {
     shape: 'square',
@@ -459,11 +459,11 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenParameter: {
     shape: 'square',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenPercolator: {
     shape: 'square',
-    color: 'euiColorVis9',
+    color: 'euiColorVis0',
   },
   tokenProperty: {
     shape: 'circle',
@@ -471,15 +471,15 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenRange: {
     shape: 'circle',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenRankFeature: {
     shape: 'square',
-    color: 'euiColorVis7',
+    color: 'euiColorVis8',
   },
   tokenRankFeatures: {
     shape: 'square',
-    color: 'euiColorVis1',
+    color: 'euiColorVis0',
   },
   tokenRepo: {
     shape: 'square',
@@ -495,7 +495,7 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenShape: {
     shape: 'circle',
-    color: 'euiColorVis7',
+    color: 'euiColorVis8',
   },
   tokenString: {
     shape: 'square',
@@ -515,15 +515,15 @@ export const TOKEN_MAP_BOREALIS: {
   },
   tokenText: {
     shape: 'square',
-    color: 'euiColorVis1',
+    color: 'euiColorVis0',
   },
   tokenTokenCount: {
     shape: 'square',
-    color: 'euiColorVis5',
+    color: 'euiColorVis6',
   },
   tokenVariable: {
     shape: 'circle',
-    color: 'euiColorVis3',
+    color: 'euiColorVis4',
   },
   tokenVectorDense: {
     shape: 'square',


### PR DESCRIPTION
Related to https://github.com/elastic/platform-ux-team/issues/561
Closes https://github.com/elastic/kibana/issues/202760

## Summary

During QA of Borealis for Discover, it was noted that the `EuiToken` colors were too light in the field list.
This was reviewed with the theme designers and the following recommendations were made:
1. (this PR) adjust the colors for greater contrast in the border and icon
2. (future) discontinue using EUI vis color palette and, instead, create a palette specific for EuiToken use

## QA
(screenshots also found in the design [issue](https://github.com/elastic/platform-ux-team/issues/561))

**In EUI**
Running EUI docs locally, `EuiToken` should look like:
<img width="640" src="https://github.com/user-attachments/assets/b719994c-fd48-47ac-9f1e-f48ea7a02d5b" />


**In Kibana**
For reference, this was also run locally in Kibana which looked like:
<img width="640" src="https://github.com/user-attachments/assets/ba09d707-fd9b-4b5b-a6bb-c663b0c68bc1" />
