### PR TITLE
[Emotion] Cherry pick style memoization commits

### DIFF
--- a/packages/eui/changelogs/upcoming/8565.md
+++ b/packages/eui/changelogs/upcoming/8565.md
@@ -1,0 +1,1 @@
+- Refactored `EuiExpression`, `EuiFacetGroup`, `EuiFacetButton`, `EuiFilterGroup`, `EuiHeader`, `EuiImage` and `EuiListGroup` to memoize their internal Emotion styles

--- a/packages/eui/src/components/expression/expression.styles.ts
+++ b/packages/eui/src/components/expression/expression.styles.ts
@@ -160,18 +160,16 @@ export const euiExpressionDescriptionStyles = ({ euiTheme }: UseEuiTheme) => {
   };
 };
 
-export const euiExpressionValueStyles = ({}: UseEuiTheme) => {
-  return {
-    euiExpression__value: css``,
-    truncate: css`
-      ${euiTextTruncate()}
-      display: inline-block;
-      vertical-align: bottom;
-    `,
-    columns: css`
-      flex-grow: 1;
-    `,
-  };
+export const euiExpressionValueStyles = {
+  euiExpression__value: css``,
+  truncate: css`
+    ${euiTextTruncate()}
+    display: inline-block;
+    vertical-align: bottom;
+  `,
+  columns: css`
+    flex-grow: 1;
+  `,
 };
 
 export const euiExpressionIconStyles = ({ euiTheme }: UseEuiTheme) => {

--- a/packages/eui/src/components/expression/expression.tsx
+++ b/packages/eui/src/components/expression/expression.tsx
@@ -14,14 +14,15 @@ import React, {
   FunctionComponent,
 } from 'react';
 import classNames from 'classnames';
+
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { EuiIcon } from '../icon';
-import { useEuiTheme } from '../../services';
 
 import {
   euiExpressionStyles,
   euiExpressionDescriptionStyles,
-  euiExpressionValueStyles,
+  euiExpressionValueStyles as valueStyles,
   euiExpressionIconStyles,
 } from './expression.styles';
 
@@ -112,8 +113,7 @@ export const EuiExpression: FunctionComponent<
 }) => {
   const calculatedColor = isInvalid ? 'danger' : color;
 
-  const theme = useEuiTheme();
-  const styles = euiExpressionStyles(theme);
+  const styles = useEuiMemoizedStyles(euiExpressionStyles);
   const cssStyles = [
     styles.euiExpression,
     onClick && styles.isClickable,
@@ -123,7 +123,9 @@ export const EuiExpression: FunctionComponent<
     display === 'columns' && styles.columns,
     textWrap === 'truncate' && styles.truncate,
   ];
-  const descriptionStyles = euiExpressionDescriptionStyles(theme);
+  const descriptionStyles = useEuiMemoizedStyles(
+    euiExpressionDescriptionStyles
+  );
   const cssDescriptionStyles = [
     descriptionStyles.euiExpression__description,
     isInvalid ? descriptionStyles.danger : descriptionStyles[color],
@@ -131,14 +133,13 @@ export const EuiExpression: FunctionComponent<
     textWrap === 'truncate' && descriptionStyles.truncate,
     display === 'columns' && descriptionStyles.columns,
   ];
-  const valueStyles = euiExpressionValueStyles(theme);
   const cssValueStyles = [
     valueStyles.euiExpression__value,
     textWrap === 'truncate' && valueStyles.truncate,
     display === 'columns' && valueStyles.columns,
   ];
 
-  const iconStyles = euiExpressionIconStyles(theme);
+  const iconStyles = useEuiMemoizedStyles(euiExpressionIconStyles);
   const cssIconStyles = [
     iconStyles.euiExpression__icon,
     display === 'columns' && iconStyles.columns,
@@ -152,15 +153,6 @@ export const EuiExpression: FunctionComponent<
     display === 'columns' && descriptionWidth
       ? { flexBasis: descriptionWidth }
       : undefined;
-
-  const invalidIcon = isInvalid ? (
-    <EuiIcon
-      className="euiExpression__icon"
-      type="warning"
-      css={cssIconStyles}
-      color={calculatedColor}
-    />
-  ) : undefined;
 
   return (
     <Component css={cssStyles} className={classes} onClick={onClick} {...rest}>
@@ -184,7 +176,14 @@ export const EuiExpression: FunctionComponent<
           {value}
         </span>
       )}
-      {invalidIcon}
+      {isInvalid && (
+        <EuiIcon
+          className="euiExpression__icon"
+          type="warning"
+          css={cssIconStyles}
+          color={calculatedColor}
+        />
+      )}
     </Component>
   );
 };

--- a/packages/eui/src/components/facet/__snapshots__/facet_button.test.tsx.snap
+++ b/packages/eui/src/components/facet/__snapshots__/facet_button.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`EuiFacetButton props icon is rendered 1`] = `
     class="emotion-euiButtonDisplayContent"
   >
     <span
-      class="euiFacetButton__icon emotion-euiFacetButton__icon"
+      class="euiFacetButton__icon"
       data-euiicon-type="dot"
     />
     <span
@@ -55,7 +55,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
     class="emotion-euiButtonDisplayContent"
   >
     <span
-      class="euiFacetButton__icon emotion-euiFacetButton__icon-isDisabled"
+      class="euiFacetButton__icon emotion-euiFacetButton__disabled"
       color="success"
       data-euiicon-type="dot"
     />
@@ -66,7 +66,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
       Content
     </span>
     <span
-      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued-euiFacetButton__quantity-isDisabled"
+      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued-euiFacetButton__disabled"
     >
       6
     </span>
@@ -92,7 +92,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
     </span>
     <span
       aria-label="Loading"
-      class="euiLoadingSpinner emotion-euiLoadingSpinner-m-euiFacetButton__loadingSpinner"
+      class="euiLoadingSpinner emotion-euiLoadingSpinner-m"
       role="progressbar"
     />
   </span>
@@ -134,7 +134,7 @@ exports[`EuiFacetButton props quantity is rendered 1`] = `
       Content
     </span>
     <span
-      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued-euiFacetButton__quantity"
+      class="euiNotificationBadge euiFacetButton__quantity emotion-euiNotificationBadge-m-subdued"
     >
       60
     </span>

--- a/packages/eui/src/components/facet/facet_button.styles.ts
+++ b/packages/eui/src/components/facet/facet_button.styles.ts
@@ -54,20 +54,7 @@ export const euiFacetButtonTextStyles = ({ euiTheme }: UseEuiTheme) => ({
   unSelected: css``,
 });
 
-export const euiFacetButtonIconStyles = () => ({
-  euiFacetButton__icon: css``,
-  isDisabled: css`
-    opacity: 0.5;
-  `,
-});
-
-export const euiFacetButtonLoadingSpinnerStyles = () => ({
-  euiFacetButton__loadingSpinner: css``,
-});
-
-export const euiFacetButtonQuantityStyles = () => ({
-  euiFacetButton__quantity: css``,
-  isDisabled: css`
-    opacity: 0.5;
-  `,
-});
+// Used by both icon and quantity siblings
+export const euiFacetButton__disabled = css`
+  opacity: 0.5;
+`;

