### PR TITLE
[Feat] Add `useIsDarkMode` hook

### DIFF
--- a/packages/eui/changelogs/upcoming/8701.md
+++ b/packages/eui/changelogs/upcoming/8701.md
@@ -1,0 +1,2 @@
+- Added `useIsDarkMode` utility
+

--- a/packages/eui/src/services/theme/hooks.test.tsx
+++ b/packages/eui/src/services/theme/hooks.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { render } from '@testing-library/react';
 import { renderHook, renderHookAct } from '../../test/rtl';
 
@@ -19,7 +19,13 @@ import {
   withEuiTheme,
   RenderWithEuiTheme,
   useEuiThemeCSSVariables,
+  useIsDarkMode,
 } from './hooks';
+import { EuiThemeProvider } from './provider';
+import {
+  COLOR_MODES_STANDARD,
+  EuiThemeColorModeStandard,
+} from '@elastic/eui-theme-common';
 
 describe('useEuiTheme', () => {
   it('returns a context with theme variables, color mode, and modifications', () => {
@@ -102,5 +108,69 @@ describe('useEuiThemeCSSVariables', () => {
     // In this case, the nearest theme is the global one, so it should set both
     expect(result.current.globalCSSVariables).toEqual({ '--hello': 'world' });
     expect(result.current.themeCSSVariables).toEqual({ '--hello': 'world' });
+  });
+});
+
+describe('useIsDarkMode', () => {
+  const Wrapper: FunctionComponent<
+    PropsWithChildren & { colorMode: EuiThemeColorModeStandard }
+  > = ({ children, colorMode }) => (
+    <EuiProvider colorMode={colorMode}>{children}</EuiProvider>
+  );
+
+  it('returns `true` for DARK `colorMode`', () => {
+    const { result } = renderHook(useIsDarkMode, {
+      wrapper: (props: PropsWithChildren) => (
+        <Wrapper {...props} colorMode="DARK" />
+      ),
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('returns `false` for LIGHT `colorMode`', () => {
+    const { result } = renderHook(useIsDarkMode, {
+      wrapper: (props: PropsWithChildren) => (
+        <Wrapper {...props} colorMode="LIGHT" />
+      ),
+    });
+    expect(result.current).toBe(false);
+  });
+
+  describe('nested providers', () => {
+    const NestedWrapper: FunctionComponent<
+      PropsWithChildren & { colorMode: EuiThemeColorModeStandard }
+    > = ({ children, colorMode }) => {
+      return (
+        <EuiProvider
+          colorMode={
+            colorMode === COLOR_MODES_STANDARD.light
+              ? COLOR_MODES_STANDARD.dark
+              : COLOR_MODES_STANDARD.light
+          }
+        >
+          <EuiThemeProvider colorMode={colorMode}>{children}</EuiThemeProvider>
+        </EuiProvider>
+      );
+    };
+
+    it('returns `false` for a nested LIGHT `colorMode`', () => {
+      const { result } = renderHook(useIsDarkMode, {
+        wrapper: (props: PropsWithChildren) => (
+          <NestedWrapper {...props} colorMode="LIGHT" />
+        ),
+      });
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns `true` for a nested DARK `colorMode`', () => {
+      const { result } = renderHook(useIsDarkMode, {
+        wrapper: (props: PropsWithChildren) => (
+          <NestedWrapper {...props} colorMode="DARK" />
+        ),
+      });
+
+      expect(result.current).toBe(true);
+    });
   });
 });

--- a/packages/eui/src/services/theme/hooks.tsx
+++ b/packages/eui/src/services/theme/hooks.tsx
@@ -7,11 +7,12 @@
  */
 
 import React, { forwardRef, useContext, useMemo } from 'react';
-import type {
-  EuiThemeColorModeStandard,
-  EuiThemeHighContrastMode,
-  EuiThemeModifications,
-  EuiThemeComputed,
+import {
+  type EuiThemeColorModeStandard,
+  type EuiThemeHighContrastMode,
+  type EuiThemeModifications,
+  type EuiThemeComputed,
+  COLOR_MODES_STANDARD,
 } from '@elastic/eui-theme-common';
 
 import {
@@ -121,4 +122,14 @@ export const useEuiThemeCSSVariables = () => {
     setNearestThemeCSSVariables,
     themeCSSVariables,
   };
+};
+
+/**
+ * Checks whether the current active `colorMode` is set to `DARK`;
+ * In case of nested providers this returns the value of the nearest provider context.
+ */
+export const useIsDarkMode = () => {
+  const { colorMode } = useEuiTheme();
+
+  return colorMode === COLOR_MODES_STANDARD.dark;
 };

--- a/packages/eui/src/services/theme/index.ts
+++ b/packages/eui/src/services/theme/index.ts
@@ -20,6 +20,7 @@ export {
   withEuiTheme,
   RenderWithEuiTheme,
   useEuiThemeCSSVariables,
+  useIsDarkMode,
 } from './hooks';
 export type { EuiThemeProviderProps } from './provider';
 export { EuiThemeProvider } from './provider';

--- a/packages/website/docs/getting-started/theming/color-mode.mdx
+++ b/packages/website/docs/getting-started/theming/color-mode.mdx
@@ -12,6 +12,26 @@ import { ProviderDetails } from './provider_details';
 
 <ProviderDetails withThemeName={false} withHighContrastMode={false} />
 
+## Checking the current color mode
+
+There are different ways to check which `colorMode` is currently active on the `EuiProvider`: You can either check the value provided by `useEuiTheme()` manually, 
+or you can use the `useIsDarkMode()` hook which handles the check internally and returns you a `boolean` value.
+
+import { Example } from '@site/src/components';
+
+
+<Example.Snippet>
+  ```tsx
+  import { COLOR_MODES_STANDARD, useEuiTheme, useIsDarkMode } from '@elastic/eui';
+
+  const { colorMode } = useEuiTheme();
+  const isDarkMode = colorMode === COLOR_MODES_STANDARD.dark
+
+  // or in 1 line
+  const isDarkMode = useIsDarkMode();
+  ```
+</Example.Snippet>
+
 ## Rendering a specific color mode
 
 While it is usually best to keep all consumptions of the global variables rendering in the same light or dark color mode, some instances benefit from an exaggerated change in contrast from the current theme. For this you can specify **EuiThemeProvider**'s `colorMode` to always be `"light"`, `"dark"`, or `"inverse"` which sets it to the opposite of the current color mode.


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8693

This PR introduces the small utility hook `useIsDarkMode` to reduce the boilerplate for consumers to add conditional `colorMode` checks manually.

## QA

- [ ] ci passes (the added unit tests should verify the functionality sufficiently)
- [ ] review the [added documentation](https://eui.elastic.co/pr_8701/docs/getting-started/theming/color-mode/#checking-the-current-color-mode)

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
