### PR TITLE
[EuiComboBox] Improve accessibility of virtualized listbox

### DIFF
--- a/packages/eui/changelogs/upcoming/8333.md
+++ b/packages/eui/changelogs/upcoming/8333.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Improved the accessibility of `EuiComboBox` by adding `aria-setsize` and `aria-posinset` to ensure correct information is provided for its virtualized listbox
+

--- a/packages/eui/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/packages/eui/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`EuiComboBox renders 1`] = `
             aria-autocomplete="list"
             aria-controls=""
             aria-expanded="false"
+            aria-haspopup="listbox"
             aria-invalid="false"
             aria-label="aria-label"
             autocomplete="off"
@@ -84,6 +85,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                 aria-autocomplete="list"
                 aria-controls="generated-id_listbox"
                 aria-expanded="true"
+                aria-haspopup="listbox"
                 aria-invalid="false"
                 autocomplete="off"
                 class="euiComboBox__input emotion-euiComboBoxInput"
@@ -135,7 +137,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
       data-focus-lock-disabled="disabled"
     >
       <div
-        aria-live="assertive"
+        aria-live="off"
         aria-modal="true"
         class="euiPanel euiPanel--plain euiPopover__panel emotion-euiPanel-grow-m-plain-euiPopover__panel-light-isOpen-isAttached-bottom"
         data-popover-open="true"
@@ -168,7 +170,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                   tabindex="0"
                 >
                   <button
+                    aria-posinset="1"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     data-test-subj="titanOption"
                     id="generated-id__option-0"
@@ -196,7 +200,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="2"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-1"
                     role="option"
@@ -223,7 +229,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="3"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-2"
                     role="option"
@@ -250,7 +258,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="4"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-3"
                     role="option"
@@ -277,7 +287,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="5"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-4"
                     role="option"
@@ -304,7 +316,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="6"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-5"
                     role="option"
@@ -331,7 +345,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="7"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-6"
                     role="option"
@@ -358,7 +374,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="8"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-7"
                     role="option"
@@ -385,7 +403,9 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                     </span>
                   </button>
                   <button
+                    aria-posinset="9"
                     aria-selected="false"
+                    aria-setsize="10"
                     class="euiFilterSelectItem emotion-euiFilterSelectItem"
                     id="generated-id__option-8"
                     role="option"

--- a/packages/eui/src/components/combo_box/combo_box.stories.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.stories.tsx
@@ -27,6 +27,11 @@ const options = [
   { label: 'Item 3' },
   { label: 'Item 4', disabled: true },
   { label: 'Item 5' },
+  { label: 'Item 6' },
+  { label: 'Item 7' },
+  { label: 'Item 8' },
+  { label: 'Item 9' },
+  { label: 'Item 10' },
 ];
 
 const meta: Meta<EuiComboBoxProps<{}>> = {

--- a/packages/eui/src/components/combo_box/combo_box.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.tsx
@@ -863,6 +863,10 @@ export class EuiComboBox<T> extends Component<
                 {...inputPopoverProps}
                 isOpen={isListOpen}
                 closePopover={this.closeList}
+                /* we don't want content changes to be announced via aria-live 
+                because ComboBox uses a virtualized list that updates itself
+                on scroll and would result in unexpected screen reader output */
+                aria-live="off"
                 input={
                   <EuiComboBoxInput
                     compressed={compressed}

--- a/packages/eui/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/packages/eui/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -379,6 +379,7 @@ export class EuiComboBoxInput<T> extends Component<
                     aria-label={ariaLabel}
                     aria-labelledby={ariaLabelledby}
                     aria-invalid={isInvalid}
+                    aria-haspopup="listbox"
                     css={styles.euiComboBoxInput}
                     className="euiComboBox__input"
                     data-test-subj="comboBoxSearchInput"

--- a/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -167,7 +167,10 @@ export class EuiComboBoxOptionsList<T> extends Component<
       renderOption,
       searchValue,
       rootId,
+      matchingOptions,
     } = this.props;
+
+    const optionIndex = matchingOptions.indexOf(option);
 
     const hasTruncationProps = this.props.truncationProps || _truncationProps;
     const truncationProps = hasTruncationProps
@@ -215,6 +218,8 @@ export class EuiComboBoxOptionsList<T> extends Component<
         showIcons={singleSelection ? true : false}
         id={rootId(`_option-${index}`)}
         title={label}
+        aria-setsize={matchingOptions.length}
+        aria-posinset={optionIndex + 1}
         {...rest}
       >
         <span className="euiComboBoxOption__contentWrapper">

--- a/packages/eui/src/components/filter_group/__snapshots__/filter_select_item.test.tsx.snap
+++ b/packages/eui/src/components/filter_group/__snapshots__/filter_select_item.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`EuiFilterSelectItem renders 1`] = `
 <button
   aria-label="aria-label"
