### PR TITLE
fix(website): add patch for infima v0.2.0-alpha.45 to update table styles

### DIFF
--- a/.yarn/patches/infima-npm-0.2.0-alpha.45-b8be224960.patch
+++ b/.yarn/patches/infima-npm-0.2.0-alpha.45-b8be224960.patch
@@ -1,0 +1,59 @@
+diff --git a/dist/css/default/default.css b/dist/css/default/default.css
+index acdcc4b48663e497ce0610789d16b9037c9d361a..8e0f7ecb999e3c3b4ee8d9b4a3e60b568b0637fc 100644
+--- a/dist/css/default/default.css
++++ b/dist/css/default/default.css
+@@ -1165,54 +1165,6 @@ ol ol ol {
+   list-style-type: lower-alpha;
+ }
+ 
+-/**
+- * Copyright (c) Facebook, Inc. and its affiliates.
+- *
+- * This source code is licensed under the MIT license found in the
+- * LICENSE file in the root directory of this source tree.
+- */
+-
+-table {
+-  border-collapse: collapse;
+-  display: block;
+-  margin-bottom: var(--ifm-spacing-vertical);
+-  overflow: auto;
+-}
+-
+-table thead tr {
+-    border-bottom: 2px solid var(--ifm-table-border-color);
+-  }
+-
+-table thead {
+-    background-color: var(--ifm-table-stripe-background);
+-  }
+-
+-table tr {
+-    background-color: var(--ifm-table-background);
+-    border-top: var(--ifm-table-border-width) solid
+-      var(--ifm-table-border-color);
+-  }
+-
+-table tr:nth-child(2n) {
+-    background-color: var(--ifm-table-stripe-background);
+-  }
+-
+-table th,
+-  table td {
+-    border: var(--ifm-table-border-width) solid var(--ifm-table-border-color);
+-    padding: var(--ifm-table-cell-padding);
+-  }
+-
+-table th {
+-    background-color: var(--ifm-table-head-background);
+-    color: var(--ifm-table-head-color);
+-    font-weight: var(--ifm-table-head-font-weight);
+-  }
+-
+-table td {
+-    color: var(--ifm-table-cell-color);
+-  }
+-
+ /**
+  * Copyright (c) Facebook, Inc. and its affiliates.
+  *

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "jsdom": "24.1.0",
     "@types/jsdom@npm:^20.0.0": "patch:@types/jsdom@npm%3A20.0.1#~/.yarn/patches/@types-jsdom-npm-20.0.1-5bb899e006.patch",
     "infima@npm:0.2.0-alpha.43": "patch:infima@npm%3A0.2.0-alpha.43#~/.yarn/patches/infima-npm-0.2.0-alpha.43-8d3b77b44d.patch",
-    "infima@npm:0.2.0-alpha.44": "patch:infima@npm%3A0.2.0-alpha.44#~/.yarn/patches/infima-npm-0.2.0-alpha.44-145834fad0.patch"
+    "infima@npm:0.2.0-alpha.44": "patch:infima@npm%3A0.2.0-alpha.44#~/.yarn/patches/infima-npm-0.2.0-alpha.44-145834fad0.patch",
+    "infima@npm:0.2.0-alpha.45": "patch:infima@npm%3A0.2.0-alpha.45#~/.yarn/patches/infima-npm-0.2.0-alpha.45-b8be224960.patch"
   },
   "packageManager": "yarn@4.6.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23407,6 +23407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"infima@patch:infima@npm%3A0.2.0-alpha.45#~/.yarn/patches/infima-npm-0.2.0-alpha.45-b8be224960.patch":
+  version: 0.2.0-alpha.45
+  resolution: "infima@patch:infima@npm%3A0.2.0-alpha.45#~/.yarn/patches/infima-npm-0.2.0-alpha.45-b8be224960.patch::version=0.2.0-alpha.45&hash=710350"
+  checksum: 10c0/b782eca8dcef067acb8b00bfa0e123ab7cbfe6581bcf24e9949c72daae6da66e4adb5a6853ab732a31a77921d2b93472d91fcb489373e484cea65c2fbf8d5c86
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"


### PR DESCRIPTION
## Summary

Recently, we've [updated the Docusaurus packages](https://github.com/elastic/eui/pull/8423). After the update, the tables were incorrectly styled:

![image](https://github.com/user-attachments/assets/9095b787-f977-42b7-a359-164adb3484ad)

The reason is because infima package has been updated from `0.2.0-alpha.44` to `0.2.0-alpha.45` and [our previous patch](https://github.com/elastic/eui/pull/8095/files#diff-35fa3084585a9993b5c782616d59eb06ff6a53db38e4bacdc5a4c36be101467c) (removing styles targeting `table`) wasn't in effect anymore.

**After the patch**, the Infima styles no longer affect the tables:

![Screenshot 2025-03-17 at 11 29 07](https://github.com/user-attachments/assets/4bee08ca-1cea-4960-82c4-d14c5ae2ec90)

Closes #8438

## QA

> [!TIP]
>  In case the Webpack is throwing an error, run `yarn clean && yarn && yarn workspace @elastic/eui-website build:workspaces && yarn workspace @elastic/eui-website start`. Usually, this resolves all issues.

- [ ] Visit the new docs and verify the tables are styled correctly
