### PR TITLE
[EuiToolTip] Support conditional screen reader output

### DIFF
--- a/packages/eui/changelogs/upcoming/8508.md
+++ b/packages/eui/changelogs/upcoming/8508.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Added `hasScreenReaderContent` prop on `EuiToolTip` to manually control if the tooltip content should be read when focusing the trigger. This prevents duplicate screen reader output when the tooltip content and `aria-label` on the trigger element have the same text content.
+

--- a/packages/eui/changelogs/upcoming/8508.md
+++ b/packages/eui/changelogs/upcoming/8508.md
@@ -1,4 +1,4 @@
 **Accessibility**
 
-- Added `hasScreenReaderContent` prop on `EuiToolTip` to manually control if the tooltip content should be read when focusing the trigger. This prevents duplicate screen reader output when the tooltip content and `aria-label` on the trigger element have the same text content.
+- Added `disableScreenReaderOutput` prop on `EuiToolTip` to manually control if the tooltip content should be read when focusing the trigger. This prevents duplicate screen reader output when the tooltip content and `aria-label` on the trigger element have the same text content.
 

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -46,6 +46,7 @@ const meta: Meta<EuiToolTipProps> = {
     anchorClassName: '',
     repositionOnScroll: false,
     title: '',
+    hasScreenReaderContent: true,
   },
 };
 enableFunctionToggleControls(meta, ['onMouseOut']);

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -46,7 +46,7 @@ const meta: Meta<EuiToolTipProps> = {
     anchorClassName: '',
     repositionOnScroll: false,
     title: '',
-    hasScreenReaderContent: true,
+    disableScreenReaderOutput: false,
   },
 };
 enableFunctionToggleControls(meta, ['onMouseOut']);

--- a/packages/eui/src/components/tool_tip/tool_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.test.tsx
@@ -167,6 +167,24 @@ describe('EuiToolTip', () => {
       ).toEqual('toolTipId');
     });
 
+    it('does not add `aria-describedby` when `hasScreenReaderContent` is `false`', async () => {
+      const { getByTestSubject } = render(
+        <EuiToolTip
+          content="Tooltip content"
+          id="toolTipId"
+          hasScreenReaderContent={false}
+        >
+          <button data-test-subj="anchor" />
+        </EuiToolTip>
+      );
+      fireEvent.mouseOver(getByTestSubject('anchor'));
+      await waitForEuiToolTipVisible();
+
+      expect(
+        getByTestSubject('anchor').getAttribute('aria-describedby')
+      ).toEqual(null);
+    });
+
     it('merges with custom consumer `aria-describedby`s', async () => {
       const { getByTestSubject } = render(
         <EuiToolTip content="Tooltip content" id="toolTipId">
@@ -179,6 +197,24 @@ describe('EuiToolTip', () => {
       expect(
         getByTestSubject('anchor').getAttribute('aria-describedby')
       ).toEqual('toolTipId customId');
+    });
+
+    it('adds custom consumer `aria-describedby` when `hasScreenReaderContent` is `false`', async () => {
+      const { getByTestSubject } = render(
+        <EuiToolTip
+          content="Tooltip content"
+          id="toolTipId"
+          hasScreenReaderContent={false}
+        >
+          <button data-test-subj="anchor" aria-describedby="customId" />
+        </EuiToolTip>
+      );
+      fireEvent.mouseOver(getByTestSubject('anchor'));
+      await waitForEuiToolTipVisible();
+
+      expect(
+        getByTestSubject('anchor').getAttribute('aria-describedby')
+      ).toEqual('customId');
     });
   });
 

--- a/packages/eui/src/components/tool_tip/tool_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.test.tsx
@@ -167,12 +167,12 @@ describe('EuiToolTip', () => {
       ).toEqual('toolTipId');
     });
 
