### PR TITLE
[EuiBasicTable] Better document `columns.nameTooltip`

### DIFF
--- a/packages/eui/src-docs/src/views/tables/basic/basic.tsx
+++ b/packages/eui/src-docs/src/views/tables/basic/basic.tsx
@@ -69,6 +69,9 @@ export default () => {
     {
       field: 'github',
       name: 'Github',
+      nameTooltip: {
+        content: 'Their mascot is the Octokitty',
+      },
       render: (username: User['github']) => (
         <EuiLink href="#" target="_blank">
           {username}

--- a/packages/eui/src-docs/src/views/tables/basic/basic_section.js
+++ b/packages/eui/src-docs/src/views/tables/basic/basic_section.js
@@ -93,8 +93,8 @@ export const section = {
         be used. This can be done using the{' '}
         <EuiCode language="js">columns.nameTooltip</EuiCode> property (e.g. the
         "GitHub" column as seen below). This approach ensures that the icon
-        remains visible even if the text gets truncated, unlike manually using
-        a React node for <EuiCode language="js">columns.name</EuiCode>.
+        remains visible even if the text gets truncated, unlike manually using a
+        React node for <EuiCode language="js">columns.name</EuiCode>.
       </p>
     </>
   ),

--- a/packages/eui/src-docs/src/views/tables/basic/basic_section.js
+++ b/packages/eui/src-docs/src/views/tables/basic/basic_section.js
@@ -93,8 +93,8 @@ export const section = {
         be used. This can be done using the{' '}
         <EuiCode language="js">columns.nameTooltip</EuiCode> property (e.g. the
         "GitHub" column as seen below). This approach ensures that the icon
-        remains visible even if the text gets cut off, unlike manually using a
-        React node for <EuiCode language="js">columns.name</EuiCode>.
+        remains visible even if the text gets truncated, unlike manually using
+        a React node for <EuiCode language="js">columns.name</EuiCode>.
       </p>
     </>
   ),

--- a/packages/eui/src-docs/src/views/tables/basic/basic_section.js
+++ b/packages/eui/src-docs/src/views/tables/basic/basic_section.js
@@ -92,9 +92,9 @@ export const section = {
         If a column name needs a longer description, an icon with a tooltip can
         be used. This can be done using the{' '}
         <EuiCode language="js">columns.nameTooltip</EuiCode> property (e.g. the
-        "GitHub" column). This approach ensures that the icon remains visible
-        even if the text gets cut off, unlike manually using a React node for{' '}
-        <EuiCode language="js">columns.name</EuiCode>.
+        "GitHub" column as seen below). This approach ensures that the icon
+        remains visible even if the text gets cut off, unlike manually using a
+        React node for <EuiCode language="js">columns.name</EuiCode>.
       </p>
     </>
   ),

--- a/packages/eui/src-docs/src/views/tables/basic/basic_section.js
+++ b/packages/eui/src-docs/src/views/tables/basic/basic_section.js
@@ -88,6 +88,7 @@ export const section = {
           properly.
         </li>
       </ul>
+      <p>If a column name needs a longer description, an icon with a tooltip can be used. This can be done using the <EuiCode language="js">columns.nameTooltip</EuiCode> property (e.g. the "GitHub" column). This approach ensures that the icon remains visible even if the text gets cut off, unlike manually using a React node for <EuiCode language="js">columns.name</EuiCode>.</p>
     </>
   ),
   props: {

--- a/packages/eui/src-docs/src/views/tables/basic/basic_section.js
+++ b/packages/eui/src-docs/src/views/tables/basic/basic_section.js
@@ -88,7 +88,14 @@ export const section = {
           properly.
         </li>
       </ul>
-      <p>If a column name needs a longer description, an icon with a tooltip can be used. This can be done using the <EuiCode language="js">columns.nameTooltip</EuiCode> property (e.g. the "GitHub" column). This approach ensures that the icon remains visible even if the text gets cut off, unlike manually using a React node for <EuiCode language="js">columns.name</EuiCode>.</p>
+      <p>
+        If a column name needs a longer description, an icon with a tooltip can
+        be used. This can be done using the{' '}
+        <EuiCode language="js">columns.nameTooltip</EuiCode> property (e.g. the
+        "GitHub" column). This approach ensures that the icon remains visible
+        even if the text gets cut off, unlike manually using a React node for{' '}
+        <EuiCode language="js">columns.name</EuiCode>.
+      </p>
     </>
   ),
   props: {

--- a/packages/eui/src/components/basic_table/table_types.ts
+++ b/packages/eui/src/components/basic_table/table_types.ts
@@ -34,6 +34,7 @@ export interface EuiTableFooterProps<T> {
   pagination?: Pagination;
 }
 
+/** Allows adding an icon with a tooltip to column names */
 export type EuiTableColumnNameTooltipProps = {
   /** The main content of the tooltip */
   content: ReactNode;

--- a/packages/website/docs/components/tabular_content/tables/basic_tables.mdx
+++ b/packages/website/docs/components/tabular_content/tables/basic_tables.mdx
@@ -147,7 +147,7 @@ In the above example, some columns displayed the value as-is (e.g. `firstName` a
 - Provide a `render` function that given the value (and the item as a second argument) returns the React node that should be displayed as the content of the cell. This can be as simple as formatting values (e.g. the "Date of Birth" column), to utilizing more complex React components (e.g. the "Online" and "Github" columns).
   - **Note:** the basic table will treat any cells that use a `render` function as being `textOnly: false`. This may cause unnecessary word breaks. Apply `textOnly: true` to ensure it breaks properly.
 
-If a column name needs a longer description, an icon with a tooltip can be used. This can be done using the `columns.nameTooltip` property. This approach ensures that the icon remains visible even if the text gets cut off, unlike manually using a React node for `columns.name`.
+If a column name needs a longer description, an icon with a tooltip can be used. This can be done using the `columns.nameTooltip` property. This approach ensures that the icon remains visible even if the text gets truncated, unlike manually using a React node for `columns.name`.
 
 ## Row selection
 

--- a/packages/website/docs/components/tabular_content/tables/basic_tables.mdx
+++ b/packages/website/docs/components/tabular_content/tables/basic_tables.mdx
@@ -76,6 +76,9 @@ export default () => {
     {
       field: 'github',
       name: 'Github',
+      nameTooltip: {
+        content: 'Their mascot is the Octokitty'
+      },
       render: (username: User['github']) => (
         <EuiLink href="#" target="_blank">
           {username}
@@ -143,6 +146,8 @@ In the above example, some columns displayed the value as-is (e.g. `firstName` a
 - Provide a hint about the type of data (e.g. the "Date of Birth" column indicates that the data it shows is of type `date`). Providing data type hints will cause built-in display components to be adjusted (e.g. numbers will become right aligned, like in Excel).
 - Provide a `render` function that given the value (and the item as a second argument) returns the React node that should be displayed as the content of the cell. This can be as simple as formatting values (e.g. the "Date of Birth" column), to utilizing more complex React components (e.g. the "Online" and "Github" columns).
   - **Note:** the basic table will treat any cells that use a `render` function as being `textOnly: false`. This may cause unnecessary word breaks. Apply `textOnly: true` to ensure it breaks properly.
+
+If a column name needs a longer description, an icon with a tooltip can be used. This can be done using the `columns.nameTooltip` property. This approach ensures that the icon remains visible even if the text gets cut off, unlike manually using a React node for `columns.name`.
 
 ## Row selection
 


### PR DESCRIPTION
## Summary

This PR adds a small paragraph to *EuiBasicTable* documentation regarding the recently added `nameTooltip` API.

## QA

Check new texts display properly in old and new docs:
- [ ] https://eui.elastic.co/pr_8343/#/tabular-content/tables%23a-basic-table
- [ ] https://eui.elastic.co/pr_8343/new-docs/docs/tabular-content/tables/basic/
