### PR TITLE
[Changelog] Update release script to not add PR link on nested children

### DIFF
--- a/packages/eui-theme-borealis/changelogs/CHANGELOG_2025.md
+++ b/packages/eui-theme-borealis/changelogs/CHANGELOG_2025.md
@@ -1,55 +1,55 @@
 ## [`v1.0.0`](https://github.com/elastic/eui/releases/v1.0.0)
 
 - Added semantic severity color tokens: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.unknown` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.neutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.success` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.warning` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.risk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.danger` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.severity.unknown`
+    - `colors.severity.neutral`
+    - `colors.severity.success`
+    - `colors.severity.warning`
+    - `colors.severity.risk`
+    - `colors.severity.danger`
 - Added semantic color tokens for variants `neutral` and `risk`: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.textNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.textRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundBaseNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundBaseRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundLightNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundLightRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderBaseNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderBaseRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderStrongNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderStrongRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.textNeutral
+    - `colors.textRisk`
+    - `colors.backgroundBaseNeutral`
+    - `colors.backgroundBaseRisk`
+    - `colors.backgroundLightNeutral`
+    - `colors.backgroundLightRisk`
+    - `colors.backgroundFilledNeutral`
+    - `colors.backgroundFilledRisk`
+    - `colors.borderBaseNeutral`
+    - `colors.borderBaseRisk`
+    - `colors.borderStrongNeutral`
+    - `colors.borderStrongRisk
 - Added button component tokens for variants `neutral` and `risk`: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundEmptyNeutralHover` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundEmptyRiskHover` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `components.buttons.backgroundNeutral`
+    - `components.buttons.backgroundRisk`
+    - `components.buttons.backgroundFilledNeutral`
+    - `components.buttons.backgroundFilledRisk`
+    - `components.buttons.backgroundEmptyNeutralHover`
+    - `components.buttons.backgroundEmptyRiskHover`
+    - `components.buttons.textColorNeutral`
+    - `components.buttons.textColorRisk`
+    - `components.buttons.textColorFilledNeutral`
+    - `components.buttons.textColorFilledRisk`
 
 **Breaking changes**
 
 - Removed numbered severity color tokens: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity0` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity1` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity2` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity3` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity4` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity5` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity6` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity7` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity8` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity9` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity10` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity11` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity12` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity13` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity14` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.vis.euiColorSeverity0`
+    - `colors.vis.euiColorSeverity1`
+    - `colors.vis.euiColorSeverity2`
+    - `colors.vis.euiColorSeverity3`
+    - `colors.vis.euiColorSeverity4`
+    - `colors.vis.euiColorSeverity5`
+    - `colors.vis.euiColorSeverity6`
+    - `colors.vis.euiColorSeverity7`
+    - `colors.vis.euiColorSeverity8`
+    - `colors.vis.euiColorSeverity9`
+    - `colors.vis.euiColorSeverity10`
+    - `colors.vis.euiColorSeverity11`
+    - `colors.vis.euiColorSeverity12`
+    - `colors.vis.euiColorSeverity13`
+    - `colors.vis.euiColorSeverity14`
 
 **Dependency updates**
 

