### PR TITLE
fix(website): fix broken links in the Tabular content section

### DIFF
--- a/packages/website/docs/components/tabular_content/data_grid/container_constraints.mdx
+++ b/packages/website/docs/components/tabular_content/data_grid/container_constraints.mdx
@@ -95,7 +95,7 @@ export default () => {
 };
 ```
 
-When placed within an [**EuiFlexGroup** and **EuiFlexItem**](../../layout/flex/flex.mdx), the data grid will have trouble shrinking to fit. To fix this, you will need to manually add a style of `min-width: 0` to the **EuiFlexItem**.
+When placed within an [EuiFlexGroup](../../layout/flex/flex_group.mdx) and [EuiFlexItem](../../layout/flex/flex_item.mdx), the data grid will have trouble shrinking to fit. To fix this, you will need to manually add a style of `min-width: 0` to the **EuiFlexItem**.
 
 ```tsx interactive
 import React, { useState, useCallback } from 'react';

--- a/packages/website/docs/components/tabular_content/data_grid/style_and_display.mdx
+++ b/packages/website/docs/components/tabular_content/data_grid/style_and_display.mdx
@@ -500,7 +500,7 @@ export default () => {
 };
 ```
 
-## Adjusting your grid to user/toolbar changes[](/docs/tabular-content/data-grid-style-display#adjusting-your-grid-to-usertoolbar-changes)
+## Adjusting your grid to user/toolbar changes
 
 You can use the optional `gridStyle.onChange` and `rowHeightsOptions.onChange` callbacks to adjust your data grid based on user density or row height changes.
 

--- a/packages/website/docs/components/tabular_content/tables/basic_tables.mdx
+++ b/packages/website/docs/components/tabular_content/tables/basic_tables.mdx
@@ -664,7 +664,7 @@ export default () => {
 
 ## Adding a footer to a table
 
-The following example shows how to add a footer to your table by adding `footer` to your column definitions. If one or more of your columns contains a `footer` definition, the footer area will be visible. By default, columns with no footer specified (undefined) will render an empty cell to preserve the table layout. Check out the [custom tables](../custom) page for more examples of how you can work with table footers in EUI.
+The following example shows how to add a footer to your table by adding `footer` to your column definitions. If one or more of your columns contains a `footer` definition, the footer area will be visible. By default, columns with no footer specified (undefined) will render an empty cell to preserve the table layout. Check out the [custom tables](custom_tables.mdx) page for more examples of how you can work with table footers in EUI.
 
 ```tsx interactive
 import React, { useState } from 'react';
