### PR TITLE
fix(website): use euiTheme from useEuiTheme hook

### DIFF
--- a/packages/website/docs/components/display/text.mdx
+++ b/packages/website/docs/components/display/text.mdx
@@ -227,6 +227,7 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiButtonGroup,
+  useEuiTheme,
 } from '@elastic/eui';
 
 const text = [
@@ -303,17 +304,19 @@ const text = [
   <h6 key={13}>This is Heading Six</h6>,
 ];
 
-const textLinesCss = ({ euiTheme }) => css`
-  background-image: linear-gradient(${euiTheme.focus.backgroundColor} 1px, transparent 1px);
-  background-size: 100% 4px;
-  background-position-y: -1px;
-
-  & > * {
-    background-color: ${euiTheme.colors.highlight};
-  }
-`;
-
 export default () => {
+  const { euiTheme } = useEuiTheme();
+
+  const textLinesCss = () => css`
+    background-image: linear-gradient(${euiTheme.focus.backgroundColor} 1px, transparent 1px);
+    background-size: 100% 4px;
+    background-position-y: -1px;
+
+    & > * {
+      background-color: ${euiTheme.colors.highlight};
+    }
+  `;
+
   const textSizeArray = ['xs', 's', 'm'];
   const textSizeNamesArray = ['Extra small', 'Small', 'Medium'];
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui/issues/8566

This PR updates the "Text can come in various sizes" example on the Text page on the new documentation site. I was failing because was trying to access `focus` in `undefined`. The reason is we were relying on `euiTheme` supplied to the `css` callback function but we cannot do that in Demo context.

![Screenshot 2025-04-14 at 19 30 15](https://github.com/user-attachments/assets/8decbe87-9fcf-464c-9240-8ebe687136e6)

## QA

- [ ] Verify that the `docs/display/text/#text-can-come-in-various-sizes` example works and displays correctly
