### PR TITLE
[EuiDataGrid] Pass scroll position data as args in onScroll

### DIFF
--- a/packages/eui/changelogs/upcoming/8688.md
+++ b/packages/eui/changelogs/upcoming/8688.md
@@ -1,0 +1,2 @@
+- Added scroll position data as arguments for `virtualizationOptions.onScroll` for virtualized `EuiDataGrid`'s
+

--- a/packages/eui/changelogs/upcoming/8688.md
+++ b/packages/eui/changelogs/upcoming/8688.md
@@ -1,2 +1,2 @@
-- Added scroll position data as arguments for `virtualizationOptions.onScroll` for virtualized `EuiDataGrid`'s
+- Added scroll position data as arguments to `virtualizationOptions.onScroll` for the virtualized `EuiDataGrid`
 

--- a/packages/eui/src/components/datagrid/body/data_grid_body_virtualized.test.tsx
+++ b/packages/eui/src/components/datagrid/body/data_grid_body_virtualized.test.tsx
@@ -8,6 +8,7 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../test/rtl';
 
 import { dataGridBodyProps } from './data_grid_body.test';
@@ -74,6 +75,55 @@ describe('EuiDataGridBodyVirtualized', () => {
     );
     expect(component.find('.test').exists()).toBe(true);
     expect(onItemsRendered).toHaveBeenCalled();
+  });
+
+  describe('scrolling', () => {
+    it('passes correct scroll position data to virtualizationOptions.onScroll', () => {
+      Object.defineProperty(Element.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 200,
+      });
+
+      Object.defineProperty(Element.prototype, 'clientHeight', {
+        configurable: true,
+        value: 100,
+      });
+
+      Object.defineProperty(Element.prototype, 'scrollTop', {
+        configurable: true,
+        value: 100,
+      });
+
+      const onScroll = jest.fn();
+
+      const { container } = render(
+        <EuiDataGridBodyVirtualized
+          {...dataGridBodyProps}
+          virtualizationOptions={{
+            onScroll,
+          }}
+        />
+      );
+
+      fireEvent.scroll(container, { target: { scrollY: 50 } });
+
+      expect(onScroll).toHaveBeenCalled();
+      expect(onScroll).toHaveBeenCalledWith({
+        scrollUpdateWasRequested: false,
+        horizontalScrollDirection: 'forward',
+        verticalScrollDirection: 'forward',
+        scrollLeft: 0,
+        scrollTop: 100,
+        scrollHeight: 200,
+        scrollWidth: 0,
+        clientHeight: 100,
+        clientWidth: 0,
+        isScrolledToBlockStart: false,
+        isScrolledToBlockEnd: true,
+        isScrolledToInlineStart: true,
+        isScrolledToInlineEnd: false,
+      });
+    });
   });
 
   // TODO: Test final height/widths

--- a/packages/eui/src/components/datagrid/data_grid.stories.tsx
+++ b/packages/eui/src/components/datagrid/data_grid.stories.tsx
@@ -10,6 +10,7 @@ import React, { useRef, useEffect } from 'react';
 import type { Meta, StoryObj, ReactRenderer } from '@storybook/react';
 import type { PlayFunctionContext } from '@storybook/csf';
 import { expect, fireEvent, waitFor } from '@storybook/test';
+import { action } from '@storybook/addon-actions';
 import { within } from '../../../.storybook/test';
 import { enableFunctionToggleControls } from '../../../.storybook/utils';
 
@@ -60,6 +61,9 @@ export const Virtualization: Story = {
     ...defaultStorybookArgs,
     width: '300px',
     height: '300px',
+    virtualizationOptions: {
+      onScroll: action('onScroll'),
+    },
   },
   render: (args: EuiDataGridProps) => <StatefulDataGrid {...args} />,
 };

--- a/packages/eui/src/components/datagrid/data_grid_types.ts
+++ b/packages/eui/src/components/datagrid/data_grid_types.ts
@@ -25,6 +25,7 @@ import {
   VariableSizeGridProps,
   VariableSizeGrid as Grid,
   GridOnItemsRenderedProps,
+  GridOnScrollProps,
 } from 'react-window';
 import { EuiListGroupItemProps } from '../list_group';
 import { EuiButtonEmpty, EuiButtonIcon } from '../button';
@@ -378,11 +379,26 @@ export type CommonGridProps = CommonProps &
       | 'overscanColumnCount'
       | 'initialScrollTop'
       | 'initialScrollLeft'
-      | 'onScroll'
       | 'onItemsRendered'
       | 'itemKey'
       | 'outerElementType'
