### PR TITLE
feat(website): add Utilities > Color Palettes page

### DIFF
--- a/packages/website/docs/components/utilities/color_palettes/_category_.yml
+++ b/packages/website/docs/components/utilities/color_palettes/_category_.yml
@@ -1,3 +1,3 @@
 link:
   type: doc
-  id: component_color_palettes_overview
+  id: utilities_color_palettes

--- a/packages/website/docs/components/utilities/color_palettes/color_palettes_components.tsx
+++ b/packages/website/docs/components/utilities/color_palettes/color_palettes_components.tsx
@@ -1,0 +1,56 @@
+import React, { ComponentProps } from 'react';
+import { css } from '@emotion/react';
+
+import {
+  EuiFlexItem,
+  EuiCopy,
+  EuiCode,
+  EuiLink,
+  useEuiTheme,
+} from '@elastic/eui';
+
+interface Props extends ComponentProps<typeof EuiFlexItem> {
+  hexCode: string;
+}
+
+export const ColorPaletteFlexItem = ({ hexCode, ...rest }: Props) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexItem
+      css={css`
+        span {
+          height: ${euiTheme.size.base};
+          width: ${euiTheme.size.l};
+        }
+
+        &--small span {
+          width: auto;
+          height: ${euiTheme.size.s};
+        }
+      `}
+      key={hexCode}
+      grow={false}
+      {...rest}
+    >
+      <span title={hexCode} style={{ backgroundColor: hexCode }} />
+    </EuiFlexItem>
+  );
+};
+
+export const ColorPaletteCopyCode = ({ textToCopy, code }) => {
+  return (
+    <span>
+      <EuiCopy
+        beforeMessage="Click to copy palette config"
+        textToCopy={textToCopy || code}
+      >
+        {(copy) => (
+          <EuiLink onClick={copy}>
+            <EuiCode>{code}</EuiCode>
+          </EuiLink>
+        )}
+      </EuiCopy>
+    </span>
+  );
+};

--- a/packages/website/docs/components/utilities/color_palettes/overview.mdx
+++ b/packages/website/docs/components/utilities/color_palettes/overview.mdx
@@ -1,9 +1,9 @@
 ---
-id: component_color_palettes_overview
-title: Color Palettes
-export_name: EuiColorPalettes
-slug: /color_palettes
+slug: /utilities/color-palettes
+id: utilities_color_palettes
 ---
+
+import { ColorPaletteCopyCode, ColorPaletteFlexItem } from './color_palettes_components';
 
 # Color palettes
 
@@ -11,449 +11,325 @@ EUI provides a base set of color palettes that return an array of hexadecimal co
 
 ## Preset qualitative palettes
 
-Qualitative palettes are best suited for communicating and comparing discrete data series. 
-EUI recommends using the `euiPaletteColorBlind()` for qualitative and categorical data.
+Qualitative palettes are best suited for communicating and comparing discrete data series. EUI recommends using the `euiPaletteColorBlind()` for qualitative and categorical data.
 
-This palette is restricted to only 10 colors. However, you can add more groups of 10 which 
-are alternates of the original. This is better than allowing the initial set to loop.
+This palette is restricted to only 10 colors. However, you can add more groups of 10 which are alternates of the original. This is better than allowing the initial set to loop.
 
-These colors are meant to be used as graphics and contrasted against the value of `euiColorEmptyShade` 
-for the current theme. When placing text on top of these colors, use the `euiPaletteColorBlindBehindText()` 
-variant. It is a brightened version of the base palette to create better contrast with text.
+These colors are meant to be used as graphics and contrasted against the value of `euiColorEmptyShade` for the current theme. When placing text on top of these colors, use the `euiPaletteColorBlindBehindText()` variant. It is a brightened version of the base palette to create better contrast with text.
 
-```tsx interactive
-import React, { Fragment } from 'react';
+<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }}>
+  ```tsx
+  import React, { Fragment } from 'react';
 
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiTitle,
-  EuiSpacer,
-  EuiBadge,
-  EuiFlexGrid,
-  euiPaletteColorBlind,
-  euiPaletteColorBlindBehindText,
-  ColorPaletteFlexItem, 
-  ColorPaletteCopyCode,
-  EUI_VIS_COLOR_STORE,
-} from '@elastic/eui';
-import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
-import { css } from '@emotion/css';
+  import {
+    EuiBadge,
+    EuiFlexGrid,
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiSpacer,
+    EuiTitle,
+    euiPaletteColorBlind,
+    euiPaletteColorBlindBehindText,
+    useEuiTheme,
+    EUI_VIS_COLOR_STORE,
+  } from '@elastic/eui';
+  import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
 
