### PR TITLE
feat(website): add Utilities > Error Boundary page

### DIFF
--- a/packages/website/docs/components/utilities/error_boundary.mdx
+++ b/packages/website/docs/components/utilities/error_boundary.mdx
@@ -1,0 +1,34 @@
+---
+slug: /utilities/error-boundary
+id: utilities_error_boundary
+---
+
+# Error boundary
+
+Use **EuiErrorBoundary** to prevent errors from taking down the entire app.
+
+<Demo>
+```tsx interactive
+import React from 'react';
+
+import { EuiErrorBoundary } from '@elastic/eui';
+
+const BadComponent = () => {
+  throw new Error(
+    "I'm here to kick butt and chew bubblegum. And I'm all out of gum."
+  );
+};
+
+export default () => (
+  <EuiErrorBoundary>
+    <BadComponent />
+  </EuiErrorBoundary>
+);
+```
+</Demo>
+
+## Props
+
+import docgen from '@elastic/eui-docgen/dist/components/error_boundary';
+
+<PropTable definition={docgen.EuiErrorBoundary} />


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui/issues/8190

Added the Error Boundary page to the new documentation site.

It's worth to point out that locally the error gets caught and the red screen appears when accessing Utilities > Error Boundary. This likely won't happen in staging and production because it's not a development environment, therefore doesn't display the red screen. For better DX though, this could be improved to not be caught by the upper-most Error Boundary.

## QA

**Checklist:**

- [x] Compare the content between the old docs and the staging.
- [x] Verify that links redirect as expected (internally, within the same tab; externally, in a new tab).
- [x] Verify that examples work as expected.
- [x] Make sure the prop tables is displayed for all relevant component.