### PR TITLE
[EuiDatGrid] Replace `expandMini` with `expand` icon in data grid

### DIFF
--- a/packages/eui/src/components/datagrid/body/cell/data_grid_cell_actions.styles.ts
+++ b/packages/eui/src/components/datagrid/body/cell/data_grid_cell_actions.styles.ts
@@ -122,12 +122,6 @@ export const euiDataGridCellActionsStyles = (euiThemeContext: UseEuiTheme) => {
       }
       /* stylelint-enable declaration-no-important */
 
-      /* Manually increase the size of the expand cell icon - it's a bit small by default */
-      &.euiDataGridRowCell__expandCell .euiIcon {
-        ${logicalCSS('width', '120%')}
-        ${logicalCSS('height', '100%')}
-      }
-
       /* Remove button borders in high contrast mode */
       ${highContrastModeStyles(euiThemeContext, {
         preferred: 'border: none;',

--- a/packages/eui/src/components/datagrid/body/cell/data_grid_cell_actions.test.tsx
+++ b/packages/eui/src/components/datagrid/body/cell/data_grid_cell_actions.test.tsx
@@ -47,7 +47,7 @@ describe('EuiDataGridCellActions', () => {
           aria-hidden="true"
           class="euiButtonIcon__icon"
           color="inherit"
-          data-euiicon-type="expandMini"
+          data-euiicon-type="expand"
         />
       </button>
     `);

--- a/packages/eui/src/components/datagrid/body/cell/data_grid_cell_actions.tsx
+++ b/packages/eui/src/components/datagrid/body/cell/data_grid_cell_actions.tsx
@@ -58,8 +58,8 @@ export const EuiDataGridCellActions = ({
             data-test-subj="euiDataGridCellExpandButton"
             display="fill"
             color="primary"
-            iconSize="m"
-            iconType="expandMini"
+            iconSize="s"
+            iconType="expand"
             aria-hidden
             onClick={onExpandClick}
             title={expandButtonTitle}

--- a/packages/website/docs/components/tabular-content/data-grid/cells-and-popovers.mdx
+++ b/packages/website/docs/components/tabular-content/data-grid/cells-and-popovers.mdx
@@ -787,7 +787,8 @@ export default () => {
         <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiToken
-              iconType="expandMini"
+              iconSize="s"
+              iconType="expand"
               color="euiColorVis0"
               shape="square"
               fill="dark"
@@ -822,7 +823,8 @@ export default () => {
         <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiToken
-              iconType="expandMini"
+              iconSize="s"
+              iconType="expand"
               color="euiColorVis0"
               shape="square"
               fill="dark"
@@ -862,7 +864,8 @@ export default () => {
         <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiToken
-              iconType="expandMini"
+              iconSize="s"
+              iconType="expand"
               color="euiColorVis0"
               shape="square"
               fill="dark"


### PR DESCRIPTION
## Summary

As part of the icon redesign effort, we will be deprecating the `expandMini` glyph. In hindsight, it is not needed given the `expand` icon can simply be sized down as evidenced by this change for data grid.

The new `expand` icon was previously implemented while `expandMini` still has the hold style. This PR removes it from the data grid and sets us up to deprecate this icon along with several others.

![CleanShot 2025-04-25 at 14 29 59@2x](https://github.com/user-attachments/assets/b305402b-7b79-4482-bace-714fa9941cf3)


## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
