### PR TITLE
chore: update pre-release link for breaking changes

### DIFF
--- a/.github/config/label_commenter_config.yml
+++ b/.github/config/label_commenter_config.yml
@@ -20,5 +20,5 @@ labels:
               - [ ] In the PR description or in a PR comment, include a count or list with the number of custom CSS overrides in Kibana that will need to be updated (if that amount is "none", include that information as well)
           - 🔍 Tip: When searching through Kibana, consider excluding `**/target, **/*.snap, **/*.storyshot` files to reduce noise and only look at source code usages
           - ⚠️ For extremely risky changes, the EUI team should potentially consider the following precautions:
-              - Using a [pre-release](https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/releasing-versions.md#pre-release-process) release candidate to test Kibana CI ahead of time
+              - Using a [pre-release](https://github.com/elastic/eui-private/wiki/Release-process#pre-release-process) release candidate to test Kibana CI ahead of time
               - Using [`kibana-a-la-carte`](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#testing-in-the-cloud) for manual QA, and to give other Kibana teams a staging server to quickly test against


### PR DESCRIPTION
## Summary

Breaking change label commenter links to the wrong pre-release instructions ([example](https://github.com/elastic/eui/pull/8758#issuecomment-2949485657)). I updated it to: https://github.com/elastic/eui/blob/main/wiki/eui-team-processes/releasing-versions.md#pre-release-process

![Screenshot 2025-06-06 at 16 50 22](https://github.com/user-attachments/assets/dc46e09b-4623-45bc-b745-34ab49b88181)
