### PR TITLE
[Docs] Updated colors page with data vis contrast and usage guidance

### DIFF
--- a/packages/website/docs/getting-started/theming/tokens/colors/index.mdx
+++ b/packages/website/docs/getting-started/theming/tokens/colors/index.mdx
@@ -269,7 +269,6 @@ Our Data visualization colors and Health and Severity colors prioritize visual c
 
 However, in dark mode, all colors meet the minimum 3:1 contrast ratio, ensuring accessibility compliance. 
 
-For users who enable [**High Contrast mode**](../../high-contrast-mode.mdx) in light mode, we provide an alternate set of tokens with increased contrast by using darker shades, improving legibility while maintaining clarity.
 
 import { EuiTable, EuiTableHeader, EuiTableHeaderCell, EuiTableRow, EuiTableRowCell } from '@elastic/eui';
 
@@ -285,9 +284,5 @@ import { EuiTable, EuiTableHeader, EuiTableHeaderCell, EuiTableRow, EuiTableRowC
   <EuiTableRow>
     <EuiTableRowCell>Light</EuiTableRowCell>
     <EuiTableRowCell>No</EuiTableRowCell>
-  </EuiTableRow>
-  <EuiTableRow>
-    <EuiTableRowCell>Light + High Contrast Mode</EuiTableRowCell>
-    <EuiTableRowCell>Yes</EuiTableRowCell>
   </EuiTableRow>
 </EuiTable>

--- a/packages/website/docs/getting-started/theming/tokens/colors/index.mdx
+++ b/packages/website/docs/getting-started/theming/tokens/colors/index.mdx
@@ -196,6 +196,11 @@ import { SpecialColorsTable } from './special_colors_table';
 
 ## Data visualization colors
 
+:::note Guidance
+
+Data visualization colors semantically tied to data visualizations and are not meant for use in other contexts. Do not use these colors in other contexts.
+:::
+
 import { DataVisColorsTable, DataVisColorsBehindTextColorsTable, DataVisBackgroundColor } from './data_vis_colors_table';
 import { DataVisColorsPreview } from './data_vis_colors_preview'
 
@@ -206,6 +211,8 @@ import { DataVisColorsPreview } from './data_vis_colors_preview'
 
     The following colors are color-blind safe and should be used in categorically seried visualizations and graphics.
     They are meant to be contrasted against the value of <DataVisBackgroundColor /> for the current theme.
+
+    See the [Color Contrast](#contrast) section for a note about color contrast.
   </Example.Description>
   <Example.Preview>
     <DataVisColorsPreview />
@@ -237,6 +244,8 @@ import { SeverityColorsPreview } from './severity_colors_preview'
     typically be associated with positive or negative values.
 
     More guidance is available in the [**Health and Color Pattern**](../../../../patterns/severity.mdx).
+
+    See the [Color Contrast](#contrast) section for a note about color contrast.
   </Example.Description>
   <Example.Preview>
     <SeverityColorsPreview />
@@ -253,3 +262,32 @@ import { SeverityColorsPreview } from './severity_colors_preview'
 <EuiSpacer />
 
 <SeverityColorsTable />
+
+## Contrast ratios and color modes {#contrast}
+
+Our Data visualization colors and Health and Severity colors prioritize visual clarity and aesthetic appeal over strict contrast compliance in light mode. **This means some colors may not meet WCAG contrast requirements against light backgrounds**, as lighter and more saturated tones help differentiate data and create a more visually engaging experience.
+
+However, in dark mode, all colors meet the minimum 3:1 contrast ratio, ensuring accessibility compliance. 
+
+For users who enable [**High Contrast mode**](../../high-contrast-mode.mdx) in light mode, we provide an alternate set of tokens with increased contrast by using darker shades, improving legibility while maintaining clarity.
+
+import { EuiTable, EuiTableHeader, EuiTableHeaderCell, EuiTableRow, EuiTableRowCell } from '@elastic/eui';
+
+<EuiTable>
+  <EuiTableHeader>
+    <EuiTableHeaderCell>Color Mode</EuiTableHeaderCell>
+    <EuiTableHeaderCell>Meets 3:1 contrast ratios?</EuiTableHeaderCell>
+  </EuiTableHeader>
+  <EuiTableRow>
+    <EuiTableRowCell>Dark</EuiTableRowCell>
+    <EuiTableRowCell>Yes</EuiTableRowCell>
+  </EuiTableRow>
+  <EuiTableRow>
+    <EuiTableRowCell>Light</EuiTableRowCell>
+    <EuiTableRowCell>No</EuiTableRowCell>
+  </EuiTableRow>
+  <EuiTableRow>
+    <EuiTableRowCell>Light + High Contrast Mode</EuiTableRowCell>
+    <EuiTableRowCell>Yes</EuiTableRowCell>
+  </EuiTableRow>
+</EuiTable>


### PR DESCRIPTION
## Summary

I updated guidance for Data Visualization colors as well as Health and Severity colors to recommend some guidance mentioned in various channels.


Also, Fixes https://github.com/elastic/eui/issues/8738 with https://github.com/elastic/eui/commit/2439190fa867c26e23e77db1b7efa976728db6ce

Once the build preview is available below, you can review this on the colors page at docs/getting-started/theming/tokens/colors/

**Screenshots**

<img width="868" alt="Screenshot 2025-06-05 at 1 45 56 PM" src="https://github.com/user-attachments/assets/2d446dcb-41da-4b93-b65b-291ef7523403" />

<img width="831" alt="Screenshot 2025-06-05 at 1 09 23 PM" src="https://github.com/user-attachments/assets/e3532c20-d4eb-47e8-bd25-6ed5fe6a1cb6" />
