### PR TITLE
chore: verify changelog in all packages

### DIFF
--- a/.github/actions/check-changelog/action.yml
+++ b/.github/actions/check-changelog/action.yml
@@ -1,0 +1,15 @@
+name: Check changelog
+description: Ensures each modified package has a changelog entry in changelogs/upcoming
+inputs:
+  pr-number:
+    required: true
+    description: PR number used as the changelog filename
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for changelog entry
+      shell: bash
+      run: .github/actions/check-changelog/entrypoint.sh
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+

--- a/.github/actions/check-changelog/entrypoint.sh
+++ b/.github/actions/check-changelog/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# The PR number provided as input
+PR_NUMBER="${PR_NUMBER}"
+
+# Search for the changelog file across all packages
+changelog_files=$(find packages/*/changelogs/upcoming/ -type f -name "${PR_NUMBER}.md")
+
+# If no changelog file is found, fail the step with an error message
+if [ -z "$changelog_files" ]; then
+  echo "❌ Changelog file for PR #${PR_NUMBER} is missing."
+  echo "You need to add a changelog to this PR before it can be merged. See https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md."
+  exit 1
+else
+  echo "✅ Changelog file for PR #${PR_NUMBER} found: $changelog_files"
+fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,17 +2,15 @@ name: "Changelog required"
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v2
+    - uses: ./.github/actions/check-changelog
       with:
-        # This should eventually by replaced with a monorepo-compatible changelog checker
-        changeLogPath: "packages/eui/changelogs/upcoming/${{ github.event.pull_request.number }}.md"
-        skipLabels: 'skip-changelog'
-        missingUpdateErrorMessage: 'You need to add a changelog to this PR before it can be merged. @see https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md'
+        pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

This PR updates the changelog PR check. It adds a custom action with a bash script that matches `packages/*/upcoming/${pr_number}`.

[`changelog-enforcer`](https://github.com/dangoslen/changelog-enforcer) doesn't work with monorepo.

In the future, we could use something like [changesets](https://github.com/changesets/changesets). For the time being, we can use this simple solution.

## QA

### Testing notes

- [x] Skipping works (with `skip-changelog` label)
- [x] The PR check fails if there are no changelog files for the PR
- [x] The PR check passes if there is a changelog file in a package other than `packages/eui`
- [x] The PR check passes if there are changelog files in several packages

<details><summary>Screenshots</summary>
<p>

![Screenshot 2025-04-24 at 11 50 53](https://github.com/user-attachments/assets/7fae0c94-4e9f-43d5-bc5a-6cd87c1ad761)
![Screenshot 2025-04-24 at 11 53 48](https://github.com/user-attachments/assets/d839622c-01f1-4eed-a46e-7d76b94ca163)
![Screenshot 2025-04-24 at 11 55 09](https://github.com/user-attachments/assets/683eee8a-3d40-494e-91d0-7a3a98fa9883)

</p>
</details> 
