### PR TITLE
Fix tagged release copy method in the `eui-deploy-docs` pipeline

### DIFF
--- a/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
@@ -147,8 +147,7 @@ echo "Successfully copied files to /${bucket_directory}"
 # Copy deployed tagged release to /
 if [[ $copy_to_root_directory == true ]]; then
   echo "Beginning to copy built files to /"
-  # Use "copy in the cloud" to speed up the process
-  gcloud storage cp "${GCLOUD_CP_ARGS[@]}" "gs://${GCLOUD_BUCKET_FULL}/${bucket_directory}" "gs://${GCLOUD_BUCKET_FULL}/"
+  gcloud storage cp "${GCLOUD_CP_ARGS[@]}" packages/website/build/* "gs://${GCLOUD_BUCKET_FULL}/"
   echo "Successfully copied files to /"
 fi
 


### PR DESCRIPTION
## Summary

This fixes the `gcloud storage cp` command to perform a regular upload copy instead of "copy in the cloud" copy that fails due to the recursive flag being passed. Going with a regular copy is safer for now.
