### PR TITLE
Remap few colors for `EuiLoadingSpinner` and `EuiLoadingChart`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,7 @@ name: 🐛 Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug, ⚠️ needs validation
+type: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,9 @@
 ---
 name: ✨ Feature request
-about: Suggest an idea for this project
+about: A request, idea, or new functionality
 title: ''
 labels: feature request
+type: 'Enhancement'
 assignees: ''
 
 ---

--- a/packages/eui-theme-borealis/src/variables/_components.ts
+++ b/packages/eui-theme-borealis/src/variables/_components.ts
@@ -242,10 +242,10 @@ export const components: _EuiThemeComponents = {
     listGroupItemBackgroundPrimaryHover:
       dark_background_colors.backgroundBaseInteractiveHover,
 
-    loadingChartMonoBackground0: SEMANTIC_COLORS.shade95,
-    loadingChartMonoBackground1: SEMANTIC_COLORS.shade105,
-    loadingChartMonoBackground2: SEMANTIC_COLORS.shade115,
-    loadingChartMonoBackground3: SEMANTIC_COLORS.shade125,
+    loadingChartMonoBackground0: SEMANTIC_COLORS.shade110,
+    loadingChartMonoBackground1: SEMANTIC_COLORS.shade100,
+    loadingChartMonoBackground2: SEMANTIC_COLORS.shade90,
+    loadingChartMonoBackground3: SEMANTIC_COLORS.shade80,
 
     markBackground: dark_background_colors.backgroundLightPrimary,
 

--- a/packages/eui/changelogs/upcoming/8255.md
+++ b/packages/eui/changelogs/upcoming/8255.md
@@ -1,0 +1,2 @@
+- Updated font-weight and font-size of `EuiBetaBadge`s to improve legibility
+

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.styles.ts
@@ -20,6 +20,10 @@ import { euiBadgeColors } from '../color_utils';
 export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme, colorMode } = euiThemeContext;
   const badgeColors = euiBadgeColors(euiThemeContext);
+  const badgeSizes = {
+    m: euiTheme.size.l,
+    s: mathWithUnits(euiTheme.size.base, (x) => x * 1.25),
+  };
 
   const hasVisColorAdjustment = euiTheme.flags?.hasVisColorAdjustment;
 
@@ -29,7 +33,7 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       border-radius: ${euiTheme.size.l};
       cursor: default;
 
-      font-weight: ${euiTheme.font.weight.bold};
+      font-weight: ${euiTheme.font.weight.semiBold};
       text-transform: uppercase;
       letter-spacing: 0.05em;
       text-align: center;
@@ -57,19 +61,23 @@ export const euiBetaBadgeStyles = (euiThemeContext: UseEuiTheme) => {
     // Font sizes
     m: css`
       font-size: ${euiFontSizeFromScale('xs', euiTheme)};
-      line-height: ${euiTheme.size.l};
+      line-height: ${badgeSizes.m};
     `,
     s: css`
-      font-size: 0.625rem;
-      line-height: ${mathWithUnits(euiTheme.size.xs, (x) => x + euiTheme.base)};
+      font-size: 0.7rem;
+      line-height: ${badgeSizes.s};
     `,
     // Padding/width sizes
     badgeSizes: {
       default: {
         m: `
-        ${logicalCSS('padding-horizontal', euiTheme.size.base)}`,
+        ${logicalCSS('height', badgeSizes.m)}
+        ${logicalCSS('padding-horizontal', euiTheme.size.base)}
+        `,
         s: `
-        ${logicalCSS('padding-horizontal', euiTheme.size.m)}`,
+        ${logicalCSS('height', badgeSizes.s)}
+        ${logicalCSS('padding-horizontal', euiTheme.size.m)}
+        `,
       },
       // When it's just an icon or a single letter, make the badge a circle
       circle: {

--- a/packages/eui/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/packages/eui/src/components/button/__snapshots__/button.test.tsx.snap
@@ -299,7 +299,7 @@ exports[`EuiButton props isLoading is rendered 1`] = `
       aria-label="Loading"
       class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
       role="progressbar"
-      style="border-color: #0077cc currentcolor currentcolor currentcolor;"
+      style="border-color: #99c9eb currentcolor currentcolor currentcolor;"
     />
   </span>
 </button>

--- a/packages/eui/src/components/button/button_display/__snapshots__/_button_display_content.test.tsx.snap
+++ b/packages/eui/src/components/button/button_display/__snapshots__/_button_display_content.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiButtonDisplayContent button icon loading icon renders disabled & loa
     aria-label="Loading"
     class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
     role="progressbar"
-    style="border-color: #0077cc currentcolor currentcolor currentcolor;"
+    style="border-color: #99c9eb currentcolor currentcolor currentcolor;"
   />
   <span
     class="eui-textTruncate"

--- a/packages/eui/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
+++ b/packages/eui/src/components/button/button_empty/__snapshots__/button_empty.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`EuiButtonEmpty props isLoading is rendered 1`] = `
       aria-label="Loading"
       class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
       role="progressbar"
-      style="border-color: #0077cc currentcolor currentcolor currentcolor;"
+      style="border-color: #99c9eb currentcolor currentcolor currentcolor;"
     />
     <span
       class="eui-textTruncate euiButtonEmpty__text"

--- a/packages/eui/src/components/button/button_icon/__snapshots__/button_icon.test.tsx.snap
+++ b/packages/eui/src/components/button/button_icon/__snapshots__/button_icon.test.tsx.snap
@@ -257,7 +257,7 @@ exports[`EuiButtonIcon props isLoading is rendered 1`] = `
     aria-label="Loading"
     class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
     role="progressbar"
-    style="border-color: #0077cc currentcolor currentcolor currentcolor;"
+    style="border-color: #99c9eb currentcolor currentcolor currentcolor;"
   />
 </button>
 `;

--- a/packages/eui/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
+++ b/packages/eui/src/components/loading/__snapshots__/loading_spinner.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`EuiLoadingSpinner custom colors 1`] = `
     aria-label="Loading"
     class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
     role="progressbar"
-    style="border-color: #0077cc white white white;"
+    style="border-color: #99c9eb white white white;"
   />
   <span
     aria-label="Loading"

--- a/packages/eui/src/components/loading/loading_spinner.styles.ts
+++ b/packages/eui/src/components/loading/loading_spinner.styles.ts
@@ -44,8 +44,8 @@ export const euiSpinnerBorderColorsCSS = (
   colors: EuiLoadingSpinnerColor = {}
 ): string => {
   const {
-    border = euiTheme.colors.lightShade,
-    highlight = euiTheme.colors.primary,
+    border = euiTheme.colors.borderBasePlain,
+    highlight = euiTheme.colors.borderStrongPrimary,
   } = colors;
   return `${highlight} ${border} ${border} ${border}`;
 };


### PR DESCRIPTION
## Summary
This small PR:
- Changes grey shades used for the `EuiLoadingChart` in mono version in dark mode:
![CleanShot 2025-01-15 at 09 22 38@2x](https://github.com/user-attachments/assets/c15672e1-e3c8-4391-90c0-bd0cd59eaebc)
- Maps `EuiLoadingSpinner` to unilize Borealis tokens instead of old Amsterdam tokens.
![CleanShot 2025-01-15 at 09 23 07@2x](https://github.com/user-attachments/assets/b8a1a0cc-7bf5-428f-b357-a6cc52784e87)

### General checklist
- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**