### PR TITLE
feat(website): add a supported environments section

### DIFF
--- a/packages/website/docs/getting-started/setup.mdx
+++ b/packages/website/docs/getting-started/setup.mdx
@@ -22,6 +22,25 @@ yarn add @elastic/eui @elastic/eui-theme-borealis @elastic/datemath @emotion/rea
 
 You can read more about other ways to <Link to="https://github.com/elastic/eui/blob/main/wiki/consuming-eui/">consume EUI</Link> in our wiki.
 
+## Supported environments
+
+EUI is designed to work in the following environments:
+
+| Environment                | Supported?  | Details |
+|----------------------------|:-----------:|---------|
+| **React 16**               |     ✅      | Fully supported (plans to [deprecate support for React 16](https://github.com/elastic/eui/issues/8578)) |
+| **React 17**               |     ✅      | Fully supported |
+| **React 18**               |     ✅      | Fully supported (recommended) |
+| **React 19**               |     ❌      | Not supported (plans to [introduce support for React 19](https://github.com/elastic/eui/issues/8720)) |
+| **Webpack**                |     ✅      | Fully supported |
+| **Vite**                   |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
+| **Rollup**                 |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
+| **esbuild**                |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
+| **Strict Mode**            |     ❌      | Not supported ([details](https://github.com/elastic/eui/issues/7774)) |
+| **Server-side rendering**  |     ❌      | Not supported ([details](https://github.com/elastic/eui/issues/5419)) |
+
+If you have questions about your environment or run into issues, please open a [GitHub issue](https://github.com/elastic/eui/issues/new/choose) or start a [discussion](https://github.com/elastic/eui/discussions/new/choose).
+
 ## Setting up your application
 
 EUI uses CSS-in-JS (specifically <Link to="https://emotion.sh/">Emotion</Link>) for its styles and theming. As such, we require an `<EuiProvider>` wrapper around your application in order for various theme-related UI & UX (such as dark/light mode switching) to work as expected.

--- a/packages/website/docs/getting-started/setup.mdx
+++ b/packages/website/docs/getting-started/setup.mdx
@@ -26,18 +26,84 @@ You can read more about other ways to <Link to="https://github.com/elastic/eui/b
 
 EUI is designed to work in the following environments:
 
-| Environment                | Supported?  | Details |
-|----------------------------|:-----------:|---------|
-| **React 16**               |     ✅      | Fully supported (plans to [deprecate support for React 16](https://github.com/elastic/eui/issues/8578)) |
-| **React 17**               |     ✅      | Fully supported |
-| **React 18**               |     ✅      | Fully supported (recommended) |
-| **React 19**               |     ❌      | Not supported (plans to [introduce support for React 19](https://github.com/elastic/eui/issues/8720)) |
-| **Webpack**                |     ✅      | Fully supported |
-| **Vite**                   |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
-| **Rollup**                 |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
-| **esbuild**                |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
-| **Strict Mode**            |     ❌      | Not supported ([details](https://github.com/elastic/eui/issues/7774)) |
-| **Server-side Rendering**  |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5419)) |
+```mdx-code-block
+import { EuiTable, EuiTableHeader, EuiTableHeaderCell, EuiTableBody, EuiTableRow, EuiTableRowCell } from '@elastic/eui';
+import { css } from '@emotion/react';
+```
+
+<EuiTable>
+  <EuiTableHeader>
+    <EuiTableHeaderCell>Environment</EuiTableHeaderCell>
+    <EuiTableHeaderCell align="center">Supported?</EuiTableHeaderCell>
+    <EuiTableHeaderCell>Details</EuiTableHeaderCell>
+  </EuiTableHeader>
+  <EuiTableBody>
+    <EuiTableRow>
+      <EuiTableRowCell>React 16</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell>
+        Fully supported (plans to <Link href="https://github.com/elastic/eui/issues/8578">deprecate support for React 16</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>React 17</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell>Fully supported</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>React 18</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell>Fully supported (recommended)</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>React 19</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell>
+        Not supported (plans to <Link href="https://github.com/elastic/eui/issues/8720">introduce support for React 19</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Webpack</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell>Fully supported</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Vite</EuiTableRowCell>
+      <EuiTableRowCell align="center">⚠️</EuiTableRowCell>
+      <EuiTableRowCell>
+        Supported with caveats (<Link href="https://github.com/elastic/eui/issues/5463">details</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Rollup</EuiTableRowCell>
+      <EuiTableRowCell align="center">⚠️</EuiTableRowCell>
+      <EuiTableRowCell>
+        Supported with caveats (<Link href="https://github.com/elastic/eui/issues/5463">details</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>esbuild</EuiTableRowCell>
+      <EuiTableRowCell align="center">⚠️</EuiTableRowCell>
+      <EuiTableRowCell>
+        Supported with caveats (<Link href="https://github.com/elastic/eui/issues/5463">details</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Strict Mode</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell>
+        Not supported (<Link href="https://github.com/elastic/eui/issues/7774">details</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Server-side Rendering</EuiTableRowCell>
+      <EuiTableRowCell align="center">⚠️</EuiTableRowCell>
+      <EuiTableRowCell>
+        Supported with caveats (<Link href="https://github.com/elastic/eui/issues/5419">details</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+  </EuiTableBody>
+</EuiTable>
 
 If you have questions about your environment or run into issues, please open a [GitHub issue](https://github.com/elastic/eui/issues/new/choose) or start a [discussion](https://github.com/elastic/eui/discussions/new/choose).
 

--- a/packages/website/docs/getting-started/setup.mdx
+++ b/packages/website/docs/getting-started/setup.mdx
@@ -37,7 +37,7 @@ EUI is designed to work in the following environments:
 | **Rollup**                 |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
 | **esbuild**                |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
 | **Strict Mode**            |     ❌      | Not supported ([details](https://github.com/elastic/eui/issues/7774)) |
-| **Server-side rendering**  |     ❌      | Not supported ([details](https://github.com/elastic/eui/issues/5419)) |
+| **Server-side Rendering**  |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5419)) |
 
 If you have questions about your environment or run into issues, please open a [GitHub issue](https://github.com/elastic/eui/issues/new/choose) or start a [discussion](https://github.com/elastic/eui/discussions/new/choose).
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui-private/issues/205

On this PR, I add a section regarding supported environments to our docs. For quick reference:

| Environment                | Supported?  | Details |
|----------------------------|:-----------:|---------|
| **React 16**               |     ✅      | Fully supported (plans to [deprecate support for React 16](https://github.com/elastic/eui/issues/8578)) |
| **React 17**               |     ✅      | Fully supported |
| **React 18**               |     ✅      | Fully supported (recommended) |
| **React 19**               |     ❌      | Not supported (plans to [introduce support for React 19](https://github.com/elastic/eui/issues/8720)) |
| **Webpack**                |     ✅      | Fully supported |
| **Vite**                   |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
| **Rollup**                 |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
| **esbuild**                |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5463)) |
| **Strict Mode**            |     ❌      | Not supported ([details](https://github.com/elastic/eui/issues/7774)) |
| **Server-side Rendering**  |     ⚠️      | Supported with caveats ([details](https://github.com/elastic/eui/issues/5419)) |

> [!NOTE]
> The table won't render correctly. Because it doesn't contain any EUI components, any interactivity, I decided to go with Markdown syntax. It will be fixed on https://github.com/elastic/eui/issues/8682

## QA

- [ ] Verify the table details are accurate
