### PR TITLE
[EuiColorPalettePicker] Make `title` optional on palettes props

### DIFF
--- a/packages/eui/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
+++ b/packages/eui/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
@@ -60,7 +60,7 @@ export interface EuiColorPalettePickerPaletteFixedProps extends CommonProps {
   /**
    *  The name of your palette
    */
-  title: string;
+  title?: string;
   /**
    * Node appended to right of title
    */
@@ -83,7 +83,7 @@ export interface EuiColorPalettePickerPaletteGradientProps extends CommonProps {
   /**
    *  The name of your palette
    */
-  title: string;
+  title?: string;
   /**
    * Node appended to right of title
    */


### PR DESCRIPTION
## Summary

Make `title` on `EuiColorPalettePickerPaletteProps` optional.

This was erroneously changed to required in #8208.

### General checklist

- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
