### PR TITLE
fix(website): fix broken links in the Forms section

### DIFF
--- a/packages/website/docs/components/forms/date_time/auto_refresh.mdx
+++ b/packages/website/docs/components/forms/date_time/auto_refresh.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Auto refresh
 
-This is a component that is used by the [**EuiSuperDatePicker**](./super_date_picker.mdx) component to create an automatic refresh configuration. It merely provides a common UI pattern but the actual refresh counter is maintained by you. It `isPaused` by default and the `refreshInterval` is set in milliseconds.
+This is a component that is used by the [EuiSuperDatePicker](./super_date_picker.mdx) component to create an automatic refresh configuration. It merely provides a common UI pattern but the actual refresh counter is maintained by you. It `isPaused` by default and the `refreshInterval` is set in milliseconds.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/date_time/date_picker_range.mdx
+++ b/packages/website/docs/components/forms/date_time/date_picker_range.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Date picker range
 
-To create a single date range control, use **EuiDatePickerRange** and pass individual [**EuiDatePicker**](./date_picker.mdx) components into the `startDateControl` and `endDateControl` props. You can control the state of both inputs as direct props on **EuiDatePickerRange** as well as control each individually. Date specific props need to applied to the individual components.
+To create a single date range control, use **EuiDatePickerRange** and pass individual [EuiDatePicker](./date_picker.mdx) components into the `startDateControl` and `endDateControl` props. You can control the state of both inputs as direct props on **EuiDatePickerRange** as well as control each individually. Date specific props need to applied to the individual components.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -48,7 +48,7 @@ export default () => {
 ```
 
 :::tip
-If you need even more functionality such as relative time, suggested date ranges, and refresh intervals, consider using [**EuiSuperDatePicker**](./super_date_picker.mdx).
+If you need even more functionality such as relative time, suggested date ranges, and refresh intervals, consider using [EuiSuperDatePicker](./super_date_picker.mdx).
 :::
 
 ## Inline display

--- a/packages/website/docs/components/forms/date_time/super_date_picker.mdx
+++ b/packages/website/docs/components/forms/date_time/super_date_picker.mdx
@@ -494,7 +494,7 @@ export default () => {
 
 Set `isAutoRefreshOnly` to `true` to limit the component to only display auto refresh content. This is useful in cases where there is no time data but auto-refresh configuration is still desired.
 
-However, since this is still the full **EuiSuperDatePicker** component it requires other props that may not be necessary for the refresh only UI. In this case, you can use the [**EuiAutoRefresh**](./auto_refresh.mdx) component directly. You will just need to manage the refresh counter yourself.
+However, since this is still the full **EuiSuperDatePicker** component it requires other props that may not be necessary for the refresh only UI. In this case, you can use the [EuiAutoRefresh](./auto_refresh.mdx) component directly. You will just need to manage the refresh counter yourself.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -549,7 +549,7 @@ export default () => {
 
 ## Elastic pattern with KQL
 
-The following is a demo pattern of how to layout the **EuiSuperDatePicker** alongside Elastic's KQL search bar using [**EuiSearchBar**](../search_filter/search_bar.mdx) and shrinking to fit when the search bar is in focus.
+The following is a demo pattern of how to layout the **EuiSuperDatePicker** alongside Elastic's KQL search bar using [EuiSearchBar](../search_filter/search_bar.mdx) and shrinking to fit when the search bar is in focus.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/form_layouts/_form_row_callout.mdx
+++ b/packages/website/docs/components/forms/form_layouts/_form_row_callout.mdx
@@ -1,5 +1,5 @@
 :::tip Wrap your form controls in a form row
 
-Use the [**EuiFormRow**](./form_row.mdx) component to easily and accessibly associate form components with labels, help text, and error text.
+Use the [EuiFormRow](./form_row.mdx) component to easily and accessibly associate form components with labels, help text, and error text.
 
 :::

--- a/packages/website/docs/components/forms/form_layouts/compressed_forms.mdx
+++ b/packages/website/docs/components/forms/form_layouts/compressed_forms.mdx
@@ -270,7 +270,7 @@ export default () => {
 
 ## Contextual help
 
-When using compressed, horizontal form styles, it is best not to overload the UI with expansive help text. If it's short and part of the validation, use `helpText`. However, if it's an explanation of the control, consider wrapping the label with an [**EuiToolTip**](../../display/tooltip.mdx) and appending the `questionInCircle` icon to it.
+When using compressed, horizontal form styles, it is best not to overload the UI with expansive help text. If it's short and part of the validation, use `helpText`. However, if it's an explanation of the control, consider wrapping the label with an [EuiToolTip](../../display/tooltip.mdx) and appending the `questionInCircle` icon to it.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/forms/form_layouts/form_row.mdx
+++ b/packages/website/docs/components/forms/form_layouts/form_row.mdx
@@ -316,7 +316,7 @@ export default () => {
 
 ## Inline
 
-Inline forms can be made with [**EuiFlexGroup**](../../layout/flex/flex_group.mdx). Apply `grow={false}` on any of the items you want to collapse (like the button below). Note that the button's **EuiFormRow** wrapper also requires an additional prop when it’s missing a label `hasEmptyLabelSpace`.
+Inline forms can be made with [EuiFlexGroup](../../layout/flex/flex_group.mdx). Apply `grow={false}` on any of the items you want to collapse (like the button below). Note that the button's **EuiFormRow** wrapper also requires an additional prop when it’s missing a label `hasEmptyLabelSpace`.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/forms/numeric/range_sliders.mdx
+++ b/packages/website/docs/components/forms/numeric/range_sliders.mdx
@@ -239,7 +239,7 @@ Tick labels can improve the accessibility of your range. If your label is a simp
 
 :::warning Minimum of 5px width per tick allowed
 
-If the width available for each tick displayed is below 5px, the range component will error. Test your usage at multiple screen widths to ensure all ticks are visible on the page at all times, or use EUI's `useIsWithinBreakpoints` [hook utility](/docs/theming/breakpoints/values?themeLanguage=js) to reduce the tick interval responsively.
+If the width available for each tick displayed is below 5px, the range component will error. Test your usage at multiple screen widths to ensure all ticks are visible on the page at all times, or use EUI's `useIsWithinBreakpoints` [hook utility](../../theming/breakpoints/values.mdx) to reduce the tick interval responsively.
 
 :::
 

--- a/packages/website/docs/components/forms/other/color_picker.mdx
+++ b/packages/website/docs/components/forms/other/color_picker.mdx
@@ -200,7 +200,7 @@ Use **EuiColorPaletteDisplay** to show the palette in use for a data visualizati
 
 Use the palette prop to pass your palette as an array of color `strings` or an array of `ColorStops` in the form of `{ stop: number, color: string }`. Use `fixed` palettes for categorical data and `gradient` palettes for continuous data.
 
-In cases you need to apply a palette, it's recommended to use the [**EuiColorPalettePicker**](/docs/forms/color-selection#color-palette-picker).
+In cases you need to apply a palette, it's recommended to use the [EuiColorPalettePicker](color_palette_picker.mdx).
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/other/file_picker.mdx
+++ b/packages/website/docs/components/forms/other/file_picker.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # File picker
 
-**EuiFilePicker** is a stylized, but generic HTML `<input type="file">` tag. It supports drag and drop as well as on click style selection of files. The example below shows how to grab the files using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/FileList" target="_blank">FileList API</a>. Like other form elements, you can wrap it in an [**EuiFormRow**](../form_layouts/form_row.mdx) to apply a label.
+**EuiFilePicker** is a stylized, but generic HTML `<input type="file">` tag. It supports drag and drop as well as on click style selection of files. The example below shows how to grab the files using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/FileList" target="_blank">FileList API</a>. Like other form elements, you can wrap it in an [EuiFormRow](../form_layouts/form_row.mdx) to apply a label.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/search_filter/filter_group.mdx
+++ b/packages/website/docs/components/forms/search_filter/filter_group.mdx
@@ -62,7 +62,7 @@ export default () => {
 
 ## Multi-select
 
-To provide a long list of grouped filters, we recommend wrapping the filter button within an [**EuiPopover**](../../layout/popover.mdx) and passing the items to a searchable [**EuiSelectable**](../selection/selectable.mdx).
+To provide a long list of grouped filters, we recommend wrapping the filter button within an [EuiPopover](../../layout/popover.mdx) and passing the items to a searchable [EuiSelectable](../selection/selectable.mdx).
 
 ### Indicating number of filters
 

--- a/packages/website/docs/components/forms/search_filter/search_bar.mdx
+++ b/packages/website/docs/components/forms/search_filter/search_bar.mdx
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 :::tip
 **EuiSearchBar**'s usage is specific to <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html" target="_blank">Elasticsearch's Query DSL</a> (domain specific language).<br />
-For more generic search use cases, consider using the basic [**EuiFieldSearch**](./search_field.mdx) component.
+For more generic search use cases, consider using the basic [EuiFieldSearch](./search_field.mdx) component.
 :::
 
 An **EuiSearchBar** is a toolbar that enables the user to create/define a search query. This can be done either by entering the query syntax in a search box or by clicking any of the configured filters. The query language is not meant to be full blown search language for arbitrary data (e.g. as required in the Discover App in Kibana), yet it does provide some useful features:

--- a/packages/website/docs/components/forms/selection/checkboxes_radios/switch.mdx
+++ b/packages/website/docs/components/forms/selection/checkboxes_radios/switch.mdx
@@ -38,7 +38,7 @@ export default () => {
 
 Make sure to pass a `label` to ensure a larger clickable area and ensure that screen readers will read out the label when the user is focused on the input. You can find more about labels usage in the [guidelines tab](guidelines.mdx#checkbox-and-radio-button-labels).
 
-If the switch is described in some other manner, like when using an [**EuiFormRow**](../../form_layouts/form_row.mdx), you can eliminate the visible label with `showLabel={false}` or use it to further describe the state.
+If the switch is described in some other manner, like when using an [EuiFormRow](../../form_layouts/form_row.mdx), you can eliminate the visible label with `showLabel={false}` or use it to further describe the state.
 
 :::accessibility Accessibility requirement
 When providing the state as the label, you'll need to provide an `aria-describedby` with the label's `id` to associate it with the switch.

--- a/packages/website/docs/components/forms/selection/combo_box.mdx
+++ b/packages/website/docs/components/forms/selection/combo_box.mdx
@@ -404,7 +404,7 @@ export default () => {
 
 ## Pill colors
 
-Useful for visualization or tagging systems. You can also pass a color in your option list. The color can be a hex value (like `#000`) or any other named color value accepted by the [**EuiBadge**](../../display/badge/badge.mdx) component.
+Useful for visualization or tagging systems. You can also pass a color in your option list. The color can be a hex value (like `#000`) or any other named color value accepted by the [EuiBadge](../../display/badge/badge.mdx) component.
 
 ```tsx interactive
 import React, { useState, useEffect } from 'react';
@@ -810,7 +810,7 @@ export default () => {
 
 ## Truncation
 
-By default, **EuiComboBox** truncates long option text at the end of the string. You can use `truncationProps` and almost any prop that [**EuiTextTruncate**](../../utilities/text_truncation.mdx) accepts to configure this behavior. This can be configured at the **EuiComboBox** level, as well as by each individual option.
+By default, **EuiComboBox** truncates long option text at the end of the string. You can use `truncationProps` and almost any prop that [EuiTextTruncate](../../utilities/text_truncation.mdx) accepts to configure this behavior. This can be configured at the **EuiComboBox** level, as well as by each individual option.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/selection/select.mdx
+++ b/packages/website/docs/components/forms/selection/select.mdx
@@ -10,7 +10,7 @@ import EuiFormRowCallout from '../form_layouts/_form_row_callout.mdx';
 
 <EuiFormRowCallout />
 
-This component renders a native HTML `<select>` element. Use **EuiSelect** to allow users to choose from a list of 7 to 12 options. When there are less than 7 options consider using a [**EuiRadioGroup**](./checkboxes_radios/overview.mdx#radio-group).
+This component renders a native HTML `<select>` element. Use **EuiSelect** to allow users to choose from a list of 7 to 12 options. When there are less than 7 options consider using a [EuiRadioGroup](./checkboxes_radios/overview.mdx#radio-group).
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/selection/selectable.mdx
+++ b/packages/website/docs/components/forms/selection/selectable.mdx
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 # Selectable
 
-**EuiSelectable** aims to make the pattern of a selectable list (with or without search) consistent across implementations. It is the same concept used in [**EuiComboBox**](./combo_box.mdx) and [**EuiFilterGroup**](../search_filter/filter_group.mdx). **This is not intended for [primary navigation](../../display/list_group.mdx)** but can be used to simplify the construction of popover navigational menus; i.e. the spaces menu in the [header](../../layout/header.mdx). See EUI's <a href="https://github.com/elastic/eui/discussions/7049" target="_blank">in-depth guide on which selection component to choose</a> for more information.
+**EuiSelectable** aims to make the pattern of a selectable list (with or without search) consistent across implementations. It is the same concept used in [EuiComboBox](./combo_box.mdx) and [EuiFilterGroup](../search_filter/filter_group.mdx). **This is not intended for [primary navigation](../../display/list_group.mdx) but can be used to simplify the construction of popover navigational menus; i.e. the spaces menu in the [header](../../layout/header.mdx). See EUI's <a href="https://github.com/elastic/eui/discussions/7049" target="_blank">in-depth guide on which selection component to choose</a> for more information.
 
 ## The basics
 
@@ -421,7 +421,7 @@ The component's children, `list, search`, are returned via the `children` functi
 
 ### Width and height
 
-The width has been made to always be 100% of its container, including stretching the search input. When used inside of [**EuiPopover**](../../layout/popover.mdx), we recommend setting a width (or min/max values) via CSS on the element containing the list to avoid expansion and contraction. By default, the height is capped at showing up to 7.5 items. It shows half of the last one to help indicate that there are more options to scroll to. To stretch the box to fill its container, pass 'full' to the `height` prop.
+The width has been made to always be 100% of its container, including stretching the search input. When used inside of [EuiPopover](../../layout/popover.mdx), we recommend setting a width (or min/max values) via CSS on the element containing the list to avoid expansion and contraction. By default, the height is capped at showing up to 7.5 items. It shows half of the last one to help indicate that there are more options to scroll to. To stretch the box to fill its container, pass 'full' to the `height` prop.
 
 ### Flexbox
 
@@ -690,7 +690,7 @@ export default () => {
 
 **EuiSelectable** defaults to `listProps.textWrap="truncate"`, which truncates long option text at the end of the string.
 
-You can use `listProps.truncationProps` and almost any prop that [**EuiTextTruncate**](../../utilities/text_truncation.mdx) accepts to configure this behavior. This can be configured at the **EuiSelectable** level, as well as by each individual option.
+You can use `listProps.truncationProps` and almost any prop that [EuiTextTruncate](../../utilities/text_truncation.mdx) accepts to configure this behavior. This can be configured at the **EuiSelectable** level, as well as by each individual option.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -852,7 +852,7 @@ export default () => {
 
 If you have longer information that you need to make available to users outside of truncated text, one approach could be adding tooltip descriptions to individual options by passing `toolTipContent`.
 
-You can additionally customize individual tooltip behavior by passing `toolTipProps`, which accepts any configuration that [**EuiToolTip**](../../display/tooltip.mdx) accepts.
+You can additionally customize individual tooltip behavior by passing `toolTipProps`, which accepts any configuration that [EuiToolTip](../../display/tooltip.mdx) accepts.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/selection/super_select.mdx
+++ b/packages/website/docs/components/forms/selection/super_select.mdx
@@ -10,7 +10,7 @@ import EuiFormRowCallout from '../form_layouts/_form_row_callout.mdx';
 
 <EuiFormRowCallout />
 
-This is a simple replacement component for [**EuiSelect**](./select.mdx) if you need more customization in either the display of the input or option. Simply pass an array of option objects:
+This is a simple replacement component for [EuiSelect](./select.mdx) if you need more customization in either the display of the input or option. Simply pass an array of option objects:
 
 *   `value`: for storing unique value of item,
 *   `inputDisplay`: what shows inside the form input when selected,

--- a/packages/website/docs/components/forms/text/inline_edit.mdx
+++ b/packages/website/docs/components/forms/text/inline_edit.mdx
@@ -362,14 +362,14 @@ export default () => {
 
 ## Customizing read and edit modes
 
-Customize the read mode by passing `readModeProps`, which accepts any [**EuiButtonEmpty**](../../navigation/button/button_empty.mdx#props) properties.
+Customize the read mode by passing `readModeProps`, which accepts any [EuiButtonEmpty](../../navigation/button/button_empty.mdx#props) properties.
 
 Customize the edit mode by passing `editModeProps`. This prop contains nested object properties that are applied to various child components in edit mode:
 
-*   `editMode.formRowProps` accepts any [**EuiFormRow**](../form_layouts/form_row.mdx#props) properties
-*   `editMode.inputProps` accepts any [**EuiFieldText**](../text/basic.mdx#props) properties
-*   `editMode.saveButtonProps` accepts any [**EuiButtonIcon**](/docs/navigation/button/#icon-button) properties
-*   `editMode.cancelButtonProps` accepts any [**EuiButtonIcon**](/docs/navigation/button/#icon-button) properties
+*   `editMode.formRowProps` accepts any [EuiFormRow](../form_layouts/form_row.mdx#props) properties
+*   `editMode.inputProps` accepts any [EuiFieldText](../text/basic.mdx#props) properties
+*   `editMode.saveButtonProps` accepts any [EuiButtonIcon](/docs/navigation/button/#icon-button) properties
+*   `editMode.cancelButtonProps` accepts any [EuiButtonIcon](/docs/navigation/button/#icon-button) properties
 
 ```tsx interactive
 import React from 'react';


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/forms`).

Closes [#8473](https://github.com/elastic/eui/issues/8473)

## QA

### Forms section

**Checklist**

- [ ] Verify that all links work in the staging environment

**Pages**

- [ ] [Range sliders](https://eui.elastic.co/pr_8533/new-docs/docs/forms/numeric/range-sliders/)
- [ ] [Color picker](https://eui.elastic.co/pr_8533/new-docs/docs/forms/color/picker/)

Optionally, the rest of the pages in the section. I just removed the bold `**` from around the components.
