### PR TITLE
[EuiButton][HCM] Fixes color of disabled buttons in high contrast mode

### DIFF
--- a/packages/eui/changelogs/upcoming/8550.md
+++ b/packages/eui/changelogs/upcoming/8550.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed a visual bug on disabled `EuiButton` in high contrast mode where wrong text colors were applied
+

--- a/packages/eui/src/global_styling/mixins/_button.ts
+++ b/packages/eui/src/global_styling/mixins/_button.ts
@@ -93,10 +93,15 @@ export const euiButtonFillColor = (
     color
   ) as keyof _EuiThemeButtonColors;
 
-  const foreground = highContrastMode
-    ? color === 'warning'
+  const highContrastForeground =
+    color === 'warning'
       ? euiTheme.colors.ink
-      : euiTheme.colors.textInverse
+      : color === 'disabled'
+      ? euiTheme.components.buttons[textColorTokenName]
+      : euiTheme.colors.textInverse;
+
+  const foreground = highContrastMode
+    ? highContrastForeground
     : euiTheme.components.buttons[textColorTokenName];
   const background = euiTheme.components.buttons[backgroundTokenName];
 


### PR DESCRIPTION
## Summary

This PR fixes a visual issue for disabled `EuiButton` with `filled={true}` where the wrong color token was applied for text and border colors in high contrast mode.

| colorMode | before | after |
|---|---|---|
| LIGHT | ![Screenshot 2025-04-04 at 13 13 10](https://github.com/user-attachments/assets/72fb2207-06f0-4e90-aa99-a8cd19eac789) | ![Screenshot 2025-04-04 at 13 13 31](https://github.com/user-attachments/assets/4442ee57-2d56-439f-9003-ad9bd07f3666) |
| DARK | ![Screenshot 2025-04-04 at 13 13 16](https://github.com/user-attachments/assets/f2d93489-cc5b-46d1-9c58-75fa3ed1aba9) | ![Screenshot 2025-04-04 at 13 13 36](https://github.com/user-attachments/assets/182bf42b-f4ee-4af3-b162-937469f523f8) |


## QA

- [x] review `EuiButton` and verify
  - [x] the offending style in disabled state is fixed
  - [x] other variants and states work as expected

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [x] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
