### PR TITLE
fix(website): fix broken links in the Display section

### DIFF
--- a/packages/website/docs/components/display/badge/beta_badge.mdx
+++ b/packages/website/docs/components/display/badge/beta_badge.mdx
@@ -9,7 +9,7 @@ The **EuiBetaBadge** was created specifically to call out modules that are not i
 
 If you pass in an `iconType`, only the icon will be used in the badge itself and the label will be applied as the title. Only use an icon when attaching the beta badge to small components. Beta badges can also be made clickable by passing `href` or `onClick` as needed.
 
-They can also be used in conjunction with [**EuiCards**](/docs/display/card) and [**EuiKeyPadMenuItems**](/docs/navigation/key-pad-menu).
+They can also be used in conjunction with [EuiCards](../card.mdx) and [EuiKeyPadMenuItems](../../navigation/key_pad_menu.mdx).
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/display/badge/notification_badge.mdx
+++ b/packages/website/docs/components/display/badge/notification_badge.mdx
@@ -5,7 +5,7 @@ id: display_badge_notification
 
 # Notification badge
 
-**EuiNotificationBadge** should be used to showcase the number of notifications, alerts, or hidden selections. This badge type is commonly used in the [**EuiHeader**](/docs/layout/header) and [**EuiFilterButton**](/docs/forms/filter-group) components.
+**EuiNotificationBadge** should be used to showcase the number of notifications, alerts, or hidden selections. This badge type is commonly used in the [EuiHeader](../../layout/header.mdx) and [EuiFilterButton](../../forms/search_filter/filter_group.mdx) components.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/display/card.mdx
+++ b/packages/website/docs/components/display/card.mdx
@@ -5,7 +5,7 @@ id: display_card
 
 # Card
 
-**EuiCard** is a content-oriented component built on top of [**EuiPanel**](/docs/layout/panel). Be sure to check out the [guidelines for properly nesting panels](/docs/layout/panel/guidelines).
+**EuiCard** is a content-oriented component built on top of [EuiPanel](../layout/panel/overview.mdx). Be sure to check out the [guidelines for properly nesting panels](../layout/panel/guidelines.mdx).
 
 ## Basic card
 

--- a/packages/website/docs/components/display/comment_list.mdx
+++ b/packages/website/docs/components/display/comment_list.mdx
@@ -5,7 +5,7 @@ id: display_comment_list
 
 # Comment list
 
-The **EuiCommentList** is a timeline component built on top of [**EuiTimeline**](../timeline). It allows you to display comments or logged actions that either a user or a system has performed.
+The **EuiCommentList** is a timeline component built on top of [EuiTimeline](timeline.mdx). It allows you to display comments or logged actions that either a user or a system has performed.
 
 :::accessibility Accessibility recommendation
 Provide a descriptive `aria-label` or the ID of an external label to the `aria-labelledby` prop of the **EuiCommentList**. A `timelineAvatarAriaLabel` should be provided for every **EuiComment** with or without a `timelineAvatar` as `IconType`.
@@ -129,12 +129,12 @@ import { CommentListProps, CommentListStyle } from './comment_list_props.tsx';
 />
 <CommentListStyle>
 
-1.  `timelineAvatar`: Shows an avatar that should indicate who is the author of the comment. To customize, pass a `string` as an `EuiIcon['type']` or an [**EuiAvatar**](../avatar). Use in conjunction with `timelineAvatarAriaLabel` to pass an aria label to the avatar. If no avatar is provided, it will default to an avatar with a `userAvatar` icon.
+1.  `timelineAvatar`: Shows an avatar that should indicate who is the author of the comment. To customize, pass a `string` as an `EuiIcon['type']` or an [EuiAvatar](avatar.mdx). Use in conjunction with `timelineAvatarAriaLabel` to pass an aria label to the avatar. If no avatar is provided, it will default to an avatar with a `userAvatar` icon.
 2.  `eventIcon`: Icon that shows before the username. Use in conjunction with `eventIconAriaLabel` to pass an aria label to the event icon.
 3.  `username`: Author of the comment.
 4.  `event`: Describes the event that took place.
 5.  `timestamp`: Time of occurrence of the event.
