### PR TITLE
Fix searching docs by component names

### DIFF
--- a/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch
+++ b/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch
@@ -43,7 +43,7 @@ index aaf552026d126c73b2e48ee671811ade25eeaf1e..3adf0a1ec2fefb52acc4040689650266
            keywords: d.keywords
          });
 diff --git a/src/theme/SearchBar/lunar-search.js b/src/theme/SearchBar/lunar-search.js
-index 241930959ec9813b6a9b93a29b431a03c7fd784c..8e2b42a717fb01c6cef698b20390262e34a552e9 100644
+index 241930959ec9813b6a9b93a29b431a03c7fd784c..401dd233427ff2aafc78eb836c0c0c40b64f0d5f 100644
 --- a/src/theme/SearchBar/lunar-search.js
 +++ b/src/theme/SearchBar/lunar-search.js
 @@ -23,16 +23,25 @@ class LunrSearchAdapter {
@@ -75,11 +75,3 @@ index 241930959ec9813b6a9b93a29b431a03c7fd784c..8e2b42a717fb01c6cef698b20390262e
              },
              url: doc.url,
              version: doc.version,
-@@ -123,6 +132,7 @@ class LunrSearchAdapter {
-     search(input) {
-         return new Promise((resolve, rej) => {
-             const results = this.getLunrResult(input);
-+            console.log(results);
-             const hits = [];
-             results.length > this.maxHits && (results.length = this.maxHits);
-             this.titleHitsRes = []

--- a/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch
+++ b/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch
@@ -1,0 +1,85 @@
+diff --git a/src/html-to-doc.js b/src/html-to-doc.js
+index 7f6bef1dc8b84a80679a6f8ca61fcbb264b91938..4b0c7b7d30e2905349ea8571392bd67955d86101 100644
+--- a/src/html-to-doc.js
++++ b/src/html-to-doc.js
+@@ -86,7 +86,7 @@ function* scanDocuments({ path, url }) {
+   for (const sectionDesc of sectionHeaders) {
+     const { title, content, ref, tagName } = sectionDesc
+     yield {
+-      title,
++      heading: title,
+       type: 1,
+       pageTitle,
+       url: `${url}#${ref}`,
+diff --git a/src/index.js b/src/index.js
+index aaf552026d126c73b2e48ee671811ade25eeaf1e..3adf0a1ec2fefb52acc404068965026606e25ee3 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -46,14 +46,15 @@ module.exports = function (context, options) {
+       if (meta.excludedCount) {
+         console.log(`docusaurus-lunr-search:: ${meta.excludedCount} documents were excluded from the search by excludeRoutes config`)
+       }
+-      
++
+       // Expose Lunr's fields configuration through docusaurus options.
+       // Fields are used to configure how Lunr treats different sources of search terms.
+       // This allows a user to boost the importance of certain fields over others.
+       const fields = {
+         title: { boost: 200, ...options.fields?.title },
+-        content: { boost: 2, ...options.fields?.content },
+-        keywords: { boost: 100, ...options.fields?.keywords },
++        heading: { boost: 20, ...options.fields?.heading },
++        keywords: { boost: 200, ...options.fields?.keywords },
++        content: { boost: 1, ...options.fields?.content },
+       };
+ 
+       const searchDocuments = []
+@@ -91,6 +92,7 @@ module.exports = function (context, options) {
+         lunrBuilder.add({
+           id: searchDocuments.length,
+           title: d.title,
++          heading: d.heading,
+           content: d.content,
+           keywords: d.keywords
+         });
+diff --git a/src/theme/SearchBar/lunar-search.js b/src/theme/SearchBar/lunar-search.js
+index 241930959ec9813b6a9b93a29b431a03c7fd784c..8e2b42a717fb01c6cef698b20390262e34a552e9 100644
+--- a/src/theme/SearchBar/lunar-search.js
++++ b/src/theme/SearchBar/lunar-search.js
+@@ -23,16 +23,25 @@ class LunrSearchAdapter {
+                 boost: 10
+             });
+             query.term(tokens, {
+-                wildcard: lunr.Query.wildcard.TRAILING
++                wildcard: lunr.Query.wildcard.LEADING | lunr.Query.wildcard.TRAILING
+             });
++
++            if (input.startsWith('eui')) {
++                const euiToken = lunr.tokenizer(input.substring(3));
++                query.term(euiToken, {
++                    fields: ['title', 'keywords'],
++                    boost: 50,
++                    wildcard: lunr.Query.wildcard.TRAILING
++                });
++            }
+         });
+     }
+ 
+     getHit(doc, formattedTitle, formattedContent) {
+         return {
+             hierarchy: {
+-                lvl0: doc.pageTitle || doc.title,
+-                lvl1: doc.type === 0 ? null : doc.title
++                lvl0: doc.type === 0 ? doc.title : doc.pageTitle,
++                lvl1: doc.type === 0 ? null : doc.heading
+             },
+             url: doc.url,
+             version: doc.version,
+@@ -123,6 +132,7 @@ class LunrSearchAdapter {
+     search(input) {
+         return new Promise((resolve, rej) => {
+             const results = this.getLunrResult(input);
++            console.log(results);
+             const hits = [];
+             results.length > this.maxHits && (results.length = this.maxHits);
+             this.titleHitsRes = []

--- a/packages/website/docs/components/containers/accordion.mdx
+++ b/packages/website/docs/components/containers/accordion.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiAccordion]
+---
+
 # Accordion
 
 **EuiAccordion** has been purposely designed with minimal styles, allowing you to visually enhance it as needed (see the accordion form example). The only styling enforced by EUI is the caret icon, which indicates to users that the item can be opened.

--- a/packages/website/docs/components/containers/bottom-bar.mdx
+++ b/packages/website/docs/components/containers/bottom-bar.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiBottomBar]
+---
+
 # Bottom bar
 
 :::tip

--- a/packages/website/docs/components/containers/card.mdx
+++ b/packages/website/docs/components/containers/card.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiCard, EuiCheckableCard]
+---
+
 # Card
 
 **EuiCard** is a content-oriented component built on top of [EuiPanel](../containers/panel/index.mdx). Be sure to check out the [guidelines for properly nesting panels](../containers/panel/index.mdx#nesting-panels).

--- a/packages/website/docs/components/containers/flyout/index.mdx
+++ b/packages/website/docs/components/containers/flyout/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiFlyoutFooter]
+---
+
 # Flyout
 
 **EuiFlyout** is a fixed position panel that pops in from the side of the window. It should be used to reveal more detailed contextual information or to provide complex forms without losing the user's current state. It is a good alternative to [modals](../modal/index.mdx) when the action is not transient.

--- a/packages/website/docs/components/containers/modal/index.mdx
+++ b/packages/website/docs/components/containers/modal/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: /containers/modal
 id: containers_modal
+keywords: [EuiModal, EuiModalBody, EuiModalFooter, EuiModalHeader, EuiModalHeaderTitle, EuiConfirmModal]
 ---
 
 # Modal

--- a/packages/website/docs/components/containers/panel/index.mdx
+++ b/packages/website/docs/components/containers/panel/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiPanel, EuiSplitPanel]
+---
+
 # Panel
 
 **EuiPanel** is a building block component. Use it as a layout helper for containing content. It is also commonly used as a base for other larger components like [EuiPage](../../templates/page-template/index.mdx), [EuiPopover](../popover.mdx) and [EuiCard](../card.mdx).

--- a/packages/website/docs/components/containers/popover.mdx
+++ b/packages/website/docs/components/containers/popover.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiPopover, EuiPopoverTitle, EuiPopoverFooter]
+---
+
 # Popover
 
 Use the **EuiPopover** component to hide controls or options behind a clickable element. A popover is temporary so keep tasks simple and narrowly focused.

--- a/packages/website/docs/components/containers/resizable-container.mdx
+++ b/packages/website/docs/components/containers/resizable-container.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiResizableContainer]
+---
+
 # Resizable container
 
 import { faker } from '@faker-js/faker';

--- a/packages/website/docs/components/containers/tabs/index.mdx
+++ b/packages/website/docs/components/containers/tabs/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiTabs, EuiTab]
+---
+
 # Tabs
 
 Use tabs to organize related but unique content for a single idea or subject. Tabs show and hide content using **in-page** navigation UI.

--- a/packages/website/docs/components/display/aspect-ratio.mdx
+++ b/packages/website/docs/components/display/aspect-ratio.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiAspectRatio]
+---
+
 # Aspect ratio
 
 :::warning

--- a/packages/website/docs/components/display/avatar.mdx
+++ b/packages/website/docs/components/display/avatar.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiAvatar]
+---
+
 # Avatar
 
 The **EuiAvatar** component typically creates a user icon. It will accept `name` (required) and `image` props and will configure the display and accessibility as needed. By default, the background colors come from the set of colors used for visualizations. Otherwise you can pass a hex value to the `color` prop.

--- a/packages/website/docs/components/display/badge/index.mdx
+++ b/packages/website/docs/components/display/badge/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiBadge, EuiBetaBadge, EuiNotificationBadge]
+---
+
 # Badge
 
 **EuiBadges** are used to focus on important bits of information. Although they will automatically space themselves if you use them in a repetitive fashion it is good form to wrap them using a **EuiBadgeGroup** so that they will wrap when width is constrained (as seen below).

--- a/packages/website/docs/components/display/beacon.mdx
+++ b/packages/website/docs/components/display/beacon.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiBeacon]
+---
+
 # Beacon
 
 Use the `EuiBeacon` component to draw visual attention to a specific location or element.

