### PR TITLE
Beta badge inner visual alignment

### DIFF
--- a/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -59,7 +59,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     s: css`
       font-size: 0.7rem;
       ${logicalCSS('height', '20px')}
-      line-height: ${mathWithUnits('20px', (x) => x * 0.97)};
+      line-height: ${mathWithUnits('20px', (x) => x * 0.98)};
     `,
     // Padding/width sizes
     badgeSizes: {
@@ -70,7 +70,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
         `,
         s: `
         ${logicalCSS('padding-horizontal', euiTheme.size.m)}
-        padding-block-start: ${mathWithUnits('20px', (x) => x * 0.03)};
+        padding-block-start: ${mathWithUnits('20px', (x) => x * 0.02)};
         `,
       },
       // When it's just an icon or a single letter, make the badge a circle

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -27,7 +27,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       border-radius: ${euiTheme.size.l};
       cursor: default;
 
-      font-weight: ${euiTheme.font.weight.bold};
+      font-weight: ${euiTheme.font.weight.semiBold};
       text-transform: uppercase;
       letter-spacing: 0.05em;
       text-align: center;
@@ -53,19 +53,25 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     // Font sizes
     m: css`
       font-size: ${euiFontSizeFromScale('xs', euiTheme)};
-      line-height: ${euiTheme.size.l};
+      ${logicalCSS('height', euiTheme.size.l)}
+      line-height: ${mathWithUnits(euiTheme.size.l, (x) => x * 0.95)};
     `,
     s: css`
-      font-size: 0.625rem;
-      line-height: ${mathWithUnits(euiTheme.size.xs, (x) => x + euiTheme.base)};
+      font-size: 0.7rem;
+      ${logicalCSS('height', '20px')}
+      line-height: ${mathWithUnits('20px', (x) => x * 0.97)};
     `,
     // Padding/width sizes
     badgeSizes: {
       default: {
         m: `
-        ${logicalCSS('padding-horizontal', euiTheme.size.base)}`,
+        ${logicalCSS('padding-horizontal', euiTheme.size.base)}
+        padding-block-start: ${mathWithUnits(euiTheme.size.l, (x) => x * 0.05)}
+        `,
         s: `
-        ${logicalCSS('padding-horizontal', euiTheme.size.m)}`,
+        ${logicalCSS('padding-horizontal', euiTheme.size.m)}
+        padding-block-start: ${mathWithUnits('20px', (x) => x * 0.03)};
+        `,
       },
       // When it's just an icon or a single letter, make the badge a circle
       circle: {
@@ -82,7 +88,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     },
     euiBetaBadge__icon: css`
       position: relative;
-      transform: translate(0, -1px);
+      transform: translate(0, -0.05em);
     `,
     // Alignments
     baseline: css`

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -54,7 +54,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     m: css`
       font-size: ${euiFontSizeFromScale('xs', euiTheme)};
       ${logicalCSS('height', euiTheme.size.l)}
-      line-height: ${mathWithUnits(euiTheme.size.l, (x) => x * 0.95)};
+      line-height: ${mathWithUnits(euiTheme.size.l, (x) => x * 0.96)};
     `,
     s: css`
       font-size: 0.7rem;
@@ -66,7 +66,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       default: {
         m: `
         ${logicalCSS('padding-horizontal', euiTheme.size.base)}
-        padding-block-start: ${mathWithUnits(euiTheme.size.l, (x) => x * 0.05)}
+        padding-block-start: ${mathWithUnits(euiTheme.size.l, (x) => x * 0.04)}
         `,
         s: `
         ${logicalCSS('padding-horizontal', euiTheme.size.m)}


### PR DESCRIPTION
## Summary

- Current `EuiBetaBadge` looks slightly unbalanced in terms of text baseline alignment: the label with uppercase letters feels like being shifted a bit more towards the top of the badge. 
- It also feels a bit too harsh when the text inside is bold, so I tried to make it semibold, and increaed the font-size for smaller badge at the same time for better readability. This also makes the text better visually balanced with icon-only badge
![Badge](https://github.com/user-attachments/assets/b6f04b64-b8a3-4b49-9e4a-a13803938c53)
