### PR TITLE
feat(website): add Utilities > Scroll page

### DIFF
--- a/packages/website/docs/components/utilities/scroll/_category_.yml
+++ b/packages/website/docs/components/utilities/scroll/_category_.yml
@@ -1,0 +1,3 @@
+link:
+  type: doc
+  id: utilities_scroll

--- a/packages/website/docs/components/utilities/scroll/overview.mdx
+++ b/packages/website/docs/components/utilities/scroll/overview.mdx
@@ -1,0 +1,242 @@
+---
+slug: /utilities/scroll
+id: utilities_scroll
+---
+
+import { css } from '@emotion/react';
+import { Example } from '@site/src/components';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiProvider,
+  EuiText,
+  logicalCSS,
+  logicalCSSWithFallback,
+  useEuiOverflowScroll,
+  useEuiScrollBar
+} from '@elastic/eui';
+
+import { ScrollContent } from './scroll_content';
+import {
+  HorizontalScrollClassNamePreview,
+  HorizontalScrollHookPreview,
+  ScrollBarClassNamePreview,
+  ScrollBarHookPreview,
+  VerticalScrollClassNamePreview,
+  VerticalScrollHookPreview
+} from './previews';
+
+# Scroll
+
+:::warning Scrollable regions must be focusable, promoted to region and with the right aria-label
+
+To ensure keyboard-only users have access to the scrollable regions, the optimal solution is to apply `tabIndex="0"` to the region. <a href="https://dequeuniversity.com/rules/axe/4.1/scrollable-region-focusable" target="_blank" rel="noopener noreferrer">**Learn more about the `scrollable-region-focusable` rule at Deque**</a>.
+:::
+
+## Scroll bar style
+
+<Example>
+  <Example.Description>
+    ### `.eui-scrollBar` <Badge color="hollow">className</Badge>
+
+    Use this utility class to style the browser's scrollbar in a minimal aesthetic. This is best used on small, inner-page contents like panels wherever you have `overflow: auto`.
+  </Example.Description>
+  <Example.Preview>
+    <ScrollBarClassNamePreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    <div tabIndex={0} className="eui-scrollBar">
+      <EuiPanel />
+      <EuiPanel />
+      <EuiPanel />
+    </div>
+    ```
+  </Example.Snippet>
+</Example>
+<Example>
+  <Example.Description>
+    ### `useEuiScrollBar()` <Badge color="hollow">hook</Badge>
+
+    Use this style function to style the browser's scrollbar in a minimal aesthetic. This is best used on small, inner-page contents like panels.
+
+    All parameters are optional and default to specific global settings.
+  </Example.Description>
+  <Example.Preview>
+    <ScrollBarHookPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    css`
+      ${useEuiScrollBar()}
+    `
+    ```
+  </Example.Snippet>
+</Example>
+
+## Vertical (scroll-y)
+
+These utilities allow for quickly applying vertical scrolling to a container. They also automatically apply the minimal scroll bar styles as well. If you do not want your content to stretch to `100%` height, you will need to manually add a `height` (or `max-height`) to the container.
+
+The `WithShadows` variants are primarily used in modals and flyouts and masks the edges to indicate there is more content. When using these variants, you may want to add a small amount padding to the top and bottom of your content so the mask doesn't overlay it.
+
+<Example>
+  <Example.Description>
+    ### `.eui-yScroll` <Badge color="hollow">className</Badge>
+
+    Quick utility class for adding vertical scrolling to a container.
+  </Example.Description>
+  <Example.Preview>
+    <VerticalScrollClassNamePreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    <div tabIndex={0} className="eui-yScrollWithShadows">
+      <EuiPanel />
+      <EuiPanel />
+      <EuiPanel />
+    </div>
+    ```
+  </Example.Snippet>
+</Example>
+<Example>
+  <Example.Description>
+    ### `useEuiOverflowScroll('y')` <Badge color="hollow">hook</Badge>
+
+    Styles hook for adding vertical scrolling to a container.
+
+    To mask the top and bottom of the scrolled content, indicating visually that there is more content below, pass in true to the second parameter `mask`.
+
+    `useEuiOverflowScroll('y', true);`
+  </Example.Description>
+  <Example.Preview>
+    <VerticalScrollHookPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    css`
+      ${useEuiOverflowScroll('y', true)}
+    `
+    ```
+  </Example.Snippet>
+</Example>
+
+## Horizontal (scroll-x)
+
+The horizontal equivalent should be used sparingly and usually only in full-height layouts or a grid of items.
+
+When using the `WithShadows` variant, you may want to add a small amount padding to the sides of your content so the mask doesn't overlay it.
+
+<Example>
+  <Example.Description>
+    ### `.eui-xScroll` <Badge color="hollow">className</Badge>
+
+    Quick utility class for adding horizontal scrolling to a container.
+  </Example.Description>
+  <Example.Preview>
+    <HorizontalScrollClassNamePreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    <div tabIndex={0} className="eui-xScrollWithShadows">
+      <EuiPanel />
+      <EuiPanel />
+      <EuiPanel />
+    </div>
+    ```
+  </Example.Snippet>
+</Example>
+<Example>
+  <Example.Description>
+    ### `useEuiOverflowScroll('x')` <Badge color="hollow">hook</Badge>
+
+    Styles hook for adding horizontal scrolling to a container.
+
+    To mask the top and bottom of the scrolled content, indicating visually that there is more content below, pass in true to the second parameter `mask`.
+
+    `useEuiOverflowScroll('x', true);`
+  </Example.Description>
+  <Example.Preview>
+    <HorizontalScrollHookPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    css`
+      ${useEuiOverflowScroll('x', true)}
+    `
+    ```
+  </Example.Snippet>
+</Example>
+
+## Full height layout
+
+<Example>
+  <Example.Description>
+    ### `.eui-fullHeight` <Badge color="hollow">className</Badge>
+
+    Quick utility for expanding the height of the element to its parents dimensions. Use it to stretch each nested element until the one that applies scroll.
+
+    Works on both flex and non-flex elements.
+  </Example.Description>
+  <Example.Preview>
+    <div style={{ height: 180 }}>
+      <EuiFlexGroup className="eui-fullHeight" gutterSize="s" responsive={false}>
+        <EuiFlexItem>
+          <EuiPanel className="eui-yScroll" color="warning" tabIndex={0}>
+            <EuiText size="s">
+              <p>
+                Orbiting this at a distance of roughly ninety-two million miles is
+                an utterly insignificant little blue green planet whose
+                ape-descended life forms are so amazingly primitive that they
+                still think digital watches are a pretty neat idea.
+              </p>
+            </EuiText>
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiPanel className="eui-yScroll" color="warning" tabIndex={0}>
+            <EuiText size="s">
+              <p>
+                Orbiting this at a distance of roughly ninety-two million miles is
+                an utterly insignificant little blue green planet whose
+                ape-descended life forms are so amazingly primitive that they
+                still think digital watches are a pretty neat idea.
+              </p>
+            </EuiText>
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </div>
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    <BodyContent style={{ height: 180 }}>
+      <EuiFlexGroup className="eui-fullHeight" responsive={false}>
+        <EuiFlexItem>
+          <BodyScroll className="eui-yScroll" tabIndex={0} />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <BodyScroll className="eui-yScroll" tabIndex={0} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </BodyContent>
+    ```
+  </Example.Snippet>
+</Example>
+<Example>
+  <Example.Description>
+    ### `euiFullHeight()` <Badge color="hollow">function</Badge>
+
+    Emotion mixin for adding full height scrolling to a container or flex child.
+
+    It applies `height: 100%; overflow: hidden;` but also adds `flex: 1 1 auto;` for use within `flex` containers.
+  </Example.Description>
+  <Example.Snippet>
+    ```tsx
+    css`
+      ${euiFullHeight()}
+    `
+    ```
+  </Example.Snippet>
+</Example>

--- a/packages/website/docs/components/utilities/scroll/previews.tsx
+++ b/packages/website/docs/components/utilities/scroll/previews.tsx
@@ -1,0 +1,98 @@
+import { css } from '@emotion/react';
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiText,
+  logicalCSS,
+  logicalCSSWithFallback,
+  useEuiOverflowScroll,
+  useEuiScrollBar,
+} from '@elastic/eui';
+
+import { ScrollContent } from './scroll_content';
+
+const verticalBaseCss = ({ euiTheme }) => css`
+  ${logicalCSSWithFallback('overflow-y', 'auto')}
+  ${logicalCSS('height', `${euiTheme.base * 12}px`)}
+`;
+
+const horizontalBaseCss = () => css`
+  ${logicalCSSWithFallback('overflow-x', 'auto')}
+  ${logicalCSS('width', '100%')}
+`;
+
+export const ScrollBarClassNamePreview = () => (
+  <div tabIndex={0} className="eui-scrollBar" css={verticalBaseCss}>
+    <ScrollContent />
+  </div>
+);
+
+export const ScrollBarHookPreview = () => (
+  <div
+    tabIndex={0}
+    css={[
+      css`
+        ${useEuiScrollBar()}
+      `,
+      verticalBaseCss,
+    ]}
+  >
+    <ScrollContent />
+  </div>
+);
+
+export const VerticalScrollClassNamePreview = () => (
+  <div tabIndex={0} className="eui-yScrollWithShadows" css={verticalBaseCss}>
+    <ScrollContent />
+  </div>
+);
+
+export const VerticalScrollHookPreview = () => (
+  <div
+    tabIndex={0}
+    css={[
+      css`
+        ${useEuiOverflowScroll('y', true)}
+      `,
+      verticalBaseCss,
+    ]}
+  >
+    <ScrollContent />
+  </div>
+);
+
+export const HorizontalScrollClassNamePreview = () => (
+  <div tabIndex={0} className="eui-xScrollWithShadows" css={horizontalBaseCss}>
+    <EuiFlexGroup
+      css={css`
+        ${logicalCSS('width', '150%')}
+      `}
+      responsive={false}
+    >
+      <ScrollContent direction="horizontal" />
+    </EuiFlexGroup>
+  </div>
+);
+
+export const HorizontalScrollHookPreview = () => (
+  <div
+    tabIndex={0}
+    css={[
+      css`
+        ${useEuiOverflowScroll('x', true)};
+      `,
+      horizontalBaseCss,
+    ]}
+  >
+    <EuiFlexGroup
+      css={css`
+        ${logicalCSS('width', '150%')}
+      `}
+      responsive={false}
+    >
+      <ScrollContent direction="horizontal" />
+    </EuiFlexGroup>
+  </div>
+);

--- a/packages/website/docs/components/utilities/scroll/scroll_content.tsx
+++ b/packages/website/docs/components/utilities/scroll/scroll_content.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/react';
+
+import { EuiPanel, logicalCSS, useEuiTheme } from '@elastic/eui';
+
+type PropsType = {
+  direction?: 'vertical' | 'horizontal';
+};
+
+export const ScrollContent = ({ direction = 'vertical' }: PropsType) => {
+  const { euiTheme } = useEuiTheme();
+
+  const baseStyle = css`
+    padding: ${euiTheme.size.xxl};
+    margin: ${euiTheme.size.base};
+  `;
+
+  const horizontalStyle = css`
+    ${logicalCSS('height', euiTheme.size.xxxl)}
+    ${logicalCSS('width', euiTheme.size.xxxxl)}
+  `;
+
+  const style = [baseStyle, direction === 'horizontal' ? horizontalStyle : {}];
+
+  return (
+    <>
+      <EuiPanel css={style} color="primary" />
+      <EuiPanel css={style} color="primary" />
+      <EuiPanel css={style} color="primary" />
+      <EuiPanel css={style} color="primary" />
+      <EuiPanel css={style} color="primary" />
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui/issues/8190

Adds the Scroll page to the new documentation site. I removed the dynamic section for Sass as it's something we're trying to migrate away from.

## QA

**Checklist:**

- [ ] Compare the content between the old docs and the staging.
- [ ] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [ ] Verify that examples work as expected.
- [ ] Make sure the prop tables is displayed for all relevant component.