### PR TITLE
[EUI+] Fix all broken links in the Guidelines section

### DIFF
--- a/packages/website/docs/components/guidelines/accessibility.mdx
+++ b/packages/website/docs/components/guidelines/accessibility.mdx
@@ -6,11 +6,12 @@ sidebar_label: Accessibility
 sidebar_position: 2
 ---
 
+import Link from '@docusaurus/Link';
 import { EuiText } from '@elastic/eui';
 
 This page provides some general accessibility guidelines. For component specific recommendations, be sure to check out their individual documentation pages.
 
-EUI provides a strong start to building accessibility into your apps. The components provided strive to meet [WCAG 2.1](https://www.w3.org/TR/WCAG21/) guidelines on semantics, keyboard functionality, color contrast, and so on. How you stitch together these components in the overall page structure also plays a large role in meeting accessibility goals. Headings, landmarks, page titles, focus management, and accessible names all work together to create accessible apps.
+EUI provides a strong start to building accessibility into your apps. The components provided strive to meet <Link to="https://www.w3.org/TR/WCAG21/">WCAG 2.1</Link> guidelines on semantics, keyboard functionality, color contrast, and so on. How you stitch together these components in the overall page structure also plays a large role in meeting accessibility goals. Headings, landmarks, page titles, focus management, and accessible names all work together to create accessible apps.
 
 Building accessibility into your app is as important as code quality, visual design, and performance, and it’s also important that you test as you go. You can approach accessibility testing from three dimensions: automated, manual, and empathetic thinking. Use automated tests to quickly cover as much ground as possible, manual tests to address more complicated scenarios, and empathy to fill in the gaps.
 
@@ -33,9 +34,9 @@ import { EuiAspectRatio } from '@elastic/eui';
 
 You can aid navigation and make pages more accessible for screen reader users by using solid headings and landmarks. **Headings** are the simplest way for screen readers to navigate pages. A good heading hierarchy:
 
-*   Uses only one `<h1>` on each page
-*   Doesn't skip levels `<h1> → <h6>`
-*   Doesn't duplicate content
+- Uses only one `<h1>` on each page
+- Doesn't skip levels `<h1> → <h6>`
+- Doesn't duplicate content
 
 ### Heading examples
 
@@ -77,7 +78,7 @@ You can aid navigation and make pages more accessible for screen reader users by
 </Guideline>
 
 :::tip
-[**EuiTitle**](/docs/display/title) gives you a way to separate your presentation from your semantic markup.
+[**EuiTitle**](../display/title.mdx) gives you a way to separate your presentation from your semantic markup.
 :::
 
 **Landmarks** are another way for screen readers to navigate pages. A benefit of landmarks is that they offer more context on the type of content to expect than a heading. This is useful for tech that offers reader modes (e.g., Firefox, Safari, and apps like Pocket) and new form factors (e.g., smartwatches). Many landmarks are mapped to HTML elements, such as `<main>`, `<aside>`, `<article>`; others are exposed through the `role` attribute.
@@ -130,13 +131,11 @@ You can implement named landmarks with `aria-label` or `aria-labelledby`. Howeve
 
 ### Further reading
 
-*   [W3C: Aria Landmarks](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html)
-*   [W3C: Page Structure Concepts Tutorial](https://www.w3.org/WAI/tutorials/page-structure/)
-*   [MDN: Good Semantics](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#Good_semantics)
-*   [Up Your A11y: Accessible Page Layouts](https://www.upyoura11y.com/page-layout/)
-*   [Up Your A11y: Heading Levels in Reusable Components](https://www.upyoura11y.com/reusable-components-with-headers/)
-
----
+- <Link to="https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html">W3C: Aria Landmarks</Link>
+- <Link to="https://www.w3.org/WAI/tutorials/page-structure/">W3C: Page Structure Concepts Tutorial</Link>
+- <Link to="https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML#Good_semantics">MDN: Good Semantics</Link>
+- <Link to="https://www.upyoura11y.com/page-layout/">Up Your A11y: Accessible Page Layouts</Link>
+- <Link to="https://www.upyoura11y.com/reusable-components-with-headers/">Up Your A11y: Heading Levels in Reusable Components</Link>
 
 ## Page titles
 
@@ -203,9 +202,7 @@ Each page requires a unique, informative title that accurately reflects what the
 
 ### Further reading
 
-*   [WCAG 2.4.2 Page Titled - Level A](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=242#page-titled)
-
-* * *
+- <Link to="https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=242#page-titled">WCAG 2.4.2 Page Titled - Level A</Link>
 
 ## Focus management
 
@@ -227,14 +224,12 @@ Navigating complex sites sometimes means your focus state will jump around (e.g.
 
 ### Further reading
 
-*   [W3C: Keyboard Compatibility](https://www.w3.org/WAI/perspective-videos/keyboard)
-*   [React docs: Programmatically managing focus](https://reactjs.org/docs/accessibility.html#programmatically-managing-focus)
-*   [MDN: Keyboard-navigable JavaScript widgets](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets)
-*   [WebAIM: Keyboard Accessibility](https://webaim.org/techniques/keyboard)
-*   [Up Your A11y: Getting Started with Keyboard Navigation and Screen Readers](https://www.upyoura11y.com/screen-reader-keyboard-navigation)
-*   [The difference between keyboard and screen reader navigation](https://tink.uk/the-difference-between-keyboard-and-screen-reader-navigation/)
-
-* * *
+- <Link to="https://www.w3.org/WAI/perspective-videos/keyboard">W3C: Keyboard Compatibility</Link>
+- <Link to="https://reactjs.org/docs/accessibility.html#programmatically-managing-focus">React docs: Programmatically managing focus</Link>
+- <Link to="https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets">MDN: Keyboard-navigable JavaScript widgets</Link>
+- <Link to="https://webaim.org/techniques/keyboard">WebAIM: Keyboard Accessibility</Link>
+- <Link to="https://www.upyoura11y.com/screen-reader-keyboard-navigation">Up Your A11y: Getting Started with Keyboard Navigation and Screen Readers</Link>
+- <Link to="https://tink.uk/the-difference-between-keyboard-and-screen-reader-navigation/">The difference between keyboard and screen reader navigation</Link>
 
 ## Disabled elements
 
@@ -242,14 +237,12 @@ Browsers remove disabled elements from the tab order. This means keyboard users 
 
 If you disable a button or form element, you need to provide clear instructions to users how to correct errors or remove the disabled state.
 
-When you add the HTML `disabled` attribute to an element, you must remove tooltips or other focus interactions. You must also remove focus interactions if you pass the `isDisabled` prop to components like [EuiAccordion](/docs/layout/accordion#disabled-state).
+When you add the HTML `disabled` attribute to an element, you must remove tooltips or other focus interactions. You must also remove focus interactions if you pass the `isDisabled` prop to components like [EuiAccordion](../layout/accordion.mdx#disabled-state).
 
 ### Further reading
 
-*   [MDN: Tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-*   [W3C: Disabled elements](https://www.w3.org/TR/2014/REC-html5-20141028/disabled-elements.html#disabled-elements)
-
-* * *
+- <Link to="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex">MDN: Tabindex</Link>
+- <Link to="https://www.w3.org/TR/2014/REC-html5-20141028/disabled-elements.html#disabled-elements">W3C: Disabled elements</Link>
 
 ## Naming
 
@@ -351,13 +344,11 @@ Here, the 3 buttons have the same accessible name. There are a few different pat
 
 ### Further reading
 
-*   [W3c: Labeling Controls](https://www.w3.org/WAI/tutorials/forms/labels/)
-*   [The Paciello Group: What is an accessible name?](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name)
-*   [WebAIM: Creating Accessible Forms](https://webaim.org/techniques/forms/controls)
-*   [Mozilla: How accessibility trees inform assistive tech](https://hacks.mozilla.org/2019/06/how-accessibility-trees-inform-assistive-tech)
-*   [A List Apart: Semantics to Screen Readers](https://alistapart.com/article/semantics-to-screen-readers)
-
-* * *
+- <Link to="https://www.w3.org/WAI/tutorials/forms/labels/">W3c: Labeling Controls</Link>
+- <Link to="https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name">The Paciello Group: What is an accessible name?</Link>
+- <Link to="https://webaim.org/techniques/forms/controls">WebAIM: Creating Accessible Forms</Link>
+- <Link to="https://hacks.mozilla.org/2019/06/how-accessibility-trees-inform-assistive-tech">Mozilla: How accessibility trees inform assistive tech</Link>
+- <Link to="https://alistapart.com/article/semantics-to-screen-readers">A List Apart: Semantics to Screen Readers</Link>
 
 ## Testing considerations
 
@@ -367,52 +358,55 @@ There are a lot of aspects to accessibility, and covering all the bases can be a
 
 While low-vision users may use many assistive technologies in tandem, this section focuses on zooming. Two ways that users can zoom the page are by increasing the base font-size with browser tools or by using a 3rd-party magnifier (sometimes, a physical magnifier) to better see the screen.
 
-[WCAG 1.4.4](https://www.w3.org/WAI/WCAG21/quickref/#resize-text) defines 200% browser zoom should continue to work with no further action from the user as a Level AA criteria.
+<Link to="https://www.w3.org/WAI/WCAG21/quickref/#resize-text">WCAG 1.4.4</Link> defines 200% browser zoom should continue to work with no further action from the user as a Level AA criteria.
 
-[ZoomText](https://www.youtube.com/watch?v=QjKG4Tx9ER8&t=473s) is the most popular 3rd-party magnifier that gives users a window they can drag over content to magnify and read it out loud. Testing for the best experiences here is exceptionally difficult because you must make visual judgement calls. Specifically, related pieces of information should be close enough together for a low-vision user to efficiently interact with the UI.
+<Link to="https://www.youtube.com/watch?v=QjKG4Tx9ER8&t=473s">ZoomText</Link> is the most popular 3rd-party magnifier that gives users a window they can drag over content to magnify and read it out loud. Testing for the best experiences here is exceptionally difficult because you must make visual judgement calls. Specifically, related pieces of information should be close enough together for a low-vision user to efficiently interact with the UI.
 
-### Low-vision/blind (screen readers)[](/docs/guidelines/accessibility#screen-readers)
+### Low-vision/blind (screen readers)
 
 Blind and low-vision users often rely on tools, such as screen readers and braille readers, to navigate the web. Screen and braille readers read the page from top to bottom. Building a page with a good structure, will make it quick and easy to navigate. Braille readers are a textual representation of what a screen reader would say so we can focus on screen reader compatibility.
 
 The 3 most common, desktop, screen readers, and their most common browser pairings are:
 
-*   JAWS with Chrome
-*   NVDA with Firefox
-*   VoiceOver with Safari
+- JAWS with Chrome
+- NVDA with Firefox
+- VoiceOver with Safari
 
 Mobile is a little simpler:
 
-*   VoiceOver for iOS
-*   TalkBack for Android
+- VoiceOver for iOS
+- TalkBack for Android
 
-*   [Apple docs: Learning VoiceOver Basics](https://www.apple.com/voiceover/info/guide/_1124.html)
-*   [WebAIM: Using VoiceOver to Evaluate Web Accessibility](https://webaim.org/articles/voiceover)
-*   [WebAIM: Using NVDA to Evaluate Web Accessibility](https://webaim.org/articles/nvda)
-*   [WebAIM: Using JAWS to Evaluate Web Accessibility](https://webaim.org/articles/jaws)
-*   [An Intro To Screen Reader Testing for Sighted Developers](http://uncaughtreferenceerror.com/a-crash-course-to-screenreaders-for-sighted-developers)
+- <Link to="https://www.apple.com/voiceover/info/guide/_1124.html">Apple docs: Learning VoiceOver Basics</Link>
+- <Link to="https://webaim.org/articles/voiceover">WebAIM: Using VoiceOver to Evaluate Web Accessibility</Link>
+- <Link to="https://webaim.org/articles/nvda">WebAIM: Using NVDA to Evaluate Web Accessibility</Link>
+- <Link to="https://webaim.org/articles/jaws">WebAIM: Using JAWS to Evaluate Web Accessibility</Link>
+- <Link to="http://uncaughtreferenceerror.com/a-crash-course-to-screenreaders-for-sighted-developers">An Intro To Screen Reader Testing for Sighted Developers</Link>
 
 ## Learning resources
 
-*   A wide-reaching [guide on accessibility on MDN](https://developer.mozilla.org/en-US/docs/Learn/Accessibility) covering basics and best practices for a variety of subjects
-*   The [caniuse](https://caniuse.com/) of ARIA attributes: [Accessibility support](https://a11ysupport.io)
-*   [Accessibility web fundamentals by Google](https://developers.google.com/web/fundamentals/accessibility), similar in content to the MDN guide, but more guided
-*   If you prefer videos to reading, a great “pick your subject” style series [A11ycasts](https://www.youtube.com/playlist?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g) is available
+- A wide-reaching <Link to="https://developer.mozilla.org/en-US/docs/Learn/Accessibility">guide on accessibility on MDN</Link> covering basics and best practices for a variety of subjects
+- The <Link to="https://a11ysupport.io">caniuse of ARIA attributes: Accessibility support</Link>
+- <Link to="https://developers.google.com/web/fundamentals/accessibility">Accessibility web fundamentals by Google</Link>, similar in content to the MDN guide, but more guided
+- If you prefer videos to reading, a great “pick your subject” style series <Link to="https://www.youtube.com/playlist?list=PLNYkxOF6rcICWx0C9LVWWVqvHlYJyqw7g">A11ycasts</Link> is available
 
 ### Practical examples
 
 For many things, there’s no need to reinvent the wheel. If your component is featured in one of these two sources, feel free to borrow heavily!
 
-*   [Inclusive Components](https://inclusive-components.design)
-*   [Accessible Components](https://github.com/scottaohara/accessible_components)
+- <Link to="https://inclusive-components.design">Inclusive Components</Link>
+- <Link to="https://github.com/scottaohara/accessible_components">Accessible Components</Link>
 
 ### Tooling
 
-*   Axe plugin for [Chrome](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd) and [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools)
+- Axe plugin for <Link to="https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd">Chrome</Link> and <Link to="https://addons.mozilla.org/en-US/firefox/addon/axe-devtools">FF</Link>
 
 ### Spec docs
 
-*   [Using ARIA](https://www.w3.org/TR/using-aria)
-*   [WCAG 2.1](https://www.w3.org/TR/WCAG21)
-*   [How to Meet WCAG (Quick Reference)](https://www.w3.org/WAI/WCAG21/quickref)
-*   [WAI ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1)
+- <Link to="https://www.w3.org/TR/using-aria">Using ARIA</Link>
+- <Link to="https://www.w3.org/TR/WCAG21">WCAG 2.1</Link>
+- <Link to="https://www.w3.org/WAI/WCAG21/quickref">How to Meet WCAG (Quick Reference)</Link>
+- <Link to="https://www.w3.org/TR/wai-aria-1.1">WAI ARIA 1.1</Link>
+
+
+[def]: https://www.upyoura11y.com/reusable-components-with-headers/

--- a/packages/website/docs/components/guidelines/getting_started.mdx
+++ b/packages/website/docs/components/guidelines/getting_started.mdx
@@ -5,25 +5,27 @@ title: Getting started
 sidebar_position: 1
 ---
 
+import Link from '@docusaurus/Link';
+
 ## Installation
 
-EUI is published through [NPM](https://www.npmjs.com/package/@elastic/eui) as a dependency. To install EUI into an existing project, use the `yarn` CLI (`npm` is not supported).
+EUI is published through <Link to="https://www.npmjs.com/package/@elastic/eui">NPM</Link> as a dependency. To install EUI into an existing project, use the `yarn` CLI (`npm` is not supported).
 
 ```bash
 yarn add @elastic/eui
 ```
 
-Note that EUI has [several `peerDependencies` requirements](https://github.com/elastic/eui/blob/main/packages/eui/package.json) that will also need to be installed when starting with a blank project.
+Note that EUI has <Link to="https://github.com/elastic/eui/blob/main/packages/eui/package.json">several `peerDependencies` requirements</Link> that will also need to be installed when starting with a blank project.
 
 ```bash
 yarn add @elastic/eui @elastic/eui-theme-borealis @elastic/datemath @emotion/react @emotion/css moment
 ```
 
-You can read more about other ways to [consume EUI](https://github.com/elastic/eui/blob/main/wiki/consuming-eui/) in our wiki.
+You can read more about other ways to <Link to="https://github.com/elastic/eui/blob/main/wiki/consuming-eui/">consume EUI</Link> in our wiki.
 
 ## Setting up your application
 
-EUI uses CSS-in-JS (specifically [Emotion](https://emotion.sh/)) for its styles and theming. As such, we require an `<EuiProvider>` wrapper around your application in order for various theme-related UI & UX (such as dark/light mode switching) to work as expected.
+EUI uses CSS-in-JS (specifically <Link to="https://emotion.sh/">Emotion</Link>) for its styles and theming. As such, we require an `<EuiProvider>` wrapper around your application in order for various theme-related UI & UX (such as dark/light mode switching) to work as expected.
 
 ```tsx
 import React from 'react';
@@ -39,13 +41,13 @@ const MyApp = () => (
 export default MyApp;
 ```
 
-For more configuration options of the provider, see the [**EuiProvider** documentation](/docs/utilities/provider).
+For more configuration options of the provider, see the [**EuiProvider** documentation](../utilities/provider.mdx).
 
 ## Styling your application
 
 You can build custom components using EUI's theme tokens, consumed via `useEuiTheme()`. The below example uses Emotion's `css` prop, but any CSS-in-JS library should be able to interpolate the JS variables.
 
-For more ways to consume EUI's theme, see the [**EuiThemeProvider** documentation](/theming/theme-provider#consuming-with-the-react-hook).
+For more ways to consume EUI's theme, see the [**EuiThemeProvider** documentation](../theming/theme_provider.mdx#consuming-with-the-react-hook).
 
 ```tsx
 import React from 'react';
@@ -54,6 +56,7 @@ import { css } from '@emotion/react';
 
 export default () => {
   const { euiTheme } = useEuiTheme();
+
   return (
     <EuiText>
       <p>
@@ -90,16 +93,18 @@ EUI's class names are not a guaranteed API and are prone to change, which will r
 
 :::
 
-While EUI's styles are generally low in <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank" rel="noopener noreferrer">**specificity**</a> due to our usage of CSS-in-JS, you may need to ensure that your CSS is defined after ours in your `<head>`. See [**EuiProvider's** cache customization for more style injection options](../utilities/provider.mdx#emotioncache-customization).
+While EUI's styles are generally low in <Link to="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity">specificity</Link> due to our usage of CSS-in-JS, you may need to ensure that your CSS is defined after ours in your `<head>`. See [**EuiProvider's** cache customization for more style injection options](../utilities/provider.mdx#emotioncache-customization).
 
 ```tsx
 import React from 'react';
 import { EuiButton } from '@elastic/eui';
+
 const myCustomCSS = `
   .myCustomButton {
     background-color: pink;
   }
 `;
+
 export default () => (
   <>
     <style>{myCustomCSS}</style>
@@ -118,7 +123,7 @@ By nature, EUI is very rigid. You shouldn't need much to make drastic changes to
 
 :::
 
-For a full list of global tokens visit [Customizing theme](/docs/theming/customizing-themes). For more examples of the `modify` prop, see the [**EuiThemeProvider** docs](/theming/theme-provider#simple-instance-overrides).
+For more examples of the `modify` prop, see the [**EuiThemeProvider** docs](../theming/theme_provider.mdx#simple-instance-overrides).
 
 ```tsx
 import React, { FunctionComponent, ReactNode } from 'react';
@@ -182,7 +187,7 @@ Or grab all weights, including italics, between 400 and 700 as a variable font.
 
 ### Embedding with `@font-face`
 
-If your application doesn't allow grabbing the font assets from a CDN, you'll need to download and locally provide the font files. You can download the files directly from their source site [rsms.me/inter/](https://rsms.me/inter/), then follow the instructions in the provided CSS file for importing. We recommend using the single variable font file and importing with the following settings:
+If your application doesn't allow grabbing the font assets from a CDN, you'll need to download and locally provide the font files. You can download the files directly from their source site <Link to="https://rsms.me/inter/">rsms.me/inter/</Link>, then follow the instructions in the provided CSS file for importing. We recommend using the single variable font file and importing with the following settings:
 
 ```css
 @font-face {

--- a/packages/website/docs/components/guidelines/testing/introduction.mdx
+++ b/packages/website/docs/components/guidelines/testing/introduction.mdx
@@ -4,6 +4,8 @@ slug: /guidelines/testing
 id: testing-introduction
 ---
 
+import Link from '@docusaurus/Link';
+
 <div style={{ fontSize: '22px' }}>
   Learn how we test our code internally and how you should test integration with EUI components to ensure
   good test coverage and easy maintainability.
@@ -11,50 +13,25 @@ id: testing-introduction
 
 ## How we test our components
 
-We maintain a large amount of integration and end-to-end tests suites for every component we develop.
-They ensure high coverage of most paths within our components, including accessibility features, and lets us know
-whenever we change something that may affect your applications.
+We maintain a large amount of integration and end-to-end tests suites for every component we develop. They ensure high coverage of most paths within our components, including accessibility features, and lets us know whenever we change something that may affect your applications.
 
-Internally, we use [Enzyme](https://enzymejs.github.io/enzyme/)
-and [React Testing Library](https://testing-library.com/) for integration testing,
-[Cypress](https://www.cypress.io/) for end-to-end component testing, as well as static code analysis
-and type checking tools that run automatically on every pull request. You can find them all in our
-[GitHub repository](https://github.com/elastic/eui).
+Internally, we use <Link to="https://enzymejs.github.io/enzyme/">Enzyme</Link> and <Link to="https://testing-library.com/">React Testing Library</Link> for integration testing, <Link to="https://www.cypress.io/">Cypress</Link> for end-to-end component testing, as well as static code analysis and type checking tools that run automatically on every pull request. You can find them all in our <Link to="https://github.com/elastic/eui">GitHub repository</Link>.
 
-All of these tests, including a manual code review and QA steps must pass before the changes are merged
-to confirm they're up to our standards.
+All of these tests, including a manual code review and QA steps must pass before the changes are merged to confirm they're up to our standards.
 
 ## How should you test views using EUI components?
 
-Testing integration with 3rd-party UI libraries like EUI is slightly different from testing first-party components.
-In general, just like with any other dependency, you should not test implementation details like the exact
-DOM structure or class names. They're likely to change between versions and usually don't prove a component works
-correctly anyway, so it's best to skip these.
+Testing integration with 3rd-party UI libraries like EUI is slightly different from testing first-party components. In general, just like with any other dependency, you should not test implementation details like the exact DOM structure or class names. They're likely to change between versions and usually don't prove a component works correctly anyway, so it's best to skip these.
 
 Instead, you should **focus on testing your code and the integration with EUI components first**.
 
-Depending on your testing stack, **integration tests** might be written using React Testing Library (RTL),
-and are meant to be low-level tests of components working together as expected. For example, if your component fetches
-and displays processed data a certain way whenever an `<EuiButton />` is clicked, you should write
-a test that simulates a click on that button and verifies the data is actually fetched and displayed the way
-you expect it to. Doing this will confirm your code integrates with `<EuiButton />` correctly by passing
-the right `onClick` handler, and so that your handler function fetches and updates the data to display the right way.
+Depending on your testing stack, **integration tests** might be written using React Testing Library (RTL), and are meant to be low-level tests of components working together as expected. For example, if your component fetches and displays processed data a certain way whenever an `<EuiButton />` is clicked, you should write a test that simulates a click on that button and verifies the data is actually fetched and displayed the way you expect it to. Doing this will confirm your code integrates with `<EuiButton />` correctly by passing the right `onClick` handler, and so that your handler function fetches and updates the data to display the right way.
 
-On top of that, we also recommend writing **end-to-end (e2e) tests** that go through the flow just like a real user
-would. In addition to testing what integration tests do, they ensure a browser loads and executes your code properly
-as a whole, reacts to real user actions, makes needed network and API calls, and way more. You can use frameworks
-like [Cypress](https://cypress.io), [Selenium](https://www.selenium.dev/), [Playwright](https://playwright.dev/),
-and more to write end-to-end tests for your application.
+On top of that, we also recommend writing **end-to-end (e2e) tests** that go through the flow just like a real user would. In addition to testing what integration tests do, they ensure a browser loads and executes your code properly as a whole, reacts to real user actions, makes needed network and API calls, and way more. You can use frameworks like <Link to="https://cypress.io">Cypress</Link>, <Link to="https://www.selenium.dev/">Selenium</Link>, <Link to="https://playwright.dev/">Playwright</Link>, and more to write end-to-end tests for your application.
 
-When written properly, integration and end-to-end tests will validate if the code you're shipping actually works for
-end users, and that the changes you introduce over time don't break the application. This means you can iterate
-faster and spend less time on manual testing.
+When written properly, integration and end-to-end tests will validate if the code you're shipping actually works for end users, and that the changes you introduce over time don't break the application. This means you can iterate faster and spend less time on manual testing.
 
-**Writing good tests isn't easy**. This is why we've prepared a set of general and component-specific guidelines
-to help you in that process, and we strongly encourage you to read them.
-In case these aren't enough, we're here to help! Please reach out to us by opening a GitHub
-[issue](https://github.com/elastic/eui/issues/new/choose) or
-[discussion](https://github.com/elastic/eui/discussions/new/choose).
+**Writing good tests isn't easy**. This is why we've prepared a set of general and component-specific guidelines to help you in that process, and we strongly encourage you to read them. In case these aren't enough, we're here to help! Please reach out to us by opening a GitHub <Link to="https://github.com/elastic/eui/issues/new/choose">issue</Link> or <Link to="https://github.com/elastic/eui/discussions/new/choose">discussion</Link>.
 
 :::info Elastic employees
 If you're an Elastic employee, we recommend reaching out on the **#eui** Slack channel first.
@@ -62,15 +39,8 @@ If you're an Elastic employee, we recommend reaching out on the **#eui** Slack c
 
 ### Choosing the right selectors
 
-Whenever writing any kind of UI tests, choosing right selectors is the key to making tests reliable long-term.
-We recommend using the `data-test-subj` attributes (e.g., `[data-test-subj="comboBoxSearchInput"]`),
-ARIA `role` attributes (e.g., `[role="dialog"]`),
-and other [semantic queries](https://testing-library.com/docs/queries/about/#priority) for selectors whenever possible
-to ensure they reference the same underlying element between versions.
+Whenever writing any kind of UI tests, choosing right selectors is the key to making tests reliable long-term. We recommend using the `data-test-subj` attributes (e.g., `[data-test-subj="comboBoxSearchInput"]`), ARIA `role` attributes (e.g., `[role="dialog"]`), and other <Link to="https://testing-library.com/docs/queries/about/#priority">semantic queries</Link> for selectors whenever possible to ensure they reference the same underlying element between versions.
 
-You can find the list of available `data-test-subj` and other attributes as well as what semantic query selectors
-we recommend to use in component-specific testing documentation pages.
+You can find the list of available `data-test-subj` and other attributes as well as what semantic query selectors we recommend to use in component-specific testing documentation pages.
 
-If you need to use a custom, non-semantic selector (e.g., `div > span.title` or `span:first-child`)
-that's not a one-off, please open a [GitHub issue](https://github.com/elastic/eui/issues/new/choose), so we can add it,
-or even better so - try adding it yourself and contribute to EUI by opening a pull request! 🎉
+If you need to use a custom, non-semantic selector (e.g., `div > span.title` or `span:first-child`) that's not a one-off, please open a <Link to="https://github.com/elastic/eui/issues/new/choose">GitHub issue</Link>, so we can add it, or even better so - try adding it yourself and contribute to EUI by opening a pull request! 🎉

--- a/packages/website/docs/components/guidelines/testing/recommendations.mdx
+++ b/packages/website/docs/components/guidelines/testing/recommendations.mdx
@@ -3,17 +3,17 @@ title: Testing recommendations
 sidebar_label: Recommendations
 ---
 
+import Link from '@docusaurus/Link';
+
 <div style={{ fontSize: '22px' }}>
   Our general set of do's and don'ts for testing components and views.
 </div>
 
 ## Choose the right selectors
 
-Follow RTL's [Guiding Principles](https://testing-library.com/docs/guiding-principles/)
-and [query priorities](https://testing-library.com/docs/queries/about/#priority) when choosing right element selectors.
+Follow RTL's <Link to="https://testing-library.com/docs/guiding-principles/">Guiding Principles</Link> and <Link to="https://testing-library.com/docs/queries/about/#priority">query priorities</Link> when choosing the right element selectors.
 
-Prioritize accessible and semantic queries (e.g., `[role="dialog"]`) followed by `data-test-subj` attributes over
-other, more complicated and prone to breaking queries (e.g. `div > span.title`) whenever possible.
+Prioritize accessible and semantic queries (e.g., `[role="dialog"]`) followed by `data-test-subj` attributes over other, more complicated and prone to breaking queries (e.g. `div > span.title`) whenever possible.
 
 Check out our component-specific testing docs to find the selectors we officially support.
 
@@ -35,13 +35,9 @@ Check out our component-specific testing docs to find the selectors we officiall
 
 ## Don't use snapshots
 
-**The EUI team strongly discourages snapshot testing**, despite its simplicity.
-Snapshot tests are prone to frequent failures due to the smallest things, like whitespace changes.
-Developers often update stored snapshots when they see them fail without thinking too much about why they fail.
+**The EUI team strongly discourages snapshot testing**, despite its simplicity. Snapshot tests are prone to frequent failures due to the smallest things, like whitespace changes. Developers often update stored snapshots when they see them fail without thinking too much about why they fail.
 
-Tests should tell a story and be considered an instant red flag whenever they fail.
-They should focus on the important details like the data a component is displaying
-or if the data is coming from a prop or being dynamically calculated.
+Tests should tell a story and be considered an instant red flag whenever they fail. They should focus on the important details like the data a component is displaying or if the data is coming from a prop or being dynamically calculated.
 
 Instead, consider writing simple but precise assertion tests.
 
@@ -62,15 +58,13 @@ Instead, consider writing simple but precise assertion tests.
 
 ## Avoid time-based waits
 
-Sometimes the easiest solution to fixing a test is adding a wait/sleep call. In most cases, though,
-this can't be considered a reliable fix, because:
+Sometimes the easiest solution to fixing a test is adding a wait/sleep call. In most cases, though, this can't be considered a reliable fix, because:
 
 1. It significantly increases total test run time, especially when used often
 2. Every machine will take a different amount of time to execute the code, and some &mdash; especially CI runners
 &mdash; are prone to lag during the test run.
 
-Instead, use the utilities available for every testing framework to wait for elements to appear
-or for asynchronous operations to finish execution.
+Instead, use the utilities available for every testing framework to wait for elements to appear or for asynchronous operations to finish execution.
 
 <Guideline type="do" panelPadding="none" text="Programmatically await changes to occur">
   ```tsx
@@ -89,8 +83,7 @@ or for asynchronous operations to finish execution.
 
 ## Write clear test names
 
-Test cases and suites should have unambiguous names and match the naming convention throughout the project.
-Use short but descriptive names written in plain English.
+Test cases and suites should have unambiguous names and match the naming convention throughout the project. Use short but descriptive names written in plain English.
 
 We recommend using the third-person singular simple present tense for its short form and ease of reading.
 
@@ -118,8 +111,7 @@ We recommend using the third-person singular simple present tense for its short 
 
 ### Wrap property names and data in  `` ` ``
 
-When including property and argument names in the test name string, wrap them in backticks (`` ` ``) to clearly
-separate them from the rest of the text.
+When including property and argument names in the test name string, wrap them in backticks (`` ` ``) to clearly separate them from the rest of the text.
 
 <Guideline type="do" panelPadding="none" text="Wrap property names in backticks">
   ```tsx
@@ -135,9 +127,7 @@ separate them from the rest of the text.
 
 ## Add debug-friendly comments or error messages
 
-Consider adding custom error messages or code comments for assertions that are not obvious.
-For [jest](https://jestjs.io/), we recommend adding a comment on top or to the right of the assertion,
-so in case of an error, it will be printed out together as the failing code fragment.
+Consider adding custom error messages or code comments for assertions that are not obvious. For <Link to="https://jestjs.io/">jest</Link>, we recommend adding a comment on top or to the right of the assertion, so in case of an error, it will be printed out together as the failing code fragment.
 
 <Guideline type="do" panelPadding="none" text="Explain the source of the asserted value in code">
   ```tsx

--- a/packages/website/docs/components/guidelines/writing/examples.mdx
+++ b/packages/website/docs/components/guidelines/writing/examples.mdx
@@ -5,6 +5,7 @@ sidebar_label: Examples
 title: Writing - examples
 ---
 
+import Link from '@docusaurus/Link';
 import {
   EuiFlexGroup,
   EuiPanel,
@@ -29,7 +30,7 @@ import {
 
 ## Buttons
 
-Label [buttons](/docs/navigation/button) with their action. Don't use Yes, OK, or Confirm when you can use a verb phrase instead.
+Label [buttons](../../navigation/button/overview.mdx) with their action. Don't use Yes, OK, or Confirm when you can use a verb phrase instead.
 
 <EuiFlexGroup gutterSize="m" alignItems="stretch">
   <Guideline text="Use a verb + noun for a button label." panelStyle={{ minHeight: '292px', display: 'flex', alignItems: 'center' }}>
@@ -65,11 +66,11 @@ Label [buttons](/docs/navigation/button) with their action. Don't use Yes, OK, o
   </Guideline>
 </EuiFlexGroup>
 
-Be sure to read the [full button guidelines](/docs/navigation/button/guidelines).
+Be sure to read the [full button guidelines](../../navigation/button/guidelines.mdx).
 
 ## Callouts
 
-Use [callouts](/docs/display/callout) to relay informational, success, warning, or error messages related to the content on the page.
+Use [callouts](../../display/callout.mdx) to relay informational, success, warning, or error messages related to the content on the page.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="Ensure the description provides information in addition to the title" panelStyle={{ minHeight: '186px', display: 'flex', alignItems: 'center' }}>
@@ -91,7 +92,7 @@ Use [callouts](/docs/display/callout) to relay informational, success, warning, 
 
 ## Empty prompts
 
-The best empty state lets users know what is happening, why it is happening, and what to do about it. Here are four types of frequently used [empty prompts](/docs/display/empty-prompt).
+The best empty state lets users know what is happening, why it is happening, and what to do about it. Here are four types of frequently used [empty prompts](../../display/empty_prompt/overview.mdx).
 
 <Guideline text="Prompt first-time users to take action.">
   <EuiEmptyPrompt
@@ -154,11 +155,11 @@ The best empty state lets users know what is happening, why it is happening, and
   />
 </Guideline>
 
-Be sure to read the [full empty prompt guidelines](/docs/display/empty-prompt/guidelines).
+Be sure to read the [full empty prompt guidelines](../../display/empty_prompt/guidelines.mdx).
 
 ## Labels
 
-Avoid long [labels](/docs/forms/form-layouts/#form-labels), but don't sacrifice clarity. If needed, put additional information in help text and tooltips.
+Avoid long [labels](../../forms/form_layouts/form_label.mdx), but don't sacrifice clarity. If needed, put additional information in help text and tooltips.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="Use labels that say what the input does." panelStyle={{ minHeight: '155px', display: 'flex', alignItems: 'center' }}>
@@ -201,12 +202,12 @@ Avoid long [labels](/docs/forms/form-layouts/#form-labels), but don't sacrifice 
 
 ## Links
 
-Use [links](/docs/navigation/link) to point to detailed information.
+Use [links](../../navigation/link.mdx) to point to detailed information.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="Place a 'Learn more' link after text that briefly introduces a topic or feature." panelStyle={{ minHeight: '314px', display: 'flex', alignItems: 'center' }}>
     <EuiCallOut size="m" title="Building a dashboard?" iconType="gear">
-      Create content directly from our Dashboard app using our new integrated workflow. [Learn more](https://www.elastic.co)
+      Create content directly from our Dashboard app using our new integrated workflow. <Link to="https://www.elastic.co">Learn more</Link>
     </EuiCallOut>
   </Guideline>
 
@@ -232,7 +233,7 @@ Use [links](/docs/navigation/link) to point to detailed information.
 
 ## Modals
 
-[Modals](/docs/layout/modal) are typically used for confirmation when the user might lose data.
+[Modals](../../layout/modal/overview.mdx) are typically used for confirmation when the user might lose data.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="For the body text, use one to two short sentences that explain the consequences." panelStyle={{ minHeight: '360px', display: 'flex', alignItems: 'center' }}>
@@ -367,7 +368,7 @@ Create separate confirmations for single and bulk actions.
 
 ## Text fields
 
-Place hints and instruction outside a [text field](/docs/forms/form-controls/#text-field) so it is always visible to the user.
+Place hints and instruction outside a [text field](../../forms/text/basic.mdx) so it is always visible to the user.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="Help users make the right decision by clarifying what goes inside a field.">
@@ -390,7 +391,7 @@ Place hints and instruction outside a [text field](/docs/forms/form-controls/#te
   </Guideline>
 </EuiFlexGroup>
 
-Use clear language for [validation](/docs/forms/form-validation) messages.
+Use clear language for [validation](../../forms/form_validation/overview.mdx) messages.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="Prefer this format for a required field.">
@@ -415,7 +416,7 @@ Use clear language for [validation](/docs/forms/form-validation) messages.
 
 ## Toasts
 
-A common use of [toasts](/docs/display/toast) is as a success message.
+A common use of [toasts](../../display/toast/overview.mdx) is as a success message.
 
 <EuiFlexGroup gutterSize="m">
   <Guideline text="For common actions such as create, add, delete, remove, and save, include the object type, the object name if available, and the past tense of the action. Don't include &quot;successfully&quot;. It's implied.">
@@ -434,7 +435,7 @@ A common use of [toasts](/docs/display/toast) is as a success message.
   </Guideline>
 </EuiFlexGroup>
 
-Be sure to read the [full toast guidelines](/docs/display/toast/guidelines).
+Be sure to read the [full toast guidelines](../../display/toast/guidelines.mdx).
 
 ## Tooltips
 

--- a/packages/website/docs/components/guidelines/writing/guidelines.mdx
+++ b/packages/website/docs/components/guidelines/writing/guidelines.mdx
@@ -5,6 +5,7 @@ title: Writing
 sidebar_position: 3
 ---
 
+import Link from '@docusaurus/Link';
 import {
   EuiCard,
   EuiCallOut,
@@ -94,10 +95,10 @@ In sentence case, only the first word and proper names are capped. In title case
 Proper nouns include product names, solutions, apps, feature tiers, and subscription levels.
 
 <Guideline type="do" text="Product and solution names are always capitalized. Same goes for feature tiers and subscription levels." panelPadding="xl">
-  *   Welcome to Elastic Observability
-  *   Elastic APM
-  *   You have chosen Security Analytics Essentials.
-  *   This feature is available for Gold subscriptions and higher.
+  - Welcome to Elastic Observability
+  - Elastic APM
+  - You have chosen Security Analytics Essentials.
+  - This feature is available for Gold subscriptions and higher.
 </Guideline>
 
 <Guideline type="do" text="App names are also capitalized, as seen in Dashboard app in this example. When referring to building a dashboard, the term is capitalized. In another example, the Machine Learning app is upper case, but the machine learning feature is lower case." panelPadding="xl">
@@ -106,7 +107,7 @@ Proper nouns include product names, solutions, apps, feature tiers, and subscrip
   </EuiCallOut>
 </Guideline>
 
-For more information, view the [Elastic name guidelines.](https://brand.elastic.co/302f66895/p/072ccc-naming-guide)
+For more information, view the <Link to="https://brand.elastic.co/302f66895/p/072ccc-naming-guide">Elastic name guidelines.</Link>
 
 ## Writing style
 
@@ -538,19 +539,25 @@ Your text can be fun as long as it fits the experience—and doesn't get in the 
 
 ## Verifying your text
 
-**Work with a writer** <br /> A writer can help determine where you need text and what it should say.
+**Work with a writer**
 
-**Read your text out loud** <br /> Word flow has a natural feel to it. Read your text out loud, make changes, and then repeat until the flow of your text feels natural.
+A writer can help determine where you need text and what it should say.
 
-**Use spell check** <br /> Run your text through a spelling and grammar checker.
+**Read your text out loud**
+
+Word flow has a natural feel to it. Read your text out loud, make changes, and then repeat until the flow of your text feels natural.
+
+**Use spell check**
+
+Run your text through a spelling and grammar checker.
 
 ## Specific component guidelines
 
 Find specific guidelines and examples by checking component details.
 
-*   [Button](/docs/navigation/button/guidelines)
-*   [Modal](/docs/layout/modal/guidelines)
-*   [Selection control labels](/docs/forms/selection-controls/guidelines)
-*   [Toast](/docs/display/toast/guidelines)
+- [Button](../../navigation/button/guidelines.mdx)
+- [Modal](../../layout/modal/guidelines.mdx)
+- [Selection control labels](../../forms/selection/guidelines.mdx)
+- [Toast](../../display/toast/guidelines.mdx)
 
-Need some more writing examples? Check out the [Examples](/docs/guidelines/writing/examples) page.
+Need some more writing examples? Check out the [Examples](./examples.mdx) page.


### PR DESCRIPTION
## Summary

On this PR:

- I replace all external links with `<Link>` component from `@docusaurus/Link` which opens them in a new tab, handles `noopener noreferrer`, supports prefetching, preloading and build-time broken link detection ([source](https://docusaurus.io/docs/docusaurus-core#link)),
- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links,
- I removed the "Customize themes" redirection because the page is currently missing. [The task](https://github.com/elastic/eui-private/issues/244) to add it back / consider adding it is planned for M2.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/guidelines`).

Closes [#8467](https://github.com/elastic/eui/issues/8467)

## QA

### Guidelines section

**Checklist**

- [x] Verify that all links work in the staging environment
- [x] Verify that all external links open in a new tab

**Pages**

- [x] [Getting Started](https://eui.elastic.co/pr_8491/new-docs/docs/guidelines/getting-started/)
- [x] [Accessibility](https://eui.elastic.co/pr_8491/new-docs/docs/guidelines/accessibility/)
- [x] [Writing > Examples](https://eui.elastic.co/pr_8491/new-docs/docs/guidelines/writing/examples/)
- [x] [Writing Guidelines](https://eui.elastic.co/pr_8491/new-docs/docs/guidelines/writing/)
- [x] [Testing > Recommendations](https://eui.elastic.co/pr_8491/new-docs/docs/components/guidelines/testing/recommendations/)
- [x] [Testing Introduction](https://eui.elastic.co/pr_8491/new-docs/docs/guidelines/testing/)