### PR TITLE
fix: remove docusaurus theme global body color override

### DIFF
--- a/packages/docusaurus-theme/src/components/theme_context/theme_overrides.ts
+++ b/packages/docusaurus-theme/src/components/theme_context/theme_overrides.ts
@@ -1,11 +1,6 @@
 import { EuiThemeModifications } from '@elastic/eui';
 
 export const EuiThemeOverrides: EuiThemeModifications = {
-  colors: {
-    LIGHT: {
-      body: '#fff',
-    },
-  },
   font: {
     lineHeightMultiplier: 1.75,
   },

--- a/packages/docusaurus-theme/src/theme/Navbar/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Navbar/Layout/index.tsx
@@ -19,7 +19,7 @@ const getStyles = ({ euiTheme }: UseEuiTheme) => {
       --ifm-navbar-item-padding-horizontal: 0;
       --ifm-navbar-item-padding-vertical: 0;
 
-      --ifm-navbar-background-color: ${euiTheme.colors.body};
+      --ifm-navbar-background-color: ${euiTheme.colors.textInverse};
 
       flex-grow: 0;
       flex-shrink: 0;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/8154

This PR removes the hardcoded custom `subdued` color from `packages/docusaurus-theme` and updates `--ifm-navbar-background-color` to use the same color value but coming from an official EUI color token. This should fix all remaining invisible `subdued` color issues.

## QA

- [ ] Open EUI+ docs and confirm all subdued color are displayed as expected (see the original issue for the list of places where it was wrong)