### PR TITLE
[EuiGlobalToastList] Ensure all toasts are removed after the timeout is cleared

### DIFF
--- a/packages/eui/changelogs/upcoming/8692.md
+++ b/packages/eui/changelogs/upcoming/8692.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiGlobalToastList` toasts not being cleaned properly when they are added and removed at the same time
+


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8611

This PR updated `EuiGlobalToastList` to save all dismissable toasts as array, instead of only the last one.
This ensures that all toasts are properly cleaned up when multiple toasts are added and dismissed at exactly the same time.

_before_

![Screenshot 2025-05-07 at 13 55 38](https://github.com/user-attachments/assets/d556deed-7b8b-4c54-9d30-8381f8ee111f)

_after_

![Screenshot 2025-05-07 at 13 56 24](https://github.com/user-attachments/assets/774dfe2c-66a1-410d-b849-78bf93d63e48)


## QA

- [x] verify the global toast list cleans up toasts as expected (use the updated story `EuiGlobalToastList > Playground` which adds multiple toasts at the same time)
  - wait until all toasts are dismissed automatically after the default timeout
  - inspect the DOM and verify all elements have been removed from the log list

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ]~ If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
