### PR TITLE
[EUI+] Fix all broken links in the Theming section

### DIFF
--- a/packages/website/docs/components/theming/colors/utilities.mdx
+++ b/packages/website/docs/components/theming/colors/utilities.mdx
@@ -11,7 +11,7 @@ import ForcedColorsWarning from './_forced_colors_warning.mdx';
 
 ## Background colors
 
-To all but ensure proper contrast of text to background, we recommend using our pre-defined shades of background colors based on the **EuiTheme** brand colors. You can also use [**EuiPanel**](/docs/layout/panel) for the same effect plus more options like padding and rounded corners.
+To all but ensure proper contrast of text to background, we recommend using our pre-defined shades of background colors based on the **EuiTheme** brand colors. You can also use [EuiPanel](../../layout/panel/overview.mdx) for the same effect plus more options like padding and rounded corners.
 
 ```mdx-code-block
 import { Example } from '@site/src/components';

--- a/packages/website/docs/components/theming/colors/values.mdx
+++ b/packages/website/docs/components/theming/colors/values.mdx
@@ -48,7 +48,7 @@ import { BrandColorsTable } from './brand_colors_table';
 
 ## Text colors
 
-Each brand color also has a corresponding text variant that should be used specifically when coloring text. As is used in [**EuiTextColor**](/docs/display/text#coloring-text).
+Each brand color also has a corresponding text variant that should be used specifically when coloring text. As is used in [EuiTextColor](../../display/text.mdx#coloring-text).
 
 import { TextColorPreview } from './text_color_preview';
 import { TextColorsTable } from './text_colors_table';
@@ -147,7 +147,7 @@ import { ShadeColorsTable } from './shade_colors_table';
 
     Since the EUI colors usually evaluate to a hex value, the easiest way to perform color operations like transparency, shading, or tinting is by using the EUI provided methods of `transparentize()`, `shade()`, and `tint()` respectively.
 
-    For all available color functions see the [Colors Utilities page](/docs/theming/colors/utilities).
+    For all available color functions see the [Colors Utilities page](./utilities.mdx).
   </Example.Description>
   <Example.Preview>
     <ShadeColorPreview />

--- a/packages/website/docs/components/theming/sizing.mdx
+++ b/packages/website/docs/components/theming/sizing.mdx
@@ -3,15 +3,16 @@ slug: /theming/sizing
 id: theming_sizing
 ---
 
+import Link from '@docusaurus/Link';
+import { EuiSpacer } from '@elastic/eui';
+
 # Sizing
 
-```mdx-code-block
 import { Example } from '@site/src/components';
 import { BasePreview } from './sizing/base_preview';
 import { SizePreview } from './sizing/size_preview';
 import { CalcPreview } from './sizing/calc_preview';
 import { SizesTable } from './sizing/sizes_table';
