### PR TITLE
[EuiSuperDatePicker] Fix duplicate value when pasting absolute value

### DIFF
--- a/packages/eui/changelogs/upcoming/8311.md
+++ b/packages/eui/changelogs/upcoming/8311.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed a bug on `EuiSuperDatePicker` where pasting an absolute date would append the date instead of replace it
+

--- a/packages/eui/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/date_popover/absolute_tab.tsx
@@ -188,6 +188,10 @@ export const EuiAbsoluteTab: FunctionComponent<EuiAbsoluteTabProps> = ({
             value={textInputValue}
             onChange={handleTextChange}
             onPaste={(event) => {
+              // preventing default here ensures no additional onChange is
+              // triggered which otherwise results in input duplication
+              event.preventDefault();
+
               setTextInputValue(event.clipboardData.getData('text'));
               setIsReadyToParse(true);
             }}


### PR DESCRIPTION
## Summary

Related Kibana issue: https://github.com/elastic/kibana/issues/205633

This PR fixes an issue on `EuiSuperDatePicker` where pasting a date would sometimes result in the date being appended instead of being replaced.
The issue was that the `onPaste` event would trigger the `onChange` event on the `EuiFieldText` input which clashed with the controlled value update. This seemed to be a race condition as depending on application this resulted either in a duplicated value or not, depending on which state was updated first.

This behavior is not reproducible on EUI (neither docs not Storybook), but it can be observed by checking the value of the internally used `EuiFieldText` which showed the duplication.

The solution is to `preventDefault` on `onPaste` and just let the controlled value update the input.

_before_

https://github.com/user-attachments/assets/2da6f3ee-9640-449f-a5d3-31bb31b1add4


_after_

https://github.com/user-attachments/assets/ee6c6af0-897f-4609-b183-0a95d5422e70


## QA

- [x] the updated unit test passes
  - [x] (optional) comment out the added `event.preventDefault` and manually run the test locally (the test should fail)
- [x] manually verify non-duplicated input value:
  - checkout this PR
  - comment out the update adding `event.preventDefault` on the `onPaste` event
  - console log the `event.target.value` on the `onChange` event of the `EuiFieldText`
    - [x] the `onChange` event is not triggered on pasting
    - [x] the input value updates correctly
    - [x] validation for the date picker works correctly
    
_EuiFieldText` value before the fix_

https://github.com/user-attachments/assets/f4cc6e9e-71cf-47b3-9c80-436fc8bf04a6


_EuiFieldText` value after the fix_


https://github.com/user-attachments/assets/e9e91721-ae05-4e54-8ea8-c5d7663840d3



### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles]~(https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
