### PR TITLE
Make `@elastic/eui-theme-common` a full dependency on `@elastic/eui-theme-borealis`

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8606.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8606.md
@@ -1,0 +1,3 @@
+**Dependency updates**
+
+- Updated `eui-theme-common` from `peer dependencies` to a `dependencies`

--- a/packages/eui-theme-borealis/changelogs/upcoming/8606.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8606.md
@@ -1,3 +1,3 @@
 **Dependency updates**
 
-- Updated `eui-theme-common` from `peer dependencies` to a `dependencies`
+- Updated `@elastic/eui-theme-common` from `peer dependencies` to a `dependencies`

--- a/packages/eui-theme-borealis/package.json
+++ b/packages/eui-theme-borealis/package.json
@@ -24,6 +24,7 @@
     "directory": "packages/eui-theme-borealis"
   },
   "dependency": {
+    "@elastic/eui-theme-common": "workspace:*",
     "chroma-js": "^2.4.2"
   },
   "devDependencies": {
@@ -52,9 +53,6 @@
     "stylelint-config-standard": "^33.0.0",
     "stylelint-config-standard-scss": "^9.0.0",
     "typescript": "^5.6.2"
-  },
-  "peerDependencies": {
-    "@elastic/eui-theme-common": "0.0.9"
   },
   "main": "lib/cjs/index.js",
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7193,8 +7193,6 @@ __metadata:
     stylelint-config-standard: "npm:^33.0.0"
     stylelint-config-standard-scss: "npm:^9.0.0"
     typescript: "npm:^5.6.2"
-  peerDependencies:
-    "@elastic/eui-theme-common": 0.0.9
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8599

This PR updates the `eui-theme-common` dependency in the `eui-theme-borealis` package from `peer dependency` to `dependencies` as `borealis` fully depends on the `common` package.

This also solves the current issue that the version for the `peer dependency` is not automatically updated when creating releases.

## QA

- [x] ci passes
- [x] verify locally that the packages build correctly