### PR TITLE
[Docs] Fix global Emotion style order in dev mode

### DIFF
--- a/packages/docusaurus-theme/src/components/theme_context/index.tsx
+++ b/packages/docusaurus-theme/src/components/theme_context/index.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import createCache from '@emotion/cache';
 import {
   EUI_THEME,
   EuiProvider,
@@ -49,9 +50,14 @@ const defaultState: AppThemeContextData = {
   changeTheme: (themeValue: string) => {},
 };
 
-export const AppThemeContext = createContext<AppThemeContextData>(
-  defaultState,
-);
+/* creating a cache and passing it to EuiProvider ensures that
+injected Emotion style tags dev mode are in an expected order
+(global css before component css) */
+const cssCache = createCache({
+  key: 'website-css',
+});
+
+export const AppThemeContext = createContext<AppThemeContextData>(defaultState);
 
 export const useAppTheme: () => AppThemeContextData = () => {
   return useContext(AppThemeContext);
@@ -113,6 +119,7 @@ export const AppThemeProvider: FunctionComponent<PropsWithChildren> = ({
         colorMode={colorMode}
         theme={theme.provider}
         highContrastMode={highContrastMode}
+        cache={cssCache}
       >
         {children}
       </EuiProvider>


### PR DESCRIPTION
## Summary

This PR adds an Emotion cache in our docs package. This solves the issue that injected Emotion style tags (in dev mode only) were not in an expected order. Previously the website specific global and component css would be injected after the EUI css, appended to the EUI default cache. This would cause issues with unexpected overrides, e.g. the global base focus styling overriding component specific outline styles when the selector specificity is equal between the style rules.

Overall previous style order:
- EUI global styles
- EUI component styles
- website global styles
- website component styles

https://github.com/user-attachments/assets/fb1c1efc-5406-4d50-ae7d-e58a5b2b422b

Overall style order after the update:
- EUI global styles
- website global styles
- EUI component styles
- website component styles

https://github.com/user-attachments/assets/ee952bf5-41e9-4b39-85da-fad7e2722929


## QA

Checkout this PR and run the docs locally and:

- [ ] verify that with the update applied the global css (`css-global` and `website-css-global`) are injected before any component css (`css` and `website-css`)
