### PR TITLE
[Docs] Fixed form link on home page

### DIFF
--- a/packages/website/src/components/homepage/highlights/index.tsx
+++ b/packages/website/src/components/homepage/highlights/index.tsx
@@ -57,7 +57,7 @@ const CONTENT_DATA = [
   },
   {
     title: 'Forms',
-    href: './docs/components/forms/form-controls/guidelines/',
+    href: './docs/components/forms/controls/guidelines/',
     svg: SvgForm,
     description: 'Inputs with validation, grouped into a flexible form layout',
   },


### PR DESCRIPTION
## Summary

Fixed broken "Forms" link on the home page of docs.

Fixes https://github.com/elastic/eui/issues/8738