### PR TITLE
feat(eui): remove EuiLoadingChart non-mono version

### DIFF
--- a/packages/eui/changelogs/upcoming/8441.md
+++ b/packages/eui/changelogs/upcoming/8441.md
@@ -1,3 +1,3 @@
-**Deprecations**
+**Breaking changes**
 
 - Removed `EuiLoadingChart` non-mono version, removed `mono` prop

--- a/packages/eui/changelogs/upcoming/8441.md
+++ b/packages/eui/changelogs/upcoming/8441.md
@@ -1,0 +1,3 @@
+**Deprecations**
+
+- Removed `EuiLoadingChart` non-mono version, removed `mono` prop

--- a/packages/eui/src-docs/src/views/loading/loading_chart.tsx
+++ b/packages/eui/src-docs/src/views/loading/loading_chart.tsx
@@ -9,12 +9,5 @@ export default () => (
     <EuiLoadingChart size="l" />
     &nbsp;&nbsp;
     <EuiLoadingChart size="xl" />
-    <br />
-    <br />
-    <EuiLoadingChart size="m" mono />
-    &nbsp;&nbsp;
-    <EuiLoadingChart size="l" mono />
-    &nbsp;&nbsp;
-    <EuiLoadingChart size="xl" mono />
   </div>
 );