--- a/packages/website/docs/components/display/callout.mdx
+++ b/packages/website/docs/components/display/callout.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiCallOut]
+---
+
 # Callout
 
 **EuiCallOut** is used to display important messages directly related to content on the page.

--- a/packages/website/docs/components/display/code.mdx
+++ b/packages/website/docs/components/display/code.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiCode, EuiCodeBlock]
+---
+
 # Code
 
 import Link from '@docusaurus/Link';

--- a/packages/website/docs/components/display/comment-list/index.mdx
+++ b/packages/website/docs/components/display/comment-list/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiCommentList, EuiComment]
+---
+
 # Comment list
 
 The **EuiCommentList** is a timeline component built on top of [EuiTimeline](../timeline.mdx). It allows you to display comments or logged actions that either a user or a system has performed.

--- a/packages/website/docs/components/display/description-list.mdx
+++ b/packages/website/docs/components/display/description-list.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiDescriptionList, EuiDescriptionListTitle, EuiDescriptionListDescription]
+---
+
 # Description list
 
 **EuiDescriptionList** is a component for listing pairs of information together. You can use the component on its own, passing in an object for the list.

--- a/packages/website/docs/components/display/drag-and-drop.mdx
+++ b/packages/website/docs/components/display/drag-and-drop.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiDragDropContext, EuiDroppable, EuiDraggable]
+---
+
 # Drag and drop
 
 An extension of [@hello-pangea/dnd](https://github.com/hello-pangea/dnd) (which is an actively maintained fork of [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd)) with a compatible API and built-in style opinions. Functionality results from 3 components working together:

--- a/packages/website/docs/components/display/empty-prompt/index.mdx
+++ b/packages/website/docs/components/display/empty-prompt/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiEmptyPrompt]
+---
+
 # Empty prompt
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/packages/website/docs/components/display/health.mdx
+++ b/packages/website/docs/components/display/health.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiHealth]
+---
+
 # Health
 
 The **EuiHealth** component should be used when showing comparative health of listed objects (like servers, HTTP response status codes(as per convenience), nodes, indexes..etc). Because icons are vague and bulky and color alone does not work, color plus text provides a recognizable, lightweight combo that works in most situations.

