### PR TITLE
[EuiSuperDatePicker] Add support for quickSelectButtonProps

### DIFF
--- a/packages/eui/changelogs/upcoming/8380.md
+++ b/packages/eui/changelogs/upcoming/8380.md
@@ -1,0 +1,2 @@
+- Added `quickSelectButtonProps` to `EuiSuperDatePicker`
+

--- a/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/quick_select_popover.tsx
@@ -13,11 +13,13 @@ import React, {
   useMemo,
   ReactNode,
   ReactElement,
+  MouseEvent,
 } from 'react';
 
 import { useEuiMemoizedStyles } from '../../../../services';
 import { useEuiI18n } from '../../../i18n';
 import { EuiButtonEmpty } from '../../../button';
+import { EuiButtonEmptyPropsForButton } from '../../../button/button_empty/button_empty';
 import { EuiIcon } from '../../../icon';
 import { EuiPopover } from '../../../popover';
 
@@ -37,6 +39,10 @@ import {
   QuickSelectPanel,
   Milliseconds,
 } from '../../types';
+
+export type EuiQuickSelectButtonProps = Partial<
+  Omit<EuiButtonEmptyPropsForButton, 'children' | 'isDisabled' | 'isLoading'>
+>;
 
 export type CustomQuickSelectRenderOptions = {
   quickSelect: ReactElement<typeof EuiQuickSelect>;
@@ -64,11 +70,18 @@ export interface EuiQuickSelectPopoverProps {
   intervalUnits?: RefreshUnitsOptions;
   start: string;
   timeOptions: TimeOptions;
+  buttonProps?: EuiQuickSelectButtonProps;
 }
 
 export const EuiQuickSelectPopover: FunctionComponent<
   EuiQuickSelectPopoverProps
-> = ({ applyTime: _applyTime, ...props }) => {
+> = ({ applyTime: _applyTime, buttonProps = {}, ...props }) => {
+  const {
+    contentProps: buttonContentProps,
+    onClick: buttonOnClick,
+    ...quickSelectButtonProps
+  } = buttonProps;
+
   const [prevQuickSelect, setQuickSelect] = useState<QuickSelect>();
   const [isOpen, setIsOpen] = useState(false);
   const closePopover = useCallback(() => setIsOpen(false), []);
@@ -94,11 +107,21 @@ export const EuiQuickSelectPopover: FunctionComponent<
 
   const styles = useEuiMemoizedStyles(euiQuickSelectPopoverStyles);
 
+  const quickSelectButtonOnClick = (
+    e: MouseEvent<HTMLButtonElement> & MouseEvent<HTMLAnchorElement>
+  ) => {
+    togglePopover();
+    buttonOnClick?.(e);
+  };
+
   const quickSelectButton = (
     <EuiButtonEmpty
       css={styles.euiQuickSelectPopoverButton}
-      contentProps={{ css: styles.euiQuickSelectPopoverButton__content }}
-      onClick={togglePopover}
+      contentProps={{
+        css: styles.euiQuickSelectPopoverButton__content,
+        ...buttonContentProps,
+      }}
+      onClick={quickSelectButtonOnClick}
       aria-label={buttonlabel}
       title={buttonlabel}
       size="xs"
@@ -106,6 +129,7 @@ export const EuiQuickSelectPopover: FunctionComponent<
       iconSide="right"
       isDisabled={props.isDisabled}
       data-test-subj="superDatePickerToggleQuickMenuButton"
+      {...quickSelectButtonProps}
     >
       <EuiIcon type="calendar" />
     </EuiButtonEmpty>
@@ -128,7 +152,7 @@ export const EuiQuickSelectPopover: FunctionComponent<
 };
 
 export const EuiQuickSelectPanels: FunctionComponent<
-  Omit<EuiQuickSelectPopoverProps, 'isDisabled'> & {
+  Omit<EuiQuickSelectPopoverProps, 'isDisabled' | 'buttonProps'> & {
     prevQuickSelect?: QuickSelect;
   }
 > = ({

--- a/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.test.tsx
@@ -150,6 +150,29 @@ describe('EuiSuperDatePicker', () => {
       expect(updateButton.className).toContain('danger');
     });
 
+    test('quickSelectButtonProps', () => {
+      const onMouseDown = jest.fn();
+      const quickSelectButtonProps: EuiSuperDatePickerProps['quickSelectButtonProps'] =
+        {
+          onMouseDown,
+          color: 'danger',
+        };
+
+      const { getByTestSubject } = render(
+        <EuiSuperDatePicker
+          onTimeChange={noop}
+          quickSelectButtonProps={quickSelectButtonProps}
+        />
+      );
+      const quickSelectButton = getByTestSubject(
+        'superDatePickerToggleQuickMenuButton'
+      )!;
+      expect(quickSelectButton.className).toContain('danger');
+      fireEvent.mouseDown(quickSelectButton);
+
+      expect(onMouseDown).toHaveBeenCalledTimes(1);
+    });
+
     it('invokes onFocus callbacks on the date popover buttons', () => {
       const focusMock = jest.fn();
       const { getByTestSubject } = render(

--- a/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -44,6 +44,7 @@ import {
 import {
   EuiQuickSelectPopover,
   CustomQuickSelectRenderOptions,
+  EuiQuickSelectButtonProps,
 } from './quick_select_popover/quick_select_popover';
 import { EuiDatePopoverButton } from './date_popover/date_popover_button';
 
@@ -206,6 +207,10 @@ export type EuiSuperDatePickerProps = CommonProps & {
    * Props passed to the update button #EuiSuperUpdateButtonProps
    */
   updateButtonProps?: EuiSuperUpdateButtonProps;
+  /**
+   * Props passed to the quick select button #EuiQuickSelectButtonProps
+   */
+  quickSelectButtonProps?: EuiQuickSelectButtonProps;
 
   /**
    * By default, relative units will be rounded up to next largest unit of time
@@ -498,6 +503,7 @@ export class EuiSuperDatePickerInternal extends Component<
       refreshIntervalUnits,
       isPaused,
       isDisabled,
+      quickSelectButtonProps,
     } = this.props;
 
     return (
@@ -519,6 +525,7 @@ export class EuiSuperDatePickerInternal extends Component<
         intervalUnits={refreshIntervalUnits}
         start={start}
         timeOptions={timeOptions}
+        buttonProps={quickSelectButtonProps}
       />
     );
   };


### PR DESCRIPTION
## Summary

This PR adds support for the props `quickSelectButtonProps` on `EuiSuperDatePicker` to allow passing additional props to the button, e.g. for handling custom events.

## QA

- [x] ci passes (added unit test verifies prop is applied)
- [x] (optional) checkout this PR and test that additional props can be passed

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
