### PR TITLE
[EUI+] Fix markdown link warnings

### DIFF
--- a/packages/website/docs/components/display/skeleton.mdx
+++ b/packages/website/docs/components/display/skeleton.mdx
@@ -445,7 +445,7 @@ export default () => {
 
 In scenarios where that is not the case (i.e., transitioning to loading), you can customize what statuses are announced to screen readers by setting `announceLoadingStatus` to true, or `announceLoadedStatus` to false. Submitting the below example announces a loading status, but not a loaded status.
 
-As an optional escape hatch, `ariaLiveProps` is also available and accepts any [**EuiScreenReaderLive**](../utilities/accessibility.mdx#screen-reader-live-region) props.
+As an optional escape hatch, `ariaLiveProps` is also available and accepts any [**EuiScreenReaderLive**](../utilities/accessibility/overview.mdx#screen-reader-live-region) props.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/utilities/overlay_mask.mdx
+++ b/packages/website/docs/components/utilities/overlay_mask.mdx
@@ -7,7 +7,7 @@ id: utilities_overlay_mask
 
 **EuiOverlayMask** is simply a display component used to obscure the main content to bring attention to its children or other content. It is best used in conjunction with hyper-focus content areas like [modals](../layout/modal/overview.mdx) and [flyouts](../layout/flyout/flyout.mdx).
 
-There are <a href="https://www.nngroup.com/articles/overuse-of-overlays/" target="_blank" rel="noopener noreferrer">many considerations</a> to make before choosing to use an overlay. At the very least, you must provide a visible button to close the overlay. You can also nest an [EuiFocusTrap](./focus_trap.mdx) to handle closing the overlay.
+There are <a href="https://www.nngroup.com/articles/overuse-of-overlays/" target="_blank" rel="noopener noreferrer">many considerations</a> to make before choosing to use an overlay. At the very least, you must provide a visible button to close the overlay. You can also nest an [EuiFocusTrap](./focus_trap/overview.mdx) to handle closing the overlay.
 
 <Demo>
 ```tsx interactive

--- a/packages/website/docs/components/utilities/portal.mdx
+++ b/packages/website/docs/components/utilities/portal.mdx
@@ -94,9 +94,9 @@ Custom flyouts should only be implemented if your design diverges a lot from [Eu
 
 **Here are some accessibility considerations you should keep in mind when implementing a custom flyout.**
 
-* Use [EuiFocusTrap](./focus_trap.mdx) to prevent keyboard-initiated focus from leaving the flyout.
-* If you use a [EuiOverlayMask](./overlay_mask.mdx), it should be dismissed when clicked outside. For that you can pass to your [EuiFocusTrap](./focus_trap.mdx) `onClickOutside` prop a method to close the flyout.
-* When pressing the ESC key your flyout should close. Use a [EuiWindowEvent](./window_events.mdx) to listen for the key down event.
+* Use [EuiFocusTrap](./focus_trap/overview.mdx) to prevent keyboard-initiated focus from leaving the flyout.
+* If you use a [EuiOverlayMask](./overlay_mask.mdx), it should be dismissed when clicked outside. For that you can pass to your [EuiFocusTrap](./focus_trap/overview.mdx) `onClickOutside` prop a method to close the flyout.
+* When pressing the ESC key your flyout should close. Use a [EuiWindowEvent](./window_events/overview.mdx) to listen for the key down event.
 * Pass an ID to the first heading in the flyout `id={headingId}`.
 * Pass to your [EuiPanel](../layout/panel/overview.mdx) `aria-labelledby={headingId}` to announce the flyout to screen readers.
 

--- a/packages/website/docs/components/utilities/provider.mdx
+++ b/packages/website/docs/components/utilities/provider.mdx
@@ -96,7 +96,7 @@ Any other options available with <a href="https://emotion.sh/docs/@emotion/cache
 This functionality is still currently in beta, and the list of components as well as defaults that EUI will be supporting is still under consideration. If you have a component you would like to see added, feel free to <a href="https://github.com/elastic/eui/discussions/6922" target="_blank" rel="noopener noreferrer">**discuss that request in EUI's GitHub repo**</a>.
 :::
 
-All EUI components ship with a set of baseline defaults that can usually be configured via props. For example, [EuiFocusTrap](./focus_trap.mdx) defaults to `crossFrame={false}` - i.e., it does not trap focus between iframes. If you wanted to change that behavior in your app across all instances of **EuiFocusTrap**, you would be stuck manually passing that prop over and over again, including in higher-level components (like modals, popovers, and flyouts) that utilize focus traps.
+All EUI components ship with a set of baseline defaults that can usually be configured via props. For example, [EuiFocusTrap](./focus_trap/overview.mdx) defaults to `crossFrame={false}` - i.e., it does not trap focus between iframes. If you wanted to change that behavior in your app across all instances of **EuiFocusTrap**, you would be stuck manually passing that prop over and over again, including in higher-level components (like modals, popovers, and flyouts) that utilize focus traps.
 
 **EuiProvider** allows overriding some component defaults across all component usages globally via the `componentDefaults` prop like so:
 

--- a/packages/website/docs/patterns/error_messages/error_validation.mdx
+++ b/packages/website/docs/patterns/error_messages/error_validation.mdx
@@ -46,9 +46,9 @@ Example:
 ![A red banner which reads, you must fix the following, your email must contain an @ character. The date you registered must be in the past.](./images/error-summary.webp)
 
 ### Text inputs
-Use the [EuiFieldText](../../components/forms/form_controls/overview.mdx#text-field) component and the prop `isInvalid=true` render the error styles.
+Use the [EuiFieldText](../../components/forms/text/basic.mdx) component and the prop `isInvalid=true` render the error styles.
 
-Use the [errors prop](../../components/forms/form_controls/overview.mdx#text-field) to display the error message alongside the field. Make sure the error message on the field matches the error message in the summary, so it’s obvious which field caused which error.
+Use the [errors prop](../../components/forms/text/basic.mdx) to display the error message alongside the field. Make sure the error message on the field matches the error message in the summary, so it’s obvious which field caused which error.
 
 ![A text input with the label 'Email'. An error message in red text positioned below the field reads, 'your email must contain an @ character'](./images/error-validation-text.webp)
 

--- a/packages/website/docs/patterns/help_content.mdx
+++ b/packages/website/docs/patterns/help_content.mdx
@@ -73,7 +73,7 @@ _Note: the formatting of the flyout here is just an example._
 
 
 **Interaction**
-- Use a [Flyout](../components/layout/flyout.mdx), in `push` mode if possible, as overlays can be disruptive.
+- Use a [Flyout](../components/layout/flyout/flyout.mdx), in `push` mode if possible, as overlays can be disruptive.
 - Locate the interaction to open the flyout somewhere visible and that matches with the context of the content:
   - If that is for an entire app, use the help button from the header
   - If that is for a significant section or area of the UI, use an explicit link near the top of the area or section or a button.
@@ -129,7 +129,7 @@ Providing reference docs directly in the product can help users stay focused on 
 **Interaction**
 - Use the <Icon type="documentation" title="book icon" /> icon with the `primary` color to indicate a reference. When possible, add an explicit link text.
 - Locate the interaction for opening the reference right next to or under the field, depending on the UI layout.
-- On click, a [Flyout](../components/layout/flyout.mdx) in `push` mode or a [popover](../components/layout/popover.mdx) opens.
+- On click, a [Flyout](../components/layout/flyout/flyout.mdx) in `push` mode or a [popover](../components/layout/popover.mdx) opens.
 - For popovers, clicking outside closes the help.
 - For flyouts, add an explicit Close button to the footer.
 

--- a/packages/website/docs/patterns/pre_ga_badges.mdx
+++ b/packages/website/docs/patterns/pre_ga_badges.mdx
@@ -15,7 +15,7 @@ When a feature becomes available for users before being officially Generally Ava
 
 Features don't necessarily go through each stage defined in this document. For example, it can start with Beta, or it can start with Technical preview and be announced as GA next.
 
-Such badges rely on the [Beta badge EUI component](../components/display/badge.mdx#beta-badge-type).
+Such badges rely on the [Beta badge EUI component](../components/display/badge/beta_badge.mdx).
 
 | Stage | Technical preview | Beta | GA |
 | ---- | ---- | ---- | ---- |


### PR DESCRIPTION
## Summary

I fixed all the warnings regarding redirections that Docusaurus reported except for the missing Typography page:

<img width="740" alt="Screenshot 2025-03-10 at 17 13 51" src="https://github.com/user-attachments/assets/39e3e0f9-1d16-4dc6-bb08-b374c0f80273" />

Closes #8421

## QA

- [ ] Checkout the branch and start the development server: `yarn workspace @elastic/eui-website start`, verify there are no warnings
- [ ] Verify that the links work in staging and locally
