### PR TITLE
fix(website): fix broken links in the Layout section

### DIFF
--- a/packages/website/docs/components/layout/accordion.mdx
+++ b/packages/website/docs/components/layout/accordion.mdx
@@ -84,7 +84,7 @@ export default () => {
 
 Use any number of **EuiAccordion** elements to visually display them as a group.
 
-Due to the previously mentioned bare styles, it is recommended to place an [**EuiSpacer**](/layout/spacer) between accordion items. Padding within each accordion item can be applied via the `paddingSize` prop.
+Due to the previously mentioned bare styles, it is recommended to place an [EuiSpacer](./spacer.mdx) between accordion items. Padding within each accordion item can be applied via the `paddingSize` prop.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/layout/bottom_bar.mdx
+++ b/packages/website/docs/components/layout/bottom_bar.mdx
@@ -6,7 +6,7 @@ id: layout_bottom_bar
 # Bottom bar
 
 :::tip
-**EuiPageTemplate** offers a quick way to [apply a bottom bar to your page layouts](/docs/templates/page-template#showing-a-bottom-bar).
+**EuiPageTemplate** offers a quick way to [apply a bottom bar to your page layouts](../templates/page_template/overview.mdx#showing-a-bottom-bar).
 :::
 
 **EuiBottomBar** is a simple wrapper component that does nothing but affix a dark bar (usually filled with buttons) to the bottom of the page. Use it when you have really long pages or complicated, multi-page forms. In the case of forms, only invoke it if a form is in a savable state.

--- a/packages/website/docs/components/layout/flex/flex.mdx
+++ b/packages/website/docs/components/layout/flex/flex.mdx
@@ -11,9 +11,9 @@ import DemoNote from './_flex_preview_note.mdx';
 
 ## Use cases
 
-- [**EuiFlexGroup**](./group) is useful for single row layouts and for quick alignment of items.
-- [**EuiFlexGrid**](./grid) should be used for repeated wrapping rows of same-width items.
-- [**EuiFlexItem**](./item) should be used as a direct child of both groups or grids. It can also, depending on the layout, be omitted if its automatic flex or grow behavior is not desired.
+- [EuiFlexGroup](./flex_group.mdx) is useful for single row layouts and for quick alignment of items.
+- [EuiFlexGrid](./flex_grid.mdx) should be used for repeated wrapping rows of same-width items.
+- [EuiFlexItem](./flex_item.mdx) should be used as a direct child of both groups or grids. It can also, depending on the layout, be omitted if its automatic flex or grow behavior is not desired.
 
 ## Shared behavior
 
@@ -27,7 +27,7 @@ export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper });
 
 :::warning Flex items are also a flexbox
 
-To support nested stretching of items, **EuiFlexItem** also has `display: flex` on it. If your children are not behaving correctly, consider using one of these [flex item workarounds](./item#flex-items-are-also-flex).
+To support nested stretching of items, **EuiFlexItem** also has `display: flex` on it. If your children are not behaving correctly, consider using one of these [flex item workarounds](./flex_item.mdx#flex-items-are-also-flex).
 
 :::
 

--- a/packages/website/docs/components/layout/flex/flex_group.mdx
+++ b/packages/website/docs/components/layout/flex/flex_group.mdx
@@ -14,7 +14,7 @@ export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper });
 
 <DemoNote />
 
-**EuiFlexGroup** is useful for setting up layouts for a single row of content. By default, any [**EuiFlexItem**](./item) within **EuiFlexGroup** will stretch and grow to match their siblings.
+**EuiFlexGroup** is useful for setting up layouts for a single row of content. By default, any [EuiFlexItem](./flex_item.mdx) within **EuiFlexGroup** will stretch and grow to match their siblings.
 
 <FlexDemo>
   ```tsx

--- a/packages/website/docs/components/layout/flex/flex_item.mdx
+++ b/packages/website/docs/components/layout/flex/flex_item.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 # Flex items
 
 :::warning
-To work correctly, **EuiFlexItem** must be a **direct child** of [**EuiFlexGroup**](./group) or [**EuiFlexGrid**](./grid). You cannot have any intermediate HTML wrappers between them.
+To work correctly, **EuiFlexItem** must be a **direct child** of [EuiFlexGroup](./flex_group.mdx) or [EuiFlexGrid](./flex_grid.mdx). You cannot have any intermediate HTML wrappers between them.
 :::
 
 import { createDemo } from '@elastic/eui-docusaurus-theme/components';
@@ -64,7 +64,7 @@ Alternatively, you can sometimes opt to omit **EuiFlexItem** completely.
 
 ## Panels grow vertically to fill flex items
 
-The [**EuiPanel**](/docs/layout/panel) component will naturally grow to fill the **EuiFlexItem** which contains it.
+The [EuiPanel](../panel/overview.mdx) component will naturally grow to fill the **EuiFlexItem** which contains it.
 
 ```tsx interactive
 import React from 'react';
@@ -107,7 +107,7 @@ export default () => (
 ## Grow
 
 :::warning
-The `grow` prop of **EuiFlexItem** only applies when used within [**EuiFlexGroup**](./group). It is ignored by [**EuiFlexGrid**](./grid), which enforces the same width for each item.
+The `grow` prop of **EuiFlexItem** only applies when used within [EuiFlexGroup](./flex_group.mdx). It is ignored by [EuiFlexGrid](./flex_grid.mdx), which enforces the same width for each item.
 :::
 
 ### Turning off item stretching

--- a/packages/website/docs/components/layout/flyout/flyout.mdx
+++ b/packages/website/docs/components/layout/flyout/flyout.mdx
@@ -5,7 +5,7 @@ id: layout_flyout
 
 # Flyout
 
-**EuiFlyout** is a fixed position panel that pops in from the side of the window. It should be used to reveal more detailed contextual information or to provide complex forms without losing the user's current state. It is a good alternative to [modals](../modal) when the action is not transient.
+**EuiFlyout** is a fixed position panel that pops in from the side of the window. It should be used to reveal more detailed contextual information or to provide complex forms without losing the user's current state. It is a good alternative to [modals](../modal/overview.mdx) when the action is not transient.
 
 Like modals, you control the visibility of the flyout using your own state management, but **EuiFlyout** requires an `onClose` handler for it's internal dismiss buttons.
 
@@ -602,7 +602,7 @@ export default () => {
 
 ## Adding a banner
 
-To highlight some information at the top of a flyout, you can pass an [**EuiCallOut**](../../display/callout) to the `banner` prop available in **EuiFlyoutBody** and its layout will adjust appropriately.
+To highlight some information at the top of a flyout, you can pass an [EuiCallOut](../../display/callout.mdx) to the `banner` prop available in **EuiFlyoutBody** and its layout will adjust appropriately.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -672,7 +672,7 @@ export default () => {
 
 ## Without ownFocus
 
-Like modals, you will usually want to obscure the page content beneath with `ownFocus` which wraps the flyout with an [**EuiOverlayMask**](../../utilities/overlay-mask) . However, there are use-cases where flyouts present more information or controls, but need to maintain the interactions of the page content. By setting `ownFocus={false}`, the underlying page content will be visible and clickable.
+Like modals, you will usually want to obscure the page content beneath with `ownFocus` which wraps the flyout with an [EuiOverlayMask](../../utilities/overlay_mask.mdx) . However, there are use-cases where flyouts present more information or controls, but need to maintain the interactions of the page content. By setting `ownFocus={false}`, the underlying page content will be visible and clickable.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/layout/header.mdx
+++ b/packages/website/docs/components/layout/header.mdx
@@ -11,9 +11,9 @@ The header is made up of **many** individual components starting with **EuiHeade
 
 *   **EuiHeaderSection**: Left/right containers with flex properties.
 *   **EuiHeaderSectionItem**: Containers for individual header items as flex items.
-*   **EuiHeaderSectionItemButton**: Specialized button that extends [**EuiButtonEmpty**](/docs/navigation/button#empty-button) but styled to fit the height of the header with additional `notification` props.
+*   **EuiHeaderSectionItemButton**: Specialized button that extends [EuiButtonEmpty](../navigation/button/button_empty.mdx) but styled to fit the height of the header with additional `notification` props.
 *   **EuiHeaderLogo**: A helpful component for creating a linked logo that fits within the header sizing.
-*   **EuiHeaderBreadcrumbs**: A set of [**EuiBreadcrumbs**](/docs/navigation/breadcrumbs) specifically stylized to fit inside the header.
+*   **EuiHeaderBreadcrumbs**: A set of [EuiBreadcrumbs](../navigation/breadcrumbs.mdx) specifically stylized to fit inside the header.
 
 <Demo scope={{ Link }}>
   ```tsx
@@ -427,7 +427,7 @@ The header is made up of **many** individual components starting with **EuiHeade
 
 ## Sections
 
-Alternatively, you can pass an array of objects to the `sections` prop that takes a key of `items` (array of children to wrap in an **EuiHeaderSectionItem**) and/or `breadcrumbs` (array of [breadcrumb](/docs/navigation/breadcrumbs) objects). Each item in the array will be wrapped in an **EuiHeaderSection**.
+Alternatively, you can pass an array of objects to the `sections` prop that takes a key of `items` (array of children to wrap in an **EuiHeaderSectionItem**) and/or `breadcrumbs` (array of [breadcrumb](../navigation/breadcrumbs.mdx) objects). Each item in the array will be wrapped in an **EuiHeaderSection**.
 
 **Note:** Passing `sections` and `children` will disregard the `children` as it is not easily interpreted at what location the children should be placed.
 
@@ -571,7 +571,7 @@ export default () => {
 
 Most consumers need a header that does not scroll away with the page contents. You can set this display by applying the property `position="fixed"`. Multiple fixed headers will automatically stack underneath one another. No manual positioning is required.
 
-If you're using [**EuiPageTemplate**](/docs/templates/page-template), a padding top will be automatically set based on the number of fixed headers on the page. [**EuiFlyouts**](../layout/flyout/flyout.mdx) will also automatically account for and sit below fixed headers.
+If you're using [EuiPageTemplate](../templates/page_template/overview.mdx), a padding top will be automatically set based on the number of fixed headers on the page. [EuiFlyouts](../layout/flyout/flyout.mdx) will also automatically account for and sit below fixed headers.
 
 If you're using your own custom layout, or have custom UI that needs to sit below your fixed header(s), EUI provides a global CSS `var(--euiFixedHeadersOffset)` variable. You can use this variable anywhere, or even override it, to correctly offset any and all fixed header heights.
 
@@ -673,9 +673,9 @@ export default () => {
 
 ## Portal content in the header
 
-Use an **EuiHeaderSectionItemButton** to display additional information in [popovers](../layout/popover.mdx) or [flyouts](../layout/flyout/flyout.mdx), such as a user profile or news feed. When using [**EuiFlyout**](../layout/flyout/flyout.mdx), be sure to wrap it in a [**EuiPortal**](../utilities/portal.mdx). When using an [**EuiPopover**](../layout/popover.mdx) in conjunction with a **fixed** header, be sure to add the `repositionOnScroll` prop to the popover.
+Use an **EuiHeaderSectionItemButton** to display additional information in [popovers](../layout/popover.mdx) or [flyouts](../layout/flyout/flyout.mdx), such as a user profile or news feed. When using [EuiFlyout](../layout/flyout/flyout.mdx), be sure to wrap it in a [EuiPortal](../utilities/portal.mdx). When using an [EuiPopover](../layout/popover.mdx) in conjunction with a **fixed** header, be sure to add the `repositionOnScroll` prop to the popover.
 
-The example below shows how to incorporate **EuiHeaderAlert** components to show a list of updates inside a [**EuiFlyout**](../layout/flyout/flyout.mdx) and a [**EuiPopover**](../layout/popover.mdx) .
+The example below shows how to incorporate **EuiHeaderAlert** components to show a list of updates inside a [EuiFlyout](../layout/flyout/flyout.mdx) and a [EuiPopover](../layout/popover.mdx) .
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -1295,7 +1295,7 @@ export default () => {
 
 ### Putting it all together
 
-The button below will launch a fullscreen example that includes two **EuiHeaders** with all the appropriate navigation pieces including [**EuiCollapsibleNav**,](/docs/navigation/collapsible-nav) **EuiHeaderAlerts**, user menu, deployment switcher, space selector, **EuiHeaderBreadcrumbs** and **EuiHeaderLinks** for app menu items.
+The button below will launch a fullscreen example that includes two **EuiHeaders** with all the appropriate navigation pieces including [EuiCollapsibleNav,](../navigation/collapsible_nav.mdx) **EuiHeaderAlerts**, user menu, deployment switcher, space selector, **EuiHeaderBreadcrumbs** and **EuiHeaderLinks** for app menu items.
 
 This is just a pattern and should be treated as such. Consuming applications will need to recreate the pattern according to their context and save the states as is appropriate to their data store.
 

--- a/packages/website/docs/components/layout/modal/overview.mdx
+++ b/packages/website/docs/components/layout/modal/overview.mdx
@@ -5,13 +5,13 @@ id: layout_modal
 
 # Modal
 
-A modal works best for focusing users' attention on a **short** amount of content and getting them to make a decision, such as a [confirmation](./confirm). Use it to temporarily interrupt a user’s current task and block interactions to the content below it.
+A modal works best for focusing users' attention on a **short** amount of content and getting them to make a decision, such as a [confirmation](./confirm_modal.mdx). Use it to temporarily interrupt a user’s current task and block interactions to the content below it.
 
-If your modal content is more complex, or requires considerable time to complete, consider using an [**EuiFlyout**](../flyout) instead.
+If your modal content is more complex, or requires considerable time to complete, consider using an [EuiFlyout](../flyout/flyout.mdx) instead.
 
 Each **EuiModal** requires a specific set of nested child components. They can be omitted if necessary, but the order cannot be changed or interrupted.
 
-Modals come a wrapping **EuiOverlayMask** to obscure the content beneath, but unlike flyouts, modals cannot be dismissed by clicking on the overlay mask. This is inline with our [modal usage guidelines](./guidelines) which requires there to be a primary action button, even if that button simply closes the modal.
+Modals come a wrapping **EuiOverlayMask** to obscure the content beneath, but unlike flyouts, modals cannot be dismissed by clicking on the overlay mask. This is inline with our [modal usage guidelines](./guidelines.mdx) which requires there to be a primary action button, even if that button simply closes the modal.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/layout/page_components/overview.mdx
+++ b/packages/website/docs/components/layout/page_components/overview.mdx
@@ -5,11 +5,11 @@ id: layout_page_components_overview
 
 # Page components
 
-Page layouts are modular and fit together in a precise manner, though certain parts can also be added or removed as needed. EUI provides both the **individual page components** and an [over-arching template](/docs/templates/page-template) for easily creating some pre-defined layouts.
+Page layouts are modular and fit together in a precise manner, though certain parts can also be added or removed as needed. EUI provides both the **individual page components** and an [over-arching template](../../templates/page_template/overview.mdx) for easily creating some pre-defined layouts.
 
 :::note The following examples showcase the individual components only.
 
-If you're looking for full page layout examples, we recommend using the [EuiPageTemplate](/docs/templates/page-template) and use this page to modify the props of each part of the template.
+If you're looking for full page layout examples, we recommend using the [EuiPageTemplate](../../templates/page_template/overview.mdx) and use this page to modify the props of each part of the template.
 
 :::
 
@@ -56,7 +56,7 @@ import { PageComponentsPreviewWrapper } from './preview_wrapper';
 </Demo>
 ## Page sections
 
-**EuiPageSection** is a stackable component that is essentially an [**EuiPanel**](/docs/layout/panel) with props for quickly creating common usages. It is meant to be a direct descendent of **EuiPageBody** You'll need to set `grow={false}` to any content that you don't want to stretch within the page.
+**EuiPageSection** is a stackable component that is essentially an [EuiPanel](../panel/overview.mdx) with props for quickly creating common usages. It is meant to be a direct descendent of **EuiPageBody** You'll need to set `grow={false}` to any content that you don't want to stretch within the page.
 
 To create dividers between contents, use the `bottomBorder` prop. The `'extended'` version ensures the border touches the sides of the parent. It also supports `restrictWidth` and `alignment` to align with common usages.
 
@@ -111,7 +111,7 @@ export default ({
 
 When piecing all of the different page components together, the state of your application will dictate how best to configure each component. Ideally, your main content should always live within a `'plain'` colored body or section.
 
-When using [**EuiEmptyPrompt**](/docs/display/empty-prompt) to replace the main contents of your page you will want to use a panel color opposite that of the section color. For example:
+When using [EuiEmptyPrompt](../../display/empty_prompt/overview.mdx) to replace the main contents of your page you will want to use a panel color opposite that of the section color. For example:
 
 <table>
   <tr>
@@ -181,7 +181,7 @@ When using [**EuiEmptyPrompt**](/docs/display/empty-prompt) to replace the main 
 </table>
 
 :::tip
-Reminder: [**EuiPageTemplate**](/docs/templates/page-template) can handle all these configurations for you.
+Reminder: [EuiPageTemplate](../../templates/page_template/overview.mdx) can handle all these configurations for you.
 :::
 
 <Demo scope={{ fakeParagraph, fakeSidebar }} previewPadding="none" previewWrapper={PageComponentsPreviewWrapper}>

--- a/packages/website/docs/components/layout/page_header.mdx
+++ b/packages/website/docs/components/layout/page_header.mdx
@@ -5,7 +5,7 @@ id: layout_page_header
 
 # Page header
 
-While the **EuiPageHeader** component can be placed anywhere within your page layout, we recommend using it within the [**EuiPageTemplate**](/docs/templates/page-template) component by passing the configuration props as its `pageHeader`.
+While the **EuiPageHeader** component can be placed anywhere within your page layout, we recommend using it within the [EuiPageTemplate](../templates/page_template/overview.mdx) component by passing the configuration props as its `pageHeader`.
 
 **EuiPageHeader** provides props for opinionated, consistent formatting of your header. Any combination of `pageTitle`, `description`, `tabs`, or any `children` will adjust the layout as needed.
 
@@ -32,7 +32,7 @@ export default () => (
 
 ## Tabs in the page header
 
-A set of `tabs` can be displayed inside the page header by passing an array of [**EuiTab**](/docs/navigation/tabs) objects using the `label` key for the tab content. When displaying tabs, the `bottomBorder` prop will be enforced to create separation of the header and content. You'll still need to manage the page content and selected tab in your own instance.
+A set of `tabs` can be displayed inside the page header by passing an array of [EuiTab](../navigation/tabs/overview.mdx) objects using the `label` key for the tab content. When displaying tabs, the `bottomBorder` prop will be enforced to create separation of the header and content. You'll still need to manage the page content and selected tab in your own instance.
 
 ```tsx interactive
 import React from 'react';
@@ -82,7 +82,7 @@ export default () => (
 
 ## Breadcrumbs in the page header
 
-[Breadcrumbs](/docs/navigation/breadcrumbs) are useful for tracking in-page flows that **are not part of the entire application architecture**. To make this easy **EuiPageHeader** provides a `breadcrumbs` prop that accepts the same configuration as `EuiBreadcrumbs.breadcrumbs`.
+[Breadcrumbs](../navigation/breadcrumbs.mdx) are useful for tracking in-page flows that **are not part of the entire application architecture**. To make this easy **EuiPageHeader** provides a `breadcrumbs` prop that accepts the same configuration as `EuiBreadcrumbs.breadcrumbs`.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/layout/panel/overview.mdx
+++ b/packages/website/docs/components/layout/panel/overview.mdx
@@ -5,7 +5,7 @@ id: layout_panel
 
 # Panel
 
-**EuiPanel** is a building block component. Use it as a layout helper for containing content. It is also commonly used as a base for other larger components like [**EuiPage**](/docs/templates/page-template), [**EuiPopover**](/docs/layout/popover) and [**EuiCard**](/docs/display/card).
+**EuiPanel** is a building block component. Use it as a layout helper for containing content. It is also commonly used as a base for other larger components like [EuiPage](../../templates/page_template/overview.mdx), [EuiPopover](../popover.mdx) and [EuiCard](../../display/card.mdx).
 
 ## Padding
 
@@ -44,7 +44,7 @@ export default () => (
 
 ## Shadow and border
 
-**EuiPanel** can give depth to your container with `hasShadow` while `hasBorder` can add containment. Just be sure not to include too many [nested panels](/docs/layout/panel/guidelines) with these settings.
+**EuiPanel** can give depth to your container with `hasShadow` while `hasBorder` can add containment. Just be sure not to include too many [nested panels](../panel/guidelines.mdx) with these settings.
 
 :::warning Certain allowed combinations of shadow, border, and color depend on the current theme.
 
@@ -100,7 +100,7 @@ export default () => (
 
 ## Growing height
 
-Using **EuiPanel** in an [**EuiFlexItem**](/docs/layout/flex#panels-grow-to-fill-flex-items) will always grow its height to match. This is great for rows of panels. However, you can also turn this feature off by setting `grow={false}`.
+Using **EuiPanel** in an [EuiFlexItem](../flex/flex_item.mdx#panels-grow-vertically-to-fill-flex-items) will always grow its height to match. This is great for rows of panels. However, you can also turn this feature off by setting `grow={false}`.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/layout/panel/split_panel.mdx
+++ b/packages/website/docs/components/layout/panel/split_panel.mdx
@@ -5,7 +5,7 @@ id: layout_panel_split
 
 # Split panels
 
-**EuiSplitPanel** is a composition of an outer and multiple inner [EuiPanels](../../panel). It is a namespaced component that you consume using `EuiSplitPanel.Outer` and `EuiSplitPanel.Inner` respectively. You can supply the same panel props to both components with the exception of a few to ensure the visual layout is correct. It also has two directions, `column` (default) and `row`.
+**EuiSplitPanel** is a composition of an outer and multiple inner [EuiPanels](./overview.mdx). It is a namespaced component that you consume using `EuiSplitPanel.Outer` and `EuiSplitPanel.Inner` respectively. You can supply the same panel props to both components with the exception of a few to ensure the visual layout is correct. It also has two directions, `column` (default) and `row`.
 
 For custom responsiveness, you can adjust at which breakpoints a `row` layout will stack by passing a new array of breakpoint names `['xs', 's']` to the `responsive` prop, or completely turn it off with `false`.
 

--- a/packages/website/docs/components/layout/popover.mdx
+++ b/packages/website/docs/components/layout/popover.mdx
@@ -17,7 +17,7 @@ Use the **EuiPopover** component to hide controls or options behind a clickable 
 
 While the visibility of the popover is maintained by the consuming application, popovers will automatically close when clicking outside of the popover bounds. Therefore all work done in a popover should automatically be saved.
 
-Avoid popover inception (popover triggering another popover), and instead use a [**EuiContextMenu**](/docs/navigation/context-menu) to swap the popover panel content.
+Avoid popover inception (popover triggering another popover), and instead use a [EuiContextMenu](../navigation/context_menu.mdx) to swap the popover panel content.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/layout/resizable_container.mdx
+++ b/packages/website/docs/components/layout/resizable_container.mdx
@@ -59,7 +59,7 @@ Simple resizable container with two panels and a resizer between. This is the mo
 
 ## Resizable panel options
 
-Each **EuiResizablePanel** is simply an **EuiPanel** wrapped with a `<div>` for controlling the width. It stretches to fill its container and accepts all of the same [**EuiPanel**](/docs/layout/panel) props to style your panel.
+Each **EuiResizablePanel** is simply an **EuiPanel** wrapped with a `<div>` for controlling the width. It stretches to fill its container and accepts all of the same [EuiPanel](./panel/overview.mdx) props to style your panel.
 
 The default props clear most of the **EuiPanel** styles, but you can add them back in with `color`, `hasShadow`, and `paddingSize`.
 


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/layout`).

Closes [#8470](https://github.com/elastic/eui/issues/8470)

## QA

### Layout section

**Checklist**

- [x] Verify that all links work in the staging environment

**Pages**

- [x] Accordion
- [x] Bottom bar
- [x] Flex
- [x] Flex group
- [x] Flex item
- [x] Flyout
- [x] Header
- [x] Modal
- [x] Page components
- [x] Page header
- [x] Panel
- [x] Split panel
- [x] Popover
- [x] Resizable container
