### PR TITLE
Add pull request job trigger

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -10,7 +10,19 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "set_commit_status": true,
-      "skip_ci_on_only_changed": ["^.github/", "^generator-eui/", "^wiki/"]
+      "skip_ci_on_only_changed": ["^.github/", "^wiki/"]
+    },
+    {
+      "enabled": true,
+      "pipeline_slug": "eui-deploy-docs",
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "set_commit_status": true,
+      "skip_ci_on_only_changed": ["^.github/", "^wiki/"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds a buildkite job trigger when PR is open or changed. It runs the `eui-deploy-docs` job added in an earlier PR today and uses the same configuration as the other `eui-pull-request-test-and-deploy` job.

## QA

There's no way to check this live before merging. Check the correctness of JSON formatting. You may also compare it to the other job trigger defined above in the same file