### PR TITLE
fix(website): fix broken links in the Navigation section

### DIFF
--- a/packages/website/docs/components/navigation/breadcrumbs.mdx
+++ b/packages/website/docs/components/navigation/breadcrumbs.mdx
@@ -5,9 +5,9 @@ id: navigation_breadcrumbs
 
 # Breadcrumbs
 
-**EuiBreadcrumbs** let the user track their progress within and back out of a UX flow and work well when used in combination with [**EuiPageHeader**](/docs/layout/page-header). They are meant to be used at lower page level flows, while [**EuiHeaderBreadcrumbs**](/docs/layout/header) should be used for application-wide navigation.
+**EuiBreadcrumbs** let the user track their progress within and back out of a UX flow and work well when used in combination with [EuiPageHeader](../layout/page_header.mdx). They are meant to be used at lower page level flows, while [EuiHeaderBreadcrumbs](../layout/header.mdx) should be used for application-wide navigation.
 
-See [**EuiTabs guidelines**](/docs/navigation/tabs/guidelines) if your application requires breadcrumbs and tabs on the same view.
+See [EuiTabs guidelines](./tabs/guidelines.mdx) if your application requires breadcrumbs and tabs on the same view.
 
 **EuiBreadcrumbs** requires an array of **EuiBreadcrumb** objects as `breadcrumbs` and handles truncation, including middle-truncation in the case of many items, and mobile responsiveness. Each item accepts an `href` prop, though we recommend the last item represent the current page and therefore the link is unnecessary.
 
