### PR TITLE
feat(website): add Utilities > Overlay Mask page

### DIFF
--- a/packages/website/docs/components/layout/flyout/flyout.mdx
+++ b/packages/website/docs/components/layout/flyout/flyout.mdx
@@ -7,7 +7,7 @@ id: layout_flyout
 
 **EuiFlyout** is a fixed position panel that pops in from the side of the window. It should be used to reveal more detailed contextual information or to provide complex forms without losing the user's current state. It is a good alternative to [modals](../modal) when the action is not transient.
 
-Like modals, you control the visibilty of the flyout using your own state management, but **EuiFlyout** requires an `onClose` handler for it's internal dismiss buttons.
+Like modals, you control the visibility of the flyout using your own state management, but **EuiFlyout** requires an `onClose` handler for it's internal dismiss buttons.
 
 :::note Accessibility recommendation
 Use `aria-labelledby={headingId}` to announce the flyout to screen readers.

--- a/packages/website/docs/components/utilities/overlay_mask.mdx
+++ b/packages/website/docs/components/utilities/overlay_mask.mdx
@@ -64,60 +64,7 @@ export default () => {
 
 ## Masks with header
 
-
-Managing z-index levels of multiple portal-positioned components and their different contexts is complicated from within the library. **EuiOverlayMask** gives you control over whether it should appear below or above an [EuiHeader](../layout/header.mdx) by providing the `headerZindexLocation` prop. By default this is set to `"above"` for common cases like with [EuiModal](../layout/modal/overview.mdx) where the header should be obscured. However, a component like [EuiFlyout](../layout/flyout/flyout.mdx) which utilizes the overlay mask but should keep the header visible should use `"below"`.
-
-<Demo>
-```tsx interactive
-import React, { useState } from 'react';
-
-import {
-  EuiOverlayMask,
-  EuiButton,
-  EuiSpacer,
-  EuiFlyout,
-  EuiFlyoutHeader,
-  EuiTitle,
-} from '@elastic/eui';
-
-export default () => {
-  const [maskOpen, changeMask] = useState(false);
-  const [showFlyout, changeFlyout] = useState(false);
-
-  const mask = (
-    <EuiOverlayMask headerZindexLocation="below">
-      <EuiButton onClick={() => changeMask(false)}>
-        Click this button to close
-      </EuiButton>
-    </EuiOverlayMask>
-  );
-
-  const flyout = (
-    <EuiFlyout size="s" onClose={() => changeFlyout(false)}>
-      <EuiFlyoutHeader>
-        <EuiTitle>
-          <h1>Click outside this flyout to close overlay. </h1>
-        </EuiTitle>
-      </EuiFlyoutHeader>
-    </EuiFlyout>
-  );
-
-  return (
-    <>
-      <EuiButton onClick={() => changeMask(true)}>
-        Overlay below header
-      </EuiButton>
-      <EuiSpacer size="xxl" />
-      <EuiButton onClick={() => changeFlyout(true)}>
-        EuiFlyout defaults to below
-      </EuiButton>
-      {maskOpen ? mask : null}
-      {showFlyout ? flyout : null}
-    </>
-  );
-};
-```
-</Demo>
+Managing z-index levels of multiple portal-positioned components and their different contexts is complicated from within the library. **EuiOverlayMask** gives you control over whether it should appear below or above an [EuiHeader](../layout/header.mdx) by providing the `headerZindexLocation` prop. By default this is set to `"above"` for common cases like with [EuiModal](../layout/modal/overview.mdx) where the header should be obscured. However, a component like [EuiFlyout](../layout/flyout/flyout.mdx) which utilizes the overlay mask but should keep the header visible should use `"below"` (which is its default value).
 
 ## Props
 

--- a/packages/website/docs/components/utilities/overlay_mask.mdx
+++ b/packages/website/docs/components/utilities/overlay_mask.mdx
@@ -1,0 +1,127 @@
+---
+slug: /utilities/overlay-mask
+id: utilities_overlay_mask
+---
+
+# Overlay mask
+
+**EuiOverlayMask** is simply a display component used to obscure the main content to bring attention to its children or other content. It is best used in conjunction with hyper-focus content areas like [modals](../layout/modal/overview.mdx) and [flyouts](../layout/flyout/flyout.mdx).
+
+There are <a href="https://www.nngroup.com/articles/overuse-of-overlays/" target="_blank" rel="noopener noreferrer">many considerations</a> to make before choosing to use an overlay. At the very least, you must provide a visible button to close the overlay. You can also nest an [EuiFocusTrap](./focus_trap.mdx) to handle closing the overlay.
+
+<Demo>
+```tsx interactive
+import React, { useState } from 'react';
+
+import {
+  EuiOverlayMask,
+  EuiButton,
+  EuiSpacer,
+  EuiTitle,
+  EuiFocusTrap,
+} from '@elastic/eui';
+
+export default () => {
+  const [maskOpen, changeMask] = useState(false);
+  const [maskWithClickOpen, changeMaskWithClick] = useState(false);
+
+  const modal = (
+    <>
+      <EuiOverlayMask>
+        <EuiFocusTrap onClickOutside={() => changeMask(false)}>
+          <EuiTitle>
+            <h2> Click anywhere to close overlay. </h2>
+          </EuiTitle>
+        </EuiFocusTrap>
+      </EuiOverlayMask>
+    </>
+  );
+
+  const maskWithClick = (
+    <EuiOverlayMask data-test-subj="yolo">
+      <EuiButton onClick={() => changeMaskWithClick(false)}>
+        Click this button to close
+      </EuiButton>
+    </EuiOverlayMask>
+  );
+
+  return (
+    <>
+      <EuiButton onClick={() => changeMaskWithClick(true)}>
+        Overlay with button
+      </EuiButton>
+      <EuiSpacer size="xxl" />
+      <EuiButton onClick={() => changeMask(true)}>
+        Overlay with EuiFocusTrap click-to-close
+      </EuiButton>
+      {maskOpen ? modal : undefined}
+      {maskWithClickOpen ? maskWithClick : undefined}
+    </>
+  );
+};
+```
+</Demo>
+
+## Masks with header
+
+
+Managing z-index levels of multiple portal-positioned components and their different contexts is complicated from within the library. **EuiOverlayMask** gives you control over whether it should appear below or above an [EuiHeader](../layout/header.mdx) by providing the `headerZindexLocation` prop. By default this is set to `"above"` for common cases like with [EuiModal](../layout/modal/overview.mdx) where the header should be obscured. However, a component like [EuiFlyout](../layout/flyout/flyout.mdx) which utilizes the overlay mask but should keep the header visible should use `"below"`.
+
+<Demo>
+```tsx interactive
+import React, { useState } from 'react';
+
+import {
+  EuiOverlayMask,
+  EuiButton,
+  EuiSpacer,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiTitle,
+} from '@elastic/eui';
+
+export default () => {
+  const [maskOpen, changeMask] = useState(false);
+  const [showFlyout, changeFlyout] = useState(false);
+
+  const mask = (
+    <EuiOverlayMask headerZindexLocation="below">
+      <EuiButton onClick={() => changeMask(false)}>
+        Click this button to close
+      </EuiButton>
+    </EuiOverlayMask>
+  );
+
+  const flyout = (
+    <EuiFlyout size="s" onClose={() => changeFlyout(false)}>
+      <EuiFlyoutHeader>
+        <EuiTitle>
+          <h1>Click outside this flyout to close overlay. </h1>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+    </EuiFlyout>
+  );
+
+  return (
+    <>
+      <EuiButton onClick={() => changeMask(true)}>
+        Overlay below header
+      </EuiButton>
+      <EuiSpacer size="xxl" />
+      <EuiButton onClick={() => changeFlyout(true)}>
+        EuiFlyout defaults to below
+      </EuiButton>
+      {maskOpen ? mask : null}
+      {showFlyout ? flyout : null}
+    </>
+  );
+};
+```
+</Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/overlay_mask';
+
+<PropTable definition={docgen.EuiOverlayMask} />
+


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui/issues/8190

Added the Overlay Mask page to the new documentation site.

Possible improvement in M2: https://github.com/elastic/eui/issues/8347

## QA

**Checklist:**

- [ ] Compare the content between the old docs and the staging.
- [ ] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [ ] Verify that examples work as expected.
- [ ] Make sure the prop tables is displayed for all relevant component.