### PR TITLE
[EuiStat] Support warning variant

### DIFF
--- a/packages/eui/changelogs/upcoming/8278.md
+++ b/packages/eui/changelogs/upcoming/8278.md
@@ -1,0 +1,2 @@
+- Added suppport for `titleColor` variant `warning` on `EuiStat`
+

--- a/packages/eui/src-docs/src/views/stat/stat_colors.js
+++ b/packages/eui/src-docs/src/views/stat/stat_colors.js
@@ -3,38 +3,27 @@ import React from 'react';
 import { EuiStat, EuiFlexItem, EuiFlexGroup } from '../../../../src/components';
 
 export default () => (
-  <div>
-    <EuiFlexGroup>
-      <EuiFlexItem>
-        <EuiStat title="1" description="Default color" />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat title="10" description="Subdued color" titleColor="subdued" />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat title="100" description="Primary color" titleColor="primary" />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat
-          title="1,000"
-          description="Success color"
-          titleColor="success"
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat
-          title="10,000"
-          description="Danger color"
-          titleColor="danger"
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat
-          title="100,000"
-          description="Accent color"
-          titleColor="accent"
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </div>
+  <EuiFlexGroup wrap>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="1" description="Default color" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="10" description="Subdued color" titleColor="subdued" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="100" description="Primary color" titleColor="primary" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="100,000" description="Accent color" titleColor="accent" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="1,000" description="Success color" titleColor="success" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="1,000" description="Warning color" titleColor="warning" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="10,000" description="Danger color" titleColor="danger" />
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );

--- a/packages/eui/src/components/stat/__snapshots__/stat.test.tsx.snap
+++ b/packages/eui/src/components/stat/__snapshots__/stat.test.tsx.snap
@@ -353,6 +353,25 @@ exports[`EuiStat props title and description are reversed 1`] = `
 </div>
 `;
 
+exports[`EuiStat props warning is rendered 1`] = `
+<div
+  class="euiStat emotion-euiStat-left"
+>
+  <div
+    class="euiText euiStat__description emotion-euiText-s"
+  >
+    <p>
+      description
+    </p>
+  </div>
+  <p
+    class="euiTitle euiStat__title emotion-euiTitle-l-euiStat__title-warning"
+  >
+    title
+  </p>
+</div>
+`;
+
 exports[`EuiStat props xs is rendered 1`] = `
 <div
   class="euiStat emotion-euiStat-left"

--- a/packages/eui/src/components/stat/stat.styles.ts
+++ b/packages/eui/src/components/stat/stat.styles.ts
@@ -43,6 +43,9 @@ export const euiStatTitleStyles = ({ euiTheme }: UseEuiTheme) => {
     success: css`
       color: ${euiTheme.colors.successText};
     `,
+    warning: css`
+      color: ${euiTheme.colors.warningText};
+    `,
     danger: css`
       color: ${euiTheme.colors.dangerText};
     `,

--- a/packages/eui/src/components/stat/stat.tsx
+++ b/packages/eui/src/components/stat/stat.tsx
@@ -28,6 +28,7 @@ export const COLORS = [
   'subdued',
   'primary',
   'success',
+  'warning',
   'danger',
   'accent',
 ] as const;

--- a/packages/website/docs/components/display/stat.mdx
+++ b/packages/website/docs/components/display/stat.mdx
@@ -31,40 +31,29 @@ import React from 'react';
 import { EuiStat, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 
 export default () => (
-  <div>
-    <EuiFlexGroup>
-      <EuiFlexItem>
-        <EuiStat title="1" description="Default color" />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat title="10" description="Subdued color" titleColor="subdued" />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat title="100" description="Primary color" titleColor="primary" />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat
-          title="1,000"
-          description="Success color"
-          titleColor="success"
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat
-          title="10,000"
-          description="Danger color"
-          titleColor="danger"
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiStat
-          title="100,000"
-          description="Accent color"
-          titleColor="accent"
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </div>
+  <EuiFlexGroup wrap>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="1" description="Default color" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="10" description="Subdued color" titleColor="subdued" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="100" description="Primary color" titleColor="primary" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="100,000" description="Accent color" titleColor="accent" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="1,000" description="Success color" titleColor="success" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="1,000" description="Warning color" titleColor="warning" />
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiStat title="10,000" description="Danger color" titleColor="danger" />
+    </EuiFlexItem>
+  </EuiFlexGroup>
 );
 ```
 


### PR DESCRIPTION
## Summary

This PR adds support for `warning` as value for the `titleColor` prop.
This was requested and approved by design.

Additionally this PR adds a tiny layout change to the docs for displaying `titleColor` variants of `EuiStat` to ensure flex items wrap to improve the layout arrangement on smaller (non-mobile) viewports.

_before_

![Screenshot 2025-01-16 at 10 15 08](https://github.com/user-attachments/assets/3473b7a6-1dcf-4e7f-a918-f071e716cddd)

_after_

![Screenshot 2025-01-16 at 10 15 00](https://github.com/user-attachments/assets/6785ca52-fcbc-4021-b1bb-1fffd2d46c68)

![Screenshot 2025-01-16 at 10 14 54](https://github.com/user-attachments/assets/a772cae2-6d71-4987-aba0-0b507037a057)


## QA

- [x] verify the new variant is output as expected in the EUI docs

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader~ modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
