### PR TITLE
chore(eui): update to typescript@v5.8.3

### DIFF
--- a/packages/eui/changelogs/upcoming/8626.md
+++ b/packages/eui/changelogs/upcoming/8626.md
@@ -1,0 +1,3 @@
+**Dependency updates**
+
+- Updated `typescript` to v5.8.3

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -248,7 +248,7 @@
     "stylelint-config-standard": "^33.0.0",
     "stylelint-config-standard-scss": "^9.0.0",
     "terser-webpack-plugin": "^5.3.5",
-    "typescript": "4.5.3",
+    "typescript": "^5.8.3",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",

--- a/packages/eui/src/components/comment_list/comment_timeline.tsx
+++ b/packages/eui/src/components/comment_list/comment_timeline.tsx
@@ -56,5 +56,5 @@ export const EuiCommentTimeline: FunctionComponent<EuiCommentTimelineProps> = ({
     );
   }
 
-  return <>{iconRender}</>;
+  return <>{iconRender as ReactNode}</>;
 };

--- a/packages/eui/src/components/datagrid/body/header/draggable_columns.tsx
+++ b/packages/eui/src/components/datagrid/body/header/draggable_columns.tsx
@@ -257,7 +257,7 @@ export const ConditionalDroppableColumns: FunctionComponent<
   canDragAndDropColumns ? (
     <DroppableColumns {...rest}>{children}</DroppableColumns>
   ) : (
-    <>{children}</>
+    <>{children as ReactNode}</>
   )
 );
 ConditionalDroppableColumns.displayName = 'ConditionalDroppableColumns';

--- a/packages/eui/src/components/form/field_password/field_password.tsx
+++ b/packages/eui/src/components/form/field_password/field_password.tsx
@@ -137,7 +137,9 @@ export const EuiFieldPassword: FunctionComponent<EuiFieldPasswordProps> = (
           title={isVisible ? maskPasswordLabel : showPasswordLabel}
           disabled={disabled}
           {...dualToggleProps}
-          onClick={(e) => handleToggle(e, isVisible)}
+          onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
+            handleToggle(e, isVisible)
+          }
         />
       );
     }

--- a/packages/eui/src/services/accessibility/html_id_generator.test.tsx
+++ b/packages/eui/src/services/accessibility/html_id_generator.test.tsx
@@ -94,6 +94,7 @@ describe('useGeneratedHtmlId', () => {
     rerender({ conditionalId: 'world' });
     expect(result.current).toEqual('world');
 
+    // @ts-expect-error we need to assign `undefined` to assert the fallback
     rerender({ conditionalId: undefined });
     expect(result.current).toBeTruthy(); // Should fall back to a generated ID
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7488,7 +7488,7 @@ __metadata:
     tabbable: "npm:^5.3.3"
     terser-webpack-plugin: "npm:^5.3.5"
     text-diff: "npm:^1.0.1"
-    typescript: "npm:4.5.3"
+    typescript: "npm:^5.8.3"
     uglifyjs-webpack-plugin: "npm:^2.2.0"
     unified: "npm:^9.2.2"
     unist-util-visit: "npm:^2.0.3"


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui/issues/7344

On this PR, I update from `typescript@v4.5.3` to `typescript@v5.8.3`. It can be merged after https://github.com/elastic/eui/pull/8624. Currently, it blocks https://github.com/elastic/eui/pull/8543.

## QA

- [ ] `yarn storybook` works correctly
- [ ] `yarn lint` yields no errors
- [ ] `yarn build` yields no errors
- [ ] `yarn workspace @elastic/eui-docgen build && yarn workspace @elastic/eui-website start` - prop tables are correct