--- a/packages/eui/src/components/facet/facet_group.styles.ts
+++ b/packages/eui/src/components/facet/facet_group.styles.ts
@@ -7,66 +7,56 @@
  */
 
 import { css } from '@emotion/react';
-import { UseEuiTheme, useEuiTheme } from '../../services';
-import { EuiFacetGroupLayout } from './facet_group';
+import { UseEuiTheme } from '../../services';
+import { mathWithUnits } from '../../global_styling';
 
-const _facetGroupGutterSize = ({
-  gutterSize,
-  layout,
-}: {
-  gutterSize: string;
-  layout: EuiFacetGroupLayout;
-}) => {
-  const { euiTheme } = useEuiTheme();
-  const isHorizontalLayout = layout === 'horizontal';
-  const gutterHorizontal = `calc(${euiTheme.size.m} + ${gutterSize})`;
-  const gutterVertical = gutterSize;
+import type { EuiFacetGroupGutterSizes } from './facet_group';
 
-  return isHorizontalLayout
-    ? `gap: ${gutterVertical} ${gutterHorizontal};`
-    : `gap: ${gutterVertical} 0;`;
+export const euiFacetGroupStyles = ({ euiTheme }: UseEuiTheme) => {
+  const gutterSizesMap = {
+    none: 0,
+    s: euiTheme.size.xs,
+    m: euiTheme.size.s,
+    l: euiTheme.size.m,
+  };
+  const _getVerticalGutters = (sizeKey: EuiFacetGroupGutterSizes) => {
+    const size = gutterSizesMap[sizeKey];
+    return `gap: ${size} 0;`;
+  };
+  const _getHorizontalGutters = (sizeKey: EuiFacetGroupGutterSizes) => {
+    const size = gutterSizesMap[sizeKey];
+    return `
+      gap: ${size} ${mathWithUnits([size, euiTheme.size.m], (x, y) => x + y)};
+    `;
+  };
+
+  return {
+    // Base
+    euiFacetGroup: css`
+      display: flex;
+      flex-grow: 1;
+    `,
+    // layouts
+    horizontal: css`
+      flex-direction: row;
+      flex-wrap: wrap;
+    `,
+    vertical: css`
+      flex-direction: column;
+    `,
+    gutterSizes: {
+      vertical: {
+        none: css(_getVerticalGutters('none')),
+        s: css(_getVerticalGutters('s')),
+        m: css(_getVerticalGutters('m')),
+        l: css(_getVerticalGutters('l')),
+      },
+      horizontal: {
+        none: css(_getHorizontalGutters('none')),
+        s: css(_getHorizontalGutters('s')),
+        m: css(_getHorizontalGutters('m')),
+        l: css(_getHorizontalGutters('l')),
+      },
+    },
+  };
 };
-
-export const euiFacetGroupStyles = (
-  { euiTheme }: UseEuiTheme,
-  layout: EuiFacetGroupLayout
-) => ({
-  // Base
-  euiFacetGroup: css`
-    display: flex;
-    flex-grow: 1;
-  `,
-  // Gutter sizes
-  none: css(
-    _facetGroupGutterSize({
-      gutterSize: '0',
-      layout,
-    })
-  ),
-  s: css(
-    _facetGroupGutterSize({
-      gutterSize: euiTheme.size.xs,
-      layout,
-    })
-  ),
-  m: css(
-    _facetGroupGutterSize({
-      gutterSize: euiTheme.size.s,
-      layout,
-    })
-  ),
-  l: css(
-    _facetGroupGutterSize({
-      gutterSize: euiTheme.size.m,
-      layout,
-    })
-  ),
-  // layouts
-  horizontal: css`
-    flex-direction: row;
-    flex-wrap: wrap;
-  `,
-  vertical: css`
-    flex-direction: column;
-  `,
-});

--- a/packages/eui/src/components/facet/facet_group.tsx
+++ b/packages/eui/src/components/facet/facet_group.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 
 import { CommonProps } from '../common';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { euiFacetGroupStyles } from './facet_group.styles';
 
 export const LAYOUTS = ['vertical', 'horizontal'] as const;
@@ -40,9 +40,12 @@ export const EuiFacetGroup: FunctionComponent<EuiFacetGroupProps> = ({
   gutterSize = 'm',
   ...rest
 }) => {
-  const theme = useEuiTheme();
-  const styles = euiFacetGroupStyles(theme, layout);
-  const cssStyles = [styles.euiFacetGroup, styles[gutterSize], styles[layout]];
+  const styles = useEuiMemoizedStyles(euiFacetGroupStyles);
+  const cssStyles = [
+    styles.euiFacetGroup,
+    styles.gutterSizes[layout][gutterSize],
+    styles[layout],
+  ];
 
   const classes = classNames('euiFacetGroup', className);
 

--- a/packages/eui/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
+++ b/packages/eui/src/components/filter_group/__snapshots__/filter_button.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`EuiFilterButton props numActiveFilters and hasActiveFilters renders 1`]
     />
     <span
       aria-label="5 active filters"
-      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-accent-euiFilterButton__notification-badgeContent"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-accent-euiFilterButton__notification"
       role="marquee"
     >
       5
@@ -132,7 +132,7 @@ exports[`EuiFilterButton props numFilters renders 1`] = `
     />
     <span
       aria-label="5 available filters"
-      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification"
       role="marquee"
     >
       5
@@ -203,7 +203,7 @@ exports[`EuiFilterButton renders zero properly 1`] = `
     />
     <span
       aria-label="0 available filters"
-      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification-badgeContent"
+      class="euiNotificationBadge euiFilterButton__notification emotion-euiNotificationBadge-s-subdued-euiFilterButton__notification"
       role="marquee"
     >
       0

--- a/packages/eui/src/components/filter_group/filter_button.tsx
+++ b/packages/eui/src/components/filter_group/filter_button.tsx
@@ -9,7 +9,7 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { useInnerText } from '../inner_text';
 import { DistributiveOmit } from '../common';
@@ -78,8 +78,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   const numActiveFiltersDefined =
     numActiveFilters != null && numActiveFilters > 0;
 
-  const euiTheme = useEuiTheme();
-  const styles = euiFilterButtonStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiFilterButtonStyles);
   const cssStyles = [
     styles.euiFilterButton,
     withNext && styles.withNext,
@@ -91,7 +90,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     content: contentStyles,
     text: textStyles,
     notification: notificationStyles,
-  } = euiFilterButtonChildStyles(euiTheme);
+  } = useEuiMemoizedStyles(euiFilterButtonChildStyles);
 
   const classes = classNames(
     'euiFilterButton',
@@ -118,21 +117,10 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
     '{count} available filters',
     { count: badgeCount }
   );
