### PR TITLE
[Visual Refresh] Fix strong border token naming

### DIFF
--- a/packages/eui-theme-borealis/src/variables/colors/_colors_dark.scss
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_dark.scss
@@ -96,26 +96,26 @@ $euiColorTextWarning: $euiColorWarning30 !default;
 $euiColorTextDanger: $euiColorDanger60 !default;
 
 // Borders
-$euiColorBorderBasePrimary: $euiColorPrimary120;
-$euiColorBorderBaseAccent: $euiColorAccent120;
-$euiColorBorderBaseAccentSecondary: $euiColorAccentSecondary120;
-$euiColorBorderBaseSuccess: $euiColorSuccess120;
-$euiColorBorderBaseWarning: $euiColorWarning120;
-$euiColorBorderBaseDanger: $euiColorDanger120;
+$euiColorBorderBasePrimary: $euiColorPrimary120 !default;
+$euiColorBorderBaseAccent: $euiColorAccent120 !default;
+$euiColorBorderBaseAccentSecondary: $euiColorAccentSecondary120 !default;
+$euiColorBorderBaseSuccess: $euiColorSuccess120 !default;
+$euiColorBorderBaseWarning: $euiColorWarning120 !default;
+$euiColorBorderBaseDanger: $euiColorDanger120 !default;
 
-$euiColorBorderBasePlain: $euiColorShade100;
-$euiColorBorderBaseSubdued: $euiColorShade120;
-$euiColorBorderBaseDisabled: $euiColorShade100;
-$euiColorBorderBaseFloating: $euiColorShade120;
-$euiColorBorderBaseFormsColorSwatch: $euiColorPlainLightAlpha32;
-$euiColorBorderBaseFormsControl: $euiColorShade80;
+$euiColorBorderBasePlain: $euiColorShade100 !default;
+$euiColorBorderBaseSubdued: $euiColorShade120 !default;
+$euiColorBorderBaseDisabled: $euiColorShade100 !default;
+$euiColorBorderBaseFloating: $euiColorShade120 !default;
+$euiColorBorderBaseFormsColorSwatch: $euiColorPlainLightAlpha32 !default;
+$euiColorBorderBaseFormsControl: $euiColorShade80 !default;
 
-$euiColorBorderStrongPrimary: $euiColorPrimary60;
-$euiColorBorderStrongAccent: $euiColorAccent60;
-$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary60;
-$euiColorBorderStrongSuccess: $euiColorSuccess60;
-$euiColorBorderStrongWarning: $euiColorWarning40;
-$euiColorBorderStrongDanger: $euiColorDanger60;
+$euiColorBorderStrongPrimary: $euiColorPrimary60 !default;
+$euiColorBorderStrongAccent: $euiColorAccent60 !default;
+$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary60 !default;
+$euiColorBorderStrongSuccess: $euiColorSuccess60 !default;
+$euiColorBorderStrongWarning: $euiColorWarning40 !default;
+$euiColorBorderStrongDanger: $euiColorDanger60 !default;
 
 // Charts
 $euiColorChartLines: $euiColorShade85 !default;

--- a/packages/eui-theme-borealis/src/variables/colors/_colors_dark.scss
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_dark.scss
@@ -110,12 +110,12 @@ $euiColorBorderBaseFloating: $euiColorShade120;
 $euiColorBorderBaseFormsColorSwatch: $euiColorPlainLightAlpha32;
 $euiColorBorderBaseFormsControl: $euiColorShade80;
 
-$euiColorStrongBasePrimary: $euiColorPrimary60;
-$euiColorStrongBaseAccent: $euiColorAccent60;
-$euiColorStrongBaseAccentSecondary: $euiColorAccentSecondary60;
-$euiColorStrongBaseSuccess: $euiColorSuccess60;
-$euiColorStrongBaseWarning: $euiColorWarning40;
-$euiColorStrongBaseDanger: $euiColorDanger60;
+$euiColorBorderStrongPrimary: $euiColorPrimary60;
+$euiColorBorderStrongAccent: $euiColorAccent60;
+$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary60;
+$euiColorBorderStrongSuccess: $euiColorSuccess60;
+$euiColorBorderStrongWarning: $euiColorWarning40;
+$euiColorBorderStrongDanger: $euiColorDanger60;
 
 // Charts
 $euiColorChartLines: $euiColorShade85 !default;

--- a/packages/eui-theme-borealis/src/variables/colors/_colors_light.scss
+++ b/packages/eui-theme-borealis/src/variables/colors/_colors_light.scss
@@ -97,27 +97,27 @@ $euiColorTextWarning: $euiColorWarning110 !default;
 $euiColorTextDanger: $euiColorDanger100 !default;
 
 // Borders
