### PR TITLE
feat(website): add Utilities > Focus Trap page

### DIFF
--- a/packages/website/docs/components/utilities/focus_trap/_category_.yml
+++ b/packages/website/docs/components/utilities/focus_trap/_category_.yml
@@ -1,0 +1,3 @@
+link:
+  type: doc
+  id: utilities_focus_trap

--- a/packages/website/docs/components/utilities/focus_trap/form_compressed.tsx
+++ b/packages/website/docs/components/utilities/focus_trap/form_compressed.tsx
@@ -1,0 +1,149 @@
+import React, { useState } from 'react';
+
+import {
+  EuiCheckboxGroup,
+  EuiComboBox,
+  EuiFieldText,
+  EuiFormRow,
+  EuiFilePicker,
+  EuiRange,
+  EuiSelect,
+  EuiSwitch,
+  EuiPanel,
+  EuiSpacer,
+  useGeneratedHtmlId,
+  EuiComboBoxOptionOption,
+} from '@elastic/eui';
+
+export default () => {
+  const compressedFormCheckboxId__1 = useGeneratedHtmlId({
+    prefix: 'compressedFormCheckbox',
+    suffix: 'first',
+  });
+  const compressedFormCheckboxId__2 = useGeneratedHtmlId({
+    prefix: 'compressedFormCheckbox',
+    suffix: 'second',
+  });
+  const compressedFormCheckboxId__3 = useGeneratedHtmlId({
+    prefix: 'compressedFormCheckbox',
+    suffix: 'third',
+  });
+  const compressedFormRangeId = useGeneratedHtmlId({
+    prefix: 'compressedFormRange',
+  });
+
+  const [checkboxes] = useState([
+    {
+      id: compressedFormCheckboxId__1,
+      label: 'Option one',
+    },
+    {
+      id: compressedFormCheckboxId__2,
+      label: 'Option two is checked by default',
+    },
+    {
+      id: compressedFormCheckboxId__3,
+      label: 'Option three',
+    },
+  ]);
+  const [isSwitchChecked, setIsSwitchChecked] = useState(false);
+  const [checkboxIdToSelectedMap, setCheckboxIdToSelectedMap] = useState({
+    [compressedFormCheckboxId__2]: true,
+  });
+
+  const [comboBoxSelectionOptions, setComboBoxSelectionOptions] = useState<
+    EuiComboBoxOptionOption<unknown>[]
+  >([]);
+
+  const [value, setValue] = useState(20);
+
+  const onRangeChange = (e) => {
+    setValue(e.target.value);
+  };
+
+  const onSwitchChange = () => {
+    setIsSwitchChecked(!isSwitchChecked);
+  };
+
+  const onCheckboxChange = (optionId) => {
+    const newCheckboxIdToSelectedMap = {
+      ...checkboxIdToSelectedMap,
+      ...{
+        [optionId]: !checkboxIdToSelectedMap[optionId],
+      },
+    };
+    setCheckboxIdToSelectedMap(newCheckboxIdToSelectedMap);
+  };
+  return (
+    <EuiPanel style={{ maxWidth: 300 }}>
+      <EuiFormRow label="Text field" helpText="I am some friendly help text.">
+        <EuiFieldText name="first" isLoading compressed />
+      </EuiFormRow>
+
+      <EuiFormRow label="Select">
+        <EuiSelect
+          options={[
+            { value: 'option_one', text: 'Option one' },
+            { value: 'option_two', text: 'Option two' },
+            { value: 'option_three', text: 'Option three' },
+          ]}
+          compressed
+        />
+      </EuiFormRow>
+
+      <EuiFormRow label="File picker">
+        <EuiFilePicker compressed display="default" />
+      </EuiFormRow>
+
+      <EuiFormRow label="Combobox">
+        <EuiComboBox
+          options={[
+            { label: 'Option one' },
+            { label: 'Option two' },
+            { label: 'Option three' },
+          ]}
+          compressed
+          selectedOptions={comboBoxSelectionOptions}
+          onChange={(comboBoxSelectionOptions) =>
+            setComboBoxSelectionOptions(comboBoxSelectionOptions)
+          }
+        />
+      </EuiFormRow>
+
+      <EuiFormRow label="Range">
+        <EuiRange
+          min={0}
+          max={100}
+          name="range"
+          id={compressedFormRangeId}
+          showInput
+          compressed
+          value={value}
+          onChange={onRangeChange}
+        />
+      </EuiFormRow>
+
+      <EuiFormRow label="Switch" hasChildLabel={false}>
+        <EuiSwitch
+          label="Setting name"
+          name="switch"
+          checked={isSwitchChecked}
+          onChange={onSwitchChange}
+          compressed
+        />
+      </EuiFormRow>
+
+      <EuiSpacer size="m" />
+
+      <EuiCheckboxGroup
+        options={checkboxes}
+        idToSelectedMap={checkboxIdToSelectedMap}
+        onChange={onCheckboxChange}
+        legend={{
+          children: 'Checkboxes',
+        }}
+        compressed
+      />
+    </EuiPanel>
+  );
+};