--- a/packages/eui/src-docs/src/views/loading/loading_example.tsx
+++ b/packages/eui/src-docs/src/views/loading/loading_example.tsx
@@ -107,14 +107,12 @@ export const LoadingExample = {
       text: (
         <p>
           To indicate that a visualization is loading, use{' '}
-          <strong>EuiLoadingChart</strong>. The multi-color version should be
-          used sparingly, and only when a single large visualization is being
-          loaded.
+          <strong>EuiLoadingChart</strong>.
         </p>
       ),
       props: { EuiLoadingChart },
       demo: <LoadingChart />,
-      snippet: ['<EuiLoadingChart size="m" />', '<EuiLoadingChart mono />'],
+      snippet: ['<EuiLoadingChart size="m" />', '<EuiLoadingChart />'],
       playground: loadingChartConfig,
     },
     {

--- a/packages/eui/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
+++ b/packages/eui/src/components/loading/__snapshots__/loading_chart.test.tsx.snap
@@ -8,37 +8,16 @@ exports[`EuiLoadingChart is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
-  />
-</span>
-`;
-
-exports[`EuiLoadingChart mono is rendered 1`] = `
-<span
-  aria-label="Loading"
-  class="euiLoadingChart emotion-euiLoadingChart-m"
-  role="progressbar"
->
-  <span
-    class="emotion-euiLoadingChart__bar-mono-m"
-  />
-  <span
-    class="emotion-euiLoadingChart__bar-mono-m"
-  />
-  <span
-    class="emotion-euiLoadingChart__bar-mono-m"
-  />
-  <span
-    class="emotion-euiLoadingChart__bar-mono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
 </span>
 `;
@@ -50,16 +29,16 @@ exports[`EuiLoadingChart size l is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-l"
+    class="emotion-euiLoadingChart__bar-l"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-l"
+    class="emotion-euiLoadingChart__bar-l"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-l"
+    class="emotion-euiLoadingChart__bar-l"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-l"
+    class="emotion-euiLoadingChart__bar-l"
   />
 </span>
 `;
@@ -71,16 +50,16 @@ exports[`EuiLoadingChart size m is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-m"
+    class="emotion-euiLoadingChart__bar-m"
   />
 </span>
 `;
@@ -92,16 +71,16 @@ exports[`EuiLoadingChart size xl is rendered 1`] = `
   role="progressbar"
 >
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-xl"
+    class="emotion-euiLoadingChart__bar-xl"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-xl"
+    class="emotion-euiLoadingChart__bar-xl"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-xl"
+    class="emotion-euiLoadingChart__bar-xl"
   />
   <span
-    class="emotion-euiLoadingChart__bar-nonmono-xl"
+    class="emotion-euiLoadingChart__bar-xl"
   />
 </span>
 `;

--- a/packages/eui/src/components/loading/loading_chart.stories.tsx
+++ b/packages/eui/src/components/loading/loading_chart.stories.tsx
@@ -15,7 +15,6 @@ const meta: Meta<EuiLoadingChartProps> = {
   component: EuiLoadingChart,
   args: {
     size: 'm',
-    mono: false,
   },
 };
 

--- a/packages/eui/src/components/loading/loading_chart.styles.ts
+++ b/packages/eui/src/components/loading/loading_chart.styles.ts
@@ -7,10 +7,7 @@
  */
 
 import { css, keyframes } from '@emotion/react';
-import {
-  _EuiThemeComponentColors,
-  _EuiThemeVisColors,
-} from '@elastic/eui-theme-common';
+import { _EuiThemeComponentColors } from '@elastic/eui-theme-common';
 
 import { UseEuiTheme } from '../../services';
 import {
@@ -41,19 +38,13 @@ export const euiLoadingChartStyles = ({ euiTheme }: UseEuiTheme) => ({
 export const BARS_COUNT = 4;
 
 export const euiLoadingChartBarStyles = ({ euiTheme }: UseEuiTheme) => {
-  const nonMonoColors = Object.keys(euiTheme.colors.vis).reduce(
-    (colors, cur) => {
-      const isVisColor = cur.match(/euiColorVis[0-9]/);
+  const backgroundColors = outputNthChildCss((index) => {
+    const token =
+      `loadingChartMonoBackground${index}` as keyof _EuiThemeComponentColors;
+    const color = euiTheme.components[token];
 
-      if (isVisColor) {
-        const color = euiTheme.colors.vis[cur as keyof _EuiThemeVisColors];
-        return [...colors, color];
-      }
-
-      return colors;
-    },
-    [] as string[]
-  );
+    return `background-color: ${color}`;
+  });
 
   return {
     euiLoadingChart__bar: css`
@@ -63,28 +54,13 @@ export const euiLoadingChartBarStyles = ({ euiTheme }: UseEuiTheme) => {
       ${euiCanAnimate} {
         animation: ${barAnimation} 1s infinite;
 
-        ${outputNthChildCss((index) => `animation-delay: 0.${index}s;`)}
+        ${outputNthChildCss((index) => `animation-delay: 0.${index}s`)}
       }
       ${euiCantAnimate} {
-        ${outputNthChildCss(
-          (index) => `transform: translateY(${22 * index}%);`
-        )}
+        ${outputNthChildCss((index) => `transform: translateY(${22 * index}%)`)}
       }
-    `,
-    nonmono: css`
-      ${outputNthChildCss(
-        (index) => `background-color: ${nonMonoColors[index]}`
-      )}
-    `,
-    mono: css`
-      /* stylelint-disable no-extra-semicolons */
-      ${outputNthChildCss((index) => {
-        const token =
-          `loadingChartMonoBackground${index}` as keyof _EuiThemeComponentColors;
-        const color = euiTheme.components[token];
 
-        return `background-color: ${color}`;
-      })}
+      ${backgroundColors}
     `,
     m: css`
       ${logicalCSS('width', euiTheme.size.xxs)}

--- a/packages/eui/src/components/loading/loading_chart.test.tsx
+++ b/packages/eui/src/components/loading/loading_chart.test.tsx
@@ -22,12 +22,6 @@ describe('EuiLoadingChart', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('mono is rendered', () => {
-    const { container } = render(<EuiLoadingChart mono />);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
-
   describe('size', () => {
     SIZES.forEach((size) => {
       test(`${size} is rendered`, () => {

--- a/packages/eui/src/components/loading/loading_chart.tsx
+++ b/packages/eui/src/components/loading/loading_chart.tsx
@@ -25,12 +25,10 @@ export type EuiLoadingChartSize = (typeof SIZES)[number];
 export type EuiLoadingChartProps = CommonProps &
   HTMLAttributes<HTMLDivElement> & {
     size?: EuiLoadingChartSize;
-    mono?: boolean;
   };
 
 export const EuiLoadingChart: FunctionComponent<EuiLoadingChartProps> = ({
   size = 'm',
-  mono = false,
   className,
   'aria-label': ariaLabel,
   ...rest
@@ -41,11 +39,7 @@ export const EuiLoadingChart: FunctionComponent<EuiLoadingChartProps> = ({
   const cssStyles = [styles.euiLoadingChart, styles[size]];
 
   const barStyles = useEuiMemoizedStyles(euiLoadingChartBarStyles);
-  const barCssStyles = [
-    barStyles.euiLoadingChart__bar,
-    mono ? barStyles.mono : barStyles.nonmono,
-    barStyles[size],
-  ];
+  const barCssStyles = [barStyles.euiLoadingChart__bar, barStyles[size]];
 
   const defaultAriaLabel = useLoadingAriaLabel();
 

--- a/packages/website/docs/components/display/loading.mdx
+++ b/packages/website/docs/components/display/loading.mdx
@@ -49,7 +49,7 @@ export default () => (
 
 ## Chart
 
-To indicate that a visualization is loading, use **EuiLoadingChart**. The multi-color version should be used sparingly, and only when a single large visualization is being loaded.
+To indicate that a visualization is loading, use **EuiLoadingChart**.
 
 ```tsx interactive
 import React from 'react';
@@ -62,13 +62,6 @@ export default () => (
     <EuiLoadingChart size="l" />
     &nbsp;&nbsp;
     <EuiLoadingChart size="xl" />
-    <br />
-    <br />
-    <EuiLoadingChart size="m" mono />
-    &nbsp;&nbsp;
-    <EuiLoadingChart size="l" mono />
-    &nbsp;&nbsp;
-    <EuiLoadingChart size="xl" mono />
   </div>
 );
 ```


### PR DESCRIPTION
## Summary

This PR **removes** `EuiLoadingChart` non-mono version (which is the default). I decided to **remove** instead of **deprecate** it and consulted the decision with @ek-so. We only need to update the code on the next Kibana upgrade by removing all mentions of `mono` prop. See the details below.

Closes #8275

### Impact

#### Cloud UI

There are **3 usages**, all use the **non-mono version**, they do not pass the `mono` prop, they **don't require an update**:

- `cloud-ui/apps/monolith/public/components/User/BillingUsage/components/CostsChart/index.tsx`
- `cloud-ui/apps/monolith/public/components/User/BillingUsage/components/CostsChartByInstance/index.tsx`
- `cloud-ui/apps/monolith/public/components/User/BillingUsage/components/ProductChart/index.tsx`

#### Kibana

<details><summary>24 times mono or mono={true} (requires code update)</summary>
<p>

Use regexp: `<EuiLoadingChart[^>]*\smono\s*(=\s*(\{?)\s*true\s*(\}?)\s*)?[^>]*>`

- `src/platform/packages/private/kbn-panel-loader/index.tsx`
- `src/platform/plugins/private/vis_default_editor/public/default_editor_controller.tsx`
- `src/platform/plugins/shared/dashboard/public/dashboard_renderer/grid/dashboard_grid_item.tsx`
- `src/platform/plugins/shared/vis_types/timeseries/public/application/components/timeseries_loading.tsx`
- `src/platform/plugins/shared/vis_types/timeseries/public/application/components/timeseries_visualization.tsx`
- `src/platform/plugins/shared/visualizations/public/components/visualization_container.tsx`
- `src/platform/plugins/shared/visualizations/public/embeddable/visualize_embeddable.tsx`
- `src/platform/plugins/shared/visualizations/public/legacy/embeddable/visualize_embeddable.tsx`
- `x-pack/platform/plugins/shared/aiops/public/components/mini_histogram/mini_histogram.tsx`
- `x-pack/platform/plugins/shared/dataset_quality/public/components/common/spark_plot.tsx`
- `x-pack/platform/plugins/shared/dataset_quality/public/components/dataset_quality_details/overview/document_trends/trend_docs_chart.tsx`
- `x-pack/platform/plugins/shared/ml/public/application/components/loading_indicator/loading_indicator.tsx`
- `x-pack/platform/plugins/shared/ml/public/application/explorer/swimlane_container.tsx`
- `x-pack/platform/plugins/shared/ml/public/embeddables/anomaly_charts/anomaly_charts_react_container.tsx`
- `x-pack/solutions/observability/plugins/apm/public/components/shared/charts/spark_plot/index.tsx`
- `x-pack/solutions/observability/plugins/infra/public/components/lens/chart_placeholder.tsx`
- `x-pack/solutions/observability/plugins/slo/public/components/alert_details/components/error_rate/error_rate_panel.tsx`
- `x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/wide_chart.tsx`
- `x-pack/solutions/observability/plugins/slo/public/pages/slo_details/components/events_chart_panel/events_chart_panel.tsx`
- `x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/data_preview_chart.tsx`
- `x-pack/solutions/observability/plugins/slo/public/pages/slos/components/slo_sparkline.tsx`
- `x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_pending_wrapper.tsx`
- `x-pack/solutions/observability/plugins/ux/public/components/app/rum_dashboard/visitor_breakdown/index.tsx`
- `x-pack/solutions/security/plugins/security_solution/public/management/components/console/components/command_execution_output.tsx`

</p>
</details> 

<details><summary>1 wrapper component (requires code update)</summary>
<p>

Name: `AsyncComponent`
Source: `x-pack/solutions/observability/plugins/profiling/public/components/async_component.tsx`

It uses mono version **once**:

- `x-pack/solutions/observability/plugins/profiling/public/components/stack_traces/index.tsx`: 1 mono, 1 non-mono

and non-mono version **7 times**:

- `x-pack/solutions/observability/plugins/profiling/public/components/stack_traces/index.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/views/flamegraphs/differential_flamegraphs/index.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/views/flamegraphs/flamegraph/index.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/views/functions/differential_topn/index.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/views/functions/topn/index.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/data_breakdown/index.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/views/storage_explorer/host_breakdown/index.tsx`

</p>
</details> 

<details><summary>37 times no mono prop</summary>
<p>

Use regexp: `<EuiLoadingChart(?![^>]*\smono\s*(=\s*(\{?)\s*true\s*(\}?)\s*)?)[^>]*>`

- `src/platform/packages/shared/kbn-alerts-ui-shared/src/alert_filter_controls/loading.tsx`
- `x-pack/platform/plugins/private/canvas/public/components/canvas_loading/canvas_loading.component.tsx`
- `x-pack/platform/plugins/private/data_usage/public/app/components/charts_loading.tsx`
- `x-pack/platform/plugins/private/watcher/public/application/sections/watch_edit_page/components/threshold_watch_edit/watch_visualization.tsx`
- `x-pack/platform/plugins/shared/logs_shared/public/components/loading/index.tsx`
- `x-pack/platform/plugins/shared/ml/public/application/jobs/jobs_list/components/datafeed_chart_flyout/datafeed_chart_flyout.tsx`
- `x-pack/platform/plugins/shared/stack_alerts/public/rule_types/threshold/visualization.tsx`
- `x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_lifecycle/ingestion_rate.tsx`
- `x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/alert_summary_widget/components/alert_summary_widget_loader.tsx`
- `x-pack/platform/plugins/shared/triggers_actions_ui/public/application/sections/common/components/execution_duration_chart.tsx`
- `x-pack/solutions/observability/plugins/apm/public/components/alerting/ui_components/chart_preview/chart_preview_helper.tsx`
- `x-pack/solutions/observability/plugins/apm/public/components/app/service_map/popover/stats_list.tsx`
- `x-pack/solutions/observability/plugins/apm/public/components/shared/charts/chart_container.tsx`
- `x-pack/solutions/observability/plugins/infra/public/alerting/common/criterion_preview_chart/criterion_preview_chart.tsx`
- `x-pack/solutions/observability/plugins/infra/public/components/asset_details/tabs/processes/process_row_charts.tsx`
- `x-pack/solutions/observability/plugins/infra/public/components/loading/index.tsx`
- `x-pack/solutions/observability/plugins/infra/public/pages/metrics/inventory_view/components/timeline/timeline.tsx`
- `x-pack/solutions/observability/plugins/observability/public/components/custom_threshold/components/criterion_preview_chart/criterion_preview_chart.tsx`
- `x-pack/solutions/observability/plugins/observability/public/pages/overview/components/chart_container/chart_container.tsx`
- `x-pack/solutions/observability/plugins/observability/public/pages/overview/components/sections/metrics/metrics_section.tsx`
- `x-pack/solutions/observability/plugins/profiling/public/embeddables/async_embeddable_component.tsx`
- `x-pack/solutions/observability/plugins/slo/public/components/slo/simple_burn_rate/burn_rate.tsx`
- `x-pack/solutions/observability/plugins/slo/public/embeddable/slo/burn_rate/burn_rate.tsx`
- `x-pack/solutions/observability/plugins/slo/public/embeddable/slo/error_budget/error_budget_burn_down.tsx`
- `x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview.tsx`
- `x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/common/charts/chart_wrapper/chart_wrapper.tsx`
- `x-pack/solutions/observability/plugins/uptime/public/legacy_uptime/components/monitor/synthetics/step_detail/waterfall/waterfall_chart_container.tsx`
- `x-pack/solutions/observability/plugins/ux/public/components/app/rum_dashboard/chart_wrapper/index.tsx`
- `x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_collection_view/analytics_collection_overview/analytics_collection_chart.tsx`
- `x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_collection_card/analytics_collection_card.test.tsx`
- `x-pack/solutions/search/plugins/enterprise_search/public/applications/analytics/components/analytics_overview/analytics_collection_card/analytics_collection_card.tsx`
- `x-pack/solutions/security/plugins/cloud_security_posture/public/components/chart_panel.tsx`
- `x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/top_assets_bar_chart.tsx`
- `x-pack/solutions/security/plugins/security_solution/public/asset_inventory/components/filters/filters_loading.tsx`

Out of regexp:

- `x-pack/solutions/security/plugins/security_solution/public/detection_engine/rule_creation_ui/components/rule_preview/loading_histogram.tsx` (styled-component override)
- `x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/step_details_page/step_waterfall_chart/waterfall/waterfall_chart_container.tsx` (multiline)

</p>
</details> 

## QA

- [ ] Check the example in [the current docs](https://eui.elastic.co/pr_8441/#/display/loading#chart)
- [ ] Check the example in [the EUI+ docs](https://eui.elastic.co/pr_8441/new-docs/docs/display/loading/#chart)
- [ ] There are no linting errors
- [ ] The tests for `EuiLoadingChart` pass
