### PR TITLE
chore(website): update README

### DIFF
--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -1,18 +1,14 @@
 # EUI documentation website
 
-This package contains sources of the upcoming new EUI documentation website
-built with [Docusaurus](https://docusaurus.io/), an open-source documentation
-platform powered by React.
+This package contains sources of the upcoming new EUI documentation website built with [Docusaurus](https://docusaurus.io/), an open-source documentation platform powered by React.
 
-This is a **private** package and is not meant to be published to npm.
-If you're looking for EUI components or utilities, check out our other [packages](../).
+This is a **private** package and is not meant to be published to npm. If you're looking for EUI components or utilities, check out our other [packages](../).
 
 ## Local development
 
 ### Prerequisites
 
-Like other packages in this repository, this package requires Node.js (check version in [.nvmrc](/.nvmrc)) 
-to be installed and [corepack](https://nodejs.org/api/corepack.html) enabled.
+Like other packages in this repository, this package requires Node.js (check version in [.nvmrc](/.nvmrc)) to be installed and [corepack](https://nodejs.org/api/corepack.html) enabled.
 
 ### Installing dependencies
 
@@ -27,56 +23,59 @@ yarn
 Before you run scripts, it's mandatory to build all local dependency packages:
 
 ```shell
-yarn workspaces foreach -Rpti --from @elastic/eui-website run build
+yarn workspace @elastic/eui-website build:workspaces
 ```
+
+This builds all EUI packages, docgen data for the prop tables and the Docusaurus theme.
 
 ### Running the development server
 
 Run a local development server with hot reloading capabilities:
 
 ```shell
-yarn start
+yarn workspace @elastic/eui-website start
 ```
 
-Please note that this command does not watch for changes in other packages' sources
-(e.g., the [theme](../docusaurus-theme) package). Please check out each package's
-README to see if watch mode is available and how to use it.
+:::warning
+This command does not watch for changes in other packages' sources (e.g., the [theme](../docusaurus-theme) package). Please check out each package's README to see if watch mode is available and how to use it.
+:::
 
 ### Building the website
 
 This step is usually unnecessary to run locally unless you're testing production builds.
 
 ```shell
-yarn build
+yarn workspace @elastic/eui-website build
 ```
 
 You can serve the built static files for local testing by running
 
 ```shell
-yarn serve
+yarn workspace @elastic/eui-website serve
 ```
 
 ### Running type checks
 
 ```shell
-yarn typecheck
+yarn workspace @elastic/eui-website typecheck
 ```
 
 ## Documentation search
 
-We use [lunr.js](https://github.com/olivernn/lunr.js) for local search
-on our documentation site. Lunr generates search indexes when the
-site is being built that we later fetch as JSON objects in runtime
-to provide users with accurate search results. This approach allows us
-to have version-specific search experience without the need to run
-a search server.
+We use [lunr.js](https://github.com/olivernn/lunr.js) for local search on our documentation site. Lunr generates search indexes when the site is being built that we later fetch as JSON objects in runtime to provide users with accurate search results. This approach allows us to have version-specific search experience without the need to run a search server.
 
-Because the search index is generated in build time, it means that
-searching is not possible when running the development server.
-Please refer to the [Building the website](#building-the-website) section
-to learn how to build the documentation site locally
-and serve it to use local search.
+Because the search index is generated in build time, it means that searching is not possible when running the development server. Please refer to the [Building the website](#building-the-website) section to learn how to build the documentation site locally and serve it to use local search.
 
 ## Links
 
 For external links, we use `<a>` tag to open them in a new tab, while for internal links (between documentation pages) we use [relative file paths](https://docusaurus.io/docs/markdown-features/links) as recommended by Docusaurus. 
+
+## Troubleshooting
+
+### The dev server failing after pushing to remote
+
+Currently, we build some dependencies on pre-push necessary to run the tests with the latest state. This can cause some build folders to be removed and the server to fail.
+
+To fix it, you have to remove all dependencies and build folders, reinstall and rebuild. You can do it with this command from the root directory:
+
+`yarn clean && yarn && yarn workspace @elastic/eui-website build:workspaces && yarn workspace @elastic/eui-website start`

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "build:workspaces": "yarn workspaces foreach -R --from @elastic/eui-website run build:workspaces && yarn workspaces foreach -Rti --from @elastic/eui-website run build",
+    "build:workspaces": "yarn workspaces foreach -Rpi --topological-dev --from @elastic/eui-website run build",
     "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider docusaurus start",
     "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Summary

I updated the README to reflect the actual steps you need to take to run EUI+.

Additionally, I updated the `build:workspaces` script to run commands in parallel and use `topological-dev` flag instead of just `topological`. Sometimes, `eui-theme-borealis` is built before `eui-theme-common` which causes the process to error out, that's because `eui-theme-common` is a peer dependency. Now, [the docs](https://yarnpkg.com/cli/workspaces/foreach#details) don't specifically mention `peerDependencies` and the [implementation](https://github.com/yarnpkg/berry/blob/3c8a90ace15092a6e51c965b3dcb5f4c6c814d6c/packages/plugin-workspace-tools/sources/commands/foreach.ts#L380-L393) does indeed use `dependencies` and `devDependencies` but with `topological-dev` the command works consistently.

Closes #8437

## QA

- [x] Check that the README changes make sense
- [x] Run `yarn workspace @elastic/eui-website build:workspaces` - it should pass successfully
- [x] CI should pass
- [x] Docs site should be built correctly