### PR TITLE
fix(src-docs): add @elastic/eui-theme-borealis dependency

### DIFF
--- a/packages/eui/src-docs/src/components/codesandbox/link.js
+++ b/packages/eui/src-docs/src/components/codesandbox/link.js
@@ -117,6 +117,7 @@ import '@elastic/charts/dist/theme_only_${colorMode}.css';`
         content: {
           dependencies: {
             '@elastic/eui': pkg.version,
+            '@elastic/eui-theme-borealis': 'latest',
             ...[
               '@elastic/datemath',
               '@emotion/cache',
@@ -127,18 +128,10 @@ import '@elastic/charts/dist/theme_only_${colorMode}.css';`
               'react-dom',
               'react-scripts',
               ...Object.keys(mergedDeps),
-            ].reduce(
-              (out, pkg) => {
-                out[pkg] = getVersion(pkg);
-                return out;
-              },
-              {
-                // The dependency is set to `workspace` which cannot be resolved in CodeSandbox,
-                // therefore we're setting "latest"; the downside is that you have to release a new version
-                // of the package to see the changes in CodeSandbox.
-                '@elastic/eui-theme-borealis': 'latest',
-              }
-            ),
+            ].reduce((out, pkg) => {
+              out[pkg] = getVersion(pkg);
+              return out;
+            }, {}),
           },
         },
       },

--- a/packages/eui/src-docs/src/components/codesandbox/link.js
+++ b/packages/eui/src-docs/src/components/codesandbox/link.js
@@ -127,10 +127,18 @@ import '@elastic/charts/dist/theme_only_${colorMode}.css';`
               'react-dom',
               'react-scripts',
               ...Object.keys(mergedDeps),
-            ].reduce((out, pkg) => {
-              out[pkg] = getVersion(pkg);
-              return out;
-            }, {}),
+            ].reduce(
+              (out, pkg) => {
+                out[pkg] = getVersion(pkg);
+                return out;
+              },
+              {
+                // The dependency is set to `workspace` which cannot be resolved in CodeSandbox,
+                // therefore we're setting "latest"; the downside is that you have to release a new version
+                // of the package to see the changes in CodeSandbox.
+                '@elastic/eui-theme-borealis': 'latest',
+              }
+            ),
           },
         },
       },


### PR DESCRIPTION
## Summary

Codesandbox was complaining about not finding the dependency: `@elastic/eui-theme-borealis`.

The solution was pretty simple but there's one caveat. I cannot use `getVersion(pkg)` for `@elastic/eui-theme-borealis` because it'll set to `workspace:^` and that's not something that Codesandbox will be able to resolve. Therefore, `latest` seems more appropriate and maintainable.

The only downside is we won't be able to see the local changes in Codesandbox, only until we release the package. But at the same time, I don't see a way in which we **could** allow for Codesandbox to build with the local state of `@elastic/eui-theme-borealis`.

Closes #8434

## QA

- [ ] Go to the current docs, choose any component, click on "Demo JS" in one of the examples and "Try out this demo on Code Sandbox", verify the sandbox works as expected

<img width="1221" alt="Screenshot 2025-03-13 at 12 26 00" src="https://github.com/user-attachments/assets/d5e6b1bc-bcf5-484e-a160-cf02ab01de02" />
