### PR TITLE
Fixed broken links on Components Overview page

### DIFF
--- a/packages/website/docs/components/index.mdx
+++ b/packages/website/docs/components/index.mdx
@@ -9,11 +9,11 @@ EUI offers a wide variety of components. This section is organized topically wit
 The adjacent [patterns](../patterns/index.mdx) section provides additional guidance for handling use cases that cross multiple components.
 
 ## Components by topic
-- [Layout](../layout/flex)
-- [Containers](../containers/accordion)
-- [Navigation](../navigation/breadcrumbs)
-- [Display](../display/badge)
-- [Forms](../forms/form-controls/guidelines)
-- [Tabular content](../tabular-content/data-grid)
-- [Templates](../templates/page-template)
-- [Editors and syntax](../editors-syntax/markdown/format)
+- [Layout](./layout/flex/index.mdx)
+- [Containers](./containers/accordion.mdx)
+- [Navigation](./navigation/breadcrumbs.mdx)
+- [Display](./display/badge/index.mdx)
+- [Forms](./forms/controls/guidelines.mdx)
+- [Tabular content](./tabular-content/tables/basic.mdx)
+- [Templates](./templates/page-template/index.mdx)
+- [Editors and syntax](./editors-and-syntax/markdown/format.mdx)


### PR DESCRIPTION
## Summary

Fixed broken links on https://eui.elastic.co/docs/components/

For the Tabular Data link, I linked to Basic Table instead. I feel like that a better page to land on, even though it's not first.

## QA

Clink on all of the links on the Overview page in the preview site and make sure they work.