@@ -345,9 +345,9 @@ export default () => {
 
 ## Popover content
 
-If you want a breadcrumb that toggles a popover, e.g. for an account switcher, you can use the `popoverContent` prop for this purpose. **EuiBreadcrumbs** will automatically handle rendering a popover indicator and popover accessibility best practices for you. We recommend using components such as [**EuiContextMenu**](/docs/navigation/context-menu) or [**EuiListGroup**](/docs/display/list-group) for displaying popover options, or potentially [**EuiSelectable**](/docs/forms/selectable) if you have many items that require filtering.
+If you want a breadcrumb that toggles a popover, e.g. for an account switcher, you can use the `popoverContent` prop for this purpose. **EuiBreadcrumbs** will automatically handle rendering a popover indicator and popover accessibility best practices for you. We recommend using components such as [EuiContextMenu](./context_menu.mdx) or [EuiListGroup](../display/list_group.mdx) for displaying popover options, or potentially [EuiSelectable](../forms/selection/selectable.mdx) if you have many items that require filtering.
 
-You may also pass `popoverProps` with almost any prop that [**EuiPopover**](/docs/layout/popover) accepts, such as customizing `panelPaddingSize` or `anchorPosition`. However, props that affect popover state such as `closePopover`, `isOpen`, and `button` are not accepted as they are controlled automatically by **EuiBreadcrumbs**.
+You may also pass `popoverProps` with almost any prop that [EuiPopover](../layout/popover.mdx) accepts, such as customizing `panelPaddingSize` or `anchorPosition`. However, props that affect popover state such as `closePopover`, `isOpen`, and `button` are not accepted as they are controlled automatically by **EuiBreadcrumbs**.
 
 If you need the ability to close the breadcrumb popover from within your popover content, `popoverContent` accepts a render function that will be passed a `closePopover` callback, which you can invoke to close the popover. See the Deployment breadcrumb below for example usage.
 

--- a/packages/website/docs/components/navigation/button/button_basic.mdx
+++ b/packages/website/docs/components/navigation/button/button_basic.mdx
@@ -10,7 +10,7 @@ The most standard button component is **EuiButton** which comes in two styles an
 
 When using colors other than `primary`, be sure that either the words or an icon also represents the status. For instance, don't rely on color alone to represent dangerous actions but use words like "Delete" not "Confirm". The `text` and `accent` colors should be used sparingly as they can easily be confused with other states like disabled and danger.
 
-All button components accept an `iconType` which must be an acceptable [**EuiIcon**](../../display/icons) type. Multi-color icons like app icons will be converted to single color. Icons can be displayed on the opposite side by passing `iconSide="right"`.
+All button components accept an `iconType` which must be an acceptable [EuiIcon](../../display/icons/overview.mdx) type. Multi-color icons like app icons will be converted to single color. Icons can be displayed on the opposite side by passing `iconSide="right"`.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -161,7 +161,7 @@ export default () => {
 
 Every button component accepts either an `href` (rendered as an `<a>`) or an `onClick` (rendered as a `<button>`). While they also accept both props to be applied simultaneously to support certain routing mechansims, it is not usually recommended. For more specific information on how to integrate EUI buttons with react-router, [see this wiki page](https://github.com/elastic/eui/blob/main/wiki/consuming-eui/react-router.md#how-react-router-works).
 
-If you are creating a purely text-based link, like the one in the previous paragraph, use [**EuiLink**](../link) instead.
+If you are creating a purely text-based link, like the one in the previous paragraph, use [EuiLink](../link.mdx) instead.
 
 ```tsx interactive
 import React, { Fragment } from 'react';

--- a/packages/website/docs/components/navigation/button/button_group.mdx
+++ b/packages/website/docs/components/navigation/button/button_group.mdx
@@ -279,7 +279,7 @@ export default () => {
 
 Buttons within a button group will automatically display a default browser tooltip containing the button `label` text. This can be customized or unset via the `title` property in your `options` button configuration.
 
-To instead display an **EuiToolTip** around your button(s), pass the `toolTipContent` property. You can also use `toolTipProps` to customize tooltip placement, title, and any other prop that [**EuiToolTip**](../../display/tooltip) accepts.
+To instead display an **EuiToolTip** around your button(s), pass the `toolTipContent` property. You can also use `toolTipProps` to customize tooltip placement, title, and any other prop that [EuiToolTip](../../display/tooltip.mdx) accepts.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -331,7 +331,7 @@ export default () => {
 
 When using button groups within compressed forms, match the form elements by adding `buttonSize="compressed"`. Compressed groups should always be `fullWidth` so they line up nicely in their small container unless they are icon only.
 
-For a more detailed example of how to integrate with forms, see the ["Complex example"](../../forms/layouts/compressed-forms#complex-example) on the compressed forms page.
+For a more detailed example of how to integrate with forms, see the ["Complex example"](../../forms/form_layouts/compressed_forms.mdx#complex-example) on the compressed forms page.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/navigation/button/overview.mdx
+++ b/packages/website/docs/components/navigation/button/overview.mdx
@@ -15,6 +15,6 @@ import ButtonIntro from './button_intro';
 
 ## Guidelines and patterns
 
-For those new to EUI, be sure to read the full [button usage guidelines](./guidelines).
+For those new to EUI, be sure to read the full [button usage guidelines](./guidelines.mdx).
 
-See [button usage patterns](./patterns) for sample configurations that achieve split or toggle buttons.
+See [button usage patterns](./patterns.mdx) for sample configurations that achieve split or toggle buttons.

--- a/packages/website/docs/components/navigation/collapsible_nav.mdx
+++ b/packages/website/docs/components/navigation/collapsible_nav.mdx
@@ -7,7 +7,7 @@ id: navigation_collapsible_nav
 
 This is a high level component that creates a flyout-style navigational pane.
 
-**EuiCollapsibleNav** is a custom implementation of [**EuiFlyout**](/docs/layout/flyout); the visibility of which must still be maintained by the consuming application. An extra feature that it provides is the ability to `dock` the flyout. This affixes the flyout to the window and pushes the body content by adding left side padding.
+**EuiCollapsibleNav** is a custom implementation of [EuiFlyout](../layout/flyout/flyout.mdx); the visibility of which must still be maintained by the consuming application. An extra feature that it provides is the ability to `dock` the flyout. This affixes the flyout to the window and pushes the body content by adding left side padding.
 
 :::warning
 Docking is not possible on small screens because it would force less real estate for the page content.
@@ -91,7 +91,7 @@ export default () => {
 
 ## Collapsible nav group
 
-An **EuiCollapsibleNavGroup** adds some basic borders and `background` color of `none`, `light`, or `dark`. Give each section a heading by providing an optional `title` and `iconType`. Make the section collapsible ([accordion style](/docs/layout/accordion)) with `isCollapsible=true`.
+An **EuiCollapsibleNavGroup** adds some basic borders and `background` color of `none`, `light`, or `dark`. Give each section a heading by providing an optional `title` and `iconType`. Make the section collapsible ([accordion style](../layout/accordion.mdx)) with `isCollapsible=true`.
 
 When in `isCollapsible` mode, a `title` and `initialIsOpen:boolean` is required.
 
@@ -154,7 +154,7 @@ export default () => (
 
 ## Nav groups with lists and other content
 
-**EuiCollapsibleNavGroups** can contain any children. They work well with [**EuiListGroup, EuiPinnableListGroup**](/docs/display/list-group) and simple [**EuiText**](/docs/navigation/link).
+**EuiCollapsibleNavGroups** can contain any children. They work well with [EuiListGroup, EuiPinnableListGroup](../display/list_group.mdx) and simple [EuiText](./link.mdx).
 
 Below are a few established patterns to use.
 
@@ -292,7 +292,7 @@ export default () => (
 
 ### Putting it all together
 
-The button below will launch a fullscreen example that includes [**EuiHeader**](/docs/layout/header) with a toggle button to open an **EuiCollapsibleNav**. The contents of which are multiple **EuiCollapsibleNavGroups** and saves the open/closed/pinned state for each section and item in local store.
+The button below will launch a fullscreen example that includes [EuiHeader](../layout/header.mdx) with a toggle button to open an **EuiCollapsibleNav**. The contents of which are multiple **EuiCollapsibleNavGroups** and saves the open/closed/pinned state for each section and item in local store.
 
 This is just a pattern and should be treated as such. Consuming applications will need to create the navigation groups according to their context and save the states as is appropriate to their data store.
 

--- a/packages/website/docs/components/navigation/context_menu.mdx
+++ b/packages/website/docs/components/navigation/context_menu.mdx
@@ -5,7 +5,7 @@ id: navigation_context_menu
 
 # Context menu
 
-**EuiContextMenu** is a nested menu system useful for navigating complicated trees. It lives within an [**EuiPopover**](/docs/layout/popover) which itself can be wrapped around any component (like a button in this example).
+**EuiContextMenu** is a nested menu system useful for navigating complicated trees. It lives within an [EuiPopover](../layout/popover.mdx) which itself can be wrapped around any component (like a button in this example).
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -463,7 +463,7 @@ export default () => {
 };
 ```
 
-## Using panels with mixed items & content[](/docs/navigation/context-menu#using-panels-with-mixed-items-content)
+## Using panels with mixed items & content
 
 ### Custom panels
 
@@ -473,7 +473,7 @@ If your panel contents have different widths or you need to ensure that a specif
 
 ### Custom items
 
-You can add separator lines in the `items` prop if you define an item as `{isSeparator: true}`. This will pass the rest of the object properties to an [**EuiHorizontalRule**](/docs/layout/horizontal-rule) component.
+You can add separator lines in the `items` prop if you define an item as `{isSeparator: true}`. This will pass the rest of the object properties to an [EuiHorizontalRule](../layout/horizontal_rule.mdx) component.
 
 For completely custom rendered items, you can use the `{renderItem}` property to pass a component or any function that returns a JSX node.
 

--- a/packages/website/docs/components/navigation/key_pad_menu.mdx
+++ b/packages/website/docs/components/navigation/key_pad_menu.mdx
@@ -50,7 +50,7 @@ export default () => (
 
 ## Menu item
 
-The **EuiKeyPadMenuItem** component can act both as an anchor as well as a button by specifying `href` or `onClick` respectively. It requires a text-based `label` and `children` for declaring the [icon](/docs/display/icons). This is the most flexible way for handling the customization of the icon itself.
+The **EuiKeyPadMenuItem** component can act both as an anchor as well as a button by specifying `href` or `onClick` respectively. It requires a text-based `label` and `children` for declaring the [icon](../display/icons/overview.mdx). This is the most flexible way for handling the customization of the icon itself.
 
 When using the `isSelected` prop to create a toggle button, you must supply both the `true` and `false` states explicitly to ensure the attribute is added for both states.
 
@@ -145,7 +145,7 @@ export default () => {
 
 ## Beta item
 
-If the item links to a module that is not GA (beta, lab, etc), you can add a `betaBadgeLabel` and `betaBadgeTooltipContent` to the card and it will properly create and position an [**EuiBetaBadge**](/docs/display/badge#beta-badge-type).
+If the item links to a module that is not GA (beta, lab, etc), you can add a `betaBadgeLabel` and `betaBadgeTooltipContent` to the card and it will properly create and position an [EuiBetaBadge](../display/badge/beta_badge.mdx).
 
 Supplying just a label will only show the first letter in the badge but displays the full label to the tooltip. You can also pass an `iconType` to replace the letter.
 

--- a/packages/website/docs/components/navigation/link.mdx
+++ b/packages/website/docs/components/navigation/link.mdx
@@ -66,7 +66,7 @@ export default () => (
 
 ## Coloring links
 
-Like any other [button component](/docs/navigation/button), links can be passed a `color`. Note that the `ghost` type should only be used on dark backgrounds (regardless of theming) as it will always create a white link.
+Like any other [button component](./button/button_basic.mdx), links can be passed a `color`. Note that the `ghost` type should only be used on dark backgrounds (regardless of theming) as it will always create a white link.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/navigation/pagination/guidelines.mdx
+++ b/packages/website/docs/components/navigation/pagination/guidelines.mdx
@@ -39,11 +39,9 @@ If you cannot provide a concrete number of results, you still have to communicat
 
 _Remember that not all users understand how your data API works. They just care about the data that's being shown to them._
 
----
-
 ## Give users control of pagination
 
-Providing a [“Rows per page” option](/docs/navigation/pagination#customizable-pagination) is often helpful enough to provide users control over the amount of data they see at once.
+Providing a [“Rows per page” option](./overview.mdx#customizable-pagination) is often helpful enough to provide users control over the amount of data they see at once.
 
 Keep the choices simple and only show “Rows per page” if there are more rows than the smallest option. For example, if there are only 9 rows and the smallest option is 10 rows per page, hide the selector.
 

--- a/packages/website/docs/components/navigation/pagination/overview.mdx
+++ b/packages/website/docs/components/navigation/pagination/overview.mdx
@@ -5,7 +5,7 @@ id: navigation_pagination
 
 # Pagination
 
-Some EUI components have pagination built-in, like [**EuiBasicTable**](/docs/tabular-content/tables), but for custom built paginated interfaces you can use **EuiPagination** manually.
+Some EUI components have pagination built-in, like [EuiBasicTable](../../tabular_content/tables/basic_tables.mdx), but for custom built paginated interfaces you can use **EuiPagination** manually.
 
 ## Basic usage with many pages
 
@@ -59,7 +59,7 @@ export default function () {
 
 ## Centered pagination
 
-You can use [**EuiFlexGroup**](/docs/layout/flex) to center the pagination in a layout.
+You can use [EuiFlexGroup](../../layout/flex/flex_group.mdx) to center the pagination in a layout.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -88,7 +88,7 @@ export default function () {
 
 Use the `compressed` prop to minimize the horizontal footprint. This will replace the numbered buttons with static numbers and rely on the first, last, next and previous icon buttons to navigate.
 
-This is also the same display that will occur when `responsive` is **not** `false`. You can adjust the responsiveness by supplying an array of [named breakpoints](/docs/theming/breakpoints) to `responsive`. The default is `['xs', 's']`.
+This is also the same display that will occur when `responsive` is **not** `false`. You can adjust the responsiveness by supplying an array of [named breakpoints](../../theming/breakpoints/values.mdx) to `responsive`. The default is `['xs', 's']`.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -134,7 +134,7 @@ export default function () {
 
 ## Table pagination
 
-You can use **EuiTablePagination** to create a combination "Rows per page" and pagination set, commonly used with [tables](/docs/tabular-content/tables#adding-pagination-to-a-table). If you pass `0` in as one of the `itemsPerPageOptions`, it will create a "Show all" option and hide the pagination.
+You can use **EuiTablePagination** to create a combination "Rows per page" and pagination set, commonly used with [tables](../../tabular_content/tables/basic_tables.mdx#pagination). If you pass `0` in as one of the `itemsPerPageOptions`, it will create a "Show all" option and hide the pagination.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -169,7 +169,7 @@ export default () => {
 
 ## Customizable pagination
 
-Or you can use [**EuiFlexGroup**](/docs/layout/flex) and [**EuiContextMenu**](/docs/navigation/context-menu#with-single-panel) to set up your own custom pagination layout.
+Or you can use [EuiFlexGroup](../../layout/flex/flex_group.mdx) and [EuiContextMenu](../context_menu.mdx#with-single-panel) to set up your own custom pagination layout.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/navigation/tabs/overview.mdx
+++ b/packages/website/docs/components/navigation/tabs/overview.mdx
@@ -137,7 +137,7 @@ export default () => {
 
 ## Tab sizes
 
-**EuiTabs** allow a `size` prop. In general you should always use the default (medium) size. The small size is best for when placing inside popovers or other small containers. Reserve using the large size for when using as primary page navigation, like inside of [**EuiPageHeader**](/docs/layout/page-header).
+**EuiTabs** allow a `size` prop. In general you should always use the default (medium) size. The small size is best for when placing inside popovers or other small containers. Reserve using the large size for when using as primary page navigation, like inside of [EuiPageHeader](../../layout/page_header.mdx).
 
 You can also use the `expand` prop to evenly stretch each tab horizontally.
 
@@ -231,7 +231,7 @@ export default () => {
 
 ## Bottom border
 
-The `bottomBorder` helps to separate the tab group from the content below and is on by default. However, some components like [flyouts](/docs/layout/flyout) already provide borders which can act as the divider. In this case you can turn the border off with `bottomBorder={false}`.
+The `bottomBorder` helps to separate the tab group from the content below and is on by default. However, some components like [flyouts](../../layout/flyout/flyout.mdx) already provide borders which can act as the divider. In this case you can turn the border off with `bottomBorder={false}`.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/navigation/tree_view.mdx
+++ b/packages/website/docs/components/navigation/tree_view.mdx
@@ -5,11 +5,11 @@ id: navigation_tree_view
 
 # Tree view
 
-**EuiTreeView** allows you to render recursive objects, such as a file directory. It is not meant to be used as primary navigation, for that we recommend using [**EuiSideNav**](/docs/navigation/side-nav).
+**EuiTreeView** allows you to render recursive objects, such as a file directory. It is not meant to be used as primary navigation, for that we recommend using [EuiSideNav](./side_nav.mdx).
 
 **EuiTreeView** does not accept `children` directly but requires an array of `EuiTreeViewNode`s through its `items` prop.
 
-Each node requires a `label` and a unique `id`. The `icon` prop accepts any [icon or token](/docs/display/icons). You can also specify a different icon for the open state with the `iconWhenExpanded` prop. Use the nodes' `children` prop to nest more nodes.
+Each node requires a `label` and a unique `id`. The `icon` prop accepts any [icon or token](../display/icons/overview.mdx). You can also specify a different icon for the open state with the `iconWhenExpanded` prop. Use the nodes' `children` prop to nest more nodes.
 
 :::accessibility Accessibility recommendation
 Provide a descriptive `aria-label` for each tree view. This component also builds in keyboard navigation allowing users to traverse the tree using the arrow keys, spacebar, and return.


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/navigation`).

Closes [#8471](https://github.com/elastic/eui/issues/8471)

## QA

### Navigation section

**Checklist**

- [x] Verify that all links work in the staging environment

**Pages**

- [x] Breadcrumbs
- [x] Button overview
- [x] Basic button
- [x] Button group
- [x] Collapsible nav
- [x] Context menu
- [x] Key pad menu
- [x] Link
- [x] Pagination
- [x] Pagination guidelines
- [x] Tabs
- [x] Tree view
