### PR TITLE
fix(website): Stat and Skeleton examples

### DIFF
--- a/packages/website/docs/components/display/skeleton.mdx
+++ b/packages/website/docs/components/display/skeleton.mdx
@@ -259,6 +259,7 @@ export default () => {
 
 ```tsx interactive
 import React, { useState } from 'react';
+import { css } from '@emotion/react';
 import {
   EuiSkeletonRectangle,
   EuiFlexGroup,
@@ -308,6 +309,10 @@ export default () => {
               height={100}
               src="https://picsum.photos/300/300"
               alt="A randomized image"
+              css={css`
+                width: 100px;
+                height: 100px;
+              `}
             />
           </EuiSkeletonRectangle>
         </EuiFlexItem>

--- a/packages/website/docs/components/display/stat.mdx
+++ b/packages/website/docs/components/display/stat.mdx
@@ -28,7 +28,7 @@ export default () => (
 
 ```tsx interactive
 import React from 'react';
-import { EuiStat, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
+import { EuiStat, EuiFlexItem, EuiFlexGroup, EuiSpacer } from '@elastic/eui';
 
 export default () => (
   <>
@@ -46,6 +46,7 @@ export default () => (
       <EuiStat title="100,000" description="Accent color" titleColor="accent" />
     </EuiFlexItem>
   </EuiFlexGroup>
+  <EuiSpacer />
   <EuiFlexGroup wrap>
     <EuiFlexItem grow={false}>
       <EuiStat title="1,000" description="Success color" titleColor="success" />

--- a/packages/website/docs/components/display/stat.mdx
+++ b/packages/website/docs/components/display/stat.mdx
@@ -31,6 +31,7 @@ import React from 'react';
 import { EuiStat, EuiFlexItem, EuiFlexGroup } from '@elastic/eui';
 
 export default () => (
+  <>
   <EuiFlexGroup wrap>
     <EuiFlexItem grow={false}>
       <EuiStat title="1" description="Default color" />
@@ -44,6 +45,8 @@ export default () => (
     <EuiFlexItem grow={false}>
       <EuiStat title="100,000" description="Accent color" titleColor="accent" />
     </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiFlexGroup wrap>
     <EuiFlexItem grow={false}>
       <EuiStat title="1,000" description="Success color" titleColor="success" />
     </EuiFlexItem>
@@ -54,6 +57,7 @@ export default () => (
       <EuiStat title="10,000" description="Danger color" titleColor="danger" />
     </EuiFlexItem>
   </EuiFlexGroup>
+  </>
 );
 ```
 
@@ -252,45 +256,6 @@ export default () => {
                   }
                 >
                   Successes
-                </EuiStat>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPanel>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiPanel hasBorder={true}>
-            <EuiFlexGroup>
-              <EuiFlexItem>
-                <EuiStat
-                  title="1,554"
-                  textAlign="left"
-                  isLoading={isLoading}
-                  titleColor="danger"
-                  description={
-                    <EuiTextColor color="accent">
-                      <span>
-                        <EuiIcon type="error" color="danger" /> 12,20%
-                      </span>
-                    </EuiTextColor>
-                  }
-                >
-                  Errors
-                </EuiStat>
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiStat
-                  title="8,888"
-                  description={
-                    <EuiTextColor color="success">
-                      <span>
-                        <EuiIcon type="sortUp" /> 23,30%
-                      </span>
-                    </EuiTextColor>
-                  }
-                  textAlign="left"
-                  isLoading={isLoading}
-                >
-                  Visitor count
                 </EuiStat>
               </EuiFlexItem>
             </EuiFlexGroup>


### PR DESCRIPTION
Resolves #8150
Resolves #8152 

Improves the examples in Stat, and fixes a little bug in a Skeleton example regarding the size of an image.

> [!IMPORTANT]
> in the Skeleton component, the issue with the spacing between bars being different is related to the component CSS itself, not any globals in Docusaurus; namely the value for `margin-block-start: 0.8571rem;` is different from the one in production, I'm guessing there's something in the tokens?

## Screenshots

### Before 🙅  

![da95f183fca6c31a2f90e496ae849d4f](https://github.com/user-attachments/assets/bb67993a-0318-4bc6-bbc3-6a6ef0a251bd)
![38f975daad8cd6aa9e17d56d0ec94e78](https://github.com/user-attachments/assets/882479f7-7c6b-45a4-a64e-97a9aed7d5e8)

### After 🆗 

![Capture-2025-04-03-201723](https://github.com/user-attachments/assets/23774846-3d10-4fe2-8e7a-d3e245d88c82)
![f9466eb5f90b5d2063b2275b309895f7](https://github.com/user-attachments/assets/905a0873-6843-4a9b-9d34-5041ff85a14e)

## QA

- [ ] Check examples in [Stat page](https://eui.elastic.co/pr_8545/new-docs/docs/display/stat/)
- [ ] Check examples in [Skeleton page](https://eui.elastic.co/pr_8545/new-docs/docs/display/skeleton/)