-6.  `actions`: Custom actions that the user can perform from the comment's header. When having multiple actions, consider grouping them in a nested menu system using a [**EuiPopover**](../../layout/popover) with a [**EuiContextMenu**](../../navigation/context-menu).
+6.  `actions`: Custom actions that the user can perform from the comment's header. When having multiple actions, consider grouping them in a nested menu system using a [EuiPopover](../layout/popover.mdx) with a [EuiContextMenu](../navigation/context_menu.mdx).
 7.  `children`: A user message or any custom component.
 
 </CommentListStyle>
@@ -331,8 +331,8 @@ export default () => {
 The timeline icon is a very important part of the comment:
 
 *   By default, each **EuiComment** shows an avatar with the `userAvatar` icon. A `timelineAvatarAriaLabel`should be provided when using this default option.
-*   You can customize your avatar by passing to the `timelineAvatar` any of the icon types that [**EuiIcon**](../icons) supports. The icon will show inside a `subdued` avatar. Consider this option when showing a system update. Providing a `timelineAvatarAriaLabel` is recommended.
-*   You can further customize the timeline icon by passing to the `timelineAvatar` a [**EuiAvatar**](../avatar).
+*   You can customize your avatar by passing to the `timelineAvatar` any of the icon types that [EuiIcon](./icons/overview.mdx) supports. The icon will show inside a `subdued` avatar. Consider this option when showing a system update. Providing a `timelineAvatarAriaLabel` is recommended.
+*   You can further customize the timeline icon by passing to the `timelineAvatar` a [EuiAvatar](avatar.mdx).
 
 ```tsx interactive
 import React from 'react';
@@ -392,7 +392,7 @@ export default () => (
 
 ## Comment event actions
 
-There are scenarios where you might want to allow the user to perform `actions` related to each comment. Some common `actions` include: editing, deleting, sharing and copying. To add custom `actions` to a comment, use the `actions`prop. These will be placed to the right of the metadata in the comment's header. We recommend using a [**EuiButtonIcon**](../../navigation/button) to trigger an action. When having multiple actions, consider grouping them in a nested menu system using a [**EuiPopover**](../../layout/popover) with a [**EuiContextMenu**](../../navigation/context-menu).
+There are scenarios where you might want to allow the user to perform `actions` related to each comment. Some common `actions` include: editing, deleting, sharing and copying. To add custom `actions` to a comment, use the `actions`prop. These will be placed to the right of the metadata in the comment's header. We recommend using a [EuiButtonIcon](../navigation/button/button_icon.mdx) to trigger an action. When having multiple actions, consider grouping them in a nested menu system using a [EuiPopover](../layout/popover.mdx) with a [EuiContextMenu](../navigation/context_menu.mdx).
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -547,7 +547,7 @@ export default () => {
 
 ## A comment system
 
-The below example uses a list of **EuiComments**, a [**EuiMarkdownEditor**](../../editors-syntax/markdown-editor), and a [**EuiMarkdownFormat**](../../editors-syntax/markdown-format) to create a simple comment system.
+The below example uses a list of **EuiComments**, a [EuiMarkdownEditor](../editors_and_syntax/markdown/editor.mdx), and a [**EuiMarkdownFormat**](../editors_and_syntax/markdown/format.mdx) to create a simple comment system.
 
 *   Each comment renders in a **EuiComment**.
 *   We use the **EuiMarkdownEditor** to post the `EuiComment.children`. This means the content uses Markdown.

--- a/packages/website/docs/components/display/empty_prompt/overview.mdx
+++ b/packages/website/docs/components/display/empty_prompt/overview.mdx
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The **EuiEmptyPrompt** is the building block to create an empty state. You can use it as a placeholder for any type of empty content. They are especially helpful for replacing entire pages or parts of a product that contain no content.
 
-Be sure to read the full [empty prompt usage guidelines](./guidelines).
+Be sure to read the full [empty prompt usage guidelines](guidelines.mdx).
 
 While no one piece of content is required, each **EuiEmptyPrompt** should contain at least a `title` (wrapped in an HTML heading element) and/or a `description`. They usually contain one or more `actions` that promotes the primary call-to-actions. You can also provide a `footer` to direct users towards making informed decisions.
 
@@ -41,7 +41,7 @@ export default () => (
 );
 ```
 
-## Less content, more actions[](/docs/display/empty-prompt#less-content-more-actions)
+## Less content, more actions
 
 You can remove parts of the prompt to simplify it. You can also provide an array of multiple actions. Be sure to list primary actions first and secondary actions as empty buttons.
 
@@ -64,9 +64,9 @@ export default () => (
 
 ## Panel options
 
-The **EuiEmptyPrompt** is wrapped by [**EuiPanel**](/docs/layout/panel). By default, the panel is set to `transparent` but you can customize other panel options like `color`, `hasBorder` and `paddingSize`. Changing the `color` prop will also attempt to adjust the `iconColor` and `footer` color.
+The **EuiEmptyPrompt** is wrapped by [EuiPanel](../../layout/panel/overview.mdx). By default, the panel is set to `transparent` but you can customize other panel options like `color`, `hasBorder` and `paddingSize`. Changing the `color` prop will also attempt to adjust the `iconColor` and `footer` color.
 
-Read the [usage guidelines](/docs/guidelines/empty-prompt) to better understand when to use certain panel props.
+Read the [usage guidelines](guidelines.mdx) to better understand when to use certain panel props.
 
 ```tsx interactive
 import React, { FunctionComponent } from 'react';
@@ -107,7 +107,7 @@ export default ({ color }: { color: EuiEmptyPromptProps['color'] }) => {
 
 ## Title sizes and icon colors
 
-Other customization options include changing the`titleSize` to any of the [**EuiTitle** sizes](/docs/display/title) and `iconColor`. When using an application or solution logo as the `iconType`, you can reset to the multi-tone colors with `iconColor="default"`
+Other customization options include changing the`titleSize` to any of the [EuiTitle sizes](../title.mdx) and `iconColor`. When using an application or solution logo as the `iconType`, you can reset to the multi-tone colors with `iconColor="default"`
 
 ```tsx interactive
 import React from 'react';
@@ -133,7 +133,7 @@ export default () => (
 
 Empty prompts can also be used to emulate loading and error states, by utilizing the same patterns.
 
-For **loading** states, instead of passing a `iconType`, you can provide a custom `icon` and pass in one of our [loading components](/docs/display/loading).
+For **loading** states, instead of passing a `iconType`, you can provide a custom `icon` and pass in one of our [loading components](../loading.mdx).
 
 ```tsx interactive
 import React from 'react';
@@ -172,7 +172,7 @@ export default () => (
 
 You can supply a `layout` of either `"horizontal"` or `"vertical"` with the default being `vertical`. When creating empty states we want the content to be short and straight to the point. So most of the time, the `vertical` layout is enough. All the content will be center aligned and this type of text alignment only works with small content.
 
-When you have longer body text with multiple calls to action, you can use the `horizontal` layout. This layout works best when you can provide a larger graphic like an illustration as the `icon`. For consistency, we recommend providing the illustration using a [**EuiImage**](/docs/display/image) with `size="fullWidth"`.
+When you have longer body text with multiple calls to action, you can use the `horizontal` layout. This layout works best when you can provide a larger graphic like an illustration as the `icon`. For consistency, we recommend providing the illustration using a [EuiImage](../image.mdx) with `size="fullWidth"`.
 
 <Demo scope={{ useBaseUrl }}>
   ```tsx
@@ -229,7 +229,7 @@ When you have longer body text with multiple calls to action, you can use the `h
 
 ## More types of empty states
 
-**EuiEmptyPrompt** can be used for more than just **empty** pages. The following example showcases different types of empty states that you can create with the **EuiEmptyPrompt**. For a full list see the [usage guidelines](/docs/guidelines/empty-prompt).
+**EuiEmptyPrompt** can be used for more than just **empty** pages. The following example showcases different types of empty states that you can create with the **EuiEmptyPrompt**. For a full list see the [usage guidelines](guidelines.mdx).
 
 import MultipleTypes from './multiple_types';
 
@@ -237,9 +237,9 @@ import MultipleTypes from './multiple_types';
 
 ## Using in a page template
 
-When using a **EuiEmptyPrompt** in a [**EuiPageTemplate**](/docs/templates/page-template), we recommend using the namespaced component so the template can determine which how to display the empty prompt based on the rest of the template configuration.
+When using a **EuiEmptyPrompt** in a [EuiPageTemplate](../../templates/page_template/overview.mdx), we recommend using the namespaced component so the template can determine which how to display the empty prompt based on the rest of the template configuration.
 
-The following example shows the usage of the [**EuiPageTemplate.EmptyPrompt**](/docs/templates/page-template#empty-pages-or-content) namespaced component.
+The following example shows the usage of the [EuiPageTemplate.EmptyPrompt](../../templates/page_template/overview.mdx#empty-pages-or-content) namespaced component.
 
 <Demo scope={{ useBaseUrl }}>
   ```tsx
@@ -291,7 +291,7 @@ The following example shows the usage of the [**EuiPageTemplate.EmptyPrompt**](/
   ```
 </Demo>
 
-You can then tie multiple types of empty states together to create a seamless loading to empty or loading to error experience. The following example shows how to incorporate these states with [**EuiPageTemplate.EmptyPrompt**](/docs/templates/page-template#empty-pages-or-content).
+You can then tie multiple types of empty states together to create a seamless loading to empty or loading to error experience. The following example shows how to incorporate these states with [EuiPageTemplate.EmptyPrompt](../../templates/page_template/overview.mdx#empty-pages-or-content).
 
 ```tsx interactive
 import React, { useState, useEffect } from 'react';

--- a/packages/website/docs/components/display/list_group.mdx
+++ b/packages/website/docs/components/display/list_group.mdx
@@ -74,7 +74,7 @@ export default () => {
 
 Display **EuiListGroupItems** as links by providing an `href` value and change their state with the `isActive` and `isDisabled` properties.
 
-If your link is external or will open in a new tab, you can manually set the `external` property. However, just like with the [**EuiLink**](/docs/navigation/link) component, setting `target="_blank"` defaults to `external={true}`.
+If your link is external or will open in a new tab, you can manually set the `external` property. However, just like with the [EuiLink](../navigation/link.mdx) component, setting `target="_blank"` defaults to `external={true}`.
 
 As is done in this example, the **EuiListGroup** component can also accept an array of items via the `listItems` property.
 
@@ -362,7 +362,7 @@ export default () => (
 
 ## Pinnable list group
 
-**EuiPinnableListGroup** is simply an extra wrapper around an [**EuiListGroup**](/docs/display/list-group) that provides visual indicators for **pinning**.
+**EuiPinnableListGroup** is simply an extra wrapper around an **EuiListGroup** that provides visual indicators for **pinning**.
 
 Pinning is the concept that users can click a pin icon and add it to a subset of links (most likely shown in different list group). By providing an `onPinClick` handler, the component will automatically add the pin action to the item. However, the consuming application must manage the `listItems`and their `pinned` state.
 

--- a/packages/website/docs/components/display/loading.mdx
+++ b/packages/website/docs/components/display/loading.mdx
@@ -5,7 +5,7 @@ id: display_loading
 
 # Loading
 
-Use loading indicators sparingly and opt for showing actual [progress](/docs/display/progress#progress-with-values) over infinite spinners. It is ok to use multiple loaders on a page if each section is progressively loaded. However, if the entire page is loaded at once, use a single, larger loading indicator.
+Use loading indicators sparingly and opt for showing actual [progress](./progress.mdx#progress-with-values) over infinite spinners. It is ok to use multiple loaders on a page if each section is progressively loaded. However, if the entire page is loaded at once, use a single, larger loading indicator.
 
 ## Elastic
 
@@ -30,7 +30,7 @@ export default () => (
 
 ## Logos
 
-**EuiLoadingLogo** accepts any of our [**EuiIcon**](/docs/display/icons#elastic-logos) logos. It should only be used in very large panels, like fullscreen pages.
+**EuiLoadingLogo** accepts any of our [EuiIcon](./icons/overview.mdx#elastic-logos) logos. It should only be used in very large panels, like fullscreen pages.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/display/progress.mdx
+++ b/packages/website/docs/components/display/progress.mdx
@@ -261,7 +261,7 @@ export default () => (
 
 ## Colors
 
-**EuiProgress** supports a few options for `color`. You can pass any value from our basic color set or from our visualization palette (`vis0` through `vis9`). To learn more about color usage, go to the [Colors](/docs/theming/colors/values) page.
+**EuiProgress** supports a few options for `color`. You can pass any value from our basic color set or from our visualization palette (`vis0` through `vis9`). To learn more about color usage, go to the [Colors](../theming/colors/values.mdx) page.
 
 Additionally, you can pass any valid color string like a hex value or named color. Each `valueText` renders with a high contrast version of the color.
 

--- a/packages/website/docs/components/display/skeleton.mdx
+++ b/packages/website/docs/components/display/skeleton.mdx
@@ -445,7 +445,7 @@ export default () => {
 
 In scenarios where that is not the case (i.e., transitioning to loading), you can customize what statuses are announced to screen readers by setting `announceLoadingStatus` to true, or `announceLoadedStatus` to false. Submitting the below example announces a loading status, but not a loaded status.
 
-As an optional escape hatch, `ariaLiveProps` is also available and accepts any [**EuiScreenReaderLive**](../utilities/accessibility/overview.mdx#screen-reader-live-region) props.
+As an optional escape hatch, `ariaLiveProps` is also available and accepts any [EuiScreenReaderLive](../utilities/accessibility/overview.mdx#screen-reader-live-region) props.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/display/timeline.mdx
+++ b/packages/website/docs/components/display/timeline.mdx
@@ -9,8 +9,8 @@ The **EuiTimeline** component standardizes the way a timeline thread is displaye
 
 This component allows you to create any type of timeline, but for more specific use cases you should consider:
 
-*   [**EuiSteps**](../../navigation/steps): a timeline that allows you to present instructional content that must be conducted in a particular order and might contain progress indications.
-*   [**EuiCommentList**](../comment-list): a timeline that allows you to display comments or logging actions that either a user or a system has performed.
+*   [EuiSteps](../navigation/steps/steps.mdx): a timeline that allows you to present instructional content that must be conducted in a particular order and might contain progress indications.
+*   [EuiCommentList](../display/comment_list.mdx): a timeline that allows you to display comments or logging actions that either a user or a system has performed.
 
 :::accessibility Accessibility requirement
 For accessibility, it is required to wrap your **EuiTimelineItem**'s with a **EuiTimeline**. It is highly recommended to provide a descriptive `aria-label`, or a text node ID of an external label to the `aria-labelledby` prop of the **EuiTimeline**.
@@ -63,7 +63,7 @@ export default () => (
 
 Each **EuiTimelineItem** has two parts: an icon on the left side and an event on the right side. To create an item you need the following props:
 
-*   `icon`: main icon that appears on the left side. Can be passed as any `IconType` string or custom node (e.g. [**EuiAvatar**](../avatar)). It is recommended not to use an element larger than 40x40.
+*   `icon`: main icon that appears on the left side. Can be passed as any `IconType` string or custom node (e.g. [EuiAvatar](avatar.mdx)). It is recommended not to use an element larger than 40x40.
 *   `children`: any node as the event content.
 
 ```tsx interactive
@@ -91,7 +91,7 @@ You can create a timeline thread by rendering multiple **EuiTimelineItem** compo
 When passing an `icon` and `children` prop to each item, there are some design considerations to take into account:
 
 *   `icon`: use icons of the same size to create a better visual consistency.
-*   `children`: when your content is just one line of text, the recommendation is to use an [**EuiText**](../text) as a wrapper. For multi-line content consider using a [**EuiPanel**](../../layout/panel) or a [**EuiSplitPanel**](../../panel#split-panels) instead. For other types of components like editors, the recommendation is to pass the children without any wrapper.
+*   `children`: when your content is just one line of text, the recommendation is to use an [EuiText](text.mdx) as a wrapper. For multi-line content consider using a [EuiPanel](../layout/panel/overview.mdx) or a [EuiSplitPanel](../layout/panel/split_panel.mdx) instead. For other types of components like editors, the recommendation is to pass the children without any wrapper.
 
 The following example shows how to display multiple **EuiTimelineItem**s and how you can use a **EuiSplitPanel** as the content wrapper.
 

--- a/packages/website/docs/components/display/toast/overview.mdx
+++ b/packages/website/docs/components/display/toast/overview.mdx
@@ -7,7 +7,7 @@ import previewWrapper from './preview_wrapper';
 
 # Toast
 
-Be sure to read the full [toast usage guidelines](./guidelines).
+Be sure to read the full [toast usage guidelines](guidelines.mdx).
 
 ## Toast list
 

--- a/packages/website/docs/components/display/tooltip.mdx
+++ b/packages/website/docs/components/display/tooltip.mdx
@@ -5,7 +5,7 @@ id: display_tooltip
 
 # Tooltip
 
-Generally, tooltips should provide short, **non-essential**, contextual information, usually naming or describing with more detail. If you need interactive content or anything other than text, we recommend using [**EuiPopover**](/docs/layout/popover) instead.
+Generally, tooltips should provide short, **non-essential**, contextual information, usually naming or describing with more detail. If you need interactive content or anything other than text, we recommend using [EuiPopover](../layout/popover.mdx) instead.
 
 :::note Tooltips have three accessibility requirements:
 

--- a/packages/website/docs/components/display/tooltip.mdx
+++ b/packages/website/docs/components/display/tooltip.mdx
@@ -7,12 +7,11 @@ id: display_tooltip
 
 Generally, tooltips should provide short, **non-essential**, contextual information, usually naming or describing with more detail. If you need interactive content or anything other than text, we recommend using [EuiPopover](../layout/popover.mdx) instead.
 
-:::note Tooltips have three accessibility requirements:
+:::accessibility Accessibility requirements
 
-*   Tooltips **must** be anchored to elements that accept keyboard focus.
-*   Put only plain text in tooltips so the content is accessible to keyboard and screen reader users.
-*   Do not add links, buttons, or other interactive content inside tooltips.
-
+- Tooltips **must** be anchored to elements that accept keyboard focus.
+- Put only plain text in tooltips so the content is accessible to keyboard and screen reader users.
+- Do not add links, buttons, or other interactive content inside tooltips.
 :::
 
 Wrap **EuiToolTip** around any item that you need a tooltip for and provide the `content` and optionally the `title`. The `position` prop will take a suggested position, but will change it if the tooltip gets too close to the edge of the screen.


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/display`).

Closes [#8472](https://github.com/elastic/eui/issues/8472)

## QA

### Display section

**Checklist**

- [ ] Verify that all links work in the staging environment

**Pages**

- [ ] [Badge > Beta badge](https://eui.elastic.co/pr_8532/new-docs/docs/display/badge/beta/)
- [ ] [Badge > Notification badge](https://eui.elastic.co/pr_8532/new-docs/docs/display/badge/notification/)
- [ ] [Card](https://eui.elastic.co/pr_8532/new-docs/docs/display/card/)
- [ ] [Comment list](https://eui.elastic.co/pr_8532/new-docs/docs/display/comment-list/)
- [ ] [Empty prompt](https://eui.elastic.co/pr_8532/new-docs/docs/display/empty-prompt/)
- [ ] [List group](https://eui.elastic.co/pr_8532/new-docs/docs/display/list-group/)
- [ ] [Loading](https://eui.elastic.co/pr_8532/new-docs/docs/display/loading/)
- [ ] [Progress](https://eui.elastic.co/pr_8532/new-docs/docs/display/progress/)
- [ ] [Skeleton](https://eui.elastic.co/pr_8532/new-docs/docs/display/skeleton/)
- [ ] [Timeline](https://eui.elastic.co/pr_8532/new-docs/docs/display/timeline/)
- [ ] [Toast](https://eui.elastic.co/pr_8532/new-docs/docs/display/toast/)
- [ ] [Tooltip](https://eui.elastic.co/pr_8532/new-docs/docs/display/tooltip/)
