### PR TITLE
[Visual Refresh] Provide hooks for color palette functions

### DIFF
--- a/packages/eui-theme-borealis/src/index.ts
+++ b/packages/eui-theme-borealis/src/index.ts
@@ -18,6 +18,8 @@ import { font } from './variables/_typography';
 import { focus } from './variables/_states';
 import { components } from './variables/_components';
 
+export { colorVis } from './variables/colors/_colors_vis';
+
 export const EUI_THEME_BOREALIS_KEY = 'EUI_THEME_BOREALIS';
 
 export const euiThemeBorealis: EuiThemeShape = {

--- a/packages/eui/src-docs/src/views/color_palette/color_palette_custom.js
+++ b/packages/eui/src-docs/src/views/color_palette/color_palette_custom.js
@@ -8,17 +8,22 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-import { euiPaletteColorBlind, colorPalette } from '../../../../src/services';
+import {
+  colorPalette,
+  useEuiPaletteColorBlind,
+} from '../../../../src/services';
 import { ColorPaletteFlexItem, ColorPaletteCopyCode } from './shared';
-
-const customPalettes = [
-  [euiPaletteColorBlind()[3]],
-  [euiPaletteColorBlind()[3], euiPaletteColorBlind()[4]],
-  [euiPaletteColorBlind()[3], euiPaletteColorBlind()[4]],
-];
 
 export default () => {
   const [length, setLength] = useState(10);
+
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
+
+  const customPalettes = [
+    [euiPaletteColorBlind[3]],
+    [euiPaletteColorBlind[3], euiPaletteColorBlind[4]],
+    [euiPaletteColorBlind[3], euiPaletteColorBlind[4]],
+  ];
 
   const onLengthChange = (e) => {
     setLength(e.currentTarget.value);

--- a/packages/eui/src-docs/src/views/color_picker/color_palette_display.js
+++ b/packages/eui/src-docs/src/views/color_picker/color_palette_display.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
 import {
-  euiPaletteColorBlind,
   euiPaletteForStatus,
   euiPaletteForTemperature,
   euiPaletteComplementary,
@@ -11,6 +10,7 @@ import {
   euiPaletteWarm,
   euiPaletteGray,
   EUI_VIS_COLOR_STORE,
+  useEuiPaletteColorBlind,
 } from '../../../../src/services/color';
 
 import {
@@ -75,6 +75,8 @@ export default () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const [size, setSize] = useState(sizes[1].value);
 
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
+
   const getPalettes = useCallback(
     () =>
       paletteNames.map((paletteName, index) => {
@@ -135,16 +137,13 @@ export default () => {
         <h3>Fixed</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiColorPaletteDisplay type="fixed" palette={euiPaletteColorBlind()} />
+      <EuiColorPaletteDisplay type="fixed" palette={euiPaletteColorBlind} />
       <EuiSpacer />
       <EuiTitle size="xxxs">
         <h3>Gradient</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      <EuiColorPaletteDisplay
-        type="gradient"
-        palette={euiPaletteColorBlind()}
-      />
+      <EuiColorPaletteDisplay type="gradient" palette={euiPaletteColorBlind} />
       <EuiSpacer />
       <EuiTitle size="xxxs">
         <h3>Fixed with stops</h3>

--- a/packages/eui/src-docs/src/views/combo_box/colors.js
+++ b/packages/eui/src-docs/src/views/combo_box/colors.js
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { EuiComboBox } from '../../../../src/components';
-import { euiPaletteColorBlindBehindText } from '../../../../src/services';
+import { useEuiPaletteColorBlindBehindText } from '../../../../src/services';
 import { DisplayToggles } from '../form_controls/display_toggles';
 
-const visColorsBehindText = euiPaletteColorBlindBehindText();
-const optionsStatic = [
+const getOptionsStatic = (visColorsBehindText) => [
   {
     label: 'Titan',
     'data-test-subj': 'titanOption',
@@ -51,8 +50,16 @@ const optionsStatic = [
 ];
 
 export default () => {
-  const [options, setOptions] = useState(optionsStatic);
+  const visColorsBehindText = useEuiPaletteColorBlindBehindText();
+
+  const [options, setOptions] = useState(getOptionsStatic(visColorsBehindText));
   const [selectedOptions, setSelected] = useState([options[2], options[5]]);
+
+  useEffect(() => {
+    const updatedOptions = getOptionsStatic(visColorsBehindText);
+    setOptions(updatedOptions);
+    setSelected([updatedOptions[2], updatedOptions[5]]);
+  }, [visColorsBehindText]);
 
   const onChange = (selectedOptions) => {
     setSelected(selectedOptions);

--- a/packages/eui/src-docs/src/views/combo_box/render_option.js
+++ b/packages/eui/src-docs/src/views/combo_box/render_option.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   EuiComboBox,
@@ -6,13 +6,11 @@ import {
   EuiHealth,
 } from '../../../../src/components';
 import {
-  euiPaletteColorBlind,
-  euiPaletteColorBlindBehindText,
+  useEuiPaletteColorBlind,
+  useEuiPaletteColorBlindBehindText,
 } from '../../../../src/services';
 
-const visColors = euiPaletteColorBlind();
-const visColorsBehindText = euiPaletteColorBlindBehindText();
-const optionsStatic = [
+const getOptionsStatic = (visColorsBehindText) => [
   {
     value: {
       size: 5,
@@ -88,8 +86,17 @@ const optionsStatic = [
 ];
 
 export default () => {
-  const [options, setOptions] = useState(optionsStatic);
+  const visColors = useEuiPaletteColorBlind();
+  const visColorsBehindText = useEuiPaletteColorBlindBehindText();
+
+  const [options, setOptions] = useState(getOptionsStatic(visColorsBehindText));
   const [selectedOptions, setSelected] = useState([options[2], options[5]]);
+
+  useEffect(() => {
+    const updatedOptions = getOptionsStatic(visColorsBehindText);
+    setOptions(updatedOptions);
+    setSelected([updatedOptions[2], updatedOptions[5]]);
+  }, [visColorsBehindText]);
 
   const onChange = (selectedOptions) => {
     setSelected(selectedOptions);

--- a/packages/eui/src-docs/src/views/elastic_charts/pie_alts.tsx
+++ b/packages/eui/src-docs/src/views/elastic_charts/pie_alts.tsx
@@ -18,10 +18,10 @@ import {
 } from '../../../../src/components';
 
 import {
-  euiPaletteForTemperature,
-  euiPaletteColorBlind,
-  euiPaletteGray,
   useEuiTheme,
+  useEuiPaletteColorBlind,
+  useEuiPaletteForTemperature,
+  useEuiPaletteGray,
 } from '../../../../src/services';
 
 import { GITHUB_DATASET, GITHUB_DATASET_MOD, DAYS_OF_RAIN } from './data';
@@ -40,15 +40,16 @@ export default () => {
   const [formattedData, setFormattedData] = useState(false);
   const [grouped, setGrouped] = useState(false);
 
-  let color = euiPaletteColorBlind({ rotations: 2, order: 'group' }).slice(
+  const paletteTemperature0 = useEuiPaletteForTemperature(0);
+  const paletteTemperature3 = useEuiPaletteForTemperature(3);
+  const paletteGray = useEuiPaletteGray(5);
+
+  let color = useEuiPaletteColorBlind({ rotations: 2, order: 'group' }).slice(
     18,
     20
   );
   if (formatted) {
-    color = [
-      euiPaletteForTemperature(0)[0],
-      euiPaletteGray(5)[isDarkTheme ? 4 : 0],
-    ];
+    color = [paletteTemperature0[0], paletteGray[isDarkTheme ? 4 : 0]];
   }
 
   let data;
@@ -58,7 +59,7 @@ export default () => {
       ? orderBy(DAYS_OF_RAIN, ['precipitation', 'days'], ['desc', 'asc'])
       : DAYS_OF_RAIN;
     usesRainData = true;
-    color = euiPaletteForTemperature(3);
+    color = paletteTemperature3;
   } else {
     const DATASET = grouped ? GITHUB_DATASET_MOD : GITHUB_DATASET;
     data = orderBy(DATASET, 'issueType', 'asc');

--- a/packages/eui/src-docs/src/views/elastic_charts/theming.tsx
+++ b/packages/eui/src-docs/src/views/elastic_charts/theming.tsx
@@ -8,6 +8,7 @@ import {
   BarSeries,
   DataGenerator,
 } from '@elastic/charts';
+import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
 
 import {
   EuiSpacer,
@@ -29,7 +30,6 @@ import {
   EUI_VIS_COLOR_STORE,
 } from '../../../../src/services';
 import { useChartBaseTheme } from './utils/use_chart_base_theme';
-import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
 
 const getPaletteData = () => ({
   euiPaletteColorBlind,

--- a/packages/eui/src-docs/src/views/elastic_charts/theming_categorical.tsx
+++ b/packages/eui/src-docs/src/views/elastic_charts/theming_categorical.tsx
@@ -18,17 +18,18 @@ import {
 
 import { CHART_COMPONENTS, type ChartType, ChartCard } from './shared';
 import {
-  euiPaletteColorBlind,
   euiPaletteGreen,
   euiPaletteForStatus,
   euiPaletteGray,
+  useEuiPaletteColorBlind,
 } from '../../../../src/services';
 import type { EuiPalette } from '../../../../src/services/color/eui_palettes';
 import { useChartBaseTheme } from './utils/use_chart_base_theme';
 
 export default () => {
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
   const chartBaseTheme = useChartBaseTheme();
-  const highlightColor = euiPaletteColorBlind()[2];
+  const highlightColor = euiPaletteColorBlind[2];
 
   const idPrefix = 'colorType';
 
@@ -246,7 +247,7 @@ export default () => {
           data={data}
           xAccessor={'x'}
           yAccessors={['y']}
-          color={[euiPaletteColorBlind()[index < 2 ? 0 : 1]]}
+          color={[euiPaletteColorBlind[index < 2 ? 0 : 1]]}
           lineSeriesStyle={{
             line: {
               strokeWidth: isOdd ? 1 : 6,

--- a/packages/eui/src-docs/src/views/elastic_charts/treemap.tsx
+++ b/packages/eui/src-docs/src/views/elastic_charts/treemap.tsx
@@ -8,7 +8,7 @@ import {
   EuiTitle,
   EuiSpacer,
 } from '../../../../src/components';
-import { euiPaletteColorBlind } from '../../../../src/services';
+import { useEuiPaletteColorBlind } from '../../../../src/services';
 
 import { GITHUB_DATASET_MOD } from './data';
 import { useChartBaseTheme } from './utils/use_chart_base_theme';
@@ -20,7 +20,7 @@ export default () => {
   /**
    * Create a 3 rotation palette (one for each level)
    */
-  const groupedPalette = euiPaletteColorBlind({
+  const groupedPalette = useEuiPaletteColorBlind({
     rotations: 3,
     order: 'group',
     sortBy: 'natural',

--- a/packages/eui/src-docs/src/views/facet/facet_layout.js
+++ b/packages/eui/src-docs/src/views/facet/facet_layout.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { useEuiPaletteColorBlind } from '../../../../src/services';
 import {
   EuiFacetButton,
   EuiFacetGroup,
@@ -7,14 +8,14 @@ import {
   EuiAvatar,
 } from '../../../../src/components';
 
-import { euiPaletteColorBlind } from '../../../../src/services';
-
 export default () => {
   const [icon, setIcon] = useState(false);
   const [disabled, setDisabled] = useState(false);
   const [avatars, setAvatars] = useState(false);
   const [loading, setLoading] = useState(false);
   const [selectedOptionId, setSelectedOptionId] = useState(undefined);
+
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
 
   const facet0Clicked = (id) => {
     setIcon(false);
@@ -65,42 +66,42 @@ export default () => {
       id: 'facet0',
       label: 'Simple, no icon',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[0],
+      iconColor: euiPaletteColorBlind[0],
       onClick: facet0Clicked,
     },
     {
       id: 'facet1',
       label: 'Label or color indicator',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[1],
+      iconColor: euiPaletteColorBlind[1],
       onClick: facet1Clicked,
     },
     {
       id: 'facet2',
       label: 'Disable all others',
       quantity: 600,
-      iconColor: euiPaletteColorBlind()[2],
+      iconColor: euiPaletteColorBlind[2],
       onClick: facet2Clicked,
     },
     {
       id: 'facet3',
       label: 'Avatars instead of icons',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[3],
+      iconColor: euiPaletteColorBlind[3],
       onClick: facet3Clicked,
     },
     {
       id: 'facet4',
       label: 'Show all as loading',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[4],
+      iconColor: euiPaletteColorBlind[4],
       onClick: facet4Clicked,
     },
     {
       id: 'facet5',
       label: 'Just here to show truncation of really long labels',
       quantity: 0,
-      iconColor: euiPaletteColorBlind()[5],
+      iconColor: euiPaletteColorBlind[5],
     },
   ];
 

--- a/packages/eui/src-docs/src/views/facet/facet_layout_horizontal.js
+++ b/packages/eui/src-docs/src/views/facet/facet_layout_horizontal.js
@@ -7,7 +7,7 @@ import {
   EuiAvatar,
 } from '../../../../src/components';
 
-import { euiPaletteColorBlind } from '../../../../src/services';
+import { useEuiPaletteColorBlind } from '../../../../src/services';
 
 export default () => {
   const [icon, setIcon] = useState(false);
@@ -15,6 +15,8 @@ export default () => {
   const [avatars, setAvatars] = useState(false);
   const [loading, setLoading] = useState(false);
   const [selectedOptionId, setSelectedOptionId] = useState(undefined);
+
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
 
   const facet0Clicked = (id) => {
     setIcon(false);
@@ -65,42 +67,42 @@ export default () => {
       id: 'facetHorizontal0',
       label: 'Simple, no icon',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[0],
+      iconColor: euiPaletteColorBlind[0],
       onClick: facet0Clicked,
     },
     {
       id: 'facetHorizontal1',
       label: 'Label or color indicator',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[1],
+      iconColor: euiPaletteColorBlind[1],
       onClick: facet1Clicked,
     },
     {
       id: 'facetHorizontal2',
       label: 'Disable all others',
       quantity: 600,
-      iconColor: euiPaletteColorBlind()[2],
+      iconColor: euiPaletteColorBlind[2],
       onClick: facet2Clicked,
     },
     {
       id: 'facetHorizontal3',
       label: 'Avatars instead of icons',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[3],
+      iconColor: euiPaletteColorBlind[3],
       onClick: facet3Clicked,
     },
     {
       id: 'facetHorizontal4',
       label: 'Show all as loading',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[4],
+      iconColor: euiPaletteColorBlind[4],
       onClick: facet4Clicked,
     },
     {
       id: 'facetHorizontal5',
       label: 'Just here to show truncation of really long labels',
       quantity: 0,
-      iconColor: euiPaletteColorBlind()[5],
+      iconColor: euiPaletteColorBlind[5],
     },
   ];
 

--- a/packages/eui/src-docs/src/views/timeline/timeline_item_event.tsx
+++ b/packages/eui/src-docs/src/views/timeline/timeline_item_event.tsx
@@ -19,7 +19,7 @@ import {
 
 import {
   useGeneratedHtmlId,
-  euiPaletteColorBlindBehindText,
+  useEuiPaletteColorBlindBehindText,
 } from '../../../../src/services';
 
 export default () => {
@@ -33,7 +33,7 @@ export default () => {
   // We could use the `euiPaletteColorBlind` for coloring the avatars
   // But because we're placing an icon on top of these colors
   // The `euiPaletteColorBlindBehindText` is a better choice to ensure better contrast
-  const colorBlindBehindText = euiPaletteColorBlindBehindText({
+  const colorBlindBehindText = useEuiPaletteColorBlindBehindText({
     sortBy: 'natural',
   });
 

--- a/packages/eui/src/components/avatar/avatar.tsx
+++ b/packages/eui/src/components/avatar/avatar.tsx
@@ -14,9 +14,9 @@ import {
   isColorDark,
   hexToRgb,
   isValidHex,
-  euiPaletteColorBlindBehindText,
+  useEuiPaletteColorBlindBehindText,
 } from '../../services/color';
-import { toInitials, useEuiMemoizedStyles, useEuiTheme } from '../../services';
+import { toInitials, useEuiMemoizedStyles } from '../../services';
 import { IconType, EuiIcon, IconSize, IconColor } from '../icon';
 
 import { euiAvatarStyles } from './avatar.styles';
@@ -127,13 +127,7 @@ export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
   checkValidInitials(initials);
   const { casing = type === 'space' ? 'none' : 'uppercase', ...rest } = props;
 
-  const { euiTheme } = useEuiTheme();
-
-  const visColors = useMemo(
-    () => euiPaletteColorBlindBehindText(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [euiTheme]
-  );
+  const visColors = useEuiPaletteColorBlindBehindText();
 
   const isPlain = color === 'plain';
   const isSubdued = color === 'subdued';

--- a/packages/eui/src/components/color_picker/color_picker.tsx
+++ b/packages/eui/src/components/color_picker/color_picker.tsx
@@ -22,8 +22,7 @@ import chroma, { ColorSpaces } from 'chroma-js';
 import {
   useEuiMemoizedStyles,
   keys,
-  euiPaletteColorBlind,
-  useEuiTheme,
+  useEuiPaletteColorBlind,
 } from '../../services';
 import { CommonProps } from '../common';
 import {
@@ -239,13 +238,8 @@ export const EuiColorPicker: FunctionComponent<EuiColorPickerProps> = ({
     ]
   );
 
-  const { euiTheme } = useEuiTheme();
-
-  const swatches = useMemo(
-    () => _swatches ?? euiPaletteColorBlind(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [_swatches, euiTheme]
-  );
+  const defaultSwatches = useEuiPaletteColorBlind();
+  const swatches = _swatches ?? defaultSwatches;
 
   const preferredFormat = useMemo(() => {
     if (format) return format;

--- a/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide.styles.ts
+++ b/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide.styles.ts
@@ -15,12 +15,12 @@ import {
 } from '../../../services';
 import { euiFontSize, logicalCSS } from '../../../global_styling';
 
-const visColors = euiPaletteColorBlind();
-
 export const euiSelectableTemplateSitewideStyles = (
   euiThemeContext: UseEuiTheme
 ) => {
   const { euiTheme } = euiThemeContext;
+
+  const visColors = euiPaletteColorBlind();
 
   return {
     euiSelectableTemplateSitewide: css`

--- a/packages/eui/src/services/color/eui_palettes.test.ts
+++ b/packages/eui/src/services/color/eui_palettes.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { colorVis } from '../../themes';
+import {
+  euiPaletteColorBlind,
+  euiPaletteColorBlindBehindText,
+  euiPaletteComplementary,
+  euiPaletteCool,
+  euiPaletteForDarkBackground,
+  euiPaletteForLightBackground,
+  euiPaletteForStatus,
+  euiPaletteForTemperature,
+  euiPaletteGray,
+  euiPaletteGreen,
+  euiPaletteRed,
+  euiPaletteWarm,
+} from './eui_palettes';
+
+describe('euiPaletteColorBlind', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = { ...colorVis, euiColorVis0: customColor };
+
+    const result = euiPaletteColorBlind({ colors });
+
+    expect(result[0]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteColorBlindBehindText', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVis0: customColor,
+    };
+
+    const result = euiPaletteColorBlindBehindText({
+      colors,
+      hasVisColorAdjustment: false,
+    });
+
+    expect(result[0]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteForLightBackground', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisAsTextLight0: customColor,
+    };
+
+    const result = euiPaletteForLightBackground({
+      colors,
+    });
+
+    expect(result[0]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteForDarkBackground', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisAsTextDark0: customColor,
+    };
+
+    const result = euiPaletteForDarkBackground({
+      colors,
+    });
+
+    expect(result[0]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteForStatus', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisSuccess0: customColor,
+    };
+
+    const result = euiPaletteForStatus(3, { colors });
+
+    expect(result[0]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteForTemperature', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisWarm2: customColor,
+    };
+
+    const result = euiPaletteForTemperature(3, { colors });
+
+    expect(result[2]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteComplementary', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisComplementary0: customColor,
+    };
+
+    const result = euiPaletteComplementary(3, { colors });
+
+    expect(result[0]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteRed', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisDanger0: customColor,
+    };
+
+    const result = euiPaletteRed(3, { colors });
+
+    expect(result[2]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteGreen', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisSuccess0: customColor,
+    };
+
+    const result = euiPaletteGreen(3, { colors });
+
+    expect(result[2]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteCool', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisCool2: customColor,
+    };
+
+    const result = euiPaletteCool(3, { colors });
+
+    expect(result[2]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteWarm', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisWarm2: customColor,
+    };
+
+    const result = euiPaletteWarm(3, { colors });
+
+    expect(result[2]).toEqual(customColor);
+  });
+});
+
+describe('euiPaletteGray', () => {
+  it('should return custom colors', () => {
+    const customColor = '#00ff00';
+    const colors = {
+      ...colorVis,
+      euiColorVisGrey3: customColor,
+    };
+
+    const result = euiPaletteGray(3, { colors });
+
+    expect(result[2]).toEqual(customColor);
+  });
+});

--- a/packages/eui/src/services/color/eui_palettes_hooks.test.tsx
+++ b/packages/eui/src/services/color/eui_palettes_hooks.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { PropsWithChildren } from 'react';
+
+import { renderHook } from '../../test/rtl';
+
+import { EuiProvider } from '../../components/provider';
+import { colorVis } from '../../themes';
+import {
+  useEuiPaletteColorBlind,
+  useEuiPaletteColorBlindBehindText,
+  useEuiPaletteComplementary,
+  useEuiPaletteForStatus,
+  useEuiPaletteForTemperature,
+  useEuiPaletteGreen,
+  useEuiPaletteRed,
+} from './eui_palettes_hooks';
+import { euiPaletteCool, euiPaletteGray, euiPaletteWarm } from './eui_palettes';
+
+// wrapper container to ensure hooks are rendered in specific test provider context
+const RenderContainer = ({ children }: PropsWithChildren) => (
+  <EuiProvider>{children}</EuiProvider>
+);
+
+describe('useEuiPaletteColorBlind', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteColorBlind(), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current).toEqual([
+      colorVis.euiColorVis0,
+      colorVis.euiColorVis1,
+      colorVis.euiColorVis2,
+      colorVis.euiColorVis3,
+      colorVis.euiColorVis4,
+      colorVis.euiColorVis5,
+      colorVis.euiColorVis6,
+      colorVis.euiColorVis7,
+      colorVis.euiColorVis8,
+      colorVis.euiColorVis9,
+    ]);
+  });
+});
+
+describe('useEuiPaletteColorBlindBehindText', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteColorBlindBehindText(), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current).toEqual([
+      colorVis.euiColorVisBehindText0.toLowerCase(),
+      colorVis.euiColorVisBehindText1.toLowerCase(),
+      colorVis.euiColorVisBehindText2.toLowerCase(),
+      colorVis.euiColorVisBehindText3.toLowerCase(),
+      colorVis.euiColorVisBehindText4.toLowerCase(),
+      colorVis.euiColorVisBehindText5.toLowerCase(),
+      colorVis.euiColorVisBehindText6.toLowerCase(),
+      colorVis.euiColorVisBehindText7.toLowerCase(),
+      colorVis.euiColorVisBehindText8.toLowerCase(),
+      colorVis.euiColorVisBehindText9.toLowerCase(),
+    ]);
+  });
+});
+
+describe('useEuiPaletteForStatus', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteForStatus(3), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current).toEqual([
+      colorVis.euiColorVisSuccess0.toLowerCase(),
+      colorVis.euiColorVisWarning0.toLowerCase(),
+      colorVis.euiColorVisDanger0.toLowerCase(),
+    ]);
+  });
+});
+
+describe('useEuiPaletteForTemperature', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteForTemperature(3), {
+      wrapper: RenderContainer,
+    });
+
+    // testing static start/end colors only as the rest is generated
+    expect(result.current[0]).toEqual(colorVis.euiColorVisCool1.toLowerCase());
+    expect(result.current[2]).toEqual(colorVis.euiColorVisWarm2.toLowerCase());
+  });
+});
+
+describe('useEuiPaletteComplementary', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteComplementary(3), {
+      wrapper: RenderContainer,
+    });
+
+    // testing static start/end colors only as the rest is generated
+    expect(result.current[0]).toEqual(
+      colorVis.euiColorVisComplementary0.toLowerCase()
+    );
+    expect(result.current[2]).toEqual(
+      colorVis.euiColorVisComplementary1.toLowerCase()
+    );
+  });
+});
+
+// NOTE: asserting last position palette colors only as the rest is generated based on input
+describe('useEuiPaletteRed', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteRed(5), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current[4]).toBe(colorVis.euiColorVisDanger0.toLowerCase());
+  });
+});
+
+describe('useEuiPaletteGreen', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => useEuiPaletteGreen(5), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current[4]).toBe(colorVis.euiColorVisSuccess0.toLowerCase());
+  });
+});
+
+describe('euiPaletteCool', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => euiPaletteCool(3), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current[2]).toEqual(colorVis.euiColorVisCool2.toLowerCase());
+  });
+});
+
+describe('euiPaletteWarm', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => euiPaletteWarm(3), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current[2]).toEqual(colorVis.euiColorVisWarm2.toLowerCase());
+  });
+});
+
+describe('euiPaletteGray', () => {
+  it('should return default colors', () => {
+    const { result } = renderHook(() => euiPaletteGray(4), {
+      wrapper: RenderContainer,
+    });
+
+    expect(result.current[3]).toEqual(colorVis.euiColorVisGrey3.toLowerCase());
+  });
+});

--- a/packages/eui/src/services/color/eui_palettes_hooks.ts
+++ b/packages/eui/src/services/color/eui_palettes_hooks.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useMemo } from 'react';
+import { useEuiTheme } from '../theme/hooks';
+import {
+  EuiPalette,
+  euiPaletteColorBlind,
+  euiPaletteColorBlindBehindText,
+  EuiPaletteColorBlindProps,
+  EuiPaletteCommonProps,
+  euiPaletteComplementary,
+  euiPaletteCool,
+  euiPaletteForStatus,
+  euiPaletteForTemperature,
+  euiPaletteGray,
+  euiPaletteGreen,
+  euiPaletteRed,
+  EuiPaletteRotationProps,
+  euiPaletteWarm,
+} from './eui_palettes';
+
+export const useEuiPaletteColorBlind = (args?: EuiPaletteColorBlindProps) => {
+  return _useEuiPaletteFn(euiPaletteColorBlind, args);
+};
+
+export const useEuiPaletteColorBlindBehindText = (
+  args?: EuiPaletteColorBlindProps
+) => {
+  return _useEuiPaletteFn(euiPaletteColorBlindBehindText, args);
+};
+
+export const useEuiPaletteForStatus = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteForStatus, steps);
+};
+
+export const useEuiPaletteForTemperature = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteForTemperature, steps);
+};
+
+export const useEuiPaletteComplementary = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteComplementary, steps);
+};
+
+export const useEuiPaletteRed = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteRed, steps);
+};
+
+export const useEuiPaletteGreen = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteGreen, steps);
+};
+
+export const useEuiPaletteCool = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteCool, steps);
+};
+
+export const useEuiPaletteWarm = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteWarm, steps);
+};
+
+export const useEuiPaletteGray = (steps: number) => {
+  return _useEuiPaletteWithStepsFn(euiPaletteGray, steps);
+};
+
+/* Internal helper utils */
+
+const _useEuiPaletteFn = (
+  palleteFn: (args: EuiPaletteColorBlindProps) => EuiPalette,
+  args?: EuiPaletteRotationProps
+) => {
+  const { euiTheme } = useEuiTheme();
+  const { colors, flags } = euiTheme;
+
+  return useMemo(() => {
+    return palleteFn({
+      ...args,
+      colors: colors.vis,
+      hasVisColorAdjustment: flags.hasVisColorAdjustment,
+    });
+  }, [colors, flags, args, palleteFn]);
+};
+
+const _useEuiPaletteWithStepsFn = (
+  palleteFn: (steps: number, args: EuiPaletteCommonProps) => EuiPalette,
+  steps: number
+) => {
+  const { euiTheme } = useEuiTheme();
+  const { colors, flags } = euiTheme;
+
+  return useMemo(
+    () =>
+      palleteFn(steps, {
+        colors: colors.vis,
+        hasVisColorAdjustment: flags.hasVisColorAdjustment,
+      }),
+    [colors, flags, steps, palleteFn]
+  );
+};

--- a/packages/eui/src/services/color/index.ts
+++ b/packages/eui/src/services/color/index.ts
@@ -37,7 +37,11 @@ export {
   euiPaletteCool,
   euiPaletteWarm,
   euiPaletteGray,
+  type EuiPaletteColorBlindProps,
+  type EuiPaletteRotationProps,
+  type EuiPaletteCommonProps,
 } from './eui_palettes';
+export * from './eui_palettes_hooks';
 export type { rgbDef, HSV, RGB } from './color_types';
 export { getSteppedGradient } from './stepped_gradient';
 export * from './manipulation';

--- a/packages/eui/src/services/index.ts
+++ b/packages/eui/src/services/index.ts
@@ -62,8 +62,12 @@ export {
   VISUALIZATION_COLORS,
   EUI_VIS_COLOR_STORE,
   wcagContrastMin,
+  type EuiPaletteColorBlindProps,
+  type EuiPaletteRotationProps,
+  type EuiPaletteCommonProps,
 } from './color';
 export type { HSV } from './color';
+export * from './color/eui_palettes_hooks';
 export { useColorPickerState, useColorStopsState } from './color_picker';
 export type { EuiSetColorMethod } from './color_picker';
 export * from './console';

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
@@ -24,7 +24,7 @@ import {
   shade,
   tint,
   transparentize,
-} from '../../../../services/color';
+} from '../../../../services/color/manipulation';
 import { computed } from '../../../../services/theme/utils';
 import {
   makeHighContrastColor,

--- a/packages/eui/src/themes/index.ts
+++ b/packages/eui/src/themes/index.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
+export { colorVis } from './amsterdam/global_styling/variables/_colors_vis';
 export type { EUI_THEME } from './themes';
 export {
   EUI_THEMES,

--- a/packages/website/docs/components/display/timeline.mdx
+++ b/packages/website/docs/components/display/timeline.mdx
@@ -114,7 +114,7 @@ import {
   EuiHorizontalRule,
   EuiTimeline,
   useGeneratedHtmlId,
-  euiPaletteColorBlindBehindText,
+  useEuiPaletteColorBlindBehindText,
 } from '@elastic/eui';
 
 export default () => {
@@ -128,7 +128,7 @@ export default () => {
   // We could use the `euiPaletteColorBlind` for coloring the avatars
   // But because we're placing an icon on top of these colors
   // The `euiPaletteColorBlindBehindText` is a better choice to ensure better contrast
-  const colorBlindBehindText = euiPaletteColorBlindBehindText({
+  const colorBlindBehindText = useEuiPaletteColorBlindBehindText({
     sortBy: 'natural',
   });
 

--- a/packages/website/docs/components/forms/color_selection.mdx
+++ b/packages/website/docs/components/forms/color_selection.mdx
@@ -48,7 +48,9 @@ import {
   EuiCode,
   EuiColorPalettePicker,
   EuiFlexGroup
+  EUI_VIS_COLOR_STORE
 } from '@elastic/eui';
+import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
 
 const getPalettes = (appendTitles) => [
   {
@@ -143,7 +145,21 @@ const AppendedTitleText = ({ label }) => (
 export default () => {
   const [selectionDisplay, setSelectionDisplay] = useState(false);
   const [showAppendedTitles, setShowAppendedTitles] = useState(false);
-  const [pallette, setPallette] = useState('pallette_1');
+  const [palettes, setPalettes] = useState(getPalettes());
+  const [selectedPalette, setSelectedPalette] = useState('palette_1');
+
+  useEffect(() => {
+    const storeId = EUI_VIS_COLOR_STORE.subscribe(
+      VIS_COLOR_STORE_EVENTS.UPDATE,
+      () => {
+        setPalettes(getPalettes());
+      }
+    );
+
+    return () => {
+      EUI_VIS_COLOR_STORE.unsubscribe(VIS_COLOR_STORE_EVENTS.UPDATE, storeId);
+    };
+  }, []);
 
   return (
     <>
@@ -171,8 +187,8 @@ export default () => {
       <DisplayToggles canPrepend={true} canAppend={true} canReadOnly={false}>
         <EuiColorPalettePicker
           palettes={getPalettes(showAppendedTitles)}
-          onChange={setPallette}
-          valueOfSelected={pallette}
+          onChange={setSelectedPalette}
+          valueOfSelected={selectedPalette}
           selectionDisplay={selectionDisplay ? 'title' : 'palette'}
         />
       </DisplayToggles>

--- a/packages/website/docs/components/forms/combo_box.mdx
+++ b/packages/website/docs/components/forms/combo_box.mdx
@@ -495,11 +495,10 @@ export default () => {
 Useful for visualization or tagging systems. You can also pass a color in your option list. The color can be a hex value (like `#000`) or any other named color value accepted by the [**EuiBadge**](/docs/display/badge) component.
 
 ```tsx interactive
-import React, { useState } from 'react';
-import { EuiComboBox, euiPaletteColorBlindBehindText } from '@elastic/eui';
+import React, { useState, useEffect } from 'react';
+import { EuiComboBox, useEuiPaletteColorBlindBehindText } from '@elastic/eui';
 
-const visColorsBehindText = euiPaletteColorBlindBehindText();
-const optionsStatic = [
+const getOptionsStatic = (visColorsBehindText) => [
   {
     label: 'Titan',
     'data-test-subj': 'titanOption',
@@ -545,8 +544,16 @@ const optionsStatic = [
 ];
 
 export default () => {
-  const [options, setOptions] = useState(optionsStatic);
+  const visColorsBehindText = useEuiPaletteColorBlindBehindText();
+
+  const [options, setOptions] = useState(getOptionsStatic(visColorsBehindText));
   const [selectedOptions, setSelected] = useState([options[2], options[5]]);
+
+  useEffect(() => {
+    const updatedOptions = getOptionsStatic(visColorsBehindText);
+    setOptions(updatedOptions);
+    setSelected([updatedOptions[2], updatedOptions[5]]);
+  }, [visColorsBehindText]);
 
   const onChange = (selectedOptions) => {
     setSelected(selectedOptions);
@@ -689,13 +696,11 @@ import {
   EuiComboBox,
   EuiHighlight,
   EuiHealth,
-  euiPaletteColorBlind,
-  euiPaletteColorBlindBehindText,
+  useEuiPaletteColorBlind,
+  useEuiPaletteColorBlindBehindText,
 } from '@elastic/eui';
 
-const visColors = euiPaletteColorBlind();
-const visColorsBehindText = euiPaletteColorBlindBehindText();
-const optionsStatic = [
+const getOptionsStatic = (visColorsBehindText) => [
   {
     value: {
       size: 5,
@@ -771,8 +776,17 @@ const optionsStatic = [
 ];
 
 export default () => {
-  const [options, setOptions] = useState(optionsStatic);
+  const visColors = useEuiPaletteColorBlind();
+  const visColorsBehindText = useEuiPaletteColorBlindBehindText();
+
+  const [options, setOptions] = useState(getOptionsStatic(visColorsBehindText));
   const [selectedOptions, setSelected] = useState([options[2], options[5]]);
+
+  useEffect(() => {
+    const updatedOptions = getOptionsStatic(visColorsBehindText);
+    setOptions(updatedOptions);
+    setSelected([updatedOptions[2], updatedOptions[5]]);
+  }, [visColorsBehindText]);
 
   const onChange = (selectedOptions) => {
     setSelected(selectedOptions);

--- a/packages/website/docs/components/forms/date_picker/date_picker.mdx
+++ b/packages/website/docs/components/forms/date_picker/date_picker.mdx
@@ -533,20 +533,20 @@ import { css } from '@emotion/css';
 <Demo scope={{ css }}>
   ```tsx interactive
   import React, { useState } from 'react';
-  import { EuiDatePicker, EuiFormRow, EuiSpacer } from '@elastic/eui';
+  import { EuiDatePicker, EuiFormRow, EuiSpacer, useEuiPaletteColorBlind } from '@elastic/eui';
   import moment from 'moment';
   import { css } from '@emotion/css'; // Generates a vanilla JS className
 
-  const visColors = euiPaletteColorBlind();
-  const backgroundCss = css`
-    background-color: ${visColors[3]};
-  `;
-  const outlineCss = css`
-    outline: solid 2px ${visColors[3]};
-  `;
-
   export default () => {
     const [startDate, setStartDate] = useState(moment());
+
+    const visColors = useEuiPaletteColorBlind();
+    const backgroundCss = css`
+      background-color: ${visColors[3]};
+    `;
+    const outlineCss = css`
+      outline: solid 2px ${visColors[3]};
+    `;
 
     const handleChange = (date) => {
       setStartDate(date);

--- a/packages/website/docs/components/navigation/facet.mdx
+++ b/packages/website/docs/components/navigation/facet.mdx
@@ -54,7 +54,7 @@ import {
   EuiFacetGroup,
   EuiIcon,
   EuiAvatar,
-  euiPaletteColorBlind,
+  useEuiPaletteColorBlind,
 } from '@elastic/eui';
 
 export default () => {
@@ -63,6 +63,8 @@ export default () => {
   const [avatars, setAvatars] = useState(false);
   const [loading, setLoading] = useState(false);
   const [selectedOptionId, setSelectedOptionId] = useState(undefined);
+
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
 
   const facet0Clicked = (id) => {
     setIcon(false);
@@ -113,42 +115,42 @@ export default () => {
       id: 'facet0',
       label: 'Simple, no icon',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[0],
+      iconColor: euiPaletteColorBlind[0],
       onClick: facet0Clicked,
     },
     {
       id: 'facet1',
       label: 'Label or color indicator',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[1],
+      iconColor: euiPaletteColorBlind[1],
       onClick: facet1Clicked,
     },
     {
       id: 'facet2',
       label: 'Disable all others',
       quantity: 600,
-      iconColor: euiPaletteColorBlind()[2],
+      iconColor: euiPaletteColorBlind[2],
       onClick: facet2Clicked,
     },
     {
       id: 'facet3',
       label: 'Avatars instead of icons',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[3],
+      iconColor: euiPaletteColorBlind[3],
       onClick: facet3Clicked,
     },
     {
       id: 'facet4',
       label: 'Show all as loading',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[4],
+      iconColor: euiPaletteColorBlind[4],
       onClick: facet4Clicked,
     },
     {
       id: 'facet5',
       label: 'Just here to show truncation of really long labels',
       quantity: 0,
-      iconColor: euiPaletteColorBlind()[5],
+      iconColor: euiPaletteColorBlind[5],
     },
   ];
 
@@ -219,6 +221,8 @@ export default () => {
   const [loading, setLoading] = useState(false);
   const [selectedOptionId, setSelectedOptionId] = useState(undefined);
 
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
+
   const facet0Clicked = (id) => {
     setIcon(false);
     setDisabled(false);
@@ -268,42 +272,42 @@ export default () => {
       id: 'facetHorizontal0',
       label: 'Simple, no icon',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[0],
+      iconColor: euiPaletteColorBlind[0],
       onClick: facet0Clicked,
     },
     {
       id: 'facetHorizontal1',
       label: 'Label or color indicator',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[1],
+      iconColor: euiPaletteColorBlind[1],
       onClick: facet1Clicked,
     },
     {
       id: 'facetHorizontal2',
       label: 'Disable all others',
       quantity: 600,
-      iconColor: euiPaletteColorBlind()[2],
+      iconColor: euiPaletteColorBlind[2],
       onClick: facet2Clicked,
     },
     {
       id: 'facetHorizontal3',
       label: 'Avatars instead of icons',
       quantity: 60,
-      iconColor: euiPaletteColorBlind()[3],
+      iconColor: euiPaletteColorBlind[3],
       onClick: facet3Clicked,
     },
     {
       id: 'facetHorizontal4',
       label: 'Show all as loading',
       quantity: 6,
-      iconColor: euiPaletteColorBlind()[4],
+      iconColor: euiPaletteColorBlind[4],
       onClick: facet4Clicked,
     },
     {
       id: 'facetHorizontal5',
       label: 'Just here to show truncation of really long labels',
       quantity: 0,
-      iconColor: euiPaletteColorBlind()[5],
+      iconColor: euiPaletteColorBlind[5],
     },
   ];
 

--- a/packages/website/docs/data_visualization/theming.mdx
+++ b/packages/website/docs/data_visualization/theming.mdx
@@ -73,6 +73,7 @@ You'll find an example of these in the demo below.
     euiPaletteRed,
     euiPaletteGreen,
     euiPaletteGray,
+    EUI_VIS_COLOR_STORE
   } from '@elastic/eui';
   import {
     Chart,
@@ -82,20 +83,22 @@ You'll find an example of these in the demo below.
     BarSeries,
     DataGenerator,
   } from '@elastic/charts';
+  import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
 
-  const paletteData = {
-    euiPaletteColorBlind,
-    euiPaletteForStatus,
-    euiPaletteForTemperature,
-    euiPaletteComplementary,
-    euiPaletteRed,
-    euiPaletteGreen,
-    euiPaletteCool,
-    euiPaletteWarm,
-    euiPaletteGray,
-  };
+  const getPaletteData = () => ({
+  euiPaletteColorBlind,
+  euiPaletteForStatus,
+  euiPaletteForTemperature,
+  euiPaletteComplementary,
+  euiPaletteRed,
+  euiPaletteGreen,
+  euiPaletteCool,
+  euiPaletteWarm,
+  euiPaletteGray,
+});
 
-  const palettes = Object.entries(paletteData).map(([paletteName, palette]) => {
+const getPalettes = () =>
+  Object.entries(getPaletteData()).map(([paletteName, palette]) => {
     return {
       value: paletteName,
       title: paletteName,
@@ -107,75 +110,95 @@ You'll find an example of these in the demo below.
     };
   });
 
-  export default () => {
-    const chartBaseTheme = useChartBaseTheme();
+export default () => {
+  const chartBaseTheme = useChartBaseTheme();
 
-    const [barPalette, setBarPalette] = useState('euiPaletteColorBlind');
+  const [palettes, setPalettes] = useState(getPalettes());
+  const [barPalette, setBarPalette] = useState('euiPaletteColorBlind');
 
-    /**
-     * Create data
-     */
-    const dg = new DataGenerator();
-    const data1 = dg.generateGroupedSeries(20, 1);
-    const data2 = dg.generateGroupedSeries(20, 5);
+  const paletteData = useMemo(
+    () => getPaletteData(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [palettes]
+  );
 
-    const themeOverrides =
-      barPalette !== 'euiPaletteColorBlind'
-        ? [
-            {
-              colors: {
-                vizColors: paletteData[barPalette as keyof typeof paletteData](5),
-              },
-            },
-          ]
-        : [];
-
-    return (
-      <>
-        <Chart size={{ height: 200 }}>
-          <Settings
-            baseTheme={chartBaseTheme}
-            theme={themeOverrides}
-            showLegend={false}
-          />
-          <BarSeries
-            id="status"
-            name="Status"
-            data={data2}
-            xAccessor={'x'}
-            yAccessors={['y']}
-            splitSeriesAccessors={['g']}
-            stackAccessors={['g']}
-          />
-          <LineSeries
-            id="control"
-            name="Control"
-            data={data1}
-            xAccessor={'x'}
-            yAccessors={['y']}
-            color={['black']}
-          />
-          <Axis id="bottom-axis" position="bottom" gridLine={{ visible: true }} />
-          <Axis
-            id="left-axis"
-            position="left"
-            gridLine={{ visible: true }}
-            tickFormat={(d) => Number(d).toFixed(2)}
-          />
-        </Chart>
-        <EuiSpacer size="xxl" />
-        <EuiFlexGroup justifyContent="center">
-          <EuiFlexItem grow={false} style={{ width: 300 }}>
-            <EuiColorPalettePicker
-              palettes={palettes}
-              onChange={setBarPalette}
-              valueOfSelected={barPalette}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </>
+  useEffect(() => {
+    const storeId = EUI_VIS_COLOR_STORE.subscribe(
+      VIS_COLOR_STORE_EVENTS.UPDATE,
+      () => {
+        setPalettes(getPalettes());
+      }
     );
-  };
+
+    return () => {
+      EUI_VIS_COLOR_STORE.unsubscribe(VIS_COLOR_STORE_EVENTS.UPDATE, storeId);
+    };
+  }, []);
+
+  /**
+   * Create data
+   */
+  const dg = new DataGenerator();
+  const data1 = dg.generateGroupedSeries(20, 1);
+  const data2 = dg.generateGroupedSeries(20, 5);
+
+  const themeOverrides =
+    barPalette !== 'euiPaletteColorBlind'
+      ? [
+          {
+            colors: {
+              vizColors: paletteData[barPalette as keyof typeof paletteData](5),
+            },
+          },
+        ]
+      : [];
+
+  return (
+    <>
+      <Chart size={{ height: 200 }}>
+        <Settings
+          baseTheme={chartBaseTheme}
+          theme={themeOverrides}
+          showLegend={false}
+        />
+        <BarSeries
+          id="status"
+          name="Status"
+          data={data2}
+          xAccessor={'x'}
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['g']}
+        />
+        <LineSeries
+          id="control"
+          name="Control"
+          data={data1}
+          xAccessor={'x'}
+          yAccessors={['y']}
+          color={['black']}
+        />
+        <Axis id="bottom-axis" position="bottom" gridLine={{ visible: true }} />
+        <Axis
+          id="left-axis"
+          position="left"
+          gridLine={{ visible: true }}
+          tickFormat={(d) => Number(d).toFixed(2)}
+        />
+      </Chart>
+      <EuiSpacer size="xxl" />
+      <EuiFlexGroup justifyContent="center">
+        <EuiFlexItem grow={false} style={{ width: 300 }}>
+          <EuiColorPalettePicker
+            palettes={palettes}
+            onChange={setBarPalette}
+            valueOfSelected={barPalette}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};
   ```
 </Demo>
 

--- a/packages/website/docs/data_visualization/types/categorical.tsx
+++ b/packages/website/docs/data_visualization/types/categorical.tsx
@@ -14,18 +14,19 @@ import {
   EuiRadioGroup,
   EuiIcon,
   EuiTitle,
-  euiPaletteColorBlind,
   euiPaletteGreen,
   euiPaletteForStatus,
   euiPaletteGray,
+  useEuiPaletteColorBlind,
 } from '@elastic/eui';
 import { CHART_COMPONENTS, type ChartType, ChartCard } from './shared';
 
 import { useChartBaseTheme } from '../use_chart_base_theme';
 
 export const Categorical = () => {
+  const euiPaletteColorBlind = useEuiPaletteColorBlind();
   const chartBaseTheme = useChartBaseTheme();
-  const highlightColor = euiPaletteColorBlind()[2];
+  const highlightColor = euiPaletteColorBlind[2];
 
   const idPrefix = 'colorType';
 
@@ -245,7 +246,7 @@ export const Categorical = () => {
           data={data}
           xAccessor={'x'}
           yAccessors={['y']}
-          color={[euiPaletteColorBlind()[index < 2 ? 0 : 1]]}
+          color={[euiPaletteColorBlind[index < 2 ? 0 : 1]]}
           lineSeriesStyle={{
             line: {
               strokeWidth: isOdd ? 1 : 6,

--- a/packages/website/docs/data_visualization/types/part_to_whole_comparisons.mdx
+++ b/packages/website/docs/data_visualization/types/part_to_whole_comparisons.mdx
@@ -184,7 +184,7 @@ import { GITHUB_DATASET_MOD } from '../data';
     EuiFlexItem,
     EuiTitle,
     EuiSpacer,
-    euiPaletteColorBlind,
+    useEuiPaletteColorBlind,
   } from '@elastic/eui';
   import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
 
@@ -197,7 +197,7 @@ import { GITHUB_DATASET_MOD } from '../data';
     /**
      * Create a 3 rotation palette (one for each level)
      */
-    const groupedPalette = euiPaletteColorBlind({
+    const groupedPalette = useEuiPaletteColorBlind({
       rotations: 3,
       order: 'group',
       sortBy: 'natural',

--- a/packages/website/docs/data_visualization/types/pie_alts.tsx
+++ b/packages/website/docs/data_visualization/types/pie_alts.tsx
@@ -15,10 +15,10 @@ import {
   EuiFlexItem,
   EuiCopy,
   EuiButton,
-  euiPaletteForTemperature,
-  euiPaletteColorBlind,
-  euiPaletteGray,
   useEuiTheme,
+  useEuiPaletteColorBlind,
+  useEuiPaletteForTemperature,
+  useEuiPaletteGray,
 } from '@elastic/eui';
 
 import { GITHUB_DATASET, GITHUB_DATASET_MOD, DAYS_OF_RAIN } from '../data';
@@ -37,15 +37,16 @@ export const PieAlts = () => {
   const [formattedData, setFormattedData] = useState(false);
   const [grouped, setGrouped] = useState(false);
 
-  let color = euiPaletteColorBlind({ rotations: 2, order: 'group' }).slice(
+  const paletteTemperature0 = useEuiPaletteForTemperature(0);
+  const paletteTemperature3 = useEuiPaletteForTemperature(3);
+  const paletteGray = useEuiPaletteGray(5);
+
+  let color = useEuiPaletteColorBlind({ rotations: 2, order: 'group' }).slice(
     18,
     20
   );
   if (formatted) {
-    color = [
-      euiPaletteForTemperature(0)[0],
-      euiPaletteGray(5)[isDarkTheme ? 4 : 0],
-    ];
+    color = [paletteTemperature0[0], paletteGray[isDarkTheme ? 4 : 0]];
   }
 
   let data;
@@ -55,7 +56,7 @@ export const PieAlts = () => {
       ? orderBy(DAYS_OF_RAIN, ['precipitation', 'days'], ['desc', 'asc'])
       : DAYS_OF_RAIN;
     usesRainData = true;
-    color = euiPaletteForTemperature(3);
+    color = paletteTemperature3;
   } else {
     const DATASET = grouped ? GITHUB_DATASET_MOD : GITHUB_DATASET;
     data = orderBy(DATASET, 'issueType', 'asc');


### PR DESCRIPTION
## Summary

>[!IMPORTANT]
This PR merges into a feature branch.

This PR changes the color palette functions to support passing `colors` as argument to enable a more flexible usage outside of a React Context where the EUI default values might not be updated as expected.

Additionally this PR adds hooks for the available color palette functions (e.g. `euiPaletteColorBlind` and `euiPaletteColorBlindBehindText` and `euiPaletteForStatus` etc) for usage in React components. 

Example added hook: `useEuiPaletteColorBlind`

These hooks are mainly a devX addition and they are added to provide a direct input of the theme colors (from the `EuiProvider` to the palette functions without having to rely on the temporary middleware `EuiVisColorStore` which was previously added to support multiple themes in the previously static color palette functions. 

To ensure vis colors are available for custom usage with palette functions, we also need to ensure to export the vis color definitions object `colorVis` from the themes.


## QA

- [ ] verify updated components update look the same between production and staging
  - [ ] EuiAvatar ([staging](https://eui.elastic.co/pr_8284/#/display/avatar), [production](https://eui.elastic.co/#/display/avatar))
  - [ ] EuiColorPalette / EuiColorPicker ([staging](https://eui.elastic.co/pr_8284/#/forms/color-selection), [production](https://eui.elastic.co/#/forms/color-selection))
  - [ ] EuiSelectableTemplateSitewide ([staging](https://eui.elastic.co/pr_8284/#/templates/sitewide-search), [production](https://eui.elastic.co/#/templates/sitewide-search))
  
- [ ] verify docs update on theme changes as expected (showing updated palette colors per theme)
  - [ ] EuiAvatar ([EUI](https://eui.elastic.co/pr_8284/#/display/avatar), [EUI+](https://eui.elastic.co/pr_8284/new-docs/docs/display/avatar/))
  - [ ] EuiColorPalette / EuiColorPicker ([EUI](https://eui.elastic.co/pr_8284/#/forms/color-selection), [EUI+](https://eui.elastic.co/pr_8284/new-docs/docs/forms/color-selection/))
  - [ ] EuiComboBox ([EUI](https://eui.elastic.co/pr_8284/#/forms/combo-box#renderOption), [EUI+](https://eui.elastic.co/pr_8284/new-docs/docs/forms/combo-box/#custom-dropdown-content))
  - [ ] elastic charts (all related subpages) (e.g. [EUI](https://eui.elastic.co/pr_8284/#/elastic-charts/part-to-whole-comparisons) - charts are not loaded as updated package with token update sin EUI+ yet)
  - [ ] EuiFacet ([EUI](https://eui.elastic.co/pr_8284/#/navigation/facet), [EUI+](https://eui.elastic.co/pr_8284/new-docs/docs/navigation/facet/))
  - [ ] EuiTimeline ([EUI](https://eui.elastic.co/pr_8284/#/display/timeline), [EUI+](https://eui.elastic.co/pr_8284/new-docs/docs/display/timeline/))