-    it('does not add `aria-describedby` when `hasScreenReaderContent` is `false`', async () => {
+    it('does not add `aria-describedby` when `disableScreenReaderOutput` is `true`', async () => {
       const { getByTestSubject } = render(
         <EuiToolTip
           content="Tooltip content"
           id="toolTipId"
-          hasScreenReaderContent={false}
+          disableScreenReaderOutput={true}
         >
           <button data-test-subj="anchor" />
         </EuiToolTip>
@@ -199,12 +199,12 @@ describe('EuiToolTip', () => {
       ).toEqual('toolTipId customId');
     });
 
-    it('adds custom consumer `aria-describedby` when `hasScreenReaderContent` is `false`', async () => {
+    it('adds custom consumer `aria-describedby` when `disableScreenReaderOutput` is `true`', async () => {
       const { getByTestSubject } = render(
         <EuiToolTip
           content="Tooltip content"
           id="toolTipId"
-          hasScreenReaderContent={false}
+          disableScreenReaderOutput={true}
         >
           <button data-test-subj="anchor" aria-describedby="customId" />
         </EuiToolTip>

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -106,6 +106,13 @@ export interface EuiToolTipProps extends CommonProps {
    * When nesting an `EuiTooltip` in a scrollable container, `repositionOnScroll` should be `true`
    */
   repositionOnScroll?: boolean;
+
+  /**
+   * Ensures the tooltip content is read by screen readers when focusing the trigger.
+   * Disable it only when the trigger has a descriptive label that duplicates or includes the tooltip content.
+   * @default true
+   */
+  hasScreenReaderContent?: boolean;
   /**
    * If supplied, called when mouse movement causes the tool tip to be
    * hidden.
@@ -141,6 +148,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
     position: 'top',
     delay: 'regular',
     display: 'inlineBlock',
+    hasScreenReaderContent: true,
   };
 
   clearAnimationTimeout = () => {
@@ -316,6 +324,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
       delay,
       display,
       repositionOnScroll,
+      hasScreenReaderContent = true,
       ...rest
     } = this.props;
 
@@ -335,7 +344,8 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           onKeyDown={this.onEscapeKey}
           onMouseOver={this.showToolTip}
           onMouseOut={this.onMouseOut}
-          id={id}
+          // `id` defines if the trigger and tooltip are automatically linked via `aria-describedby`.
+          id={hasScreenReaderContent ? id : undefined}
           className={anchorClasses}
           display={display!}
           isVisible={visible}

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -108,11 +108,14 @@ export interface EuiToolTipProps extends CommonProps {
   repositionOnScroll?: boolean;
 
   /**
-   * Ensures the tooltip content is read by screen readers when focusing the trigger.
-   * Disable it only when the trigger has a descriptive label that duplicates or includes the tooltip content.
-   * @default true
+   * Disables the tooltip content being read by screen readers when focusing the trigger element.
+   * Do not use when the trigger `aria-label` and tooltip `content` can be rephrased to be standalone
+   * information (action & additional information).
+   * Enable this prop only when the trigger has a descriptive label that either duplicates or includes
+   * the tooltip content and would result in repetitive output.
+   * @default false
    */
-  hasScreenReaderContent?: boolean;
+  disableScreenReaderOutput?: boolean;
   /**
    * If supplied, called when mouse movement causes the tool tip to be
    * hidden.
@@ -148,7 +151,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
     position: 'top',
     delay: 'regular',
     display: 'inlineBlock',
-    hasScreenReaderContent: true,
+    disableScreenReaderOutput: false,
   };
 
   clearAnimationTimeout = () => {
@@ -324,7 +327,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
       delay,
       display,
       repositionOnScroll,
-      hasScreenReaderContent = true,
+      disableScreenReaderOutput = false,
       ...rest
     } = this.props;
 
@@ -345,7 +348,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
           onMouseOver={this.showToolTip}
           onMouseOut={this.onMouseOut}
           // `id` defines if the trigger and tooltip are automatically linked via `aria-describedby`.
-          id={hasScreenReaderContent ? id : undefined}
+          id={!disableScreenReaderOutput ? id : undefined}
           className={anchorClasses}
           display={display!}
           isVisible={visible}

--- a/packages/eui/src/components/tool_tip/tool_tip_anchor.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip_anchor.tsx
@@ -73,9 +73,10 @@ export const EuiToolTipAnchor = forwardRef<
             onBlur();
             children.props.onBlur && children.props.onBlur(e);
           },
-          'aria-describedby': isVisible
-            ? classNames(id, children.props['aria-describedby'])
-            : children.props['aria-describedby'],
+          'aria-describedby':
+            isVisible && id
+              ? classNames(id, children.props['aria-describedby'])
+              : children.props['aria-describedby'],
         })}
       </span>
     );


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/214104#issuecomment-2752091195
Relates to https://github.com/elastic/eui/issues/8429

This PR enables `EuiToolTip` to optionally disable the automatic linking of trigger and tooltip element via `aria-describedby`. In most cases this should not be used, as we want the tooltip content to be available for screen reader users when focusing the trigger element.
There are use cases though were this automatic screen reader output for the tooltip content is an issue because it creates duplication. In those cases the tooltip is used solely as visual text alternative, not as accessible one.

**Example use cases:**
- the trigger element already has a descriptive `aria-label` which is identical to the tooltip content (e.g. when used with an icon button where the tooltip is only a visual text alternative to the icon graphic) 
  - ⚠️ most of the time we should try to advise to change the `aria-label` copy instead to make it more actionable and the tooltip content more into "additional information"

- the trigger element already has a descriptive `aria-label` which includes the content of the tooltip (e.g. color labels on `EuiColorPickerSwatch`: `Select {color} as the color` & `{color}`)

![Screenshot 2025-03-27 at 16 44 36](https://github.com/user-attachments/assets/1512b6d3-544a-42cf-af2b-a53b046607a9)


| `hasScreenReaderContent=true` (default) | `hasScreenReaderContent=false` |
|----|----|
| ![Screenshot 2025-03-26 at 17 40 26](https://github.com/user-attachments/assets/b7062c45-9001-4b49-8e20-38bc8c973145) | ![Screenshot 2025-03-26 at 17 41 40](https://github.com/user-attachments/assets/b4231f47-3818-4292-a36f-ce13112b922f) |


### Changes

- adds prop `disableScreenReaderOutput` on `EuiTooltip` (default value: `true`)

>[!IMPORTANT]
I purposefully did not add any further description about the prop in our docs, as on average we don't want consumers to use this pattern but instead ensure an `aria-label` on the trigger and the tooltip content are standalone information. 


## QA

- [ ] verify `EuiTooltip` functionality does not have any regression
- [ ] verify that toggling `disableScreenReaderOutput` en/disables if the tooltip content is output by screen readers. 

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - ~(_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [x] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
