### PR TITLE
[ESLint] Add eslint-deprecation plugin

### DIFF
--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Danger.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Danger.tsx
@@ -1,8 +1,8 @@
+import { JSX } from 'react';
 import OriginalDanger from '@theme-init/Admonition/Type/Danger';
 import type WarningType from '@theme-init/Admonition/Type/Danger';
 import type { WrapperProps } from '@docusaurus/types';
 import { CallOut } from '../../../components/call_out';
-
 type Props = WrapperProps<typeof WarningType>;
 
 const Danger = (props: Props): JSX.Element => {

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Info.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Info.tsx
@@ -1,8 +1,8 @@
+import { JSX } from 'react';
 import OriginalInfo from '@theme-init/Admonition/Type/Info';
 import type InfoType from '@theme-init/Admonition/Type/Info';
 import type { WrapperProps } from '@docusaurus/types';
 import { CallOut } from '../../../components/call_out';
-
 type Props = WrapperProps<typeof InfoType>;
 
 const Note = (props: Props): JSX.Element => {

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Note.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Note.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import OriginalNote from '@theme-init/Admonition/Type/Note';
 import type NoteType from '@theme-init/Admonition/Type/Note';
 import type { WrapperProps } from '@docusaurus/types';

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Tip.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Tip.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import OriginalTip from '@theme-init/Admonition/Type/Tip';
 import type TipType from '@theme-init/Admonition/Type/Tip';
 import type { WrapperProps } from '@docusaurus/types';

--- a/packages/docusaurus-theme/src/theme/Admonition/Type/Warning.tsx
+++ b/packages/docusaurus-theme/src/theme/Admonition/Type/Warning.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import OriginalWarning from '@theme-init/Admonition/Type/Warning';
 import type WarningType from '@theme-init/Admonition/Type/Warning';
 import type { WrapperProps } from '@docusaurus/types';

--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -1,4 +1,4 @@
-import React, { isValidElement, type ReactNode } from 'react';
+import React, { isValidElement, type ReactNode, JSX } from 'react';
 import { EuiCodeBlock } from '@elastic/eui';
 import type { Props } from '@theme/CodeBlock';
 import { Demo } from '../../components/demo';

--- a/packages/docusaurus-theme/src/theme/ColorModeToggle/index.tsx
+++ b/packages/docusaurus-theme/src/theme/ColorModeToggle/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect, JSX } from 'react';
 import { translate } from '@docusaurus/Translate';
 import type { Props } from '@theme-original/ColorModeToggle';
 

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/Home/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/Items/Home/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { translate } from '@docusaurus/Translate';

--- a/packages/docusaurus-theme/src/theme/DocBreadcrumbs/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocBreadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { type ReactNode, JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import { ThemeClassNames } from '@docusaurus/theme-common';

--- a/packages/docusaurus-theme/src/theme/DocItem/Content/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Content/index.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import { ThemeClassNames } from '@docusaurus/theme-common';

--- a/packages/docusaurus-theme/src/theme/DocItem/Footer/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Footer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';

--- a/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import { JSX } from 'react';
 import { EuiHorizontalRule } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useWindowSize } from '@docusaurus/theme-common';

--- a/packages/docusaurus-theme/src/theme/DocItem/Metadata/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Metadata/index.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import {PageMetadata} from '@docusaurus/theme-common';
+import { JSX } from 'react';
+import { PageMetadata } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 
 export default function DocItemMetadata(): JSX.Element {
-  const {metadata, frontMatter, assets} = useDoc();
+  const { metadata, frontMatter, assets } = useDoc();
   return (
     <PageMetadata
       title={metadata.title}

--- a/packages/docusaurus-theme/src/theme/DocItem/Paginator/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Paginator/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import DocPaginator from '@theme-original/DocPaginator';
 

--- a/packages/docusaurus-theme/src/theme/DocItem/TOC/Desktop/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/TOC/Desktop/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 

--- a/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { css } from '@emotion/react';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';

--- a/packages/docusaurus-theme/src/theme/DocItem/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { HtmlClassNameProvider } from '@docusaurus/theme-common';
 import { DocProvider } from '@docusaurus/plugin-content-docs/client';
 import type { Props } from '@theme/DocItem';

--- a/packages/docusaurus-theme/src/theme/DocPaginator/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocPaginator/index.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import { css } from '@emotion/react';
 import Translate, { translate } from '@docusaurus/Translate';
 import PaginatorNavLink from '@theme-original/PaginatorNavLink';

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/Main/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/Main/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, useState, useCallback } from 'react';
+import React, { type ReactNode, useState, useCallback, JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import {

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState, JSX } from 'react';
 import { css } from '@emotion/react';
 import { useDocsSidebar } from '@docusaurus/plugin-content-docs/client';
 import useIsBrowser from '@docusaurus/useIsBrowser';

--- a/packages/docusaurus-theme/src/theme/DocSidebarItem/Category/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocSidebarItem/Category/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps, useEffect, useMemo } from 'react';
+import { type ComponentProps, useEffect, useMemo, JSX } from 'react';
 import clsx from 'clsx';
 import { css, Interpolation, Theme } from '@emotion/react';
 import {

--- a/packages/docusaurus-theme/src/theme/DocSidebarItem/Link/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocSidebarItem/Link/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import { ThemeClassNames } from '@docusaurus/theme-common';

--- a/packages/docusaurus-theme/src/theme/DocSidebarItem/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocSidebarItem/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import type { Props } from '@theme-original/DocSidebarItem';
 import DocSidebarItemHtml from '@theme-original/DocSidebarItem/Html';
 import DocSidebarItemCategory from './Category';

--- a/packages/docusaurus-theme/src/theme/DocSidebarItems/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocSidebarItems/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import { memo, JSX } from 'react';
 import {
   DocSidebarItemsExpandedStateProvider,
   useVisibleSidebarItems,

--- a/packages/docusaurus-theme/src/theme/EditThisPage/index.tsx
+++ b/packages/docusaurus-theme/src/theme/EditThisPage/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { css } from '@emotion/react';
 import Translate from '@docusaurus/Translate';
 import type { Props } from '@theme-original/EditThisPage';

--- a/packages/docusaurus-theme/src/theme/Logo/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Logo/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext, JSX } from 'react';
 import { css } from '@emotion/react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/packages/docusaurus-theme/src/theme/MDXComponents/A.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/A.tsx
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { JSX } from 'react';
 import type AType from '@theme-init/MDXComponents/A';
 import type { WrapperProps } from '@docusaurus/types';
 import { css } from '@emotion/react';

--- a/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Code.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { JSX } from 'react';
 import type CodeType from '@theme-init/MDXComponents/Code';
 import CodeBlock from '@theme/CodeBlock';
 import type { WrapperProps } from '@docusaurus/types';
@@ -54,7 +54,7 @@ const Code = ({ children, className, ...rest }: Props): JSX.Element => {
     <CodeBlock className={className} {...rest}>
       {children}
     </CodeBlock>
-  )
+  );
 };
 
 export default Code;

--- a/packages/docusaurus-theme/src/theme/MDXComponents/Heading.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Heading.tsx
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { JSX } from 'react';
 import Heading, { Props as HeadingProps } from '@theme/Heading';
 
 const MDXHeading = (props: HeadingProps): JSX.Element => (

--- a/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
@@ -5,14 +5,14 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
+import { JSX } from 'react';
 import OriginalMDXContent from '@theme-init/MDXContent';
 import type MDXContentType from '@theme-init/MDXContent';
 import type { WrapperProps } from '@docusaurus/types';
 
 type Props = WrapperProps<typeof MDXContentType>;
 
-const MDXContent = (props: Props): React.JSX.Element => (
+const MDXContent = (props: Props): JSX.Element => (
   <div data-search-children={true}>
     <OriginalMDXContent {...props} />
   </div>

--- a/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXContent/index.tsx
@@ -12,7 +12,7 @@ import type { WrapperProps } from '@docusaurus/types';
 
 type Props = WrapperProps<typeof MDXContentType>;
 
-const MDXContent = (props: Props): JSX.Element => (
+const MDXContent = (props: Props): React.JSX.Element => (
   <div data-search-children={true}>
     <OriginalMDXContent {...props} />
   </div>

--- a/packages/docusaurus-theme/src/theme/Navbar/Content/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Navbar/Content/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import { type ReactNode, JSX } from 'react';
 import { css, Global } from '@emotion/react';
 import { useThemeConfig, ErrorCauseBoundary } from '@docusaurus/theme-common';
 import {

--- a/packages/docusaurus-theme/src/theme/Navbar/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Navbar/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps } from 'react';
+import { type ComponentProps, JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import { useThemeConfig } from '@docusaurus/theme-common';

--- a/packages/docusaurus-theme/src/theme/Navbar/MobileSidebar/Header/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Navbar/MobileSidebar/Header/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal';
 import { translate } from '@docusaurus/Translate';
 import NavbarColorModeToggle from '@theme-original/Navbar/ColorModeToggle';

--- a/packages/docusaurus-theme/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { JSX } from 'react';
 import { css } from '@emotion/react';
 import Layout from '@theme-init/Navbar/MobileSidebar/Layout';
 import type LayoutType from '@theme-init/Navbar/MobileSidebar/Layout';

--- a/packages/docusaurus-theme/src/theme/NavbarItem/DropdownNavbarItem/index.tsx
+++ b/packages/docusaurus-theme/src/theme/NavbarItem/DropdownNavbarItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import {

--- a/packages/docusaurus-theme/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/packages/docusaurus-theme/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import { FunctionComponent, JSX } from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import isInternalUrl from '@docusaurus/isInternalUrl';

--- a/packages/docusaurus-theme/src/theme/PaginatorNavLink/index.tsx
+++ b/packages/docusaurus-theme/src/theme/PaginatorNavLink/index.tsx
@@ -37,7 +37,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => {
   };
 };
 
-export default function PaginatorNavLink(props: Props): JSX.Element {
+export default function PaginatorNavLink(props: Props): React.JSX.Element {
   const { permalink, title, subLabel, isNext } = props;
   const isPrev = !isNext;
   const styles = useEuiMemoizedStyles(getStyles);

--- a/packages/docusaurus-theme/src/theme/PaginatorNavLink/index.tsx
+++ b/packages/docusaurus-theme/src/theme/PaginatorNavLink/index.tsx
@@ -1,3 +1,4 @@
+import { JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import Link from '@docusaurus/Link';
@@ -37,7 +38,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => {
   };
 };
 
-export default function PaginatorNavLink(props: Props): React.JSX.Element {
+export default function PaginatorNavLink(props: Props): JSX.Element {
   const { permalink, title, subLabel, isNext } = props;
   const isPrev = !isNext;
   const styles = useEuiMemoizedStyles(getStyles);

--- a/packages/docusaurus-theme/src/theme/TOCCollapsible/CollapseButton/index.tsx
+++ b/packages/docusaurus-theme/src/theme/TOCCollapsible/CollapseButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { JSX } from 'react';
 import clsx from 'clsx';
 import { css } from '@emotion/react';
 import Translate from '@docusaurus/Translate';
@@ -23,7 +23,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => {
 export default function TOCCollapsibleCollapseButton({
   collapsed,
   ...props
-}: Props): React.JSX.Element {
+}: Props): JSX.Element {
   const styles = useEuiMemoizedStyles(getStyles);
 
   return (

--- a/packages/docusaurus-theme/src/theme/TOCCollapsible/CollapseButton/index.tsx
+++ b/packages/docusaurus-theme/src/theme/TOCCollapsible/CollapseButton/index.tsx
@@ -23,7 +23,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => {
 export default function TOCCollapsibleCollapseButton({
   collapsed,
   ...props
-}: Props): JSX.Element {
+}: Props): React.JSX.Element {
   const styles = useEuiMemoizedStyles(getStyles);
 
   return (

--- a/packages/docusaurus-theme/src/theme/TOCItems/Tree.tsx
+++ b/packages/docusaurus-theme/src/theme/TOCItems/Tree.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { JSX } from 'react';
 import { css } from '@emotion/react';
 import Link from '@docusaurus/Link';
 import type { Props } from '@theme-original/TOCItems/Tree';

--- a/packages/eui/.eslintrc.js
+++ b/packages/eui/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
     'deprecation'
   ],
   rules: {
+    'deprecation/deprecation': 'warn',
     'block-scoped-var': 'error',
     camelcase: 'off',
     'dot-notation': ['error', { allowKeywords: true }],

--- a/packages/eui/.eslintrc.js
+++ b/packages/eui/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
   },
   extends: [
     'plugin:@typescript-eslint/recommended',
+    'plugin:deprecation/recommended',
     'plugin:storybook/recommended',
     // Prettier options need to come last, in order to override other style rules
     'plugin:prettier/recommended',
@@ -47,6 +48,7 @@ module.exports = {
     'react',
     'react-hooks',
     '@emotion',
+    'deprecation'
   ],
   rules: {
     'block-scoped-var': 'error',

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -25,7 +25,7 @@
     "extract-i18n-strings": "node ./scripts/babel/fetch-i18n-strings",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-css-in-js && yarn lint-sass",
     "lint-fix": "yarn lint-es --fix && yarn lint-css-in-js --fix",
-    "lint-es": "eslint --cache \"{src,src-docs}/**/*.{ts,tsx,js}\" --max-warnings 0",
+    "lint-es": "eslint --cache \"{src,src-docs}/**/*.{ts,tsx,js}\"",
     "lint-css-in-js": "yarn stylelint \"**/*.styles.ts\" \"./src/themes/**/*.ts\" \"./src/global_styling/**/*.ts\" --quiet-deprecation-warnings",
     "lint-sass": "yarn stylelint \"**/*.scss\" --quiet-deprecation-warnings",
     "test": "yarn lint && yarn test-unit",

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -25,7 +25,7 @@
     "extract-i18n-strings": "node ./scripts/babel/fetch-i18n-strings",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-css-in-js && yarn lint-sass",
     "lint-fix": "yarn lint-es --fix && yarn lint-css-in-js --fix",
-    "lint-es": "eslint --cache \"{src,src-docs}/**/*.{ts,tsx,js}\"",
+    "lint-es": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache \"{src,src-docs}/**/*.{ts,tsx,js}\"",
     "lint-css-in-js": "yarn stylelint \"**/*.styles.ts\" \"./src/themes/**/*.ts\" \"./src/global_styling/**/*.ts\" --quiet-deprecation-warnings",
     "lint-sass": "yarn stylelint \"**/*.scss\" --quiet-deprecation-warnings",
     "test": "yarn lint && yarn test-unit",

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -186,6 +186,7 @@
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-webpack": "^0.13.2",
+    "eslint-plugin-deprecation": "2.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^28.5.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",

--- a/packages/eui/scripts/tests/update-changelog.test.js
+++ b/packages/eui/scripts/tests/update-changelog.test.js
@@ -103,7 +103,7 @@ describe('collateChangelogFiles', () => {
 
   it('throws an error when the upcoming changelogs directory is empty', () => {
     glob.sync.mockReturnValueOnce([]);
-    expect(() => collateChangelogFiles()).toThrowError(
+    expect(() => collateChangelogFiles()).toThrow(
       /No upcoming changelog files/
     );
   });

--- a/packages/eui/src-docs/src/store/configure_store.js
+++ b/packages/eui/src-docs/src/store/configure_store.js
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore, compose } from 'redux';
+import { applyMiddleware, legacy_createStore, compose } from 'redux';
 import thunk from 'redux-thunk';
 
 import Routes from '../routes';
@@ -19,7 +19,7 @@ export default function configureStore(initialState) {
     };
   }
 
-  return compose(applyMiddleware(thunk))(createStore)(
+  return compose(applyMiddleware(thunk))(legacy_createStore)(
     rootReducer,
     initialState
   );

--- a/packages/eui/src-docs/src/store/configure_store.js
+++ b/packages/eui/src-docs/src/store/configure_store.js
@@ -1,4 +1,4 @@
-import { applyMiddleware, legacy_createStore, compose } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
 import thunk from 'redux-thunk';
 
 import Routes from '../routes';
@@ -19,7 +19,7 @@ export default function configureStore(initialState) {
     };
   }
 
-  return compose(applyMiddleware(thunk))(legacy_createStore)(
+  return compose(applyMiddleware(thunk))(createStore)(
     rootReducer,
     initialState
   );

--- a/packages/eui/src/components/accordion/accordion.test.tsx
+++ b/packages/eui/src/components/accordion/accordion.test.tsx
@@ -223,8 +223,8 @@ describe('EuiAccordion', () => {
         );
 
         fireEvent.click(getAllByRole('button')[0]);
-        expect(onToggleHandler).toBeCalled();
-        expect(onToggleHandler).toBeCalledWith(true);
+        expect(onToggleHandler).toHaveBeenCalled();
+        expect(onToggleHandler).toHaveBeenCalledWith(true);
       });
     });
 
@@ -330,12 +330,12 @@ describe('EuiAccordion', () => {
       );
 
       fireEvent.click(getAllByRole('button')[0]);
-      expect(onToggleHandler).toBeCalled();
-      expect(onToggleHandler).toBeCalledWith(true);
+      expect(onToggleHandler).toHaveBeenCalled();
+      expect(onToggleHandler).toHaveBeenCalledWith(true);
 
       fireEvent.click(getAllByRole('button')[0]);
-      expect(onToggleHandler).toBeCalled();
-      expect(onToggleHandler).toBeCalledWith(false);
+      expect(onToggleHandler).toHaveBeenCalled();
+      expect(onToggleHandler).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/packages/eui/src/components/avatar/avatar.test.tsx
+++ b/packages/eui/src/components/avatar/avatar.test.tsx
@@ -160,7 +160,7 @@ describe('EuiAvatar', () => {
     const component = () =>
       render(<EuiAvatar name="name" color="rgba(0,0,0,0)" />);
 
-    expect(component).toThrowError(
+    expect(component).toThrow(
       'EuiAvatar needs to pass a valid color. This can either be a three or six character hex value'
     );
   });

--- a/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
+++ b/packages/eui/src/components/badge/beta_badge/beta_badge.tsx
@@ -12,6 +12,7 @@ import React, {
   HTMLAttributes,
   MouseEventHandler,
   ReactNode,
+  JSX,
 } from 'react';
 import classNames from 'classnames';
 

--- a/packages/eui/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
+++ b/packages/eui/src/components/collapsible_nav/collapsible_nav_group/collapsible_nav_group.test.tsx
@@ -151,7 +151,7 @@ describe('EuiCollapsibleNavGroup', () => {
         <EuiCollapsibleNavGroup iconType="bolt" id="id" />
       );
 
-      expect(consoleStub).toBeCalled();
+      expect(consoleStub).toHaveBeenCalled();
       expect(consoleStub.mock.calls[0][0]).toMatch(
         'not render an icon without `title`'
       );

--- a/packages/eui/src/components/color_picker/color_picker.test.tsx
+++ b/packages/eui/src/components/color_picker/color_picker.test.tsx
@@ -188,7 +188,7 @@ describe('EuiColorPicker', () => {
     );
 
     fireEvent.click(getByTestSubject('euiColorPickerAnchor'));
-    expect(onFocusHandler).toBeCalled();
+    expect(onFocusHandler).toHaveBeenCalled();
     expect(getByTestSubject('euiColorPickerPopover')).toBeInTheDocument();
   });
 
@@ -209,7 +209,7 @@ describe('EuiColorPicker', () => {
     });
     await (async () => {
       expect(getByTestSubject('euiColorPickerPopover')).not.toBeInTheDocument();
-      expect(onBlurHandler).toBeCalled(); // The blur handler is called just before the portal would be removed.
+      expect(onBlurHandler).toHaveBeenCalled(); // The blur handler is called just before the portal would be removed.
     });
   });
 
@@ -235,8 +235,8 @@ describe('EuiColorPicker', () => {
     const event = { target: { value: '#000000' } };
     fireEvent.change(getByTestSubject('euiColorPickerAnchor'), event);
 
-    expect(onChange).toBeCalled();
-    expect(onChange).toBeCalledWith('#000000', {
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith('#000000', {
       hex: '#000000',
       isValid: true,
       rgba: [0, 0, 0, 1],
@@ -252,8 +252,8 @@ describe('EuiColorPicker', () => {
     expect(swatches.length).toBe(VISUALIZATION_COLORS.length);
 
     fireEvent.click(swatches[0]);
-    expect(onChange).toBeCalled();
-    expect(onChange).toBeCalledWith(VISUALIZATION_COLORS[0], {
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith(VISUALIZATION_COLORS[0], {
       hex: '#16c5c0',
       isValid: true,
       rgba: [22, 197, 192, 1],
@@ -270,14 +270,14 @@ describe('EuiColorPicker', () => {
     // Slider
     const [range, input] = getAllByTestSubject('euiColorPickerAlpha');
     fireEvent.change(range, { target: { value: '50' } });
-    expect(onChange).toBeCalledWith('#ffeedd80', {
+    expect(onChange).toHaveBeenCalledWith('#ffeedd80', {
       hex: '#ffeedd80',
       isValid: true,
       rgba: [255, 238, 221, 0.5],
     });
     // Number input
     fireEvent.change(input, { target: { value: '25' } });
-    expect(onChange).toBeCalledWith('#ffeedd40', {
+    expect(onChange).toHaveBeenCalledWith('#ffeedd40', {
       hex: '#ffeedd40',
       isValid: true,
       rgba: [255, 238, 221, 0.25],
@@ -290,8 +290,8 @@ describe('EuiColorPicker', () => {
     );
 
     fireEvent.click(getByLabelText('Clear input'));
-    expect(onChange).toBeCalled();
-    expect(onChange).toBeCalledWith('', {
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith('', {
       hex: '',
       isValid: false,
       rgba: [NaN, NaN, NaN, 1],

--- a/packages/eui/src/components/color_picker/saturation.tsx
+++ b/packages/eui/src/components/color_picker/saturation.tsx
@@ -33,7 +33,7 @@ import { getEventPosition } from './utils';
 import { euiSaturationStyles } from './saturation.styles';
 
 export type SaturationClientRect = Pick<
-  ClientRect,
+  DOMRect,
   'left' | 'top' | 'width' | 'height'
 >;
 

--- a/packages/eui/src/components/color_picker/utils.ts
+++ b/packages/eui/src/components/color_picker/utils.ts
@@ -15,8 +15,8 @@ export const getEventPosition = (
 ) => {
   const { x, y } = location;
   const { width, height, left, top } = container.getBoundingClientRect();
-  let leftPos = x - (left + window.pageXOffset);
-  let topPos = y - (top + window.pageYOffset);
+  let leftPos = x - (left + window.scrollX);
+  let topPos = y - (top + window.scrollY);
 
   if (leftPos < 0) {
     leftPos = 0;

--- a/packages/eui/src/components/common.ts
+++ b/packages/eui/src/components/common.ts
@@ -15,7 +15,6 @@ import {
   JSXElementConstructor,
   MouseEventHandler,
   JSX,
-  ReactElement,
 } from 'react';
 import { Interpolation, Theme } from '@emotion/react';
 

--- a/packages/eui/src/components/common.ts
+++ b/packages/eui/src/components/common.ts
@@ -14,6 +14,8 @@ import {
   FunctionComponent,
   JSXElementConstructor,
   MouseEventHandler,
+  JSX,
+  ReactElement,
 } from 'react';
 import { Interpolation, Theme } from '@emotion/react';
 

--- a/packages/eui/src/components/context/context.tsx
+++ b/packages/eui/src/components/context/context.tsx
@@ -10,9 +10,9 @@ import React, {
   createContext,
   Context,
   FunctionComponent,
-  ReactChild,
   ReactNode,
 } from 'react';
+import { ReactChild } from '../common';
 
 export interface RenderableValues {
   // undefined values are ignored, but including support here improves usability

--- a/packages/eui/src/components/context/context.tsx
+++ b/packages/eui/src/components/context/context.tsx
@@ -12,14 +12,13 @@ import React, {
   FunctionComponent,
   ReactNode,
 } from 'react';
-import { ReactChild } from '../common';
 
 export interface RenderableValues {
   // undefined values are ignored, but including support here improves usability
-  [key: string]: ReactChild | undefined;
+  [key: string]: ReactNode | undefined;
 }
 
-export type Renderable<T> = ReactChild | ((values: T) => ReactChild);
+export type Renderable<T> = ReactNode | ((values: T) => ReactNode);
 
 export interface I18nShape {
   mapping?: {

--- a/packages/eui/src/components/datagrid/data_grid_types.ts
+++ b/packages/eui/src/components/datagrid/data_grid_types.ts
@@ -19,7 +19,7 @@ import {
   Component,
   ComponentClass,
   KeyboardEventHandler,
-  JSX
+  JSX,
 } from 'react';
 import {
   VariableSizeGridProps,

--- a/packages/eui/src/components/datagrid/data_grid_types.ts
+++ b/packages/eui/src/components/datagrid/data_grid_types.ts
@@ -19,6 +19,7 @@ import {
   Component,
   ComponentClass,
   KeyboardEventHandler,
+  JSX
 } from 'react';
 import {
   VariableSizeGridProps,
@@ -528,11 +529,11 @@ export interface EuiDataGridCustomBodyProps {
   /**
    * Header row component to render by custom renderer
    * */
-  headerRow: React.JSX.Element;
+  headerRow: JSX.Element;
   /**
    * Footer row component to render by custom renderer
    * */
-  footerRow: React.JSX.Element | null;
+  footerRow: JSX.Element | null;
 }
 
 export type EuiDataGridSetCustomGridBodyProps = CommonProps &

--- a/packages/eui/src/components/flyout/flyout.tsx
+++ b/packages/eui/src/components/flyout/flyout.tsx
@@ -19,6 +19,7 @@ import React, {
   FunctionComponent,
   MutableRefObject,
   ReactNode,
+  JSX,
 } from 'react';
 import classnames from 'classnames';
 

--- a/packages/eui/src/components/form/checkbox/checkbox_group.behavior.test.tsx
+++ b/packages/eui/src/components/form/checkbox/checkbox_group.behavior.test.tsx
@@ -28,7 +28,7 @@ describe('EuiCheckboxGroup behavior', () => {
     );
 
     component.find('input[type="checkbox"]').simulate('change');
-    expect(onChangeHandler).toBeCalledTimes(1);
+    expect(onChangeHandler).toHaveBeenCalledTimes(1);
     expect(onChangeHandler.mock.calls[0][0]).toBe('1');
   });
 });

--- a/packages/eui/src/components/form/form.tsx
+++ b/packages/eui/src/components/form/form.tsx
@@ -13,6 +13,7 @@ import React, {
   useCallback,
   useMemo,
   forwardRef,
+  JSX,
 } from 'react';
 import classNames from 'classnames';
 

--- a/packages/eui/src/components/header/header.test.tsx
+++ b/packages/eui/src/components/header/header.test.tsx
@@ -117,7 +117,7 @@ describe('EuiHeader', () => {
         </EuiHeader>
       );
 
-      expect(consoleStub).toBeCalled();
+      expect(consoleStub).toHaveBeenCalled();
       expect(consoleStub.mock.calls[0][0]).toMatch(
         'cannot accept both `children` and `sections`'
       );

--- a/packages/eui/src/components/i18n/i18n.test.tsx
+++ b/packages/eui/src/components/i18n/i18n.test.tsx
@@ -6,10 +6,11 @@
  * Side Public License, v 1.
  */
 
-import React, { ReactChild } from 'react';
+import React from 'react';
 import { mount } from 'enzyme';
 import { EuiContext } from '../context';
 import { EuiI18n, useEuiI18n } from './i18n';
+import { ReactChild } from '../common';
 
 /* eslint-disable local/i18n */
 

--- a/packages/eui/src/components/i18n/i18n.test.tsx
+++ b/packages/eui/src/components/i18n/i18n.test.tsx
@@ -6,11 +6,10 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { mount } from 'enzyme';
 import { EuiContext } from '../context';
 import { EuiI18n, useEuiI18n } from './i18n';
-import { ReactChild } from '../common';
 
 /* eslint-disable local/i18n */
 
@@ -64,7 +63,7 @@ describe('EuiI18n', () => {
       it('renders render prop result to the dom', () => {
         const component = mount(
           <EuiI18n token="test" default="This is a basic string.">
-            {(result: ReactChild) => `A nifty thing: ${result}`}
+            {(result: ReactNode) => `A nifty thing: ${result}`}
           </EuiI18n>
         );
         expect(component).toMatchSnapshot();
@@ -77,7 +76,7 @@ describe('EuiI18n', () => {
             default="This is a {type} with {special}."
             values={{ type: 'string', special: 'values' }}
           >
-            {(result: ReactChild) => `Here's something cool: ${result}`}
+            {(result: ReactNode) => `Here's something cool: ${result}`}
           </EuiI18n>
         );
         expect(component).toMatchSnapshot();
@@ -109,7 +108,7 @@ describe('EuiI18n', () => {
               'This is the second basic string.',
             ]}
           >
-            {([one, two]: ReactChild[]) => (
+            {([one, two]: ReactNode[]) => (
               <div>
                 {one} {two}
               </div>
@@ -129,7 +128,7 @@ describe('EuiI18n', () => {
             ]}
             values={{ placeholder: 'value' }}
           >
-            {([one, two]: ReactChild[]) => (
+            {([one, two]: ReactNode[]) => (
               <div>
                 {one} {two}
               </div>
@@ -190,7 +189,7 @@ describe('EuiI18n', () => {
         const component = mount(
           <EuiContext i18n={{ mapping: { test: 'An overridden string.' } }}>
             <EuiI18n token="test" default="This is a basic string.">
-              {(result: ReactChild) => `A nifty thing: ${result}`}
+              {(result: ReactNode) => `A nifty thing: ${result}`}
             </EuiI18n>
           </EuiContext>
         );
@@ -209,7 +208,7 @@ describe('EuiI18n', () => {
               default="This is a {type} with {special}."
               values={{ type: 'string', special: 'values' }}
             >
-              {(result: ReactChild) => `Here's something cool: ${result}`}
+              {(result: ReactNode) => `Here's something cool: ${result}`}
             </EuiI18n>
           </EuiContext>
         );
@@ -224,7 +223,7 @@ describe('EuiI18n', () => {
         const component = mount(
           <EuiContext i18n={{ mapping: { test: renderCallback } }}>
             <EuiI18n token="test" default={renderCallback} values={values}>
-              {(result: ReactChild) => `Here's something neat: ${result}`}
+              {(result: ReactNode) => `Here's something neat: ${result}`}
             </EuiI18n>
           </EuiContext>
         );
@@ -243,7 +242,7 @@ describe('EuiI18n', () => {
             'This is the second basic string.',
           ]}
         >
-          {([one, two]: ReactChild[]) => (
+          {([one, two]: ReactNode[]) => (
             <div>
               {one} {two}
             </div>

--- a/packages/eui/src/components/i18n/i18n.tsx
+++ b/packages/eui/src/components/i18n/i18n.tsx
@@ -8,13 +8,12 @@
 
 import React, {
   Fragment,
-  ReactChild,
   FunctionComponent,
   useContext,
   ReactElement,
 } from 'react';
 import { EuiI18nConsumer } from '../context';
-import { ExclusiveUnion } from '../common';
+import { ExclusiveUnion, ReactChild } from '../common';
 import {
   I18nContext,
   I18nShape,

--- a/packages/eui/src/components/i18n/i18n.tsx
+++ b/packages/eui/src/components/i18n/i18n.tsx
@@ -11,9 +11,10 @@ import React, {
   FunctionComponent,
   useContext,
   ReactElement,
+  ReactNode,
 } from 'react';
 import { EuiI18nConsumer } from '../context';
-import { ExclusiveUnion, ReactChild } from '../common';
+import { ExclusiveUnion } from '../common';
 import {
   I18nContext,
   I18nShape,
@@ -71,7 +72,7 @@ function lookupToken<
 
   const children = processStringToChildren(renderable, values, i18nMappingFunc);
   if (typeof children === 'string') {
-    // likewise, `processStringToChildren` returns a string or ReactChild[] depending on
+    // likewise, `processStringToChildren` returns a string or ReactNode[] depending on
     // the type of `values`, so we will make the assumption that the default value is correct.
     return children as RESOLVED;
   }
@@ -92,7 +93,7 @@ interface I18nTokenShape<T, DEFAULT extends Renderable<T>> {
   /**
    * Render function that returns a ReactElement
    */
-  children?: (x: ResolvedType<DEFAULT>) => ReactChild;
+  children?: (x: ResolvedType<DEFAULT>) => ReactNode;
   values?: T;
 }
 
@@ -102,8 +103,8 @@ export interface I18nTokensShape<T extends any[]> {
   /**
    * Render function that returns a ReactElement
    */
-  children: (x: Array<T[number]>) => ReactChild;
-  values?: Record<string, ReactChild>;
+  children: (x: Array<T[number]>) => ReactNode;
+  values?: Record<string, ReactNode>;
 }
 
 export type EuiI18nProps<
@@ -165,7 +166,7 @@ const EuiI18n = <
 );
 
 // A single default could be a string, react child, or render function
-type DefaultRenderType<T, K extends Renderable<T>> = K extends ReactChild
+type DefaultRenderType<T, K extends Renderable<T>> = K extends ReactNode
   ? K
   : K extends () => infer RetValue
   ? RetValue

--- a/packages/eui/src/components/i18n/i18n_number.stories.tsx
+++ b/packages/eui/src/components/i18n/i18n_number.stories.tsx
@@ -6,13 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { EuiI18nNumber, EuiI18nNumberProps } from './i18n_number';
 import { EuiText } from '../text';
-import { ReactChild } from '../common';
 
 const meta: Meta<EuiI18nNumberProps> = {
   title: 'Utilities/EuiI18nNumber',
@@ -47,7 +46,7 @@ export const MultipleValues: Story = {
   },
   args: {
     values: [0, 1, 2],
-    children: (values: ReactChild[]) => (
+    children: (values: ReactNode[]) => (
       <>
         {values.map((value, index) => (
           <EuiText key={index}>

--- a/packages/eui/src/components/i18n/i18n_number.stories.tsx
+++ b/packages/eui/src/components/i18n/i18n_number.stories.tsx
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { ReactChild } from 'react';
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { EuiI18nNumber, EuiI18nNumberProps } from './i18n_number';
 import { EuiText } from '../text';
+import { ReactChild } from '../common';
 
 const meta: Meta<EuiI18nNumberProps> = {
   title: 'Utilities/EuiI18nNumber',

--- a/packages/eui/src/components/i18n/i18n_number.tsx
+++ b/packages/eui/src/components/i18n/i18n_number.tsx
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, ReactChild, ReactElement } from 'react';
+import React, { FunctionComponent, ReactElement } from 'react';
 import { EuiI18nConsumer } from '../context';
-import { ExclusiveUnion } from '../common';
+import { ExclusiveUnion, ReactChild } from '../common';
 
 const defaultFormatter = new Intl.NumberFormat('en');
 function defaultFormatNumber(value: number) {

--- a/packages/eui/src/components/i18n/i18n_number.tsx
+++ b/packages/eui/src/components/i18n/i18n_number.tsx
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, ReactElement } from 'react';
+import React, { FunctionComponent, ReactElement, ReactNode } from 'react';
 import { EuiI18nConsumer } from '../context';
-import { ExclusiveUnion, ReactChild } from '../common';
+import { ExclusiveUnion } from '../common';
 
 const defaultFormatter = new Intl.NumberFormat('en');
 function defaultFormatNumber(value: number) {
@@ -17,7 +17,7 @@ function defaultFormatNumber(value: number) {
 
 interface EuiI18nNumberValueShape {
   value: number;
-  children?: (x: ReactChild) => ReactElement<any>;
+  children?: (x: ReactNode) => ReactElement<any>;
 }
 
 interface EuiI18nNumberValuesShape {
@@ -25,7 +25,7 @@ interface EuiI18nNumberValuesShape {
   /**
    * ReactNode to render as this component's content
    */
-  children: (x: ReactChild[]) => ReactElement<any>;
+  children: (x: ReactNode[]) => ReactElement<any>;
 }
 
 export type EuiI18nNumberProps = ExclusiveUnion<

--- a/packages/eui/src/components/i18n/i18n_util.tsx
+++ b/packages/eui/src/components/i18n/i18n_util.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { cloneElement } from 'react';
+import { cloneElement, ReactNode } from 'react';
 import {
   isBoolean,
   isString,
@@ -15,15 +15,14 @@ import {
 } from '../../services/predicate';
 import { isElement } from 'react-is';
 import { RenderableValues } from '../context/context';
-import { ReactChild } from '../common';
 
-function isPrimitive(value: ReactChild | undefined) {
+function isPrimitive(value: ReactNode | undefined) {
   return (
     isBoolean(value) || isString(value) || isNumber(value) || isUndefined(value)
   );
 }
 
-type Child = string | { propName: string } | ReactChild | undefined;
+type Child = string | { propName: string } | ReactNode | undefined;
 
 function hasPropName(child: Child): child is { propName: string } {
   return child
@@ -37,14 +36,14 @@ function hasPropName(child: Child): child is { propName: string } {
  * @param {string} input
  * @param {RenderableValues} values
  * @param {Function} i18nMappingFunc
- * @returns {string | React.ReactChild[]}
+ * @returns {string | ReactNode[]}
  */
 export function processStringToChildren(
   input: string,
   values: RenderableValues,
   i18nMappingFunc?: (token: string) => string
-): string | ReactChild[] {
-  const children: ReactChild[] = [];
+): string | ReactNode[] {
+  const children: ReactNode[] = [];
 
   let child: Child;
 

--- a/packages/eui/src/components/i18n/i18n_util.tsx
+++ b/packages/eui/src/components/i18n/i18n_util.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { cloneElement, ReactChild } from 'react';
+import { cloneElement } from 'react';
 import {
   isBoolean,
   isString,
@@ -15,6 +15,7 @@ import {
 } from '../../services/predicate';
 import { isElement } from 'react-is';
 import { RenderableValues } from '../context/context';
+import { ReactChild } from '../common';
 
 function isPrimitive(value: ReactChild | undefined) {
   return (

--- a/packages/eui/src/components/inline_edit/inline_edit_form.test.tsx
+++ b/packages/eui/src/components/inline_edit/inline_edit_form.test.tsx
@@ -402,7 +402,7 @@ describe('EuiInlineEditForm', () => {
         });
 
         fireEvent.click(getByTestSubject('euiInlineEditModeSaveButton'));
-        expect(onSave).toBeCalledTimes(1);
+        expect(onSave).toHaveBeenCalledTimes(1);
 
         await act(() => {
           promiseResolve(false);

--- a/packages/eui/src/components/key_pad_menu/key_pad_menu_item.test.tsx
+++ b/packages/eui/src/components/key_pad_menu/key_pad_menu_item.test.tsx
@@ -193,7 +193,7 @@ describe('EuiKeyPadMenuItem', () => {
       </EuiKeyPadMenuItem>
     );
 
-    expect(onClickHandler).not.toBeCalled();
+    expect(onClickHandler).not.toHaveBeenCalled();
   });
 
   test('onClick is called when the button is clicked', () => {
@@ -207,7 +207,7 @@ describe('EuiKeyPadMenuItem', () => {
 
     $button.simulate('click');
 
-    expect(onClickHandler).toBeCalledTimes(1);
+    expect(onClickHandler).toHaveBeenCalledTimes(1);
   });
 
   describe('checkable', () => {

--- a/packages/eui/src/components/key_pad_menu/key_pad_menu_item.tsx
+++ b/packages/eui/src/components/key_pad_menu/key_pad_menu_item.tsx
@@ -13,6 +13,7 @@ import React, {
   Ref,
   LabelHTMLAttributes,
   useMemo,
+  JSX,
 } from 'react';
 import classNames from 'classnames';
 

--- a/packages/eui/src/components/list_group/list_group_item.test.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.test.tsx
@@ -310,7 +310,7 @@ describe('EuiListGroupItem', () => {
         <EuiListGroupItem label="" iconType="empty" icon={<span />} />
       );
 
-      expect(consoleStub).toBeCalled();
+      expect(consoleStub).toHaveBeenCalled();
       expect(consoleStub.mock.calls[0][0]).toMatch(
         '`iconType` and `icon` were passed'
       );

--- a/packages/eui/src/components/markdown_editor/markdown_editor.test.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor.test.tsx
@@ -218,7 +218,7 @@ describe('EuiMarkdownEditor', () => {
       render(<EuiMarkdownEditor {...testProps} {...requiredProps} />);
 
       expect(testProps.onParse).toHaveBeenCalledTimes(1);
-      expect(testProps.onParse).toBeCalledWith(null, {
+      expect(testProps.onParse).toHaveBeenCalledWith(null, {
         ast: expect.anything(),
         messages: testMessage,
       });

--- a/packages/eui/src/components/markdown_editor/markdown_editor_footer.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor_footer.tsx
@@ -10,7 +10,6 @@ import React, {
   useState,
   useMemo,
   Fragment,
-  ReactChild,
   forwardRef,
   useContext,
 } from 'react';
@@ -42,6 +41,7 @@ import { EuiMarkdownContext } from './markdown_context';
 // @ts-ignore a react svg
 import MarkdownLogo from './icons/markdown_logo';
 import { euiMarkdownEditorFooterStyles } from './markdown_editor_footer.styles';
+import { ReactChild } from '../common';
 
 interface EuiMarkdownEditorFooterProps {
   uiPlugins: EuiMarkdownEditorUiPlugin[];

--- a/packages/eui/src/components/markdown_editor/markdown_editor_footer.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor_footer.tsx
@@ -12,6 +12,7 @@ import React, {
   Fragment,
   forwardRef,
   useContext,
+  ReactNode,
 } from 'react';
 
 import { useEuiMemoizedStyles } from '../../services';
@@ -41,7 +42,6 @@ import { EuiMarkdownContext } from './markdown_context';
 // @ts-ignore a react svg
 import MarkdownLogo from './icons/markdown_logo';
 import { euiMarkdownEditorFooterStyles } from './markdown_editor_footer.styles';
-import { ReactChild } from '../common';
 
 interface EuiMarkdownEditorFooterProps {
   uiPlugins: EuiMarkdownEditorUiPlugin[];
@@ -256,7 +256,7 @@ export const EuiMarkdownEditorFooter = forwardRef<
                   {([
                     syntaxModalDescriptionPrefix,
                     syntaxModalDescriptionSuffix,
-                  ]: ReactChild[]) => (
+                  ]: ReactNode[]) => (
                     <p>
                       {syntaxModalDescriptionPrefix} {mdSyntaxLink}.{' '}
                       {syntaxModalDescriptionSuffix}
@@ -315,7 +315,7 @@ export const EuiMarkdownEditorFooter = forwardRef<
           tokens={['euiMarkdownEditorFooter.syntaxPopoverDescription']}
           defaults={['This editor uses']}
         >
-          {([syntaxPopoverDescription]: ReactChild[]) => (
+          {([syntaxPopoverDescription]: ReactNode[]) => (
             <p>
               {syntaxPopoverDescription} {mdSyntaxLink}.
             </p>

--- a/packages/eui/src/components/page/page_body/page_body.tsx
+++ b/packages/eui/src/components/page/page_body/page_body.tsx
@@ -17,7 +17,7 @@ import { EuiPanel, EuiPanelProps } from '../../panel';
 import { useEuiPaddingCSS, EuiPaddingSize } from '../../../global_styling';
 import { euiPageBodyStyles } from './page_body.styles';
 
-type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType<any>;
+type ComponentTypes = keyof React.JSX.IntrinsicElements | ComponentType<any>;
 
 export type EuiPageBodyProps<T extends ComponentTypes = 'main'> =
   PropsWithChildren &

--- a/packages/eui/src/components/page/page_body/page_body.tsx
+++ b/packages/eui/src/components/page/page_body/page_body.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { PropsWithChildren, ComponentType, ComponentProps } from 'react';
+import React, { PropsWithChildren, ComponentType, ComponentProps, JSX } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
 import {
@@ -17,7 +17,7 @@ import { EuiPanel, EuiPanelProps } from '../../panel';
 import { useEuiPaddingCSS, EuiPaddingSize } from '../../../global_styling';
 import { euiPageBodyStyles } from './page_body.styles';
 
-type ComponentTypes = keyof React.JSX.IntrinsicElements | ComponentType<any>;
+type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType<any>;
 
 export type EuiPageBodyProps<T extends ComponentTypes = 'main'> =
   PropsWithChildren &

--- a/packages/eui/src/components/page/page_body/page_body.tsx
+++ b/packages/eui/src/components/page/page_body/page_body.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { PropsWithChildren, ComponentType, ComponentProps, JSX } from 'react';
+import React, {
+  PropsWithChildren,
+  ComponentType,
+  ComponentProps,
+  JSX,
+} from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../../common';
 import {

--- a/packages/eui/src/components/page/page_section/page_section.tsx
+++ b/packages/eui/src/components/page/page_section/page_section.tsx
@@ -56,7 +56,7 @@ export type EuiPageSectionProps = CommonProps &
     /**
      * Sets which HTML element to render.
      */
-    component?: keyof JSX.IntrinsicElements | ComponentType;
+    component?: keyof React.JSX.IntrinsicElements | ComponentType;
   } & Omit<HTMLAttributes<Element>, 'color'>;
 
 export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({

--- a/packages/eui/src/components/page/page_section/page_section.tsx
+++ b/packages/eui/src/components/page/page_section/page_section.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, ComponentType, HTMLAttributes, JSX } from 'react';
+import React, {
+  FunctionComponent,
+  ComponentType,
+  HTMLAttributes,
+  JSX,
+} from 'react';
 import { CommonProps } from '../../common';
 
 import {

--- a/packages/eui/src/components/page/page_section/page_section.tsx
+++ b/packages/eui/src/components/page/page_section/page_section.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, ComponentType, HTMLAttributes } from 'react';
+import React, { FunctionComponent, ComponentType, HTMLAttributes, JSX } from 'react';
 import { CommonProps } from '../../common';
 
 import {
@@ -56,7 +56,7 @@ export type EuiPageSectionProps = CommonProps &
     /**
      * Sets which HTML element to render.
      */
-    component?: keyof React.JSX.IntrinsicElements | ComponentType;
+    component?: keyof JSX.IntrinsicElements | ComponentType;
   } & Omit<HTMLAttributes<Element>, 'color'>;
 
 export const EuiPageSection: FunctionComponent<EuiPageSectionProps> = ({

--- a/packages/eui/src/components/page_template/inner/page_inner.tsx
+++ b/packages/eui/src/components/page_template/inner/page_inner.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { PropsWithChildren, ComponentType, ComponentProps } from 'react';
+import React, { PropsWithChildren, ComponentType, ComponentProps, JSX } from 'react';
 import { CommonProps } from '../../common';
 import {
   EuiPaddingSize,
@@ -16,7 +16,7 @@ import {
 import { useEuiTheme, useIsWithinBreakpoints } from '../../../services';
 import { euiPageInnerStyles } from './page_inner.styles';
 
-export type ComponentTypes = keyof React.JSX.IntrinsicElements | ComponentType;
+export type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType;
 
 export type _EuiPageInnerProps<T extends ComponentTypes = 'main'> =
   PropsWithChildren &

--- a/packages/eui/src/components/page_template/inner/page_inner.tsx
+++ b/packages/eui/src/components/page_template/inner/page_inner.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { PropsWithChildren, ComponentType, ComponentProps, JSX } from 'react';
+import React, {
+  PropsWithChildren,
+  ComponentType,
+  ComponentProps,
+  JSX,
+} from 'react';
 import { CommonProps } from '../../common';
 import {
   EuiPaddingSize,

--- a/packages/eui/src/components/page_template/inner/page_inner.tsx
+++ b/packages/eui/src/components/page_template/inner/page_inner.tsx
@@ -16,7 +16,7 @@ import {
 import { useEuiTheme, useIsWithinBreakpoints } from '../../../services';
 import { euiPageInnerStyles } from './page_inner.styles';
 
-export type ComponentTypes = keyof JSX.IntrinsicElements | ComponentType;
+export type ComponentTypes = keyof React.JSX.IntrinsicElements | ComponentType;
 
 export type _EuiPageInnerProps<T extends ComponentTypes = 'main'> =
   PropsWithChildren &

--- a/packages/eui/src/components/provider/provider.tsx
+++ b/packages/eui/src/components/provider/provider.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, JSX } from 'react';
 import type { EmotionCache } from '@emotion/css';
 import { EuiThemeBorealis } from '@elastic/eui-theme-borealis';
 
@@ -55,12 +55,12 @@ export interface EuiProviderProps<T>
    * Provide global styles via `@emotion/react` `Global` for your custom theme.
    * Pass `false` to remove the default EUI global styles.
    */
-  globalStyles?: false | ((params: any) => React.JSX.Element | null);
+  globalStyles?: false | ((params: any) => JSX.Element | null);
   /**
    * Provide utility classes.
    * Pass `false` to remove the default EUI utility classes.
    */
-  utilityClasses?: false | ((params: any) => React.JSX.Element | null);
+  utilityClasses?: false | ((params: any) => JSX.Element | null);
   /**
    * Provide a cache configuration(s) from `@emotion/cache`.
    *

--- a/packages/eui/src/components/provider/provider.tsx
+++ b/packages/eui/src/components/provider/provider.tsx
@@ -55,12 +55,12 @@ export interface EuiProviderProps<T>
    * Provide global styles via `@emotion/react` `Global` for your custom theme.
    * Pass `false` to remove the default EUI global styles.
    */
-  globalStyles?: false | ((params: any) => JSX.Element | null);
+  globalStyles?: false | ((params: any) => React.JSX.Element | null);
   /**
    * Provide utility classes.
    * Pass `false` to remove the default EUI utility classes.
    */
-  utilityClasses?: false | ((params: any) => JSX.Element | null);
+  utilityClasses?: false | ((params: any) => React.JSX.Element | null);
   /**
    * Provide a cache configuration(s) from `@emotion/cache`.
    *

--- a/packages/eui/src/components/side_nav/side_nav_item.tsx
+++ b/packages/eui/src/components/side_nav/side_nav_item.tsx
@@ -14,6 +14,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  JSX,
 } from 'react';
 import classNames from 'classnames';
 

--- a/packages/eui/src/components/table/table_header_cell.tsx
+++ b/packages/eui/src/components/table/table_header_cell.tsx
@@ -37,7 +37,7 @@ import { HEADER_CELL_SCOPE } from './table_header_cell_shared';
 export type TableHeaderCellScope = (typeof HEADER_CELL_SCOPE)[number];
 
 export type EuiTableHeaderCellProps = CommonProps &
-  Omit<ThHTMLAttributes<HTMLTableHeaderCellElement>, 'align' | 'scope'> & {
+  Omit<ThHTMLAttributes<HTMLTableCellElement>, 'align' | 'scope'> & {
     align?: HorizontalAlignment;
     isSortAscending?: boolean;
     isSorted?: boolean;

--- a/packages/eui/src/components/table/table_header_cell_checkbox.tsx
+++ b/packages/eui/src/components/table/table_header_cell_checkbox.tsx
@@ -27,7 +27,7 @@ export interface EuiTableHeaderCellCheckboxProps {
 
 export const EuiTableHeaderCellCheckbox: FunctionComponent<
   CommonProps &
-    ThHTMLAttributes<HTMLTableHeaderCellElement> &
+    ThHTMLAttributes<HTMLTableCellElement> &
     EuiTableHeaderCellCheckboxProps
 > = ({ children, className, scope = 'col', style, width, append, ...rest }) => {
   const classes = classNames('euiTableHeaderCellCheckbox', className);

--- a/packages/eui/src/components/table/utils.test.ts
+++ b/packages/eui/src/components/table/utils.test.ts
@@ -49,7 +49,7 @@ describe('resolveWidthAsStyle', () => {
     it('returns width overriding style', () => {
       const style = { width: '20%', color: 'red' };
       expect(resolveWidthAsStyle(style, '10%')).toEqual(result);
-      expect(consoleStub).toBeCalled();
+      expect(consoleStub).toHaveBeenCalled();
     });
     it('returns style merged with width', () => {
       const style = { color: 'red' };

--- a/packages/eui/src/components/tabs/tab.test.tsx
+++ b/packages/eui/src/components/tabs/tab.test.tsx
@@ -33,7 +33,7 @@ describe('EuiTab', () => {
         const $button = shallow(<EuiTab onClick={onClickHandler} />);
 
         $button.simulate('click');
-        expect(onClickHandler).toBeCalled();
+        expect(onClickHandler).toHaveBeenCalled();
       });
     });
 

--- a/packages/eui/src/components/tabs/tabbed_content/tabbed_content.test.tsx
+++ b/packages/eui/src/components/tabs/tabbed_content/tabbed_content.test.tsx
@@ -50,8 +50,8 @@ describe('EuiTabbedContent', () => {
           <EuiTabbedContent onTabClick={onTabClickHandler} tabs={tabs} />
         );
         fireEvent.click(getByTestSubject('kibanaTab'));
-        expect(onTabClickHandler).toBeCalledTimes(1);
-        expect(onTabClickHandler).toBeCalledWith(kibanaTab);
+        expect(onTabClickHandler).toHaveBeenCalledTimes(1);
+        expect(onTabClickHandler).toHaveBeenCalledWith(kibanaTab);
       });
     });
 

--- a/packages/eui/src/components/text_diff/text_diff.tsx
+++ b/packages/eui/src/components/text_diff/text_diff.tsx
@@ -85,7 +85,7 @@ export const useEuiTextDiff = ({
 
   // specifically defining the return type here as the
   // inferred type is not correct: array vs tuple
-  const textDiffResult: [JSX.Element, typeof textDiff] = [
+  const textDiffResult: [React.JSX.Element, typeof textDiff] = [
     <span css={styles.euiTextDiff} className={classes} {...rest}>
       {rendereredHtml}
     </span>,

--- a/packages/eui/src/components/text_diff/text_diff.tsx
+++ b/packages/eui/src/components/text_diff/text_diff.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, useMemo, ElementType } from 'react';
+import React, { HTMLAttributes, useMemo, ElementType, JSX } from 'react';
 import Diff from 'text-diff';
 import classNames from 'classnames';
 import { useEuiMemoizedStyles } from '../../services';
@@ -85,7 +85,7 @@ export const useEuiTextDiff = ({
 
   // specifically defining the return type here as the
   // inferred type is not correct: array vs tuple
-  const textDiffResult: [React.JSX.Element, typeof textDiff] = [
+  const textDiffResult: [JSX.Element, typeof textDiff] = [
     <span css={styles.euiTextDiff} className={classes} {...rest}>
       {rendereredHtml}
     </span>,

--- a/packages/eui/src/components/toast/global_toast_list.test.tsx
+++ b/packages/eui/src/components/toast/global_toast_list.test.tsx
@@ -124,11 +124,11 @@ describe('EuiGlobalToastList', () => {
         act(() => {
           jest.advanceTimersByTime(TOAST_FADE_OUT_MS - 1);
         });
-        expect(dismissToastSpy).not.toBeCalled();
+        expect(dismissToastSpy).not.toHaveBeenCalled();
         act(() => {
           jest.advanceTimersByTime(1);
         });
-        expect(dismissToastSpy).toBeCalled();
+        expect(dismissToastSpy).toHaveBeenCalled();
       });
 
       test('is called when the toast lifetime elapses', () => {
@@ -150,11 +150,11 @@ describe('EuiGlobalToastList', () => {
         act(() => {
           jest.advanceTimersByTime(TOAST_LIFE_TIME_MS + TOAST_FADE_OUT_MS - 1);
         });
-        expect(dismissToastSpy).not.toBeCalled();
+        expect(dismissToastSpy).not.toHaveBeenCalled();
         act(() => {
           jest.advanceTimersByTime(1);
         });
-        expect(dismissToastSpy).toBeCalled();
+        expect(dismissToastSpy).toHaveBeenCalled();
       });
 
       test('toastLifeTimeMs is overrideable by individidual toasts', () => {
@@ -180,11 +180,11 @@ describe('EuiGlobalToastList', () => {
         act(() => {
           jest.advanceTimersByTime(notYetTime);
         });
-        expect(dismissToastSpy).not.toBeCalled();
+        expect(dismissToastSpy).not.toHaveBeenCalled();
         act(() => {
           jest.advanceTimersByTime(nowItsTime - notYetTime);
         });
-        expect(dismissToastSpy).toBeCalled();
+        expect(dismissToastSpy).toHaveBeenCalled();
       });
     });
 

--- a/packages/eui/src/components/toast/toast.test.tsx
+++ b/packages/eui/src/components/toast/toast.test.tsx
@@ -62,7 +62,7 @@ describe('EuiToast', () => {
         const closeButton = findTestSubject(component, 'toastCloseButton');
         closeButton.simulate('click');
 
-        expect(onCloseHandler).toBeCalledTimes(1);
+        expect(onCloseHandler).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/eui/src/services/color_picker/index.ts
+++ b/packages/eui/src/services/color_picker/index.ts
@@ -7,4 +7,5 @@
  */
 
 export type { EuiSetColorMethod } from './color_picker';
+// eslint-disable-next-line deprecation/deprecation
 export { useColorPickerState, useColorStopsState } from './color_picker';

--- a/packages/eui/src/services/color_picker/index.ts
+++ b/packages/eui/src/services/color_picker/index.ts
@@ -7,5 +7,4 @@
  */
 
 export type { EuiSetColorMethod } from './color_picker';
-// eslint-disable-next-line deprecation/deprecation
 export { useColorPickerState, useColorStopsState } from './color_picker';

--- a/packages/eui/src/services/console/warn_once.test.ts
+++ b/packages/eui/src/services/console/warn_once.test.ts
@@ -16,13 +16,13 @@ describe('warnOnce', () => {
   it('should warn only once per id', () => {
     warnOnce('1', 'message');
     warnOnce('1', 'message');
-    expect(warn).toBeCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
     warnOnce('2', 'message');
-    expect(warn).toBeCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(2);
     warnOnce('2', 'message');
-    expect(warn).toBeCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(2);
     warnOnce('1', 'message');
-    expect(warn).toBeCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(2);
   });
   afterAll(() => warn.mockRestore());
 });

--- a/packages/eui/src/services/copy/copy_to_clipboard.ts
+++ b/packages/eui/src/services/copy/copy_to_clipboard.ts
@@ -14,11 +14,11 @@ function createHiddenTextElement(text: string): HTMLSpanElement {
   // prevents scrolling to the end of the page
   textElement.style.position = 'fixed';
   textElement.style.top = '0';
-  textElement.style.clip = 'rect(0, 0, 0, 0)';
+  textElement.style.clipPath = 'rect(0, 0, 0, 0)';
   // used to preserve spaces and line breaks
   textElement.style.whiteSpace = 'pre';
   // do not inherit user-select (it may be `none`)
-  textElement.style.webkitUserSelect = 'text';
+  textElement.style.userSelect = 'text';
   // @ts-ignore this one doesn't appear in the TS definitions for some reason
   textElement.style.MozUserSelect = 'text';
   // @ts-ignore this one doesn't appear in the TS definitions for some reason

--- a/packages/eui/src/services/copy/copy_to_clipboard.ts
+++ b/packages/eui/src/services/copy/copy_to_clipboard.ts
@@ -23,7 +23,6 @@ function createHiddenTextElement(text: string): HTMLSpanElement {
   textElement.style.MozUserSelect = 'text';
   // @ts-ignore this one doesn't appear in the TS definitions for some reason
   textElement.style.msUserSelect = 'text';
-  textElement.style.userSelect = 'text';
   return textElement;
 }
 

--- a/packages/eui/src/services/index.ts
+++ b/packages/eui/src/services/index.ts
@@ -68,6 +68,7 @@ export {
 } from './color';
 export type { HSV } from './color';
 export * from './color/eui_palettes_hooks';
+// eslint-disable-next-line deprecation/deprecation
 export { useColorPickerState, useColorStopsState } from './color_picker';
 export type { EuiSetColorMethod } from './color_picker';
 export * from './console';

--- a/packages/eui/src/services/index.ts
+++ b/packages/eui/src/services/index.ts
@@ -68,7 +68,6 @@ export {
 } from './color';
 export type { HSV } from './color';
 export * from './color/eui_palettes_hooks';
-// eslint-disable-next-line deprecation/deprecation
 export { useColorPickerState, useColorStopsState } from './color_picker';
 export type { EuiSetColorMethod } from './color_picker';
 export * from './console';

--- a/packages/eui/src/services/popover/popover_positioning.test.ts
+++ b/packages/eui/src/services/popover/popover_positioning.test.ts
@@ -460,9 +460,9 @@ describe('popover_positioning', () => {
     beforeEach(() => {
       // reset any scrolling before each test
       // @ts-ignore setting a "readonly" property
-      window.pageXOffset = 0;
+      window.scrollX = 0;
       // @ts-ignore setting a "readonly" property
-      window.pageYOffset = 0;
+      window.scrollY = 0;
     });
 
     describe('placement in desired position', () => {
@@ -657,9 +657,9 @@ describe('popover_positioning', () => {
     describe('scrolling', () => {
       it('adds body scroll position to position values', () => {
         // @ts-ignore setting a "readonly" property
-        window.pageYOffset = 100;
+        window.scrollY = 100;
         // @ts-ignore setting a "readonly" property
-        window.pageXOffset = 15;
+        window.scrollX = 15;
 
         const anchor = document.createElement('div');
         anchor.getBoundingClientRect = () =>

--- a/packages/eui/src/services/popover/popover_positioning.ts
+++ b/packages/eui/src/services/popover/popover_positioning.ts
@@ -224,8 +224,8 @@ export function findPopoverPosition({
       bestPosition = {
         fit: screenCoordinates.fit,
         position: iterationPosition,
-        top: screenCoordinates.top + window.pageYOffset,
-        left: screenCoordinates.left + window.pageXOffset,
+        top: screenCoordinates.top + window.scrollY,
+        left: screenCoordinates.left + window.scrollX,
         arrow: screenCoordinates.arrow,
       };
 

--- a/packages/eui/src/services/theme/style_memoization.test.tsx
+++ b/packages/eui/src/services/theme/style_memoization.test.tsx
@@ -86,7 +86,7 @@ describe('useEuiMemoizedStyles', () => {
         renderHook(() => useEuiMemoizedStyles(() => ({})), {
           wrapper: EuiThemeProvider,
         })
-      ).toThrowError(
+      ).toThrow(
         'Styles are memoized per function. Your style functions must be statically defined in order to not create a new map entry every rerender.'
       );
       setEuiDevProviderWarning(undefined);

--- a/packages/eui/src/services/theme/warning.test.ts
+++ b/packages/eui/src/services/theme/warning.test.ts
@@ -73,7 +73,7 @@ describe('EUI provider dev warnings', () => {
     it('throws an error when level is error', () => {
       setEuiDevProviderWarning('error');
 
-      expect(() => emitEuiProviderWarning(providerMessage)).toThrowError(
+      expect(() => emitEuiProviderWarning(providerMessage)).toThrow(
         'hello world'
       );
 

--- a/packages/eui/src/services/time/timer.test.ts
+++ b/packages/eui/src/services/time/timer.test.ts
@@ -14,14 +14,14 @@ describe('Timer', () => {
       const callbackSpy = jest.fn();
       new Timer(callbackSpy, 5);
       setTimeout(() => {
-        expect(callbackSpy).toBeCalled();
+        expect(callbackSpy).toHaveBeenCalled();
         done();
       }, 8);
     });
     test('creates no timeout for Infinity value', (done) => {
       const callbackSpy = jest.fn();
       new Timer(callbackSpy, Infinity);
-      expect(callbackSpy).not.toBeCalled();
+      expect(callbackSpy).not.toHaveBeenCalled();
       done();
     });
   });
@@ -33,7 +33,7 @@ describe('Timer', () => {
       timer.pause();
 
       setTimeout(() => {
-        expect(callbackSpy).not.toBeCalled();
+        expect(callbackSpy).not.toHaveBeenCalled();
         done();
       }, 8);
     });
@@ -47,7 +47,7 @@ describe('Timer', () => {
       timer.resume();
 
       setTimeout(() => {
-        expect(callbackSpy).toBeCalled();
+        expect(callbackSpy).toHaveBeenCalled();
         done();
       }, 8);
     });
@@ -60,7 +60,7 @@ describe('Timer', () => {
       timer.clear();
 
       setTimeout(() => {
-        expect(callbackSpy).not.toBeCalled();
+        expect(callbackSpy).not.toHaveBeenCalled();
         done();
       }, 8);
     });
@@ -71,7 +71,7 @@ describe('Timer', () => {
       const callbackSpy = jest.fn();
       const timer = new Timer(callbackSpy, 5);
       timer.finish();
-      expect(callbackSpy).toBeCalled();
+      expect(callbackSpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -49,7 +49,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => ({
   `,
 });
 
-export default function Home(): JSX.Element {
+export default function Home(): React.JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   const isBrowser = useIsBrowser();
   const styles = useEuiMemoizedStyles(getStyles);

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { JSX } from 'react';
 import { css } from '@emotion/react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useIsBrowser from '@docusaurus/useIsBrowser';
@@ -49,7 +50,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => ({
   `,
 });
 
-export default function Home(): React.JSX.Element {
+export default function Home(): JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   const isBrowser = useIsBrowser();
   const styles = useEuiMemoizedStyles(getStyles);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4913,6 +4913,7 @@ __metadata:
     eslint: "npm:^8.41.0"
     eslint-config-prettier: "npm:^8.8.0"
     eslint-import-resolver-webpack: "npm:^0.13.2"
+    eslint-plugin-deprecation: "npm:2.0.0"
     eslint-plugin-import: "npm:^2.27.5"
     eslint-plugin-jest: "npm:^28.5.0"
     eslint-plugin-jsx-a11y: "npm:^6.7.1"
@@ -8304,6 +8305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.12":
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8":
   version: 7.0.9
   resolution: "@types/json-schema@npm:7.0.9"
@@ -8711,6 +8719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.5.0":
+  version: 7.5.8
+  resolution: "@types/semver@npm:7.5.8"
+  checksum: 10c0/8663ff927234d1c5fcc04b33062cb2b9fcfbe0f5f351ed26c4d1e1581657deebd506b41ff7fdf89e787e3d33ce05854bc01686379b89e9c49b564c4cfa988efa
+  languageName: node
+  linkType: hard
+
 "@types/send@npm:*":
   version: 0.17.2
   resolution: "@types/send@npm:0.17.2"
@@ -8973,6 +8988,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/visitor-keys": "npm:6.21.0"
+  checksum: 10c0/eaf868938d811cbbea33e97e44ba7050d2b6892202cea6a9622c486b85ab1cf801979edf78036179a8ba4ac26f1dfdf7fcc83a68c1ff66be0b3a8e9a9989b526
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:7.12.0":
   version: 7.12.0
   resolution: "@typescript-eslint/scope-manager@npm:7.12.0"
@@ -9011,6 +9036,13 @@ __metadata:
   version: 5.62.0
   resolution: "@typescript-eslint/types@npm:5.62.0"
   checksum: 10c0/7febd3a7f0701c0b927e094f02e82d8ee2cada2b186fcb938bc2b94ff6fbad88237afc304cbaf33e82797078bbbb1baf91475f6400912f8b64c89be79bfa4ddf
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/types@npm:6.21.0"
+  checksum: 10c0/020631d3223bbcff8a0da3efbdf058220a8f48a3de221563996ad1dcc30d6c08dadc3f7608cc08830d21c0d565efd2db19b557b9528921c78aabb605eef2d74d
   languageName: node
   linkType: hard
 
@@ -9071,6 +9103,25 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/d7984a3e9d56897b2481940ec803cb8e7ead03df8d9cfd9797350be82ff765dfcf3cfec04e7355e1779e948da8f02bc5e11719d07a596eb1cb995c48a95e38cf
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/visitor-keys": "npm:6.21.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.4"
+    ts-api-utils: "npm:^1.0.1"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/af1438c60f080045ebb330155a8c9bb90db345d5069cdd5d01b67de502abb7449d6c75500519df829f913a6b3f490ade3e8215279b6bdc63d0fb0ae61034df5f
   languageName: node
   linkType: hard
 
@@ -9148,6 +9199,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^6.0.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/utils@npm:6.21.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@types/json-schema": "npm:^7.0.12"
+    "@types/semver": "npm:^7.5.0"
+    "@typescript-eslint/scope-manager": "npm:6.21.0"
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/typescript-estree": "npm:6.21.0"
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 10c0/ab2df3833b2582d4e5467a484d08942b4f2f7208f8e09d67de510008eb8001a9b7460f2f9ba11c12086fd3cdcac0c626761c7995c2c6b5657d5fa6b82030a32d
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:^6.0.0 || ^7.0.0":
   version: 7.12.0
   resolution: "@typescript-eslint/utils@npm:7.12.0"
@@ -9179,6 +9247,16 @@ __metadata:
     "@typescript-eslint/types": "npm:5.62.0"
     eslint-visitor-keys: "npm:^3.3.0"
   checksum: 10c0/7c3b8e4148e9b94d9b7162a596a1260d7a3efc4e65199693b8025c71c4652b8042501c0bc9f57654c1e2943c26da98c0f77884a746c6ae81389fcb0b513d995d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    eslint-visitor-keys: "npm:^3.4.1"
+  checksum: 10c0/7395f69739cfa1cb83c1fb2fad30afa2a814756367302fb4facd5893eff66abc807e8d8f63eba94ed3b0fe0c1c996ac9a1680bcbf0f83717acedc3f2bb724fbf
   languageName: node
   linkType: hard
 
@@ -16402,6 +16480,20 @@ __metadata:
     eslint:
       optional: true
   checksum: 10c0/c7a8d1a58d76ec8217a8fea49271ec8132d1b9390965a75f6a4ecbc9e5983d742195b46d2e4378231d2186801439fe1aa5700714b0bfd4eb17aac6e1b65309df
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-deprecation@npm:2.0.0":
+  version: 2.0.0
+  resolution: "eslint-plugin-deprecation@npm:2.0.0"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^6.0.0"
+    tslib: "npm:^2.3.1"
+    tsutils: "npm:^3.21.0"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+    typescript: ^4.2.4 || ^5.0.0
+  checksum: 10c0/6b9cb65ecd3e98d29683bb9b7e5af01e8ac8acadacc313e18757b8120c3850a5a11bfea67f3203975a82e018ea1c07d79dabe20ade921658e8bc03c736469079
   languageName: node
   linkType: hard
 
@@ -25117,6 +25209,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:9.0.3":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/85f407dcd38ac3e180f425e86553911d101455ca3ad5544d6a7cec16286657e4f8a9aa6695803025c55e31e35a91a2252b5dc8e7d527211278b8b65b4dbd5eac
   languageName: node
   linkType: hard
 
@@ -34395,6 +34496,15 @@ __metadata:
   dependencies:
     glob: "npm:^7.1.2"
   checksum: 10c0/6235caddf342fd04281001e6724fd302bdc77b4977bcff4d1fea8ca3539e75398b14120b48f1cf3de9a0ce35a5fa1aaf62e0e0a60e7322a1b37e772af876e19b
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.4.3
+  resolution: "ts-api-utils@npm:1.4.3"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 10c0/e65dc6e7e8141140c23e1dc94984bf995d4f6801919c71d6dc27cf0cd51b100a91ffcfe5217626193e5bea9d46831e8586febdc7e172df3f1091a7384299e23a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

clone of https://github.com/elastic/eui/pull/8198

closes #6914 

>[!NOTE]
This PR is a copy of this community PR [#8198](https://github.com/elastic/eui/pull/8198).
All relevant commits have been cherry-picked (leaving out commits that did not actually change anything or were reverted)

## Additional changes

- resolves leftover linting errors
- removes the `max-warnings` setting for eslint
- increases `max-old-space-size` for the eslint script as the current amount of warnings otherwise result in `JavaScript heap out of memory` error 🫠 

## QA

ℹ️ This PR was already QAed on the [original PR](https://github.com/elastic/eui/pull/8198).
Review is only needed for the additional changes

- [x] ci passes