### PR TITLE
Fixed links on docs site

### DIFF
--- a/packages/website/docs/components/display/beacon.mdx
+++ b/packages/website/docs/components/display/beacon.mdx
@@ -5,7 +5,7 @@ Use the `EuiBeacon` component to draw visual attention to a specific location or
 ## Component
 
 :::tip
-It is strongly encouraged to use **EuiBeacon** in conjunction with [**EuiTour**](./tour). Standalone, the beacon is a visual cue that may lack context.
+It is strongly encouraged to use **EuiBeacon** in conjunction with [**EuiTour**](./tour/index.mdx). Standalone, the beacon is a visual cue that may lack context.
 :::
 
 <Demo>

--- a/packages/website/docs/components/display/code.mdx
+++ b/packages/website/docs/components/display/code.mdx
@@ -9,7 +9,7 @@ JSX code (often React) has distinct language syntaxes from the base JavaScript a
 ## Components
 
 :::tip
-**EuiCode** and **EuiCodeBlock** are intended to render static lines or blocks of code in **read-only** contexts. If you need capabilities to edit, or want to print long code (e.g., printing JSON from an API), we recommend installing a version of Monaco. If you are building within the Kibana platform, you can use their [**CodeEditor**](https://github.com/elastic/kibana/tree/main/packages/shared-ux/code_editor/impl).
+**EuiCode** and **EuiCodeBlock** are intended to render static lines or blocks of code in **read-only** contexts. If you need capabilities to edit, or want to print long code (e.g., printing JSON from an API), we recommend installing a version of Monaco. If you are building within the Kibana platform, you can use their [**CodeEditor**](https://github.com/elastic/kibana/tree/main/src/platform/packages/shared/shared-ux/code_editor/impl).
 :::
 
 ### Inline

--- a/packages/website/docs/components/display/empty-prompt/types_of_empty_states/use_cases.tsx
+++ b/packages/website/docs/components/display/empty-prompt/types_of_empty_states/use_cases.tsx
@@ -60,7 +60,7 @@ export const TYPES_OF_USE_CASES: {
           <p>Help users understand how they can start using the product.</p>
           <p>
             For no data use cases, consider using a{' '}
-            <EuiLink href="/docs/display/card/">EuiCard</EuiLink>. In Kibana,
+            <EuiLink href="/docs/components/containers/card">EuiCard</EuiLink>. In Kibana,
             you just need to pass a no data configuration into your{' '}
             <EuiLink
               href="https://github.com/elastic/kibana/blob/main/dev_docs/tutorials/kibana_page_template.mdx"

--- a/packages/website/docs/dataviz/theming.mdx
+++ b/packages/website/docs/dataviz/theming.mdx
@@ -25,7 +25,7 @@ const chartBaseTheme = isDarkTheme ? DARK_THEME : LIGHT_THEME;
 
 :::note Kibana engineers
 
-EUI provides a plugin utility for ease of pulling in the correct theme object depending on the current Kibana theme. Learn more from this [readme](https://github.com/elastic/kibana/tree/main/src/plugins/charts).
+EUI provides a plugin utility for ease of pulling in the correct theme object depending on the current Kibana theme. Learn more from this [readme](https://github.com/elastic/kibana/tree/main/src/platform/plugins/shared/charts).
 
 :::
 

--- a/packages/website/docs/dataviz/types/metric-chart.mdx
+++ b/packages/website/docs/dataviz/types/metric-chart.mdx
@@ -14,7 +14,7 @@ import * as ElasticCharts from '@elastic/charts';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 ```
 
-The **Metric** chart is a single value visualization available from [Elastic Charts](https://elastic.github.io/elastic-charts). It allows you to represent a metric, a KPI, a specific state with a very simple interface, similar to [**EuiStat**](/docs/display/stat) but with more data visualization oriented capabilities.
+The **Metric** chart is a single value visualization available from [Elastic Charts](https://elastic.github.io/elastic-charts). It allows you to represent a metric, a KPI, a specific state with a very simple interface, similar to [**EuiStat**](/docs/components/display/stat.mdx) but with more data visualization oriented capabilities.
 
 ![Overview of metric component.](./metric_intro.png)
 

--- a/packages/website/docs/getting-started/theming/utilities/typography.mdx
+++ b/packages/website/docs/getting-started/theming/utilities/typography.mdx
@@ -294,7 +294,7 @@ import { ColorInheritPreview } from './preview_utilities';
 
     Forces the component to inherit its text color from its parent.
 
-    For changing the color of your text to on of the named colors, [use **EuiText** or **EuiTextColor**](../../../display/text#coloring-text).
+    For changing the color of your text to on of the named colors, [use **EuiText** or **EuiTextColor**](../../../components/display/text.mdx#coloring-text).
 
   </Example.Description>
   <Example.Preview>

--- a/packages/website/docs/patterns/index.mdx
+++ b/packages/website/docs/patterns/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 Patterns are preferred solutions to specific user needs, ensuring consistency in design, behavior, and interaction.
 
 :::warning
-Our pattern documentation is evolving. [Join the discussion](https://github.com/orgs/elastic/projects/1150) (<i>available to Elastic employees only</i>) to make it better.
+Our pattern documentation is evolving. [Join the discussion](https://github.com/elastic/eui/discussions) to make it better.
 :::
 
 
@@ -53,7 +53,7 @@ Patterns are not set in stone, but rather, do evolve over time as problem and so
 
 ## Contributing
 
-The content available here reflects collective insights and best practices. If you see opportunities for improvement or have new ideas, we encourage [contributions](https://github.com/elastic/eui-docs/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=). Your expertise helps ensure our design system remains relevant and user-focused.
+The content available here reflects collective insights and best practices. If you see opportunities for improvement or have new ideas, we encourage [contributions](https://github.com/elastic/eui/discussions). Your expertise helps ensure our design system remains relevant and user-focused.
 
 ---
 


### PR DESCRIPTION
## Summary


### 1. Forms link on homepage

<img width="354" alt="Image" src="https://github.com/user-attachments/assets/910a890a-3baa-453c-b6dd-304e4cd9ba13" />

###  2. https://eui.elastic.co/docs/dataviz/theming/
Readme link

<img width="936" alt="Image" src="https://github.com/user-attachments/assets/247cbc5d-ecc6-4eb5-aa12-8773aa952e96" />

###  3. https://eui.elastic.co/docs/components/display/beacon/
EuiTour link

<img width="950" alt="Image" src="https://github.com/user-attachments/assets/88256a67-f6c0-4484-8dbb-4f030171f9bd" />

### 4. https://eui.elastic.co/docs/components/display/code/
CodeEditor link

<img width="843" alt="Image" src="https://github.com/user-attachments/assets/f7331951-6e35-4f79-8fd1-88cdebc63eef" />

### 5. https://eui.elastic.co/docs/components/display/empty-prompt/
EuiCard link

<img width="573" alt="Image" src="https://github.com/user-attachments/assets/e08f2c19-789c-4563-b178-a339200a1d6a" />

### 6. https://eui.elastic.co/docs/getting-started/theming/utilities/typography/
"use EuiText or EuiTextColor" link

<img width="958" alt="Image" src="https://github.com/user-attachments/assets/1e1172e5-71dc-4a8d-9ffe-5c7816929e51" />

### 7. https://eui.elastic.co/docs/dataviz/types/metric-chart/
EuiStat

<img width="975" alt="Image" src="https://github.com/user-attachments/assets/b7dae864-aad1-473b-82f3-5fb9f761192d" />

### 8. https://eui.elastic.co/docs/patterns/
Contributions and join the discussion links

<img width="1193" alt="Image" src="https://github.com/user-attachments/assets/25c33bea-9dc0-4285-82d3-8a6103c83cb2" />