### PR TITLE
[EuiFlyout] Add `aria-modal` to overlay flyouts

### DIFF
--- a/packages/eui/changelogs/upcoming/8591.md
+++ b/packages/eui/changelogs/upcoming/8591.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Added `aria-modal` to `EuiFlyout` with `type="overlay"`
+

--- a/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`EuiCollapsibleNav close button can be hidden 1`] = `
     >
       <nav
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
@@ -67,6 +68,7 @@ exports[`EuiCollapsibleNav is rendered 1`] = `
       <nav
         aria-describedby="generated-id"
         aria-label="aria-label"
+        aria-modal="true"
         class="euiFlyout euiCollapsibleNav testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay-euiTestCss"
         data-autofocus="true"
         data-test-subj="test subject string"
@@ -118,6 +120,7 @@ exports[`EuiCollapsibleNav props accepts EuiFlyout props 1`] = `
   >
     <nav
       aria-describedby="generated-id"
+      aria-modal="true"
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
       data-autofocus="true"
       id="id"
@@ -173,6 +176,7 @@ exports[`EuiCollapsibleNav props button 1`] = `
     >
       <nav
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
@@ -224,6 +228,7 @@ exports[`EuiCollapsibleNav props dockedBreakpoint 1`] = `
     >
       <nav
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
@@ -299,6 +304,7 @@ exports[`EuiCollapsibleNav props onClose 1`] = `
     >
       <nav
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
@@ -379,6 +385,7 @@ exports[`EuiCollapsibleNav props size 1`] = `
     >
       <nav
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"

--- a/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`EuiFlyout is rendered 1`] = `
       <div
         aria-describedby="generated-id"
         aria-label="aria-label"
+        aria-modal="true"
         class="euiFlyout testClass1 testClass2 emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right-euiTestCss"
         data-autofocus="true"
         data-test-subj="test subject string"
@@ -63,6 +64,7 @@ exports[`EuiFlyout props accepts div props 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         id="imaflyout"
@@ -112,6 +114,7 @@ exports[`EuiFlyout props closeButtonPosition can be outside 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -160,6 +163,7 @@ exports[`EuiFlyout props closeButtonProps 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -208,6 +212,7 @@ exports[`EuiFlyout props hideCloseButton 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -243,6 +248,7 @@ exports[`EuiFlyout props is rendered as nav 1`] = `
     >
       <nav
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -291,6 +297,7 @@ exports[`EuiFlyout props maxWidth can be set to a custom number 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -340,6 +347,7 @@ exports[`EuiFlyout props maxWidth can be set to a custom value and measurement 1
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -389,6 +397,7 @@ exports[`EuiFlyout props maxWidth can be set to a default 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -437,6 +446,7 @@ exports[`EuiFlyout props outsideClickCloses 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -485,6 +495,7 @@ exports[`EuiFlyout props ownFocus can alter mask props with maskProps without th
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -532,6 +543,7 @@ exports[`EuiFlyout props ownFocus can be false 1`] = `
   >
     <div
       aria-describedby="generated-id"
+      aria-modal="true"
       class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
       data-autofocus="true"
       role="dialog"
@@ -579,6 +591,7 @@ exports[`EuiFlyout props paddingSize l is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -627,6 +640,7 @@ exports[`EuiFlyout props paddingSize m is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-m-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -675,6 +689,7 @@ exports[`EuiFlyout props paddingSize none is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-none-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -723,6 +738,7 @@ exports[`EuiFlyout props paddingSize s is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-s-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -792,6 +808,7 @@ exports[`EuiFlyout props sides left is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-left-left"
         data-autofocus="true"
         role="dialog"
@@ -840,6 +857,7 @@ exports[`EuiFlyout props sides right is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -888,6 +906,7 @@ exports[`EuiFlyout props size accepts custom number 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -937,6 +956,7 @@ exports[`EuiFlyout props size l is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-l-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -985,6 +1005,7 @@ exports[`EuiFlyout props size m is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -1033,6 +1054,7 @@ exports[`EuiFlyout props size s is rendered 1`] = `
     >
       <div
         aria-describedby="generated-id"
+        aria-modal="true"
         class="euiFlyout emotion-euiFlyout-l-s-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
@@ -1090,6 +1112,7 @@ exports[`EuiFlyout renders extra screen reader instructions when fixed EuiHeader
         <div
           aria-describedby="generated-id"
           aria-label="aria-label"
+          aria-modal="true"
           class="euiFlyout testClass1 testClass2 emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right-euiTestCss"
           data-autofocus="true"
           data-test-subj="test subject string"

--- a/packages/eui/src/components/flyout/flyout.tsx
+++ b/packages/eui/src/components/flyout/flyout.tsx
@@ -409,6 +409,7 @@ export const EuiFlyout = forwardRef(
             ref={setRef}
             {...(rest as ComponentPropsWithRef<T>)}
             role={!isPushed ? 'dialog' : rest.role}
+            aria-modal={!isPushed || undefined}
             tabIndex={!isPushed ? 0 : rest.tabIndex}
             aria-describedby={!isPushed ? ariaDescribedBy : _ariaDescribedBy}
             data-autofocus={!isPushed || undefined}


### PR DESCRIPTION
## Summary

This PR ensures that for overlay flyouts (that essentially behave as modals with `role="dialog"`) also have the appropriate `aria-modal` applied.

## QA

- [x] verify that `EuiFlyout` with `type="overlay"` (default) have `aria-modal="true"` applied in the DOM

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