--- a/packages/website/docs/components/display/icons/index.mdx
+++ b/packages/website/docs/components/display/icons/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiIcon]
+---
+
 # Icons
 
 import { EuiCodeBlock, EuiSpacer, EuiSplitPanel, EuiToken } from '@elastic/eui';

--- a/packages/website/docs/components/display/image.mdx
+++ b/packages/website/docs/components/display/image.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiImage]
+---
+
 # Image
 
 Use **EuiImage** when you need to place a static image into a page with an optional caption.

--- a/packages/website/docs/components/display/list-group.mdx
+++ b/packages/website/docs/components/display/list-group.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiListGroup, EuiListGroupItem]
+---
+
 # List group
 
 The **EuiListGroup** component is used to present **EuiListGroupItems** in a neatly formatted list. Use the `flush` and `bordered` properties for full-width and bordered presentations, respectively.

--- a/packages/website/docs/components/display/loading.mdx
+++ b/packages/website/docs/components/display/loading.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiLoadingElastic, EuiLoadingLogo, EuiLoadingChart, EuiLoadingSpinner]
+---
+
 # Loading
 
 Use loading indicators sparingly and opt for showing actual [progress](./progress.mdx#progress-with-values) over infinite spinners. It is ok to use multiple loaders on a page if each section is progressively loaded. However, if the entire page is loaded at once, use a single, larger loading indicator.

--- a/packages/website/docs/components/display/progress.mdx
+++ b/packages/website/docs/components/display/progress.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiProgress]
+---
+
 # Progress
 
 The **EuiProgress** component by default will display in an indeterminate loading state (rendered as a single div) until you define a `max` and `value` prop. The `size` prop refers to its vertical height. It will always stretch `100%` to its container.

--- a/packages/website/docs/components/display/skeleton.mdx
+++ b/packages/website/docs/components/display/skeleton.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiSkeletonText, EuiSkeletonTitle, EuiSkeletonCircle, EuiSkeletonRectangle, EuiSkeletonLoading]
+---
+
 # Skeleton
 
 The **EuiSkeleton** components are placeholder components for content which has yet to load. They provide meaningful previews, avoid layout content shifts, and add accessible announcements to screen readers when content is done loading.

--- a/packages/website/docs/components/display/stat.mdx
+++ b/packages/website/docs/components/display/stat.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiStat]
+---
+
 # Stat
 
 **EuiStat** can be used to display prominent text or number values. It consists of `title`and `description` elements with several visual styling properties (examples below).

--- a/packages/website/docs/components/display/text.mdx
+++ b/packages/website/docs/components/display/text.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiText]
+---
+
 # Text
 
 **EuiText** is a generic catchall wrapper that will apply our standard typography styling and spacing to naked HTML. Because of its forced styles, it **only accepts raw XHTML**.

--- a/packages/website/docs/components/display/timeline.mdx
+++ b/packages/website/docs/components/display/timeline.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiTimeline]
+---
+
 # Timeline
 
 The **EuiTimeline** component standardizes the way a timeline thread is displayed. Pass an array of **EuiTimelineItem** objects and **EuiTimeline** will generate a timeline thread.

--- a/packages/website/docs/components/display/title.mdx
+++ b/packages/website/docs/components/display/title.mdx
@@ -1,4 +1,6 @@
-# Title
+---
+keywords: [EuiTitle]
+---
 
 # Title
 

--- a/packages/website/docs/components/display/toast/index.mdx
+++ b/packages/website/docs/components/display/toast/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiToast, EuiGlobalToastList]
+---
+
 # Toast
 
 import previewWrapper from './_preview_wrapper';

--- a/packages/website/docs/components/display/tooltip.mdx
+++ b/packages/website/docs/components/display/tooltip.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiToolTip]
+---
+
 # Tooltip
 
 Generally, tooltips should provide short, **non-essential**, contextual information, usually naming or describing with more detail. If you need interactive content or anything other than text, we recommend using [EuiPopover](../containers/popover.mdx) instead.

--- a/packages/website/docs/components/display/tour/index.mdx
+++ b/packages/website/docs/components/display/tour/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiTour, EuiTourStep, useEuiTour]
+---
+
 # Tour
 
 The tour components provided by EUI allow for a flexible and customizable way to showcase items on a page in an ordered manner by augmenting existing elements on the page without altering functionality.

--- a/packages/website/docs/components/editors-and-syntax/markdown/editor.mdx
+++ b/packages/website/docs/components/editors-and-syntax/markdown/editor.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiMarkdownEditor]
+---
+
 # Editor
 
 **EuiMarkdownEditor** provides a markdown authoring experience for the user. The component consists of a toolbar, text area, and a drag-and-drop zone to accept files (if configured to do so). There are two modes: a textarea that keeps track of cursor position, and a rendered preview mode that is powered by [EuiMarkdownFormat](./format.mdx). State is maintained between the two and it is possible to pass changes from the preview area to the textarea and vice versa.

--- a/packages/website/docs/components/editors-and-syntax/markdown/format.mdx
+++ b/packages/website/docs/components/editors-and-syntax/markdown/format.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiMarkdownFormat]
+---
+
 # Format
 
 **EuiMarkdownFormat** is a read-only way to render markdown-style content in a page. It is a peer component to [EuiMarkdownEditor](./editor.mdx) and has the ability to be modified by additional [markdown plugins](./plugins.mdx).

--- a/packages/website/docs/components/forms/date-and-time/auto-refresh.mdx
+++ b/packages/website/docs/components/forms/date-and-time/auto-refresh.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+keywords: [EuiAutoRefresh, EuiAutoRefreshButton]
 ---
 
 # Auto refresh

