### PR TITLE
[EuiBasicTable] Improve JSDoc and param names for column types

### DIFF
--- a/packages/eui/src/components/basic_table/table_types.ts
+++ b/packages/eui/src/components/basic_table/table_types.ts
@@ -116,9 +116,10 @@ export interface EuiTableFieldDataColumnType<T>
     render?: (item: T) => ReactNode;
   };
   /**
-   * Describe a custom renderer function for the content.
-   * Different from computed-type columns and the `mobileOptions.render` function,
-   * this one takes the `field` value as first param, and the full data item as second.
+   * A custom renderer for this column's cell content.
+   * Unlike computed columns or `mobileOptions.render`, this function receives:
+   * - `value`: The value of the specified field for this row
+   * - `item`: The full data item (row object)
    */
   render?: (value: any, item: T) => ReactNode;
   /**


### PR DESCRIPTION
## Summary

This tiny PR introduces the following changes for types in `EuiBasicTableColumn`:

- makes param names consistent in `render` functions
- expands a comment on `EuiTableFieldDataColumnType['render']` to make it clearer (hopefully) that it takes 2 params instead of 1

```diff
EuiTableFieldDataColumnType['mobileOptions']['render'] =  (item: T) => ...
-EuiTableFieldDataColumnType['render'] =  (value: any, record: T) => ...
+EuiTableFieldDataColumnType['render'] =  (value: any, item: T) => ...
-EuiTableComputedColumnType['render'] =  (record: T) => ...
+EuiTableComputedColumnType['render'] =  (item: T) => ...
```

## QA

- [ ] Check whether JSDoc comment is clear enough (feedback welcome)
- [ ] I think that's it
