### PR TITLE
[EuiInlineEditForm] Support onCancel callback for non-controlled usage

### DIFF
--- a/packages/eui/changelogs/upcoming/8307.md
+++ b/packages/eui/changelogs/upcoming/8307.md
@@ -1,0 +1,2 @@
+- Updated `EuiInlineEditForm`'s `onCancel` prop type to allow un-controlled mode usage
+

--- a/packages/eui/changelogs/upcoming/8307.md
+++ b/packages/eui/changelogs/upcoming/8307.md
@@ -1,2 +1,2 @@
-- Updated `EuiInlineEditForm`'s `onCancel` prop type to allow un-controlled mode usage
+- Updated `EuiInlineEditForm`'s `onCancel` prop type to allow uncontrolled mode usage
 

--- a/packages/eui/src/components/inline_edit/inline_edit_form.tsx
+++ b/packages/eui/src/components/inline_edit/inline_edit_form.tsx
@@ -96,6 +96,7 @@ export type EuiInlineEditCommonProps = Omit<
        * Initial inline edit text value
        */
       defaultValue: string;
+      onCancel?: (perviousValue: string) => void;
     },
     {
       /**

--- a/packages/eui/src/components/inline_edit/inline_edit_form.tsx
+++ b/packages/eui/src/components/inline_edit/inline_edit_form.tsx
@@ -96,7 +96,7 @@ export type EuiInlineEditCommonProps = Omit<
        * Initial inline edit text value
        */
       defaultValue: string;
-      onCancel?: (perviousValue: string) => void;
+      onCancel?: (previousValue: string) => void;
     },
     {
       /**
@@ -110,7 +110,7 @@ export type EuiInlineEditCommonProps = Omit<
       /**
        * Callback required to reset `value` to the previous read mode text value.
        */
-      onCancel: (perviousValue: string) => void;
+      onCancel: (previousValue: string) => void;
     }
   >;
 


### PR DESCRIPTION
## Summary

This PR updates the type definition for  `EuiInlineEditForm`s `onCancel` prop to support using it for non-controlled usage next to the already available controlled usage. 

When the component is in edit mode, we have two actions: "Save" and "Cancel" and currently only the "Save" action provides a callback for non-controlled usage.
Instead we should also allow `onCancel` to be always allowed considering that the action is always available too. 
The main purpose of the `onCancel` callback is to reset the `value` in controlled usage, but there might be a need to use `onCancel` for non-controlled usages as well to handle other side effects.

>[!NOTE]
No functional changes have been made in this PR. The callback was already always technically available, just that the type definition prohibited its usage.

## QA

- checkout this PR and try the following combinations on e.g. `EuiInlineEditTitle`
  - [x] using `defaultValue` & `onCancel` does not trigger a type error
  - [x] using `value` & `onChange` and `onCancel` does not trigger a type error

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
