### PR TITLE
fix(website): fix broken links in the Editors & Syntax section

### DIFF
--- a/packages/website/docs/components/editors_and_syntax/code.mdx
+++ b/packages/website/docs/components/editors_and_syntax/code.mdx
@@ -1047,7 +1047,7 @@ export default () => (
 
 ```
 
-In places like [flyouts](/docs/layout/flyout), you can use `overflowHeight="100%"` to stretch the code block to fill the space. Just be sure that it's parent container is also `height: 100%`.
+In places like [flyouts](../layout/flyout/flyout.mdx), you can use `overflowHeight="100%"` to stretch the code block to fill the space. Just be sure that it's parent container is also `height: 100%`.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/editors_and_syntax/markdown/editor.mdx
+++ b/packages/website/docs/components/editors_and_syntax/markdown/editor.mdx
@@ -5,13 +5,13 @@ id: editors_syntax_markdown_editor
 
 # Editor
 
-**EuiMarkdownEditor** provides a markdown authoring experience for the user. The component consists of a toolbar, text area, and a drag-and-drop zone to accept files (if configured to do so). There are two modes: a textarea that keeps track of cursor position, and a rendered preview mode that is powered by **[EuiMarkdownFormat](../format)**. State is maintained between the two and it is possible to pass changes from the preview area to the textarea and vice versa.
+**EuiMarkdownEditor** provides a markdown authoring experience for the user. The component consists of a toolbar, text area, and a drag-and-drop zone to accept files (if configured to do so). There are two modes: a textarea that keeps track of cursor position, and a rendered preview mode that is powered by [EuiMarkdownFormat](./format.mdx). State is maintained between the two and it is possible to pass changes from the preview area to the textarea and vice versa.
 
 ## Base editor
 
-Use the base editor to produce technical content in markdown which can contain text, code, and images. Besides this default markdown content, the base editor comes with several [default plugins](../plugins#default-plugins) that let you add emojis, to-do lists, and tooltips, which can be [configured](../plugins#configuring-the-default-plugins) or [removed](../plugins#unregistering-plugins) as needed.
+Use the base editor to produce technical content in markdown which can contain text, code, and images. Besides this default markdown content, the base editor comes with several [default plugins](./plugins.mdx#default-plugins) that let you add emojis, to-do lists, and tooltips, which can be [configured](./plugins.mdx#configuring-the-default-plugins) or [removed](./plugins.mdx#unregistering-plugins) as needed.
 
-Consider applying the `readOnly` prop to restrict editing during asynchronous submit events, like when submitting a [comment](../../../display/comment-list). This will ensure users understand that the content cannot be changed while the comment is being submitted.
+Consider applying the `readOnly` prop to restrict editing during asynchronous submit events, like when submitting a [comment](../../display/comment_list.mdx). This will ensure users understand that the content cannot be changed while the comment is being submitted.
 
 ```tsx interactive
 import React, { useCallback, useState } from 'react';
@@ -115,13 +115,17 @@ export default () => {
     </>
   );
 };
