### PR TITLE
fix(website): fix the EuiSuperDatePicker Sizing example

### DIFF
--- a/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
+++ b/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
@@ -390,13 +390,11 @@ import {
   OnTimeChangeProps,
 } from '@elastic/eui';
 
-export default ({
-  width,
-  compressed,
-}: {
-  width: EuiSuperDatePickerProps['width'];
-  compressed: boolean;
-}) => {
+export default () => {
+  const { euiTheme } = useEuiTheme();
+
+  const [compressed, setCompressed] = useState(false);
+  const [width, setWidth] = useState<EuiSuperDatePickerProps['width']>('restricted');
   const [start, setStart] = useState('now-30m');
   const [end, setEnd] = useState('now');
 
@@ -406,13 +404,36 @@ export default ({
   };
 
   return (
-    <EuiSuperDatePicker
-      start={start}
-      end={end}
-      onTimeChange={onTimeChange}
-      width={width}
-      compressed={compressed}
-    />
+    <>
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiSelect
+            fullWidth
+            compressed
+            value={width}
+            options={[
+              { value: 'restricted', text: 'Restricted' },
+              { value: 'full', text: 'Full' },
+              { value: 'auto', text: 'Auto' },
+            ]}
+            onChange={(e) => setWidth(e.target.value as EuiSuperDatePickerProps['width'])}
+          />
+        </EuiFlexItem>
+        <EuiSwitch
+          checked={compressed}
+          onChange={(e) => setCompressed(e.target.checked)}
+          label="Compressed"
+        />
+      </EuiFlexGroup>
+      <EuiSpacer />
+      <EuiSuperDatePicker
+        start={start}
+        end={end}
+        onTimeChange={onTimeChange}
+        width={width}
+        compressed={compressed}
+      />
+    </EuiSpacer>
   );
 };
 ```


### PR DESCRIPTION
## Summary

On this PR, I add a `EuiSwitch` and `EuiSelect` to control the `compressed` and `width` props of the `EuiSuperDatePicker` component in the Sizing example on the documentation website.

## QA

- [ ] Verify the example behaves correctly ([staging link](https://eui.elastic.co/pr_8625/docs/components/forms/date-and-time/super-date-picker/#sizing))

<details><summary>Testing video</summary>
<p>

https://github.com/user-attachments/assets/dc4aa817-5940-4658-891e-3aba63aa5bf7

</p>
</details> 
