### PR TITLE
[Docs] Fix EuiDataGrid draggable column example import

### DIFF
--- a/packages/eui/src-docs/src/views/datagrid/schema_columns/column_dragging.js
+++ b/packages/eui/src-docs/src/views/datagrid/schema_columns/column_dragging.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { faker } from '@faker-js/faker';
 
-import { EuiDataGrid, EuiAvatar } from '../../../../src/components';
+import { EuiDataGrid, EuiAvatar } from '../../../../../src/components';
 
 const columns = [
   {


### PR DESCRIPTION
## Summary

This PR updates an import for the `EuiDataGrid` "draggable columns" example in our current EUI docs.
This link was unexpectedly updated in this [previous PR](https://github.com/elastic/eui/pull/8183) ([code](https://github.com/elastic/eui/pull/8183/commits/786bb804317e4a00ea0fa8e7658af9ff18507c56#diff-93a6d3a89919e5af82640a23ba3034507da0536e395cbf45ca2fe19053ac4707R4)).

![Screenshot 2025-03-06 at 11 32 20](https://github.com/user-attachments/assets/f60b2f24-f27f-4249-89b5-d510b4cda313)

## QA

- [x] verify the "Draggable columns" [example](https://eui.elastic.co/pr_8401/#/tabular-content/data-grid-schema-columns#draggable-columns) for `EuiDataGrid` works as expected.