### PR TITLE
[Visual Refresh] Update floating border on EuiPanel

### DIFF
--- a/packages/eui/src/components/panel/panel.styles.ts
+++ b/packages/eui/src/components/panel/panel.styles.ts
@@ -18,6 +18,23 @@ import {
 export const euiPanelStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
 
+  const borderStyle = `
+    position: relative;
+
+    /* Using a pseudo element for the border instead of floating border only 
+      because the transparent border might otherwise be visible with arbitrary 
+      full-width/height content in light mode. */
+    ::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border: ${euiTheme.border.width.thin} solid
+        ${euiTheme.colors.borderBaseFloating};
+      border-radius: inherit;
+      pointer-events: none;
+    }
+  `;
+
   return {
     // Base
     euiPanel: css`
@@ -30,8 +47,8 @@ export const euiPanelStyles = (euiThemeContext: UseEuiTheme) => {
 
     hasShadow: css`
       ${euiShadow(euiThemeContext, 'm')}
-      border: ${euiTheme.border.width.thin} solid ${euiTheme.colors
-        .borderBaseFloating};
+
+      ${borderStyle}
     `,
 
     hasBorder: css`


### PR DESCRIPTION
## Summary

>[!IMPORTANT]
This PR merges into a feature branch.

This PR updates the implementation of the floating border on `EuiPanel` to fix the issue of the transparent border on light mode showing with colored full-width content (e.g. for `EuiSplitPanel`)

Instead of adding the floating border on the panel element directly, this PR adds a pseudo element for the border.
This will:
- prevent transparent borders from showing as the border overlaps the content instead of sitting around the content
- ensures layout parity between light and dark mode (having a conditional border on dark mode would otherwise mean that light and dark mode have slightly different dimensions for panels as borders add to the size)

| before | after|
|-------|------|
| ![Screenshot 2025-01-13 at 10 52 52](https://github.com/user-attachments/assets/2ea65e83-7b37-443f-af96-b42548a1e7ae) | ![Screenshot 2025-01-13 at 10 53 31](https://github.com/user-attachments/assets/2deb814f-6245-462c-ac19-2e151ca25e32) |


## QA

>[!NOTE]
To enable Borealis in EUI PR deployments, you'll need to:
>- add the following localStorage item: `eui-experimental-theme-enabled: true`
>- reload the page
>- select Borealis from the theme switcher

- [x] verify the floating border on `EuiSplitPanel` ([Storybook](https://eui.elastic.co/pr_8270/storybook/index.html?path=/story/layout-euisplitpanel--split-panel-inner), [EUI docs](https://github.com/elastic/eui/pull/8270)) is visible for Borealis only
- [x] verify the border does not affect dimensions between light and dark mode
- [x] verify panels look the same between [production](https://eui.elastic.co/#/layout/panel) and [staging](https://eui.elastic.co/pr_8270/#/layout/panel)