### PR TITLE
[HCM] Fix theme high contrast overrides

### DIFF
--- a/packages/eui-theme-borealis/src/variables/_overrides.ts
+++ b/packages/eui-theme-borealis/src/variables/_overrides.ts
@@ -14,6 +14,12 @@ export const overrides: _EuiThemeOverrides = {
     colors: {
       ink: PRIMITIVE_COLORS.black,
       ghost: PRIMITIVE_COLORS.white,
+      LIGHT: {
+        primary: '#00ff00',
+      },
+      DARK: {
+        primary: '#0000ff',
+      },
     },
   },
 };

--- a/packages/eui-theme-common/changelogs/upcoming/8742.md
+++ b/packages/eui-theme-common/changelogs/upcoming/8742.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed a wrong variable in `getComputed` theme function which prevented high contrast overrides from being applied
+

--- a/packages/eui-theme-common/src/utils.ts
+++ b/packages/eui-theme-common/src/utils.ts
@@ -308,7 +308,7 @@ export const getComputed = <T = EuiThemeShape>(
 
         // combine internal overrides with manual overrides
         const combinedOverValue =
-          isObject(overValue) && isObject(hcmOverValue)
+          isObject(overValue) && isObject(hcmCombinedOverValue)
             ? mergeDeep(overValue, hcmCombinedOverValue)
             : // optional overrides e.g. on provider level should still override theme level
               overValue ?? hcmCombinedOverValue;

--- a/packages/eui/changelogs/upcoming/8742.md
+++ b/packages/eui/changelogs/upcoming/8742.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed high contrast theme token overrides not being applied
+

--- a/packages/eui/src/components/button/button.stories.tsx
+++ b/packages/eui/src/components/button/button.stories.tsx
@@ -16,6 +16,7 @@ import {
 
 import { EuiButtonEmpty } from './button_empty';
 import { EuiButton, Props as EuiButtonProps } from './button';
+import { useEuiTheme } from '../../services';
 
 const meta: Meta<EuiButtonProps> = {
   title: 'Navigation/EuiButton',
@@ -63,4 +64,17 @@ export const HighContrast: Story = {
       <EuiButtonEmpty>Empty</EuiButtonEmpty>
     </div>
   ),
+};
+
+export const TESTING_EXAMPLE: Story = {
+  render: function Render() {
+    const { euiTheme } = useEuiTheme();
+
+    return (
+      <>
+        <EuiButton>ink: {euiTheme.colors.ink}</EuiButton>
+        <EuiButton>primary: {euiTheme.colors.primary}</EuiButton>
+      </>
+    );
+  },
 };


### PR DESCRIPTION
## Summary

This PR fixes a small mistake in the theme overrides functionality (introduced in [this commit](https://github.com/elastic/eui/pull/8558/commits/95fe71de26c5aefdb731b9fd3ffa4b3b4b5cd79d)) which resulted in overrides not being applied 🫠 
The issue was that a wrong variable was used which would not hold all expected override values.

## QA

Checkout the PR and in Storybook:

- [ ] verify that the overrides ([code](https://github.com/elastic/eui/pull/8742/files#diff-24325b9407dcf6b823be817fdb86917a655bc96bd25e91408cc1dcb8f2e9f9f3R17)) are applied in this testing example (output as string)
  - set HCM in the Storybook top toolbar
  - verify that both light and dark mode overrides are applied

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