@@ -1005,7 +1005,7 @@ export default () => {
 
 ## Responsive tables
 
-Tables will be mobile-responsive by default, breaking down each row into its own card section and individually displaying each table header above the cell contents. The default breakpoint at which the table will responsively shift into cards is the [`m` window size](../../../theming/breakpoints/values), which can be customized with the `responsiveBreakpoint` prop (e.g., `responsiveBreakpoint="s"`).
+Tables will be mobile-responsive by default, breaking down each row into its own card section and individually displaying each table header above the cell contents. The default breakpoint at which the table will responsively shift into cards is the [`m` window size](../../theming/breakpoints/values.mdx), which can be customized with the `responsiveBreakpoint` prop (e.g., `responsiveBreakpoint="s"`).
 
 To never render your table responsively (e.g. for tables with very few columns), you may set `responsiveBreakpoint={false}`. Inversely, if you always want your table to render in a mobile-friendly manner, pass `true`. The below example table switches between `true/false` for quick/easy preview between mobile and desktop table UIs at all breakpoints.
 
@@ -1227,7 +1227,7 @@ export default () => {
 This is primarily useful for large amounts of API-based data, where storing or sorting all rows in-memory would pose significant performance issues. Your API backend should then asynchronously handle sorting/filtering/caching your data.
 
 :::tip
-For non-asynchronous and smaller datasets use-cases (in the hundreds or less), we recommend using [**EuiInMemoryTable**](../in-memory), which automatically handles pagination, sorting, and searching in-memory.
+For non-asynchronous and smaller datasets use-cases (in the hundreds or less), we recommend using [EuiInMemoryTable](in_memory_tables.mdx), which automatically handles pagination, sorting, and searching in-memory.
 :::
 
 ### Pagination

--- a/packages/website/docs/components/tabular_content/tables/custom_tables.mdx
+++ b/packages/website/docs/components/tabular_content/tables/custom_tables.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Custom tables
 
-If you need more custom behavior than either [**EuiBasicTable**](../basic) or [**EuiInMemoryTable**](../in-memory) allow, you can opt to completely construct your own table from EUI's low-level table building block components, like **EuiTableHeader** and **EuiTableRowCell**.
+If you need more custom behavior than either [EuiBasicTable](basic_tables.mdx) or [EuiInMemoryTable](in_memory_tables.mdx) allow, you can opt to completely construct your own table from EUI's low-level table building block components, like **EuiTableHeader** and **EuiTableRowCell**.
 
 There are several important caveats to keep in mind while doing so:
 

--- a/packages/website/docs/components/tabular_content/tables/in_memory_tables.mdx
+++ b/packages/website/docs/components/tabular_content/tables/in_memory_tables.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # In-memory tables
 
-**EuiInMemoryTable** is a higher level component wrapper around [**EuiBasicTable**](../basic) aimed at automatically handling certain functionality (selection, search, sorting, and pagination) in-memory for you, within certain preset configurations. It takes the full set of data that must include all possible items.
+**EuiInMemoryTable** is a higher level component wrapper around [EuiBasicTable](basic_tables.mdx) aimed at automatically handling certain functionality (selection, search, sorting, and pagination) in-memory for you, within certain preset configurations. It takes the full set of data that must include all possible items.
 
 :::warning Column names must be referentially stable
 
@@ -160,7 +160,7 @@ import InMemoryTableSelection from './table_selection';
 
 ### Search bar
 
-This example shows how to configure **EuiInMemoryTable** to display a search bar by passing the `search` prop. For more detailed information about the syntax and configuration accepted by this prop, see [**EuiSearchBar**](../../../forms/search-bar).
+This example shows how to configure **EuiInMemoryTable** to display a search bar by passing the `search` prop. For more detailed information about the syntax and configuration accepted by this prop, see [EuiSearchBar](../../forms/search_filter/search_bar.mdx).
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/tabular_content/tables/overview.mdx
+++ b/packages/website/docs/components/tabular_content/tables/overview.mdx
@@ -9,8 +9,8 @@ Tables can get complicated very fast. EUI provides both opinionated and non-opin
 
 - **Opinionated high-level components:**
   - These high-level components remove the need to worry about constructing individual building blocks together. You simply arrange your data in the format it asks for.
-  - [**EuiBasicTable**](./basic) handles mobile row selection, row actions, row expansion, and mobile UX out of the box with relatively simple-to-use APIs. It is best used with asynchronous data, or static datasets that do not need pagination/sorting.
-  - [**EuiInMemoryTable**](./in-memory) has all the features that EuiBasicTable has, and additionally handles pagination, sorting, and searching the passed data out-of-the-box with relatively minimal APIs. It is best used with smaller synchronous datasets.
+  - [EuiBasicTable](basic_tables.mdx) handles mobile row selection, row actions, row expansion, and mobile UX out of the box with relatively simple-to-use APIs. It is best used with asynchronous data, or static datasets that do not need pagination/sorting.
+  - [EuiInMemoryTable](in_memory_tables.mdx) has all the features that EuiBasicTable has, and additionally handles pagination, sorting, and searching the passed data out-of-the-box with relatively minimal APIs. It is best used with smaller synchronous datasets.
 - **Non-opinionated building blocks:**
-  - If your table requires completely custom behavior, you can use individual building block components like [EuiTable, EuiTableRow, EuiTableRowCell, and more](./custom) to do what you need.
-  - Please note that if you go this route, you must handle your own data management as well as table accessibility and mobile UX.
+  - If your table requires completely custom behavior, you can use individual building block components like [EuiTable, EuiTableRow, EuiTableRowCell, and more](custom_tables.mdx) to do what you need.
+  - Please note that if you go this route, you must han`dle your own data management as well as table accessibility and mobile UX.


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/tabular_content`).

Closes [#8474](https://github.com/elastic/eui/issues/8474)

## QA

### Tabular content section

**Checklist**

- [ ] Verify that all links work in the staging environment

**Pages**

- [ ] [Data grid > Container constraints](https://eui.elastic.co/pr_8534/new-docs/docs/tabular-content/data-grid/container-constraints/)
- [ ] [Data grid > Style and display](https://eui.elastic.co/pr_8534/new-docs/docs/tabular-content/data-grid/style-and-display/)
- [ ] [Tables](https://eui.elastic.co/pr_8534/new-docs/docs/tabular-content/tables/)
- [ ] [Tables > Basic tables](https://eui.elastic.co/pr_8534/new-docs/docs/tabular-content/tables/basic/)
- [ ] [Tables > Custom tables](https://eui.elastic.co/pr_8534/new-docs/docs/tabular-content/tables/custom/)
- [ ] [Tables > In-memory tables](https://eui.elastic.co/pr_8534/new-docs/docs/tabular-content/tables/in-memory/)
