### PR TITLE
feat(website): add data vis tokens section to Colors page

### DIFF
--- a/packages/website/docs/components/theming/colors/data_vis_colors_table.tsx
+++ b/packages/website/docs/components/theming/colors/data_vis_colors_table.tsx
@@ -1,0 +1,133 @@
+import { EuiCode, EuiSpacer, EuiText, useEuiTheme } from '@elastic/eui';
+import { ColorsTable } from './colors_table';
+
+export const DataVisColorsTable = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <EuiSpacer />
+      <EuiText>
+        <p>
+          The following colors are color-blind safe and should be used in
+          categorically seried visualizations and graphics. They are meant to be
+          contrasted against the value of{' '}
+          <EuiCode>
+            {euiTheme.themeName === 'EUI_THEME_AMSTERDAM'
+              ? 'colors.emptyShade'
+              : 'colors.backgroundBasePlain'}
+          </EuiCode>{' '}
+          for the current theme.
+        </p>
+      </EuiText>
+      <EuiSpacer />
+      <ColorsTable
+        colors={[
+          {
+            value: euiTheme.colors.vis.euiColorVis0,
+            token: 'colors.vis.euiColorVis0',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis1,
+            token: 'colors.vis.euiColorVis1',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis2,
+            token: 'colors.vis.euiColorVis2',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis3,
+            token: 'colors.vis.euiColorVis3',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis4,
+            token: 'colors.vis.euiColorVis4',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis5,
+            token: 'colors.vis.euiColorVis5',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis6,
+            token: 'colors.vis.euiColorVis6',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis7,
+            token: 'colors.vis.euiColorVis7',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis8,
+            token: 'colors.vis.euiColorVis8',
+          },
+          {
+            value: euiTheme.colors.vis.euiColorVis9,
+            token: 'colors.vis.euiColorVis9',
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+export const DataVisColorsBehindTextColorsTable = () => {
+  const { euiTheme } = useEuiTheme();
+
+  if (euiTheme.themeName === 'EUI_THEME_AMSTERDAM')
+    return (
+      <>
+        <EuiSpacer />
+        <EuiText>
+          <p>
+            When using the palette as a background for text (i.e. badges), use
+            the <EuiCode>BehindText</EuiCode> variant. It is a brightened
+            version of the base palette to create better contrast with text.
+          </p>
+        </EuiText>
+        <EuiSpacer />
+        <ColorsTable
+          colors={[
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText0,
+              token: 'colors.vis.euiColorVisBehindText0',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText1,
+              token: 'colors.vis.euiColorVisBehindText1',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText2,
+              token: 'colors.vis.euiColorVisBehindText2',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText3,
+              token: 'colors.vis.euiColorVisBehindText3',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText4,
+              token: 'colors.vis.euiColorVisBehindText4',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText5,
+              token: 'colors.vis.euiColorVisBehindText5',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText6,
+              token: 'colors.vis.euiColorVisBehindText6',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText7,
+              token: 'colors.vis.euiColorVisBehindText7',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText8,
+              token: 'colors.vis.euiColorVisBehindText8',
+            },
+            {
+              value: euiTheme.colors.vis.euiColorVisBehindText9,
+              token: 'colors.vis.euiColorVisBehindText9',
+            },
+          ]}
+        />
+      </>
+    );
+};

--- a/packages/website/docs/components/theming/colors/values.mdx
+++ b/packages/website/docs/components/theming/colors/values.mdx
@@ -3,6 +3,8 @@ slug: /theming/colors
 id: theming_colors
 ---
 
+import { EuiSpacer, EuiCodeBlock } from '@elastic/eui';
+
 # Colors
 
 Elastic UI builds with a color palette that is based on predefined 14-step scales for a core set of three colors (blue / teal / pink) as well as a green / yellow / red qualitative set and combined with a 28-step grayscale. 
@@ -14,11 +16,9 @@ When switching between light and dark color modes, the theme keys do not change,
 
 Elastic has two main brand colors. The other three are used for statefulness like indicating between successful and dangerous actions.
 
-```mdx-code-block
 import { Example } from '@site/src/components';
 import { BrandColorPreview } from './brand_color_preview';
 import { BrandColorsTable } from './brand_colors_table';
-```
 
 <Example>
   <Example.Description>
@@ -38,7 +38,7 @@ import { BrandColorsTable } from './brand_colors_table';
   </Example.Snippet>
 </Example>
 
-<br />
+<EuiSpacer />
 
 <BrandColorsTable />
 
@@ -46,10 +46,8 @@ import { BrandColorsTable } from './brand_colors_table';
 
 Each brand color also has a corresponding text variant that should be used specifically when coloring text. As is used in [**EuiTextColor**](/docs/display/text#coloring-text).
 
-```mdx-code-block
 import { TextColorPreview } from './text_color_preview';
 import { TextColorsTable } from './text_colors_table';
-```
 
 <Example>
   <Example.Description>
@@ -69,7 +67,7 @@ import { TextColorsTable } from './text_colors_table';
   </Example.Snippet>
 </Example>
 
-<br />
+<EuiSpacer />
 
 <TextColorsTable />
 
@@ -79,10 +77,8 @@ Semantic background colors. These should be used according to their semantic pur
 
 If a border is needed use the semantically related border color, e.g. `backgroundBasePrimary` with `borderBasePrimary`.
 
-```mdx-code-block
 import { BackgroundColorPreview } from './background_color_preview';
 import { BackgroundColorsTable } from './background_colors_table';
-```
 
 <Example>
   <Example.Description>
@@ -100,7 +96,7 @@ import { BackgroundColorsTable } from './background_colors_table';
   </Example.Snippet>
 </Example>
 
-<br />
+<EuiSpacer />
 
 <BackgroundColorsTable />
 
@@ -111,10 +107,8 @@ Semantic border colors. These should be used according to their semantic purpose
 The default border color (used as `border.color`) `borderBaseSubdued`.
 Use the `base` border colors for most cases. Use `borderBasePlain` for a slightly stronger border (e.g. for forms).
 
-```mdx-code-block
 import { BorderColorPreview } from './border_color_preview';
 import { BorderColorsTable } from './border_colors_table';
-```
 
 <Example>
   <Example.Description>
@@ -140,10 +134,8 @@ import { BorderColorsTable } from './border_colors_table';
 
 A six-color grayscale palette. Variation beyond these colors is minimal and always done through computations against this set.
 
-```mdx-code-block
 import { ShadeColorPreview } from './shade_color_preview';
 import { ShadeColorsTable } from './shade_colors_table';
-```
 
 <Example>
   <Example.Description>
@@ -165,7 +157,7 @@ import { ShadeColorsTable } from './shade_colors_table';
   </Example.Snippet>
 </Example>
 
-<br />
+<EuiSpacer />
 
 <ShadeColorsTable />
 
@@ -173,10 +165,8 @@ import { ShadeColorsTable } from './shade_colors_table';
 
 These are used a lot for special cases.
 
-```mdx-code-block
 import { SpecialColorsPreview } from './special_colors_preview';
 import { SpecialColorsTable } from './special_colors_table';
-```
 
 <Example>
   <Example.Description>
@@ -197,6 +187,15 @@ import { SpecialColorsTable } from './special_colors_table';
   </Example.Snippet>
 </Example>
 
-<br />
+<EuiSpacer />
 
 <SpecialColorsTable />
+
+## Data visualization colors
+
+import { DataVisColorsTable, DataVisColorsBehindTextColorsTable } from './data_vis_colors_table';
+
+### `euiTheme.colors.vis[token]` <Badge color="hollow">token</Badge>
+
+<DataVisColorsTable />
+<DataVisColorsBehindTextColorsTable />


### PR DESCRIPTION
## Summary

We are moving away from supporting SCSS in the direction of Emotion, therefore any mentions of SCSS should be removed in the new docs. In case somebody needs to check SCSS variables, they can go back in docs version.

There was a section in the [Utilities > Color palettes](https://eui.elastic.co/#/utilities/color-palettes#sass-variables) page called "Sass variables" that enumerated the data vis "tokens". We don't have an equivalent section in the Theming > Colors page. This PR adds the section.

Closes #8340

### Amsterdam

| Light mode | Dark mode |
| ----------- | ----------- |
| ![Screenshot 2025-03-19 at 11 58 26](https://github.com/user-attachments/assets/1228cb6f-4b7c-4bb6-adeb-0c9f973f9456) | ![Screenshot 2025-03-19 at 11 58 20](https://github.com/user-attachments/assets/ba8c450a-dab9-4523-9210-57e951d30ca1) |

### Borealis

| Light mode | Dark mode |
| ----------- | ----------- |
| ![Screenshot 2025-03-19 at 11 57 49](https://github.com/user-attachments/assets/26a371ec-92ac-4848-b1f9-c41f34bb1250) | ![Screenshot 2025-03-19 at 11 58 01](https://github.com/user-attachments/assets/c7ff342d-d4ce-41f4-ad3d-3ff0694e1724) |

## QA

- [ ] Check mobile responsiveness in:
  - [ ] Amsterdam
  - [ ] Borealis
- [ ] Check the colors, values and copy accuracy in:
  - [ ] Amsterdam light mode
  - [ ] Amsterdam dark mode
  - [ ] Borealis light mode
  - [ ] Borealis dark mode
