### PR TITLE
chore(wiki): add a section about `css` usage, behavior and required Babel preset

### DIFF
--- a/wiki/consuming-eui/README.md
+++ b/wiki/consuming-eui/README.md
@@ -49,9 +49,15 @@ import { findTestSubject } from '@elastic/eui/lib/test'; // Enzyme
 import { findByTestSubject, render, screen } from '@elastic/eui/lib/test/rtl'; // React Testing Library
 ```
 
+### Custom styles
+
+EUI uses a CSS-in-JS approach for styling, specifically [Emotion](https://emotion.sh) library. We recommend using the `css` function from `@emotion/react`, which automatically sets the generated `className` and combines all passed styles into a single ruleset. To enable `css` concatenation, you'll need the [Babel preset](https://www.npmjs.com/package/@emotion/babel-preset-css-prop).
+
+You can find more information [here](https://github.com/elastic/eui/discussions/6828).
+
 ### Theming
 
-EUI uses CSS-in-JS (specifically [Emotion](https://emotion.sh)) for its styles and theming. As such, we require an `<EuiProvider>` wrapper around your application in order for various theme-related UI & UX (such as dark/light mode switching) to work as expected.
+EUI leverages [Emotion](https://emotion.sh) for its theming as well. As such, we require an `<EuiProvider>` wrapper around your application in order for various theme-related UI & UX (such as dark/light mode switching) to work as expected.
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
## Summary

Just a small wiki update to make it clearer for EUI consumers that we recommend `css` function for custom styles and that a `css` Babel preset is required for the style merging to work.

[Slack thread](https://elastic.slack.com/archives/C7QC1JV6F/p1739412284558149?thread_ts=1739370511.863949&cid=C7QC1JV6F)