--- a/packages/website/docs/components/forms/date-and-time/date-picker-range.mdx
+++ b/packages/website/docs/components/forms/date-and-time/date-picker-range.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiDatePickerRange]
 ---
 
 # Date picker range

--- a/packages/website/docs/components/forms/date-and-time/date-picker.mdx
+++ b/packages/website/docs/components/forms/date-and-time/date-picker.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+keywords: [EuiDatePicker]
 ---
 
 # Date picker

--- a/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
+++ b/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiSuperDatePicker]
 ---
 
 # Super date picker

--- a/packages/website/docs/components/forms/layouts/controls.mdx
+++ b/packages/website/docs/components/forms/layouts/controls.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+keywords: [EuiFormControlLayout, EuiFormControlLayoutDelimited]
 ---
 
 # Form control layouts

--- a/packages/website/docs/components/forms/layouts/described-groups.mdx
+++ b/packages/website/docs/components/forms/layouts/described-groups.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiDescribedFormGroup]
 ---
 
 # Described form groups

--- a/packages/website/docs/components/forms/layouts/row.mdx
+++ b/packages/website/docs/components/forms/layouts/row.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiFormRow]
 ---
 
 # Form rows

--- a/packages/website/docs/components/forms/numeric/basic.mdx
+++ b/packages/website/docs/components/forms/numeric/basic.mdx
@@ -1,6 +1,7 @@
 ---
 slug: .
 sidebar_label: Number
+keywords: [EuiFieldNumber]
 ---
 
 # Basic number field

--- a/packages/website/docs/components/forms/numeric/range-sliders.mdx
+++ b/packages/website/docs/components/forms/numeric/range-sliders.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiRange, EuiDualRange]
+---
+
 # Range sliders
 
 :::tip Understanding precision

--- a/packages/website/docs/components/forms/other/color-picker.mdx
+++ b/packages/website/docs/components/forms/other/color-picker.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiColorPicker]
 ---
 
 # Color picker

--- a/packages/website/docs/components/forms/other/file-picker.mdx
+++ b/packages/website/docs/components/forms/other/file-picker.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+keywords: [EuiFilePicker]
 ---
 
 # File picker

--- a/packages/website/docs/components/forms/other/palette-picker.mdx
+++ b/packages/website/docs/components/forms/other/palette-picker.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiColorPalettePicker, EuiColorPaletteDisplay]
 ---
 
 # Color palette picker

--- a/packages/website/docs/components/forms/search-and-filter/expression.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/expression.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+keywords: [EuiExpression]
 ---
 
 # Expression

--- a/packages/website/docs/components/forms/search-and-filter/filter-group.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/filter-group.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiFilterGroup]
 ---
 
 # Filter group

--- a/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiSearchBar]
 ---
 
 # Search bar

--- a/packages/website/docs/components/forms/search-and-filter/search.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: Search
+keywords: [EuiFieldSearch]
 ---
 
 # Basic search field

--- a/packages/website/docs/components/forms/selection/checkboxes-and-radios/index.mdx
+++ b/packages/website/docs/components/forms/selection/checkboxes-and-radios/index.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiCheckbox, EuiCheckboxGroup, EuiRadio, EuiRadioGroup]
 ---
 
 # Checkboxes and radios

--- a/packages/website/docs/components/forms/selection/checkboxes-and-radios/switch.mdx
+++ b/packages/website/docs/components/forms/selection/checkboxes-and-radios/switch.mdx
@@ -1,6 +1,7 @@
 ---
 slug: /forms/selection/checkboxes-and-radios/switch
 id: forms_selection_switch
+keywords: [EuiSwitch]
 ---
 
 # Switches

--- a/packages/website/docs/components/forms/selection/combo-box.mdx
+++ b/packages/website/docs/components/forms/selection/combo-box.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+keywords: [EuiComboBox]
 ---
 
 # Combo box

--- a/packages/website/docs/components/forms/selection/select.mdx
+++ b/packages/website/docs/components/forms/selection/select.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiSelect]
 ---
 
 # Basic select

--- a/packages/website/docs/components/forms/selection/selectable.mdx
+++ b/packages/website/docs/components/forms/selection/selectable.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+keywords: [EuiSelectable, EuiSelectableOption]
 ---
 
 # Selectable

--- a/packages/website/docs/components/forms/selection/super-select.mdx
+++ b/packages/website/docs/components/forms/selection/super-select.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+keywords: [EuiSuperSelect]
 ---
 
 # Super select

--- a/packages/website/docs/components/forms/text/basic.mdx
+++ b/packages/website/docs/components/forms/text/basic.mdx
@@ -1,6 +1,7 @@
 ---
 slug: .
 sidebar_label: Text
+keywords: [EuiFieldText, EuiTextArea]
 ---
 
 # Basic text controls

--- a/packages/website/docs/components/forms/text/inline-edit.mdx
+++ b/packages/website/docs/components/forms/text/inline-edit.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiInlineEdit, EuiInlineEditText, EuiInlineEditTitle]
+---
+
 # Inline edit
 
 The **EuiInlineEdit** components are useful for updating single lines of text outside a form. The component has two states: `readMode` shows editable text inside of a button and `editMode` displays a form control to update the text.

--- a/packages/website/docs/components/forms/text/password.mdx
+++ b/packages/website/docs/components/forms/text/password.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiFieldPassword]
+---
+
 # Password field
 
 import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';

--- a/packages/website/docs/components/layout/flex/grid.mdx
+++ b/packages/website/docs/components/layout/flex/grid.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiFlexGrid]
 ---
 
 # Flex grids

--- a/packages/website/docs/components/layout/flex/group.mdx
+++ b/packages/website/docs/components/layout/flex/group.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+keywords: [EuiFlexGroup]
 ---
 
 # Flex groups