+  aria-selected="false"
   class="euiFilterSelectItem testClass1 testClass2 emotion-euiFilterSelectItem-euiTestCss"
   data-test-subj="test subject string"
   role="option"

--- a/packages/eui/src/components/filter_group/filter_select_item.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.tsx
@@ -143,7 +143,7 @@ export class EuiFilterSelectItemClass extends Component<
         ref={(ref) => (this.buttonRef = ref)}
         role="option"
         type="button"
-        aria-selected={isFocused}
+        aria-selected={checked === 'on'}
         className={classes}
         css={cssStyles}
         disabled={disabled}

--- a/packages/eui/src/components/popover/popover.tsx
+++ b/packages/eui/src/components/popover/popover.tsx
@@ -636,6 +636,7 @@ export class EuiPopover extends Component<Props, State> {
       buffer,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      'aria-live': ariaLiveProp,
       container,
       focusTrapProps,
       initialFocus: initialFocusProp,
@@ -678,7 +679,7 @@ export class EuiPopover extends Component<Props, State> {
           initialFocus = () => this.panel!;
         }
       } else {
-        ariaLive = 'assertive';
+        ariaLive = ariaLiveProp ?? 'assertive';
       }
 
       let focusTrapScreenReaderText;


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8267

This PR updates `EuiComboBox` adding/updating it's markup to ensure expected output for screen readers.
The updates are based on the common web pattern for a combobox ([ref](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/))

---

**Unexpected behavior:**

- the appended items being read out by the screen reader because the panel has an aria-live="assertive" applied
- the list size is updated
- the item position index is updated correctly
- navigated/focused options are marked as selected


_NVDA (Windows) & Chrome_

https://github.com/user-attachments/assets/93eb50f7-51c6-44c9-b3fc-d5941813e8ac


_VoiceOver (macOS) & Chrome_

https://github.com/user-attachments/assets/b0fcf8e6-3a33-4378-86a4-7926edda7f8a

---

**Expected behavior:**

- the appended items are not read out (remove `aria-live-"assertive" for the listbox)
- the list size stays static and matches the available list item length (apply `aria-setsize`)
- the item position index does not update and matches the index in the options array (apply `aria-posinset`
- navigated/focused options are not semantically marked as selected (`EuiComboBox` removes selected items, so currently they are never selected inside the listbox) (apply correct condition for `aria-selected`)

_NVDA (Windows) & Chrome_

https://github.com/user-attachments/assets/a9dc01bf-26f0-45c9-86ff-b7124c0077dc


_VoiceOver (macOS) & Chrome_

https://github.com/user-attachments/assets/39649175-9b1d-48b0-9866-eaa239dba4a7


>[!NOTE]
There seems to be an issue in Safari + VoiceOver(testing in Safari `18.3` and macOS `14.7.4`): Navigating the option inside the list is not announced.
This seems to be related to the focus staying inside the input, but the options should actually be announced due to the correctly placed `aria-descendant` even if the focus is not actually moved to the options.
This is also happening for the current production state and can also be observed in external components e.g. for [MUI ComboBox component](https://mui.com/material-ui/react-autocomplete/#combo-box).
This should rather be looked into separately if it's something we can influence or it's an issue with Safari + VoiceOver specifically. Maybe it's also macOS/browser version specific 🤷‍♀️ 🤔 


## QA

- [x] verify the mouse and keyboard behavior in [staging](https://eui.elastic.co/pr_8333/storybook/index.html?path=/story/forms-euicombobox--playground) is the same as on [production](https://eui.elastic.co/storybook/index.html?path=/story/forms-euicombobox--playground)
- [x] verify that for screen readers the correct list size and option position are announced
- [x] verify that newly added list options (when scrolling new options into view) do not trigger additional screen reader output

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
