### PR TITLE
feat(eui): add tooltipProps prop to EuiCopy

### DIFF
--- a/packages/eui/changelogs/upcoming/8758.md
+++ b/packages/eui/changelogs/upcoming/8758.md
@@ -1,0 +1,5 @@
+- Added `tooltipProps` prop to `EuiCopy` to spread onto `EuiToolTip` component
+
+**Breaking changes**
+
+- `EuiCopy` no longer receives props directly for the underlying `EuiToolTip` component, you have to pass them through `tooltipProps`

--- a/packages/eui/changelogs/upcoming/8758.md
+++ b/packages/eui/changelogs/upcoming/8758.md
@@ -1,5 +1,3 @@
-- Added `tooltipProps` prop to `EuiCopy` to spread onto `EuiToolTip` component
-
 **Breaking changes**
 
-- `EuiCopy` no longer receives props directly for the underlying `EuiToolTip` component, you have to pass them through `tooltipProps`
+- Added `tooltipProps` to `EuiCopy` which replaces spreading all props to `EuiToolTip`

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, queryByAttribute } from '@testing-library/react';
 import {
   waitForEuiToolTipVisible,
   waitForEuiToolTipHidden,
@@ -82,6 +82,37 @@ describe('EuiCopy', () => {
       await waitForEuiToolTipVisible();
       // The afterMessage should be shown after the copy action
       expect(getByText(afterMessage)).toBeInTheDocument();
+      fireEvent.mouseOut(getByRole('button'));
+      await waitForEuiToolTipHidden();
+    });
+
+    it('tooltipProps', async () => {
+      const tooltipProps = {
+        'data-test-subj': 'customTooltip',
+        className: 'myTooltipClass',
+      };
+      const beforeMessage = 'copy this';
+      const { getByRole } = render(
+        <EuiCopy
+          textToCopy="some text"
+          beforeMessage={beforeMessage}
+          tooltipProps={tooltipProps}
+        >
+          {() => (
+            <button onMouseOver={() => {}} onFocus={() => {}}>
+              Click to copy input text
+            </button>
+          )}
+        </EuiCopy>
+      );
+      // Simulate mouse over to show the tooltip
+      fireEvent.mouseOver(getByRole('button'));
+      await waitForEuiToolTipVisible();
+      // The tooltip portalled, so search the global document
+      const queryByTestSubj = queryByAttribute.bind(null, 'data-test-subj');
+      const tooltip = queryByTestSubj(document.body, 'customTooltip');
+      expect(tooltip instanceof HTMLElement).toBe(true);
+      expect(tooltip?.className).toContain('myTooltipClass');
       fireEvent.mouseOut(getByRole('button'));
       await waitForEuiToolTipHidden();
     });

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -92,7 +92,7 @@ describe('EuiCopy', () => {
         className: 'myTooltipClass',
       };
       const beforeMessage = 'copy this';
-      const { getByRole } = render(
+      const { getByRole, getByTestSubject } = render(
         <EuiCopy
           textToCopy="some text"
           beforeMessage={beforeMessage}
@@ -109,9 +109,8 @@ describe('EuiCopy', () => {
       fireEvent.mouseOver(getByRole('button'));
       await waitForEuiToolTipVisible();
       // The tooltip portalled, so search the global document
-      const queryByTestSubj = queryByAttribute.bind(null, 'data-test-subj');
-      const tooltip = queryByTestSubj(document.body, 'customTooltip');
-      expect(tooltip instanceof HTMLElement).toBe(true);
+      const tooltip = getByTestSubject('customTooltip');
+      expect(tooltip).toBeInTheDocument();
       expect(tooltip?.className).toContain('myTooltipClass');
       fireEvent.mouseOut(getByRole('button'));
       await waitForEuiToolTipHidden();

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { fireEvent, queryByAttribute } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import {
   waitForEuiToolTipVisible,
   waitForEuiToolTipHidden,

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -7,13 +7,33 @@
  */
 
 import React from 'react';
-import { shallow } from 'enzyme';
-import { render } from '../../test/rtl';
+import { fireEvent } from '@testing-library/react';
+import {
+  waitForEuiToolTipVisible,
+  waitForEuiToolTipHidden,
+  render,
+} from '../../test/rtl';
 import { requiredProps } from '../../test';
 
 import { EuiCopy } from './copy';
 
 describe('EuiCopy', () => {
+  const originalExecCommand = document.execCommand;
+
+  beforeAll(() => {
+    Object.defineProperty(document, 'execCommand', {
+      value: jest.fn(() => true),
+      writable: true,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(document, 'execCommand', {
+      value: originalExecCommand,
+      writable: true,
+    });
+  });
+
   it('renders', () => {
     const { container } = render(
       <EuiCopy textToCopy="some text" {...requiredProps}>
@@ -24,23 +44,46 @@ describe('EuiCopy', () => {
   });
 
   describe('props', () => {
-    test('beforeMessage', () => {
-      const component = shallow(
-        <EuiCopy textToCopy="some text" beforeMessage="copy this">
-          {(copy) => <button onClick={copy}>Click to copy input text</button>}
+    it('beforeMessage', async () => {
+      const beforeMessage = 'copy this';
+      const { getByRole, getByText } = render(
+        <EuiCopy textToCopy="some text" beforeMessage={beforeMessage}>
+          {() => (
+            <button onMouseOver={() => {}} onFocus={() => {}}>
+              Click to copy input text
+            </button>
+          )}
         </EuiCopy>
       );
-      expect(component.state('tooltipText')).toBe('copy this');
+      // Simulate mouse over to show the tooltip
+      fireEvent.mouseOver(getByRole('button'));
+      await waitForEuiToolTipVisible();
+      // The beforeMessage should be shown in the tooltip
+      expect(getByText(beforeMessage)).toBeInTheDocument();
+      fireEvent.mouseOut(getByRole('button'));
+      await waitForEuiToolTipHidden();
     });
 
-    test('afterMessage', () => {
-      const component = shallow<EuiCopy>(
-        <EuiCopy textToCopy="some text" afterMessage="successfuly copied">
-          {(copy) => <button onClick={copy}>Click to copy input text</button>}
+    it('afterMessage', async () => {
+      const afterMessage = 'successfully copied';
+      const { getByRole, getByText } = render(
+        <EuiCopy textToCopy="some text" afterMessage={afterMessage}>
+          {(copy) => (
+            <button onClick={copy} onMouseOver={() => {}} onFocus={() => {}}>
+              Click to copy input text
+            </button>
+          )}
         </EuiCopy>
       );
-      const instance = component.instance();
-      expect(instance.props.afterMessage).toBe('successfuly copied');
+
+      // Simulate a click to copy the text
+      fireEvent.click(getByRole('button'));
+      fireEvent.mouseOver(getByRole('button'));
+      await waitForEuiToolTipVisible();
+      // The afterMessage should be shown after the copy action
+      expect(getByText(afterMessage)).toBeInTheDocument();
+      fireEvent.mouseOut(getByRole('button'));
+      await waitForEuiToolTipHidden();
     });
   });
 });

--- a/packages/eui/src/components/copy/copy.tsx
+++ b/packages/eui/src/components/copy/copy.tsx
@@ -11,9 +11,7 @@ import { CommonProps } from '../common';
 import { copyToClipboard } from '../../services';
 import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 
-export interface EuiCopyProps
-  extends CommonProps,
-    Partial<Omit<EuiToolTipProps, 'children'>> {
+export interface EuiCopyProps extends CommonProps {
   /**
    * Text that will be copied to clipboard when copy function is executed.
    */
@@ -32,6 +30,10 @@ export interface EuiCopyProps
    * Use your own logic to create the component that users interact with when triggering copy.
    */
   children(copy: () => void): ReactElement;
+  /**
+   * Optional props to pass to the EuiToolTip component.
+   */
+  tooltipProps?: Partial<EuiToolTipProps>;
 }
 
 interface EuiCopyState {
@@ -67,8 +69,7 @@ export class EuiCopy extends Component<EuiCopyProps, EuiCopyState> {
   };
 
   render() {
-    const { children, textToCopy, beforeMessage, afterMessage, ...rest } =
-      this.props;
+    const { children, tooltipProps } = this.props;
 
     return (
       // See `src/components/tool_tip/tool_tip.js` for explanation of below eslint-disable
@@ -76,7 +77,7 @@ export class EuiCopy extends Component<EuiCopyProps, EuiCopyState> {
       <EuiToolTip
         content={this.state.tooltipText}
         onMouseOut={this.resetTooltipText}
-        {...rest}
+        {...tooltipProps}
       >
         {children(this.copy)}
       </EuiToolTip>

--- a/packages/eui/src/components/copy/copy.tsx
+++ b/packages/eui/src/components/copy/copy.tsx
@@ -33,7 +33,9 @@ export interface EuiCopyProps extends CommonProps {
   /**
    * Optional props to pass to the EuiToolTip component.
    */
-  tooltipProps?: Partial<EuiToolTipProps>;
+  tooltipProps?: Partial<
+    Omit<EuiToolTipProps, 'children' | 'content' | 'onMouseOut'>
+  >;
 }
 
 interface EuiCopyState {

--- a/packages/website/docs/components/display/icons/index.mdx
+++ b/packages/website/docs/components/display/icons/index.mdx
@@ -36,7 +36,7 @@ import { iconSizes, iconSizesText } from './icon_sizes';
     <EuiFlexGrid direction="row" columns={3}>
       {iconSizes.map((size, index) => (
         <EuiFlexItem key={size}>
-          <EuiCopy display="block" textToCopy={size} afterMessage={`${size} copied`}>
+          <EuiCopy textToCopy={size} afterMessage={`${size} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => (
               <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
                 <EuiIcon className="eui-alignMiddle" type="logoElasticsearch" size={size} /> &emsp;{' '}
@@ -69,7 +69,7 @@ import { iconColors } from './icon_colors.ts'
     <EuiFlexGrid direction="row" columns={3}>
       {iconColors.map((color) => (
         <EuiFlexItem key={color}>
-          <EuiCopy display="block" textToCopy={color} afterMessage={`${color} copied`}>
+          <EuiCopy textToCopy={color} afterMessage={`${color} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => {
               const panel = (
                 <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
@@ -107,7 +107,7 @@ import { iconTypes } from './icon_types';
     <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
-          <EuiCopy display="block" textToCopy={iconType} afterMessage={`${iconType} copied`}>
+          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => (
               <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
                 <EuiIcon className="eui-alignMiddle" type={iconType} /> &emsp;{' '}
@@ -134,7 +134,7 @@ import { iconTypesEditor } from './icon_types_editor';
     <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
-          <EuiCopy display="block" textToCopy={iconType} afterMessage={`${iconType} copied`}>
+          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => (
               <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
                 <EuiIcon className="eui-alignMiddle" type={iconType} /> &emsp;{' '}
@@ -196,7 +196,7 @@ import { iconTypesLogos } from './icon_types_logos';
           <EuiFlexGrid direction="row" columns={3}>
             {iconTypes.map((iconType) => (
               <EuiFlexItem key={iconType}>
-                <EuiCopy display="block" textToCopy={iconType} afterMessage={`${iconType} copied`}>
+                <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
                   {(copy) => (
                     <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s" color="transparent">
                       <EuiIcon
@@ -237,7 +237,7 @@ import { iconTypesApps } from './icon_types_apps';
     <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
-          <EuiCopy display="block" textToCopy={iconType} afterMessage={`${iconType} copied`}>
+          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => (
               <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
                 <EuiIcon className="eui-alignMiddle" type={iconType} size="xl" /> &emsp;{' '}
@@ -268,7 +268,7 @@ import { iconTypesML } from './icon_types_ml';
     <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
-          <EuiCopy display="block" textToCopy={iconType} afterMessage={`${iconType} copied`}>
+          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => (
               <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
                 <EuiIcon className="eui-alignMiddle" type={iconType} size="xl" /> &emsp;{' '}
@@ -299,7 +299,7 @@ import { iconTypesTokens } from './icon_types_tokens';
     <EuiFlexGrid direction="row" columns={3}>
       {iconTypes.map((iconType) => (
         <EuiFlexItem key={iconType}>
-          <EuiCopy display="block" textToCopy={iconType} afterMessage={`${iconType} copied`}>
+          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
             {(copy) => (
               <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
                 <EuiToken className="eui-alignMiddle" iconType={iconType} /> &emsp;{' '}

--- a/packages/website/docs/components/navigation/buttons/guidelines_context_menu.tsx
+++ b/packages/website/docs/components/navigation/buttons/guidelines_context_menu.tsx
@@ -24,7 +24,10 @@ export default () => {
   };
 
   const items = [
-    <EuiCopy textToCopy="Copied some text!" anchorClassName="eui-fullWidth">
+    <EuiCopy
+      textToCopy="Copied some text!"
+      tooltipProps={{ anchorClassName: 'eui-fullWidth' }}
+    >
       {(copy) => (
         <EuiContextMenuItem key="copy" icon="copy" onClick={copy} size="s">
           Copy

--- a/packages/website/docs/components/navigation/context-menu.mdx
+++ b/packages/website/docs/components/navigation/context-menu.mdx
@@ -199,7 +199,7 @@ export default () => {
   };
 
   const items = [
-    <EuiCopy textToCopy="Copied some text!" anchorClassName="eui-fullWidth">
+    <EuiCopy textToCopy="Copied some text!" tooltipProps={{ anchorClassName: "eui-fullWidth" }}>
       {(copy) => (
         <EuiContextMenuItem key="copy" icon="copy" onClick={copy} size="s">
           Copy


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> This is a **breaking change**.

Closes https://github.com/elastic/eui/issues/8382

On this PR, I:

- [feat(eui): add tooltipProps prop to EuiCopy](https://github.com/elastic/eui/commit/6f125458541afd497d2066765ec2b1a5bc0c9e96)
- [chore(eui): rewrite EuiCopy tests to RTL](https://github.com/elastic/eui/commit/9fc6b39965ee4108f66ab09ac1a41ded711d7d17)
- [chore(eui): add a test for tooltipProps in EuiCopy](https://github.com/elastic/eui/commit/6a78cfd7e0f8ebc2da88183aa7840c1608e44cef)
- [refactor(website): use tooltipProps for EuiCopy](https://github.com/elastic/eui/commit/2fcd641eb44d0d04de9ff9e52de3d09fc1801b3f)

### Storybook

Control displays correctly:

![Screenshot 2025-06-06 at 17 12 48](https://github.com/user-attachments/assets/f916fd9d-03c5-489c-83e7-caed0239167b)

No VRT references difference that could be a result of the changes on this PR.

### Docs impact

#### Button guidelines ([Staging link](https://eui.elastic.co/pr_8758/docs/components/navigation/buttons/guidelines/#stack-action-sets-into-one-button))

| Production | Localhost |
| ----------- | --------- |
| ![image](https://s7.ezgif.com/tmp/ezgif-7b98d5301a7f78.gif) | ![image](https://s7.ezgif.com/tmp/ezgif-7ba9b34ec8ec37.gif) |

It set `anchorClassName` to `eui-fullWidth` so that the anchor takes the whole width of the container. Otherwise, the result would be:

![full width classname](https://github.com/user-attachments/assets/21a36921-37aa-4d39-8f3b-ff007468c8ab)

#### Context menu ([Staging link](https://eui.elastic.co/pr_8758/docs/components/navigation/context-menu/#sizes))

| Production | Localhost |
| ----------- | --------- |
| ![image](https://s7.ezgif.com/tmp/ezgif-75d184513321f6.gif) | ![image](https://s7.ezgif.com/tmp/ezgif-7bb680d2100baa.gif) |

It set `anchorClassName` to `eui-fullWidth` so that the anchor takes the whole width of the container.

#### Icons ([Staging link](https://eui.elastic.co/pr_8758/docs/components/display/icons/))

| Production | Localhost |
| ----------- | --------- |
| ![image](https://s7.ezgif.com/tmp/ezgif-78e8fcd1e7589b.gif) | ![image](https://s7.ezgif.com/tmp/ezgif-7b72a59491b81f.gif) |

It set `display="block"` on the `EuiToolTip` anchor:

https://github.com/elastic/eui/blob/f319078347eaf905afb667c7492c989fdb1d581e/packages/eui/src/components/tool_tip/tool_tip.tsx#L345-L358

### Kibana impact

There are 3 usages that pass props other than: `textToCopy` (required), `beforeMessage`, `afterMessage`

- [`src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx`](https://github.com/elastic/kibana/blob/7c948829c7112b23ef6d204d433fae1c8b86d6b2/src/platform/packages/private/kbn-esql-editor/src/editor_footer/history_starred_queries.tsx#L298) (`content`)
- [`src/platform/packages/private/kbn-reporting/public/share/share_context_menu/reporting_panel_content/reporting_panel_content.tsx`](https://github.com/elastic/kibana/blob/7c948829c7112b23ef6d204d433fae1c8b86d6b2/src/platform/packages/private/kbn-reporting/public/share/share_context_menu/reporting_panel_content/reporting_panel_content.tsx#L143) (`anchorClassName`)
- [`src/platform/plugins/shared/share/public/components/url_panel_content.tsx`](https://github.com/elastic/kibana/blob/7c948829c7112b23ef6d204d433fae1c8b86d6b2/src/platform/plugins/shared/share/public/components/url_panel_content.tsx#L411) (`anchorClassName`)

[All usages](https://github.com/search?q=repo%3Aelastic%2Fkibana+%3CEuiCopy&type=code) | [Update commit](https://github.com/weronikaolejniczak/kibana/commit/997a7d3c911832fe984675c27c887c7119829e80)

### Cloud UI impact

There are no usages that pass props other than: `textToCopy` (required), `beforeMessage`, `afterMessage`

[All usages](https://github.com/search?q=repo%3Aelastic%2Fcloud+%3CEuiCopy&type=code)

## QA

### Specific checklist

- [ ] The unit tests pass in CI
- [ ] The doc pages have no regression (staging links above)
- [ ] The `EuiCopy` component has no regression in Storybook (you have to run Storybook locally with: `yarn workspace @elastic/eui start`) or on [the documentation page](https://eui.elastic.co/pr_8758/docs/utilities/copy/)
- [ ] The Kibana and Cloud UI affected usages lists are complete

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ]  ~Checked in **mobile**~
    - [ ]  ~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~
    - [ ]  ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ]  ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~ (updated it)
    - [ ]  ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~ (control for the prop, by default object)
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) ~and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [x] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
