### PR TITLE
chore(eui): change the `no-restricted-eui-imports` warning message

### DIFF
--- a/packages/eslint-plugin/changelogs/upcoming/8613.md
+++ b/packages/eslint-plugin/changelogs/upcoming/8613.md
@@ -1,0 +1,1 @@
+- Updated the `no-restricted-eui-imports` warning to clarify that JSON tokens remain supported for server-side or non-React use cases

--- a/packages/eslint-plugin/src/rules/no_restricted_eui_imports.test.ts
+++ b/packages/eslint-plugin/src/rules/no_restricted_eui_imports.test.ts
@@ -43,7 +43,7 @@ ruleTester.run('no-restricted-eui-imports', NoRestrictedEuiImports, {
         {
           // @ts-expect-error @typescript-eslint types expect `messageId` here but `message` is also allowed in eslint API
           message:
-            'For client-side, please use `useEuiTheme` instead. Direct JSON token imports will be removed as per the EUI Deprecation schedule: https://github.com/elastic/eui/issues/1469.',
+            'For client-side, please use `useEuiTheme` instead.',
         },
       ],
     },
@@ -53,7 +53,7 @@ ruleTester.run('no-restricted-eui-imports', NoRestrictedEuiImports, {
         {
           // @ts-expect-error @typescript-eslint types expect `messageId` here but `message` is also allowed in eslint API
           message:
-            'For client-side, please use `useEuiTheme` instead. Direct JSON token imports will be removed as per the EUI Deprecation schedule: https://github.com/elastic/eui/issues/1469.',
+            'For client-side, please use `useEuiTheme` instead.',
         },
       ],
     },

--- a/packages/eslint-plugin/src/rules/no_restricted_eui_imports.ts
+++ b/packages/eslint-plugin/src/rules/no_restricted_eui_imports.ts
@@ -29,7 +29,7 @@ const DEFAULT_RESTRICTED_IMPORT_OPTIONS: Option[] = [
   {
     patterns: ['@elastic/eui/dist/eui_theme_*\\.json'],
     message:
-      'For client-side, please use `useEuiTheme` instead. Direct JSON token imports will be removed as per the EUI Deprecation schedule: https://github.com/elastic/eui/issues/1469.',
+      'For client-side, please use `useEuiTheme` instead.',
   },
 ];
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui/issues/8612

This PR removes the mention of removing JSON tokens as per the deprecation schedule from the `no-restricted-eui-imports` warning message. We still need to support them for server-side / non-React.

## QA

- [ ] Unit tests for `packages/eslint-plugin` pass
- [ ] There are no mentions of removing JSON tokens
