### PR TITLE
chore(website): add postrelease script

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,7 +14,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "spellcheck": "cspell ./docs"
+    "spellcheck": "cspell ./docs",
+    "postrelease": "node ./scripts/update-versions.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",

--- a/packages/website/scripts/update-versions.js
+++ b/packages/website/scripts/update-versions.js
@@ -1,0 +1,62 @@
+const path = require('path');
+const fs = require('fs');
+const { exec } = require('child_process');
+
+const version = require('@elastic/eui/package.json').version;
+const versionsFile = path.join(__dirname, '../static/versions.json');
+
+const isValidVersion = (version) => {
+  const semverRegex = /^\d+\.\d+\.\d+$/;
+  return semverRegex.test(version);
+};
+
+/**
+ * Updates the `versions.json` file used by the documentation version switcher.
+ *
+ * To test locally, run `node ./scripts/update-versions.js`,
+ * then verify the contents of `static/versions.json`.
+ */
+
+const updateVersions = async () => {
+  try {
+    const fileContent = fs.readFileSync(versionsFile, 'utf8');
+    const jsonData = JSON.parse(fileContent);
+
+    if (!jsonData.euiVersions || !Array.isArray(jsonData.euiVersions)) {
+      throw new Error(
+        'Invalid JSON structure: Missing or invalid `euiVersions` array'
+      );
+    }
+
+    if (!isValidVersion(version)) {
+      console.warn(
+        'Skipping update: Invalid version format or unofficial release'
+      );
+      return;
+    }
+
+    if (jsonData.euiVersions.includes(version)) {
+      console.warn('Skipping update: Current version has already been logged');
+      return;
+    }
+
+    // Prepend the new version
+    jsonData.euiVersions.unshift(version);
+
+    // Write the updated JSON back to the file
+    fs.writeFileSync(versionsFile, JSON.stringify(jsonData, null, 2));
+
+    // Stage the file for commit
+    exec(`git add ${versionsFile}`, (err) => {
+      if (err) {
+        throw new Error('Error staging the file:', err);
+      } else {
+        console.log('Version added and file staged successfully');
+      }
+    });
+  } catch (error) {
+    throw new Error('Error updating versions:', err);
+  }
+};
+
+updateVersions();

--- a/packages/website/scripts/update-versions.js
+++ b/packages/website/scripts/update-versions.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
 const path = require('path');
 const fs = require('fs');
 const { exec } = require('child_process');


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui-private/issues/316

This PR adds a `postrelease` script to `@elastic/eui-website` package so that on each EUI release, a new version is added to the `versions.json` file, and subsequently to the version switcher.

Only official releases following the semantic versioning `vX.Y.Z` are added. Snapshot and backport releases are skipped.

## QA

### Instructions

1. Checkout this branch: `gh checkout pr 8638`
2. Ensure you're logged out of npm: `yarn npm logout`
3. Run a local registry to which the packages are publish instead of npm: `docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio`
4. Update the root `.yarnrc.yml` file by adding:
```yaml
npmRegistryServer: "http://localhost:4873"
unsafeHttpWhitelist:
  - localhost
  - "localhost:4873"
```
5. Login to the local registry. When asked for a user and password you can set anything, e.g. test/test. When asked for an OTP token click Enter, as the local registry has no two-factor authentication configured and OTP is not needed. `yarn npm login`
6. Disable checking if the working directory is clean in `packages/release-cli/src/git_utils.ts` by returning true in `isWorkingTreeClean():`
```tsx
# example
export const isWorkingTreeClean = async () => {
  return true;
};
```
7. Uncomment `packages/release-cli/src/steps/init_checks.ts:34` check. We're running the official release script on verdaccio instance so we don't need to worry about launching it not from `main`. **Be sure you changed `.yarnrc.yml` file!**
```tsx
if (currentBranch !== 'main' && type === 'official') {
    throw new ValidationError(
      'Official releases are only allowed from the `main` branch!'
    );
}
```
8. Build the dependencies: `yarn`
9. Build the `release-cli` package: `yarn workspace @elastic/eui-release-cli run build`
10. Build the release from the monorepo root: `yarn release run official --workspaces @elastic/eui-theme-common @elastic/eui-theme-borealis @elastic/eui`

### Checklist

- [x] Verify that you have correct staged changes in `packages/website/static/versions.json`
- [ ] Verify that a snapshot release is skipped: `yarn release run snapshot --allow-custom --workspaces @elastic/eui-theme-common @elastic/eui-theme-borealis @elastic/eui`
- [ ] Verify that on releasing e.g. `@elastic/eslint-plugin-eui` (by adding a temporary changelog) it's released without any issue and `packages/website/static/versions.json` remains unchanged