### PR TITLE
Update writing-documentation.md

### DIFF
--- a/wiki/contributing-to-eui/documenting/writing-documentation.md
+++ b/wiki/contributing-to-eui/documenting/writing-documentation.md
@@ -17,6 +17,7 @@
   - [Dos and Don'ts](#dos-and-donts)
   - [Figma embed](#figma-embed)
   - [Props table](#props-table)
+  - [Blockquotes](#blockquotes)
 
 Code for the Elastic UI [documentation site](https://eui.elastic.co) can be found in the `packages/website` directory. The site is built with [Docusaurus](https://docusaurus.io/).
 
@@ -338,3 +339,11 @@ If more than one table is needed because the component has many exports, place o
     <PropTable definition={docgen.EuiPageSidebar} />
 
 To customize the table `PropTable` also takes a `headingLevel` prop (h1–h6) and a `showTitle` boolean.
+
+### Blockquotes
+
+Must be preceeded by two spaces:
+
+```
+  > Some quote here
+```


### PR DESCRIPTION
For some reason, block quotes require two spaces in front of them to work.

This may not actually be true.

On some pages, they don't work at all.

On other pages, they only work with two spaces before them. I don't understand what's happening.