### PR TITLE
feat(release-cli): Support custom (classic) releases

### DIFF
--- a/packages/release-cli/src/cli.ts
+++ b/packages/release-cli/src/cli.ts
@@ -39,7 +39,7 @@ export const cli = () => {
           })
           .option('allowCustom', {
             type: 'boolean',
-            description: '[UNSAFE!] Allow custom releases from unpushed changes. This should only be used with snapshot releases or',
+            description: '[UNSAFE!] Allow custom releases from unpushed changes. This should only be used with snapshot or custom releases',
             default: false,
           })
           .option('verbose', {

--- a/packages/release-cli/src/cli.ts
+++ b/packages/release-cli/src/cli.ts
@@ -39,6 +39,7 @@ export const cli = () => {
           })
           .option('allowCustom', {
             type: 'boolean',
+            description: '[UNSAFE!] Allow custom releases from unpushed changes. This should only be used with snapshot releases or',
             default: false,
           })
           .option('verbose', {
@@ -51,6 +52,11 @@ export const cli = () => {
             type: 'boolean',
             description:
               'Skip user prompts and proceed with recommended settings. Use in CI only!',
+            default: false,
+          })
+          .option('skipUpdateVersions', {
+            type: 'boolean',
+            description: '[UNSAFE!] Skip the update version step. This should only be used for special releases like backports. The --workspaces argument is required when this argument is set.',
             default: false,
           })
           .option('useAuthToken', {
@@ -68,6 +74,7 @@ export const cli = () => {
           allowCustom,
           verbose,
           skipPrompts,
+          skipUpdateVersions,
           useAuthToken,
         } = argv;
         const logger = new Logger(verbose);
@@ -79,6 +86,7 @@ export const cli = () => {
             workspaces,
             logger,
             skipPrompts,
+            skipUpdateVersions,
             useAuthToken,
             allowCustomReleases: allowCustom,
           });

--- a/packages/release-cli/src/release.ts
+++ b/packages/release-cli/src/release.ts
@@ -47,8 +47,8 @@ export const release = async (options: ReleaseOptions) => {
 
     if (options.tag !== 'latest') {
       logger.warning(
-        `A custom tag "${options.tag}" provided for the \`official\` ` +
-        `release type. This should be used only for special releases like` +
+        `A custom tag "${options.tag}" was provided for the official` +
+        ` release type. This should be used only for special releases like` +
         ` backports. Stop here if you don't know what you're doing!`
       );
     }

--- a/packages/release-cli/src/release.ts
+++ b/packages/release-cli/src/release.ts
@@ -29,6 +29,7 @@ export interface ReleaseOptions {
   logger: Logger;
   allowCustomReleases: boolean;
   skipPrompts: boolean;
+  skipUpdateVersions: boolean;
   useAuthToken: boolean;
 }
 
@@ -45,8 +46,10 @@ export const release = async (options: ReleaseOptions) => {
     }
 
     if (options.tag !== 'latest') {
-      throw new ValidationError(
-        'Custom tags are not allowed for type `official`! Please use another type to perform custom releases'
+      logger.warning(
+        `A custom tag "${options.tag}" provided for the \`official\` ` +
+        `release type. This should be used only for special releases like` +
+        ` backports. Stop here if you don't know what you're doing!`
       );
     }
   } else if (type === 'snapshot') {
@@ -66,6 +69,10 @@ export const release = async (options: ReleaseOptions) => {
     logger.warning('Using npmjs auth token');
   } else if (options.skipPrompts) {
     throw new ValidationError('Skipping prompts is not allowed when not using auth tokens');
+  }
+
+  if (options.skipUpdateVersions && !options.workspaces?.length) {
+    throw new ValidationError('--workspaces must be set when --skip-update-version is used');
   }
 
   const allWorkspaces = await getYarnWorkspaces();

--- a/packages/release-cli/src/release.ts
+++ b/packages/release-cli/src/release.ts
@@ -71,8 +71,12 @@ export const release = async (options: ReleaseOptions) => {
     throw new ValidationError('Skipping prompts is not allowed when not using auth tokens');
   }
 
-  if (options.skipUpdateVersions && !options.workspaces?.length) {
-    throw new ValidationError('--workspaces must be set when --skip-update-version is used');
+  if (options.skipUpdateVersions) {
+    logger.warning('--skip-update-versions is set');
+
+    if (!options.workspaces?.length) {
+      throw new ValidationError('--workspaces must be set when --skip-update-version is used');
+    }
   }
 
   const allWorkspaces = await getYarnWorkspaces();

--- a/packages/release-cli/src/steps/init_checks.ts
+++ b/packages/release-cli/src/steps/init_checks.ts
@@ -56,12 +56,6 @@ export const stepInitChecks = async (options: ReleaseOptions) => {
   logger.debug(`Local HEAD = ${localHash}`);
 
   if (localHash !== remoteHash) {
-    if (type === 'official') {
-      throw new ValidationError(
-        'Local `main` branch is out of sync with the upstream branch. Please pull the latest changes and try again.'
-      );
-    }
-
     if (!allowCustomReleases) {
       throw new ValidationError(
         'Local HEAD does not match the remote HEAD. Use --allow-custom to create a custom non-official release ' +

--- a/packages/release-cli/src/steps/init_checks.ts
+++ b/packages/release-cli/src/steps/init_checks.ts
@@ -31,7 +31,7 @@ export const stepInitChecks = async (options: ReleaseOptions) => {
 
   // Check if releasing from main branch
   const currentBranch = await getCurrentBranch();
-  if (currentBranch !== 'main' && type === 'official') {
+  if (currentBranch !== 'main' && type === 'official' && !allowCustomReleases) {
     throw new ValidationError(
       'Official releases are only allowed from the `main` branch!'
     );
@@ -39,9 +39,10 @@ export const stepInitChecks = async (options: ReleaseOptions) => {
 
   if (!(await isWorkingTreeClean())) {
     throw new ValidationError(
-      'Git working tree is dirty. Please clean up your working tree from any uncommited changes and try again.',
-      `To clean local changes and restore the branch to remote state, please run:` +
-        `\n  ${chalk.yellowBright(
+      'Git working tree is dirty. Please clean up your working tree' +
+      ' from any uncommited changes and try again.',
+      `To clean local changes and restore the branch to remote state,` +
+        ` please run:\n  ${chalk.yellowBright(
           `git reset --hard upstream/${currentBranch}`
         )}\n` +
         `Please note that ${chalk.underline.bold(
@@ -58,8 +59,9 @@ export const stepInitChecks = async (options: ReleaseOptions) => {
   if (localHash !== remoteHash) {
     if (!allowCustomReleases) {
       throw new ValidationError(
-        'Local HEAD does not match the remote HEAD. Use --allow-custom to create a custom non-official release ' +
-          'if that really is what you were planning to do.'
+        'Local HEAD does not match the remote HEAD. Use --allow-custom to' +
+          ' create a custom non-official release if that really is what' +
+          'you were planning to do.'
       );
     } else {
       logger.warning('Local HEAD does not match the remote HEAD');
@@ -76,7 +78,8 @@ export const stepInitChecks = async (options: ReleaseOptions) => {
   const registryUser = await getAuthenticatedUser();
   if (!registryUser) {
     throw new ValidationError(
-      'Authentication to npmjs is required. Please log in before running this command again.',
+      'Authentication to npmjs is required. Please log in before running' +
+      ' this command again.',
       `To authenticate run the following command:\n` +
         `  ${chalk.yellowBright('yarn npm login')}`
     );

--- a/packages/release-cli/src/steps/update_versions.ts
+++ b/packages/release-cli/src/steps/update_versions.ts
@@ -35,7 +35,12 @@ export const stepUpdateVersions = async (
   options: ReleaseOptions,
   workspaces: Array<YarnWorkspace>
 ) => {
-  const { logger } = options;
+  const { logger, skipUpdateVersions } = options;
+
+  if (skipUpdateVersions) {
+    logger.warning('Skipping the update versions step');
+    return workspaces;
+  }
 
   logger.info('Updating package versions and changelogs');
 


### PR DESCRIPTION
Resolves https://github.com/elastic/eui-private/issues/273

## Summary

This adds support for custom official releases to the release CLI. We need these releases for the `classic`/`amsterdam` backport releases we do weekly to support the old Amsterdam theme in Kibana 8.x.

The way we create these releases is manual and requires cherry picking specific commits on top of branched out `main`. They follow the regular EUI release versioning, but are suffixed with an `amsterdam` prerelease identifier (preid) for easy distinction. This process will stay manual since managing branches and cherry picks in a script is quite painful and can easily lead to an unpredictable state.

The point of this update is to allow releasing these custom backport releases with the release CLI instead of having to manually build and publish the `@elastic/eui` package. The work in this PR isn't meant to make the process perfect, but it simplifies it by sticking to a single release tool.

## QA

**Please wait with QA until this PR is ready for review**

1. Checkout this PR
    ```shell
    gh pr checkout 8629 && yarn && yarn workspaces @elastic/eui-release-cli run build
    ```
2. Log out from the npmjs registry and verify you're unauthenticated
    ```shell
    yarn npm logout
    yarn npm whoami
    ```
3. Run verdaccio locally
    ```shell
    docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio
    ```
4. Update `.yarnrc.yml` to use the local registry
    ```shell
    yarn config set npmRegistryServer http://localhost:4873
    yarn config set unsafeHttpWhitelist localhost
    ```
6. Authenticate with the local registry
    ```shell
    yarn npm login # username: test, password: test
    ```
7. Update `"version"` in `/packages/eui/package.json` to `101.4.0-custom-release-test.0` and commit it
8. Run the release script
    ```shell
    yarn release run official --tag custom-release-test --skip-update-versions --allow-custom --workspaces @elastic/eui
    ```
    When asked for an OTP, just click <kbd>Enter &#9166;</kbd>
9. Drop the version string update commit or reset your local branch to the remote's state