-
-  const badgeContent = showBadge && (
-    <EuiNotificationBadge
-      className="euiFilterButton__notification"
-      css={[
-        notificationStyles.euiFilterButton__notification,
-        isDisabled && notificationStyles.disabled,
-      ]}
-      aria-label={hasActiveFilters ? activeBadgeLabel : availableBadgeLabel}
-      color={isDisabled || !hasActiveFilters ? 'subdued' : badgeColor}
-      role="marquee" // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role
-    >
-      {badgeCount}
-    </EuiNotificationBadge>
-  );
+  const badgeStyles = [
+    notificationStyles.euiFilterButton__notification,
+    isDisabled && notificationStyles.disabled,
+  ];
 
   /**
    * Text
@@ -151,19 +139,6 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   const [ref, innerText] = useInnerText();
   const dataText =
     children && typeof children === 'string' ? children : innerText;
-
-  const textContent = (
-    <span
-      ref={ref}
-      data-text={dataText}
-      title={dataText}
-      {...textProps}
-      className={buttonTextClassNames}
-      css={textCssStyles}
-    >
-      {children}
-    </span>
-  );
 
   return (
     <EuiButtonEmpty
@@ -185,8 +160,28 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
       }}
       {...rest}
     >
-      {textContent}
-      {badgeContent}
+      <span
+        ref={ref}
+        data-text={dataText}
+        title={dataText}
+        {...textProps}
+        className={buttonTextClassNames}
+        css={textCssStyles}
+      >
+        {children}
+      </span>
+
+      {showBadge && (
+        <EuiNotificationBadge
+          className="euiFilterButton__notification"
+          css={badgeStyles}
+          aria-label={hasActiveFilters ? activeBadgeLabel : availableBadgeLabel}
+          color={isDisabled || !hasActiveFilters ? 'subdued' : badgeColor}
+          role="marquee" // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role
+        >
+          {badgeCount}
+        </EuiNotificationBadge>
+      )}
     </EuiButtonEmpty>
   );
 };

--- a/packages/eui/src/components/filter_group/filter_group.tsx
+++ b/packages/eui/src/components/filter_group/filter_group.tsx
@@ -9,7 +9,7 @@
 import React, { HTMLAttributes, ReactNode, FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
 
 import { euiFilterGroupStyles } from './filter_group.styles';
@@ -34,8 +34,7 @@ export const EuiFilterGroup: FunctionComponent<EuiFilterGroupProps> = ({
   compressed,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiFilterGroupStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiFilterGroupStyles);
   const cssStyles = [
     styles.euiFilterGroup,
     fullWidth && styles.fullWidth,

--- a/packages/eui/src/components/header/header.tsx
+++ b/packages/eui/src/components/header/header.tsx
@@ -16,7 +16,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme, useEuiThemeCSSVariables } from '../../services';
+import { useEuiMemoizedStyles, useEuiThemeCSSVariables } from '../../services';
 import { mathWithUnits, logicalStyles } from '../../global_styling';
 import { CommonProps } from '../common';
 import { EuiBreadcrumb, EuiBreadcrumbsProps } from '../breadcrumbs';
@@ -84,45 +84,44 @@ export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
 }) => {
   const classes = classNames('euiHeader', className);
 
-  const euiTheme = useEuiTheme();
-  const styles = euiHeaderStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiHeaderStyles);
   const cssStyles = [styles.euiHeader, styles[position], styles[theme]];
 
-  let contents;
-  if (sections) {
-    if (children) {
-      // In case both children and sections are passed, warn in the console that the children will be disregarded
-      console.warn(
-        'EuiHeader cannot accept both `children` and `sections`. It will disregard the `children`.'
-      );
-    }
-
-    contents = sections.map((section, index) => {
-      const content = [];
-      if (section.items) {
-        // Items get wrapped in EuiHeaderSection and each item in a EuiHeaderSectionItem
-        content.push(
-          <EuiHeaderSection key={`items-${index}`}>
-            {createHeaderSection(section.items)}
-          </EuiHeaderSection>
-        );
-      }
-      if (section.breadcrumbs) {
-        content.push(
-          // Breadcrumbs are separate and cannot be contained in a EuiHeaderSection
-          // in order for truncation to work
-          <EuiHeaderBreadcrumbs
-            key={`breadcrumbs-${index}`}
-            breadcrumbs={section.breadcrumbs}
-            {...section.breadcrumbProps}
-          />
-        );
-      }
-      return content;
-    });
-  } else {
-    contents = children;
+  if (sections && children) {
+    // In case both children and sections are passed, warn in the console that the children will be disregarded
+    console.warn(
+      'EuiHeader cannot accept both `children` and `sections`. It will disregard the `children`.'
+    );
   }
+
+  const contents =
+    useMemo(() => {
+      if (!sections || !sections.length) return null;
+
+      return sections.map((section, index) => {
+        const content = [];
+        if (section.items) {
+          // Items get wrapped in EuiHeaderSection and each item in a EuiHeaderSectionItem
+          content.push(
+            <EuiHeaderSection key={`items-${index}`}>
+              {createHeaderSection(section.items)}
+            </EuiHeaderSection>
+          );
+        }
+        if (section.breadcrumbs) {
+          content.push(
+            // Breadcrumbs are separate and cannot be contained in a EuiHeaderSection
+            // in order for truncation to work
+            <EuiHeaderBreadcrumbs
+              key={`breadcrumbs-${index}`}
+              breadcrumbs={section.breadcrumbs}
+              {...section.breadcrumbProps}
+            />
+          );
+        }
+        return content;
+      });
+    }, [sections]) || children;
 
   return position === 'fixed' ? (
     <EuiFixedHeader css={cssStyles} className={classes} {...rest}>
@@ -151,8 +150,7 @@ export const EuiFixedHeader: FunctionComponent<EuiHeaderProps> = ({
   ...rest
 }) => {
   const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
-  const euiTheme = useEuiTheme();
-  const headerHeight = euiHeaderVariables(euiTheme).height;
+  const headerHeight = useEuiMemoizedStyles(euiHeaderVariables).height;
   const getHeaderOffset = useCallback(
     () => mathWithUnits(headerHeight, (x) => x * euiFixedHeadersCount),
     [headerHeight]

--- a/packages/eui/src/components/header/header_alert/header_alert.tsx
+++ b/packages/eui/src/components/header/header_alert/header_alert.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import { CommonProps } from '../../common';
 
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
-import { useEuiTheme, useGeneratedHtmlId } from '../../../services';
+import { useEuiMemoizedStyles, useGeneratedHtmlId } from '../../../services';
 
 import { euiHeaderAlertStyles } from './header_alert.styles';
 
@@ -40,8 +40,7 @@ export const EuiHeaderAlert: FunctionComponent<EuiHeaderAlertProps> = ({
   badge,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiHeaderAlertStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiHeaderAlertStyles);
 
   const classes = classNames('euiHeaderAlert', className);
 

--- a/packages/eui/src/components/header/header_links/header_links.tsx
+++ b/packages/eui/src/components/header/header_links/header_links.tsx
@@ -17,7 +17,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../../services';
+import { useEuiMemoizedStyles } from '../../../services';
 import { CommonProps } from '../../common';
 import { EuiIcon, IconType } from '../../icon';
 import { EuiPopover, EuiPopoverProps } from '../../popover';
@@ -76,8 +76,7 @@ export const EuiHeaderLinks: FunctionComponent<EuiHeaderLinksProps> = ({
   popoverProps,
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiHeaderLinksStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiHeaderLinksStyles);
 
   const {
     onClick,
@@ -110,20 +109,6 @@ export const EuiHeaderLinks: FunctionComponent<EuiHeaderLinksProps> = ({
 
   const classes = classNames('euiHeaderLinks', className);
 
-  const button = (
-    <EuiI18n token="euiHeaderLinks.openNavigationMenu" default="Open menu">
-      {(openNavigationMenu: string) => (
-        <EuiHeaderSectionItemButton
-          aria-label={openNavigationMenu}
-          onClick={onMenuButtonClick}
-          {...popoverButtonRest}
-        >
-          <EuiIcon type={iconType} size="m" />
-        </EuiHeaderSectionItemButton>
-      )}
-    </EuiI18n>
-  );
-
   const renderedChildren =
     typeof children === 'function' ? children(closeMenu) : children;
 
@@ -150,7 +135,22 @@ export const EuiHeaderLinks: FunctionComponent<EuiHeaderLinksProps> = ({
 
           <EuiShowFor sizes={popoverBreakpoints}>
             <EuiPopover
-              button={button}
+              button={
+                <EuiI18n
+                  token="euiHeaderLinks.openNavigationMenu"
+                  default="Open menu"
+                >
+                  {(openNavigationMenu: string) => (
+                    <EuiHeaderSectionItemButton
+                      aria-label={openNavigationMenu}
+                      onClick={onMenuButtonClick}
+                      {...popoverButtonRest}
+                    >
+                      <EuiIcon type={iconType} size="m" />
+                    </EuiHeaderSectionItemButton>
+                  )}
+                </EuiI18n>
+              }
               isOpen={mobileMenuIsOpen}
               anchorPosition="downRight"
               closePopover={closeMenu}

--- a/packages/eui/src/components/header/header_logo/header_logo.tsx
+++ b/packages/eui/src/components/header/header_logo/header_logo.tsx
@@ -13,7 +13,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme, getSecureRelForTarget } from '../../../services';
+import { useEuiMemoizedStyles, getSecureRelForTarget } from '../../../services';
 import { validateHref } from '../../../services/security/href_validator';
 import { EuiIcon, IconType } from '../../icon';
 import { CommonProps } from '../../common';
@@ -44,8 +44,7 @@ export const EuiHeaderLogo: FunctionComponent<EuiHeaderLogoProps> = ({
   ...rest
 }) => {
   const classes = classNames('euiHeaderLogo', className);
-  const euiTheme = useEuiTheme();
-  const styles = euiHeaderLogoStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiHeaderLogoStyles);
 
   const secureRel = getSecureRelForTarget({ href, rel, target });
   const isHrefValid = !href || validateHref(href);

--- a/packages/eui/src/components/header/header_section/__snapshots__/header_section_item_button.test.tsx.snap
+++ b/packages/eui/src/components/header/header_section/__snapshots__/header_section_item_button.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`EuiHeaderSectionItemButton renders notification as a badge 1`] = `
         class="euiHeaderSectionItemButton__content emotion-euiHeaderSectionItemButton__content"
       />
       <span
-        class="euiNotificationBadge euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge emotion-euiNotificationBadge-s-accent-euiHeaderSectionItemButton__notification-badge-buttonNotification"
+        class="euiNotificationBadge euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge emotion-euiNotificationBadge-s-accent-euiHeaderSectionItemButton__notification-badge"
       >
         1
       </span>
@@ -103,7 +103,7 @@ exports[`EuiHeaderSectionItemButton renders notification as a dot 1`] = `
         class="euiHeaderSectionItemButton__content emotion-euiHeaderSectionItemButton__content"
       />
       <span
-        class="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--dot emotion-euiHeaderSectionItemButton__notification-dot-notificationDot"
+        class="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--dot emotion-euiHeaderSectionItemButton__notification-dot"
         color="accent"
         data-euiicon-type="dot"
       />
@@ -127,7 +127,7 @@ exports[`EuiHeaderSectionItemButton renders notification color 1`] = `
         class="euiHeaderSectionItemButton__content emotion-euiHeaderSectionItemButton__content"
       />
       <span
-        class="euiNotificationBadge euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge emotion-euiNotificationBadge-s-subdued-euiHeaderSectionItemButton__notification-badge-buttonNotification"
+        class="euiNotificationBadge euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge emotion-euiNotificationBadge-s-subdued-euiHeaderSectionItemButton__notification-badge"
       >
         1
       </span>

--- a/packages/eui/src/components/header/header_section/header_section_item.tsx
+++ b/packages/eui/src/components/header/header_section/header_section_item.tsx
@@ -9,7 +9,7 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../../services';
+import { useEuiMemoizedStyles } from '../../../services';
 import { CommonProps } from '../../common';
 
 import { euiHeaderSectionItemStyles } from './header_section_item.styles';
@@ -27,8 +27,7 @@ export type EuiHeaderSectionItemProps = CommonProps & {
 export const EuiHeaderSectionItem: FunctionComponent<
   EuiHeaderSectionItemProps
 > = ({ children, className, ...rest }) => {
-  const euiTheme = useEuiTheme();
-  const styles = euiHeaderSectionItemStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiHeaderSectionItemStyles);
 
   const classes = classNames('euiHeaderSectionItem', className);
 

--- a/packages/eui/src/components/header/header_section/header_section_item_button.tsx
+++ b/packages/eui/src/components/header/header_section/header_section_item_button.tsx
@@ -10,18 +10,21 @@ import React, {
   PropsWithChildren,
   forwardRef,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../../services';
+import {
+  useEuiMemoizedStyles,
+  useIsWithinMaxBreakpoint,
+} from '../../../services';
 import {
   EuiNotificationBadgeProps,
   EuiNotificationBadge,
 } from '../../badge/notification_badge/badge_notification';
 import { EuiIcon } from '../../icon';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../../button';
-import { EuiHideFor, EuiShowFor } from '../../responsive';
 
 import { euiHeaderSectionItemButtonStyles } from './header_section_item_button.styles';
 
@@ -190,46 +193,41 @@ export const EuiHeaderSectionItemButton = forwardRef<
       []
     );
 
-    const euiTheme = useEuiTheme();
-    const styles = euiHeaderSectionItemButtonStyles(euiTheme);
-
+    const styles = useEuiMemoizedStyles(euiHeaderSectionItemButtonStyles);
     const classes = classNames('euiHeaderSectionItemButton', className);
 
-    const notificationDot = (
-      <EuiIcon
-        className="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--dot"
-        css={[
-          styles.notification.euiHeaderSectionItemButton__notification,
-          styles.notification.dot,
-        ]}
-        color={notificationColor}
-        type="dot"
-        size="l"
-      />
-    );
+    const isSmallScreen = useIsWithinMaxBreakpoint('s');
+    const shouldShowDot =
+      notification === true || !!(notification && isSmallScreen);
 
-    let buttonNotification;
-    if (notification === true) {
-      buttonNotification = notificationDot;
-    } else if (notification) {
-      buttonNotification = (
-        <>
-          <EuiHideFor sizes={['xs']}>
-            <EuiNotificationBadge
-              className="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge"
-              css={[
-                styles.notification.euiHeaderSectionItemButton__notification,
-                styles.notification.badge,
-              ]}
-              color={notificationColor}
-            >
-              {notification}
-            </EuiNotificationBadge>
-          </EuiHideFor>
-          <EuiShowFor sizes={['xs']}>{notificationDot}</EuiShowFor>
-        </>
-      );
-    }
+    const buttonNotification = useMemo(() => {
+      const cssStyles = [
+        styles.notification.euiHeaderSectionItemButton__notification,
+        shouldShowDot ? styles.notification.dot : styles.notification.badge,
+      ];
+
+      if (shouldShowDot) {
+        return (
+          <EuiIcon
+            className="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--dot"
+            css={cssStyles}
+            color={notificationColor}
+            type="dot"
+            size="l"
+          />
+        );
+      } else if (notification) {
+        return (
+          <EuiNotificationBadge
+            className="euiHeaderSectionItemButton__notification euiHeaderSectionItemButton__notification--badge"
+            css={cssStyles}
+            color={notificationColor}
+          >
+            {notification}
+          </EuiNotificationBadge>
+        );
+      }
+    }, [notification, notificationColor, styles.notification, shouldShowDot]);
 
     return (
       <EuiButtonEmpty

--- a/packages/eui/src/components/image/image.tsx
+++ b/packages/eui/src/components/image/image.tsx
@@ -9,13 +9,12 @@
 import React, { FunctionComponent, useState } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 
 import { EuiImageWrapper } from './image_wrapper';
 import { euiImageStyles } from './image.styles';
 import { EuiImageFullScreenWrapper } from './image_fullscreen_wrapper';
 import type { EuiImageProps, EuiImageSize } from './image_types';
-
 import { SIZES } from './image_types';
 
 export const EuiImage: FunctionComponent<EuiImageProps> = ({
@@ -35,17 +34,13 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
   onFullScreen,
   ...rest
 }) => {
-  const [isFullScreen, setIsFullScreen] = useState(false);
-
+  const isFullWidth = size === 'fullWidth';
   const isNamedSize =
     typeof size === 'string' && SIZES.includes(size as EuiImageSize);
+  const isCustomSize = !isNamedSize && size !== 'original';
 
   const classes = classNames('euiImage', className);
-
-  const euiTheme = useEuiTheme();
-
-  const styles = euiImageStyles(euiTheme);
-
+  const styles = useEuiMemoizedStyles(euiImageStyles);
   const cssStyles = [
     styles.euiImage,
     isNamedSize && styles[size as EuiImageSize],
@@ -53,9 +48,9 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
     hasShadow && styles.hasShadow,
   ];
 
+  const [isFullScreen, setIsFullScreen] = useState(false);
   const cssIsFullScreenStyles = [styles.euiImage, styles.isFullScreen];
 
-  const isCustomSize = !isNamedSize && size !== 'original';
   const customSize = typeof size === 'string' ? size : `${size}px`;
   const imageStyleWithCustomSize = isCustomSize
     ? {
@@ -64,8 +59,6 @@ export const EuiImage: FunctionComponent<EuiImageProps> = ({
         maxHeight: customSize,
       }
     : style;
-
-  const isFullWidth = size === 'fullWidth';
 
   const commonWrapperProps = {
     hasShadow,

--- a/packages/eui/src/components/image/image_button.tsx
+++ b/packages/eui/src/components/image/image_button.tsx
@@ -8,7 +8,7 @@
 
 import React, { FunctionComponent } from 'react';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { useEuiI18n } from '../i18n';
 import { EuiIcon } from '../icon';
 import { EuiScreenReaderOnly } from '../accessibility';
@@ -40,9 +40,7 @@ export const EuiImageButton: FunctionComponent<EuiImageButtonProps> = ({
   fullScreenIconColor = 'light',
   ...rest
 }) => {
-  const euiTheme = useEuiTheme();
-
-  const buttonStyles = euiImageButtonStyles(euiTheme);
+  const buttonStyles = useEuiMemoizedStyles(euiImageButtonStyles);
 
   const cssButtonStyles = [
     buttonStyles.euiImageButton,
@@ -50,7 +48,7 @@ export const EuiImageButton: FunctionComponent<EuiImageButtonProps> = ({
     !isFullScreen && isFullWidth && buttonStyles.fullWidth,
   ];
 
-  const iconStyles = euiImageButtonIconStyles(euiTheme);
+  const iconStyles = useEuiMemoizedStyles(euiImageButtonIconStyles);
   const cssIconStyles = [
     iconStyles.euiImageButton__icon,
     iconStyles.openFullScreen,
@@ -69,39 +67,37 @@ export const EuiImageButton: FunctionComponent<EuiImageButtonProps> = ({
     fullScreenIconColorMap[fullScreenIconColor as EuiImageButtonIconColor];
 
   return (
-    <>
-      <button
-        type="button"
-        css={cssButtonStyles}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-        {...rest}
-      >
-        {isFullScreen && (
-          // In fullscreen mode, instructions should come first to allow screen reader
-          // users to quickly exit vs. potentially reading out long/unskippable alt text
+    <button
+      type="button"
+      css={cssButtonStyles}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      {...rest}
+    >
+      {isFullScreen && (
+        // In fullscreen mode, instructions should come first to allow screen reader
+        // users to quickly exit vs. potentially reading out long/unskippable alt text
+        <EuiScreenReaderOnly>
+          <p>
+            {closeFullScreenInstructions}
+            {hasAlt && ' — '}
+          </p>
+        </EuiScreenReaderOnly>
+      )}
+
+      {children}
+
+      {!isFullScreen && (
+        <div css={cssIconStyles}>
           <EuiScreenReaderOnly>
             <p>
-              {closeFullScreenInstructions}
               {hasAlt && ' — '}
+              {openFullScreenInstructions}
             </p>
           </EuiScreenReaderOnly>
-        )}
-
-        {children}
-
-        {!isFullScreen && (
-          <div css={cssIconStyles}>
-            <EuiScreenReaderOnly>
-              <p>
-                {hasAlt && ' — '}
-                {openFullScreenInstructions}
-              </p>
-            </EuiScreenReaderOnly>
-            <EuiIcon type="fullScreen" color={iconColor} />
-          </div>
-        )}
-      </button>
-    </>
+          <EuiIcon type="fullScreen" color={iconColor} />
+        </div>
+      )}
+    </button>
   );
 };

--- a/packages/eui/src/components/image/image_caption.tsx
+++ b/packages/eui/src/components/image/image_caption.tsx
@@ -8,15 +8,14 @@
 
 import React, { forwardRef, Ref } from 'react';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 
 import { euiImageCaptionStyles } from './image_caption.styles';
 import type { EuiImageCaptionProps } from './image_types';
 
 export const EuiImageCaption = forwardRef<HTMLDivElement, EuiImageCaptionProps>(
   ({ caption, isOnOverlayMask = false }, ref: Ref<HTMLDivElement>) => {
-    const euiTheme = useEuiTheme();
-    const styles = euiImageCaptionStyles(euiTheme);
+    const styles = useEuiMemoizedStyles(euiImageCaptionStyles);
     const cssStyles = [
       styles.euiImageCaption,
       isOnOverlayMask && styles.isOnOverlayMask,

--- a/packages/eui/src/components/image/image_fullscreen_wrapper.tsx
+++ b/packages/eui/src/components/image/image_fullscreen_wrapper.tsx
@@ -9,19 +9,17 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles, keys } from '../../services';
+import { useInnerText } from '../inner_text';
 import { EuiFocusTrap } from '../focus_trap';
 import { EuiOverlayMask } from '../overlay_mask';
 import { EuiIcon } from '../icon';
-import { useEuiTheme, keys } from '../../services';
-import { useInnerText } from '../inner_text';
 
-import { euiImageFullscreenWrapperStyles } from './image_fullscreen_wrapper.styles';
 import type { EuiImageWrapperProps } from './image_types';
-
 import { EuiImageButton } from './image_button';
 import { euiImageButtonIconStyles } from './image_button.styles';
-
 import { EuiImageCaption } from './image_caption';
+import { euiImageFullscreenWrapperStyles } from './image_fullscreen_wrapper.styles';
 
 export const EuiImageFullScreenWrapper: FunctionComponent<
   EuiImageWrapperProps
@@ -36,24 +34,19 @@ export const EuiImageFullScreenWrapper: FunctionComponent<
   fullScreenIconColor,
   onFullScreen,
 }) => {
-  const euiTheme = useEuiTheme();
-
-  const styles = euiImageFullscreenWrapperStyles(euiTheme);
-
-  const cssStyles = [styles.euiImageFullscreenWrapper, wrapperProps?.css];
-
   const classes = classNames(
     'euiImageFullScreenWrapper',
     wrapperProps && wrapperProps.className
   );
 
-  const onKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === keys.ESCAPE) {
-      event.preventDefault();
-      event.stopPropagation();
-      closeFullScreen();
-    }
-  };
+  const styles = useEuiMemoizedStyles(euiImageFullscreenWrapperStyles);
+  const cssStyles = [styles.euiImageFullscreenWrapper, wrapperProps?.css];
+
+  const iconStyles = useEuiMemoizedStyles(euiImageButtonIconStyles);
+  const cssIconStyles = [
+    iconStyles.euiImageButton__icon,
+    iconStyles.closeFullScreen,
+  ];
 
   const closeFullScreen = () => {
     setIsFullScreen(false);
@@ -62,12 +55,6 @@ export const EuiImageFullScreenWrapper: FunctionComponent<
 
   const [optionalCaptionRef, optionalCaptionText] = useInnerText();
 
-  const iconStyles = euiImageButtonIconStyles(euiTheme);
-  const cssIconStyles = [
-    iconStyles.euiImageButton__icon,
-    iconStyles.closeFullScreen,
-  ];
-
   return (
     <EuiOverlayMask data-test-subj="fullScreenOverlayMask">
       <EuiFocusTrap
@@ -75,34 +62,38 @@ export const EuiImageFullScreenWrapper: FunctionComponent<
         preventScrollOnFocus
         onClickOutside={closeFullScreen}
       >
-        <>
-          <figure
-            aria-label={optionalCaptionText}
-            {...wrapperProps}
-            className={classes}
-            css={cssStyles}
+        <figure
+          aria-label={optionalCaptionText}
+          {...wrapperProps}
+          className={classes}
+          css={cssStyles}
+        >
+          <EuiImageButton
+            hasAlt={!!alt}
+            hasShadow={hasShadow}
+            onClick={closeFullScreen}
+            onKeyDown={(event: React.KeyboardEvent) => {
+              if (event.key === keys.ESCAPE) {
+                event.preventDefault();
+                event.stopPropagation();
+                closeFullScreen();
+              }
+            }}
+            data-test-subj="deactivateFullScreenButton"
+            isFullScreen={true}
+            isFullWidth={isFullWidth}
+            fullScreenIconColor={fullScreenIconColor}
           >
-            <EuiImageButton
-              hasAlt={!!alt}
-              hasShadow={hasShadow}
-              onClick={closeFullScreen}
-              onKeyDown={onKeyDown}
-              data-test-subj="deactivateFullScreenButton"
-              isFullScreen={true}
-              isFullWidth={isFullWidth}
-              fullScreenIconColor={fullScreenIconColor}
-            >
-              {children}
-            </EuiImageButton>
-            <EuiImageCaption
-              caption={caption}
-              ref={optionalCaptionRef}
-              isOnOverlayMask={true}
-            />
-          </figure>
-          {/* Must be outside the `figure` element in order to escape the translateY transition. see https://www.w3.org/TR/css-transforms-1/#transform-rendering */}
-          <EuiIcon type="fullScreenExit" color="ghost" css={cssIconStyles} />
-        </>
+            {children}
+          </EuiImageButton>
+          <EuiImageCaption
+            caption={caption}
+            ref={optionalCaptionRef}
+            isOnOverlayMask={true}
+          />
+        </figure>
+        {/* Must be outside the `figure` element in order to escape the translateY transition. see https://www.w3.org/TR/css-transforms-1/#transform-rendering */}
+        <EuiIcon type="fullScreenExit" color="ghost" css={cssIconStyles} />
       </EuiFocusTrap>
     </EuiOverlayMask>
   );

