### PR TITLE
feat(docs): add a warning for EuiSelectable virtualization in jsdom

### DIFF
--- a/packages/website/docs/components/forms/selection/selectable.mdx
+++ b/packages/website/docs/components/forms/selection/selectable.mdx
@@ -907,6 +907,12 @@ When virtualization is on, **every row must be the same height** in order for th
 
 If `listProps.isVirtualized` is set to `false`, each row will fit its content. You can also remove truncation by setting `textWrap="wrap"` when virtualization is off. Note that while this is useful for dynamic options, it can also be computationally expensive as _all_ off-screen options will be rendered to the DOM. We do not recommend turning off virtualization for high numbers of options, but if you absolutely must do so, we suggest using methods such as async loading more options.
 
+:::warning Virtualization in testing environment
+
+In a testing environment, it might be necessary to set `listProps.isVirtualized={false}` to ensure that all options are rendered.
+
+:::
+
 ### Custom content
 
 While it is best to stick to the `option.label, option.append, option.prepend` and `listProps.showIcons` props, you can pass a custom `renderOption` function which will pass back the single `option` object and the `searchValue` to use for highlighting.

--- a/packages/website/docs/components/forms/selection/selectable.mdx
+++ b/packages/website/docs/components/forms/selection/selectable.mdx
@@ -909,7 +909,7 @@ If `listProps.isVirtualized` is set to `false`, each row will fit its content. Y
 
 :::warning Virtualization in testing environment
 
-In a testing environment, it might be necessary to set `listProps.isVirtualized={false}` to ensure that all options are rendered.
+In a testing environment, it might be necessary to set `listProps.isVirtualized` to `false` to ensure that all options are rendered.
 
 :::
 

--- a/packages/website/docs/components/navigation/side-nav.mdx
+++ b/packages/website/docs/components/navigation/side-nav.mdx
@@ -4,7 +4,7 @@ keywords: [EuiSideNav]
 
 # Side nav
 
-**EuiSideNav** is a responsive menu system that usually sits on the left side of a page layout. It will expand to the width of its container. This is the same menu system used for the EUI documentation.
+**EuiSideNav** is a responsive menu system that usually sits on the left side of a page layout. It will expand to the width of its container.
 
 Configure the content of a **EuiSideNav** by passing in an `items` prop. Refer to the source code for an example of this data structure’s anatomy.
 


### PR DESCRIPTION
## Summary

On this PR, I update the docs to offer more guidance and reflect the current state.

- [feat(docs): add a warning for EuiSelectable virtualization in jsdom](https://github.com/elastic/eui/commit/4c2c72fd96e46841bef5121234b8348cf959094b)
- [feat(website): remove mention about old docs in EuiSideNav](https://github.com/elastic/eui/commit/764ac6dceb4373eb121ba46dc109bf724cb63cff)

## QA

- [ ] Verify the admonition renders correctly, the text has no typos and is useful
- [ ] Verify the mention about `EuiSideNav` usage on the docs page is removed