-$euiColorBorderBasePrimary: $euiColorPrimary30;
-$euiColorBorderBaseAccent: $euiColorAccent30;
-$euiColorBorderBaseAccentSecondary: $euiColorAccentSecondary30;
-$euiColorBorderBaseSuccess: $euiColorSuccess30;
-$euiColorBorderBaseWarning: $euiColorWarning30;
-$euiColorBorderBaseDanger: $euiColorDanger30;
+$euiColorBorderBasePrimary: $euiColorPrimary30 !default;
+$euiColorBorderBaseAccent: $euiColorAccent30 !default;
+$euiColorBorderBaseAccentSecondary: $euiColorAccentSecondary30 !default;
+$euiColorBorderBaseSuccess: $euiColorSuccess30 !default;
+$euiColorBorderBaseWarning: $euiColorWarning30 !default;
+$euiColorBorderBaseDanger: $euiColorDanger30 !default;
 
-$euiColorBorderBasePlain: $euiColorShade30;
-$euiColorBorderBaseSubdued: $euiColorShade20;
-$euiColorBorderBaseDisabled: $euiColorShade30;
-$euiColorBorderBaseFloating: $euiColorTransparent;
+$euiColorBorderBasePlain: $euiColorShade30 !default;
+$euiColorBorderBaseSubdued: $euiColorShade20 !default;
+$euiColorBorderBaseDisabled: $euiColorShade30 !default;
+$euiColorBorderBaseFloating: $euiColorTransparent !default;
 
-$euiColorBorderBaseFormsColorSwatch: $euiColorShade100Alpha24;
-$euiColorBorderBaseFormsControl: $euiColorShade60;
+$euiColorBorderBaseFormsColorSwatch: $euiColorShade100Alpha24 !default;
+$euiColorBorderBaseFormsControl: $euiColorShade60 !default;
 
-$euiColorBorderStrongPrimary: $euiColorPrimary100;
-$euiColorBorderStrongAccent: $euiColorAccent100;
-$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary100;
-$euiColorBorderStrongSuccess: $euiColorSuccess100;
-$euiColorBorderStrongWarning: $euiColorWarning100;
-$euiColorBorderStrongDanger: $euiColorDanger100;
+$euiColorBorderStrongPrimary: $euiColorPrimary100 !default;
+$euiColorBorderStrongAccent: $euiColorAccent100 !default;
+$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary100 !default;
+$euiColorBorderStrongSuccess: $euiColorSuccess100 !default;
+$euiColorBorderStrongWarning: $euiColorWarning100 !default;
+$euiColorBorderStrongDanger: $euiColorDanger100 !default;
 
 // Charts
 $euiColorChartLines: $euiColorShade30 !default;

--- a/packages/eui/src/themes/amsterdam/_colors_dark.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_dark.scss
@@ -95,26 +95,26 @@ $euiColorTextDanger: $euiColorDangerText !default;
 $euiLinkColor: $euiColorPrimaryText !default;
 
 // Borders
-$euiColorBorderBasePrimary: shade($euiColorPrimary, 0.6);
-$euiColorBorderBaseAccent: shade($euiColorAccent, 0.6);
-$euiColorBorderBaseAccentSecondary: shade($euiColorAccentSecondary, 0.6);
-$euiColorBorderBaseSuccess: shade($euiColorSuccess, 0.6);
-$euiColorBorderBaseWarning: shade($euiColorWarning, 0.6);
-$euiColorBorderBaseDanger: shade($euiColorDanger, 0.6);
+$euiColorBorderBasePrimary: shade($euiColorPrimary, 0.6) !default;
+$euiColorBorderBaseAccent: shade($euiColorAccent, 0.6) !default;
+$euiColorBorderBaseAccentSecondary: shade($euiColorAccentSecondary, 0.6) !default;
+$euiColorBorderBaseSuccess: shade($euiColorSuccess, 0.6) !default;
+$euiColorBorderBaseWarning: shade($euiColorWarning, 0.6) !default;
+$euiColorBorderBaseDanger: shade($euiColorDanger, 0.6) !default;
 
-$euiColorBorderBasePlain: $euiColorLightShade;
-$euiColorBorderBaseSubdued: $euiColorLightShade;
-$euiColorBorderBaseDisabled: transparentize($euiColorGhost, 0.1);
-$euiColorBorderBaseFloating: $euiColorLightShade;
-$euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1);
-$euiColorBorderBaseFormsControl: tint($euiColorLightestShade, 0.31);
+$euiColorBorderBasePlain: $euiColorLightShade !default;
+$euiColorBorderBaseSubdued: $euiColorLightShade !default;
+$euiColorBorderBaseDisabled: transparentize($euiColorGhost, 0.1) !default;
+$euiColorBorderBaseFloating: $euiColorLightShade !default;
+$euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
+$euiColorBorderBaseFormsControl: tint($euiColorLightestShade, 0.31) !default;
 
