### PR TITLE
feat(docusaurus-theme): use the Heading component in prop table

### DIFF
--- a/packages/docusaurus-theme/src/components/prop_table/prop_table.tsx
+++ b/packages/docusaurus-theme/src/components/prop_table/prop_table.tsx
@@ -6,7 +6,6 @@ import {
   EuiFlexGroup,
   EuiCode,
   UseEuiTheme,
-  EuiTitle,
   useEuiMemoizedStyles,
   EuiLink,
 } from '@elastic/eui';
@@ -17,6 +16,7 @@ import {
 import { useCallback, useMemo } from 'react';
 import { css } from '@emotion/react';
 import { PropTableExtendedTypes } from './extended_types';
+import Heading from '@theme/Heading';
 
 export interface PropTableProps {
   definition: ProcessedComponent;
@@ -77,7 +77,7 @@ const getPropTableStyles = ({ euiTheme }: UseEuiTheme) => ({
 
 export const PropTable = ({
   definition,
-  headingLevel: HeadingLevel = 'h3',
+  headingLevel = 'h3',
   showTitle = true,
 }: PropTableProps) => {
   const styles = useEuiMemoizedStyles(getPropTableStyles);
@@ -182,9 +182,9 @@ export const PropTable = ({
     >
       <header css={styles.header}>
         {showTitle && (
-          <EuiTitle size="m">
-            <HeadingLevel>{definition.displayName}</HeadingLevel>
-          </EuiTitle>
+          <Heading as={headingLevel} id={definition.displayName}>
+            {definition.displayName}
+          </Heading>
         )}
         <PropTableExtendedTypes definition={definition} />
       </header>


### PR DESCRIPTION
## Summary

On this PR, I use the Docusaurus' `Heading` component that contains the copy anchor icon button and I pass an `id` so that the prop table title becomes an anchor.

![Screenshot 2025-04-07 at 14 07 54](https://github.com/user-attachments/assets/d5e5b884-62c0-4f56-be15-fa7904663ffe)

Closes https://github.com/elastic/eui/issues/8556

## QA

### Instructions

1. Checkout the branch: `gh pr checkout 8557` or access the staging environment.
2. Access any component page, e.g. [Accordion](https://eui.elastic.co/pr_8557/new-docs/docs/layout/accordion/).
3. Scroll down (or use TOC) to "Props" section.

### Checklist

- [x] Check whether the prop table title is `h3` and has appropriate styles (is smaller than the "Props" section title)
- [x] Verify that when you hover over the title, an icon button appears and you can copy the anchor link
- [x] Verify that the anchor link works as expected