### PR TITLE
feat(website): add Utilities > Inner text page

### DIFF
--- a/packages/website/docs/components/utilities/inner_text.mdx
+++ b/packages/website/docs/components/utilities/inner_text.mdx
@@ -1,0 +1,147 @@
+---
+slug: /utilities/inner-text
+id: utilities_inner_text
+---
+
+# Inner text
+
+For instances where accessing the text content of a component that may be wrapped or interspersed with other components, two utilities are available:
+
+* `useInnerText` - A custom React hook, usable in function components
+* `<EuiInnerText />` - A higher order `useInnerText` component for use in class components
+
+Both utilities make available a `ref` reference to add to the target DOM element, and the resulting `innerText` value to use as needed.
+
+## Rendered
+
+<Demo>
+```tsx interactive
+import React, { useEffect, useState } from 'react';
+
+import {
+  EuiBadge,
+  EuiCode,
+  EuiHighlight,
+  EuiHorizontalRule,
+  EuiPanel,
+  EuiText,
+  EuiSpacer,
+  EuiInnerText,
+} from '@elastic/eui';
+
+export default () => {
+  const first = 'First';
+  const second = 'Second';
+
+  const [thing, setThing] = useState(first);
+  const [[thing2, type], setThingAndType] = useState([first, 'span']);
+
+  useEffect(() => {
+    setTimeout(() => {
+      const newThing = thing === second ? first : second;
+      const newType = type === 'div' ? 'span' : 'div';
+      setThing(newThing);
+      setThingAndType([newThing, newType]);
+    }, 5000);
+  }, [thing, type]);
+
+  return (
+    <EuiText size="s">
+      <p>
+        <strong>Example:</strong>
+      </p>
+      <EuiInnerText>
+        {(ref, innerText) => (
+          <React.Fragment>
+            <EuiPanel paddingSize="s" className="eui-displayInlineBlock">
+              <span ref={ref} title={innerText}>
+                Simple string content
+              </span>
+            </EuiPanel>
+            <EuiSpacer />
+            <p className="eui-displayInlineBlock">
+              <strong>Output:</strong>
+            </p>{' '}
+            <EuiCode>{innerText}</EuiCode>
+          </React.Fragment>
+        )}
+      </EuiInnerText>
+      <EuiHorizontalRule margin="xl" />
+      <p>
+        <strong>Example with complex children:</strong>
+      </p>
+      <EuiInnerText>
+        {(ref, innerText) => (
+          <React.Fragment>
+            <EuiPanel paddingSize="s" className="eui-displayInlineBlock">
+              <span ref={ref} title={innerText}>
+                <EuiHighlight search="content">
+                  EuiHighlight content
+                </EuiHighlight>{' '}
+                <EuiBadge>with EuiBadge</EuiBadge>
+              </span>
+            </EuiPanel>
+            <EuiSpacer />
+            <p className="eui-displayInlineBlock">
+              <strong>Output:</strong>
+            </p>{' '}
+            <EuiCode>{innerText}</EuiCode>
+          </React.Fragment>
+        )}
+      </EuiInnerText>
+      <EuiHorizontalRule margin="xl" />
+      <p>
+        <strong>Example with updating content:</strong>
+      </p>
+      <EuiInnerText>
+        {(ref, innerText) => (
+          <React.Fragment>
+            <EuiPanel paddingSize="s" className="eui-displayInlineBlock">
+              <span ref={ref} title={innerText}>
+                {thing}
+              </span>
+            </EuiPanel>
+            <EuiSpacer />
+            <p className="eui-displayInlineBlock">
+              <strong>Output:</strong>
+            </p>{' '}
+            <EuiCode>{innerText}</EuiCode>
+          </React.Fragment>
+        )}
+      </EuiInnerText>
+      <EuiHorizontalRule margin="xl" />
+      <p>
+        <strong>Example with updating element:</strong>
+      </p>
+      <EuiInnerText>
+        {(ref, innerText) => (
+          <React.Fragment>
+            <EuiPanel paddingSize="s" className="eui-displayInlineBlock">
+              {React.createElement(
+                type,
+                {
+                  ref,
+                  title: innerText,
+                },
+                thing2
+              )}
+            </EuiPanel>
+            <EuiSpacer />
+            <p className="eui-displayInlineBlock">
+              <strong>Output:</strong>
+            </p>{' '}
+            <EuiCode>{innerText}</EuiCode>
+          </React.Fragment>
+        )}
+      </EuiInnerText>
+    </EuiText>
+  );
+};
+```
+</Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/inner_text';
+
+<PropTable definition={docgen.EuiInnerText} />


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui/issues/8190

Added the Inner Text page to the new documentation site.

## QA

**Checklist:**

- [x] Compare the content between the old docs and the staging.
- [x] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [x] Verify that examples work as expected.
- [x] Make sure the prop tables is displayed for all relevant component.