### PR TITLE
fix(website): fix broken links in the Utilities section

### DIFF
--- a/packages/website/docs/components/utilities/css_utility_classes.mdx
+++ b/packages/website/docs/components/utilities/css_utility_classes.mdx
@@ -24,7 +24,7 @@ For text and typography specific utilities, go to [the Text documentation page](
 
 :::info Responsive utilities have moved
 
-For responsive specific utilities, go to [the Breakpoint utilities page](../theming/breakpoints.mdx).
+For responsive specific utilities, go to [the Breakpoint utilities page](../theming/breakpoints/values.mdx).
 :::
 
 ## Display


### PR DESCRIPTION
## Summary

On this PR:

- I changed a relative link to file path as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix a broken link.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/components/utilities`).

Closes [#8476](https://github.com/elastic/eui/issues/8476)

## QA

### Utilities section

**Checklist**

- [ ] Verify that the link works in the staging environment

**Pages**

- [ ] [CSS utility classes](https://eui.elastic.co/pr_8536/new-docs/docs/utilities/css-utility-classes/)

Optionally, check other pages.