### PR TITLE
fix(website): remove button in EuiTour fullscreen example

### DIFF
--- a/packages/website/docs/components/display/tour/overview.mdx
+++ b/packages/website/docs/components/display/tour/overview.mdx
@@ -685,9 +685,6 @@ export default () => {
 };
 ```
 
-<!--
-COMMENTED OUT AS EXAMPLECONTEXT NOT AVAILABLE IN SERVICES
-
 ## Tour demo
 
 A complete tour set in a more realistic application UI. Unlike other examples on this page, the demo does not use `localStorage` to persist state.
@@ -706,7 +703,6 @@ import {
   EuiTourStep,
   useEuiTour,
 } from '@elastic/eui';
-import { ExampleContext } from '@elastic/eui/lib/services';
 
 const demoTourSteps = [
   {
@@ -866,15 +862,6 @@ export default () => {
       <EuiPageTemplate.Header
         {...{
           pageTitle: 'My app',
-          rightSideItems: [
-            <ExampleContext.Consumer>
-              {({ parentPath }) => (
-                <EuiButton fill href={`#${parentPath}`} iconType="fullScreenExit">
-                  Exit demo
-                </EuiButton>
-              )}
-            </ExampleContext.Consumer>,
-          ],
           tabs: tabs.map((tab, index) => {
             return {
               key: index,
@@ -900,7 +887,7 @@ export default () => {
     </EuiPageTemplate>
   );
 };
-``` -->
+```
 
 ## Props
 


### PR DESCRIPTION
## Summary

This PR fixes the "require is not defined" error in the fullscreen example on the Tour page. The issue was the import:

`import { ExampleContext } from '../../services';`

that couldn't be resolved to anything. I removed it alongside the "Exit fullscreen demo" button because it's non-functional (see how it works in prod [here](https://eui.elastic.co/#/display/tour#fullscreen-demo)). The example works as expected now, even without the fullscreen mode.

![Screenshot 2025-03-24 at 11 25 48](https://github.com/user-attachments/assets/99380dd9-02ad-4e2f-af39-792e15c4e295)

> [!NOTE]
> Fullscreen demos will be rethought on https://github.com/elastic/eui/issues/8151, this PR only aims to fix the error and make the preview display.

Closes #8480

## QA

**Steps:**

1. Run the docs locally and / or access the staging environment.
2. Go to the Display > Tour page.
3. Scroll down to the Fullscreen demo section.
4. Verify that the example preview shows.