### PR TITLE
Update release versioning for snapshot releases

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,5 @@ nmHoistingLimits: none
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
+
+npmRegistryServer: "https://registry.npmjs.org/"

--- a/packages/eui-theme-borealis/package.json
+++ b/packages/eui-theme-borealis/package.json
@@ -32,7 +32,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
-    "@elastic/eui-theme-common": "workspace:^",
+    "@elastic/eui-theme-common": "workspace:*",
     "@types/chroma-js": "^2.4.0",
     "@types/jest": "^29.5.12",
     "@types/prettier": "2.7.3",

--- a/packages/eui-theme-common/package.json
+++ b/packages/eui-theme-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/eui-theme-common",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "description": "EUI theme common",
   "license": "SEE LICENSE IN LICENSE.txt",
   "scripts": {

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -52,7 +52,7 @@
     "url": "https://github.com/elastic/eui.git"
   },
   "dependencies": {
-    "@elastic/eui-theme-common": "workspace:^",
+    "@elastic/eui-theme-common": "workspace:*",
     "@elastic/prismjs-esql": "^1.0.0",
     "@hello-pangea/dnd": "^16.6.0",
     "@types/lodash": "^4.14.202",
@@ -106,7 +106,7 @@
     "@cypress/webpack-dev-server": "^1.7.0",
     "@elastic/charts": "^64.1.0",
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui-theme-borealis": "workspace:^",
+    "@elastic/eui-theme-borealis": "workspace:*",
     "@emotion/babel-preset-css-prop": "^11.11.0",
     "@emotion/cache": "^11.11.0",
     "@emotion/css": "^11.11.0",

--- a/packages/release-cli/src/version.ts
+++ b/packages/release-cli/src/version.ts
@@ -56,6 +56,16 @@ export const getUpcomingVersion = (currentVersion: string, target: string): stri
   return [major, minor, patch].join('.');
 };
 
+export const getUpcomingSnapshotVersion = (currentVersion: string, uniqueId: string): string => {
+  // remove preid part of the version string if exists
+  const [version, _] = currentVersion.split('-');
+  return `${version}-snapshot.${uniqueId}`;
+};
+
+export const getUniqueSnapshotId = () => {
+  return Date.now().toString();
+}
+
 export const getVersionTypeFromChangelog = (changelogMap: ChangelogMap): VersionType => {
   const hasFeatures = changelogMap['Features'].length > 0;
   const hasBugFixes = changelogMap['Bug fixes'].length > 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,7 +4672,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elastic/eui-theme-borealis@workspace:^, @elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis":
+"@elastic/eui-theme-borealis@workspace:*, @elastic/eui-theme-borealis@workspace:^, @elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis":
   version: 0.0.0-use.local
   resolution: "@elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis"
   dependencies:
@@ -4681,7 +4681,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.21.5"
     "@babel/preset-react": "npm:^7.18.6"
     "@babel/preset-typescript": "npm:^7.21.5"
-    "@elastic/eui-theme-common": "workspace:^"
+    "@elastic/eui-theme-common": "workspace:*"
     "@types/chroma-js": "npm:^2.4.0"
     "@types/jest": "npm:^29.5.12"
     "@types/prettier": "npm:2.7.3"
@@ -4706,7 +4706,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elastic/eui-theme-common@workspace:^, @elastic/eui-theme-common@workspace:packages/eui-theme-common":
+"@elastic/eui-theme-common@workspace:*, @elastic/eui-theme-common@workspace:^, @elastic/eui-theme-common@workspace:packages/eui-theme-common":
   version: 0.0.0-use.local
   resolution: "@elastic/eui-theme-common@workspace:packages/eui-theme-common"
   dependencies:
@@ -4822,8 +4822,8 @@ __metadata:
     "@cypress/webpack-dev-server": "npm:^1.7.0"
     "@elastic/charts": "npm:^64.1.0"
     "@elastic/datemath": "npm:^5.0.3"
-    "@elastic/eui-theme-borealis": "workspace:^"
-    "@elastic/eui-theme-common": "workspace:^"
+    "@elastic/eui-theme-borealis": "workspace:*"
+    "@elastic/eui-theme-common": "workspace:*"
     "@elastic/prismjs-esql": "npm:^1.0.0"
     "@emotion/babel-preset-css-prop": "npm:^11.11.0"
     "@emotion/cache": "npm:^11.11.0"


### PR DESCRIPTION
## Summary

This PR improves the way snapshot releases (`yarn release snapshot`) are versioned. Previously, both `official` and `snapshot` releases used the regular changelog-based new version calculation. It wasn't correct since snapshot releases are meant for testing, and they should not use the same versioning scheme, even if suffixed with `-snapshot`.

The updated code builds and publishes packages with a timestamp-based versioning, for example:
* `99.4.0` -> `99.4.0-snapshot.1741123162416`
* `1.2.3-borealis.0` -> `1.2.3-snapshot.1741123163100`

With this change, the updated `package.json` versions will not be committed. Keep in mind, though, that the file is still edited, and will be marked as modified by git. There's no reset logic to get them back to the original state yet but it may be implemented in near future.

## QA

1. Ensure you're logged out of the npmjs registry - `npm logout` and `yarn npm logout`
2. Checkout this branch - `gh pr checkout <id>`
3. Run Verdaccio in a separate tab - `docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio` and login as with `yarn npm login` (enter the same user/password pair as previously, e.g. `test/test`)
4. Update and commit `.yarnrc` to use the custom local verdaccio registry
    ```yml
    npmRegistryServer: "http://localhost:4873"
    unsafeHttpWhitelist:
      - localhost
      - "localhost:4873"
    ```
6. Install dependencies - `yarn`
7. Build release scripts - `yarn workspace @elastic/eui-release-cli run build` (this will be automated soon)
8. Run the release script from the monorepo root - `yarn release run snapshot --allow-custom --workspaces @elastic/eui-theme-common @elastic/eui-theme-borealis @elastic/eui` and follow its instructions
    * When asked for OTP click enter to skip; verdaccio doesn't need it
9. Confirm the packages are published with snapshot tag and `<version>-snapshot.<timestamp>` versions on http://localhost:4873