### PR TITLE
docs(EuiEmptyPrompt): Fix missing icons in EUI+ docs

### DIFF
--- a/packages/docusaurus-theme/package.json
+++ b/packages/docusaurus-theme/package.json
@@ -22,10 +22,8 @@
   },
   "main": "lib/index.js",
   "exports": {
-    "./lib/*": "./lib/*",
-    ".": {
-      "default": "./lib/index.js"
-    }
+    "./components": "./lib/components/index.js",
+    ".": "./lib/index.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",

--- a/packages/docusaurus-theme/src/components/index.ts
+++ b/packages/docusaurus-theme/src/components/index.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
-export { createDemo } from './demo';
+export { createDemo, Demo, type DemoProps } from './demo';
 export { Guideline, GuidelineText } from './guideline';
+export { PropTable } from './prop_table';
 export { AppThemeContext } from './theme_context';

--- a/packages/website/docs/components/display/empty_prompt/multiple_types.tsx
+++ b/packages/website/docs/components/display/empty_prompt/multiple_types.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { EuiSelect, useEuiTheme } from '@elastic/eui';
 
-import { Demo } from '@elastic/eui-docusaurus-theme/lib/components/demo/demo.js';
+import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 const types: Array<{
   value: string;

--- a/packages/website/docs/components/display/empty_prompt/types_of_empty_states/empty_snippet.tsx
+++ b/packages/website/docs/components/display/empty_prompt/types_of_empty_states/empty_snippet.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import {
@@ -26,17 +27,21 @@ export const EmptySnippet = ({ radioUseCaseId }: Props) => {
     isDarkTheme ? example.iconDark2x : example.iconLight2x
   );
 
-  const icon =
-    example.iconLoading && radioUseCaseId === 'loading'
-      ? example.iconLoading
-      : example.iconType || (
-          <EuiImage
-            alt={example.alt || ''}
-            size="fullWidth"
-            src={src}
-            srcSet={`${src} 1x, ${src2x} 2x`}
-          />
-        );
+  // Conditionally set the `icon` prop if a non-standard icon is needed
+  // See EuiEmptyPrompt docs to learn more about custom icon usage
+  let icon: ReactNode | undefined;
+  if (example.iconLoading) {
+    icon = example.iconLoading;
+  } else if (example.iconLight && example.iconDark) {
+    icon = (
+      <EuiImage
+        size="fullWidth"
+        alt={example.alt ?? ''}
+        src={src}
+        srcSet={`${src} 1x, ${src2x} 2x`}
+      />
+    )
+  }
 
   const snippet = convertToJsxString(
     <EuiPageTemplate minHeight="0" panelled={false} style={{ minHeight: 420 }}>
@@ -45,6 +50,7 @@ export const EmptySnippet = ({ radioUseCaseId }: Props) => {
           actions={example.actions}
           body={example.body}
           color={radioUseCaseId === 'error' ? 'danger' : 'plain'}
+          iconType={example.iconType}
           icon={icon}
           layout={example.layout ?? 'vertical'}
           title={example.title}

--- a/packages/website/docs/components/display/empty_prompt/types_of_empty_states/empty_snippet.tsx
+++ b/packages/website/docs/components/display/empty_prompt/types_of_empty_states/empty_snippet.tsx
@@ -7,7 +7,7 @@ import {
   EuiEmptyPrompt,
   useEuiTheme,
 } from '@elastic/eui';
-import { Demo } from '@elastic/eui-docusaurus-theme/lib/components/demo/demo.js';
+import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';

--- a/packages/website/docs/components/display/empty_prompt/types_of_empty_states/multiple_snippet.tsx
+++ b/packages/website/docs/components/display/empty_prompt/types_of_empty_states/multiple_snippet.tsx
@@ -11,7 +11,7 @@ import {
   useEuiTheme,
   EuiLoadingSpinner,
 } from '@elastic/eui';
-import { Demo } from '@elastic/eui-docusaurus-theme/lib/components/demo/demo.js';
+import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';

--- a/packages/website/docs/components/display/empty_prompt/types_of_empty_states/multiple_snippet.tsx
+++ b/packages/website/docs/components/display/empty_prompt/types_of_empty_states/multiple_snippet.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import {
@@ -32,19 +33,21 @@ export const MultipleSnippet = ({ radioUseCaseId }: Props) => {
     isDarkTheme ? example.iconDark2x : example.iconLight2x
   );
 
-  const icon =
-    example.iconLoading && radioUseCaseId === 'loading' ? (
-      <EuiLoadingSpinner size="l" />
-    ) : (
-      example.iconType || (
-        <EuiImage
-          alt={example.alt || ''}
-          size="fullWidth"
-          src={src}
-          srcSet={`${src} 1x, ${src2x} 2x`}
-        />
-      )
-    );
+  // Conditionally set the `icon` prop if a non-standard icon is needed
+  // See EuiEmptyPrompt docs to learn more about custom icon usage
+  let icon: ReactNode | undefined;
+  if (example.iconLoading) {
+    icon = <EuiLoadingSpinner size="l" />;
+  } else if (example.iconLight && example.iconDark) {
+    icon = (
+      <EuiImage
+        size="fullWidth"
+        alt={example.alt ?? ''}
+        src={src}
+        srcSet={`${src} 1x, ${src2x} 2x`}
+      />
+    )
+  }
 
   const centerStyles = {
     alignItems: 'center',
@@ -63,6 +66,7 @@ export const MultipleSnippet = ({ radioUseCaseId }: Props) => {
             color={radioUseCaseId === 'error' ? 'danger' : 'plain'}
             hasBorder={!(radioUseCaseId === 'error')}
             icon={icon}
+            iconType={example.iconType}
             layout={example.layout ?? 'vertical'}
             style={centerStyles}
             title={example.title}

--- a/packages/website/docs/components/display/empty_prompt/types_of_empty_states/sidebar_snippet.tsx
+++ b/packages/website/docs/components/display/empty_prompt/types_of_empty_states/sidebar_snippet.tsx
@@ -8,7 +8,7 @@ import {
   useEuiTheme,
   useIsWithinBreakpoints,
 } from '@elastic/eui';
-import { Demo } from '@elastic/eui-docusaurus-theme/lib/components/demo/demo.js';
+import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';

--- a/packages/website/docs/components/display/empty_prompt/types_of_empty_states/sidebar_snippet.tsx
+++ b/packages/website/docs/components/display/empty_prompt/types_of_empty_states/sidebar_snippet.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import {
@@ -11,19 +12,6 @@ import { Demo } from '@elastic/eui-docusaurus-theme/lib/components/demo/demo.js'
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';
-
-import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
-import { icon as EuiLogoSecurity } from '@elastic/eui/es/components/icon/assets/logo_security';
-import { icon as EuiLogoKibana } from '@elastic/eui/es/components/icon/assets/logo_kibana';
-import { icon as EuiLock } from '@elastic/eui/es/components/icon/assets/lock';
-import { icon as EuiError } from '@elastic/eui/es/components/icon/assets/error';
-
-appendIconComponentCache({
-  logoSecurity: EuiLogoSecurity,
-  logoKibana: EuiLogoKibana,
-  lock: EuiLock,
-  error: EuiError,
-});
 
 type Props = {
   radioUseCaseId: string;
@@ -45,17 +33,21 @@ export const SidebarSnippet = ({ radioUseCaseId }: Props) => {
     isDarkTheme ? example.iconDark2x : example.iconLight2x
   );
 
-  const icon =
-    example.iconLoading && radioUseCaseId === 'loading'
-      ? example.iconLoading
-      : example.iconType || (
-          <EuiImage
-            alt={example.alt || ''}
-            size="fullWidth"
-            src={src}
-            srcSet={`${src} 1x, ${src2x} 2x`}
-          />
-        );
+  // Conditionally set the `icon` prop if a non-standard icon is needed
+  // See EuiEmptyPrompt docs to learn more about custom icon usage
+  let icon: ReactNode | undefined;
+  if (example.iconLoading) {
+    icon = example.iconLoading;
+  } else if (example.iconLight && example.iconDark) {
+    icon = (
+      <EuiImage
+        size="fullWidth"
+        alt={example.alt ?? ''}
+        src={src}
+        srcSet={`${src} 1x, ${src2x} 2x`}
+      />
+    )
+  }
 
   const snippet = convertToJsxString(
     <EuiPageTemplate minHeight="0" offset={0} style={{ minHeight: 420 }}>
@@ -71,6 +63,7 @@ export const SidebarSnippet = ({ radioUseCaseId }: Props) => {
           actions={example.actions}
           body={example.body}
           color={radioUseCaseId === 'error' ? 'danger' : 'subdued'}
+          iconType={example.iconType}
           icon={icon}
           layout={example.layout ?? 'vertical'}
           title={example.title}
@@ -84,7 +77,6 @@ export const SidebarSnippet = ({ radioUseCaseId }: Props) => {
     <Demo
       key={`${radioUseCaseId}-${colorMode}`}
       previewPadding="s"
-      scope={{ EuiLogoSecurity, EuiLogoKibana, EuiLock, EuiError }}
     >
       {snippet}
     </Demo>

--- a/packages/website/docs/components/layout/flex/flex.mdx
+++ b/packages/website/docs/components/layout/flex/flex.mdx
@@ -5,7 +5,7 @@ id: layout_flex
 
 # Flex
 
-import { createDemo } from '@elastic/eui-docusaurus-theme/lib/components';
+import { createDemo } from '@elastic/eui-docusaurus-theme/components';
 import { FlexPreviewWrapper } from './flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 

--- a/packages/website/docs/components/layout/flex/flex_grid.mdx
+++ b/packages/website/docs/components/layout/flex/flex_grid.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Flex grids
 
-import { createDemo } from '@elastic/eui-docusaurus-theme/lib/components';
+import { createDemo } from '@elastic/eui-docusaurus-theme/components';
 import { FlexPreviewWrapper } from './flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 

--- a/packages/website/docs/components/layout/flex/flex_group.mdx
+++ b/packages/website/docs/components/layout/flex/flex_group.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Flex groups
 
-import { createDemo } from '@elastic/eui-docusaurus-theme/lib/components';
+import { createDemo } from '@elastic/eui-docusaurus-theme/components';
 import { FlexPreviewWrapper } from './flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 

--- a/packages/website/docs/components/layout/flex/flex_item.mdx
+++ b/packages/website/docs/components/layout/flex/flex_item.mdx
@@ -10,7 +10,7 @@ sidebar_position: 2
 To work correctly, **EuiFlexItem** must be a **direct child** of [**EuiFlexGroup**](./group) or [**EuiFlexGrid**](./grid). You cannot have any intermediate HTML wrappers between them.
 :::
 
-import { createDemo } from '@elastic/eui-docusaurus-theme/lib/components';
+import { createDemo } from '@elastic/eui-docusaurus-theme/components';
 import { FlexPreviewWrapper } from './flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 

--- a/packages/website/docs/components/layout/panel/split_panel_props.tsx
+++ b/packages/website/docs/components/layout/panel/split_panel_props.tsx
@@ -1,4 +1,4 @@
-import { PropTable } from '@elastic/eui-docusaurus-theme/lib/components/prop_table/prop_table.js';
+import { PropTable } from '@elastic/eui-docusaurus-theme/components';
 
 import docgen from '@elastic/eui-docgen/dist/components/panel/split_panel/split_panel.json';
 // Rename the component's generated displayName to match consumer usage

--- a/packages/website/docs/components/tabular_content/tables/table_selection.tsx
+++ b/packages/website/docs/components/tabular_content/tables/table_selection.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
 
 import { EuiSwitch } from '@elastic/eui';
-
-// @ts-expect-error Docusaurus theme is missing types for this component
-import { Demo } from '@elastic/eui-docusaurus-theme/lib/components/demo';
+import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 const userDataSetup = (
   varName: string = 'users',
@@ -158,7 +156,7 @@ export default () => {
     });
     setSelectedItems([]);
   }
-  
+
   return (
     <>
       <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">

--- a/packages/website/src/theme/Root.tsx
+++ b/packages/website/src/theme/Root.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import { AppThemeContext } from '@elastic/eui-docusaurus-theme/lib/components/theme_context';
+import { AppThemeContext } from '@elastic/eui-docusaurus-theme/components';
 import chartsLightThemeUrl from '!file-loader!@elastic/charts/dist/theme_only_light.css';
 import chartsDarkThemeUrl from '!file-loader!@elastic/charts/dist/theme_only_dark.css';
 import Root from '@theme-original/Root';

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -4,5 +4,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "jsxImportSource": "@emotion/react",
+    "moduleResolution": "nodenext"
   }
 }


### PR DESCRIPTION
## Summary

Resolves #8312

This fixes icon rendering in EUI+ EuiEmptyPrompt docs. Utilizing both `iconType` and `icon` props felt easiest to achieve what we want.

## QA

Please note that EuiEmptyPrompt guidelines use `renderToJSXString`, which is incompatible with Docusaurus and our Demo component when used in prod builds. Additionally, EuiPageTemplate's sidebar gets rendered incorrectly as reported [here](https://github.com/elastic/eui/issues/8164). These pages currently work only when running locally, which is unrelated to this PR. 

1. Checkout this PR - `gh pr checkout <id> && yarn`
2. Build website dependencies - `yarn workspace @elastic/eui-website run build:workspaces`
3. Run Docusaurus - `yarn workspace @elastic/eui-website run start`
4. [ ] Ensure the EuiEmptyPrompt's _Types of empty states_ example works comparably to the [current docs site](https://eui.elastic.co/#/display/empty-prompt/guidelines)