### PR TITLE
fix(website): fix broken links in the Templates section

### DIFF
--- a/packages/website/docs/components/templates/page_template/overview.mdx
+++ b/packages/website/docs/components/templates/page_template/overview.mdx
@@ -11,16 +11,16 @@ id: templates_page_template
 
 All templates should start with a wrapping `EuiPageTemplate` to control some shared settings like `paddingSize`, `bottomBorder`, `restrictWidth`, and `panelled`. Then each direct child will be evaluated for if it is one of the other namespaced components. If so, it will place it in the appropriate spot and apply the appropriate props based on the full configuration of child elements. These namespaced components include:
 
-*   **EuiPageTemplate.Sidebar** extends [**EuiPageSidebar**](#providing-a-sidebar)
-*   **EuiPageTemplate.Header** extends [**EuiPageHeader**](/docs/layout/page-header)
-*   **EuiPageTemplate.Section** extends [**EuiPageSection**](/docs/layout/page-layout-components#page-sections)
-*   **EuiPageTemplate.BottomBar** extends [**EuiBottomBar**](/docs/layout/bottom-bar)
-*   **EuiPageTemplate.EmptyPrompt** extends [**EuiEmptyPrompt**](/docs/display/empty-prompt)
+- **EuiPageTemplate.Sidebar** extends [EuiPageSidebar](#providing-a-sidebar)
+- **EuiPageTemplate.Header** extends [EuiPageHeader](../../layout/page_header.mdx)
+- **EuiPageTemplate.Section** extends [EuiPageSection](../../layout/page_components/overview.mdx#page-sections)
+- **EuiPageTemplate.BottomBar** extends [EuiBottomBar](../../layout/bottom_bar.mdx)
+- **EuiPageTemplate.EmptyPrompt** extends [EuiEmptyPrompt](../../display/empty_prompt/overview.mdx)
 
 With the exception of `.Sidebar` and `.BottomBar`, the stacking order of the page contents is determined by the order they are passed in. You can also override the outer props by simply applying them directly to the child element.
 
 :::tip
-If you have a fixed position [headers](/docs/layout/header#fixed-header), the template will automatically account for the padding `offset` based on the total number of page headers. If you do not want the template to calculate this, you can pass `0` in as the manual `offset`.
+If you have a fixed position [headers](../../layout/header.mdx#fixed-header), the template will automatically account for the padding `offset` based on the total number of page headers. If you do not want the template to calculate this, you can pass `0` in as the manual `offset`.
 :::
 
 ```tsx interactive
@@ -83,7 +83,7 @@ export default ({
 
 If your application requires the use of side navigation or other sidebar content, you can pass and **EuiPageTemplate.Sidebar** component containing your sidebar content. The template will automatically adjust the layout when this content is provided.
 
-This component will set its content to stick to the top of the browser window and scroll independently of the rest of the layout. If you have any fixed [**EuiHeaders**](/docs/display/page-header), these will be accounted for as well. You can turn this behavior off with `sticky={false}`.
+This component will set its content to stick to the top of the browser window and scroll independently of the rest of the layout. If you have any fixed [**EuiHeaders**](../../layout/page_header.mdx), these will be accounted for as well. You can turn this behavior off with `sticky={false}`.
 
 Typically when a sidebar is included and `restrictedWidth` is defined, we recommend keeping the `borderBottom={true}` though you can also expand particular sections with `borderBottom="extended"`.
 
@@ -156,7 +156,7 @@ export default ({
 
 ## Showing a bottom bar
 
-Adding an [**EuiBottomBar**](/docs/layout/bottom-bar) can be tricky to use and account for any sidebars. **EuiPageTemplate** handles this nicely by supplying a **EuiPageTemplate.BottomBar** component for passing the contents of your bottom bar that extends **EuiBottomBar**.
+Adding an [**EuiBottomBar**](../../layout/bottom_bar.mdx) can be tricky to use and account for any sidebars. **EuiPageTemplate** handles this nicely by supplying a **EuiPageTemplate.BottomBar** component for passing the contents of your bottom bar that extends **EuiBottomBar**.
 
 It uses the `sticky` position so that it sticks to the bottom of and remains within the bounds of page body. This way it will never overlap the sidebar, no matter the screen size. It also means not needing to accommodate for the height of the bar in the body element.
 
@@ -220,7 +220,7 @@ export default ({
 
 ## Empty pages or content
 
-When the content is in an empty/pre-setup state, we recommend then using an [**EuiEmptyPrompt**](/docs/display/empty-prompt) to direct users on next steps. Using **EuiPageTemplate.EmptyPrompt** will automatically center the prompt vertically and horizontally.
+When the content is in an empty/pre-setup state, we recommend then using an [**EuiEmptyPrompt**](../../display/empty_prompt/overview.mdx) to direct users on next steps. Using **EuiPageTemplate.EmptyPrompt** will automatically center the prompt vertically and horizontally.
 
 The prompt's panel color depends on the other configurations but can be manually passed in via the `color` prop.
 

--- a/packages/website/docs/components/templates/sitewide_search.mdx
+++ b/packages/website/docs/components/templates/sitewide_search.mdx
@@ -5,13 +5,13 @@ id: templates_sitewide_search
 
 # Sitewide search
 
-**EuiSelectableTemplateSitewide** is an opinionated wrapper around [**EuiSelectable**](/docs/forms/selectable) to provide a reusable template across the Elastic products that will share the same global search capabilities. It creates the search input that triggers a popover containing the list of options.
+**EuiSelectableTemplateSitewide** is an opinionated wrapper around [EuiSelectable](../forms/selection/selectable.mdx) to provide a reusable template across the Elastic products that will share the same global search capabilities. It creates the search input that triggers a popover containing the list of options.
 
 ## Basic setup
 
 ### Search input
 
-The search ability of [**EuiSelectable**](/docs/forms/selectable) is still hooked up to the options provided. It will highlight the portion of the label that matches the search string.
+The search ability of [EuiSelectable](../forms/selection/selectable.mdx) is still hooked up to the options provided. It will highlight the portion of the label that matches the search string.
 
 :::note
 
@@ -21,7 +21,7 @@ The demo showcases the possibility to allow a keyboard shortcut (command + K) to
 
 ### Popover
 
-The popover itself allows you to display a `popoverTitle` node, `popoverFooter` node, or pass any of the `popoverProps` to the [**EuiPopover**](/docs/layout/popover) component.
+The popover itself allows you to display a `popoverTitle` node, `popoverFooter` node, or pass any of the `popoverProps` to the [EuiPopover](../layout/popover.mdx) component.
 
 ### Selection
 
@@ -425,10 +425,10 @@ import { SitewideOption } from './sitewide_option';
   ```
 </details>
 
-*   `label` (required): The name of the item itself. By default, the search box will only use this to match the search term against, but you can supply a separate `searchableLabel` that combines the label and meta data to search on.
-*   `icon`: Only display the solution or application's logo when the option links to the application itself (Dashboard app) and not lower-level items such as individual dashboards. Size and color are predetermined but can be overridden.
-*   `avatar`: Represents the Kibana Space that the item is located in, **if** multiple spaces are present. Type and size are predetermined but can be overridden.
-*   `meta`: This bottom line should only contain items if the option is a lower-level item (individual dashboard). The display of which defaults to simple text, but if you pass one of the predetermined `types`, they will be styled according to the design pattern.
+- `label` (required): The name of the item itself. By default, the search box will only use this to match the search term against, but you can supply a separate `searchableLabel` that combines the label and meta data to search on.
+- `icon`: Only display the solution or application's logo when the option links to the application itself (Dashboard app) and not lower-level items such as individual dashboards. Size and color are predetermined but can be overridden.
+- `avatar`: Represents the Kibana Space that the item is located in, **if** multiple spaces are present. Type and size are predetermined but can be overridden.
+- `meta`: This bottom line should only contain items if the option is a lower-level item (individual dashboard). The display of which defaults to simple text, but if you pass one of the predetermined `types`, they will be styled according to the design pattern.
 
 :::note
 The demo shows how you can temporarily replace the icon for a subset of options to display a short list of recently viewed options.


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/templates`).

Closes [#8468](https://github.com/elastic/eui/issues/8469)

## QA

### Templates section

**Checklist**

- [ ] Verify that all links work in the staging environment

**Pages**

- [ ] Page template
- [ ] Sitewide search