-```
 
 ## Base
 
@@ -59,7 +60,7 @@ All sizing values, including font sizes, are calculated from a single base integ
   <Example.Description>
     ### `calc()` <Badge color="accent">CSS function</Badge>
 
-    When doing calculations on top of the named key values, you have to use the [CSS `calc()` function](https://developer.mozilla.org/en-US/docs/Web/CSS/calc\(\)) because the value that is returned is a string value with the appended unit.
+    When doing calculations on top of the named key values, you have to use the <Link to="https://developer.mozilla.org/en-US/docs/Web/CSS/calc()">CSS `calc()` function</Link> because the value that is returned is a string value with the appended unit.
   </Example.Description>
   <Example.Preview>
     <CalcPreview />
@@ -73,5 +74,5 @@ All sizing values, including font sizes, are calculated from a single base integ
   </Example.Snippet>
 </Example>
 
-<br />
+<EuiSpacer />
 <SizesTable />

--- a/packages/website/docs/components/theming/theme_provider.mdx
+++ b/packages/website/docs/components/theming/theme_provider.mdx
@@ -4,24 +4,25 @@ slug: /theming/theme-provider
 id: theming_theme_provider
 ---
 
+import Link from '@docusaurus/Link';
+
 # Theme provider
 
-While [**EuiProvider**](#utilities/provider) should not be wrapped around your application root more than once, you may use multiple nested **EuiThemeProviders** to customize section-specific or component-specific [color modes](/docs/theming/color-mode#rendering-a-specific-color-mode) or theme overrides.
+While [EuiProvider](../utilities/provider.mdx) should not be wrapped around your application root more than once, you may use multiple nested **EuiThemeProviders** to customize section-specific or component-specific [color modes](../theming/color_mode.mdx#rendering-a-specific-color-mode) or theme overrides.
 
 ## EuiThemeProvider
 
 The context layer that enables theming (including the default theme styles) comes from `EuiThemeProvider`. `EuiThemeProvider` accepts four main props (all of which have default values and are therefore optional):
 
-* `theme:` Raw theme values. Calculated values are acceptable.
-     * For the full shape of an EUI theme, see the [global values](/docs/theming/customizing-themes) page.
-* `modify:` Accepts an object of overrides for theme values.
-     * For examples of this prop, see [Simple instance overrides](#simple-instance-overrides) below.
-* `colorMode:` Accepts 'light', 'dark', or 'inverse'.
-     * For usage, see the [Color mode](/docs/theming/color-mode) page.
-* `highContrastMode`: Accepts a true/false boolean.
-     * For usage, see the [High contrast mode](/docs/theming/high-contrast-mode) page.
+- `theme:` Raw theme values. Calculated values are acceptable.
+- `modify:` Accepts an object of overrides for theme values.
+    - For examples of this prop, see [Simple instance overrides](#simple-instance-overrides) below.
+- `colorMode:` Accepts 'light', 'dark', or 'inverse'.
+    - For usage, see the [Color mode](./color_mode.mdx) page.
+- `highContrastMode`: Accepts a true/false boolean.
+    - For usage, see the [High contrast mode](./high_contrast_mode.mdx) page.
 
- To use the default EUI theme, no configuration is required.
+To use the default EUI theme, no configuration is required.
 
 import { ProviderDetails } from './provider_details';
 
@@ -31,10 +32,10 @@ import { ProviderDetails } from './provider_details';
 
 Using the React hook `useEuiTheme()` makes it very easy to consume the EUI static and computed variables like colors and sizing. It simply passes back an object of the current theme which includes:
 
-* `euiTheme:` All the calculated keys including any modifications
-* `modifications:` Only the modification keys
-* `colorMode:` Either 'LIGHT' or 'DARK'
-* `highContrastMode:` Either 'forced', 'preferred', or `false`
+- `euiTheme:` All the calculated keys including any modifications
+- `modifications:` Only the modification keys
+- `colorMode:` Either 'LIGHT' or 'DARK'
+- `highContrastMode:` Either 'forced', 'preferred', or `false`
 
 When consuming the theme's keys like `euiTheme.colors.primary`, you'll want to pass them via the `css` property to take advantage of Emotion's compilation.
 
@@ -108,7 +109,7 @@ export default <ConsumingHOC />;
 
 ## Consuming with Emotion's theming
 
-**EuiThemeProvider** by default sets an [Emotion theme context](https://emotion.sh/docs/theming) with the results of **useEuiTheme()**. This is a syntactical sugar convenience that allows you to take advantage of Emotion's `styled` syntax, or use a function in the `css` prop.
+**EuiThemeProvider** by default sets an <Link to="https://emotion.sh/docs/theming">Emotion theme context</Link> with the results of **useEuiTheme()**. This is a syntactical sugar convenience that allows you to take advantage of Emotion's `styled` syntax, or use a function in the `css` prop.
 
 {/*
 The following section is commented out due to @emotion/react version mismatch. We can't easily fix it unless we disable nohoist


### PR DESCRIPTION
## Summary

On this PR:

- I replace all external links with `<Link>` component from `@docusaurus/Link` which opens them in a new tab, handles `noopener noreferrer`, supports prefetching, preloading and build-time broken link detection ([source](https://docusaurus.io/docs/docusaurus-core#link)),
- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links,
- I removed the "Customize themes" redirection because the page is currently missing. [The task](https://github.com/elastic/eui-private/issues/244) to add it back / consider adding it is planned for M2.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/theming`).

Closes #8468

## QA

### Theming section

**Checklist**

- [x] Verify that all links work in the staging environment
- [x] Verify that all external links open in a new tab

**Pages**

- [x] [Theme Provider](https://eui.elastic.co/pr_8492/new-docs/docs/theming/theme-provider/)
- [x] [Breakpoints > Values](https://eui.elastic.co/pr_8492/new-docs/docs/theming/breakpoints/values/) (fixed on https://github.com/elastic/eui/pull/8494)
- [x] [Colors > Values](https://eui.elastic.co/pr_8492/new-docs/docs/theming/colors/)
- [x] [Colors > Utilities](https://eui.elastic.co/pr_8492/new-docs/docs/theming/colors/utilities/)
- [x] [Sizing](https://eui.elastic.co/pr_8492/new-docs/docs/theming/sizing/)
