### PR TITLE
fix(website): responsiveness of TOC

### DIFF
--- a/packages/docusaurus-theme/src/components/demo/demo.tsx
+++ b/packages/docusaurus-theme/src/components/demo/demo.tsx
@@ -62,6 +62,7 @@ const getDemoStyles = (euiTheme: UseEuiTheme) => ({
     border: 1px solid var(--docs-demo-border-color);
     border-radius: var(--docs-demo-border-radius);
     margin-block: ${euiTheme.euiTheme.size.xl};
+    word-break: break-word;
   `,
 });
 

--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -1,4 +1,5 @@
 import React, { isValidElement, type ReactNode, JSX } from 'react';
+import { css } from '@emotion/react';
 import { EuiCodeBlock } from '@elastic/eui';
 import type { Props } from '@theme/CodeBlock';
 import { Demo } from '../../components/demo';
@@ -37,6 +38,9 @@ export default function CodeBlock({
       overflowHeight={450}
       language={language}
       isCopyable
+      css={css`
+        word-break: break-word;
+      `}
     >
       {children}
     </EuiCodeBlock>

--- a/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
@@ -70,9 +70,7 @@ function useDocTOC() {
   const hidden = frontMatter.hide_table_of_contents ?? false;
   const canRender = !hidden && toc.length > 0;
 
-  // We're using media queries to hide/show the TOC on mobile/desktop
-  // because we want to show the desktop TOC at a greater breakpoint than default AND
-  // keep the mobile TOC until then because why hide it?
+  // Hide/show for TOC elements is handled by media queries
   const mobile = canRender ? <DocItemTOCMobile /> : undefined;
   const desktop = canRender ? <DocItemTOCDesktop /> : undefined;
 

--- a/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/Layout/index.tsx
@@ -23,6 +23,10 @@ import DocItemTOCDesktop from '../TOC/Desktop';
 import DocItemContent from '../Content';
 import DocItemFooter from '../Footer';
 
+// At 1280px there's enough space to show the TOC,
+// until then we show the mobile/collapsible TOC
+const BREAKPOINT_TOC = 1280;
+
 // converted from css modules to emotion
 const styles = {
   docItemContainer: css`
@@ -36,7 +40,22 @@ const styles = {
   `,
   docItemCol: css`
     @media (min-width: 997px) {
-      max-width: 830px;
+      font-size: 100%;
+      max-width: 94ch;
+      /* Ensure TOC won't wrap */
+      overflow-x: auto;
+    }
+  `,
+  docItemTOCDesktopContainter: css`
+    display: none;
+
+    @media (min-width: ${BREAKPOINT_TOC}px) {
+      display: block;
+    }
+  `,
+  docItemTOCMobileContainter: css`
+    @media (min-width: ${BREAKPOINT_TOC}px) {
+      display: none;
     }
   `,
 };
@@ -51,12 +70,11 @@ function useDocTOC() {
   const hidden = frontMatter.hide_table_of_contents ?? false;
   const canRender = !hidden && toc.length > 0;
 
+  // We're using media queries to hide/show the TOC on mobile/desktop
+  // because we want to show the desktop TOC at a greater breakpoint than default AND
+  // keep the mobile TOC until then because why hide it?
   const mobile = canRender ? <DocItemTOCMobile /> : undefined;
-
-  const desktop =
-    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
-      <DocItemTOCDesktop />
-    ) : undefined;
+  const desktop = canRender ? <DocItemTOCDesktop /> : undefined;
 
   return {
     hidden,
@@ -78,7 +96,7 @@ export default function DocItemLayout({ children }: typeof Props): JSX.Element {
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />
-            {docTOC.mobile}
+            <div css={styles.docItemTOCMobileContainter}>{docTOC.mobile}</div>
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
           </article>
@@ -86,7 +104,11 @@ export default function DocItemLayout({ children }: typeof Props): JSX.Element {
           <DocItemPaginator />
         </div>
       </div>
-      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+      {docTOC.desktop && (
+        <div className="col col--3" css={styles.docItemTOCDesktopContainter}>
+          {docTOC.desktop}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
@@ -10,7 +10,8 @@ const tocStyles = {
   tocMobile: css`
     @media (min-width: 997px) {
       /* Prevent hydration FOUC, as the mobile TOC needs to be server-rendered */
-      display: none;
+      /* ! Not needed because it's handled in DocItem/Layout */
+      /* display: none; */
     }
 
     @media print {

--- a/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocItem/TOC/Mobile/index.tsx
@@ -8,12 +8,6 @@ import TOCCollapsible from '@theme-original/TOCCollapsible';
 // converted from css modules to emotion
 const tocStyles = {
   tocMobile: css`
-    @media (min-width: 997px) {
-      /* Prevent hydration FOUC, as the mobile TOC needs to be server-rendered */
-      /* ! Not needed because it's handled in DocItem/Layout */
-      /* display: none; */
-    }
-
     @media print {
       display: none;
     }

--- a/packages/docusaurus-theme/src/theme/DocRoot/Layout/Sidebar/index.tsx
+++ b/packages/docusaurus-theme/src/theme/DocRoot/Layout/Sidebar/index.tsx
@@ -10,24 +10,6 @@ import { useLocation } from '@docusaurus/router';
 import DocSidebar from '@theme-original/DocSidebar';
 import type { Props } from '@theme-original/DocRoot/Layout/Sidebar';
 import ExpandButton from '@theme-original/DocRoot/Layout/Sidebar/ExpandButton';
-import { useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
-
-const getGlobalStyles = ({ euiTheme }: UseEuiTheme) => {
-  return {
-    sidebar: css`
-      --doc-sidebar-width: 258px;
-      --doc-sidebar-hidden-width: 30px;
-      --ifm-toc-border-color: ${euiTheme.border.color};
-
-      // ensure scrolling still works
-      display: flex;
-
-      .theme-doc-sidebar-menu.menu__list {
-        padding: 0 ${euiTheme.size.s};
-      }
-    `,
-  };
-};
 
 // converted from css modules to Emotion
 const styles = {
@@ -35,13 +17,18 @@ const styles = {
     display: none;
 
     @media (min-width: 997px) {
-      display: block;
+      // ensure scrolling still works
+      display: flex;
       width: var(--doc-sidebar-width);
       margin-top: calc(-1 * var(--ifm-navbar-height));
       border-right: 1px solid var(--ifm-toc-border-color);
       will-change: width;
       transition: width var(--ifm-transition-fast) ease;
       clip-path: inset(0);
+    }
+
+    .theme-doc-sidebar-menu.menu__list {
+      padding-inline-end: var(--eui-size-s);
     }
   `,
   docSidebarContainerHidden: css`
@@ -74,7 +61,6 @@ export default function DocRootLayoutSidebar({
   setHiddenSidebarContainer,
 }: Props): JSX.Element {
   const { pathname } = useLocation();
-  const globalStyles = useEuiMemoizedStyles(getGlobalStyles);
 
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   const toggleSidebar = useCallback(() => {
@@ -96,7 +82,6 @@ export default function DocRootLayoutSidebar({
         styles.docSidebarContainer.name // adding the name here to preserve the functionality of the class check further down
       )}
       css={[
-        globalStyles.sidebar,
         styles.docSidebarContainer,
         hiddenSidebarContainer && styles.docSidebarContainerHidden,
       ]}

--- a/packages/docusaurus-theme/src/theme/Root.styles.ts
+++ b/packages/docusaurus-theme/src/theme/Root.styles.ts
@@ -114,7 +114,6 @@ export const getGlobalStyles = (theme: UseEuiTheme) => {
 
       --ifm-toc-border-color: ${euiTheme.border.color};
 
-      /* Originally defined in :root in DocRoot/Layout/Sidebar */
       --doc-sidebar-width: 258px;
       --doc-sidebar-hidden-width: 30px;
     }

--- a/packages/docusaurus-theme/src/theme/Root.styles.ts
+++ b/packages/docusaurus-theme/src/theme/Root.styles.ts
@@ -111,6 +111,12 @@ export const getGlobalStyles = (theme: UseEuiTheme) => {
       --ifm-h6-font-size: var(--eui-font-size-xxs);
 
       --ifm-global-radius: ${euiTheme.border.radius.small};
+
+      --ifm-toc-border-color: ${euiTheme.border.color};
+
+      /* Originally defined in :root in DocRoot/Layout/Sidebar */
+      --doc-sidebar-width: 258px;
+      --doc-sidebar-hidden-width: 30px;
     }
   `;
 };


### PR DESCRIPTION
## Summary

Resolves #8161 

This improves the layout for "middle" breakpoints by showing the desktop TOC (content menu on the right hand side) at a greater breakpoint than by default, while keeping the mobile TOC.

In summary: more space for content, TOC is _always_ visible.

It also fixes the problem with the desktop TOC wrapping down the content (original issue).

## Screenshots

### ~1040px breakpoint

![localhost_3000_docs_theming_color-mode_1040](https://github.com/user-attachments/assets/8b018dfd-7b2b-48ab-8a3f-be4b3ef6d68f)

### ~1200px breakpoint

![localhost_3000_docs_theming_color-mode_ (1)_1200](https://github.com/user-attachments/assets/e0a635d5-6826-48b0-8f51-7b78690f66d7)

### ~1450px breakpoint

![localhost_3000_docs_theming_color-mode_ (2)_1450](https://github.com/user-attachments/assets/202339d7-d81f-415a-8c5c-ecc3abf1d55d)

### Bonus

<details>
<summary>Improved inline spacing for sidebar navigation</summary>

![localhost_3000_docs_theming_color-mode_](https://github.com/user-attachments/assets/59bbb672-78e9-4d05-8340-654b6a0dd815)
</details>

## QA

Reviewing [by commit](https://github.com/elastic/eui/pull/8505/commits) is recommended.

* [x] navigate the new docs site in breakpoints between 997px and 1300px, make sure the desktop TOC is always on the right (not wrapped)

<details>
<summary>List of pages with wide content that could be problematic</summary>
&nbsp;

- [guidelines/writing](https://eui.elastic.co/pr_8505/new-docs/docs/guidelines/writing/)
- [guidelines/writing/examples](https://eui.elastic.co/pr_8505/new-docs/docs/guidelines/writing/examples/)
- [theming/theme-provider](https://eui.elastic.co/pr_8505/new-docs/docs/theming/theme-provider/)
- [theming/color-mode](https://eui.elastic.co/pr_8505/new-docs/docs/theming/color-mode/)
- [templates/page-template/guidelines](https://eui.elastic.co/pr_8505/new-docs/docs/templates/page-template/guidelines/)
- [layout/accordion](https://eui.elastic.co/pr_8505/new-docs/docs/layout/accordion/)
- [layout/bottom-bar](https://eui.elastic.co/pr_8505/new-docs/docs/layout/bottom-bar/)
- [layout/flex](https://eui.elastic.co/pr_8505/new-docs/docs/layout/flex/)
- [layout/flex/item](https://eui.elastic.co/pr_8505/new-docs/docs/layout/flex/item/)
- [layout/header](https://eui.elastic.co/pr_8505/new-docs/docs/layout/header/)
- [layout/modal/guidelines](https://eui.elastic.co/pr_8505/new-docs/docs/layout/modal/guidelines/)
- [layout/page-components](https://eui.elastic.co/pr_8505/new-docs/docs/layout/page-components/)
- [layout/resizable-container](https://eui.elastic.co/pr_8505/new-docs/docs/layout/resizable-container/)
- [navigation/breadcrumbs](https://eui.elastic.co/pr_8505/new-docs/docs/navigation/breadcrumbs/)
- [navigation/button/empty](https://eui.elastic.co/pr_8505/new-docs/docs/navigation/button/empty/)
- [navigation/button/group](https://eui.elastic.co/pr_8505/new-docs/docs/navigation/button/group/)
- [navigation/button/patterns](https://eui.elastic.co/pr_8505/new-docs/docs/navigation/button/patterns/)
- [navigation/button/guidelines](https://eui.elastic.co/pr_8505/new-docs/docs/navigation/button/guidelines/)
- [navigation/pagination/guidelines](https://eui.elastic.co/pr_8505/new-docs/docs/navigation/pagination/guidelines/)
- [display/empty-prompt/guidelines](https://eui.elastic.co/pr_8505/new-docs/docs/display/empty-prompt/guidelines/)
- [display/icons](https://eui.elastic.co/pr_8505/new-docs/docs/display/icons/)
- [display/image](https://eui.elastic.co/pr_8505/new-docs/docs/display/image/)
- [display/stat](https://eui.elastic.co/pr_8505/new-docs/docs/display/stat/)
- [display/tooltip](https://eui.elastic.co/pr_8505/new-docs/docs/display/tooltip/)
- [display/tour](https://eui.elastic.co/pr_8505/new-docs/docs/display/tour/)
- [forms/layouts/guidelines](https://eui.elastic.co/pr_8505/new-docs/docs/forms/layouts/guidelines/)
- [forms/layouts/prepend-append](https://eui.elastic.co/pr_8505/new-docs/docs/forms/layouts/prepend-append/)
- [forms/search-filter/search-bar](https://eui.elastic.co/pr_8505/new-docs/docs/forms/search-filter/search-bar/)
- [forms/search-filter/filter-group](https://eui.elastic.co/pr_8505/new-docs/docs/forms/search-filter/filter-group/)
- [forms/date-picker/super](https://eui.elastic.co/pr_8505/new-docs/docs/forms/date-picker/super/)
- [tabular-content/tables/basic](https://eui.elastic.co/pr_8505/new-docs/docs/tabular-content/tables/basic/)
- [tabular-content/tables/in-memory](https://eui.elastic.co/pr_8505/new-docs/docs/tabular-content/tables/in-memory/)
- [tabular-content/data-grid](https://eui.elastic.co/pr_8505/new-docs/docs/tabular-content/data-grid/)
- [tabular-content/data-grid/advanced/ref](https://eui.elastic.co/pr_8505/new-docs/docs/tabular-content/data-grid/advanced/ref/)
- [tabular-content/data-grid/advanced/custom-body-rendering](https://eui.elastic.co/pr_8505/new-docs/docs/tabular-content/data-grid/advanced/custom-body-rendering/)
- [editors-syntax/code](https://eui.elastic.co/pr_8505/new-docs/docs/editors-syntax/code/)
- [editors-syntax/markdown/format](https://eui.elastic.co/pr_8505/new-docs/docs/editors-syntax/markdown/format/)
- [editors-syntax/markdown/editor](https://eui.elastic.co/pr_8505/new-docs/docs/editors-syntax/markdown/editor/)
- [utilities/accessibility](https://eui.elastic.co/pr_8505/new-docs/docs/utilities/accessibility/)
- [utilities/color-palettes](https://eui.elastic.co/pr_8505/new-docs/docs/utilities/color-palettes/)
- [utilities/scroll](https://eui.elastic.co/pr_8505/new-docs/docs/utilities/scroll/)
- [utilities/text-truncation](https://eui.elastic.co/pr_8505/new-docs/docs/utilities/text-truncation/)
- [utilities/window-events](https://eui.elastic.co/pr_8505/new-docs/docs/utilities/window-events/)
</details>
