### PR TITLE
Added background image guide to icons page

### DIFF
--- a/packages/website/docs/components/display/icons/index.mdx
+++ b/packages/website/docs/components/display/icons/index.mdx
@@ -515,7 +515,7 @@ import customSvg from '!url-loader!./custom.svg';
 
 ### Using icons as background images
 
-EUI currently only supports icon usage via name references passed to various components (ex.: `<EuiIcon type="grid" />`). We do not export the underlying asset, which precludes referencing it directly for use in CSS as a background image.
+EUI only lets you use icons by referring to their names in components (like `<EuiIcon type="grid" />`). The actual icon files aren’t exported, so you can’t use them directly in CSS as background images.
 
 ## Props
 

--- a/packages/website/docs/components/display/icons/index.mdx
+++ b/packages/website/docs/components/display/icons/index.mdx
@@ -513,6 +513,10 @@ import customSvg from '!url-loader!./custom.svg';
   ```
 </Demo>
 
+### Using icons as background images
+
+EUI currently only supports icon usage via name references passed to various components (ex.: `<EuiIcon type="grid" />`). We do not export the underlying asset, which precludes referencing it directly for use in CSS as a background image.
+
 ## Props
 
 import docgen from '@elastic/eui-docgen/dist/components/icon';


### PR DESCRIPTION
## Summary

This question came up during support week. I thought it would be worthwhile to document it, as part of our `support-duty-flywheel`. I've labeled it as such.

<img width="1634" alt="Screenshot 2025-04-24 at 11 38 58 AM" src="https://github.com/user-attachments/assets/5dca3e57-ce21-4cb5-be87-dc52f2e034f5" />

## QA

Just review the wording and double check it in the preview deployment.