### PR TITLE
[Content] Adds relevant content guidelines and examples from obsolete files

### DIFF
--- a/packages/website/docs/content/index.mdx
+++ b/packages/website/docs/content/index.mdx
@@ -16,4 +16,6 @@ Our content guidelines cover the main principles we follow for crafting consiste
 Some more specific guidelines and best practices apply in certain situations or for certain components:
 
 - [Patterns](../patterns/index.mdx)
+  - Find the right way to add help content to a UI: [Help content patterns](../patterns/help-content.mdx).
+  - Write helpful [error messages](../patterns/error-messages.mdx).
 - [Components](../components/index.mdx)

--- a/packages/website/docs/content/language.mdx
+++ b/packages/website/docs/content/language.mdx
@@ -2,6 +2,12 @@
 sidebar_position: 5
 ---
 
+import {
+  EuiFlexGroup,
+  EuiButton,
+  htmlIdGenerator,
+} from '@elastic/eui';
+
 # Language
 
 Guidelines for using consistent spelling and terminology in the UI.
@@ -52,15 +58,24 @@ In American English, nouns that end with 'og' usually end with 'ogue' in British
 | catalog | catalogue |
 | epilog | epilogue |
 
-## Case
+## Case and capitalization
 
 Use **sentence case** by default. This goes for navigation menus, titles and headers, buttons, and so on.
 
-- **Do:** Developer tools, **not** Developer Tools.
+<EuiFlexGroup>
+<Guideline type="do" text="Sentence case fits most situations.">
+  <EuiButton fill>Check for new data</EuiButton>
+</Guideline>
 
-The only exceptions are proper nouns and [branded terms](https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide/t/159934) like solution and application names.
+<Guideline type="dont" text="Capitalize every word in buttons or titles.">
+  <EuiButton fill>Check For New Data</EuiButton>
+</Guideline>
+</EuiFlexGroup>
 
-- **Do:** Elastic Observability **not** elastic observability.
+Even with sentence case, make sure to capitalize the following terms and expressions:
+
+- [Branded terms](https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide/t/159934) like solution and application names. For example, always write Elastic Observability, **not** elastic observability.
+- Acronyms, such as URL and API.
 
 Note that some names don't need to be capitalized when they're used as common names. For example, **Elastic Cloud Serverless** and **our serverless architecture** are both correct.
 
@@ -97,6 +112,19 @@ Don't use periods with:
 * titles
 * placeholders
 * list items that are incomplete sentences
+
+## Contractions
+
+Use contractions if they make your text flow more naturally, such as "didn't" instead of "did not" and "can't" instead of "cannot."
+
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" text="Use contractions if they make the text easier to read.">
+    Didn't find what you were looking for?
+  </Guideline>
+  <Guideline type="dont" text="Without the contraction, this text sounds stilted.">
+    Did not find what you were looking for?
+  </Guideline>
+</EuiFlexGroup>
 
 ## Vocabulary
 

--- a/packages/website/docs/content/style.mdx
+++ b/packages/website/docs/content/style.mdx
@@ -16,7 +16,7 @@ Real people, talking to real people.
 | User-focused       | Address users directly. Don't abuse possessive markers like "yours".[1]        |
 | Plainspoken | Be conversational, yet professional. Write close to how you'd talk. Use contractions and active voice.      |
 | Inclusive    | Write for all audiences. Our users are from everywhere. Don't use terms that might discriminate or offend and avoid complex language for non-native English speakers such as phrasal verbs. |
-| Empathetic | Write what matters to users. Use words that you normally use.               |
+| Empathetic | Write what matters to users. Use words that you and users normally use.               |
 
 > [1] Sometimes, we give the user full ownership of an action. In that case, it's acceptable to use "I" and "my". For example, for a legal agreement checkbox "I agree to follow the terms of service". We can also use "We" when talking about actions Elastic takes for users.
 
@@ -28,7 +28,9 @@ Get the user's job done.
 |-------------|-----------------------------------------------------------------------------------------|
 | Timely      | Help users when it's needed. Not everything is critical to describe in more details or at once. Make information discovery progress at the same pace as the user.   |
 | Informative | Ensure all content serves a purpose and is not just decoration. Be straight to the point. It's not mandatory to have help text and descriptions for everything.|
+| Action-oriented | Whenever possible, drive actions and support user intent with action verbs.|
 | Precise | Avoid using verbs or determiners alone without a noun in buttons and action menus to add clarity. For example, prefer "Save dashboard" over "Save". Or "this setting" over "this".|
+| Consistent | Use the same terminology to mean the same thing. Make sure spelling, capitalization, punctuation, labels, and use of abbreviations are all consistent.|
 | Succinct    | Shorten the content to something meaningful and scannable, without sacrificing clarity. Delete unnecessary or vague wording like most adverbs. |
 
 


### PR DESCRIPTION
This PR adds a few details and missing pieces to the updated content guidelines. These details are retrieved from obsolete files deleted in https://github.com/elastic/eui/pull/8683.

Closes: https://github.com/elastic/platform-docs-team/issues/674