### PR TITLE
[EuiTable] Add util to check if previous sibling selector is supported

### DIFF
--- a/packages/eui/changelogs/upcoming/8498.md
+++ b/packages/eui/changelogs/upcoming/8498.md
@@ -1,0 +1,1 @@
+- Updates `EuiTableRow` styles to check support for `:has(+)` selector

--- a/packages/eui/src/components/table/table_row.styles.ts
+++ b/packages/eui/src/components/table/table_row.styles.ts
@@ -11,6 +11,7 @@ import { euiShadow } from '@elastic/eui-theme-common';
 
 import { UseEuiTheme } from '../../services';
 import { euiCanAnimate, logicalCSS, mathWithUnits } from '../../global_styling';
+import { cssSupportsHasWithNextSibling } from '../../global_styling/functions/supports';
 
 import { euiTableVariables } from './table.styles';
 
@@ -81,10 +82,16 @@ export const euiTableRowStyles = (euiThemeContext: UseEuiTheme) => {
         background-color: ${euiTheme.colors.backgroundBasePlain};
         border-radius: ${euiTheme.border.radius.medium};
 
-        &:has(+ .euiTableRow-isExpandedRow) {
-          ${logicalCSS('border-bottom-left-radius', 0)}
-          ${logicalCSS('border-bottom-right-radius', 0)}
-        }
+        /* :has(+) is not supported in all environments (mainly not in older jsdom versions)
+        TODO: Remove the wrapper once consumers have updated their jsdom to >= 24 */
+        ${cssSupportsHasWithNextSibling(
+          `
+            &:has(+ .euiTableRow-isExpandedRow) {
+              ${logicalCSS('border-bottom-left-radius', 0)}
+              ${logicalCSS('border-bottom-right-radius', 0)}
+            }
+          `
+        )}
       `,
       selected: css`
         &,

--- a/packages/eui/src/global_styling/functions/supports.ts
+++ b/packages/eui/src/global_styling/functions/supports.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const cssSupportsSelector = (selector: string, value: string) => {
+  return `
+       @supports selector(${selector}) {${value}}
+    `;
+};
+
+/**
+ * Util to check if the "previous sibling" selector :has(+) is supported
+ */
+export const cssSupportsHasWithNextSibling = (value: string) => {
+  return cssSupportsSelector(':has(+ *)', value);
+};


### PR DESCRIPTION
## Summary

We recently introduced a styling updated on `EuiTableRow` that makes use of the "previous sibling" selector `:has(+ )` (original code [here](https://github.com/elastic/eui/pull/8226/files#diff-94fe0817d4294ace9f97d5146cecf6a6389cc1ec4488534bfcd9a07f56977d53R89), merged [here](https://github.com/elastic/eui/pull/8444))

<details>
<summary>See screenshots of the style here</summary>

| before | after |
|-------|-------|
| ![Screenshot 2025-03-24 at 20 30 05](https://github.com/user-attachments/assets/9efccc97-be1f-4918-9d01-3a437bcd79e3) | ![Screenshot 2025-03-24 at 20 29 53](https://github.com/user-attachments/assets/0d508650-9f01-4008-a376-2aa9cfb0d688) |

</details>


This selector will currently break tests in CloudUI as their current `jsdom` version (20.0.0) does not support the newer CSS syntax yet (EUI updated to a fixed resolution version of `24.1.0` [here](https://github.com/elastic/eui/pull/7821/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R33))

This PR adds a small util for checking if the CSS syntax to is supported.

By adding the wrapper we ensure that:
- we can use the styling on our side
- we don't break test environments

### Changes

- adds `cssSupportsSelector` and `cssSupportsHasWithNextSibling` utils
- updates `EuiTableRow` styles to use the util

ℹ️ This issue was also previously marked [here](https://github.com/elastic/eui/blob/main/packages/eui/src/components/form/form.styles.ts#L438) in `form.styles`.

## QA

- [x] verify the styling is applied :
  - toggle `isExpandedRow` to see the border-radius adjustments for `EuiTableRow` [here](https://eui.elastic.co/pr_8498/storybook/index.html?path=/story/tabular-content-euitable-euitablerow-euitablerow--playground)
  - (optional) verify styles are applied locally (e.g. by adding additional styles
  
ℹ️ I verified locally with local EUI packages that this change ensures the tests on CloudUI run as expected.

![Screenshot 2025-03-24 at 20 34 05](https://github.com/user-attachments/assets/546c6ad3-be16-4fa5-a4ee-2b418b2e7faf)


### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
