### PR TITLE
[EuiAccordion] Disable transition on initial render when initialsOpen

### DIFF
--- a/packages/eui/changelogs/upcoming/8327.md
+++ b/packages/eui/changelogs/upcoming/8327.md
@@ -1,0 +1,2 @@
+- Updated `EuiAccordion` to prevent content from being transitioned on initial render when `initialIsOpen=true`
+

--- a/packages/eui/src/components/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/packages/eui/src/components/accordion/__snapshots__/accordion.test.tsx.snap
@@ -830,7 +830,7 @@ exports[`EuiAccordion props initialIsOpen is rendered 1`] = `
   </div>
   <div
     aria-labelledby="generated-id"
-    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper-isOpen"
+    class="euiAccordion__childWrapper emotion-euiAccordion__childWrapper-isOpen-noTransition"
     id="12"
     role="group"
     style="block-size: 0;"

--- a/packages/eui/src/components/accordion/accordion.tsx
+++ b/packages/eui/src/components/accordion/accordion.tsx
@@ -234,6 +234,7 @@ export class EuiAccordionClass extends Component<
           isLoading={isLoading}
           isLoadingMessage={isLoadingMessage}
           isOpen={this.isOpen}
+          initialIsOpen={initialIsOpen}
         >
           {children}
         </EuiAccordionChildren>

--- a/packages/eui/src/components/accordion/accordion_children/accordion_children.styles.ts
+++ b/packages/eui/src/components/accordion/accordion_children/accordion_children.styles.ts
@@ -59,6 +59,15 @@ export const euiAccordionChildWrapperStyles = (
          users on Chrome & FF */
       ${euiFocusRing(euiThemeContext)}
     `,
+    // choosing to override transition instead of applying it conditionally
+    // to keep a more logical style appliance:
+    // default case = has transition as part of default styles (all cases expect initial isOpen=true when initialIsOpen=true)
+    // special case: no transition for initial isOpen=true when initialIsOpen=true
+    noTransition: css`
+      ${euiCanAnimate} {
+        transition: none;
+      }
+    `,
     isClosed: css`
       ${logicalCSS('height', 0)}
       opacity: 0;

--- a/packages/eui/src/components/accordion/accordion_children/accordion_children.tsx
+++ b/packages/eui/src/components/accordion/accordion_children/accordion_children.tsx
@@ -10,6 +10,7 @@ import React, {
   FunctionComponent,
   HTMLAttributes,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -28,7 +29,12 @@ import {
 type _EuiAccordionChildrenProps = HTMLAttributes<HTMLDivElement> &
   Pick<
     EuiAccordionProps,
-    'role' | 'children' | 'paddingSize' | 'isLoading' | 'isLoadingMessage'
+    | 'role'
+    | 'children'
+    | 'paddingSize'
+    | 'initialIsOpen'
+    | 'isLoading'
+    | 'isLoadingMessage'
   > & {
     isOpen: boolean;
   };
@@ -41,6 +47,7 @@ export const EuiAccordionChildren: FunctionComponent<
   isLoading,
   isLoadingMessage,
   isOpen,
+  initialIsOpen,
   ...rest
 }) => {
   /**
@@ -61,11 +68,21 @@ export const EuiAccordionChildren: FunctionComponent<
   /**
    * Wrapper
    */
+  const [hasTransition, setHasTransition] = useState(false);
   const wrapperStyles = euiAccordionChildWrapperStyles(euiTheme);
   const wrapperCssStyles = [
     wrapperStyles.euiAccordion__childWrapper,
     isOpen ? wrapperStyles.isOpen : wrapperStyles.isClosed,
+    initialIsOpen && !hasTransition && isOpen && wrapperStyles.noTransition,
   ];
+
+  /* Controls enabling opening/closing transitions on first interaction
+  when initialIsOpen=true; this only runs once */
+  useEffect(() => {
+    if (initialIsOpen && !isOpen && !hasTransition) {
+      setHasTransition(true);
+    }
+  }, [isOpen, initialIsOpen, hasTransition]);
 
   /**
    * Update the accordion wrapper height whenever the accordion opens, and also


### PR DESCRIPTION
## Summary

closes #8299 

This PR updates `EuiAccordion` to disable transitioning the content on initial render when `initialIsOpen=true`. 
The transition should only happen on open/close toggle, not initial render.

_before_

https://github.com/user-attachments/assets/f1a0227a-92a3-4805-894a-27f12ef74abb

_after_

https://github.com/user-attachments/assets/d4800913-19d7-492e-a26b-673759cc35b4


## QA

- [x] verify the [EuiAccordion](https://eui.elastic.co/pr_8327/#/layout/accordion#opened-on-initial-render) does not transition the `isOpen` state on initial render when `initialIsOpen=true`
- [x] verify transition happens for any other open or close toggle

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
