### PR TITLE
Update running-eui-locally.md

### DIFF
--- a/wiki/contributing-to-eui/running-eui-locally.md
+++ b/wiki/contributing-to-eui/running-eui-locally.md
@@ -72,6 +72,12 @@ yarn start
 
 ### Website
 
+If running for the first time, build dependant workspaces:
+
+```
+yarn workspace @elastic/eui-website build:workspaces
+```
+
 You can run the documentation locally at [http://localhost:3000/](http://localhost:3000/) with the following command:
 
 ```shell


### PR DESCRIPTION
## Summary

Someone was trying to run docs locally and encountered the following issue.

![CleanShot 2025-05-22 at 12 21 28@2x](https://github.com/user-attachments/assets/20799e30-dd0f-4a82-bfb7-6f2437e9ca7c)

After running the following command, they were able to get it to work:

```
yarn workspace @elastic/eui-website build:workspaces
```

I believe we were missing this step from these docs, as mentioned [here](https://github.com/elastic/eui/tree/main/packages/website), so I added it.