### PR TITLE
[Docs] Add data vis color tokens to EUI docs

### DIFF
--- a/packages/eui/src-docs/src/views/guidelines/_index.scss
+++ b/packages/eui/src-docs/src/views/guidelines/_index.scss
@@ -252,6 +252,12 @@
   background: $euiColorInk;
 }
 
+.guideSass__dataVis {
+  padding: $euiSizeS;
+  color: $euiColorInk;
+  background: $euiColorVis0;
+}
+
 .guideSass__fontFamily {
   font-size: $euiSizeL;
   background: $euiColorDarkestShade;

--- a/packages/eui/src-docs/src/views/theme/color/_color_js.tsx
+++ b/packages/eui/src-docs/src/views/theme/color/_color_js.tsx
@@ -13,6 +13,8 @@ import {
   logicalCSS,
   useEuiPaddingCSS,
   AMSTERDAM_NAME_KEY,
+  EuiThemeAmsterdam,
+  colorVis,
 } from '../../../../../src';
 
 import { EuiThemeColors, ThemeRowType } from '../_props';
@@ -365,6 +367,65 @@ export const SpecialValuesJS = () => {
             type: props[color],
             // @ts-ignore TODO
             value: euiTheme.colors[color],
+          };
+        })}
+        render={(item) => <EuiColorPickerSwatch color={item.value} disabled />}
+      />
+    </>
+  );
+};
+
+export const DataVisJS: FunctionComponent<ThemeRowType> = ({ description }) => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <>
+      <ThemeExample
+        title={<code>euiTheme.colors.vis[dataVis]</code>}
+        description={description}
+        example={
+          <div
+            css={css`
+              padding: ${euiTheme.size.s};
+              color: ${euiTheme.colors.plainDark};
+              background-color: ${euiTheme.colors.vis.euiColorVis0};
+            `}
+          >
+            <strong>background: {euiTheme.colors.vis.euiColorVis0}</strong>
+          </div>
+        }
+        snippet={`background-color: \${euiTheme.colors.vis.euiColorVis0};`}
+        snippetLanguage="emotion"
+      />
+    </>
+  );
+};
+
+const dataVisKeys = Object.keys(colorVis).filter((key) =>
+  key.match(/euiColorVis[0-9]/)
+);
+const dataVisAdditionalKeys = Object.keys(colorVis).filter((key) =>
+  key.match(/euiColorVisBehindText[0-9]/)
+);
+
+export const DataVisValuesJS = () => {
+  const { euiTheme } = useEuiTheme();
+  const props = getPropsFromComponent(EuiThemeColors);
+  const colorKeys =
+    euiTheme.themeName === EuiThemeAmsterdam.key
+      ? [...dataVisKeys, ...dataVisAdditionalKeys]
+      : dataVisKeys;
+
+  return (
+    <>
+      <ThemeValuesTable
+        items={colorKeys.map((color) => {
+          return {
+            id: color,
+            token: `colors.vis.${color}`,
+            type: props[color],
+            // @ts-ignore TODO
+            value: euiTheme.colors.vis[color],
           };
         })}
         render={(item) => <EuiColorPickerSwatch color={item.value} disabled />}

--- a/packages/eui/src-docs/src/views/theme/color/_color_sass.tsx
+++ b/packages/eui/src-docs/src/views/theme/color/_color_sass.tsx
@@ -1,7 +1,12 @@
 import React, { FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 
-import { EuiCode, EuiColorPickerSwatch } from '../../../../../src';
+import {
+  EuiCode,
+  EuiColorPickerSwatch,
+  EuiThemeAmsterdam,
+  useEuiTheme,
+} from '../../../../../src';
 
 // @ts-ignore Importing from JS
 import { useJsonVars } from '../_json/_get_json_vars';
@@ -290,6 +295,56 @@ export const SpecialValuesSass = () => {
     <>
       <ThemeValuesTable
         items={euiSpecialColors.map((color) => {
+          return {
+            id: color,
+            token: `$${color}`,
+            value: values[color],
+          };
+        })}
+        render={(item) => <EuiColorPickerSwatch color={item.value} disabled />}
+      />
+    </>
+  );
+};
+
+export const DataVisSass: FunctionComponent<ThemeRowType> = ({
+  description,
+}) => {
+  const values = useJsonVars();
+
+  return (
+    <>
+      <ThemeExample
+        title={<code>$euiColor[DataVis]</code>}
+        description={description}
+        example={
+          <div className="guideSass__dataVis">
+            <strong>background: {values.euiColorVis0}</strong>
+          </div>
+        }
+        snippet={`background-color: \$euiColorVis0;`}
+        snippetLanguage="scss"
+      />
+    </>
+  );
+};
+
+export const DataVisValuesSass = () => {
+  const { euiTheme } = useEuiTheme();
+  const values = useJsonVars();
+  const dataVisKeys =
+    euiTheme.themeName === EuiThemeAmsterdam.key
+      ? Object.keys(values).filter((key: string) =>
+          key.match(/euiColorVis[0-9]$|euiColorVis[0-9]_behindText/)
+        )
+      : Object.keys(values).filter((key: string) =>
+          key.match(/euiColorVis[0-9]$/)
+        );
+
+  return (
+    <>
+      <ThemeValuesTable
+        items={dataVisKeys.map((color) => {
           return {
             id: color,
             token: `$${color}`,

--- a/packages/eui/src-docs/src/views/theme/color/tokens.tsx
+++ b/packages/eui/src-docs/src/views/theme/color/tokens.tsx
@@ -7,6 +7,7 @@ import {
   EuiCode,
   EuiSpacer,
   EuiText,
+  EuiThemeAmsterdam,
   useEuiTheme,
 } from '../../../../../src';
 import { GuideSection } from '../../../components/guide_section/guide_section';
@@ -21,6 +22,8 @@ import {
   BorderValuesJS,
   BrandJS,
   BrandValuesJS,
+  DataVisJS,
+  DataVisValuesJS,
   ShadeJS,
   ShadeValuesJS,
   SpecialJS,
@@ -35,6 +38,8 @@ import {
   BorderValuesSass,
   BrandSass,
   BrandValuesSass,
+  DataVisSass,
+  DataVisValuesSass,
   ShadeSass,
   ShadeValuesSass,
   SpecialSass,
@@ -125,6 +130,7 @@ export const colorsSections = [
   { title: 'Border colors', id: 'border-colors' },
   { title: 'Shades', id: 'shades' },
   { title: 'Special colors', id: 'special-colors' },
+  { title: 'Data visualization colors', id: 'data-vis-colors' },
 ];
 
 export default () => {
@@ -192,6 +198,11 @@ export default () => {
     );
     if (showSass) return <SpecialSass description={description} />;
     return <SpecialJS description={description} />;
+  }, [showSass]);
+
+  const dataVisContent = useMemo(() => {
+    if (showSass) return <DataVisSass />;
+    return <DataVisJS />;
   }, [showSass]);
 
   return (
@@ -340,6 +351,40 @@ export default () => {
 
       <GuideSection color="transparent">
         {showSass ? <SpecialValuesSass /> : <SpecialValuesJS />}
+      </GuideSection>
+
+      {/* Data vis colors */}
+      <GuideSection color="subdued">
+        <EuiText grow={false}>
+          {' '}
+          <h2 id={`${colorsSections[6].id}`}>{`${colorsSections[6].title}`}</h2>
+          <p>
+            The following colors are color-blind safe and should be used in
+            categorically seried visualizations and graphics. They are meant to
+            be contrasted against the value of{' '}
+            <EuiCode>
+              {euiTheme.themeName === EuiThemeAmsterdam.key
+                ? 'colors.emptyShade'
+                : 'colors.backgroundBasePlain'}
+            </EuiCode>{' '}
+            for the current theme.
+          </p>
+          {euiTheme.themeName === EuiThemeAmsterdam.key && (
+            <p>
+              When using the palette as a background for text (i.e. badges), use
+              the <EuiCode>BehindText</EuiCode> variant. It is a brightened
+              version of the base palette to create better contrast with text.
+            </p>
+          )}
+        </EuiText>
+
+        <EuiSpacer size="xl" />
+
+        {dataVisContent}
+      </GuideSection>
+
+      <GuideSection color="transparent">
+        {showSass ? <DataVisValuesSass /> : <DataVisValuesJS />}
       </GuideSection>
     </>
   );

--- a/packages/website/docs/components/theming/colors/data_vis_colors_preview.tsx
+++ b/packages/website/docs/components/theming/colors/data_vis_colors_preview.tsx
@@ -1,0 +1,18 @@
+import { useEuiTheme } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const DataVisColorsPreview = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <div
+      css={css`
+        padding: ${euiTheme.size.s};
+        color: ${euiTheme.colors.plainDark};
+        background-color: ${euiTheme.colors.vis.euiColorVis0};
+      `}
+    >
+      <strong>background: {euiTheme.colors.vis.euiColorVis0}</strong>
+    </div>
+  );
+};

--- a/packages/website/docs/components/theming/colors/data_vis_colors_table.tsx
+++ b/packages/website/docs/components/theming/colors/data_vis_colors_table.tsx
@@ -1,71 +1,66 @@
 import { EuiCode, EuiSpacer, EuiText, useEuiTheme } from '@elastic/eui';
 import { ColorsTable } from './colors_table';
 
+export const DataVisBackgroundColor = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiCode>
+      {euiTheme.themeName === 'EUI_THEME_AMSTERDAM'
+        ? 'colors.emptyShade'
+        : 'colors.backgroundBasePlain'}
+    </EuiCode>
+  );
+};
+
 export const DataVisColorsTable = () => {
   const { euiTheme } = useEuiTheme();
 
   return (
-    <>
-      <EuiSpacer />
-      <EuiText>
-        <p>
-          The following colors are color-blind safe and should be used in
-          categorically seried visualizations and graphics. They are meant to be
-          contrasted against the value of{' '}
-          <EuiCode>
-            {euiTheme.themeName === 'EUI_THEME_AMSTERDAM'
-              ? 'colors.emptyShade'
-              : 'colors.backgroundBasePlain'}
-          </EuiCode>{' '}
-          for the current theme.
-        </p>
-      </EuiText>
-      <EuiSpacer />
-      <ColorsTable
-        colors={[
-          {
-            value: euiTheme.colors.vis.euiColorVis0,
-            token: 'colors.vis.euiColorVis0',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis1,
-            token: 'colors.vis.euiColorVis1',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis2,
-            token: 'colors.vis.euiColorVis2',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis3,
-            token: 'colors.vis.euiColorVis3',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis4,
-            token: 'colors.vis.euiColorVis4',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis5,
-            token: 'colors.vis.euiColorVis5',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis6,
-            token: 'colors.vis.euiColorVis6',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis7,
-            token: 'colors.vis.euiColorVis7',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis8,
-            token: 'colors.vis.euiColorVis8',
-          },
-          {
-            value: euiTheme.colors.vis.euiColorVis9,
-            token: 'colors.vis.euiColorVis9',
-          },
-        ]}
-      />
-    </>
+    <ColorsTable
+      colors={[
+        {
+          value: euiTheme.colors.vis.euiColorVis0,
+          token: 'colors.vis.euiColorVis0',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis1,
+          token: 'colors.vis.euiColorVis1',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis2,
+          token: 'colors.vis.euiColorVis2',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis3,
+          token: 'colors.vis.euiColorVis3',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis4,
+          token: 'colors.vis.euiColorVis4',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis5,
+          token: 'colors.vis.euiColorVis5',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis6,
+          token: 'colors.vis.euiColorVis6',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis7,
+          token: 'colors.vis.euiColorVis7',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis8,
+          token: 'colors.vis.euiColorVis8',
+        },
+        {
+          value: euiTheme.colors.vis.euiColorVis9,
+          token: 'colors.vis.euiColorVis9',
+        },
+      ]}
+    />
   );
 };
 

--- a/packages/website/docs/components/theming/colors/values.mdx
+++ b/packages/website/docs/components/theming/colors/values.mdx
@@ -197,9 +197,30 @@ import { SpecialColorsTable } from './special_colors_table';
 
 ## Data visualization colors
 
-import { DataVisColorsTable, DataVisColorsBehindTextColorsTable } from './data_vis_colors_table';
+import { DataVisColorsTable, DataVisColorsBehindTextColorsTable, DataVisBackgroundColor } from './data_vis_colors_table';
+import { DataVisColorsPreview } from './data_vis_colors_preview'
 
-### `euiTheme.colors.vis[token]` <Badge color="hollow">token</Badge>
+
+<Example>
+  <Example.Description>
+    ### `euiTheme.colors.vis[token]` <Badge color="hollow">token</Badge>
+
+    The following colors are color-blind safe and should be used in categorically seried visualizations and graphics. 
+    They are meant to be contrasted against the value of <DataVisBackgroundColor /> for the current theme.
+  </Example.Description>
+  <Example.Preview>
+    <DataVisColorsPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```
+    css`
+      background-color: ${euiTheme.colors.vis.euiColorVis0};
+    `
+    ```
+  </Example.Snippet>
+</Example>
+
+<EuiSpacer />
 
 <DataVisColorsTable />
 <DataVisColorsBehindTextColorsTable />


### PR DESCRIPTION
## Summary

Previously we added the data vir color tokens to the new EUI+ docs in [this PR](https://github.com/elastic/eui/pull/8462) but we currently don't showcase them in our current docs.
For the time being we still want to add them in the current docs to document them until the new docs are released.

>[!NOTE]
We purposefully only add docs for the base data vis color tokens.
Once other tokens are more stable we can add those as needed.

### Changes

- adds a section for current data vis color tokens in the EUI docs

| Borealis | Amsterdam |
|-----|----|
| ![Screenshot 2025-03-27 at 11 08 37](https://github.com/user-attachments/assets/4e49cbfc-6642-4d54-874b-c38f8f6a9b3f) | ![Screenshot 2025-03-27 at 11 08 53](https://github.com/user-attachments/assets/71cfe63d-3a8e-423b-b1e7-1a5f9672ec3f) |


- updates the previously added section for data vis color tokens in EUI+ docs:
  - move text to the markdown file where possible (we generally want text to be in markdown files to make the maintenance easier)
  - adds a missing usage example
  
| Borealis | Amsterdam |
|-----|----|
| ![Screenshot 2025-03-27 at 11 09 06](https://github.com/user-attachments/assets/e89459f9-e594-4ea2-a0b8-d42e44ba546f) | ![Screenshot 2025-03-27 at 11 09 28](https://github.com/user-attachments/assets/08503533-e618-436c-8d0e-f4b3a4c18109) |

## QA

- [ ] review the added data vis token section in [EUI docs](https://eui.elastic.co/pr_8511/#/theming/colors/values#data-vis-colors) and verify the tokens are displayed, updated properly per theme
- [ ] review the updated data vis token section in the [EUI+ docs](https://eui.elastic.co/pr_8511/new-docs/docs/theming/colors/#data-visualization-colors) and verify the example and tokens output as expected