### PR TITLE
[EuiPageHeader] Style updates

### DIFF
--- a/packages/eui/changelogs/upcoming/8445.md
+++ b/packages/eui/changelogs/upcoming/8445.md
@@ -1,0 +1,1 @@
+- Updated title, description, and tab sizes in `EuiPageHeader`

--- a/packages/eui/src-docs/src/components/guide_section/_guide_section.scss
+++ b/packages/eui/src-docs/src/components/guide_section/_guide_section.scss
@@ -1,3 +1,7 @@
+.guideSectionTabs__pageHeader h1 {
+  @include euiFontSizeXXL;
+}
+
 .guideSection__tableCodeBlock {
   padding-left: $euiSizeXS;
   padding-right: $euiSizeXS;

--- a/packages/eui/src-docs/src/components/guide_tabbed_page/guide_tabbed_page.tsx
+++ b/packages/eui/src-docs/src/components/guide_tabbed_page/guide_tabbed_page.tsx
@@ -209,6 +209,7 @@ export const GuideTabbedPage: FunctionComponent<GuideTabbedPageProps> = ({
     <>
       {renderNotice()}
       <EuiPageHeader
+        className="guideSectionTabs__pageHeader"
         restrictWidth
         paddingSize="l"
         pageTitle={

--- a/packages/eui/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/packages/eui/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -32,13 +32,13 @@ exports[`EuiPageHeader props alignItems bottom is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
       >
         <h1
-          class="euiTitle emotion-euiTitle-l"
+          class="euiTitle emotion-euiTitle-m"
         >
           Page title
         </h1>
       </div>
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -74,13 +74,13 @@ exports[`EuiPageHeader props alignItems center is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
       >
         <h1
-          class="euiTitle emotion-euiTitle-l"
+          class="euiTitle emotion-euiTitle-m"
         >
           Page title
         </h1>
       </div>
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -116,13 +116,13 @@ exports[`EuiPageHeader props alignItems stretch is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
       >
         <h1
-          class="euiTitle emotion-euiTitle-l"
+          class="euiTitle emotion-euiTitle-m"
         >
           Page title
         </h1>
       </div>
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -158,13 +158,13 @@ exports[`EuiPageHeader props alignItems top is rendered 1`] = `
         class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
       >
         <h1
-          class="euiTitle emotion-euiTitle-l"
+          class="euiTitle emotion-euiTitle-m"
         >
           Page title
         </h1>
       </div>
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+        class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
       >
         <div
           class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -276,7 +276,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
       >
         <h1
           aria-label="aria-label"
-          class="euiTitle testClass1 testClass2 emotion-euiTitle-l-euiTestCss"
+          class="euiTitle testClass1 testClass2 emotion-euiTitle-m-euiTestCss"
           data-test-subj="test subject string"
         >
           <span
@@ -292,7 +292,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           class="euiSpacer euiSpacer--l emotion-euiSpacer-l"
         />
         <div
-          class="euiText emotion-euiText-constrainedWidth-m"
+          class="euiText emotion-euiText-constrainedWidth-s"
         >
           <p>
             Description
@@ -307,7 +307,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
       </div>
       <div
         aria-label="aria-label"
-        class="euiFlexGroup testClass1 testClass2 emotion-euiFlexGroup-responsive-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems-euiTestCss"
+        class="euiFlexGroup testClass1 testClass2 emotion-euiFlexGroup-responsive-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems-euiTestCss"
         data-test-subj="test subject string"
       >
         <div
@@ -334,7 +334,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
       />
       <div
         aria-label="aria-label"
-        class="euiTabs testClass1 testClass2 emotion-euiTabs-l-euiTestCss"
+        class="euiTabs testClass1 testClass2 emotion-euiTabs-m-euiTestCss"
         data-test-subj="test subject string"
         role="tablist"
       >
@@ -346,7 +346,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           type="button"
         >
           <span
-            class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
           >
             Tab 1
           </span>
@@ -359,7 +359,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           type="button"
         >
           <span
-            class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
           >
             Tab 2
           </span>

--- a/packages/eui/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/packages/eui/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -27,13 +27,13 @@ exports[`EuiPageHeaderContent props alignItems bottom is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         Page title
       </h1>
     </div>
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -65,13 +65,13 @@ exports[`EuiPageHeaderContent props alignItems center is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         Page title
       </h1>
     </div>
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -103,13 +103,13 @@ exports[`EuiPageHeaderContent props alignItems stretch is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         Page title
       </h1>
     </div>
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -141,13 +141,13 @@ exports[`EuiPageHeaderContent props alignItems top is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         Page title
       </h1>
     </div>
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -258,7 +258,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         Page title
       </h1>
@@ -268,7 +268,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
       Child
     </div>
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -293,7 +293,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
       class="euiSpacer euiSpacer--l emotion-euiSpacer-l"
     />
     <div
-      class="euiTabs emotion-euiTabs-l"
+      class="euiTabs emotion-euiTabs-m"
       role="tablist"
     >
       <button
@@ -304,7 +304,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
         type="button"
       >
         <span
-          class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
+          class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
         >
           Tab 1
         </span>
@@ -317,7 +317,7 @@ exports[`EuiPageHeaderContent props children is rendered even if content props a
         type="button"
       >
         <span
-          class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
+          class="euiTab__content eui-textTruncate emotion-euiTab__content-m"
         >
           Tab 2
         </span>
@@ -338,7 +338,7 @@ exports[`EuiPageHeaderContent props description is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <div
-        class="euiText emotion-euiText-constrainedWidth-m"
+        class="euiText emotion-euiText-constrainedWidth-s"
       >
         <p>
           Description
@@ -360,7 +360,7 @@ exports[`EuiPageHeaderContent props pageTitle is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         Page title
       </h1>
@@ -380,7 +380,7 @@ exports[`EuiPageHeaderContent props pageTitle is rendered with icon 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         <span
           class="emotion-euiPageHeaderContent__titleIcon"
@@ -404,7 +404,7 @@ exports[`EuiPageHeaderContent props pageTitle is rendered with icon and iconProp
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     >
       <h1
-        class="euiTitle emotion-euiTitle-l"
+        class="euiTitle emotion-euiTitle-m"
       >
         <span
           class="testClass1 testClass2 emotion-euiPageHeaderContent__titleIcon-euiTestCss"
@@ -432,7 +432,7 @@ exports[`EuiPageHeaderContent props pageTitle is rendered with pageTitleProps 1`
     >
       <h1
         aria-label="aria-label"
-        class="euiTitle testClass1 testClass2 emotion-euiTitle-l-euiTestCss"
+        class="euiTitle testClass1 testClass2 emotion-euiTitle-m-euiTestCss"
         data-test-subj="test subject string"
       >
         Page title
@@ -481,7 +481,7 @@ exports[`EuiPageHeaderContent props rightSideItems is rendered 1`] = `
       class="euiFlexItem emotion-euiFlexItem-grow-2-euiPageHeaderContent__leftSideItems"
     />
     <div
-      class="euiFlexGroup emotion-euiFlexGroup-wrap-l-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
+      class="euiFlexGroup emotion-euiFlexGroup-wrap-m-flexStart-stretch-row-euiPageHeaderContent__rightSideItems"
     >
       <div
         class="euiFlexItem emotion-euiFlexItem-growZero-euiPageHeaderContent__rightSideItem"
@@ -514,7 +514,7 @@ exports[`EuiPageHeaderContent props rightSideItems is rendered with rightSideGro
     />
     <div
       aria-label="aria-label"
-      class="euiFlexGroup testClass1 testClass2 emotion-euiFlexGroup-wrap-l-flexStart-stretch-column-euiPageHeaderContent__rightSideItems-euiTestCss"
+      class="euiFlexGroup testClass1 testClass2 emotion-euiFlexGroup-wrap-m-flexStart-stretch-column-euiPageHeaderContent__rightSideItems-euiTestCss"
       data-test-subj="test subject string"
     >
       <div
@@ -552,7 +552,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
         Tab 1
       </h1>
       <div
-        class="euiTabs emotion-euiTabs-xl"
+        class="euiTabs emotion-euiTabs-l"
         role="tablist"
       >
         <button
@@ -563,7 +563,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
           >
             Tab 1
           </span>
@@ -576,7 +576,7 @@ exports[`EuiPageHeaderContent props tabs is rendered 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
           >
             Tab 2
           </span>
@@ -604,7 +604,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
       </h1>
       <div
         aria-label="aria-label"
-        class="euiTabs testClass1 testClass2 emotion-euiTabs-xl-euiTestCss"
+        class="euiTabs testClass1 testClass2 emotion-euiTabs-l-euiTestCss"
         data-test-subj="test subject string"
         role="tablist"
       >
@@ -616,7 +616,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
           >
             Tab 1
           </span>
@@ -629,7 +629,7 @@ exports[`EuiPageHeaderContent props tabs is rendered with tabsProps 1`] = `
           type="button"
         >
           <span
-            class="euiTab__content eui-textTruncate emotion-euiTab__content-xl"
+            class="euiTab__content eui-textTruncate emotion-euiTab__content-l"
           >
             Tab 2
           </span>

--- a/packages/eui/src/components/page/page_header/page_header_content.tsx
+++ b/packages/eui/src/components/page/page_header/page_header_content.tsx
@@ -257,7 +257,7 @@ export const EuiPageHeaderContent: FunctionComponent<
       iconProps?.css,
     ];
     const icon = iconType ? (
-      <EuiIcon size="xl" {...iconProps} css={iconCssStyles} type={iconType} />
+      <EuiIcon size="l" {...iconProps} css={iconCssStyles} type={iconType} />
     ) : undefined;
 
     pageTitleNode = (

--- a/packages/eui/src/components/page/page_header/page_header_content.tsx
+++ b/packages/eui/src/components/page/page_header/page_header_content.tsx
@@ -236,7 +236,7 @@ export const EuiPageHeaderContent: FunctionComponent<
     descriptionNode = (
       <>
         {(pageTitle || tabs) && <EuiSpacer />}
-        <EuiText grow={false}>
+        <EuiText grow={false} size="s">
           <p>{description}</p>
         </EuiText>
       </>
@@ -261,7 +261,7 @@ export const EuiPageHeaderContent: FunctionComponent<
     ) : undefined;
 
     pageTitleNode = (
-      <EuiTitle {...pageTitleProps} size="l">
+      <EuiTitle {...pageTitleProps} size="m">
         <h1>
           {icon}
           {pageTitle}
@@ -272,7 +272,7 @@ export const EuiPageHeaderContent: FunctionComponent<
 
   let tabsNode;
   if (tabs) {
-    const tabsSize: EuiTabsProps['size'] = pageTitle ? 'l' : 'xl';
+    const tabsSize: EuiTabsProps['size'] = pageTitle ? 'm' : 'l';
 
     const renderTabs = () => {
       return tabs.map((tab, index) => {
@@ -379,7 +379,7 @@ export const EuiPageHeaderContent: FunctionComponent<
 
     rightSideFlexItem = (
       <EuiFlexGroup
-        gutterSize="l"
+        gutterSize="m"
         responsive={false}
         wrap
         {...rightSideGroupProps}


### PR DESCRIPTION
Related to https://github.com/elastic/eui/discussions/8425#discussion-8061920

> [!IMPORTANT]
> This will be shared as a POC prior to review/merge

## Summary

The now-previous theme, Amsterdam, brought a larger base font size with noticeably heavy titles. Some of these aspects were baked directly into the `EuiPageHeader`.

1. Tone down some hallmark elements of Amsterdam
2. Fix spacing between right side items

--------

### Changes

#### For item 1
- Decrease title size (and associated icon)
- Decrease description size
- Decrease tabs size

<img width="420" src="https://github.com/user-attachments/assets/f453bdc3-e7a1-4607-acd7-a8b83da4f040" />


#### For item 2
- Gutter size reduced on right-side items to match the original design as long seen in the Figma component.

<img width="420" src="https://github.com/user-attachments/assets/4703b073-4e3d-4814-905f-7af5d45655d4" />

--------

### EUI docs

> [!NOTE]
> The current EUI docs site uses the page header component.

This PR contains a style override that preserves visual hierarchy of headings in the EUI docs site. The style override results in no visual changes to longtime users of the current docs site (i.e. title font size remains `30px`).

Alternatively, I considered reworking all the 'guidelines' titles - downsizing each - but decided against this given the imminent switchover to EUI+.

<img width="320" src="https://github.com/user-attachments/assets/47b6c098-0c9d-497d-917b-54ca9e22b5fe" />

--------

### XL tabs

> [!NOTE]
> It is likely we will deprecate/downsize `xl` tabs, separately.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
