### PR TITLE
[Docs] Remove Docusaurus global focus outline styles

### DIFF
--- a/packages/docusaurus-preset/src/index.ts
+++ b/packages/docusaurus-preset/src/index.ts
@@ -16,18 +16,22 @@ import type {
 import { Options } from './options';
 
 /**
- * Docusaurus plugin to ignore any Infima stylesheet imports.
+ * Docusaurus plugin to ignore any unwanted style imports, e.g. like Infima stylesheet imports.
  * This is needed so that Infima doesn't pollute global CSS scope
  * and affect how EUI components are rendered
  */
-const ignoreInfimaPlugin: PluginModule = () => ({
-  name: 'ignore-infima-plugin',
+const ignoreInheritedStylesPlugin: PluginModule = () => ({
+  name: 'ignore-styles-plugin',
   configureWebpack() {
     return {
       module: {
         rules: [
           {
             test: /node_modules\/infima/,
+            use: 'null-loader',
+          },
+          {
+            test: /node_modules\/@docusaurus\/theme-common\/lib\/hooks\/styles.css/,
             use: 'null-loader',
           },
         ],
@@ -61,7 +65,7 @@ export default function preset(
   ];
 
   const plugins: PluginConfig[] = [
-    ignoreInfimaPlugin,
+    ignoreInheritedStylesPlugin,
     makePluginConfig('@docusaurus/plugin-content-docs', options.docs),
     makePluginConfig('@docusaurus/plugin-content-pages', options.pages),
     makePluginConfig('@docusaurus/plugin-svgr', options.svgr),


### PR DESCRIPTION
## Summary

This PR excludes a specific style file from being loaded in our docs, as it interferes with EUI focus styles.

The style rule ([code](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-common/src/hooks/styles.css)) has a higher specificity than regular styles and causes issues for the upcoming input design changes.

![Screenshot 2025-06-05 at 18 06 24](https://github.com/user-attachments/assets/3ccbd518-c971-42dc-b04e-35bf86952b51)

```
body:not(.navigation-with-keyboard) *:not(input):focus {
  outline: none;
}
```

Since EUI handles focus outline styling and uses the `outline` property for it, this style is causing issues as it overrides EUI.

### Screenshots

Taken on input VR changes on `eui-theme/borealis-v2-poc` (not merged)

_before_

![Screenshot 2025-06-05 at 18 07 53](https://github.com/user-attachments/assets/8f162335-1185-4e39-a807-aed0ae8c87f6)

_after_

![Screenshot 2025-06-05 at 18 09 30](https://github.com/user-attachments/assets/f012036a-7b14-4782-9eda-345c332e26c7)


### Changes

- renames`ignoreInfimaPlugin` to `ignoreInheritedStylesPlugin` to indicate it's generally about ignoring applied styles instead of only infima styles
-  adds an additional rule to `ignoreInheritedStylesPlugin` to exclude `/node_modules/@docusaurus/theme-common/lib/hooks/styles.css` from being loaded

## QA

- [x] checkout `eui-theme/borealis-v2-poc`, run `yarn`, in `packages/website` build the dependencies with `yarn build:workspaces` and then run the docs with `yarn start`. On `/docs/components/forms/layouts/row/` you can see the initial issue for the `EuiSelect` element
  - apply the changes from this PR, then go to `packages/docusaurus-preset` and run `yarn build` 
  - restart the docs with `yarn start`, the issue should be resolved and the focus outline correctly applied