### PR TITLE
fix(eui): add scroll offset for actions menu in EuiDataGrid

### DIFF
--- a/packages/eui/changelogs/upcoming/8640.md
+++ b/packages/eui/changelogs/upcoming/8640.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed an issue where the actions menu was hidden under the header when clicking on a cell to scroll into view
+- Resolved an issue where the `EuiDataGrid` cell actions menu was hidden by the header when a cell was clicked to scroll into view

--- a/packages/eui/changelogs/upcoming/8640.md
+++ b/packages/eui/changelogs/upcoming/8640.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an issue where the actions menu was hidden under the header when clicking on a cell to scroll into view

--- a/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
@@ -316,7 +316,7 @@ describe('useScrollCellIntoView', () => {
       ).result.current;
 
       scrollCellIntoView({ rowIndex: 1, colIndex: 0 });
-      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 50, scrollLeft: 0 });
+      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 28, scrollLeft: 0 });
     });
 
     it('accounts for the sticky header', () => {
@@ -330,7 +330,7 @@ describe('useScrollCellIntoView', () => {
       ).result.current;
 
       scrollCellIntoView({ rowIndex: 1, colIndex: 0 });
-      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 20, scrollLeft: 0 });
+      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: -2, scrollLeft: 0 });
     });
 
     it('scrolls to the top side over the bottom if the cell height is larger than the grid height', () => {
@@ -354,7 +354,7 @@ describe('useScrollCellIntoView', () => {
       ).result.current;
 
       scrollCellIntoView({ rowIndex: 1, colIndex: 0 });
-      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 50, scrollLeft: 0 });
+      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 28, scrollLeft: 0 });
     });
 
     it('makes no vertical adjustments if the cell is a sticky header cell', () => {

--- a/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
@@ -316,7 +316,7 @@ describe('useScrollCellIntoView', () => {
       ).result.current;
 
       scrollCellIntoView({ rowIndex: 1, colIndex: 0 });
-      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 28, scrollLeft: 0 });
+      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 29, scrollLeft: 0 });
     });
 
     it('accounts for the sticky header', () => {
@@ -330,7 +330,7 @@ describe('useScrollCellIntoView', () => {
       ).result.current;
 
       scrollCellIntoView({ rowIndex: 1, colIndex: 0 });
-      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: -2, scrollLeft: 0 });
+      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: -1, scrollLeft: 0 });
     });
 
     it('scrolls to the top side over the bottom if the cell height is larger than the grid height', () => {
@@ -354,7 +354,7 @@ describe('useScrollCellIntoView', () => {
       ).result.current;
 
       scrollCellIntoView({ rowIndex: 1, colIndex: 0 });
-      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 28, scrollLeft: 0 });
+      expect(scrollTo).toHaveBeenCalledWith({ scrollTop: 29, scrollLeft: 0 });
     });
 
     it('makes no vertical adjustments if the cell is a sticky header cell', () => {

--- a/packages/eui/src/components/datagrid/utils/scrolling.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.tsx
@@ -23,7 +23,7 @@ import { EuiDataGridStyle } from '../data_grid_types';
 import { DataGridFocusContext } from './focus';
 import { euiDataGridScrollBarStyles } from './scrolling.styles';
 
-const ACTIONS_MENU_HEIGHT = 22;
+const ACTIONS_MENU_HEIGHT = 21;
 
 interface ScrollCellIntoView {
   rowIndex: number;

--- a/packages/eui/src/components/datagrid/utils/scrolling.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.tsx
@@ -23,6 +23,8 @@ import { EuiDataGridStyle } from '../data_grid_types';
 import { DataGridFocusContext } from './focus';
 import { euiDataGridScrollBarStyles } from './scrolling.styles';
 
+const ACTIONS_MENU_HEIGHT = 22;
+
 interface ScrollCellIntoView {
   rowIndex: number;
   colIndex: number;
@@ -180,7 +182,9 @@ export const useScrollCellIntoView = ({
         if (topHeightOutOfView > 0) {
           // Note: This overrides the bottom side being out of bounds, as we want to prefer
           // showing the top-left corner of items if a cell is larger than the grid container
-          adjustedScrollTop = cellTopPos - headerRowHeight;
+          // Additionally, add an offset for the actions menu
+          adjustedScrollTop =
+            cellTopPos - headerRowHeight - ACTIONS_MENU_HEIGHT;
         }
       }
 


### PR DESCRIPTION
## Summary

Closes #8484

On this PR, I fix the issue where the actions menu gets hidden under the header in the `EuiDataGrid` when scrolling into view (when clicking on the cell) in the top direction.

The offset is applied conditionally to the top because as you can see below, the down direction doesn't need any adjustment.

I thought about accessing the actions menu height programmatically which would make it more robust BUT we don't plan on changing the height or supporting customizing the height of the actions menu. Any logic that'd calculate the height is at a performance cost. A simple constant is enough for now.

**Before**

https://github.com/user-attachments/assets/1c0cbfb3-6849-47cd-8bbf-14744d71735f

**After**

https://github.com/user-attachments/assets/a4c7a092-f369-4d32-b1ea-343c3eb85fea

## QA

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, ~**Edge**~, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
