### PR TITLE
Fix broken hoisting limits in yarn-plugin-validate-env

### DIFF
--- a/packages/yarn-plugin-validate-env/package.json
+++ b/packages/yarn-plugin-validate-env/package.json
@@ -19,5 +19,8 @@
   },
   "devDependencies": {
     "typescript": "^5.8.3"
+  },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
   }
 }


### PR DESCRIPTION
## Summary

This fixes hoisting limits for yarn-plugin-validate-env that made the release-cli build fail due to package version conflicts after merging https://github.com/elastic/eui/pull/8450. `yarn-plugin-validate-env` is a whole separate utility package that isn't built often and can have hoisting limits set to `workspaces`.

## QA

- [x] CI is passing for this PR
- [ ] Checkout this PR locally, run `rm -rf node_modules packages/*/node_modules && yarn` and check if `yarn workspace @elastic/eui-release-cli run build` works as expected