-const ColorPaletteFlexItem = ({ hexCode, className, ...rest }) => {
+  const getCustomPalettes = () => [
+    {
+      title: 'Max 10 colors',
+      palette: euiPaletteColorBlind(),
+      code: 'euiPaletteColorBlind()',
+    },
+    {
+      title: 'More than 10 colors are needed',
+      palette: euiPaletteColorBlind({ rotations: 2 }),
+      code: 'euiPaletteColorBlind({rotations: 2})',
+    },
+    {
+      title:
+        'Series may have multiple metrics and so the colors must coordinate but be distinguishable',
+      palette: euiPaletteColorBlind({
+        rotations: 3,
+        order: 'group',
+        direction: 'both',
+      }),
+      code: "euiPaletteColorBlind({rotations: 3, order: 'group', direction: 'both'})",
+    },
+    {
+      title:
+        "The default sort order is close but not exactly aligned with the color wheel. To sort this better add the 'natural' sort param.",
+      palette: euiPaletteColorBlind({ sortBy: 'natural' }),
+      code: "euiPaletteColorBlind({sortBy: 'natural'})",
+    },
+  ];
+
+  export default () => {
     const { euiTheme } = useEuiTheme();
 
-  return (
-    <EuiFlexItem
-      key={hexCode}
-      grow={false}
-        css={{
-          'span': {
-            height: euiTheme.size.base,
-            width: euiTheme.size.l,
-          },
-          '&--small span': {
-            width: 'auto',
-            height: euiTheme.size.s,
-          },
-        }}
-        {...rest}
-        >
-      <span title={hexCode} style={{ backgroundColor: hexCode }} />
-    </EuiFlexItem>
-  );
-};
+    const [customPalettes, setCustomPalettes] = useState(getCustomPalettes);
 
-const ColorPaletteCopyCode = ({ textToCopy, code }) => {
-  return (
-    <span>
-      <EuiCopy
-        beforeMessage="Click to copy palette config"
-        textToCopy={textToCopy || code}
-      >
-        {(copy) => (
-          <EuiLink onClick={copy}>
-            <EuiCode>{code}</EuiCode>
-          </EuiLink>
-        )}
-      </EuiCopy>
-    </span>
-  );
-};
-
-const getCustomPalettes = () => [
-  {
-    title: 'Max 10 colors',
-    palette: euiPaletteColorBlind(),
-    code: 'euiPaletteColorBlind()',
-  },
-  {
-    title: 'More than 10 colors are needed',
-    palette: euiPaletteColorBlind({ rotations: 2 }),
-    code: 'euiPaletteColorBlind({rotations: 2})',
-  },
-  {
-    title:
-      'Series may have multiple metrics and so the colors must coordinate but be distinguishable',
-    palette: euiPaletteColorBlind({
-      rotations: 3,
-      order: 'group',
-      direction: 'both',
-    }),
-    code: "euiPaletteColorBlind({rotations: 3, order: 'group', direction: 'both'})",
-  },
-  {
-    title:
-      "The default sort order is close but not exactly aligned with the color wheel. To sort this better add the 'natural' sort param.",
-    palette: euiPaletteColorBlind({ sortBy: 'natural' }),
-    code: "euiPaletteColorBlind({sortBy: 'natural'})",
-  },
-];
-
-export default () => {
-  const { euiTheme } = useEuiTheme();
-
-  const [customPalettes, setCustomPalettes] = useState(getCustomPalettes);
-
-  const handleVisColorThemeChange = () => {
-    const palette = getCustomPalettes();
-    setCustomPalettes(palette);
-  };
-
-  useEffect(() => {
-    const storeId = EUI_VIS_COLOR_STORE.subscribe(
-      VIS_COLOR_STORE_EVENTS.UPDATE,
-      handleVisColorThemeChange
-    );
-
-    return () => {
-      EUI_VIS_COLOR_STORE.unsubscribe(VIS_COLOR_STORE_EVENTS.UPDATE, storeId);
+    const handleVisColorThemeChange = () => {
+      const palette = getCustomPalettes();
+      setCustomPalettes(palette);
     };
-  }, []);
 
-  return (
-    <Fragment>
-      {customPalettes.map((palette) => (
-        <Fragment key={palette.title}>
-          <EuiTitle size="xxs">
-            <h3>{palette.title}</h3>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-          <EuiFlexGroup alignItems="center">
-            <EuiFlexItem grow={false} style={{ maxWidth: 240 }}>
-              <EuiFlexGroup
-                className="guideColorPalette__swatchHolder"
-                gutterSize="none"
-                alignItems="flexStart"
-                responsive={false}
-                wrap
-                css={{
-                  borderRadius: euiTheme.border.radius.medium,
-                  overflow: 'hidden',
-                }}
-              >
-                {palette.palette.map((hexCode) => (
-                  <ColorPaletteFlexItem
-                    className="guideColorPalette__swatch--notRound"
-                    hexCode={hexCode}
-                    key={hexCode}
-                  />
-                ))}
-              </EuiFlexGroup>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <ColorPaletteCopyCode code={palette.code} />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="xl" />
-        </Fragment>
-      ))}
-      <EuiTitle size="xxs">
-        <h3>Behind text variant</h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      <EuiFlexGroup alignItems="center">
-        <EuiFlexItem grow={false} style={{ maxWidth: 240 }}>
-          <EuiFlexGrid columns={4} gutterSize="s">
-            {euiPaletteColorBlindBehindText({ sortBy: 'natural' }).map(
-              (color, i) => (
-                <EuiFlexItem key={i} grow={false}>
-                  <span>
-                    <EuiBadge color={color}>Text</EuiBadge>
-                  </span>
-                </EuiFlexItem>
-              )
-            )}
-          </EuiFlexGrid>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <ColorPaletteCopyCode
-            textToCopy={"euiPaletteColorBlindBehindText({ sortBy: 'natural' })"}
-            code={"euiPaletteColorBlindBehindText({ sortBy: 'natural' })"}
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </Fragment>
-  )
-};
+    useEffect(() => {
+      const storeId = EUI_VIS_COLOR_STORE.subscribe(
+        VIS_COLOR_STORE_EVENTS.UPDATE,
+        handleVisColorThemeChange
+      );
+
+      return () => {
+        EUI_VIS_COLOR_STORE.unsubscribe(VIS_COLOR_STORE_EVENTS.UPDATE, storeId);
+      };
+    }, []);
+
+    return (
+      <Fragment>
+        {customPalettes.map((palette) => (
+          <Fragment key={palette.title}>
+            <EuiTitle size="xxs">
+              <h3>{palette.title}</h3>
+            </EuiTitle>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup alignItems="center">
+              <EuiFlexItem grow={false} style={{ maxWidth: 240 }}>
+                <EuiFlexGroup
+                  className="guideColorPalette__swatchHolder"
+                  gutterSize="none"
+                  alignItems="flexStart"
+                  responsive={false}
+                  wrap
+                  css={css`
+                    border-radius: ${euiTheme.border.radius.medium};
+                    overflow: hidden;
+                  `}>
+                  {palette.palette.map((hexCode) => (
+                    <ColorPaletteFlexItem
+                      className="guideColorPalette__swatch--notRound"
+                      hexCode={hexCode}
+                      key={hexCode}
+                    />
+                  ))}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <ColorPaletteCopyCode code={palette.code} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="xl" />
+          </Fragment>
+        ))}
+        <EuiTitle size="xxs">
+          <h3>Behind text variant</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiFlexGroup alignItems="center">
+          <EuiFlexItem grow={false} style={{ maxWidth: 240 }}>
+            <EuiFlexGrid columns={4} gutterSize="s">
+              {euiPaletteColorBlindBehindText({ sortBy: 'natural' }).map(
+                (color, i) => (
+                  <EuiFlexItem key={i} grow={false}>
+                    <span>
+                      <EuiBadge color={color}>Text</EuiBadge>
+                    </span>
+                  </EuiFlexItem>
+                )
+              )}
+            </EuiFlexGrid>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <ColorPaletteCopyCode
+              textToCopy={"euiPaletteColorBlindBehindText({ sortBy: 'natural' })"}
+              code={"euiPaletteColorBlindBehindText({ sortBy: 'natural' })"}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </Fragment>
+    )
+  };
 ```
+</Demo>
 
 ## Recommended quantitative palettes
 
-Quantitative palettes are best suited for displaying data on a continuum, as in the case of health statuses 
-and large geographic or demographic-based data sets.
-EUI provides the following common palettes for quantitative data and [charts](#/docs/elastic-charts/creating-charts/).
-Just pass in the number of steps needed and the function will interpolate between the colors.
+Quantitative palettes are best suited for displaying data on a continuum, as in the case of health statuses and large geographic or demographic-based data sets.
+
+EUI provides the following common palettes for quantitative data and [charts](../../../data_visualization/elastic_charts_design_system.mdx). Just pass in the number of steps needed and the function will interpolate between the colors.
 
 :::warning
 The palette for status is the only palette that has proper contrast ratios. When using the other palettes, consider adding another form of the data for screen readers.
 :::
 
-```tsx interactive
-import React, { Fragment, useState } from 'react';
-import { css } from '@emotion/css';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiRange,
-  EuiFormRow,
-  EuiSpacer,
-  euiPaletteComplementary,
-  euiPaletteForStatus,
-  euiPaletteForTemperature,
-  euiPaletteCool,
-  euiPaletteWarm,
-  euiPaletteRed,
-  euiPaletteGreen,
-  euiPaletteGray,
-} from '@elastic/eui';
+<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }}>
+  ```tsx interactive
+  import React, { Fragment, useState } from 'react';
 
-const ColorPaletteFlexItem = ({ hexCode, className, ...rest }) => {
-    const { euiTheme } = useEuiTheme();
+  import {
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiRange,
+    EuiFormRow,
+    EuiSpacer,
+    euiPaletteComplementary,
+    euiPaletteForStatus,
+    euiPaletteForTemperature,
+    euiPaletteCool,
+    euiPaletteWarm,
+    euiPaletteRed,
+    euiPaletteGreen,
+    euiPaletteGray,
+    useEuiTheme,
+  } from '@elastic/eui';
 
-  return (
-    <EuiFlexItem
-      key={hexCode}
-      grow={false}
-        css={{
-          'span': {
-            height: euiTheme.size.base,
-            width: euiTheme.size.l,
-          },
-          '&--small span': {
-            width: 'auto',
-            height: euiTheme.size.s,
-          },
-        }}
-        {...rest}
-        >
-      <span title={hexCode} style={{ backgroundColor: hexCode }} />
-    </EuiFlexItem>
-  );
-};
-
-const ColorPaletteCopyCode = ({ textToCopy, code }) => {
-  return (
-    <span>
-      <EuiCopy
-        beforeMessage="Click to copy palette config"
-        textToCopy={textToCopy || code}
-      >
-        {(copy) => (
-          <EuiLink onClick={copy}>
-            <EuiCode>{code}</EuiCode>
-          </EuiLink>
-        )}
-      </EuiCopy>
-    </span>
-  );
-};
-
-const paletteData = {
-  euiPaletteForStatus,
-  euiPaletteForTemperature,
-  euiPaletteComplementary,
-  euiPaletteRed,
-  euiPaletteGreen,
-  euiPaletteCool,
-  euiPaletteWarm,
-  euiPaletteGray,
-};
-const paletteNames = Object.keys(paletteData);
-
-export default () => {
-  const { euiTheme } = useEuiTheme();
-  const [length, setLength] = useState(5);
-
-  const onLengthChange = (e) => {
-    setLength(e.currentTarget.value);
+  const paletteData = {
+    euiPaletteForStatus,
+    euiPaletteForTemperature,
+    euiPaletteComplementary,
+    euiPaletteRed,
+    euiPaletteGreen,
+    euiPaletteCool,
+    euiPaletteWarm,
+    euiPaletteGray,
   };
 
-  return (
-    <Fragment>
-      <EuiFormRow label="Number of steps" display="columnCompressed">
-        <EuiRange
-          value={length}
-          onChange={onLengthChange}
-          min={1}
-          max={20}
-          compressed
-          showValue
-        />
-      </EuiFormRow>
+  const paletteNames = Object.keys(paletteData);
 
-      <EuiSpacer />
+  export default () => {
+    const { euiTheme } = useEuiTheme();
+    const [length, setLength] = useState(5);
 
-      {paletteNames.map((paletteName) => (
-        <EuiFlexGroup alignItems="center" key={paletteName}>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup
-              className="guideColorPalette__swatchHolder"
-              gutterSize="none"
-              responsive={false}
-              css={{
-                borderRadius: euiTheme.border.radius.medium,
-                overflow: 'hidden',
-              }}
-            >
-              {paletteData[paletteName](Number(length)).map((hexCode) => (
-                <ColorPaletteFlexItem hexCode={hexCode} key={hexCode} />
-              ))}
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <ColorPaletteCopyCode
-              textToCopy={`${paletteName}(${length});`}
-              code={`${paletteName}(${length})`}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ))}
-    </Fragment>
-  );
-};
+    const onLengthChange = (e) => {
+      setLength(e.currentTarget.value);
+    };
 
-```
+    return (
+      <Fragment>
+        <EuiFormRow label="Number of steps" display="columnCompressed">
+          <EuiRange
+            value={length}
+            onChange={onLengthChange}
+            min={1}
+            max={20}
+            compressed
+            showValue
+          />
+        </EuiFormRow>
+        <EuiSpacer />
+        {paletteNames.map((paletteName) => (
+          <EuiFlexGroup alignItems="center" key={paletteName}>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup
+                css={css`
+                  border-radius: ${euiTheme.border.radius.medium};
+                  overflow: hidden;
+                `}
+                gutterSize="none"
+                responsive={false}
+              >
+                {paletteData[paletteName](Number(length)).map((hexCode) => (
+                  <ColorPaletteFlexItem hexCode={hexCode} key={hexCode} />
+                ))}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <ColorPaletteCopyCode
+                textToCopy={`${paletteName}(${length});`}
+                code={`${paletteName}(${length})`}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ))}
+      </Fragment>
+    );
+  };
+  ```
+</Demo>
 
 ## Custom palettes
 
-Use the `colorPalette` service to generate a custom, gradiated palette array of any length from one or more
-hexadecimal color codes. The third parameter divergent, will interpolate between the two halves of the 
-spectrums separately. If a middle point is not provided, it will graduate to light gray.
+Use the `colorPalette` service to generate a custom, gradiated palette array of any length from one or more hexadecimal color codes. The third parameter `divergent`, will interpolate between the two halves of the spectrums separately. If a middle point is not provided, it will graduate to light gray.
 
-```tsx interactive
-import React, { Fragment, useState } from 'react';
-import { css } from '@emotion/css';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiRange,
-  EuiFormRow,
-  EuiSpacer,
-  euiPaletteColorBlind,
-  colorPalette
-} from '@elastic/eui';
+<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }}>
+  ```tsx interactive
+  import React, { Fragment, useState } from 'react';
 
-const ColorPaletteFlexItem = ({ hexCode, className, ...rest }) => {
+  import {
+    EuiFlexGroup,
+    EuiFlexItem,
+    EuiRange,
+    EuiFormRow,
+    EuiSpacer,
+    euiPaletteColorBlind,
+    colorPalette,
+    useEuiTheme,
+  } from '@elastic/eui';
+
+  const customPalettes = [
+    [euiPaletteColorBlind()[3]],
+    [euiPaletteColorBlind()[3], euiPaletteColorBlind()[4]],
+    [euiPaletteColorBlind()[3], euiPaletteColorBlind()[4]],
+  ];
+
+  export default () => {
     const { euiTheme } = useEuiTheme();
+    const [length, setLength] = useState(10);
 
-  return (
-    <EuiFlexItem
-      key={hexCode}
-      grow={false}
-        css={{
-          'span': {
-            height: euiTheme.size.base,
-            width: euiTheme.size.l,
-          },
-          '&--small span': {
-            width: 'auto',
-            height: euiTheme.size.s,
-          },
-        }}
-        {...rest}
-        >
-      <span title={hexCode} style={{ backgroundColor: hexCode }} />
-    </EuiFlexItem>
-  );
-};
+    const onLengthChange = (e) => {
+      setLength(e.currentTarget.value);
+    };
 
-const ColorPaletteCopyCode = ({ textToCopy, code }) => {
-  return (
-    <span>
-      <EuiCopy
-        beforeMessage="Click to copy palette config"
-        textToCopy={textToCopy || code}
-      >
-        {(copy) => (
-          <EuiLink onClick={copy}>
-            <EuiCode>{code}</EuiCode>
-          </EuiLink>
-        )}
-      </EuiCopy>
-    </span>
-  );
-};
-
-const customPalettes = [
-  [euiPaletteColorBlind()[3]],
-  [euiPaletteColorBlind()[3], euiPaletteColorBlind()[4]],
-  [euiPaletteColorBlind()[3], euiPaletteColorBlind()[4]],
-];
-
-export default () => {
-  const { euiTheme } = useEuiTheme();
-  const [length, setLength] = useState(10);
-
-  const onLengthChange = (e) => {
-    setLength(e.currentTarget.value);
+    return (
+      <Fragment>
+        <EuiFormRow label="Number of steps" display="columnCompressed">
+          <EuiRange
+            value={length}
+            onChange={onLengthChange}
+            min={2}
+            max={20}
+            compressed
+            showValue
+          />
+        </EuiFormRow>
+        <EuiSpacer />
+        {customPalettes.map((palette, i) => (
+          <EuiFlexGroup alignItems="center" key={i}>
+            <EuiFlexItem grow={false}>
+              <EuiFlexGroup
+                css={css`
+                  border-radius: ${euiTheme.border.radius.medium};
+                  overflow: hidden;
+                `}
+                gutterSize="none"
+                responsive={false}
+              >
+                {colorPalette(palette, Number(length), i > 1).map((hexCode) => (
+                  <ColorPaletteFlexItem hexCode={hexCode} key={hexCode} />
+                ))}
+              </EuiFlexGroup>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <ColorPaletteCopyCode
+                textToCopy={`colorPalette([], ${length}${
+                  i > 1 ? ', true' : ''
+                });`}
+                code={`colorPalette([${palette}], ${length}${
+                  i > 1 ? ', true' : ''
+                });`}
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        ))}
+      </Fragment>
+    );
   };
+  ```
+</Demo>
 
