### PR TITLE
Add `eui-deploy-docs` pipeline to build and deploy new documentation website 

### DIFF
--- a/.buildkite/pipelines/deploy_docs.yml
+++ b/.buildkite/pipelines/deploy_docs.yml
@@ -1,0 +1,11 @@
+agents:
+  provider: gcp
+  # 4 AMD Rome / Milan vCPUs, 16GB RAM
+  machineType: 'n2d-standard-4'
+  # No spot instances to protect against agent losses during file upload
+  preemptible: false
+
+steps:
+  - label: ':docusaurus: Build and deploy documentation website'
+    timeout_in_minutes: 90
+    command: .buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh

--- a/.buildkite/pipelines/deploy_docs.yml
+++ b/.buildkite/pipelines/deploy_docs.yml
@@ -7,5 +7,6 @@ agents:
 
 steps:
   - label: ':docusaurus: Build and deploy documentation website'
+    image: "family/eui-ubuntu-2204"
     timeout_in_minutes: 90
     command: .buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh

--- a/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_deploy_docs.yml
@@ -6,10 +6,3 @@ steps:
     agents:
       provider: "gcp"
     if: build.branch != "main" # We don't want to deploy docs on main, only on manual release
-  - command: .buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
-    label: ":docusaurus: Build and deploy new documentation website"
-    agents:
-      provider: gcp
-      machineType: "n2-standard-2"
-      image: "family/eui-ubuntu-2204"
-    if: build.branch != "main"

--- a/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
@@ -20,8 +20,13 @@ if [[ -n "${BUILDKITE_PULL_REQUEST}" ]] && [[ "${BUILDKITE_PULL_REQUEST}" != "fa
   export STORYBOOK_BASE_URL="https://eui.elastic.co/${PR_SLUG}/storybook"
   bucket_directory="${PR_SLUG}/new-docs/"
   echo "Detected a PR preview environment configuration. The built files will be copied to ${bucket_directory}"
+elif [[ -n "${BUILDKITE_BRANCH}" ]] && [[ "${BUILDKITE_BRANCH}" == "main" ]]; then
+  # TODO: Detect if 'main' branch updated due to a new version being released based on BUILDKITE_TAG
+  export STORYBOOK_BASE_URL="https://eui.elastic.co/storybook"
+  bucket_directory="next/"
+  echo "Detected a 'main' branch environment configuration. The built files will be copied to ${bucket_directory}"
 else
-  echo "The script has been triggered with no pull request or tag information. This is a no-op."
+  echo "The script has been triggered with no pull request or branch information. This is a no-op."
   exit 1
 fi
 
@@ -67,3 +72,5 @@ echo "Beginning to copy built files to /${bucket_directory}"
 gcloud storage cp "${GCLOUD_CP_ARGS[@]}" packages/website/build/* "gs://${GCLOUD_BUCKET_FULL}/${bucket_directory}"
 
 echo "New documentation website deployed: https://eui.elastic.co/${bucket_directory}" | buildkite-agent annotate --style "success" --context "deployed"
+
+echo "* [Documentation website](https://eui.elastic.co/${bucket_directory})" | buildkite-agent meta-data set pr_comment:docs_deployment_link:head

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -125,6 +125,8 @@ spec:
 # Pull request - deploy docs website PR preview
 ##
 
+# TODO: Remove when the old documentation site is replaced with EUI+
+
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
@@ -339,6 +341,56 @@ spec:
       teams:
         eui-team:
           access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+---
+##
+# buildkite-pipeline-eui-deploy-docs
+# Pull request - run tests and deploy docs website PR preview
+##
+
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-eui-deploy-docs
+  description: EUI pipeline to deploy the documentation website
+  links: [
+    {
+      title: "EUI - deploy-docs",
+      url: "https://buildkite.com/elastic/eui-deploy-docs",
+    }
+  ]
+
+spec:
+  type: buildkite-pipeline
+  owner: group:eui-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: eui-deploy-docs
+    spec:
+      repository: elastic/eui
+      pipeline_file: ".buildkite/pipelines/deploy_docs.yml"
+      default_branch: main
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+      cancel_intermediate_builds: true
+      # Prevent cancelling builds from 'main' to avoid cancellations during file upload
+      cancel_intermediate_builds_branch_filter: "!main"
+      provider_settings:
+        build_branches: true
+        build_pull_requests: true
+        build_tags: false
+        filter_enabled: true
+        # Allow PRs and 'main' branch updates
+        filter_condition: (build.pull_request.id != null || build.branch == "main")
+      teams:
+        eui-team:
+         access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui-private/issues/118.

This PR adds a new `eui-deploy-docs` pipeline configuration and descriptor to enable building the new documentation site from `main` and publish it under https://eui.elastic.co/next. It adds to the existing `pipeline_deploy_new_docs.sh` script we've used for a while now to build and deploy the new documentation site.

## QA

There's no way to test the pipeline without merging it to `main`. Please check the correctness of the bash script and `catalog-info.yml` configuration changes.