### PR TITLE
docs: blockquotes in MDX / `border.radius.medium` info

### DIFF
--- a/packages/docusaurus-theme/src/theme/MDXComponents/Blockquote.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Blockquote.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { HTMLAttributes } from 'react';
+import { EuiText, useEuiMemoizedStyles } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+const getBlockquoteStyles = () => css`
+  margin-block: var(--eui-theme-content-vertical-spacing);
+
+  &:first-child {
+    margin-block-start: 0;
+  }
+
+  &:last-child {
+    margin-block-end: 0;
+  }
+`;
+
+export const Blockquote = ({ children }: HTMLAttributes<HTMLQuoteElement>) => {
+  const styles = useEuiMemoizedStyles(getBlockquoteStyles);
+
+  return (
+    <EuiText size="m" css={styles}>
+      <blockquote>
+        {children}
+      </blockquote>
+    </EuiText>
+  );
+};

--- a/packages/docusaurus-theme/src/theme/MDXComponents/index.ts
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/index.ts
@@ -13,6 +13,7 @@ import { FigmaEmbed } from '../../components/figma_embed';
 import { Demo, DemoSource } from '../../components/demo';
 import { PropTable } from '../../components/prop_table';
 import { ListItem } from './ListItem';
+import { Blockquote } from './Blockquote';
 import { Paragraph } from './Paragraph';
 import { UnorderedList } from './UnorderedList';
 import { OrderedList } from './OrderedList';
@@ -25,6 +26,7 @@ const MDXComponents = {
   li: ListItem,
   ul: UnorderedList,
   ol: OrderedList,
+  blockquote: Blockquote,
 
   // Custom components
   Badge,

--- a/packages/website/docs/getting-started/theming/tokens/borders/border_radii_table.tsx
+++ b/packages/website/docs/getting-started/theming/tokens/borders/border_radii_table.tsx
@@ -24,7 +24,7 @@ export const BorderRadiiTable = () => {
       render={(item) => (
         <EuiColorPickerSwatch
           showToolTip={false}
-          color={euiTheme.colors.emptyShade}
+          color={euiTheme.colors.backgroundBasePlain}
           css={css`
             border: ${euiTheme.border.thick};
             border-radius: ${item.value};

--- a/packages/website/docs/getting-started/theming/tokens/borders/border_widths_table.tsx
+++ b/packages/website/docs/getting-started/theming/tokens/borders/border_widths_table.tsx
@@ -21,7 +21,7 @@ export const BorderWidthsTable = () => {
       render={(item) => (
         <EuiColorPickerSwatch
           showToolTip={false}
-          color={euiTheme.colors.emptyShade}
+          color={euiTheme.colors.backgroundBasePlain}
           css={css`
             border: ${euiTheme.border.thick};
             border-width: ${item.value};

--- a/packages/website/docs/getting-started/theming/tokens/borders/borders_table.tsx
+++ b/packages/website/docs/getting-started/theming/tokens/borders/borders_table.tsx
@@ -25,7 +25,7 @@ export const BordersTable = () => {
       render={(item) => (
         <EuiColorPickerSwatch
           showToolTip={false}
-          color={euiTheme.colors.emptyShade}
+          color={euiTheme.colors.backgroundBasePlain}
           css={css`
             border: ${item.value};
           `}

--- a/packages/website/docs/getting-started/theming/tokens/borders/index.mdx
+++ b/packages/website/docs/getting-started/theming/tokens/borders/index.mdx
@@ -122,3 +122,9 @@ import { BorderRadiiTable } from './border_radii_table';
 </Example>
 
 <BorderRadiiTable />
+
+:::info We recently reduced `border.radius.medium` in size
+
+It is now the same as `border.radius.small`. We plan to [update or remove the small size](https://github.com/elastic/eui/issues/8645). In the meantime, use `border.radius.medium`.
+
+:::


### PR DESCRIPTION
## Summary

- Add missing Blockquote component in MDX 1603cf11ff4b92e0c755289ef73c1298679880c8
- Add info regarding border radius size in Tokens section 853c71f8ce2679bd9d0a248dbe168fda3c5b0224

Closes https://github.com/elastic/eui-private/issues/325

## QA

* [x] Check [Gettings Started > Theming > Tokens > Borders](https://eui.elastic.co/pr_8675/docs/getting-started/theming/tokens/borders/#radius) page for wording in the new info admonition
* [x] Test blockquotes in Markdown syntax (`> foo`) render as expected 