-  return (
-    <Fragment>
-      <EuiFormRow label="Number of steps" display="columnCompressed">
-        <EuiRange
-          value={length}
-          onChange={onLengthChange}
-          min={2}
-          max={20}
-          compressed
-          showValue
-        />
-      </EuiFormRow>
+## Props
 
-      <EuiSpacer />
+import docgen from '@elastic/eui-docgen/dist/services/color';
 
-      {customPalettes.map((palette, i) => (
-        <EuiFlexGroup alignItems="center" key={i}>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup
-              className="guideColorPalette__swatchHolder"
-              gutterSize="none"
-              responsive={false}
-              css={{
-                borderRadius: euiTheme.border.radius.medium,
-                overflow: 'hidden',
-              }}
-            >
-              {colorPalette(palette, Number(length), i > 1).map((hexCode) => (
-                <ColorPaletteFlexItem hexCode={hexCode} key={hexCode} />
-              ))}
-            </EuiFlexGroup>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <ColorPaletteCopyCode
-              textToCopy={`colorPalette([], ${length}${
-                i > 1 ? ', true' : ''
-              });`}
-              code={`colorPalette([${palette}], ${length}${
-                i > 1 ? ', true' : ''
-              });`}
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      ))}
-    </Fragment>
-  );
-};
-```
+<PropTable definition={docgen.euiPaletteColorBlind} />
+

--- a/packages/website/docs/data_visualization/theming.mdx
+++ b/packages/website/docs/data_visualization/theming.mdx
@@ -32,7 +32,7 @@ EUI provides a plugin utility for ease of pulling in the correct theme object de
 
 :::
 
-EUI also provides some basic [color palettes and functions](/docs/utilities/color-palettes) if you would like to change the default color blind safe scheme to another palette. You can import these from the services folder. Create a new partial theme object with your chosen colors and prepend it to the list of themes supplied to Settings.
+EUI also provides some basic [color palettes and functions](../components/utilities/color_palettes.mdx) if you would like to change the default color blind safe scheme to another palette. You can import these from the services folder. Create a new partial theme object with your chosen colors and prepend it to the list of themes supplied to Settings.
 
 ```tsx
 import { DARK_THEME, LIGHT_THEME } from '@elastic/charts';

--- a/packages/website/docs/data_visualization/theming.mdx
+++ b/packages/website/docs/data_visualization/theming.mdx
@@ -32,7 +32,7 @@ EUI provides a plugin utility for ease of pulling in the correct theme object de
 
 :::
 
-EUI also provides some basic [color palettes and functions](../components/utilities/color_palettes.mdx) if you would like to change the default color blind safe scheme to another palette. You can import these from the services folder. Create a new partial theme object with your chosen colors and prepend it to the list of themes supplied to Settings.
+EUI also provides some basic [color palettes and functions](../components/utilities/color_palettes/overview.mdx) if you would like to change the default color blind safe scheme to another palette. You can import these from the services folder. Create a new partial theme object with your chosen colors and prepend it to the list of themes supplied to Settings.
 
 ```tsx
 import { DARK_THEME, LIGHT_THEME } from '@elastic/charts';


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui/issues/8190

Removed the "Sass variables" section from Utilities > Color palettes page and created a task to document vis color palette tokens on the Theming > Colors page: https://github.com/elastic/eui/issues/8340

## QA

**Checklist:**

- [ ] Compare the content between the old docs and the staging.
- [ ] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [ ] Verify that examples work as expected.
- [ ] Make sure the prop tables is displayed for all relevant component.