### PR TITLE
docs: add new site banner to old site

### DIFF
--- a/packages/eui/src-docs/src/components/guide_page/guide_page_header.tsx
+++ b/packages/eui/src-docs/src/components/guide_page/guide_page_header.tsx
@@ -125,8 +125,17 @@ export const GuidePageHeader = () => {
         overflow-inline: auto;
       `}
     >
-      <EuiPanel borderRadius="none" color="warning">
-        <EuiText component="p" size="s">
+      <EuiPanel
+        borderRadius="none"
+        color="warning"
+        paddingSize="s"
+        css={css`
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+        `}
+      >
+        <EuiText component="p" size="m">
           We have a new website!{' '}
           <EuiLink href="https://eui.elastic.co/next" external>
             Please help us test it and tell us what you think


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/8549

This adds a "new site" banner to the old site.

There was probably an idiomatic way to add a banner, but I thought there was no point in trying to figure it out 😅 

## Screenshot (updated https://github.com/elastic/eui/pull/8582/commits/b41e5a6c37ddd65427b4d23dadc1cc37878c29d0)

![localhost_8030_ (3)](https://github.com/user-attachments/assets/f4e266e8-bccb-4040-a2f4-a4dd892ec905)


## QA

- [x] Check wording, color, etc. is appropriate
- [x] Check link works