--- a/packages/eui/src/components/image/image_wrapper.tsx
+++ b/packages/eui/src/components/image/image_wrapper.tsx
@@ -9,11 +9,10 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-import { useEuiTheme } from '../../services';
+import { useEuiMemoizedStyles } from '../../services';
 import { useInnerText } from '../inner_text';
 
 import type { EuiImageWrapperProps } from './image_types';
-
 import { euiImageWrapperStyles } from './image_wrapper.styles';
 import { EuiImageButton } from './image_button';
 import { EuiImageCaption } from './image_caption';
@@ -32,19 +31,12 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
   isFullWidth,
   onFullScreen,
 }) => {
-  const openFullScreen = () => {
-    setIsFullScreen(true);
-    onFullScreen?.(true);
-  };
-
   const classes = classNames(
     'euiImageWrapper',
     wrapperProps && wrapperProps.className
   );
 
-  const euiTheme = useEuiTheme();
-
-  const styles = euiImageWrapperStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiImageWrapperStyles);
   const cssFigureStyles = [
     styles.euiImageWrapper,
     float && styles[float],
@@ -64,18 +56,19 @@ export const EuiImageWrapper: FunctionComponent<EuiImageWrapperProps> = ({
       css={cssFigureStyles}
     >
       {allowFullScreen ? (
-        <>
-          <EuiImageButton
-            hasAlt={!!alt}
-            hasShadow={hasShadow}
-            onClick={openFullScreen}
-            data-test-subj="activateFullScreenButton"
-            isFullWidth={isFullWidth}
-            fullScreenIconColor={fullScreenIconColor}
-          >
-            {children}
-          </EuiImageButton>
-        </>
+        <EuiImageButton
+          hasAlt={!!alt}
+          hasShadow={hasShadow}
+          onClick={() => {
+            setIsFullScreen(true);
+            onFullScreen?.(true);
+          }}
+          data-test-subj="activateFullScreenButton"
+          isFullWidth={isFullWidth}
+          fullScreenIconColor={fullScreenIconColor}
+        >
+          {children}
+        </EuiImageButton>
       ) : (
         children
       )}

--- a/packages/eui/src/components/list_group/list_group_item.styles.ts
+++ b/packages/eui/src/components/list_group/list_group_item.styles.ts
@@ -170,17 +170,15 @@ export const euiListGroupItemInnerStyles = (euiThemeContext: UseEuiTheme) => {
   };
 };
 
-export const euiListGroupItemLabelStyles = () => {
-  return {
-    // Base
-    euiListGroupItem__label: css``,
-    truncate: css`
-      ${euiTextTruncate()}
-    `,
-    wrapText: css`
-      ${euiTextBreakWord()}
-    `,
-  };
+export const euiListGroupItemLabelStyles = {
+  // Base
+  euiListGroupItem__label: css``,
+  truncate: css`
+    ${euiTextTruncate()}
+  `,
+  wrapText: css`
+    ${euiTextBreakWord()}
+  `,
 };
 
 export const euiListGroupItemIconStyles = ({ euiTheme }: UseEuiTheme) => {
@@ -194,12 +192,10 @@ export const euiListGroupItemIconStyles = ({ euiTheme }: UseEuiTheme) => {
   };
 };
 
-export const euiListGroupItemTooltipStyles = () => {
-  return {
-    // Base
-    euiListGroupItem__tooltip: css`
-      display: inline-flex; /* Allows the wrapped button/text to grow */
-      ${logicalCSS('width', '100%')}
-    `,
-  };
+export const euiListGroupItemTooltipStyles = {
+  // Base
+  euiListGroupItem__tooltip: css`
+    display: inline-flex; /* Allows the wrapped button/text to grow */
+    ${logicalCSS('width', '100%')}
+  `,
 };

--- a/packages/eui/src/components/list_group/list_group_item.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.tsx
@@ -7,7 +7,6 @@
  */
 
 import React, {
-  Fragment,
   HTMLAttributes,
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
@@ -18,23 +17,22 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
+import {
+  getSecureRelForTarget,
+  useEuiMemoizedStyles,
+  cloneElementWithCss,
+} from '../../services';
+import { validateHref } from '../../services/security/href_validator';
+import { ExclusiveUnion, CommonProps } from '../common';
+import { useInnerText } from '../inner_text';
 import { EuiIcon, IconType, EuiIconProps } from '../icon';
 import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
-import { useInnerText } from '../inner_text';
-import { ExclusiveUnion, CommonProps } from '../common';
+import { EuiExternalLinkIcon } from '../link/external_link_icon';
+
 import {
   EuiListGroupItemExtraAction,
   EuiListGroupItemExtraActionProps,
 } from './list_group_item_extra_action';
-
-import {
-  getSecureRelForTarget,
-  useEuiTheme,
-  cloneElementWithCss,
-} from '../../services';
-import { validateHref } from '../../services/security/href_validator';
-import { EuiExternalLinkIcon } from '../link/external_link_icon';
-
 import {
   euiListGroupItemStyles,
   euiListGroupItemIconStyles,
@@ -185,9 +183,7 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   const isHrefValid = !href || validateHref(href);
   const isDisabled = _isDisabled || !isHrefValid;
 
-  const euiTheme = useEuiTheme();
-
-  const iconStyles = euiListGroupItemIconStyles(euiTheme);
+  const iconStyles = useEuiMemoizedStyles(euiListGroupItemIconStyles);
   const cssIconStyles = [iconStyles.euiListGroupItem__icon, iconProps?.css];
 
   let iconNode;
@@ -243,7 +239,7 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
     );
   }
 
-  const labelStyles = euiListGroupItemLabelStyles();
+  const labelStyles = euiListGroupItemLabelStyles;
   const cssLabelStyles = [
     labelStyles.euiListGroupItem__label,
     wrapText ? labelStyles.wrapText : labelStyles.truncate,
@@ -271,7 +267,7 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   // Handle the variety of interaction behavior
   let itemContent;
 
-  const innerStyles = euiListGroupItemInnerStyles(euiTheme);
+  const innerStyles = useEuiMemoizedStyles(euiListGroupItemInnerStyles);
   const cssInnerStyles = [
     innerStyles.euiListGroupItem__inner,
     innerStyles[size],
@@ -321,7 +317,7 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
     );
   }
 
-  const styles = euiListGroupItemStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(euiListGroupItemStyles);
   const cssStyles = [
     styles.euiListGroupItem,
     !isDisabled && isActive && styles.colors.isActive[color],
@@ -333,7 +329,7 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
   const classes = classNames('euiListGroupItem', className);
 
   if (showToolTip) {
-    const tooltipStyles = euiListGroupItemTooltipStyles();
+    const tooltipStyles = euiListGroupItemTooltipStyles;
     const cssTooltipStyles = [
       tooltipStyles.euiListGroupItem__tooltip,
       toolTipProps?.anchorProps?.css,
@@ -375,5 +371,5 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
     );
   }
 
-  return <Fragment>{itemContent}</Fragment>;
+  return <>{itemContent}</>;
 };

--- a/packages/eui/src/components/list_group/list_group_item_extra_action.test.tsx
+++ b/packages/eui/src/components/list_group/list_group_item_extra_action.test.tsx
@@ -19,12 +19,10 @@ describe('EuiListGroupItem', () => {
     iconType: 'star',
   };
 
-  shouldRenderCustomStyles(<EuiListGroupItemExtraAction iconType="star" />);
+  shouldRenderCustomStyles(<EuiListGroupItemExtraAction {...props} />);
 
   test('is rendered', () => {
-    const { container } = render(
-      <EuiListGroupItemExtraAction {...requiredProps} iconType="star" />
-    );
+    const { container } = render(<EuiListGroupItemExtraAction {...props} />);
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/packages/eui/src/components/list_group/list_group_item_extra_action.tsx
+++ b/packages/eui/src/components/list_group/list_group_item_extra_action.tsx
@@ -9,9 +9,9 @@
 import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 
+import { useEuiMemoizedStyles } from '../../services';
 import { EuiButtonIcon, EuiButtonIconPropsForButton } from '../button';
 
-import { useEuiTheme } from '../../services';
 import { euiListGroupItemExtraActionStyles } from './list_group_item_extra_action.styles';
 
 export type EuiListGroupItemExtraActionProps = {
@@ -36,9 +36,9 @@ export const EuiListGroupItemExtraAction: FunctionComponent<
     className
   );
 
-  const euiTheme = useEuiTheme();
-
-  const extraActionStyles = euiListGroupItemExtraActionStyles(euiTheme);
+  const extraActionStyles = useEuiMemoizedStyles(
+    euiListGroupItemExtraActionStyles
+  );
   const cssExtraActionStyles = [
     extraActionStyles.euiListGroupItemExtraAction,
     alwaysShow && extraActionStyles.alwaysShow,

--- a/packages/eui/src/components/list_group/pinnable_list_group/pinnable_list_group.tsx
+++ b/packages/eui/src/components/list_group/pinnable_list_group/pinnable_list_group.tsx
@@ -6,15 +6,15 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useMemo } from 'react';
 import classNames from 'classnames';
-import { CommonProps } from '../../common';
 
-import { EuiI18n } from '../../i18n';
+import { useEuiMemoizedStyles } from '../../../services';
+import { CommonProps } from '../../common';
+import { useEuiI18n } from '../../i18n';
+
 import { EuiListGroup, EuiListGroupProps } from '../list_group';
 import { EuiListGroupItemProps } from '../list_group_item';
-import { useEuiTheme } from '../../../services';
-
 import { euiPinnableListGroupItemExtraActionStyles } from './pinnable_list_group.styles';
 
 export type EuiPinnableListGroupItemProps = EuiListGroupItemProps & {
@@ -60,32 +60,22 @@ export const EuiPinnableListGroup: FunctionComponent<
   EuiPinnableListGroupProps
 > = ({ className, listItems, pinTitle, unpinTitle, onPinClick, ...rest }) => {
   const classes = classNames('euiPinnableListGroup', className);
-  const euiTheme = useEuiTheme();
-  const itemExtraActionStyles =
-    euiPinnableListGroupItemExtraActionStyles(euiTheme);
+  const styles = useEuiMemoizedStyles(
+    euiPinnableListGroupItemExtraActionStyles
+  );
 
-  const pinExtraAction: EuiListGroupItemProps['extraAction'] = {
-    iconType: 'pinFilled',
-    iconSize: 's',
-    css: itemExtraActionStyles.euiPinnableListGroup__itemExtraAction,
-  };
-
-  const pinnedExtraAction: EuiListGroupItemProps['extraAction'] = {
-    iconType: 'pinFilled',
-    iconSize: 's',
-    css: [
-      itemExtraActionStyles.euiPinnableListGroup__itemExtraAction,
-      itemExtraActionStyles.pinned,
-    ],
-    alwaysShow: true,
-  };
+  const pinExtraActionLabel = useEuiI18n(
+    'euiPinnableListGroup.pinExtraActionLabel',
+    'Pin item'
+  );
+  const pinnedExtraActionLabel = useEuiI18n(
+    'euiPinnableListGroup.pinnedExtraActionLabel',
+    'Unpin item'
+  );
 
   // Alter listItems object with extra props
-  const getNewListItems = (
-    pinExtraActionLabel: string,
-    pinnedExtraActionLabel: string
-  ) =>
-    listItems.map((item) => {
+  const pinnableListItems = useMemo(() => {
+    return listItems.map((item) => {
       const { pinned, pinnable = true, ...itemProps } = item;
       // Make some declarations of props for the nav implementation
       itemProps.className = classNames(
@@ -93,22 +83,33 @@ export const EuiPinnableListGroup: FunctionComponent<
         item.className
       );
 
-      // Add the pinning action unless the item has it's own extra action
+      // Add the pinning action unless the item has its own extra action
       if (pinnable && !itemProps.extraAction) {
         // Different displays for pinned vs unpinned
+        const sharedProps: EuiListGroupItemProps['extraAction'] = {
+          iconType: 'pinFilled',
+          iconSize: 's',
+          css: [
+            styles.euiPinnableListGroup__itemExtraAction,
+            pinned && styles.pinned,
+          ],
+        };
         if (pinned) {
+          const title = unpinTitle ? unpinTitle(item) : pinnedExtraActionLabel;
+
           itemProps.extraAction = {
-            ...pinnedExtraAction,
-            title: unpinTitle ? unpinTitle(item) : pinnedExtraActionLabel,
-            'aria-label': unpinTitle
-              ? unpinTitle(item)
-              : pinnedExtraActionLabel,
+            ...sharedProps,
+            alwaysShow: true,
+            'aria-label': title,
+            title,
           };
         } else {
+          const title = pinTitle ? pinTitle(item) : pinExtraActionLabel;
+
           itemProps.extraAction = {
-            ...pinExtraAction,
-            title: pinTitle ? pinTitle(item) : pinExtraActionLabel,
-            'aria-label': pinTitle ? pinTitle(item) : pinExtraActionLabel,
+            ...sharedProps,
+            'aria-label': title,
+            title,
           };
         }
         // Return the item on click
@@ -117,28 +118,17 @@ export const EuiPinnableListGroup: FunctionComponent<
 
       return itemProps;
     });
+  }, [
+    listItems,
+    pinTitle,
+    pinExtraActionLabel,
+    unpinTitle,
+    pinnedExtraActionLabel,
+    onPinClick,
+    styles,
+  ]);
 
   return (
-    <EuiI18n
-      tokens={[
-        'euiPinnableListGroup.pinExtraActionLabel',
-        'euiPinnableListGroup.pinnedExtraActionLabel',
-      ]}
-      defaults={['Pin item', 'Unpin item']}
-    >
-      {([pinExtraActionLabel, pinnedExtraActionLabel]: string[]) => {
-        const newListItems = getNewListItems(
-          pinExtraActionLabel,
-          pinnedExtraActionLabel
-        );
-        return (
-          <EuiListGroup
-            className={classes}
-            listItems={newListItems}
-            {...rest}
-          />
-        );
-      }}
-    </EuiI18n>
+    <EuiListGroup className={classes} listItems={pinnableListItems} {...rest} />
   );
 };


### PR DESCRIPTION
## Summary

This PR contains cherry-picked commits from Cee's PR https://github.com/elastic/eui/pull/8172 in order to make it more straightforward to review and omit some of the changes incompatible with post-Borealis EUI source.

## QA

- [x] Compare updated components with `main` and confirm there are no visual regressions

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
