### PR TITLE
fix(eslint-plugin): add optional chaining in no_css_color

### DIFF
--- a/packages/eslint-plugin/src/rules/no_css_color.ts
+++ b/packages/eslint-plugin/src/rules/no_css_color.ts
@@ -94,7 +94,7 @@ const raiseReportIfPropertyHasInvalidCssColor = (
 
     const identifierDeclarationInit = (
       identifierDeclaration?.defs[0].node as TSESTree.VariableDeclarator
-    ).init;
+    )?.init;
 
     if (
       identifierDeclarationInit?.type === 'Literal' &&
@@ -133,7 +133,7 @@ const raiseReportIfPropertyHasInvalidCssColor = (
 
     const expressionRootDeclarationInit = (
       expressionRootDeclaration?.defs[0].node as TSESTree.VariableDeclarator
-    ).init;
+    )?.init;
 
     if (expressionRootDeclarationInit?.type === 'ObjectExpression') {
       (


### PR DESCRIPTION
## Summary

Pipeline is failing at the [linting stage](https://buildkite.com/elastic/kibana-pull-request/builds/288757) on the PR: https://github.com/elastic/kibana/pull/210082 because we're trying access `init` in `undefined` in the `@elastic/eui/no-css-color`.

Related to https://github.com/elastic/eui-private/issues/275

## QA

1. Checkout this branch: `gh pr checkout `
2. Build the ESLint plugin: `yarn workspace @elastic/eslint-plugin-eui build`
3. Publish locally: `cd packages/eslint-plugin && yalc publish`

Then, in Kibana:

1. Install the local ESLint plugin version: `yalc add @elastic/eslint-plugin-eui`
2. Reinstall dependencies: `yarn kbn bootstrap --no-validate`

Test files:

- [x] `src/platform/packages/shared/kbn-discover-utils/src/components/custom_control_columns/degraded_docs_control.tsx`
- [x] `src/platform/plugins/shared/console/public/application/containers/editor/editor.tsx`
- [x] `src/platform/plugins/shared/unified_search/public/saved_query_management/saved_query_management_list.tsx`

There should be no errors in the ESLint output. Other warnings should display as appropriate.