--- a/packages/eui-theme-common/changelogs/CHANGELOG_2025.md
+++ b/packages/eui-theme-common/changelogs/CHANGELOG_2025.md
@@ -2,55 +2,55 @@
 
 - Added `severity` key on `_EuiThemeConstantColors` to support tokens on `colors.severity` ([#8601](https://github.com/elastic/eui/pull/8601))
 - Added type for semantic severity color tokens ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.unknown` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.neutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.success` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.warning` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.risk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.danger` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.severity.unknown`
+    - `colors.severity.neutral`
+    - `colors.severity.success`
+    - `colors.severity.warning`
+    - `colors.severity.risk`
+    - `colors.severity.danger`
 - Added types for semantic color tokens for variants `neutral` and `risk`: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.textNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.textRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundBaseNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundBaseRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundLightNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundLightRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderBaseNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderBaseRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderStrongNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderStrongRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.textNeutral`
+    - `colors.textRisk`
+    - `colors.backgroundBaseNeutral`
+    - `colors.backgroundBaseRisk`
+    - `colors.backgroundLightNeutral`
+    - `colors.backgroundLightRisk`
+    - `colors.backgroundFilledNeutral`
+    - `colors.backgroundFilledRisk`
+    - `colors.borderBaseNeutral`
+    - `colors.borderBaseRisk`
+    - `colors.borderStrongNeutral`
+    - `colors.borderStrongRisk`
 - Added types for button component tokens for variants `neutral` and `risk`: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundEmptyNeutralHover` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.backgroundEmptyRiskHover` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `components.buttons.textColorFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `components.buttons.backgroundNeutral`
+    - `components.buttons.backgroundRisk`
+    - `components.buttons.backgroundFilledNeutral`
+    - `components.buttons.backgroundFilledRisk`
+    - `components.buttons.backgroundEmptyNeutralHover`
+    - `components.buttons.backgroundEmptyRiskHover`
+    - `components.buttons.textColorNeutral`
+    - `components.buttons.textColorRisk`
+    - `components.buttons.textColorFilledNeutral`
+    - `components.buttons.textColorFilledRisk`
 
 **Breaking changes**
 
 - Removed types for numbered severity color tokens: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity0` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity1` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity2` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity3` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity4` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity5` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity6` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity7` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity8` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity9` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity10` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity11` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity12` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity13` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity14` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.vis.euiColorSeverity0`
+    - `colors.vis.euiColorSeverity1`
+    - `colors.vis.euiColorSeverity2`
+    - `colors.vis.euiColorSeverity3`
+    - `colors.vis.euiColorSeverity4`
+    - `colors.vis.euiColorSeverity5`
+    - `colors.vis.euiColorSeverity6`
+    - `colors.vis.euiColorSeverity7`
+    - `colors.vis.euiColorSeverity8`
+    - `colors.vis.euiColorSeverity9`
+    - `colors.vis.euiColorSeverity10`
+    - `colors.vis.euiColorSeverity11`
+    - `colors.vis.euiColorSeverity12`
+    - `colors.vis.euiColorSeverity13`
+    - `colors.vis.euiColorSeverity14`
 
 ## [`v0.2.0`](https://github.com/elastic/eui/releases/v0.2.0)
 

--- a/packages/eui/changelogs/CHANGELOG_2025.md
+++ b/packages/eui/changelogs/CHANGELOG_2025.md
@@ -1,52 +1,52 @@
 ## [`v102.0.0`](https://github.com/elastic/eui/releases/v102.0.0)
 
 - Added semantic severity color tokens: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.unknown` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.neutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.success` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.warning` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.risk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.severity.danger` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.severity.unknown`
+    - `colors.severity.neutral`
+    - `colors.severity.success`
+    - `colors.severity.warning`
+    - `colors.severity.risk` 
+    - `colors.severity.danger` 
 - Added semantic color tokens for variants `neutral` and `risk`: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.textNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.textRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundBaseNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundBaseRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundLightNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundLightRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundFilledNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.backgroundFilledRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderBaseNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderBaseRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderStrongNeutral` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.borderStrongRisk` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.textNeutral`
+    - `colors.textRisk`
+    - `colors.backgroundBaseNeutral`
+    - `colors.backgroundBaseRisk`
+    - `colors.backgroundLightNeutral`
+    - `colors.backgroundLightRisk`
+    - `colors.backgroundFilledNeutral`
+    - `colors.backgroundFilledRisk`
+    - `colors.borderBaseNeutral`
+    - `colors.borderBaseRisk`
+    - `colors.borderStrongNeutral`
+    - `colors.borderStrongRisk`
 - Added semantic color variants `neutral` and `risk` for the following components: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `EuiButton` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `EuiButtonEmpty` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `EuiButtonIcon` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `EuiBadge` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `EuiIcon` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `EuiPanel` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `EuiButton`
+    - `EuiButtonEmpty`
+    - `EuiButtonIcon`
+    - `EuiBadge`
+    - `EuiIcon`
+    - `EuiPanel`
 - Aligned `EuiFormControlLayoutIcons` to the top (instead of center) to improve usability in multi-line form controls like `EuiComboBox` with many selected options ([#8610](https://github.com/elastic/eui/pull/8610))
 
 **Breaking changes**
 
 - Removed numbered severity color tokens: ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity0` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity1` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity2` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity3` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity4` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity5` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity6` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity7` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity8` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity9` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity10` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity11` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity12` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity13` ([#8601](https://github.com/elastic/eui/pull/8601))
-    - `colors.vis.euiColorSeverity14` ([#8601](https://github.com/elastic/eui/pull/8601))
+    - `colors.vis.euiColorSeverity0`
+    - `colors.vis.euiColorSeverity1`
+    - `colors.vis.euiColorSeverity2`
+    - `colors.vis.euiColorSeverity3`
+    - `colors.vis.euiColorSeverity4`
+    - `colors.vis.euiColorSeverity5`
+    - `colors.vis.euiColorSeverity6`
+    - `colors.vis.euiColorSeverity7`
+    - `colors.vis.euiColorSeverity8`
+    - `colors.vis.euiColorSeverity9`
+    - `colors.vis.euiColorSeverity10`
+    - `colors.vis.euiColorSeverity11`
+    - `colors.vis.euiColorSeverity12`
+    - `colors.vis.euiColorSeverity13`
+    - `colors.vis.euiColorSeverity14`
 
 **Accessibility**
 

--- a/packages/release-cli/src/update_changelog.ts
+++ b/packages/release-cli/src/update_changelog.ts
@@ -85,7 +85,7 @@ export const collateChangelogFiles = async (packageRootDir: string) => {
         let items = text.split(/\r?\n/).map((item) => {
           // Skip indented changelog items - they're presumably a child item providing more info, and don't need individual links
           // (depends on indentation: 2 or 4 spaces)
-          const isNestedChild = Array.isArray(item.match(/( ){2,}(-|\*)/));
+          const isNestedChild = /( ){2,}(-|\*)/.test(item);
 
           return isNestedChild ? item : `${item} ${pullRequestMarkdownLink}`;
         });

--- a/packages/release-cli/src/update_changelog.ts
+++ b/packages/release-cli/src/update_changelog.ts
@@ -13,14 +13,23 @@ import { rimraf } from 'rimraf';
 
 const CHANGELOGS_DIR_PATH = 'changelogs';
 
-type ChangelogGroupName = 'Features' | 'Bug fixes' | 'Deprecations' | 'Breaking changes' | string;
+type ChangelogGroupName =
+  | 'Features'
+  | 'Bug fixes'
+  | 'Deprecations'
+  | 'Breaking changes'
+  | string;
 export type ChangelogMap = Record<ChangelogGroupName, string[]>;
 
 /**
  * Convert individual changelog files into a single changelog string
  */
 export const collateChangelogFiles = async (packageRootDir: string) => {
-  const upcomingChangelogsDir = path.resolve(packageRootDir, CHANGELOGS_DIR_PATH, 'upcoming');
+  const upcomingChangelogsDir = path.resolve(
+    packageRootDir,
+    CHANGELOGS_DIR_PATH,
+    'upcoming'
+  );
 
   const upcomingChangelogMap: ChangelogMap = {
     Features: [],
@@ -73,10 +82,13 @@ export const collateChangelogFiles = async (packageRootDir: string) => {
 
       if (text) {
         // Split changelog text into discrete log items (if there are multiple) and append a PR link for each
-        let items = text.split(/\r?\n/).map((item) =>
+        let items = text.split(/\r?\n/).map((item) => {
           // Skip indented changelog items - they're presumably a child item providing more info, and don't need individual links
-          item.startsWith('  -') ? item : `${item} ${pullRequestMarkdownLink}`
-        );
+          // (depends on indentation: 2 or 4 spaces)
+          const isNestedChild = Array.isArray(item.match(/( ){2,}(-|\*)/));
+
+          return isNestedChild ? item : `${item} ${pullRequestMarkdownLink}`;
+        });
 
         if (!heading) {
           // No heading, so must be new features/enhancements only
@@ -117,13 +129,21 @@ export const collateChangelogFiles = async (packageRootDir: string) => {
 /**
  * Write to latest year's changelog file, delete individual upcoming changelog files, & stage changes
  */
-export const updateChangelogContent = async (packageRootDir: string, upcomingChangelog: string, version: string) => {
+export const updateChangelogContent = async (
+  packageRootDir: string,
+  upcomingChangelog: string,
+  version: string
+) => {
   if (!upcomingChangelog) {
     throw new Error('Cannot update changelog - no changes found');
   }
 
   const year = new Date().getUTCFullYear();
-  const pathToChangelog = path.resolve(packageRootDir, CHANGELOGS_DIR_PATH, `CHANGELOG_${year}.md`);
+  const pathToChangelog = path.resolve(
+    packageRootDir,
+    CHANGELOGS_DIR_PATH,
+    `CHANGELOG_${year}.md`
+  );
 
   let changelogArchive = '';
   try {
@@ -151,4 +171,4 @@ export const updateChangelogContent = async (packageRootDir: string, upcomingCha
 
 export const deleteObsoleteChangelogs = async (changelogFiles: string[]) => {
   return rimraf(changelogFiles);
-}
+};


### PR DESCRIPTION
## Summary

This PR updates the`update_changelog.ts` script in our `release-cli` package to ensure that nested children won't have a PR link attached. The parent bullet point will have the link, anything else that's nested is too verbose.

_output before the update_
![image](https://github.com/user-attachments/assets/1b13d050-11cb-4050-b61a-cdc21bb39811)

The update assumes that anything with +2 spaces followed by a `-` or  `*` is a nested item

_output after the update_

![Screenshot 2025-04-28 at 14 56 15](https://github.com/user-attachments/assets/3ba04de1-ea25-49bd-ba44-50588caf168a)

## QA

- [x] (manual QA) checkout this PR and:
  - add a changelog item in `packages/eui/changelogs/upcoming` that has nested items:
  
  ```
  - Testing multiple nested levels
    - level 1
        - level 2
            - level 3
    * level 1.1
  ```
  
  - make sure you're logged out from any registry: `yarn npm logout` and if needed `npm logout`
  - run a local npm registry with `docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio`
  - update the `.yarnrc.yml` with
  ```
  npmRegistryServer: "http://localhost:4873"
  unsafeHttpWhitelist:
    - localhost
    - "localhost:4873"
  ```
  - login to the local registry: `yarn npm login` (any user/pw works)
  - update `release.ts` in `packages/release-cli` to only run: `stepInitChecks` and `stepUpdateVersions`
  - update `updatete_versions.ts` to remove the check for `options.type === 'snapshot'`
  - update `isWorkingTreeClean` in `git_utils.ts` to return `true`
  - build the release-cli package: `yarn workspace @elastic/eui-release-cli run build`
  - run the snapshot release script: `yarn release run snapshot --workspaces @elastic/eui --allow-custom`
    - the script will show the local registry: `[warning] A custom npm registry server (http://localhost:4873) will be used!`
    - the `stepInitChecks` will required a `y/n` input - press `y`
- [x] verify the generated changelog did not add PR links to the nested children items
