### PR TITLE
chore(docusaurus-preset): missing .gitignore file

### DIFF
--- a/packages/docusaurus-preset/.gitignore
+++ b/packages/docusaurus-preset/.gitignore
@@ -1,0 +1,5 @@
+# Production
+/lib
+
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
## Summary

This adds a `.gitignore` file to the new `docusaurus-preset` package, so the lib folder isn't tracked.

