### PR TITLE
fix(website): fix a broken link on the Content page

### DIFF
--- a/packages/website/docs/content/overview.mdx
+++ b/packages/website/docs/content/overview.mdx
@@ -17,5 +17,5 @@ Our content guidelines cover the main principles we follow for crafting consiste
 
 Some more specific guidelines and best practices apply in certain situations or for certain components:
 
-- [Patterns](../patterns/)
-- [Components](../components/)
+- [Patterns](../patterns/overview.mdx)
+- [Components](../components/guidelines/getting_started.mdx)


### PR DESCRIPTION
## Summary

On this PR:

- I change relative links to file paths as recommended in [Markdown links | Docusaurus](https://docusaurus.io/docs/markdown-features/links),
- I fix broken links.

> [!TIP]
> I use `\[(.*?)\]\((.*?)\)|<a\s+[^>]*href=["'](.*?)["'][^>]*>(.*?)<\/a>` regexp to find all Markdown links and anchor tags in the specific section (e.g. `website/docs/content`).

Closes [#8478](https://github.com/elastic/eui/issues/8478)

## QA

### Content page

**Checklist**

- [ ] Verify that the links work in the staging environment on the [Content page](https://eui.elastic.co/pr_8538/new-docs/docs/content/)
