### PR TITLE
Fix: Add missing changelogs for theme packages

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8444.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8444.md
@@ -1,0 +1,5 @@
+- Added new component tokens:
+  - `buttonGroupBackgroundDisabledSelected`
+  - `overlayMaskBackground`
+  - `overlayMaskBackgroundHighContrast`
+  - `skeletonBackgroundSkeletonMiddleHighContrast`

--- a/packages/eui-theme-common/changelogs/upcoming/8444.md
+++ b/packages/eui-theme-common/changelogs/upcoming/8444.md
@@ -1,0 +1,13 @@
+- Removed type `EuiShadowCustomColor`
+- Added types: 
+  - `EuiShadowOptions`
+  - `EuiThemeHighContrastModeProp`
+  - `EuiThemeHighContrastMode`
+- Updated shadow utils to accepts a second `options` argument and return borders in high contrast mode:
+  - `euiShadow`
+  - `euiShadowXSmall`
+  - `euiShadowSmall`
+  - `euiShadowMedium`
+  - `euiShadowLarge`
+  - `euiSlightShadowHover`
+  - `euiShadowFlat`

--- a/packages/eui/changelogs/upcoming/8490.md
+++ b/packages/eui/changelogs/upcoming/8490.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Resolved an internal issue with linked package versions

--- a/wiki/eui-team-processes/releasing-versions.md
+++ b/wiki/eui-team-processes/releasing-versions.md
@@ -24,8 +24,8 @@ git checkout main
 
 If you're already on the `main` branch, make sure you're on the latest state:
 ```sh
-yarn fetch
-yarn pull
+git fetch
+git pull
 ```
 
 Ensure the release-cli is build:


### PR DESCRIPTION
## Summary

This PR is a cleanup after #8444.

With the new release workflow in place we now have to add changes as changelogs to all internal packages that will be released (this currently means `eui` as well as `eui-theme-borealis` and `eui-theme-common`)

This PR adds the missing changelogs for the changes added in #8444 

Additionally this PR fixes a small mistake in the previously added release documentation ([PR](https://github.com/elastic/eui/pull/8396)).