### PR TITLE
[EuiSuperDatePicker] Fix locale date string test

### DIFF
--- a/packages/eui/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx
@@ -115,13 +115,17 @@ describe('EuiAbsoluteTab', () => {
         locale: LocaleSpecifier;
         dateString: string;
       }>([
-        { locale: 'en', dateString: 'Mon Jan 1st' },
-        { locale: 'zh-CN', dateString: '周一 1月 1日' },
-        { locale: 'ja-JP', dateString: '月 1月 1日' },
-        { locale: 'fr-FR', dateString: 'lun. janv. 1er' },
+        { locale: 'en', dateString: 'Mon Jan 2024 1st' },
+        { locale: 'zh-CN', dateString: '周一 1月 2024 1日' },
+        { locale: 'ja-JP', dateString: '月 1月 2024 1日' },
+        { locale: 'fr-FR', dateString: 'lun. janv. 2024 1er' },
       ])('%p', ({ locale, dateString }) => {
         const { getByTestSubject } = render(
-          <EuiAbsoluteTab {...props} dateFormat="ddd MMM Do" locale={locale} />
+          <EuiAbsoluteTab
+            {...props}
+            dateFormat="ddd MMM YYYY Do"
+            locale={locale}
+          />
         );
         const input = getByTestSubject('superDatePickerAbsoluteDateInput');
 


### PR DESCRIPTION
## Summary

This PR updates the `EuiSuperdatePicker` `absolute_tab.test.tsx` test by adding a year to the passed date string to prevent tests breaking on yearly changing week days.

Example failing test:

```
EuiAbsoluteTab › date parsing › parses date string in locale › {"dateString": "lun. janv. 1er", "locale": "fr-FR"}
```

The issue was that January 1st was a Monday in 2024, but is not a Monday in 2025.
We should fix the date to the year to ensure the test works generally.

## QA

- [x] CI passes
- [ ] verify tests pass
  - checkout this PR
  - move to `packages/eui` and run `yarn test-unit src/components/date_picker/super_date_picker/date_popover/absolute_tab.test.tsx`