### PR TITLE
fix(website): fix broken homepage links

### DIFF
--- a/packages/website/src/components/homepage/header/index.tsx
+++ b/packages/website/src/components/homepage/header/index.tsx
@@ -8,7 +8,6 @@ import {
   EuiDescriptionList,
   EuiDescriptionListDescription,
   EuiDescriptionListTitle,
-  EuiIcon,
   EuiLink,
   useEuiMemoizedStyles,
   UseEuiTheme,
@@ -131,12 +130,12 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
         block-size: ${form.controlHeight};
       }
 
-      // overwrride original header use case behavior
+      // override original header use case behavior
       .ds-dropdown-menu {
         position: absolute !important;
 
         &:before {
-          left: ${euiTheme.size.xl}; // align carret with search input
+          left: ${euiTheme.size.xl}; // align caret with search input
         }
       }
     `,
@@ -184,11 +183,11 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
         right: 0;
         bottom: 0;
         overflow: hidden;
+        z-index: -1;
       `,
       decor: css`
         position: absolute;
         top: 0;
-        z-index: -1;
         block-size: 100%;
         inline-size: 15%;
 
@@ -246,13 +245,23 @@ export function HomepageHeader() {
             </NavbarSearch>
           </div>
           <div css={styles.actions}>
-            <EuiButton href="/docs" fill css={styles.button}>
+            <EuiButton
+              href="/docs/guidelines/getting-started"
+              fill
+              css={styles.button}
+            >
               Get started
             </EuiButton>
-            <EuiLink href="https://github.com/elastic/eui/tree/main/packages/eui/changelogs">
+            <EuiLink
+              href="https://github.com/elastic/eui/tree/main/packages/eui/changelogs"
+              target="_blank"
+            >
               What's new?
             </EuiLink>
-            <EuiLink href="https://github.com/elastic/eui/tree/main/wiki/contributing-to-eui">
+            <EuiLink
+              href="https://github.com/elastic/eui/tree/main/wiki/contributing-to-eui"
+              target="_blank"
+            >
               Contribute
             </EuiLink>
           </div>

--- a/packages/website/src/components/homepage/header/index.tsx
+++ b/packages/website/src/components/homepage/header/index.tsx
@@ -246,7 +246,7 @@ export function HomepageHeader() {
           </div>
           <div css={styles.actions}>
             <EuiButton
-              href="/docs/guidelines/getting-started"
+              href="./docs/guidelines/getting-started"
               fill
               css={styles.button}
             >

--- a/packages/website/src/components/homepage/highlights/index.tsx
+++ b/packages/website/src/components/homepage/highlights/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Heading from '@theme/Heading';
 import {
   EuiButtonEmpty,
@@ -56,7 +57,7 @@ const CONTENT_DATA = [
   },
   {
     title: 'Forms',
-    href: '/docs/components/form-controls',
+    href: '/docs/forms/text/',
     svg: SvgForm,
     description: 'Inputs with validation, grouped into a flexible form layout',
   },
@@ -101,7 +102,7 @@ const CONTENT_DATA = [
   },
   {
     title: 'Table',
-    href: '/docs/components/table',
+    href: '/docs/tabular-content/tables',
     svg: SvgTable,
     description:
       'Flexible tables with sorting, pagination, selection and actions',
@@ -263,7 +264,7 @@ export const HomepageHighlights = () => {
         </ul>
 
         <div css={styles.actions}>
-          <EuiButtonEmpty href="/docs/components/" css={styles.button}>
+          <EuiButtonEmpty href="/docs/guidelines/getting-started/" css={styles.button}>
             All components
             <EuiIcon type="sortRight" size="s" css={styles.icon} />
           </EuiButtonEmpty>

--- a/packages/website/src/components/homepage/highlights/index.tsx
+++ b/packages/website/src/components/homepage/highlights/index.tsx
@@ -29,80 +29,80 @@ import SvgTable from './svg/table.svg';
 const CONTENT_DATA = [
   {
     title: 'Flexible layout',
-    href: '/docs/layout/flex',
+    href: './docs/layout/flex',
     svg: SvgFlex,
     description:
       'Flex groups, grids, panels and items to build responsive page layout',
   },
   {
     title: 'Spacer',
-    href: '/docs/layout/spacer/',
+    href: './docs/layout/spacer/',
     svg: SvgSpacer,
     description:
       'Component with strictly defined height to organise content blocks',
   },
   {
     title: 'Text',
-    href: '/docs/display/text',
+    href: './docs/display/text',
     svg: SvgText,
     description:
       'Simple HTML text like paragraphs or lists, wrapped in a single component',
   },
   {
     title: 'Title',
-    href: '/docs/display/title',
+    href: './docs/display/title',
     svg: SvgTitle,
     description:
       'Component for styling the page, section, and content headings',
   },
   {
     title: 'Forms',
-    href: '/docs/forms/text/',
+    href: './docs/forms/text/',
     svg: SvgForm,
     description: 'Inputs with validation, grouped into a flexible form layout',
   },
   {
     title: 'Button',
-    href: '/docs/navigation/button',
+    href: './docs/navigation/button',
     svg: SvgButton,
     description:
       'Variety of buttons and button groups with different styles and colours',
   },
   {
     title: 'Link',
-    href: '/docs/navigation/link',
+    href: './docs/navigation/link',
     svg: SvgLink,
     description: 'Component designed to display nicely within a block of text',
   },
   {
     title: 'Tooltip',
-    href: '/docs/display/tooltip',
+    href: './docs/display/tooltip',
     svg: SvgTooltip,
     description:
       'Contextual information hint with flexible positioning and behavior',
   },
   {
     title: 'Panel',
-    href: '/docs/layout/panel',
+    href: './docs/layout/panel',
     svg: SvgPanel,
     description: 'Layout helper, commonly used as a base for other components',
   },
   {
     title: 'Callout',
-    href: '/docs/display/callout',
+    href: './docs/display/callout',
     svg: SvgCallout,
     description: 'Important message directly related to content on the page',
   },
   {
     title: 'Card',
-    href: '/docs/display/card',
+    href: './docs/display/card',
     svg: SvgCard,
     description:
       'Vertical or horizontal cards, containing any custom components needed',
   },
   {
     title: 'Table',
-    href: '/docs/tabular-content/tables',
+    href: './docs/tabular-content/tables',
     svg: SvgTable,
     description:
       'Flexible tables with sorting, pagination, selection and actions',
@@ -264,7 +264,7 @@ export const HomepageHighlights = () => {
         </ul>
 
         <div css={styles.actions}>
-          <EuiButtonEmpty href="/docs/guidelines/getting-started/" css={styles.button}>
+          <EuiButtonEmpty href="./docs/guidelines/getting-started/" css={styles.button}>
             All components
             <EuiIcon type="sortRight" size="s" css={styles.icon} />
           </EuiButtonEmpty>

--- a/packages/website/src/components/homepage/users/index.tsx
+++ b/packages/website/src/components/homepage/users/index.tsx
@@ -18,7 +18,7 @@ const CONTENT_DATA = {
     {
       title: 'Getting started',
       description: 'Install framework and make initial adjustments',
-      href: '/docs/guidelines/getting-started/',
+      href: './docs/guidelines/getting-started/',
       icon: 'keyboard',
     },
     {
@@ -31,7 +31,7 @@ const CONTENT_DATA = {
     {
       title: 'Tokens',
       description: 'Speed up your work by using and customizing tokens',
-      href: '/docs/theming/colors/',
+      href: './docs/theming/colors/',
       icon: 'brush',
     },
   ],
@@ -39,19 +39,19 @@ const CONTENT_DATA = {
     {
       title: 'Patterns',
       description: 'Preferred solutions to specific user needs',
-      href: '/docs/patterns/confirmation-prompts/',
+      href: './docs/patterns/confirmation-prompts/',
       icon: 'logPatternAnalysis',
     },
     {
       title: 'Content',
       description: 'Write thoughtful and consistent in-product copy',
-      href: '/docs/content',
+      href: './docs/content',
       icon: 'pencil',
     },
     {
       title: 'Icons',
       description: 'A wide variety of icons to enhance your designs',
-      href: '/docs/display/icons',
+      href: './docs/display/icons',
       icon: 'package',
     },
   ],

--- a/packages/website/src/components/homepage/users/index.tsx
+++ b/packages/website/src/components/homepage/users/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { css } from '@emotion/react';
 import Heading from '@theme/Heading';
 import {
@@ -25,11 +26,12 @@ const CONTENT_DATA = {
       description: 'Help EUI improve even faster',
       href: 'https://github.com/elastic/eui/tree/main/wiki/contributing-to-eui',
       icon: 'plusInCircle',
+      target: '_blank',
     },
     {
       title: 'Tokens',
       description: 'Speed up your work by using and customizing tokens',
-      href: '/docs/',
+      href: '/docs/theming/colors/',
       icon: 'brush',
     },
   ],
@@ -49,7 +51,7 @@ const CONTENT_DATA = {
     {
       title: 'Icons',
       description: 'A wide variety of icons to enhance your designs',
-      href: '/docs/components/icons',
+      href: '/docs/display/icons',
       icon: 'package',
     },
   ],


### PR DESCRIPTION
## Summary

Closes #8465

I fixed the **hero button and links** that were not clickable due to an overlapping decor wrapper. I also fixed **several broken links** across the page. Additionally, I updated external links to **open in a new tab** for improved user experience.

<details><summary>Screenshots</summary>
<p>

![Screenshot 2025-03-20 at 12 08 02](https://github.com/user-attachments/assets/95d639a9-c11c-46e3-82e8-32069ab5db50)
![Screenshot 2025-03-20 at 13 19 34](https://github.com/user-attachments/assets/18273be2-67d2-4f92-a4f1-510b43923ec8)
![Screenshot 2025-03-20 at 13 19 48](https://github.com/user-attachments/assets/0cc5880a-7f74-4277-b2a7-3c0b5cece5b4)
![Screenshot 2025-03-20 at 13 19 59](https://github.com/user-attachments/assets/cd94deab-d63f-482e-8e80-a5bfdc3ca418)
![Screenshot 2025-03-20 at 13 20 10](https://github.com/user-attachments/assets/3746b73f-7cc5-4588-941f-cea4f31f1f60)
![Screenshot 2025-03-20 at 13 20 20](https://github.com/user-attachments/assets/24ec7eb2-f1a3-4bf4-a23e-76ffa2afb544)
![Screenshot 2025-03-20 at 13 20 24](https://github.com/user-attachments/assets/3a889a34-7a5e-4310-b7a2-abacba328cdf)

</p>
</details> 

For cases where the topic spanned multiple pages, I chose the page I thought would be most useful:

- "Form" card > "Basic text controls" page
- "All components" button > "Getting Started" page
- "Tokens" card > "Colors" page

## QA

- [ ] Verify that all the links on the homepage are functional
- [ ] including ensuring external links opening in a new tab
