### PR TITLE
[POC] CSS variables naive implementation

### DIFF
--- a/packages/eui-theme-borealis/package.json
+++ b/packages/eui-theme-borealis/package.json
@@ -24,7 +24,7 @@
     "directory": "packages/eui-theme-borealis"
   },
   "dependency": {
-    "@elastic/eui-theme-common": "workspace:*",
+    "@elastic/eui-theme-common": "1.0.0",
     "chroma-js": "^2.4.2"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",
-    "@elastic/eui-theme-common": "workspace:*",
+    "@elastic/eui-theme-common": "1.0.0",
     "@types/chroma-js": "^2.4.0",
     "@types/jest": "^29.5.12",
     "@types/prettier": "2.7.3",

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -50,7 +50,7 @@
     "url": "https://github.com/elastic/eui.git"
   },
   "dependencies": {
-    "@elastic/eui-theme-common": "workspace:*",
+    "@elastic/eui-theme-common": "1.0.0",
     "@elastic/prismjs-esql": "^1.1.0",
     "@hello-pangea/dnd": "^16.6.0",
     "@types/lodash": "^4.14.202",
@@ -104,7 +104,7 @@
     "@cypress/webpack-dev-server": "^1.7.0",
     "@elastic/charts": "^64.1.0",
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui-theme-borealis": "workspace:*",
+    "@elastic/eui-theme-borealis": "1.0.0",
     "@emotion/babel-preset-css-prop": "^11.11.0",
     "@emotion/cache": "^11.11.0",
     "@emotion/css": "^11.11.0",

--- a/packages/eui/src/services/theme/index.ts
+++ b/packages/eui/src/services/theme/index.ts
@@ -6,6 +6,10 @@
  * Side Public License, v 1.
  */
 
+import { defaultComputedTheme } from './context';
+import { EuiThemeComputed, EuiThemeShape } from './types';
+import { EuiThemeShapeBase } from '@elastic/eui-theme-common';
+
 export {
   EuiSystemContext,
   EuiThemeContext,
@@ -54,3 +58,56 @@ export type {
   EuiThemeSystem,
 } from './types';
 export { COLOR_MODES_STANDARD } from './types';
+
+
+const generateThemeCSSVarMapping = (
+  obj: EuiThemeComputed<EuiThemeShape>,
+  prefix = '--euiTheme'
+): StringifiedEuiThemeShapeBase => {
+  const result: Record<string, any> = {};
+  const stack: { target: Record<string, any>; value: any; path: string[] }[] = [
+    { target: result, value: obj, path: [] },
+  ];
+
+  while (stack.length) {
+    const { target, value, path } = stack.pop()!;
+
+    for (const key in value) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        const val = value[key];
+        if (typeof val === 'object' && val !== null) {
+          target[key] = {};
+          stack.push({ target: target[key], value: val, path: [...path, key] });
+        } else {
+          const varRef = `var(${prefix}_${[...path, key].join('_')})`;
+          target[key] = varRef;
+        }
+      }
+    }
+  }
+
+  return result as unknown as StringifiedEuiThemeShapeBase;
+};
+
+type DeepStringify<T> = {
+  [K in keyof T]: T[K] extends object ? DeepStringify<T[K]> : string;
+};
+
+export type StringifiedEuiThemeShapeBase = DeepStringify<EuiThemeComputed<EuiThemeShape>>;
+
+/**
+ * Mirrors the structure of `euiTheme`, but replaces the actual values with corresponding CSS variable names.
+ * These variables are resolved at runtime via the theme provider.
+ *
+ * Example:
+ * const euiThemeCssVariables = {
+ *   colors: {
+ *     ghost: 'var(--euiTheme_colors_ghost)',
+ *     ink: 'var(--euiTheme_colors_ink)',
+ *     ...
+ *   },
+ *  border: {...}
+ * }
+ */
+export const euiThemeCssVariables = generateThemeCSSVarMapping(defaultComputedTheme);
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -7166,7 +7166,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elastic/eui-theme-borealis@workspace:*, @elastic/eui-theme-borealis@workspace:^, @elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis":
+"@elastic/eui-theme-borealis@npm:1.0.0, @elastic/eui-theme-borealis@workspace:^, @elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis":
   version: 0.0.0-use.local
   resolution: "@elastic/eui-theme-borealis@workspace:packages/eui-theme-borealis"
   dependencies:
@@ -7175,7 +7175,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.21.5"
     "@babel/preset-react": "npm:^7.18.6"
     "@babel/preset-typescript": "npm:^7.21.5"
-    "@elastic/eui-theme-common": "workspace:*"
+    "@elastic/eui-theme-common": "npm:1.0.0"
     "@types/chroma-js": "npm:^2.4.0"
     "@types/jest": "npm:^29.5.12"
     "@types/prettier": "npm:2.7.3"
@@ -7198,7 +7198,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@elastic/eui-theme-common@workspace:*, @elastic/eui-theme-common@workspace:^, @elastic/eui-theme-common@workspace:packages/eui-theme-common":
+"@elastic/eui-theme-common@npm:1.0.0, @elastic/eui-theme-common@workspace:^, @elastic/eui-theme-common@workspace:packages/eui-theme-common":
   version: 0.0.0-use.local
   resolution: "@elastic/eui-theme-common@workspace:packages/eui-theme-common"
   dependencies:
@@ -7318,8 +7318,8 @@ __metadata:
     "@cypress/webpack-dev-server": "npm:^1.7.0"
     "@elastic/charts": "npm:^64.1.0"
     "@elastic/datemath": "npm:^5.0.3"
-    "@elastic/eui-theme-borealis": "workspace:*"
-    "@elastic/eui-theme-common": "workspace:*"
+    "@elastic/eui-theme-borealis": "npm:1.0.0"
+    "@elastic/eui-theme-common": "npm:1.0.0"
     "@elastic/prismjs-esql": "npm:^1.1.0"
     "@emotion/babel-preset-css-prop": "npm:^11.11.0"
     "@emotion/cache": "npm:^11.11.0"


### PR DESCRIPTION
## Summary

This PR introduces a proof of concept for generating and consuming EUI theme values as CSS variables.

**What's included:**

`euiThemeCssVariables`: Exported variable that mirrors the default computed theme but with all values replaced by their CSS variable names. Uses `generateThemeCSSVarMapping` that recursively maps the full euiTheme structure to a mirror object, replacing values with var(--euiTheme_...) references.

`StringifiedEuiThemeShapeBase`: Utility type to represent a theme shape where all values are strings (i.e., CSS variable references),.

`flattenThemeToCSSVars`: Helper that flattens a nested theme object into a flat map of CSS variable definitions (e.g., --euiTheme_colors_primary: "#0079a1").

Provider changes to inject these variables at runtime into the DOM using <Global styles={{ ':root': flattenedTheme }} />.