--- a/packages/website/docs/components/utilities/focus_trap/overview.mdx
+++ b/packages/website/docs/components/utilities/focus_trap/overview.mdx
@@ -5,7 +5,7 @@ id: utilities_focus_trap
 
 # Focus trap
 
-Use **EuiFocusTrap** to prevent keyboard-initiated focus from leaving a defined area. Temporary flows and UX escapes that occur in components such as [EuiModal](../layout/modal/overview.mdx) and [EuiFlyout](../layout/flyout/flyout.mdx) are prime examples.
+Use **EuiFocusTrap** to prevent keyboard-initiated focus from leaving a defined area. Temporary flows and UX escapes that occur in components such as [EuiModal](../../layout/modal/overview.mdx) and [EuiFlyout](../../layout/flyout/flyout.mdx) are prime examples.
 
 For components that project content in a React portal, **EuiFocusTrap** will maintain the tab order expected by users.
 

--- a/packages/website/docs/components/utilities/focus_trap/overview.mdx
+++ b/packages/website/docs/components/utilities/focus_trap/overview.mdx
@@ -1,0 +1,66 @@
+---
+slug: /utilities/focus-trap
+id: utilities_focus_trap
+---
+
+# Focus trap
+
+Use **EuiFocusTrap** to prevent keyboard-initiated focus from leaving a defined area. Temporary flows and UX escapes that occur in components such as [EuiModal](../layout/modal/overview.mdx) and [EuiFlyout](../layout/flyout/flyout.mdx) are prime examples.
+
+For components that project content in a React portal, **EuiFocusTrap** will maintain the tab order expected by users.
+
+* Use `clickOutsideDisables` to disable the focus trap when the user clicks outside the trap.
+* Use `noIsolation={false}` when pointer events on outside elements should be disallowed.
+* Use `crossFrame={true}` when focus should not be allowed on other iframes on the page.
+
+import FormExample from './form_compressed';
+
+<Demo scope={{ FormExample }}>
+```tsx interactive
+import React, { useState } from 'react';
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiFocusTrap,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+
+export default () => {
+  const [isDisabled, changeDisabled] = useState(true);
+
+  const toggleDisabled = () => changeDisabled(!isDisabled);
+
+  return (
+    <div>
+      <EuiBadge>Trap is {isDisabled ? 'disabled' : 'enabled'}</EuiBadge>
+      <EuiSpacer size="s" />
+      <EuiFocusTrap disabled={isDisabled}>
+        <EuiPanel>
+          <FormExample />
+          <EuiSpacer size="m" />
+          <EuiButton onClick={toggleDisabled}>
+            {`${!isDisabled ? 'Disable' : 'Enable'} Focus Trap`}
+          </EuiButton>
+        </EuiPanel>
+      </EuiFocusTrap>
+      <EuiSpacer size="l" />
+      <EuiText>
+        The button below is not focusable by keyboard as long as the focus trap
+        is enabled.
+      </EuiText>
+      <EuiButton onClick={() => {}}>External Focusable Element</EuiButton>
+    </div>
+  );
+};
+```
+</Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/focus_trap';
+
+<PropTable definition={docgen.EuiFocusTrap} />
+


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui/issues/8190

Added the Focus Trap page to the new documentation site.

## QA

**Checklist:**

- [ ] Compare the content between the old docs and the staging.
- [ ] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [ ] Verify that examples work as expected.
- [ ] Make sure the prop tables is displayed for all relevant component.