### PR TITLE
chore(eui): update anchor links to have exact names

### DIFF
--- a/packages/eui/src/components/header/header.tsx
+++ b/packages/eui/src/components/header/header.tsx
@@ -33,7 +33,7 @@ type EuiHeaderSectionItemType = EuiHeaderSectionItemProps['children'];
 
 export interface EuiHeaderSections {
   /**
-   * An arry of items that will be wrapped in a #EuiHeaderSectionItem
+   * An array of items that will be wrapped in a #EuiHeaderSectionItem
    */
   items?: EuiHeaderSectionItemType[];
   /**
@@ -58,7 +58,7 @@ export type EuiHeaderProps = CommonProps &
     /**
      * An array of objects to wrap in a #EuiHeaderSection.
      * Each section is spaced using `space-between`.
-     * See #EuiHeaderSectionsProp for object details.
+     * See #EuiHeaderSections for object details.
      * This prop disregards the prop `children` if both are passed.
      */
     sections?: EuiHeaderSections[];

--- a/packages/eui/src/components/key_pad_menu/key_pad_menu.tsx
+++ b/packages/eui/src/components/key_pad_menu/key_pad_menu.tsx
@@ -43,7 +43,7 @@ export type EuiKeyPadMenuProps = CommonProps &
   HTMLAttributes<HTMLElement> & {
     /**
      * Renders the the group as a `fieldset`.
-     * Set to `true` to customize the labelling, or pass an #EuiKeyPadMenuCheckableProps object to add a `legend` or `ariaLegend`
+     * Set to `true` to customize the labelling, or pass an #_EuiKeyPadMenuCheckableProps object to add a `legend` or `ariaLegend`
      */
     checkable?: _EuiKeyPadMenuCheckableProps | true;
   };

--- a/packages/eui/src/components/list_group/pinnable_list_group/pinnable_list_group.tsx
+++ b/packages/eui/src/components/list_group/pinnable_list_group/pinnable_list_group.tsx
@@ -34,7 +34,7 @@ export interface EuiPinnableListGroupProps
     EuiListGroupProps {
   /**
    * Extends `EuiListGroupItemProps`, at the very least, expecting a `label`.
-   * See #EuiPinnableListGroupItem
+   * See #EuiPinnableListGroupItemProps
    */
   listItems: EuiPinnableListGroupItemProps[];
   /**

--- a/packages/eui/src/components/selectable/selectable.tsx
+++ b/packages/eui/src/components/selectable/selectable.tsx
@@ -109,7 +109,7 @@ export type EuiSelectableProps<T = {}> = CommonProps &
       search: ReactElement<typeof EuiSelectableSearch> | undefined
     ) => ReactNode;
     /**
-     * Array of EuiSelectableOption objects. See #EuiSelectableOptionProps
+     * Array of EuiSelectableOption objects. See #EuiSelectableOption
      */
     options: Array<EuiSelectableOption<T>>;
     /**
@@ -149,7 +149,7 @@ export type EuiSelectableProps<T = {}> = CommonProps &
      */
     height?: number | 'full';
     /**
-     * See #EuiSelectableOptionsList
+     * See #EuiSelectableOptionsListProps
      */
     listProps?: EuiSelectableOptionsListPropsWithDefaults;
     /**

--- a/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -43,7 +43,7 @@ export type EuiSelectableTemplateSitewideProps = Partial<
   Omit<EuiSelectableProps<{ [key: string]: any }>, 'options'>
 > & {
   /**
-   * Extends the typical EuiSelectable #Options with the addition of pre-composed elements
+   * Extends the typical #EuiSelectableTemplateSitewideOption with the addition of pre-composed elements
    * such as `icon`, `avatar`and `meta`
    */
   options: EuiSelectableTemplateSitewideOption[];

--- a/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
+++ b/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide_option.tsx
@@ -58,7 +58,7 @@ export type EuiSelectableTemplateSitewideOption<T = { [key: string]: any }> = {
    */
   avatar?: EuiAvatarProps;
   /**
-   * An array of inline #MetaData displayed beneath the label and separated by bullets.
+   * An array of inline #EuiSelectableTemplateSitewideMetaData displayed beneath the label and separated by bullets.
    */
   meta?: EuiSelectableTemplateSitewideMetaData[];
 } & EuiSelectableOption<T>;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui/issues/8555

This PR updates anchor links to have exact names (like the interface / type, not the prop table header).

> [!IMPORTANT]
> This will break prop table description redirections at times.

## QA

- [ ] Verify that all anchor links have the name like the interface / type 