### PR TITLE
fix(website): use useEuiTheme instead of css prop function argument

### DIFF
--- a/packages/website/docs/components/utilities/scroll/previews.tsx
+++ b/packages/website/docs/components/utilities/scroll/previews.tsx
@@ -2,66 +2,95 @@ import { css } from '@emotion/react';
 
 import {
   EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiText,
   logicalCSS,
   logicalCSSWithFallback,
   useEuiOverflowScroll,
   useEuiScrollBar,
+  useEuiTheme,
 } from '@elastic/eui';
 
 import { ScrollContent } from './scroll_content';
-
-const verticalBaseCss = ({ euiTheme }) => css`
-  ${logicalCSSWithFallback('overflow-y', 'auto')}
-  ${logicalCSS('height', `${euiTheme.base * 12}px`)}
-`;
 
 const horizontalBaseCss = () => css`
   ${logicalCSSWithFallback('overflow-x', 'auto')}
   ${logicalCSS('width', '100%')}
 `;
 
-export const ScrollBarClassNamePreview = () => (
-  <div tabIndex={0} className="eui-scrollBar" css={verticalBaseCss}>
-    <ScrollContent />
-  </div>
-);
+export const ScrollBarClassNamePreview = () => {
+  const { euiTheme } = useEuiTheme();
 
-export const ScrollBarHookPreview = () => (
-  <div
-    tabIndex={0}
-    css={[
-      css`
-        ${useEuiScrollBar()}
-      `,
-      verticalBaseCss,
-    ]}
-  >
-    <ScrollContent />
-  </div>
-);
+  return (
+    <div
+      tabIndex={0}
+      className="eui-scrollBar"
+      css={css`
+        ${logicalCSSWithFallback('overflow-y', 'auto')}
+        ${logicalCSS('height', `${euiTheme.base * 12}px`)}
+      `}
+    >
+      <ScrollContent />
+    </div>
+  );
+};
 
-export const VerticalScrollClassNamePreview = () => (
-  <div tabIndex={0} className="eui-yScrollWithShadows" css={verticalBaseCss}>
-    <ScrollContent />
-  </div>
-);
+export const ScrollBarHookPreview = () => {
+  const { euiTheme } = useEuiTheme();
 
-export const VerticalScrollHookPreview = () => (
-  <div
-    tabIndex={0}
-    css={[
-      css`
-        ${useEuiOverflowScroll('y', true)}
-      `,
-      verticalBaseCss,
-    ]}
-  >
-    <ScrollContent />
-  </div>
-);
+  return (
+    <div
+      tabIndex={0}
+      css={[
+        css`
+          ${useEuiScrollBar()}
+        `,
+        css`
+          ${logicalCSSWithFallback('overflow-y', 'auto')}
+          ${logicalCSS('height', `${euiTheme.base * 12}px`)}
+        `,
+      ]}
+    >
+      <ScrollContent />
+    </div>
+  );
+};
+
+export const VerticalScrollClassNamePreview = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div
+      tabIndex={0}
+      className="eui-yScrollWithShadows"
+      css={css`
+        ${logicalCSSWithFallback('overflow-y', 'auto')}
+        ${logicalCSS('height', `${euiTheme.base * 12}px`)}
+      `}
+    >
+      <ScrollContent />
+    </div>
+  );
+};
+
+export const VerticalScrollHookPreview = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div
+      tabIndex={0}
+      css={[
+        css`
+          ${useEuiOverflowScroll('y', true)}
+        `,
+        css`
+          ${logicalCSSWithFallback('overflow-y', 'auto')}
+          ${logicalCSS('height', `${euiTheme.base * 12}px`)}
+        `,
+      ]}
+    >
+      <ScrollContent />
+    </div>
+  );
+};
 
 export const HorizontalScrollClassNamePreview = () => (
   <div tabIndex={0} className="eui-xScrollWithShadows" css={horizontalBaseCss}>


### PR DESCRIPTION
## Summary

The `euiTheme` argument in `verticalBaseCss` (`packages/website/docs/components/utilities/scroll/previews.tsx`) is undefined, therefore trying to access `base` results in an error. `verticalBaseCss` is passed to the `css` prop but it doesn't pass the `euiTheme`, so the simplest fix is to use `useEuiTheme` instead.

I tried using the `@emotion/babel-plugin` ([source](https://github.com/emotion-js/emotion/blob/HEAD/docs/css-prop.mdx#babel-preset)) to make the `css` prop work as expected but it still failed. I might be missing something there but I don't want to keep digging, considering there's a simple fix available and that the pipeline is blocked for all PRs.

## QA

- [x] run `yarn workspace @elastic/eui-website build`, it should be successful
- [x] the CI should pass and a staging version for the EUI+ should be generated and deployed
