### PR TITLE
fix(EuiMarkdownFormat): Render unknown code block languages as plain text

### DIFF
--- a/packages/eui/src/components/markdown_editor/plugins/remark/remark_prismjs.ts
+++ b/packages/eui/src/components/markdown_editor/plugins/remark/remark_prismjs.ts
@@ -18,7 +18,7 @@ const attacher: Plugin = () => {
   function visitor(node: any) {
     const { data = {}, lang: language } = node;
 
-    if (!language) {
+    if (!language || !refractor.registered(language)) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/eui/issues/8728

## Summary

This fixes an issue in `EuiMarkdownFormat`, causing the component to render markdown content as plain text when an unregistered language is passed to a fenced code block.

## QA

1. Open `EuiMarkdownFormat` docs page
2. Edit the example code so that `markdownContent` variable is set to:
    ```tsx
    const markdownContent = `
    # Hello, World!
    ~~~blah
    console.log(123);
    ~~~
    `
    ```
3. Confirm the heading and code block are rendered correctly. The code block should be rendered as plain text since the `blah` language is not registered.

### General checklist

- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