-
 ```
 
 ## Error handling and feedback
 
-The `errors` prop allows you to pass an array of errors if syntax is malformed. The below example starts with an incomplete tooltip tag, showing this error message by default. These errors are meant to be ephemeral and part of the editing experience. They should not be a substitute for [form validation](../../../forms/form-validation).
+The `errors` prop allows you to pass an array of errors if syntax is malformed. The below example starts with an incomplete tooltip tag, showing this error message by default. These errors are meant to be ephemeral and part of the editing experience. They should not be a substitute for [form validation](../../forms/form_validation/overview.mdx).
 
+```mdx-code-block
+import Link from '@docusaurus/Link';
+```
+
+<Demo scope={{ Link }}>
 ```tsx interactive
 import React, { useCallback, useState, useRef } from 'react';
 import {
@@ -146,10 +150,12 @@ export default () => {
   const [messages, setMessages] = useState([]);
   const [ast, setAst] = useState(null);
   const [isAstShowing, setIsAstShowing] = useState(false);
+
   const onParse = useCallback((err, { messages, ast }) => {
     setMessages(err ? [err] : messages);
     setAst(JSON.stringify(ast, null, 2));
   }, []);
+
   return (
     <>
       <EuiMarkdownEditor
@@ -170,7 +176,7 @@ export default () => {
       >
         Utilize error text or{' '}
         <strong>
-          <a href="#/forms/form-validation">EuiFormRow</a>
+          <Link to="/docs/forms/validation">EuiFormRow</Link>
         </strong>{' '}
         for more permanent error feedback
       </EuiFormErrorText>
@@ -190,8 +196,8 @@ export default () => {
     </>
   );
 };
-
 ```
+</Demo>
 
 ## Controlling the height
 

--- a/packages/website/docs/components/editors_and_syntax/markdown/format.mdx
+++ b/packages/website/docs/components/editors_and_syntax/markdown/format.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Format
 
-**EuiMarkdownFormat** is a read-only way to render markdown-style content in a page. It is a peer component to **[EuiMarkdownEditor](../editor)** and has the ability to be modified by additional [markdown plugins](../plugins).
+**EuiMarkdownFormat** is a read-only way to render markdown-style content in a page. It is a peer component to [EuiMarkdownEditor](./editor.mdx) and has the ability to be modified by additional [markdown plugins](./plugins.mdx).
 
 ## Built in plugins
 
@@ -47,7 +47,7 @@ export default () => {
 
 ## Text sizing and coloring
 
-**EuiMarkdownFormat** uses [EuiText](../../../display/text) as a wrapper to handle all the CSS styling when rendering the HTML. It also gives the ability to control the text size and color with the `textSize` and `color` props, respectively.
+**EuiMarkdownFormat** uses [EuiText](../../display/text.mdx) as a wrapper to handle all the CSS styling when rendering the HTML. It also gives the ability to control the text size and color with the `textSize` and `color` props, respectively.
 
 ```tsx interactive
 import React from 'react';

--- a/packages/website/docs/components/editors_and_syntax/markdown/plugins.mdx
+++ b/packages/website/docs/components/editors_and_syntax/markdown/plugins.mdx
@@ -5,7 +5,7 @@ id: editors_syntax_markdown_plugins
 
 # Plugins
 
-Both **[EuiMarkdownEditor](../editor)** and **[EuiMarkdownFormat](../format)** utilize the same underlying plugin architecture to transform string based syntax into React components. At a high level [Unified JS](https://www.npmjs.com/package/unified) is used in combination with [Remark](https://www.npmjs.com/package/remark-parse) to provide EUI's markdown components, which are separated into a **parsing** and **processing** layer. These two concepts are kept distinct in EUI components to provide concrete locations for your plugins to be injected, be it editing or rendering. Finally you provide **UI** to the component to handle interactions with the editor.
+Both [EuiMarkdownEditor](./editor.mdx) and [EuiMarkdownFormat](./format.mdx) utilize the same underlying plugin architecture to transform string based syntax into React components. At a high level [Unified JS](https://www.npmjs.com/package/unified) is used in combination with [Remark](https://www.npmjs.com/package/remark-parse) to provide EUI's markdown components, which are separated into a **parsing** and **processing** layer. These two concepts are kept distinct in EUI components to provide concrete locations for your plugins to be injected, be it editing or rendering. Finally you provide **UI** to the component to handle interactions with the editor.
 
 In addition to running the full pipeline, **EuiMarkdownEditor** uses just the parsing configuration to determine the input's validity, provide messages back to the application, and allow the toolbar buttons to interact with existing markdown tags.
 
@@ -39,9 +39,9 @@ These plugin definitions can be obtained by calling `getDefaultEuiMarkdownParsin
 
 The above plugin utils, as well as `getDefaultEuiMarkdownPlugins`, accept an optional configuration object of:
 
-*   `exclude`: an array of default plugins to [unregister](#unregistering-plugins)
-*   `parsingConfig`: allows overriding the configuration of any default parsing plugin
-*   `processingConfig`: currently only accepts a `linkProps` key, which accepts any prop that [EuiLink](../../../navigation/link) accepts
+- `exclude`: an array of default plugins to [unregister](#unregistering-plugins)
+- `parsingConfig`: allows overriding the configuration of any default parsing plugin
+- `processingConfig`: currently only accepts a `linkProps` key, which accepts any prop that [EuiLink](../../navigation/link.mdx) accepts
 
 The below example has the `emoji` plugin excluded, and custom configuration on the link validator parsing plugin and link processing plugin. See the **Props** table for all plugin config options.
 


### PR DESCRIPTION
## Summary

On this PR:

- I change all relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links,
- I used `<Link>` from Docusaurus in an example `packages/website/docs/components/editors_and_syntax/markdown/editor.mdx#error-handling-and-feedback`.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/editors_and_syntax`).

Closes [#8475](https://github.com/elastic/eui/issues/8475)

## QA

### Editors & Syntax section

**Checklist**

- [ ] Verify that all links work in the staging environment

**Pages**

- [ ] [Code](https://eui.elastic.co/pr_8535/new-docs/docs/editors-syntax/code/)
- [ ] [Editor](https://eui.elastic.co/pr_8535/new-docs/docs/editors-syntax/markdown/editor/)
- [ ] [Format](https://eui.elastic.co/pr_8535/new-docs/docs/editors-syntax/markdown/format/)
- [ ] [Plugins](https://eui.elastic.co/pr_8535/new-docs/docs/editors-syntax/markdown/plugins/)
