### PR TITLE
docs: improve `i18n` section

### DIFF
--- a/packages/eui/src-docs/src/views/i18n/i18n_example.js
+++ b/packages/eui/src-docs/src/views/i18n/i18n_example.js
@@ -2,7 +2,13 @@ import React from 'react';
 
 import { GuideSectionTypes } from '../../components';
 
-import { EuiCode, EuiI18n, EuiContext } from '../../../../src/components';
+import {
+  EuiCode,
+  EuiI18n,
+  EuiContext,
+  EuiLink,
+  EuiCallOut,
+} from '../../../../src/components';
 
 import I18nBasic from './i18n_basic';
 const i18nBasicSource = require('!!raw-loader!./i18n_basic');
@@ -46,7 +52,7 @@ const multiValueSnippet = [
   ['filename.label', 'filename.text'],
   ['Default Label', 'Default Text']
 );
-  
+
 return <p aria-label={label}>{text}</p>;
 `,
   `<EuiI18n
@@ -71,6 +77,47 @@ import { I18nShapeProps } from './props';
 export const I18nExample = {
   title: 'I18n',
   sections: [
+    {
+      text: (
+        <>
+          <p>
+            Translations for EUI components can be provided globally in an
+            application via <strong>EuiContext</strong>,{' '}
+            <EuiLink href="#/utilities/i18n%23context">
+              documented below
+            </EuiLink>
+            . A list of all <EuiCode>tokens</EuiCode> —also usually called ids—
+            can be found in the{' '}
+            <EuiLink href="/#/package/i18n-tokens">I18n tokens</EuiLink> page.
+          </p>
+          <p>
+            While developing an EUI component, any text that is included by
+            default must be translatable. <strong>EuiI18n</strong> is the proper
+            way to do this. Examples of such text are the{' '}
+            <EuiCode>aria-label</EuiCode> in the clear button of{' '}
+            <EuiLink href="/#/forms/combo-box">
+              <strong>EuiComboBox</strong>
+            </EuiLink>
+            , or the visible text in{' '}
+            <EuiLink href="/#/navigation/pagination%23compressed-and-responsive">
+              <strong>EuiPagination</strong>
+            </EuiLink>{' '}
+            compressed e.g. "1 of 24".
+          </p>
+          <EuiCallOut
+            iconType="alert"
+            color="warning"
+            title="These utilities are mostly internal"
+          >
+            <p>
+              The purpose of these utilities is to allow internationalizing EUI
+              components. This is not a full-fledged solution for
+              internationalizing your app.
+            </p>
+          </EuiCallOut>
+        </>
+      ),
+    },
     {
       title: 'Internationalization',
       source: [

--- a/packages/eui/src-docs/src/views/package/i18n_tokens.js
+++ b/packages/eui/src-docs/src/views/package/i18n_tokens.js
@@ -26,7 +26,7 @@ const columns = [
           <EuiLink
             target="_blank"
             color="subdued"
-            href={`https://github.com/elastic/eui/blob/main/${filepath}#L${loc.start.line}`}
+            href={`https://github.com/elastic/eui/blob/main/packages/eui/${filepath}#L${loc.start.line}`}
           >
             {filepath}:{loc.start.line}:{loc.start.column}
           </EuiLink>

--- a/packages/website/docs/getting_started/utilities/i18n.mdx
+++ b/packages/website/docs/getting_started/utilities/i18n.mdx
@@ -5,6 +5,14 @@ id: utilities_i18n
 
 # I18n
 
+Translations for EUI components can be provided globally in an application via [EuiContext, documented below](#context). A list of all `tokens` —also usually called ids— can be found in the [I18n tokens](#TODO) page.
+
+While developing an EUI component, any text that is included by default must be translatable. [EuiI18n](#internalization) is the proper way to do this. Examples of such text are the `aria-label` in the clear button of [EuiComboBox](#TODO), or the visible text in [EuiPagination](#TODO) compressed e.g. "1 of 24".
+
+:::warning These utilities are mostly internal
+The purpose of these utilities is to allow internationalizing EUI components. This is not a full-fledged solution for internationalizing your app.
+:::
+
 ## Internalization
 
 **useEuiI18n** and **EuiI18n** allows localizing string and numeric values for internationalization. There are two provided ways to use this: a React hook and a render prop component. In their simplest form, these take a `token` and a `default` value. `token` provides a reference to use when mapping to a localized value and `default` provides the untranslated value when no mapping is available.
@@ -238,7 +246,7 @@ export default () => {
     ['euiI18nMulti.title', 'euiI18nMulti.description'],
     ['Card Title', 'Card Description']
   );
-  
+
   return (
     <>
       <EuiTitle size="xs">

--- a/packages/website/docs/getting_started/utilities/i18n.mdx
+++ b/packages/website/docs/getting_started/utilities/i18n.mdx
@@ -5,7 +5,7 @@ id: utilities_i18n
 
 # I18n
 
-Translations for EUI components can be provided globally in an application via [EuiContext, documented below](#context). A list of all `tokens` —also usually called ids— can be found in the [I18n tokens](#TODO) page.
+Translations for EUI components can be provided globally in an application via [EuiContext, documented below](#context). All available `tokens` —also usually called ids— can be found in [this automatically generated JSON file](https://github.com/elastic/eui/blob/main/packages/eui/i18ntokens.json).
 
 While developing an EUI component, any text that is included by default must be translatable. [EuiI18n](#internalization) is the proper way to do this. Examples of such text are the `aria-label` in the clear button of [EuiComboBox](#TODO), or the visible text in [EuiPagination](#TODO) compressed e.g. "1 of 24".
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui-private/issues/268

This PR adds a couple of paragraphs and a warning to the `i18n` utilities page, in order to make it clearer for what it is and what it isn't.

It also fixes a broken link to GitHub in the `i18n tokens` package page (old site). Source code e.g. `src/components/basic_table/basic_table.tsx:320:6` links point to the previous project structure before the monorepo.

>[!WARNING]
> A couple of links are missing for the new docs, waiting for #8547 

## QA

- [x] Check wording is appropriate and the message is conveyed clearly.

Staging links:
- [Old docs](https://eui.elastic.co/pr_8554/#/utilities/i18n)
- [Old docs, tokens package → GitHub links](https://eui.elastic.co/pr_8554/#/package/i18n-tokens)
- [New site](https://eui.elastic.co/pr_8554/new-docs/docs/utilities/i18n/)
