### PR TITLE
feat(website): add Utilities > Text diff page

### DIFF
--- a/packages/website/docs/components/utilities/text_diff.mdx
+++ b/packages/website/docs/components/utilities/text_diff.mdx
@@ -1,0 +1,104 @@
+---
+slug: /utilities/text-diff
+id: utilities_text_diff
+---
+
+# Text diff
+
+The hook, useEuiTextDiff, generates a set of changes between two strings. It returns both React elements for displaying the diff and an object representing the identified changes. The timeout prop is used to set how many seconds any diff's exploration phase may take. The default value is 0.1, a value of 0 disables the timeout and lets diff run until completion. The higher the timeout, the more detailed the comparison.
+
+`const [rendered, textDiffObject] = useEuiTextDiff({ beforeText, afterText });`
+
+<Demo>
+```tsx interactive
+import React, { useState, useEffect } from 'react';
+
+import {
+  useEuiTextDiff,
+  EuiCode,
+  EuiSpacer,
+  EuiTextColor,
+  EuiText,
+} from '@elastic/eui';
+
+export default () => {
+  const [del, setDel] = useState(0);
+  const [ins, setIns] = useState(0);
+
+  const beforeText =
+    'Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape- descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.';
+  const afterText =
+    'Orbiting those at a distance of roughly ninety-nine billion yards is not insignificant dwaf red green planet whose ape- ascended life forms are so amazingly primitive that they still think digital clocks are a pretty neat idea.';
+  
+  const [rendered, textDiffObject] = useEuiTextDiff({
+    beforeText,
+    afterText,
+  });
+
+  useEffect(() => {
+    textDiffObject.forEach((el) => {
+      if (el[0] === 1) {
+        setIns((add) => add + 1);
+      } else if (el[0] === -1) {
+        setDel((sub) => sub + 1);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <EuiText>
+        <p>{rendered}</p>
+      </EuiText>
+      <EuiSpacer />
+      <EuiCode>
+        <EuiTextColor color="success"> {ins} </EuiTextColor> Insertions,
+        <EuiTextColor color="danger"> {del} </EuiTextColor>
+        Deletions
+      </EuiCode>
+    </>
+  );
+};
+```
+</Demo>
+
+## Custom rendered elements
+
+By default, the hook will wrap deletions with `<del>` and insertions with `<ins>` elements. You can replace these elements with the `deleteComponent` and `insertComponent` props respectively.
+
+Also, since `rendered` is simple html string, you can wrap it in any contextual element like [EuiText](../display/text.mdx) or [EuiCodeBlock](../editors_and_syntax/code.mdx).
+
+<Demo>
+```tsx interactive
+import React from 'react';
+
+import { useEuiTextDiff, EuiCodeBlock } from '@elastic/eui';
+
+export default () => {
+  const beforeText =
+    'Orbiting this at a distance of roughly ninety-two million miles is an utterly insignificant little blue green planet whose ape- descended life forms are so amazingly primitive that they still think digital watches are a pretty neat idea.';
+  const afterText =
+    'Orbiting those at a distance of roughly ninety-nine billion yards is not insignificant dwaf red green planet whose ape- ascended life forms are so amazingly primitive that they still think digital clocks are a pretty neat idea.';
+  
+  const [rendered] = useEuiTextDiff({
+    beforeText,
+    afterText,
+    insertComponent: 'strong',
+    deleteComponent: 's',
+  });
+
+  return (
+    <EuiCodeBlock fontSize="m" paddingSize="m">
+      {rendered}
+    </EuiCodeBlock>
+  );
+};
+```
+</Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/text_diff';
+
+<PropTable definition={docgen.useEuiTextDiff} />


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui/issues/8190

Added the Text Diff page to the new documentation site.

## QA

**Checklist:**

- [ ] Compare the content between the old docs and the staging.
- [ ] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [ ] Verify that examples work as expected.
- [ ] Make sure the prop tables is displayed for all relevant component.