-    >;
+    > & {
+      /**
+       * Called when the grid scroll positions changes, as a result of user scrolling or scroll-to method calls.
+       */
+      onScroll?: (
+        args: GridOnScrollProps & {
+          scrollHeight: number;
+          scrollWidth: number;
+          clientHeight: number;
+          clientWidth: number;
+          isScrolledToBlockStart: boolean;
+          isScrolledToBlockEnd: boolean;
+          isScrolledToInlineStart: boolean;
+          isScrolledToInlineEnd: boolean;
+        }
+      ) => void;
+    };
     /**
      * A {@link EuiDataGridRowHeightsOptions} object that provides row heights options.
      * Allows configuring both default and specific heights of grid rows.

--- a/packages/website/docs/components/tabular-content/data-grid/container-constraints.mdx
+++ b/packages/website/docs/components/tabular-content/data-grid/container-constraints.mdx
@@ -746,7 +746,6 @@ export default () => {
   const [isScrolledToInlineEnd, setIsScrolledToInlineEnd] = useState(false);
 
   const onScroll = ({ isScrolledToBlockEnd, isScrolledToInlineEnd }) => {
-    console.log('scroll!', isScrolledToBlockEnd, isScrolledToInlineEnd )
     setIsScrolledToBlockEnd(isScrolledToBlockEnd);
     setIsScrolledToInlineEnd(isScrolledToInlineEnd);
   }
@@ -782,10 +781,7 @@ export default () => {
             scrollAnchorRow: 'start',
           }}
           virtualizationOptions={{
-            onScroll: (args) => {
-              console.log(args);
-              onScroll(args);
-            }
+            onScroll,
           }}
         />
       </DataContext.Provider>

--- a/packages/website/docs/components/tabular-content/data-grid/container-constraints.mdx
+++ b/packages/website/docs/components/tabular-content/data-grid/container-constraints.mdx
@@ -588,6 +588,213 @@ export default () => {
 };
 ```
 
+import { Example } from '@site/src/components';
+
+### Scroll position
+
+If you need access to the current scroll position of a virtualized `EuiDataGrid` you can make use of the `virtualizationOptions.onScroll` callback. 
+It passes along the scroll data and provides scroll position checks out of the box.
+
+
+<Example.Snippet>
+  ```ts
+  onScroll(args: {
+    horizontalScrollDirection: ScrollDirection;
+    verticalScrollDirection: ScrollDirection;
+    scrollUpdateWasRequested: boolean;
+    scrollLeft: number;
+    scrollTop: number;
+    scrollHeight: number;
+    scrollWidth: number;
+    clientHeight: number;
+    clientWidth: number;
+    isScrolledToBlockStart: boolean;
+    isScrolledToBlockEnd: boolean;
+    isScrolledToInlineStart: boolean;
+    isScrolledToInlineEnd: boolean;   
+  }) => void
+  ```
+</Example.Snippet>
+
+```tsx interactive
+import React, {
+  useCallback,
+  useState,
+  createContext,
+  useContext,
+  useMemo,
+  useEffect,
+} from 'react';
+import {
+  EuiDataGrid,
+  EuiLink,
+  EuiText,
+  EuiSpacer,
+  EuiFlexGroup,
+} from '@elastic/eui';
+import { faker } from '@faker-js/faker';
+
+const DataContext = createContext();
+
+const columns = [
+  {
+    id: 'name',
+    displayAsText: 'Name',
+    defaultSortDirection: 'asc',
+  },
+  {
+    id: 'email',
+  },
+  {
+    id: 'location',
+  },
+  {
+    id: 'account',
+  },
+  {
+    id: 'date',
+    defaultSortDirection: 'desc',
+  },
+  {
+    id: 'amount',
+  },
+  {
+    id: 'phone',
+    isSortable: false,
+  },
+  {
+    id: 'version',
+    defaultSortDirection: 'desc',
+    initialWidth: 65,
+    isResizable: false,
+  },
+];
+
+// it is expensive to compute 10000 rows of fake data
+// instead of loading up front, generate entries on the fly
+const raw_data = [];
+function RenderCellValue({ rowIndex, columnId }) {
+  const { data, adjustMountedCellCount } = useContext(DataContext);
+
+  useEffect(() => {
+    adjustMountedCellCount(1);
+    return () => adjustMountedCellCount(-1);
+  }, [adjustMountedCellCount]);
+
+  if (data[rowIndex] == null) {
+    const email = faker.internet.email();
+    const name = `${faker.person.lastName()}, ${faker.person.firstName()}`;
+    const suffix = faker.person.suffix();
+    data[rowIndex] = {
+      name: `${name} ${suffix}`,
+      email: <EuiLink href="">{email}</EuiLink>,
+      location: (
+        <>
+          {`${faker.location.city()}, `}
+          <EuiLink href="https://google.com">
+            {faker.location.country()}
+          </EuiLink>
+        </>
+      ),
+      date: `${faker.date.past()}`,
+      account: faker.finance.accountNumber(),
+      amount: faker.commerce.price(),
+      phone: faker.phone.number(),
+      version: faker.system.semver(),
+    };
+  }
+  return data.hasOwnProperty(rowIndex) ? data[rowIndex][columnId] : null;
+}
+
+export default () => {
+  // Pagination
+  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 50 });
+  const onChangeItemsPerPage = useCallback(
+    (pageSize) =>
+      setPagination((pagination) => ({
+        ...pagination,
+        pageSize,
+        pageIndex: 0,
+      })),
+    [setPagination]
+  );
+  const onChangePage = useCallback(
+    (pageIndex) =>
+      setPagination((pagination) => ({ ...pagination, pageIndex })),
+    [setPagination]
+  );
+
+  // Column visibility
+  const [visibleColumns, setVisibleColumns] = useState(
+    columns.map(({ id }) => id)
+  );
+
+  const [mountedCellCount, setMountedCellCount] = useState(0);
+
+  const dataContext = useMemo(
+    () => ({
+      data: raw_data,
+      adjustMountedCellCount: (adjustment) =>
+        setMountedCellCount(
+          (mountedCellCount) => mountedCellCount + adjustment
+        ),
+    }),
+    []
+  );
+
+  const [isScrolledToBlockEnd, setIsScrolledToBlockEnd] = useState(false);
+  const [isScrolledToInlineEnd, setIsScrolledToInlineEnd] = useState(false);
+
+  const onScroll = ({ isScrolledToBlockEnd, isScrolledToInlineEnd }) => {
+    console.log('scroll!', isScrolledToBlockEnd, isScrolledToInlineEnd )
+    setIsScrolledToBlockEnd(isScrolledToBlockEnd);
+    setIsScrolledToInlineEnd(isScrolledToInlineEnd);
+  }
+
+  return (
+    <>
+      <EuiFlexGroup>
+        <EuiText>
+          <p>
+            <code>isScrolledToBlockEnd</code>: <b>{isScrolledToBlockEnd.toString()}</b>
+          </p>
+        </EuiText>
+        <EuiText>
+          <p>
+            <code>isScrolledToInlineEnd:</code> <b>{isScrolledToInlineEnd.toString()}</b>
+          </p>
+        </EuiText>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      <DataContext.Provider value={dataContext}>
+        <EuiDataGrid
+          aria-label="Virtualized data grid scrolling demo"
+          height={300}
+          width={400}
+          columns={columns}
+          columnVisibility={{ visibleColumns, setVisibleColumns }}
+          rowCount={10}
+          renderCellValue={RenderCellValue}
+          rowHeightsOptions={{
+            defaultHeight: 'auto',
+            scrollAnchorRow: 'start',
+          }}
+          virtualizationOptions={{
+            onScroll: (args) => {
+              console.log(args);
+              onScroll(args);
+            }
+          }}
+        />
+      </DataContext.Provider>
+    </>
+  );
+};
+```
+
+
 ## Props
 
 import docgen from '@elastic/eui-docgen/dist/components/datagrid/data_grid_types.docgen.json';


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8422

This PR updates the `virtualizationOptions.onScroll` prop on `EuiDataGrid` by passing additional scroll position data as callback arguments. This allows consumers to handle additional checks based on scroll position, e.g. identify when a user has scrolled to the end of the grid.

## QA

- [x] review the added [documentation](https://eui.elastic.co/pr_8688/docs/components/tabular-content/data-grid/container-constraints/#scroll-position) and updated [props definition](https://eui.elastic.co/pr_8688/docs/components/tabular-content/data-grid/container-constraints/#EuiDataGridVirtualizationOptions)
- [x] verify the functionality works as expected to provide information if the user scrolled to the end ([example](https://eui.elastic.co/pr_8688/docs/components/tabular-content/data-grid/container-constraints/#scroll-position))

![Screenshot 2025-05-07 at 09 15 52](https://github.com/user-attachments/assets/3bc8c0a2-1f0e-4480-9a4c-6f196d1441de)

- [x] (optional) checkout this PR and review the new functionality in Storybook:
  - open the "Virtualization" story and scroll
  - review the `onScroll` arguments output in the "Actions" tab and confirm the values update correctly
  
![Screenshot 2025-05-06 at 14 41 33](https://github.com/user-attachments/assets/40eb362b-2083-4cd9-bb12-c7b48ced7622)




### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
