### PR TITLE
feat(EuiFilterButton): accept percentages in `numActiveFilters` prop

### DIFF
--- a/packages/eui/changelogs/upcoming/8705.md
+++ b/packages/eui/changelogs/upcoming/8705.md
@@ -1,0 +1,1 @@
+- Updated EuiFilterButton's `numActiveFilters` prop to accept percentage values

--- a/packages/eui/src/components/filter_group/filter_button.stories.tsx
+++ b/packages/eui/src/components/filter_group/filter_button.stories.tsx
@@ -19,6 +19,7 @@ const meta: Meta<EuiFilterButtonProps> = {
   component: EuiFilterButton as any,
   argTypes: {
     color: { control: 'select', options: BUTTON_COLORS },
+    numActiveFilters: { control: 'text' },
   },
   args: {
     // Component defaults

--- a/packages/eui/src/components/filter_group/filter_button.tsx
+++ b/packages/eui/src/components/filter_group/filter_button.tsx
@@ -39,7 +39,7 @@ export type EuiFilterButtonProps = {
    *
    * Accepted values are integers and percentages (e.g., 20%).
    * Passing other values is not supported and may break the layout.
-   *ą
+   *
    * @example 10
    * @example '20%'
    */

--- a/packages/eui/src/components/filter_group/filter_button.tsx
+++ b/packages/eui/src/components/filter_group/filter_button.tsx
@@ -34,10 +34,16 @@ export type EuiFilterButtonProps = {
    */
   numFilters?: number;
   /**
-   * Pass the number of selected filters and it will
-   * add a bright notification badge showing the number
+   * The number of active (selected) filters.
+   * The value will be displayed as a bright notification badge.
+   *
+   * Accepted values are integers and percentages (e.g., 20%).
+   * Passing other values is not supported and may break the layout.
+   *ą
+   * @example 10
+   * @example '20%'
    */
-  numActiveFilters?: number;
+  numActiveFilters?: number | string;
   /**
    * Applies a visual state to the button useful when using with a popover.
    */
@@ -85,8 +91,7 @@ export const EuiFilterButton: FunctionComponent<EuiFilterButtonProps> = ({
   ...rest
 }) => {
   const numFiltersDefined = numFilters != null; // != instead of !== to allow for null and undefined
-  const numActiveFiltersDefined =
-    numActiveFilters != null && numActiveFilters > 0;
+  const numActiveFiltersDefined = !!numActiveFilters;
 
   const styles = useEuiMemoizedStyles(euiFilterButtonStyles);
   const cssStyles = [

--- a/packages/website/docs/components/forms/search-and-filter/filter-group.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/filter-group.mdx
@@ -65,7 +65,12 @@ To provide a long list of grouped filters, we recommend wrapping the filter butt
 
 ### Indicating number of filters
 
-By passing a number to `numFilters` you can express the number of filters available. When the user has applied these filter add the prop `hasActiveFilters` as before and this will change the coloring of the indicator. You can also supply a number to `numActiveFilters`which will change the number displayed.
+You can use the `numFilters` prop to display the total number of filters
+available and `numActiveFilters` to set the number of currently active filters.
+Pass `hasActiveFilters` to visually indicate that there are active filters.
+
+`numActiveFilters` accepts integer numbers. In special cases, you may pass
+a percentage value as a string if UX justifies it.
 
 ```tsx interactive
 import React, { useEffect, useRef, useState } from 'react';


### PR DESCRIPTION
## Summary

Resolves #8695

This PR extends the type of `numActiveFilters` to accept percentage values as strings. For simplicity, there's no fancy string type checking - instead, we trust the user and save a little bit of time during type resolution.

## QA

- [x] Open Storybook and confirm percentage values like `"20%"` are accepted in `numActiveFilters` prop
- [x] Confirm there are no type errors when passing a percentage value string to `numActiveFilters` prop

### General checklist

- Browser QA
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.