### PR TITLE
[Docs] Remove `accentSecdondary` from button examples

### DIFF
--- a/packages/eui/src-docs/src/views/button/button.js
+++ b/packages/eui/src-docs/src/views/button/button.js
@@ -17,14 +17,17 @@ export default () => {
   const [fullButton, setFullButton] = useState(false);
   const [smallButton, setSmallButton] = useState(false);
   const [withIconButton, setWithIconButton] = useState(false);
-  const buttonColorsOptions = COLORS.map((name) => {
+
+  // While `accentSecondary` is currently available on the component, it is likely to be removed
+  const filteredColors = COLORS.filter((name) => name !== 'accentSecondary');
+  const buttonColorsOptions = filteredColors.map((name) => {
     return {
       value: name,
       text: name,
     };
   });
 
-  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[3].value);
+  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[2].value);
 
   const onChangeButtonColor = (e) => {
     setButtonColor(e.target.value);

--- a/packages/eui/src-docs/src/views/button/button_icon.js
+++ b/packages/eui/src-docs/src/views/button/button_icon.js
@@ -15,9 +15,11 @@ import { COLORS } from '../../../../src/components/button/button';
 const DISPLAY_TYPES = ['empty', 'base', 'fill'];
 const DISPLAY_SIZES = ['xs', 's', 'm'];
 const ICON_SIZES = ['s', 'm', 'l', 'xl', 'xxl', 'original'];
+// While `accentSecondary` is currently available on the component, it is likely to be removed
+const filteredColors = COLORS.filter((name) => name !== 'accentSecondary');
 
 export default () => {
-  const buttonColorsOptions = COLORS.map((name) => {
+  const buttonColorsOptions = filteredColors.map((name) => {
     return {
       value: name,
       text: name,
@@ -45,7 +47,7 @@ export default () => {
   const [displayType, setDisplayType] = useState(displayTypeOptions[0].value);
   const [displaySize, setDisplaySize] = useState(displaySizeOptions[0].value);
   const [iconSize, setIconSize] = useState(iconSizeOptions[1].value);
-  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[3].value);
+  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[2].value);
 
   const onChangeDisplayType = (e) => {
     setDisplayType(e.target.value);

--- a/packages/website/docs/components/navigation/button/button_basic.mdx
+++ b/packages/website/docs/components/navigation/button/button_basic.mdx
@@ -31,14 +31,17 @@ export default () => {
   const [fullButton, setFullButton] = useState(false);
   const [smallButton, setSmallButton] = useState(false);
   const [withIconButton, setWithIconButton] = useState(false);
-  const buttonColorsOptions = COLORS.map((name) => {
+
+  // While `accentSecondary` is currently available on the component, it is likely to be removed
+  const filteredColors = COLORS.filter((name) => name !== 'accentSecondary');
+  const buttonColorsOptions = filteredColors.map((name) => {
     return {
       value: name,
       text: name,
     };
   });
   
-  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[3].value);
+  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[2].value);
 
   const onChangeButtonColor = (e) => {
     setButtonColor(e.target.value);

--- a/packages/website/docs/components/navigation/button/button_icon.mdx
+++ b/packages/website/docs/components/navigation/button/button_icon.mdx
@@ -28,9 +28,11 @@ import { COLORS } from '@elastic/eui/es/components/button/button';
 const DISPLAY_TYPES = ['empty', 'base', 'fill'];
 const DISPLAY_SIZES = ['xs', 's', 'm'];
 const ICON_SIZES = ['s', 'm', 'l', 'xl', 'xxl', 'original'];
+// While `accentSecondary` is currently available on the component, it is likely to be removed
+const filteredColors = COLORS.filter((name) => name !== 'accentSecondary');
 
 export default () => {
-  const buttonColorsOptions = COLORS.map((name) => {
+  const buttonColorsOptions = filteredColors.map((name) => {
     return {
       value: name,
       text: name,
@@ -58,7 +60,7 @@ export default () => {
   const [displayType, setDisplayType] = useState(displayTypeOptions[0].value);
   const [displaySize, setDisplaySize] = useState(displaySizeOptions[0].value);
   const [iconSize, setIconSize] = useState(iconSizeOptions[1].value);
-  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[3].value);
+  const [buttonColor, setButtonColor] = useState(buttonColorsOptions[2].value);
 
   const onChangeDisplayType = (e) => {
     setDisplayType(e.target.value);


### PR DESCRIPTION
## Summary

TL;DR - Hide `accentSecondary` from docs examples until it gets removed from the component

While `accentSecondary` is currently an available color option, it is not recommended for use. In essence, it exists as a 'backward compatible' option where the teal color from the viz palette was previously used. These instances should ultimately be replaced with `primary`, `accent`, or `success` depending on the use case. This color will very likely be deprecated once the color used for `accent` is re-evaluated.

### `accentSecondary` removed from basic and icon button examples

#### Old site
![CleanShot 2025-03-24 at 10 15 12@2x](https://github.com/user-attachments/assets/70635e12-a297-4ec3-a138-e84634245a1e)


#### New site

![CleanShot 2025-03-24 at 10 16 40@2x](https://github.com/user-attachments/assets/64b5cd7c-d5e7-4601-ae59-cab166439bd1)