-$euiColorBorderStrongPrimary: $euiColorBorderBasePrimary;
-$euiColorBorderStrongAccent: $euiColorBorderBaseAccent;
-$euiColorBorderStrongAccentSecondary: $euiColorBorderBaseAccentSecondary;
-$euiColorBorderStrongSuccess: $euiColorBorderBaseSuccess;
-$euiColorBorderStrongWarning: $euiColorBorderBaseWarning;
-$euiColorBorderStrongDanger: $euiColorBorderBaseDanger;
+$euiColorBorderStrongPrimary: $euiColorBorderBasePrimary !default;
+$euiColorBorderStrongAccent: $euiColorBorderBaseAccent !default;
+$euiColorBorderStrongAccentSecondary: $euiColorBorderBaseAccentSecondary !default;
+$euiColorBorderStrongSuccess: $euiColorBorderBaseSuccess !default;
+$euiColorBorderStrongWarning: $euiColorBorderBaseWarning !default;
+$euiColorBorderStrongDanger: $euiColorBorderBaseDanger !default;
 
 // Charts
 $euiColorChartLines: $euiColorLightShade !default;

--- a/packages/eui/src/themes/amsterdam/_colors_light.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_light.scss
@@ -95,26 +95,26 @@ $euiColorTextDanger: $euiColorDangerText !default;
 $euiLinkColor: $euiColorPrimaryText !default;
 
 // Borders
-$euiColorBorderBasePrimary: tint($euiColorPrimary, 0.6);
-$euiColorBorderBaseAccent: tint($euiColorAccent, 0.6);
-$euiColorBorderBaseAccentSecondary: tint($euiColorAccentSecondary, 0.6);
-$euiColorBorderBaseSuccess: tint($euiColorSuccess, 0.6);
-$euiColorBorderBaseWarning: tint($euiColorWarning, 0.6);
-$euiColorBorderBaseDanger: tint($euiColorDanger, 0.6);
+$euiColorBorderBasePrimary: tint($euiColorPrimary, 0.6) !default;
+$euiColorBorderBaseAccent: tint($euiColorAccent, 0.6) !default;
+$euiColorBorderBaseAccentSecondary: tint($euiColorAccentSecondary, 0.6) !default;
+$euiColorBorderBaseSuccess: tint($euiColorSuccess, 0.6) !default;
+$euiColorBorderBaseWarning: tint($euiColorWarning, 0.6) !default;
+$euiColorBorderBaseDanger: tint($euiColorDanger, 0.6) !default;
 
-$euiColorBorderBasePlain: $euiColorLightShade;
-$euiColorBorderBaseSubdued: $euiColorLightShade;
-$euiColorBorderBaseDisabled: transparentize(darken($euiColorLightShade, 40%), 0.1);
-$euiColorBorderBaseFloating: 'transparent';
-$euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1);
-$euiColorBorderBaseFormsControl: shade($euiColorLightestShade, 0.4);
+$euiColorBorderBasePlain: $euiColorLightShade !default;
+$euiColorBorderBaseSubdued: $euiColorLightShade !default;
+$euiColorBorderBaseDisabled: transparentize(darken($euiColorLightShade, 40%), 0.1) !default;
+$euiColorBorderBaseFloating: 'transparent' !default;
+$euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
+$euiColorBorderBaseFormsControl: shade($euiColorLightestShade, 0.4) !default;
 
-$euiColorBorderStrongPrimary: $euiColorBorderBasePrimary;
-$euiColorBorderStrongAccent: $euiColorBorderBaseAccent;
-$euiColorBorderStrongAccentSecondary: $euiColorBorderBaseAccentSecondary;
-$euiColorBorderStrongSuccess: $euiColorBorderBaseSuccess;
-$euiColorBorderStrongWarning: $euiColorBorderBaseWarning;
-$euiColorBorderStrongDanger: $euiColorBorderBaseDanger;
+$euiColorBorderStrongPrimary: $euiColorBorderBasePrimary !default;
+$euiColorBorderStrongAccent: $euiColorBorderBaseAccent !default;
+$euiColorBorderStrongAccentSecondary: $euiColorBorderBaseAccentSecondary !default;
+$euiColorBorderStrongSuccess: $euiColorBorderBaseSuccess !default;
+$euiColorBorderStrongWarning: $euiColorBorderBaseWarning !default;
+$euiColorBorderStrongDanger: $euiColorBorderBaseDanger !default;
 
 // Charts
 $euiColorChartLines: shade($euiColorLightestShade, 3%) !default;


### PR DESCRIPTION
## Summary

We noticed that there seems to have been some typos in the `borderStrong` SCSS tokens 🫠 
This causes the variables to not actually be available for use.

## Changes

- renames SCSS `borderStrong` tokens for Borealis dark
- adds missing `!default` flag (since we're here 🤷‍♀️)

## QA

- [x] verify the tokens are available:
  - checkout this PR
  - use the border tokens, e.g. `$euiColorBorderStrongSuccess` in our EUI docs, e.g. in `packages/eui/src-docs/src/views/home/_home.scss` to add a background color somewhere
  
  ```css
  // example
  .guideSideNav {
    background-color: $euiColorBorderStrongSuccess !important;
  }
  ```
![Screenshot 2025-01-08 at 17 37 11](https://github.com/user-attachments/assets/3fdd9c3d-974e-4d7e-91e7-3d8017a22473)