--- a/packages/website/docs/components/layout/flex/item.mdx
+++ b/packages/website/docs/components/layout/flex/item.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiFlexItem]
 ---
 
 # Flex items

--- a/packages/website/docs/components/layout/header.mdx
+++ b/packages/website/docs/components/layout/header.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiHeader, EuiHeaderSection, EuiHeaderSectionItem, EuiHeaderSectionItemButton, EuiHeaderLogo, EuiHeaderBreadcrumbs]
+---
+
 # Header
 
 import Link from '@docusaurus/Link';

--- a/packages/website/docs/components/layout/horizontal-rule.mdx
+++ b/packages/website/docs/components/layout/horizontal-rule.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiHorizontalRule]
+---
+
 # Horizontal rule
 
 **EuiHorizontalRule** is a styled `<hr>` element. It can be one of three provided sizes (lengths), by default it will be `full`.

--- a/packages/website/docs/components/layout/page-header.mdx
+++ b/packages/website/docs/components/layout/page-header.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiPageHeader]
+---
+
 # Page header
 
 While the **EuiPageHeader** component can be placed anywhere within your page layout, we recommend using it within the [EuiPageTemplate](../templates/page-template/index.mdx) component by passing the configuration props as its `pageHeader`.

--- a/packages/website/docs/components/layout/page_components/index.mdx
+++ b/packages/website/docs/components/layout/page_components/index.mdx
@@ -1,6 +1,7 @@
 ---
 slug: /layout/page-components
 id: layout_page_components_overview
+keywords: [EuiPageBody, EuiPageSection, EuiPageSidebar, EuiPageHeader, EuiPageTitle]
 ---
 
 # Page components
