### PR TITLE
[Visual Refresh] Add behindText vis color tokens

### DIFF
--- a/packages/eui-theme-borealis/src/variables/colors/_colors_vis.ts
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_vis.ts
@@ -59,6 +59,17 @@ export const colorVis: _EuiThemeVisColors = {
   euiColorVis8: euiPaletteColorBlind.euiColorVis8.graphic,
   euiColorVis9: euiPaletteColorBlind.euiColorVis9.graphic,
 
+  euiColorVisBehindText0: euiPaletteColorBlind.euiColorVis0.graphic,
+  euiColorVisBehindText1: euiPaletteColorBlind.euiColorVis1.graphic,
+  euiColorVisBehindText2: euiPaletteColorBlind.euiColorVis2.graphic,
+  euiColorVisBehindText3: euiPaletteColorBlind.euiColorVis3.graphic,
+  euiColorVisBehindText4: euiPaletteColorBlind.euiColorVis4.graphic,
+  euiColorVisBehindText5: euiPaletteColorBlind.euiColorVis5.graphic,
+  euiColorVisBehindText6: euiPaletteColorBlind.euiColorVis6.graphic,
+  euiColorVisBehindText7: euiPaletteColorBlind.euiColorVis7.graphic,
+  euiColorVisBehindText8: euiPaletteColorBlind.euiColorVis8.graphic,
+  euiColorVisBehindText9: euiPaletteColorBlind.euiColorVis9.graphic,
+
   euiColorVisAsTextLight0: SEMANTIC_COLORS.accentSecondary100,
   euiColorVisAsTextLight1: SEMANTIC_COLORS.primary100,
   euiColorVisAsTextLight2: SEMANTIC_COLORS.accent100,

--- a/packages/eui-theme-common/src/global_styling/variables/colors.ts
+++ b/packages/eui-theme-common/src/global_styling/variables/colors.ts
@@ -266,6 +266,27 @@ export type _EuiThemeVisColors = {
   euiColorVis8: string;
   euiColorVis9: string;
 
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText0: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText1: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText2: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText3: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText4: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText5: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText6: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText7: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText8: string;
+  /* deprecated - temp token; used only during theme migration */
+  euiColorVisBehindText9: string;
+
   euiColorVisAsTextLight0: string;
   euiColorVisAsTextLight1: string;
   euiColorVisAsTextLight2: string;

--- a/packages/eui-theme-common/src/global_styling/variables/colors.ts
+++ b/packages/eui-theme-common/src/global_styling/variables/colors.ts
@@ -266,25 +266,25 @@ export type _EuiThemeVisColors = {
   euiColorVis8: string;
   euiColorVis9: string;
 
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText0: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText1: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText2: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText3: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText4: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText5: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText6: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText7: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText8: string;
-  /* deprecated - temp token; used only during theme migration */
+  /** @deprecated - temp token; used only during theme migration */
   euiColorVisBehindText9: string;
 
   euiColorVisAsTextLight0: string;

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors_vis.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors_vis.ts
@@ -62,6 +62,17 @@ export const colorVis: _EuiThemeVisColors = {
   euiColorVis8: euiPaletteColorBlind.euiColorVis8.graphic,
   euiColorVis9: euiPaletteColorBlind.euiColorVis9.graphic,
 
+  euiColorVisBehindText0: '#6dccb1',
+  euiColorVisBehindText1: '#79aad9',
+  euiColorVisBehindText2: '#ee789d',
+  euiColorVisBehindText3: '#a987d1',
+  euiColorVisBehindText4: '#e4a6c7',
+  euiColorVisBehindText5: '#f1d86f',
+  euiColorVisBehindText6: '#d2c0a0',
+  euiColorVisBehindText7: '#f5a35c',
+  euiColorVisBehindText8: '#c47c6c',
+  euiColorVisBehindText9: '#ff7e62',
+
   euiColorVisAsTextLight0: '#006BB4',
   euiColorVisAsTextLight1: '#017D73',
   euiColorVisAsTextLight2: '#F5A700',

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors_vis.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors_vis.ts
@@ -20,33 +20,43 @@ import { _EuiThemeVisColors } from '@elastic/eui-theme-common';
 const euiPaletteColorBlind = {
   euiColorVis0: {
     graphic: '#54B399',
+    behindText: '#6DCCB1',
   },
   euiColorVis1: {
     graphic: '#6092C0',
+    behindText: '#79AAD9',
   },
   euiColorVis2: {
     graphic: '#D36086',
+    behindText: '#EE789D',
   },
   euiColorVis3: {
     graphic: '#9170B8',
+    behindText: '#A987D1',
   },
   euiColorVis4: {
     graphic: '#CA8EAE',
+    behindText: '#E4A6C7',
   },
   euiColorVis5: {
     graphic: '#D6BF57',
+    behindText: '#F1D86F',
   },
   euiColorVis6: {
     graphic: '#B9A888',
+    behindText: '#D2C0A0',
   },
   euiColorVis7: {
     graphic: '#DA8B45',
+    behindText: '#F5A35C',
   },
   euiColorVis8: {
     graphic: '#AA6556',
+    behindText: '#C47C6C',
   },
   euiColorVis9: {
     graphic: '#E7664C',
+    behindText: '#FF7E62',
   },
 };
 
@@ -62,16 +72,20 @@ export const colorVis: _EuiThemeVisColors = {
   euiColorVis8: euiPaletteColorBlind.euiColorVis8.graphic,
   euiColorVis9: euiPaletteColorBlind.euiColorVis9.graphic,
 
-  euiColorVisBehindText0: '#6dccb1',
-  euiColorVisBehindText1: '#79aad9',
-  euiColorVisBehindText2: '#ee789d',
-  euiColorVisBehindText3: '#a987d1',
-  euiColorVisBehindText4: '#e4a6c7',
-  euiColorVisBehindText5: '#f1d86f',
-  euiColorVisBehindText6: '#d2c0a0',
-  euiColorVisBehindText7: '#f5a35c',
-  euiColorVisBehindText8: '#c47c6c',
-  euiColorVisBehindText9: '#ff7e62',
+  /**
+   * behindText variables are temp tokens; used only during theme migration.
+   * TODO: remove once Amsterdam is fully migrated
+   */
+  euiColorVisBehindText0: euiPaletteColorBlind.euiColorVis0.behindText,
+  euiColorVisBehindText1: euiPaletteColorBlind.euiColorVis1.behindText,
+  euiColorVisBehindText2: euiPaletteColorBlind.euiColorVis2.behindText,
+  euiColorVisBehindText3: euiPaletteColorBlind.euiColorVis3.behindText,
+  euiColorVisBehindText4: euiPaletteColorBlind.euiColorVis4.behindText,
+  euiColorVisBehindText5: euiPaletteColorBlind.euiColorVis5.behindText,
+  euiColorVisBehindText6: euiPaletteColorBlind.euiColorVis6.behindText,
+  euiColorVisBehindText7: euiPaletteColorBlind.euiColorVis7.behindText,
+  euiColorVisBehindText8: euiPaletteColorBlind.euiColorVis8.behindText,
+  euiColorVisBehindText9: euiPaletteColorBlind.euiColorVis9.behindText,
 
   euiColorVisAsTextLight0: '#006BB4',
   euiColorVisAsTextLight1: '#017D73',


### PR DESCRIPTION
## Summary

>[!NOTE]
This PR merges into a feature branch.

This PR adds `_behindText` vis color tokens. These have not been part of the theme, as they are not in usage in the new theme.
During upgrades to the new theme, we realized that it's rather cumbersome for teams to migrate these JSON token usages properly to the `euiTheme` tokens without a 1:1 equivalent.

These tokens are temporary for the purpose of making migration easier for Kibana teams. We will need to remove those tokens again at some point as they are not be used in Borealis.

```ts
euiColorVisBehindText0
euiColorVisBehindText1
euiColorVisBehindText2
euiColorVisBehindText3
euiColorVisBehindText4
euiColorVisBehindText5
euiColorVisBehindText6
euiColorVisBehindText7
euiColorVisBehindText8
euiColorVisBehindText9
```

## QA

These tokens are not used anywhere. Make sure the values make sense:
- Amsterdam - uses values returned from `euiPaletteColorBlindBehindText()`
- Borealis maps to default vis colors

- [x] CI passes
