### PR TITLE
[Docs] Improve tour page

### DIFF
--- a/packages/eui/src-docs/src/components/guide_section/guide_section.tsx
+++ b/packages/eui/src-docs/src/components/guide_section/guide_section.tsx
@@ -244,11 +244,10 @@ export const GuideSection: FunctionComponent<GuideSectionProps> = ({
                   <div>{demo}</div>
                 ) : demo == null ? (
                   <EuiButton
-                    fill
                     iconType="fullScreen"
                     href={`#${path}/${fullScreen.slug}`}
                   >
-                    Fullscreen demo
+                    Open demo
                   </EuiButton>
                 ) : (
                   demo

--- a/packages/eui/src-docs/src/views/tour/fullscreen.js
+++ b/packages/eui/src-docs/src/views/tour/fullscreen.js
@@ -175,7 +175,11 @@ export default () => {
           rightSideItems: [
             <ExampleContext.Consumer>
               {({ parentPath }) => (
-                <EuiButton fill href={`#${parentPath}`} iconType="fullScreenExit">
+                <EuiButton
+                  fill
+                  href={`#${parentPath}`}
+                  iconType="fullScreenExit"
+                >
                   Exit demo
                 </EuiButton>
               )}

--- a/packages/eui/src-docs/src/views/tour/fullscreen.js
+++ b/packages/eui/src-docs/src/views/tour/fullscreen.js
@@ -85,6 +85,7 @@ export default () => {
           <EuiSpacer />
           <EuiTourStep
             {...euiTourStepOne}
+            zIndex={1}
             content={
               <div>
                 <p>This is a neat thing. You enter queries here.</p>
@@ -136,7 +137,7 @@ export default () => {
     {
       id: 'stat',
       name: (
-        <EuiTourStep {...euiTourStepThree}>
+        <EuiTourStep zIndex={1} {...euiTourStepThree}>
           <span>Stats</span>
         </EuiTourStep>
       ),
@@ -146,6 +147,7 @@ export default () => {
           <EuiSpacer />
           <EuiTourStep
             {...euiTourStepFour}
+            zIndex={1}
             content={
               <div>
                 <p>That about does it.</p>
@@ -173,8 +175,8 @@ export default () => {
           rightSideItems: [
             <ExampleContext.Consumer>
               {({ parentPath }) => (
-                <EuiButton fill href={`#${parentPath}`} iconType="exit">
-                  Exit fullscreen demo
+                <EuiButton fill href={`#${parentPath}`} iconType="fullScreenExit">
+                  Exit demo
                 </EuiButton>
               )}
             </ExampleContext.Consumer>,

--- a/packages/eui/src-docs/src/views/tour/managed.js
+++ b/packages/eui/src-docs/src/views/tour/managed.js
@@ -56,7 +56,7 @@ export default () => {
   }
 
   return (
-    <EuiTour steps={demoTourSteps} initialState={state}>
+    <EuiTour zIndex={1} steps={demoTourSteps} initialState={state}>
       {([euiTourStepOne, euiTourStepTwo], actions, reducerState) => {
         useEffect(() => {
           localStorage.setItem(STORAGE_KEY, JSON.stringify(reducerState));
@@ -80,16 +80,16 @@ export default () => {
         };
         return (
           <React.Fragment>
-            <EuiButtonEmpty iconType="refresh" flush="left" onClick={resetTour}>
-              Start or reset tour
+            <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+              Begin tour
             </EuiButtonEmpty>
-            <EuiSpacer />
+            <EuiSpacer size="m" />
             <EuiForm component="form">
-              <EuiFormRow label="Enter an ES SQL query">
-                <EuiTourStep {...euiTourStepOne}>
+              <EuiFormRow label="Query">
+                <EuiTourStep zIndex={1} {...euiTourStepOne}>
                   <EuiTextArea
                     placeholder="Placeholder text"
-                    aria-label="Enter ES SQL query"
+                    aria-label="Query"
                     value={queryValue}
                     onChange={onChange}
                     style={{ width: 400 }}
@@ -97,10 +97,10 @@ export default () => {
                 </EuiTourStep>
               </EuiFormRow>
 
-              <EuiSpacer />
+              <EuiSpacer size="m" />
 
-              <EuiTourStep {...euiTourStepTwo}>
-                <EuiButton onClick={handleClick}>Save query</EuiButton>
+              <EuiTourStep zIndex={1} {...euiTourStepTwo}>
+                <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
               </EuiTourStep>
             </EuiForm>
           </React.Fragment>

--- a/packages/eui/src-docs/src/views/tour/managed.js
+++ b/packages/eui/src-docs/src/views/tour/managed.js
@@ -80,7 +80,12 @@ export default () => {
         };
         return (
           <React.Fragment>
-            <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+            <EuiButtonEmpty
+              size="s"
+              iconType="refresh"
+              flush="left"
+              onClick={resetTour}
+            >
               Begin tour
             </EuiButtonEmpty>
             <EuiSpacer size="m" />
@@ -100,7 +105,9 @@ export default () => {
               <EuiSpacer size="m" />
 
               <EuiTourStep zIndex={1} {...euiTourStepTwo}>
-                <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
+                <EuiButton fill size="s" onClick={handleClick}>
+                  Save
+                </EuiButton>
               </EuiTourStep>
             </EuiForm>
           </React.Fragment>

--- a/packages/eui/src-docs/src/views/tour/managed_hook.js
+++ b/packages/eui/src-docs/src/views/tour/managed_hook.js
@@ -82,7 +82,12 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+      <EuiButtonEmpty
+        size="s"
+        iconType="refresh"
+        flush="left"
+        onClick={resetTour}
+      >
         Begin tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
@@ -102,7 +107,9 @@ export default () => {
         <EuiSpacer size="m" />
 
         <EuiTourStep zIndex={1} {...euiTourStepTwo}>
-          <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
+          <EuiButton fill size="s" onClick={handleClick}>
+            Save
+          </EuiButton>
         </EuiTourStep>
       </EuiForm>
     </div>

--- a/packages/eui/src-docs/src/views/tour/managed_hook.js
+++ b/packages/eui/src-docs/src/views/tour/managed_hook.js
@@ -37,7 +37,7 @@ const demoTourSteps = [
 
 const tourConfig = {
   currentTourStep: 1,
-  isTourActive: true,
+  isTourActive: false,
   tourPopoverWidth: 360,
   tourSubtitle: 'Demo tour',
 };
@@ -82,16 +82,16 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty iconType="refresh" flush="left" onClick={resetTour}>
-        Reset tour
+      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+        Begin tour
       </EuiButtonEmpty>
-      <EuiSpacer />
+      <EuiSpacer size="m" />
       <EuiForm component="form">
-        <EuiFormRow label="Enter an ES SQL query">
-          <EuiTourStep {...euiTourStepOne}>
+        <EuiFormRow label="Query">
+          <EuiTourStep zIndex={1} {...euiTourStepOne}>
             <EuiTextArea
               placeholder="Placeholder text"
-              aria-label="Enter ES SQL query"
+              aria-label="Query"
               value={queryValue}
               onChange={onChange}
               style={{ width: 400 }}
@@ -99,10 +99,10 @@ export default () => {
           </EuiTourStep>
         </EuiFormRow>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
-        <EuiTourStep {...euiTourStepTwo}>
-          <EuiButton onClick={handleClick}>Save query</EuiButton>
+        <EuiTourStep zIndex={1} {...euiTourStepTwo}>
+          <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
         </EuiTourStep>
       </EuiForm>
     </div>

--- a/packages/eui/src-docs/src/views/tour/not_action_driven.tsx
+++ b/packages/eui/src-docs/src/views/tour/not_action_driven.tsx
@@ -94,7 +94,12 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+      <EuiButtonEmpty
+        size="s"
+        iconType="refresh"
+        flush="left"
+        onClick={resetTour}
+      >
         Begin tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />

--- a/packages/eui/src-docs/src/views/tour/not_action_driven.tsx
+++ b/packages/eui/src-docs/src/views/tour/not_action_driven.tsx
@@ -44,7 +44,7 @@ const demoTourSteps = [
 
 const tourConfig = {
   currentTourStep: 1,
-  isTourActive: true,
+  isTourActive: false,
   tourPopoverWidth: 360,
   tourSubtitle: 'Demo tour',
 };
@@ -94,8 +94,12 @@ export default () => {
 
   return (
     <div>
-      <EuiPanel style={{ width: 'max-content' }}>
-        <EuiFlexGroup responsive={false}>
+      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+        Begin tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
+      <EuiPanel hasBorder style={{ width: 'max-content' }}>
+        <EuiFlexGroup gutterSize="s" responsive={false}>
           {demoTourSteps.map((step, index) => (
             <EuiFlexItem grow={false}>
               <EuiTourStep
@@ -109,7 +113,8 @@ export default () => {
                 stepsTotal={demoTourSteps.length}
                 subtitle={state.tourSubtitle}
                 title={step.title}
-                anchorPosition="rightUp"
+                anchorPosition="downLeft"
+                zIndex={1}
                 footerAction={
                   // if it's the last step, we don't want to show the next button
                   index === demoTourSteps.length - 1 ? (
@@ -132,16 +137,12 @@ export default () => {
                   )
                 }
               >
-                <EuiButtonIcon iconType={step.iconType} color="text" />
+                <EuiButtonIcon size="m" iconType={step.iconType} color="text" />
               </EuiTourStep>
             </EuiFlexItem>
           ))}
         </EuiFlexGroup>
       </EuiPanel>
-      <EuiSpacer size="m" />
-      <EuiButtonEmpty iconType="refresh" onClick={resetTour}>
-        Reset tour
-      </EuiButtonEmpty>
     </div>
   );
 };

--- a/packages/eui/src-docs/src/views/tour/step.js
+++ b/packages/eui/src-docs/src/views/tour/step.js
@@ -1,16 +1,26 @@
 import React, { useState } from 'react';
 
 import {
-  EuiLink,
+  EuiButtonEmpty,
+  EuiFieldText,
   EuiText,
   EuiSpacer,
   EuiTourStep,
 } from '../../../../src/components';
 
 export default () => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const beginTour = () => {
+    setIsOpen(true);
+  };
+
   return (
     <div>
+      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={beginTour}>
+        Begin tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
       <EuiTourStep
         content={
           <EuiText>
@@ -24,15 +34,13 @@ export default () => {
         stepsTotal={1}
         title="Title of the current step"
         subtitle="Title of the full tour (optional)"
-        anchorPosition="rightUp"
+        anchorPosition="rightCenter"
+        zIndex={1}
       >
-        <EuiText>
-          The tour step{' '}
-          <EuiLink onClick={() => setIsOpen(!isOpen)}>anchor point</EuiLink>.
-        </EuiText>
+        <EuiFieldText
+          placeholder="Placeholder text"
+        />
       </EuiTourStep>
-      <EuiSpacer size="xxl" />
-      <EuiSpacer size="xxl" />
     </div>
   );
 };

--- a/packages/eui/src-docs/src/views/tour/step.js
+++ b/packages/eui/src-docs/src/views/tour/step.js
@@ -17,7 +17,12 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={beginTour}>
+      <EuiButtonEmpty
+        size="s"
+        flush="left"
+        iconType="refresh"
+        onClick={beginTour}
+      >
         Begin tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
@@ -37,9 +42,7 @@ export default () => {
         anchorPosition="rightCenter"
         zIndex={1}
       >
-        <EuiFieldText
-          placeholder="Placeholder text"
-        />
+        <EuiFieldText placeholder="Placeholder text" />
       </EuiTourStep>
     </div>
   );

--- a/packages/eui/src-docs/src/views/tour/step_dom.js
+++ b/packages/eui/src-docs/src/views/tour/step_dom.js
@@ -1,7 +1,8 @@
 import React, { useRef, useState } from 'react';
 
 import {
-  EuiButtonIcon,
+  EuiButton,
+  EuiButtonEmpty,
   EuiText,
   EuiSpacer,
   EuiTourStep,
@@ -9,11 +10,15 @@ import {
 } from '../../../../src/components';
 
 export default () => {
-  const [isOpenRef, setIsOpenRef] = useState(true);
-  const [isOpenSelector, setIsOpenSelector] = useState(true);
+  const [isOpenRef, setIsOpenRef] = useState(false);
+  const [isOpenSelector, setIsOpenSelector] = useState(false);
   const anchorRef = useRef();
   return (
     <div>
+      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenRef(true); setIsOpenSelector(false); }}>
+        Beign tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
       <EuiTourStep
         anchor={() => anchorRef.current}
         content={
@@ -29,18 +34,23 @@ export default () => {
         step={1}
         stepsTotal={1}
         title="React ref as anchor location"
-        anchorPosition="rightDown"
+        anchorPosition="rightCenter"
+        zIndex={1}
       />
-      <EuiButtonIcon
-        onClick={() => setIsOpenRef(!isOpenRef)}
-        iconType="globe"
+      <EuiButton
+        color="text"
         aria-label="Anchor"
         buttonRef={anchorRef}
-      />
+      >
+        Anchor to <strong>buttonRef</strong>
+      </EuiButton>
 
       <EuiSpacer size="xxl" />
-      <EuiSpacer size="xxl" />
 
+      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenSelector(true); setIsOpenRef(false); }}>
+        Beign tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
       <EuiTourStep
         anchor="#anchorTarget"
         content={
@@ -56,16 +66,16 @@ export default () => {
         step={1}
         stepsTotal={1}
         title="DOM selector as anchor location"
-        anchorPosition="rightUp"
+        anchorPosition="rightDown"
+        zIndex={1}
       />
-      <EuiButtonIcon
-        onClick={() => setIsOpenSelector(!isOpenSelector)}
-        iconType="globe"
+      <EuiButton
+        color="text"
         aria-label="Anchor"
         id="anchorTarget"
-      />
-      <EuiSpacer size="xxl" />
-      <EuiSpacer size="xxl" />
+      >
+        Anchor to <strong>id</strong>
+      </EuiButton>
     </div>
   );
 };

--- a/packages/eui/src-docs/src/views/tour/step_dom.js
+++ b/packages/eui/src-docs/src/views/tour/step_dom.js
@@ -15,7 +15,15 @@ export default () => {
   const anchorRef = useRef();
   return (
     <div>
-      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenRef(true); setIsOpenSelector(false); }}>
+      <EuiButtonEmpty
+        size="s"
+        flush="left"
+        iconType="refresh"
+        onClick={() => {
+          setIsOpenRef(true);
+          setIsOpenSelector(false);
+        }}
+      >
         Beign tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
@@ -37,17 +45,21 @@ export default () => {
         anchorPosition="rightCenter"
         zIndex={1}
       />
-      <EuiButton
-        color="text"
-        aria-label="Anchor"
-        buttonRef={anchorRef}
-      >
+      <EuiButton color="text" aria-label="Anchor" buttonRef={anchorRef}>
         Anchor to <strong>buttonRef</strong>
       </EuiButton>
 
       <EuiSpacer size="xxl" />
 
-      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenSelector(true); setIsOpenRef(false); }}>
+      <EuiButtonEmpty
+        size="s"
+        flush="left"
+        iconType="refresh"
+        onClick={() => {
+          setIsOpenSelector(true);
+          setIsOpenRef(false);
+        }}
+      >
         Beign tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
@@ -69,11 +81,7 @@ export default () => {
         anchorPosition="rightDown"
         zIndex={1}
       />
-      <EuiButton
-        color="text"
-        aria-label="Anchor"
-        id="anchorTarget"
-      >
+      <EuiButton color="text" aria-label="Anchor" id="anchorTarget">
         Anchor to <strong>id</strong>
       </EuiButton>
     </div>

--- a/packages/eui/src-docs/src/views/tour/tour.js
+++ b/packages/eui/src-docs/src/views/tour/tour.js
@@ -36,7 +36,7 @@ const demoTourSteps = [
 
 const tourConfig = {
   currentTourStep: 1,
-  isTourActive: true,
+  isTourActive: false,
   tourPopoverWidth: 360,
   tourSubtitle: 'Demo tour',
 };
@@ -97,12 +97,12 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty iconType="refresh" flush="left" onClick={resetTour}>
-        Reset tour
+      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+        Begin tour
       </EuiButtonEmpty>
-      <EuiSpacer />
+      <EuiSpacer size="m" />
       <EuiForm component="form">
-        <EuiFormRow label="Enter an ES SQL query">
+        <EuiFormRow label="Query">
           <EuiTourStep
             content={demoTourSteps[0].content}
             isStepOpen={state.currentTourStep === 1 && state.isTourActive}
@@ -113,10 +113,11 @@ export default () => {
             subtitle={state.tourSubtitle}
             title={demoTourSteps[0].title}
             anchorPosition="rightUp"
+            zIndex={1}
           >
             <EuiTextArea
               placeholder="Placeholder text"
-              aria-label="Enter ES SQL query"
+              aria-label="Query"
               value={queryValue}
               onChange={onChange}
               style={{ width: 400 }}
@@ -124,7 +125,7 @@ export default () => {
           </EuiTourStep>
         </EuiFormRow>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
         <EuiTourStep
           anchorPosition="rightUp"
@@ -137,7 +138,7 @@ export default () => {
           subtitle={state.tourSubtitle}
           title={demoTourSteps[1].title}
         >
-          <EuiButton onClick={handleClick}>Save query</EuiButton>
+          <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
         </EuiTourStep>
       </EuiForm>
     </div>

--- a/packages/eui/src-docs/src/views/tour/tour.js
+++ b/packages/eui/src-docs/src/views/tour/tour.js
@@ -97,7 +97,12 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+      <EuiButtonEmpty
+        size="s"
+        iconType="refresh"
+        flush="left"
+        onClick={resetTour}
+      >
         Begin tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
@@ -138,7 +143,9 @@ export default () => {
           subtitle={state.tourSubtitle}
           title={demoTourSteps[1].title}
         >
-          <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
+          <EuiButton fill size="s" onClick={handleClick}>
+            Save
+          </EuiButton>
         </EuiTourStep>
       </EuiForm>
     </div>

--- a/packages/eui/src-docs/src/views/tour/tour_example.js
+++ b/packages/eui/src-docs/src/views/tour/tour_example.js
@@ -108,8 +108,8 @@ export const TourExample = {
           <p>
             Instead of wrapping the target element, use the{' '}
             <EuiCode>anchor</EuiCode> prop to specify a DOM node. Accepted
-            values include an HTML element reference, a function returning
-            an HTML element, or a CSS selector string such as{' '}
+            values include an HTML element reference, a function returning an
+            HTML element, or a CSS selector string such as{' '}
             <EuiCode>anchor="#anchorTarget"</EuiCode>.
           </p>
         </>
@@ -127,10 +127,9 @@ export const TourExample = {
       text: (
         <>
           <p>
-            Uers proceed through tour steps without needing to complete
-            actions on the underlying page. In this scenario, consider
-            showing both <strong>Close tour</strong> and{' '}
-            <strong>Next</strong> buttons.
+            Uers proceed through tour steps without needing to complete actions
+            on the underlying page. In this scenario, consider showing both{' '}
+            <strong>Close tour</strong> and <strong>Next</strong> buttons.
           </p>
         </>
       ),
@@ -187,10 +186,9 @@ export const TourExample = {
       text: (
         <p>
           The <strong>EuiTour</strong> render prop component provides minimal
-          state management. An alternative to the{' '}
-          <strong>useEuiTour</strong> hook, <strong>EuiTour</strong> can be
-          used for React class components and use cases with a single wrapping
-          component.
+          state management. An alternative to the <strong>useEuiTour</strong>{' '}
+          hook, <strong>EuiTour</strong> can be used for React class components
+          and use cases with a single wrapping component.
         </p>
       ),
       demo: <Managed />,
@@ -205,8 +203,8 @@ export const TourExample = {
       ],
       text: (
         <p>
-          A complete tour set in a more realistic application UI. Unlike
-          other examples on this page, the demo does not use{' '}
+          A complete tour set in a more realistic application UI. Unlike other
+          examples on this page, the demo does not use{' '}
           <EuiCode>localStorage</EuiCode> to persist state.
         </p>
       ),

--- a/packages/eui/src-docs/src/views/tour/tour_example.js
+++ b/packages/eui/src-docs/src/views/tour/tour_example.js
@@ -66,13 +66,13 @@ export const TourExample = {
       wrapText: false,
       text: (
         <EuiCallOut
-          iconType="save"
-          title="The examples on this page, use localStorage to persist state to demonstrate starting a tour at different stages."
+          iconType="iInCircle"
+          title="Examples on this page use localStorage to persist state."
         />
       ),
     },
     {
-      title: 'Step options',
+      title: 'Wrap target element',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -96,6 +96,7 @@ export const TourExample = {
       snippet: stepSnippet,
     },
     {
+      title: 'Anchor to DOM element',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -104,16 +105,37 @@ export const TourExample = {
       ],
       text: (
         <>
-          <h3>Using DOM selector as anchor location</h3>
           <p>
             Instead of wrapping the target element, use the{' '}
             <EuiCode>anchor</EuiCode> prop to specify a DOM node. Accepted
-            values include an HTML element, a function returning an HTML
-            element, or a DOM query selector.
+            values include an HTML element reference, a function returning
+            an HTML element, or a CSS selector string such as{' '}
+            <EuiCode>anchor="#anchorTarget"</EuiCode>.
           </p>
         </>
       ),
       demo: <StepDom />,
+    },
+    {
+      title: 'Guided tour',
+      source: [
+        {
+          type: GuideSectionTypes.TSX,
+          code: notActionDriven,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            Uers proceed through tour steps without needing to complete
+            actions on the underlying page. In this scenario, consider
+            showing both <strong>Close tour</strong> and{' '}
+            <strong>Next</strong> buttons.
+          </p>
+        </>
+      ),
+      demo: <NotActionDriven />,
+      demoPanelProps: { color: 'subdued' },
     },
     {
       title: 'Standalone steps',
@@ -135,7 +157,7 @@ export const TourExample = {
       demo: <Tour />,
     },
     {
-      title: 'Managed state with the useEuiTour custom hook',
+      title: 'useEuiTour hook',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -144,7 +166,7 @@ export const TourExample = {
       ],
       text: (
         <p>
-          Use the <strong>useEuiTour</strong> hook for minimal state management
+          The <strong>useEuiTour</strong> hook provides minimal state management
           using a predefined React reducer. Pass an array of steps consisting of
           accepted props, and an object of global configuration. The result is a
           full configuration object for each step, a set of reducer actions to
@@ -155,7 +177,7 @@ export const TourExample = {
       demo: <ManagedHook />,
     },
     {
-      title: 'Managed state via EuiTour render prop component',
+      title: 'EuiTour render prop component',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -164,34 +186,17 @@ export const TourExample = {
       ],
       text: (
         <p>
-          Use the <strong>EuiTour</strong> render prop component for minimal
-          state management. This is an alternative to the{' '}
-          <strong>useEuiTour</strong> hook for React class components, or use
-          cases where a single wrapping component can be used.
+          The <strong>EuiTour</strong> render prop component provides minimal
+          state management. An alternative to the{' '}
+          <strong>useEuiTour</strong> hook, <strong>EuiTour</strong> can be
+          used for React class components and use cases with a single wrapping
+          component.
         </p>
       ),
       demo: <Managed />,
     },
     {
-      title: 'Passive tour',
-      source: [
-        {
-          type: GuideSectionTypes.TSX,
-          code: notActionDriven,
-        },
-      ],
-      text: (
-        <p>
-          Use the <strong>EuiTour</strong> to provide sequential help without
-          the user performing any actions (e.g. filling out a form or copying a
-          text). In this scenario, consider using two buttons,{' '}
-          <strong>Close tour</strong> and <strong>Next</strong>.
-        </p>
-      ),
-      demo: <NotActionDriven />,
-    },
-    {
-      title: 'Fullscreen demo',
+      title: 'Tour demo',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -200,7 +205,8 @@ export const TourExample = {
       ],
       text: (
         <p>
-          Unlike the other examples on this page, this example does not use{' '}
+          A complete tour set in a more realistic application UI. Unlike
+          other examples on this page, the demo does not use{' '}
           <EuiCode>localStorage</EuiCode> to persist state.
         </p>
       ),

--- a/packages/website/docs/components/display/tour/overview.mdx
+++ b/packages/website/docs/components/display/tour/overview.mdx
@@ -8,10 +8,10 @@ id: display_tour
 The tour components provided by EUI allow for a flexible and customizable way to showcase items on a page in an ordered manner by augmenting existing elements on the page without altering functionality.
 
 :::note
-The examples on this page use localStorage to persist state to demonstrate starting a tour at different stages.
+Examples on this page use localStorage to persist state.
 :::
 
-## Step options
+## Wrap target element
 
 The **EuiTourStep** component is the base for building a feature tour or an individual popover for onboarding.
 
@@ -19,12 +19,21 @@ All content and actions including titles, headings, and buttons are customizable
 
 ```tsx interactive
 import React, { useState } from 'react';
-import { EuiLink, EuiText, EuiSpacer, EuiTourStep } from '@elastic/eui';
+import { EuiButtonEmpty, EuiFieldText, EuiText, EuiSpacer, EuiTourStep } from '@elastic/eui';
 
 export default () => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const beginTour = () => {
+    setIsOpen(true);
+  };
+
   return (
     <div>
+      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={beginTour}>
+        Begin tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
       <EuiTourStep
         content={
           <EuiText>
@@ -38,28 +47,27 @@ export default () => {
         stepsTotal={1}
         title="Title of the current step"
         subtitle="Title of the full tour (optional)"
-        anchorPosition="rightUp"
+        anchorPosition="rightCenter"
+        zIndex={1}
       >
-        <EuiText>
-          The tour step{' '}
-          <EuiLink onClick={() => setIsOpen(!isOpen)}>anchor point</EuiLink>.
-        </EuiText>
+        <EuiFieldText
+          placeholder="Placeholder text"
+        />
       </EuiTourStep>
-      <EuiSpacer size="xxl" />
-      <EuiSpacer size="xxl" />
     </div>
   );
 };
 ```
 
-### Using DOM selector as anchor location
+### Anchor to DOM element
 
-Instead of wrapping the target element, use the `anchor` prop to specify a DOM node. Accepted values include an HTML element, a function returning an HTML element, or a DOM query selector.
+Instead of wrapping the target element, use the `anchor` prop to specify a DOM node. Accepted values include an HTML element reference, a function returning an HTML element, or a CSS selector string such as `anchor="#anchorTarget"`.
 
 ```tsx interactive
 import React, { useRef, useState } from 'react';
 import {
-  EuiButtonIcon,
+  EuiButton,
+  EuiButtonEmpty,
   EuiText,
   EuiSpacer,
   EuiTourStep,
@@ -67,11 +75,15 @@ import {
 } from '@elastic/eui';
 
 export default () => {
-  const [isOpenRef, setIsOpenRef] = useState(true);
-  const [isOpenSelector, setIsOpenSelector] = useState(true);
+  const [isOpenRef, setIsOpenRef] = useState(false);
+  const [isOpenSelector, setIsOpenSelector] = useState(false);
   const anchorRef = useRef();
   return (
     <div>
+      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenRef(true); setIsOpenSelector(false); }}>
+        Beign tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
       <EuiTourStep
         anchor={() => anchorRef.current}
         content={
@@ -87,18 +99,23 @@ export default () => {
         step={1}
         stepsTotal={1}
         title="React ref as anchor location"
-        anchorPosition="rightDown"
+        anchorPosition="rightCenter"
+        zIndex={1}
       />
-      <EuiButtonIcon
-        onClick={() => setIsOpenRef(!isOpenRef)}
-        iconType="globe"
+      <EuiButton
+        color="text"
         aria-label="Anchor"
         buttonRef={anchorRef}
-      />
+      >
+        Anchor to <strong>buttonRef</strong>
+      </EuiButton>
 
       <EuiSpacer size="xxl" />
-      <EuiSpacer size="xxl" />
 
+      <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenSelector(true); setIsOpenRef(false); }}>
+        Beign tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
       <EuiTourStep
         anchor="#anchorTarget"
         content={
@@ -114,16 +131,170 @@ export default () => {
         step={1}
         stepsTotal={1}
         title="DOM selector as anchor location"
-        anchorPosition="rightUp"
+        anchorPosition="rightDown"
+        zIndex={1}
       />
-      <EuiButtonIcon
-        onClick={() => setIsOpenSelector(!isOpenSelector)}
-        iconType="globe"
+      <EuiButton
+        color="text"
         aria-label="Anchor"
         id="anchorTarget"
-      />
-      <EuiSpacer size="xxl" />
-      <EuiSpacer size="xxl" />
+      >
+        Anchor to <strong>id</strong>
+      </EuiButton>
+    </div>
+  );
+};
+```
+
+## Guided tour
+
+Uers proceed through tour steps without needing to complete actions on the underlying page. In this scenario, consider showing both **Close tour** and **Next** buttons.
+
+```tsx interactive
+import React, { useEffect, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiSpacer,
+  EuiTourStep,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiButtonIcon,
+} from '@elastic/eui';
+
+const demoTourSteps = [
+  {
+    step: 1,
+    title: 'Preview mode',
+    content: <p>See what your project looks like.</p>,
+    anchorRef: 'notActionDrivenStep1',
+    iconType: 'eye',
+  },
+  {
+    step: 2,
+    title: 'Build Mode',
+    content: <p>Build your project.</p>,
+    anchorRef: 'notActionDrivenStep2',
+    iconType: 'editorCodeBlock',
+  },
+  {
+    step: 3,
+    title: 'Comment mode',
+    content: <p>Collaborate with your colleagues.</p>,
+    anchorRef: 'notActionDrivenStep3',
+    iconType: 'editorComment',
+  },
+  {
+    step: 2,
+    title: 'Share',
+    content: <p>Share your project.</p>,
+    anchorRef: 'notActionDrivenStep4',
+    iconType: 'share',
+  },
+];
+
+const tourConfig = {
+  currentTourStep: 1,
+  isTourActive: false,
+  tourPopoverWidth: 360,
+  tourSubtitle: 'Demo tour',
+};
+
+const STORAGE_KEY = 'notActionDrivenDemoTour';
+
+export default () => {
+  const [state, setState] = useState(() => {
+    let initialState: any = localStorage.getItem(STORAGE_KEY);
+    if (initialState) {
+      initialState = JSON.parse(initialState);
+    } else {
+      initialState = tourConfig;
+    }
+    return initialState;
+  });
+  useEffect(() => {
+    // Store the tour data
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state]);
+
+  const incrementStep = () => {
+    setState({
+      ...state,
+      currentTourStep: state.currentTourStep + 1,
+    });
+  };
+
+  const handleClick = () => {
+    incrementStep();
+  };
+
+  const resetTour = () => {
+    setState({
+      ...state,
+      currentTourStep: 1,
+      isTourActive: true,
+    });
+  };
+
+  const finishTour = () => {
+    setState({
+      ...state,
+      isTourActive: false,
+    });
+  };
+
+  return (
+    <div>
+      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+        Begin tour
+      </EuiButtonEmpty>
+      <EuiSpacer size="m" />
+      <EuiPanel hasBorder style={{ width: 'max-content' }}>
+        <EuiFlexGroup gutterSize="s" responsive={false}>
+          {demoTourSteps.map((step, index) => (
+            <EuiFlexItem grow={false}>
+              <EuiTourStep
+                content={step.content}
+                isStepOpen={
+                  state.isTourActive && state.currentTourStep === index + 1
+                }
+                minWidth={state.tourPopoverWidth}
+                onFinish={finishTour}
+                step={index + 1}
+                stepsTotal={demoTourSteps.length}
+                subtitle={state.tourSubtitle}
+                title={step.title}
+                anchorPosition="downLeft"
+                zIndex={1}
+                footerAction={
+                  // if it's the last step, we don't want to show the next button
+                  index === demoTourSteps.length - 1 ? (
+                    <EuiButton color="success" size="s" onClick={finishTour}>
+                      Finish tour
+                    </EuiButton>
+                  ) : (
+                    [
+                      <EuiButtonEmpty
+                        size="s"
+                        color="text"
+                        onClick={finishTour}
+                      >
+                        Close tour
+                      </EuiButtonEmpty>,
+                      <EuiButton color="success" size="s" onClick={handleClick}>
+                        Next
+                      </EuiButton>,
+                    ]
+                  )
+                }
+              >
+                <EuiButtonIcon size="m" iconType={step.iconType} color="text" />
+              </EuiTourStep>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      </EuiPanel>
     </div>
   );
 };
@@ -171,7 +342,7 @@ const demoTourSteps = [
 
 const tourConfig = {
   currentTourStep: 1,
-  isTourActive: true,
+  isTourActive: false,
   tourPopoverWidth: 360,
   tourSubtitle: 'Demo tour',
 };
@@ -232,12 +403,12 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty iconType="refresh" flush="left" onClick={resetTour}>
-        Reset tour
+      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+        Begin tour
       </EuiButtonEmpty>
-      <EuiSpacer />
+      <EuiSpacer size="m" />
       <EuiForm component="form">
-        <EuiFormRow label="Enter an ES SQL query">
+        <EuiFormRow label="Query">
           <EuiTourStep
             content={demoTourSteps[0].content}
             isStepOpen={state.currentTourStep === 1 && state.isTourActive}
@@ -248,10 +419,11 @@ export default () => {
             subtitle={state.tourSubtitle}
             title={demoTourSteps[0].title}
             anchorPosition="rightUp"
+            zIndex={1}
           >
             <EuiTextArea
               placeholder="Placeholder text"
-              aria-label="Enter ES SQL query"
+              aria-label="Query"
               value={queryValue}
               onChange={onChange}
               style={{ width: 400 }}
@@ -259,7 +431,7 @@ export default () => {
           </EuiTourStep>
         </EuiFormRow>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
         <EuiTourStep
           anchorPosition="rightUp"
@@ -272,7 +444,7 @@ export default () => {
           subtitle={state.tourSubtitle}
           title={demoTourSteps[1].title}
         >
-          <EuiButton onClick={handleClick}>Save query</EuiButton>
+          <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
         </EuiTourStep>
       </EuiForm>
     </div>
@@ -280,9 +452,9 @@ export default () => {
 };
 ```
 
-## Managed state with the useEuiTour custom hook
+## useEuiTour hook
 
-Use the **useEuiTour** hook for minimal state management using a predefined React reducer. Pass an array of steps consisting of accepted props, and an object of global configuration. The result is a full configuration object for each step, a set of reducer actions to perform state changes, and an up-to-date state object derived from the internal reducer.
+The **useEuiTour** hook provides minimal state management using a predefined React reducer. Pass an array of steps consisting of accepted props, and an object of global configuration. The result is a full configuration object for each step, a set of reducer actions to perform state changes, and an up-to-date state object derived from the internal reducer.
 
 ```tsx interactive
 import React, { useEffect, useState } from 'react';
@@ -323,7 +495,7 @@ const demoTourSteps = [
 
 const tourConfig = {
   currentTourStep: 1,
-  isTourActive: true,
+  isTourActive: false,
   tourPopoverWidth: 360,
   tourSubtitle: 'Demo tour',
 };
@@ -368,16 +540,16 @@ export default () => {
 
   return (
     <div>
-      <EuiButtonEmpty iconType="refresh" flush="left" onClick={resetTour}>
-        Reset tour
+      <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+        Begin tour
       </EuiButtonEmpty>
-      <EuiSpacer />
+      <EuiSpacer size="m" />
       <EuiForm component="form">
-        <EuiFormRow label="Enter an ES SQL query">
-          <EuiTourStep {...euiTourStepOne}>
+        <EuiFormRow label="Query">
+          <EuiTourStep zIndex={1} {...euiTourStepOne}>
             <EuiTextArea
               placeholder="Placeholder text"
-              aria-label="Enter ES SQL query"
+              aria-label="Query"
               value={queryValue}
               onChange={onChange}
               style={{ width: 400 }}
@@ -385,10 +557,10 @@ export default () => {
           </EuiTourStep>
         </EuiFormRow>
 
-        <EuiSpacer />
+        <EuiSpacer size="m" />
 
-        <EuiTourStep {...euiTourStepTwo}>
-          <EuiButton onClick={handleClick}>Save query</EuiButton>
+        <EuiTourStep zIndex={1} {...euiTourStepTwo}>
+          <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
         </EuiTourStep>
       </EuiForm>
     </div>
@@ -396,9 +568,9 @@ export default () => {
 };
 ```
 
-## Managed state via EuiTour render prop component
+## EuiTour render prop component
 
-Use the **EuiTour** render prop component for minimal state management. This is an alternative to the **useEuiTour** hook for React class components, or use cases where a single wrapping component can be used.
+The **EuiTour** render prop component provides minimal state management. An alternative to the **useEuiTour** hook, **EuiTour** can be used for React class components and use cases with a single wrapping component.
 
 ```tsx interactive
 import React, { useEffect, useState } from 'react';
@@ -458,7 +630,7 @@ export default () => {
   }
 
   return (
-    <EuiTour steps={demoTourSteps} initialState={state}>
+    <EuiTour zIndex={1} steps={demoTourSteps} initialState={state}>
       {([euiTourStepOne, euiTourStepTwo], actions, reducerState) => {
         useEffect(() => {
           localStorage.setItem(STORAGE_KEY, JSON.stringify(reducerState));
@@ -482,16 +654,16 @@ export default () => {
         };
         return (
           <React.Fragment>
-            <EuiButtonEmpty iconType="refresh" flush="left" onClick={resetTour}>
-              Start or reset tour
+            <EuiButtonEmpty size="s" iconType="refresh" flush="left" onClick={resetTour}>
+              Begin tour
             </EuiButtonEmpty>
-            <EuiSpacer />
+            <EuiSpacer size="m" />
             <EuiForm component="form">
-              <EuiFormRow label="Enter an ES SQL query">
-                <EuiTourStep {...euiTourStepOne}>
+              <EuiFormRow label="Query">
+                <EuiTourStep zIndex={1} {...euiTourStepOne}>
                   <EuiTextArea
                     placeholder="Placeholder text"
-                    aria-label="Enter ES SQL query"
+                    aria-label="Query"
                     value={queryValue}
                     onChange={onChange}
                     style={{ width: 400 }}
@@ -499,10 +671,10 @@ export default () => {
                 </EuiTourStep>
               </EuiFormRow>
 
-              <EuiSpacer />
+              <EuiSpacer size="m" />
 
-              <EuiTourStep {...euiTourStepTwo}>
-                <EuiButton onClick={handleClick}>Save query</EuiButton>
+              <EuiTourStep zIndex={1} {...euiTourStepTwo}>
+                <EuiButton fill size="s" onClick={handleClick}>Save</EuiButton>
               </EuiTourStep>
             </EuiForm>
           </React.Fragment>
@@ -513,162 +685,12 @@ export default () => {
 };
 ```
 
-## Passive tour
+<!--
+COMMENTED OUT AS EXAMPLECONTEXT NOT AVAILABLE IN SERVICES
 
-Use the **EuiTour** to provide sequential help without the user performing any actions (e.g. filling out a form or copying a text). In this scenario, consider using two buttons, **Close tour** and **Next**.
+## Tour demo
 
-```tsx interactive
-import React, { useEffect, useState } from 'react';
-import {
-  EuiButton,
-  EuiButtonEmpty,
-  EuiSpacer,
-  EuiTourStep,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiPanel,
-  EuiButtonIcon,
-} from '@elastic/eui';
-
-const demoTourSteps = [
-  {
-    step: 1,
-    title: 'Preview mode',
-    content: <p>See what your project looks like.</p>,
-    anchorRef: 'notActionDrivenStep1',
-    iconType: 'eye',
-  },
-  {
-    step: 2,
-    title: 'Build Mode',
-    content: <p>Build your project.</p>,
-    anchorRef: 'notActionDrivenStep2',
-    iconType: 'editorCodeBlock',
-  },
-  {
-    step: 3,
-    title: 'Comment mode',
-    content: <p>Collaborate with your colleagues.</p>,
-    anchorRef: 'notActionDrivenStep3',
-    iconType: 'editorComment',
-  },
-  {
-    step: 2,
-    title: 'Share',
-    content: <p>Share your project.</p>,
-    anchorRef: 'notActionDrivenStep4',
-    iconType: 'share',
-  },
-];
-
-const tourConfig = {
-  currentTourStep: 1,
-  isTourActive: true,
-  tourPopoverWidth: 360,
-  tourSubtitle: 'Demo tour',
-};
-
-const STORAGE_KEY = 'notActionDrivenDemoTour';
-
-export default () => {
-  const [state, setState] = useState(() => {
-    let initialState: any = localStorage.getItem(STORAGE_KEY);
-    if (initialState) {
-      initialState = JSON.parse(initialState);
-    } else {
-      initialState = tourConfig;
-    }
-    return initialState;
-  });
-  useEffect(() => {
-    // Store the tour data
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  }, [state]);
-
-  const incrementStep = () => {
-    setState({
-      ...state,
-      currentTourStep: state.currentTourStep + 1,
-    });
-  };
-
-  const handleClick = () => {
-    incrementStep();
-  };
-
-  const resetTour = () => {
-    setState({
-      ...state,
-      currentTourStep: 1,
-      isTourActive: true,
-    });
-  };
-
-  const finishTour = () => {
-    setState({
-      ...state,
-      isTourActive: false,
-    });
-  };
-
-  return (
-    <div>
-      <EuiPanel style={{ width: 'max-content' }}>
-        <EuiFlexGroup responsive={false}>
-          {demoTourSteps.map((step, index) => (
-            <EuiFlexItem grow={false}>
-              <EuiTourStep
-                content={step.content}
-                isStepOpen={
-                  state.isTourActive && state.currentTourStep === index + 1
-                }
-                minWidth={state.tourPopoverWidth}
-                onFinish={finishTour}
-                step={index + 1}
-                stepsTotal={demoTourSteps.length}
-                subtitle={state.tourSubtitle}
-                title={step.title}
-                anchorPosition="rightUp"
-                footerAction={
-                  // if it's the last step, we don't want to show the next button
-                  index === demoTourSteps.length - 1 ? (
-                    <EuiButton color="success" size="s" onClick={finishTour}>
-                      Finish tour
-                    </EuiButton>
-                  ) : (
-                    [
-                      <EuiButtonEmpty
-                        size="s"
-                        color="text"
-                        onClick={finishTour}
-                      >
-                        Close tour
-                      </EuiButtonEmpty>,
-                      <EuiButton color="success" size="s" onClick={handleClick}>
-                        Next
-                      </EuiButton>,
-                    ]
-                  )
-                }
-              >
-                <EuiButtonIcon iconType={step.iconType} color="text" />
-              </EuiTourStep>
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGroup>
-      </EuiPanel>
-      <EuiSpacer size="m" />
-      <EuiButtonEmpty iconType="refresh" onClick={resetTour}>
-        Reset tour
-      </EuiButtonEmpty>
-    </div>
-  );
-};
-```
-
-## Fullscreen demo
-
-Unlike the other examples on this page, this example does not use `localStorage` to persist state.
+A complete tour set in a more realistic application UI. Unlike other examples on this page, the demo does not use `localStorage` to persist state.
 
 ```tsx interactive
 import React, { Fragment, useState } from 'react';
@@ -684,7 +706,7 @@ import {
   EuiTourStep,
   useEuiTour,
 } from '@elastic/eui';
-import { ExampleContext } from '../../services';
+import { ExampleContext } from '@elastic/eui/lib/services';
 
 const demoTourSteps = [
   {
@@ -757,6 +779,7 @@ export default () => {
           <EuiSpacer />
           <EuiTourStep
             {...euiTourStepOne}
+            zIndex={1}
             content={
               <div>
                 <p>This is a neat thing. You enter queries here.</p>
@@ -808,7 +831,7 @@ export default () => {
     {
       id: 'stat',
       name: (
-        <EuiTourStep {...euiTourStepThree}>
+        <EuiTourStep zIndex={1} {...euiTourStepThree}>
           <span>Stats</span>
         </EuiTourStep>
       ),
@@ -818,6 +841,7 @@ export default () => {
           <EuiSpacer />
           <EuiTourStep
             {...euiTourStepFour}
+            zIndex={1}
             content={
               <div>
                 <p>That about does it.</p>
@@ -845,8 +869,8 @@ export default () => {
           rightSideItems: [
             <ExampleContext.Consumer>
               {({ parentPath }) => (
-                <EuiButton fill href={`#${parentPath}`} iconType="exit">
-                  Exit fullscreen demo
+                <EuiButton fill href={`#${parentPath}`} iconType="fullScreenExit">
+                  Exit demo
                 </EuiButton>
               )}
             </ExampleContext.Consumer>,
@@ -876,13 +900,12 @@ export default () => {
     </EuiPageTemplate>
   );
 };
-
-```
+``` -->
 
 ## Props
 
 import docgen from '@elastic/eui-docgen/dist/components/tour';
 
-<PropTable definition={docgen.EuiTour} />
 <PropTable definition={docgen.EuiTourStep} />
 <PropTable definition={docgen.EuiTourStepIndicator} />
+<PropTable definition={docgen.EuiTour} />


### PR DESCRIPTION
## Summary

A busted design no more!

The issues with the current Tour page speak for themselves. This PR...
- introduces a manual 'Begin tour' trigger versus having tour steps initially open,
- sets a `z-index` so that tour steps go below the top nav bar, and
- a number of copy improvements.

>[!NOTE]
>The **Tour Demo** section is commented out for now on the new site as `ExampleContent` does not appear to be included in the **@elastic/eui** package

**Before**
_Shenanigans_
![CleanShot 2025-03-21 at 11 30 08@2x](https://github.com/user-attachments/assets/cd374b2c-7947-4e91-bbb4-99972028b686)

**After**
_This pattern was applied to each section_

![CleanShot 2025-03-21 at 13 17 20](https://github.com/user-attachments/assets/b5c804d2-e3ae-4413-8336-858f8e5ace22)

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