@@ -207,7 +208,7 @@ Reminder: [EuiPageTemplate](../../templates/page-template/index.mdx) can handle 
   ```tsx
   import React, { ReactElement, useState } from 'react';
   import { css } from '@emotion/react';
-  
+
   import {
     EuiEmptyPrompt,
     EuiFlexGroup,

--- a/packages/website/docs/components/layout/spacer/index.mdx
+++ b/packages/website/docs/components/layout/spacer/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiSpacer]
+---
+
 # Spacer
 
 The **EuiSpacer** component is for adding vertical space between items and should be used in place of the `<br />` tag. There are many different heights you can specify via the `size` prop which align to the EUI vertical grid sizing.

--- a/packages/website/docs/components/navigation/breadcrumbs.mdx
+++ b/packages/website/docs/components/navigation/breadcrumbs.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiBreadcrumbs, EuiBreadcrumb]
+---
+
 # Breadcrumbs
 
 **EuiBreadcrumbs** let the user track their progress within and back out of a UX flow and work well when used in combination with [EuiPageHeader](../layout/page-header.mdx). They are meant to be used at lower page level flows, while [EuiHeaderBreadcrumbs](../layout/header.mdx) should be used for application-wide navigation.

--- a/packages/website/docs/components/navigation/buttons/button.mdx
+++ b/packages/website/docs/components/navigation/buttons/button.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+keywords: [EuiButton]
 ---
 
 # Button

--- a/packages/website/docs/components/navigation/buttons/empty.mdx
+++ b/packages/website/docs/components/navigation/buttons/empty.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiButtonEmpty]
 ---
 
 # Empty button

--- a/packages/website/docs/components/navigation/buttons/group.mdx
+++ b/packages/website/docs/components/navigation/buttons/group.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+keywords: [EuiButtonGroup]
 ---
 
 # Button group

--- a/packages/website/docs/components/navigation/buttons/icon.mdx
+++ b/packages/website/docs/components/navigation/buttons/icon.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiButtonIcon]
 ---
 
 # Icon button

--- a/packages/website/docs/components/navigation/collapsible-nav.mdx
+++ b/packages/website/docs/components/navigation/collapsible-nav.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiCollapsibleNav, EuiCollapsibleNavGroup]
+---
+
 # Collapsible nav
 
 This is a high level component that creates a flyout-style navigational pane.

--- a/packages/website/docs/components/navigation/context-menu.mdx
+++ b/packages/website/docs/components/navigation/context-menu.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiContextMenu, EuiContextMenuPanel, EuiContextMenuItem]
+---
+
 # Context menu
 
 **EuiContextMenu** is a nested menu system useful for navigating complicated trees. It lives within an [EuiPopover](../containers/popover.mdx) which itself can be wrapped around any component (like a button in this example).

--- a/packages/website/docs/components/navigation/facet.mdx
+++ b/packages/website/docs/components/navigation/facet.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiFacetButton, EuiFacetGroup]
+---
+
 # Facet
 
 **EuiFacetButtons** are to be used when allowing lists with multiple search params to be filtered down by these particular params. They allow for an `icon` node and/or `quantity` to be passed. You can also indicate the current selection with `isSelected`. Other props include `isDisabled` and `isLoading` (which will swap the quantity indicator with a loading icon).

--- a/packages/website/docs/components/navigation/key-pad-menu.mdx
+++ b/packages/website/docs/components/navigation/key-pad-menu.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiKeyPadMenu, EuiKeyPadMenuItem]
+---
+
 # Key pad menu
 
 The **EuiKeyPadMenu** component presents **EuiKeyPadMenuItems** in a tiled format, with a fixed width which will accommodate three items and then wrap.

--- a/packages/website/docs/components/navigation/link.mdx
+++ b/packages/website/docs/components/navigation/link.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiLink]
+---
+
 # Link
 
 **EuiLink** is any anchor or button element that is designed to display nicely within a block of text. It also provides more anchor-specific styling onto links and makes sure they are accessible.

--- a/packages/website/docs/components/navigation/pagination/index.mdx
+++ b/packages/website/docs/components/navigation/pagination/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiPagination]
+---
+
 # Pagination
 
 Some EUI components have pagination built-in, like [EuiBasicTable](../../tabular-content/tables/basic.mdx), but for custom built paginated interfaces you can use **EuiPagination** manually.

--- a/packages/website/docs/components/navigation/side-nav.mdx
+++ b/packages/website/docs/components/navigation/side-nav.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiSideNav]
+---
+
 # Side nav
 
 **EuiSideNav** is a responsive menu system that usually sits on the left side of a page layout. It will expand to the width of its container. This is the same menu system used for the EUI documentation.

--- a/packages/website/docs/components/navigation/steps/index.mdx
+++ b/packages/website/docs/components/navigation/steps/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiSteps, EuiStepsHorizontal]
+---
+
 # Steps
 
 **EuiSteps** presents procedural content in a numbered outline format. It is best used when presenting instructional content that must be conducted in a particular order. It requires a `title` and `children` to be present and will automatically increment the step number based on the initial `firstStepNumber`.

--- a/packages/website/docs/components/navigation/tree-view.mdx
+++ b/packages/website/docs/components/navigation/tree-view.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiTreeView]
+---
+
 # Tree view
 
 **EuiTreeView** allows you to render recursive objects, such as a file directory. It is not meant to be used as primary navigation, for that we recommend using [EuiSideNav](./side-nav.mdx).

--- a/packages/website/docs/components/tabular-content/data-grid/data-grid.mdx
+++ b/packages/website/docs/components/tabular-content/data-grid/data-grid.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiDataGrid]
+---
+
 # Data grid
 
 **EuiDataGrid** is for displaying large amounts of tabular data. It is a better choice over [EUI tables](../tables/index.mdx) when there are many columns, the data in those columns is fairly uniform, and when schemas and sorting are important for comparison. Although it is similar to traditional spreedsheet software, EuiDataGrid's current strengths are in rendering rather than creating content.

--- a/packages/website/docs/components/tabular-content/tables/basic.mdx
+++ b/packages/website/docs/components/tabular-content/tables/basic.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+keywords: [EuiBasicTable]
 ---
 
 # Basic tables

--- a/packages/website/docs/components/tabular-content/tables/custom.mdx
+++ b/packages/website/docs/components/tabular-content/tables/custom.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+keywords: [EuiTable, EuiTableBody, EuiTableFooter, EuiTableFooterCell, EuiTableHeader, EuiTableHeaderCell, EuiTableHeaderCellCheckbox, EuiTablePagination, EuiTableRow, EuiTableRowCell, EuiTableRowCellCheckbox,]
 ---
 
 # Custom tables

--- a/packages/website/docs/components/tabular-content/tables/in-memory.mdx
+++ b/packages/website/docs/components/tabular-content/tables/in-memory.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+keywords: [EuiInMemoryTable]
 ---
 
 # In-memory tables

--- a/packages/website/docs/components/templates/page-template/index.mdx
+++ b/packages/website/docs/components/templates/page-template/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiPageTemplate]
+---
+
 # Page template
 
 **EuiPageTemplate** is a namespaced component for creating the different types of page layout patterns described in these docs. It is somewhat opinionated, but still has the ability to customize most of the inner components directly on their instance.

--- a/packages/website/docs/components/templates/sitewide-search/index.mdx
+++ b/packages/website/docs/components/templates/sitewide-search/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiSelectableTemplateSitewide]
+---
+
 # Sitewide search
 
 **EuiSelectableTemplateSitewide** is an opinionated wrapper around [EuiSelectable](../../forms/selection/selectable.mdx) to provide a reusable template across the Elastic products that will share the same global search capabilities. It creates the search input that triggers a popover containing the list of options.

--- a/packages/website/docs/utilities/accessibility/index.mdx
+++ b/packages/website/docs/utilities/accessibility/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiScreenReaderOnly, EuiScreenReaderLive, EuiSkipLink]
+---
+
 # Accessibility
 
 import { Example } from '@site/src/components';

--- a/packages/website/docs/utilities/auto-sizer.mdx
+++ b/packages/website/docs/utilities/auto-sizer.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiAutoSizer]
+---
+
 # Auto sizer
 
 `EuiAutoSizer` helps components that use virtualized rendering and/or require explicit dimensions to fill all available space in the parent container. See the [react-virtualized AutoSizer](https://github.com/bvaughn/react-virtualized/blob/master/docs/AutoSizer.md) documentation as `EuiAutoSizer` is a passthrough component for `AutoSizer`.

--- a/packages/website/docs/utilities/copy.mdx
+++ b/packages/website/docs/utilities/copy.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiCopy]
+---
+
 # Copy
 
 The **EuiCopy** component is a utility for copying text to clipboard. Wrap a function that returns a component. The first argument will be a `copy` function.

--- a/packages/website/docs/utilities/delay.mdx
+++ b/packages/website/docs/utilities/delay.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiDelayRender]
+---
+
 # Delay
 
 ## Delay render

--- a/packages/website/docs/utilities/error-boundary.mdx
+++ b/packages/website/docs/utilities/error-boundary.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiErrorBoundary]
+---
+
 # Error boundary
 
 Use **EuiErrorBoundary** to prevent errors from taking down the entire app.

--- a/packages/website/docs/utilities/focus-trap/index.mdx
+++ b/packages/website/docs/utilities/focus-trap/index.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiFocusTrap]
+---
+
 # Focus trap
 
 Use **EuiFocusTrap** to prevent keyboard-initiated focus from leaving a defined area. Temporary flows and UX escapes that occur in components such as [EuiModal](../../components/containers/modal/index.mdx) and [EuiFlyout](../../components/containers/flyout/index.mdx) are prime examples.

--- a/packages/website/docs/utilities/highlight-and-mark.mdx
+++ b/packages/website/docs/utilities/highlight-and-mark.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiHighlight, EuiMark]
+---
+
 # Highlight and mark
 
 ## Highlight

--- a/packages/website/docs/utilities/html-id-generator.mdx
+++ b/packages/website/docs/utilities/html-id-generator.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [htmlIdGenerator]
+---
+
 # HTML ID generator
 
 Use `htmlIdGenerator()()` to generate unique IDs for elements with an optional `prefix` and/or `suffix`. The first call to `htmlIdGenerator` accepts the prefix as an optional argument and returns a second function which accepts an optional suffix and returns the generated ID.

--- a/packages/website/docs/utilities/i18n.mdx
+++ b/packages/website/docs/utilities/i18n.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiI18n, useEuiI18n]
+---
+
 # I18n
 
 Translations for EUI components can be provided globally in an application via [EuiContext, documented below](#context). All available `tokens` —also usually called ids— can be found in [this automatically generated JSON file](https://github.com/elastic/eui/blob/main/packages/eui/i18ntokens.json).

--- a/packages/website/docs/utilities/inner-text.mdx
+++ b/packages/website/docs/utilities/inner-text.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiInnerText, useInnerText]
+---
+
 # Inner text
 
 For instances where accessing the text content of a component that may be wrapped or interspersed with other components, two utilities are available:

--- a/packages/website/docs/utilities/mutation-observer.mdx
+++ b/packages/website/docs/utilities/mutation-observer.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiMutationObserver]
+---
+
 # Mutation observer
 
 **EuiMutationObserver** is a wrapper around the <a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver" target="_blank" rel="noopener noreferrer">Mutation Observer API</a> which allows watching for DOM changes to elements and their children. **EuiMutationObserver** takes the same configuration object as the browser API to describe what to watch for, and fires the callback when that mutation happens.

--- a/packages/website/docs/utilities/outside-click-detector.mdx
+++ b/packages/website/docs/utilities/outside-click-detector.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiOutsideClickDetector]
+---
+
 # Outside click detector
 
 Use **EuiOutsideClickDetector** to trigger a handler when the user clicks outside of the child element.

--- a/packages/website/docs/utilities/overlay-mask.mdx
+++ b/packages/website/docs/utilities/overlay-mask.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiOverlayMask]
+---
+
 # Overlay mask
 
 **EuiOverlayMask** is simply a display component used to obscure the main content to bring attention to its children or other content. It is best used in conjunction with hyper-focus content areas like [modals](../components/containers/modal/index.mdx) and [flyouts](../components/containers/flyout/index.mdx).

--- a/packages/website/docs/utilities/portal.mdx
+++ b/packages/website/docs/utilities/portal.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiPortal]
+---
+
 # Portal
 
 **EuiPortal** allows you to append its contained children onto the document body. It is useful for moving fixed elements like modals, tooltips or toasts when you are worried about a z-index or overflow conflict.

--- a/packages/website/docs/utilities/pretty-duration.mdx
+++ b/packages/website/docs/utilities/pretty-duration.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [usePrettyDuration]
+---
+
 # Pretty duration
 
 Use the `<PrettyDuration />` component (for JSX display) or `usePrettyDuration()` hook (for attribute strings) to convert a start and end date string to a human-friendly format. Both utilities take the following props:

--- a/packages/website/docs/utilities/provider.mdx
+++ b/packages/website/docs/utilities/provider.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiProvider]
+---
+
 # Provider
 
 import { EuiBetaBadge, EuiSpacer } from '@elastic/eui';

--- a/packages/website/docs/utilities/resize-observer.mdx
+++ b/packages/website/docs/utilities/resize-observer.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiResizeObserver]
+---
+
 # Resize observer
 
 **EuiResizeObserver** is a wrapper around the <a href="https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver" target="_blank" rel="noopener noreferrer">**Resizer Observer API**</a> which allows watching for changes to the content rectangle of DOM elements. Unlike [EuiMutationObserver](./mutation-observer.mdx), **EuiResizeObserver** does not take parameters, but it does fire a more efficient and informative callback when resize events occur.

--- a/packages/website/docs/utilities/text-diff.mdx
+++ b/packages/website/docs/utilities/text-diff.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [useEuiTextDiff]
+---
+
 # Text diff
 
 The hook, useEuiTextDiff, generates a set of changes between two strings. It returns both React elements for displaying the diff and an object representing the identified changes. The timeout prop is used to set how many seconds any diff's exploration phase may take. The default value is 0.1, a value of 0 disables the timeout and lets diff run until completion. The higher the timeout, the more detailed the comparison.

--- a/packages/website/docs/utilities/text-truncation.mdx
+++ b/packages/website/docs/utilities/text-truncation.mdx
@@ -1,3 +1,7 @@
+---
+keywords: [EuiTextTruncate]
+---
+
 # Text truncation
 
 import { throttle } from 'lodash';

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -77,44 +77,19 @@ const config: Config = {
       'docusaurus-lunr-search',
       {
         disableVersioning: true, // We don't use docusaurus docs versioning
-        /*
-         * Configure lunr fields to increase search boost on page titles.
-         *
-         * There are two types of `title` fields indexed under the same `title`
-         * name. One is the actual page titles (h1 tags) with no other
-         * `content` and the other is other headings (h2 and h3 tags) with
-         * the `content` field pointing to that section's text content.
-         *
-         * Since we don't have access to the internal `type` property that
-         * distinguishes these two, we distinguish these by the `content`
-         * field.
-         */
         fields: {
-          // Page titles (h1 tags)
           title: {
-            boost: 20,
+            // We need high enough boost to ensure titles are prioritized
+            // even if it's not a 100% match.
+            // lunr scoring logic seems to be very picky about that
+            boost: 200,
             extractor(doc) {
-              if (doc.content.trim().length) {
-                return null;
-              }
-
-              return doc.title;
+              // We need to include keywords in the title field/index
+              // to boost their importance when searching.
+              // They're not rendered in search results
+              return `${doc.title}${doc.keywords ? ` ${doc.keywords}` : ''}`;
             },
           },
-          // We can't create new fields, so reusing the defined keywords
-          // field seems like the next best thing.
-          // This makes `keywords` the h2 and h3 headings
-          keywords: {
-            boost: 3,
-            extractor(doc) {
-              if (doc.content.trim().length) {
-                return doc.title;
-              }
-
-              return null;
-            },
-          },
-          // No boost to other content (page body)
           content: { boost: 1 },
         },
       },

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.5.1",
     "clsx": "^2.0.0",
     "cross-env": "^7.0.3",
-    "docusaurus-lunr-search": "^3.6.1",
+    "docusaurus-lunr-search": "patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch",
     "hast-util-is-element": "1.1.0",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19440,7 +19440,7 @@ __metadata:
 
 "docusaurus-lunr-search@patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch":
   version: 3.6.1
-  resolution: "docusaurus-lunr-search@patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch::version=3.6.1&hash=b9cdf8"
+  resolution: "docusaurus-lunr-search@patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch::version=3.6.1&hash=945fef"
   dependencies:
     autocomplete.js: "npm:^0.37.1"
     clsx: "npm:^2.1.1"
@@ -19460,7 +19460,7 @@ __metadata:
     "@docusaurus/core": ^2.0.0-alpha.60 || ^2.0.0 || ^3.0.0
     react: ^16.8.4 || ^17 || ^18 || ^19
     react-dom: ^16.8.4 || ^17 || ^18 || ^19
-  checksum: 10c0/d0f781ea4db7e104e3be3cda37ff546c7c305f0d56dab4fc96b5feaeada824b202b4a311895bfef5a7bc633e755df39b5e903d92c3a8f409e1307fdfc74c57f4
+  checksum: 10c0/0baf4e27243dd84fd98ef160339e22cac23fd5e6d744798cf7f25a01c800756705e95b597df9366695913bc84cf78fbd8cf92d9b1c2a9cd55cf77f4b50a16b06
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7280,7 +7280,7 @@ __metadata:
     clsx: "npm:^2.0.0"
     cross-env: "npm:^7.0.3"
     cspell: "npm:^8.17.5"
-    docusaurus-lunr-search: "npm:^3.6.1"
+    docusaurus-lunr-search: "patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch"
     hast-util-is-element: "npm:1.1.0"
     lodash: "npm:^4.17.21"
     moment: "npm:^2.30.1"
@@ -19412,7 +19412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-lunr-search@npm:^3.6.1":
+"docusaurus-lunr-search@npm:3.6.1":
   version: 3.6.1
   resolution: "docusaurus-lunr-search@npm:3.6.1"
   dependencies:
@@ -19435,6 +19435,32 @@ __metadata:
     react: ^16.8.4 || ^17 || ^18 || ^19
     react-dom: ^16.8.4 || ^17 || ^18 || ^19
   checksum: 10c0/89962e2a8004bac0fa0999cd189c05ee0b34a4268c038f10db62d5ec41de89d9b672375832a21d93776d277c4a14bc022a717dffdc7a85048255969cc0eeb583
+  languageName: node
+  linkType: hard
+
+"docusaurus-lunr-search@patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch":
+  version: 3.6.1
+  resolution: "docusaurus-lunr-search@patch:docusaurus-lunr-search@npm%3A3.6.1#~/.yarn/patches/docusaurus-lunr-search-npm-3.6.1-9688befeb3.patch::version=3.6.1&hash=b9cdf8"
+  dependencies:
+    autocomplete.js: "npm:^0.37.1"
+    clsx: "npm:^2.1.1"
+    gauge: "npm:^3.0.2"
+    hast-util-select: "npm:^4.0.2"
+    hast-util-to-text: "npm:^2.0.1"
+    hogan.js: "npm:^3.0.2"
+    lunr: "npm:^2.3.9"
+    lunr-languages: "npm:^1.4.0"
+    mark.js: "npm:^8.11.1"
+    minimatch: "npm:^3.1.2"
+    rehype-parse: "npm:^7.0.1"
+    to-vfile: "npm:^6.1.0"
+    unified: "npm:^9.2.2"
+    unist-util-is: "npm:^4.1.0"
+  peerDependencies:
+    "@docusaurus/core": ^2.0.0-alpha.60 || ^2.0.0 || ^3.0.0
+    react: ^16.8.4 || ^17 || ^18 || ^19
+    react-dom: ^16.8.4 || ^17 || ^18 || ^19
+  checksum: 10c0/d0f781ea4db7e104e3be3cda37ff546c7c305f0d56dab4fc96b5feaeada824b202b4a311895bfef5a7bc633e755df39b5e903d92c3a8f409e1307fdfc74c57f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/eui/issues/8637

This patches docusaurus-lunr-search with an improved input query tokenization and weights to prioritize `Eui*` component names. It's wild that this custom logic is needed. It took me way too long to try to fix it generically or in a way we could contribute back to the original library but the bug probably has something to do with tokenizing phrases like `eui`, or we just expected too much.

I tried using the `keywords` field to increase score in searches - the default behavior of concatenating all keywords into a single string didn't result in high enough item scores to make a difference, and modifying it to be an array instead made it work slightly better but without a way to retrieve what idx got matched from lunr metadata (that could just be me not knowing what metadata field to read but I checked all and couldn't find it).

This solution isn't perfect, and some results might not feel 100% there. What's important is that searching by component names seems to work good enough for now, and this fix covers ~95% cases. 

## QA

- [ ] Test search on the PR preview environment and confirm searching by component names (like `EuiProvider`) works similarly to searching by page names (e.g., `Provider`)