### PR TITLE
feat(website): render guidelines side-by-side in accessibility

### DIFF
--- a/packages/website/docs/components/display/toast/_guidelines.mdx
+++ b/packages/website/docs/components/display/toast/_guidelines.mdx
@@ -68,7 +68,7 @@ This page documents patterns for using toasts, short messages that appears on th
 
 <EuiSpacer />
 
-## Use a toast for a timely message
+### Use a toast for a timely message
 
 Toasts are appropriate for short feedback related to a user action. A toast should contain a message about a current action, not a historical action.
 
@@ -89,7 +89,7 @@ Toasts are appropriate for short feedback related to a user action. A toast shou
   </Guideline>
 </EuiFlexGroup>
 
-## Most often, it's a single line of text
+### Most often, it's a single line of text
 
 By default, a toast stays on the screen 10 seconds. Users should be able read the message in 6 to 7 seconds. The message should get straight to the point and rarely include more than one line.
 
@@ -116,7 +116,7 @@ By default, a toast stays on the screen 10 seconds. Users should be able read th
   </Guideline>
 </EuiFlexGroup>
 
-## Toasts should only contain a single action
+### Toasts should only contain a single action
 
 A toast can have a single action, styled as a standard button. If more actions are needed, or if the action is important enough to interrupt the user, use a modal instead.
 
@@ -150,7 +150,7 @@ A toast can have a single action, styled as a standard button. If more actions a
   </Guideline>
 </EuiFlexGroup>
 
-## Icons should emphasize actions
+### Icons should emphasize actions
 
 An icon on the left of the message can help define the message type.
 
@@ -180,7 +180,7 @@ An icon on the left of the message can help define the message type.
   </Guideline>
 </EuiFlexGroup>
 
-## Display one toast at a time
+### Display one toast at a time
 
 Users should be able to take in all the details from one toast before the next one arrives.
 
@@ -211,7 +211,7 @@ Users should be able to take in all the details from one toast before the next o
   </Guideline>
 </EuiFlexGroup>
 
-## Keep messages as short as possible
+### Keep messages as short as possible
 
 For common actions such as create, add, delete, remove, and save, include the object type, the object name if available, and the past tense of the action.
 
@@ -270,7 +270,7 @@ For a message about multiple objects, include the object count, but not the name
   </Guideline>
 </EuiFlexGroup>
 
-## Use call-to-action buttons when the content needs more room
+### Use call-to-action buttons when the content needs more room
 
 Occasionally, the content of a toast is too involved to fit into the constrained space of a toast. This is common in long error messages. In these cases use the toast to deliver the summary of the information and use a button to provide a call-to-action for the full message.
 

--- a/packages/website/docs/components/display/tour/_guidelines.mdx
+++ b/packages/website/docs/components/display/tour/_guidelines.mdx
@@ -6,7 +6,7 @@ import image6Example from '!url-loader!./tour_6.gif';
 
 This page documents best practices for tour design including content, length and use cases.
 
-## When to use tours
+### When to use tours
 
 Use tours when you want users to learn about specific UI elements and how interacting with them will help them achieve a goal. When you want to help users perform an action but don't want to provide step by step guidance, you can use empty states instead as seen in EuiEmptyPrompt.
 
@@ -18,7 +18,7 @@ For certain users, product tours can feel intrusive so first assess the fit for 
 
 Additionally, consider asking users if they're interested in checking out your product tour instead of just showing it to them.
 
-## Provide concise yet valuable information
+### Provide concise yet valuable information
 
 If you include information that is too obvious or basic, it is more likely that the user will dismiss the product tour and start perceiving them as low value. If further explanation is needed, consider linking out to documentation.
 
@@ -39,7 +39,7 @@ If you include information that is too obvious or basic, it is more likely that 
   </Guideline>
 </EuiFlexGroup>
 
-## Explain why the actions you want users to perform are useful
+### Explain why the actions you want users to perform are useful
 
 If users see value in an action they'll be more likely to engage.
 
@@ -52,7 +52,7 @@ If users see value in an action they'll be more likely to engage.
   />
 </EuiAspectRatio>
 
-## Keep the tone conversational and friendly
+### Keep the tone conversational and friendly
 
 Good copy is a key element for a product tour's success. Make sure you work alongside a writer in this process.
 
@@ -65,7 +65,7 @@ Good copy is a key element for a product tour's success. Make sure you work alon
   />
 </EuiAspectRatio>
 
-## Allow users to end and restart the tour at any time
+### Allow users to end and restart the tour at any time
 
 You can include a “Skip tour” button in your step's footer. Users might be quick to dismiss a tour but realize they need to use it later on. Give them the option to re-trigger the tour at any time. A good spot for a tour's trigger is the application's help menu.
 
@@ -82,23 +82,23 @@ You can include a “Skip tour” button in your step's footer. Users might be q
 
 <EuiFlexGroup>
   <EuiFlexItem>
-    ## Keep your tours short
+    ### Keep your tours short
 
     The more steps, the less likely it is that a user will complete a tour. If you need to decide which steps to drop, think of the ones the user is more likely to be able to figure out on their own.
   </EuiFlexItem>
   <EuiFlexItem>
-    ## Be careful when using action-driven tours
+    ### Be careful when using action-driven tours
 
     Tours where one step cannot be completed until the previous step has been completed can lead to the user feeling trapped. A nice detail when using this type of tours is to automatically take the user to the next step upon completion of the current step, instead of having to click on Next.
   </EuiFlexItem>
   <EuiFlexItem>
-    ## Adjust your tour based on UX research
+    ### Adjust your tour based on UX research
 
     Once your tour goes live, monitor user behavior to learn about what's working and identify drop-off points. Based on that, iterate on your tour.
   </EuiFlexItem>
 </EuiFlexGroup>
 
-## Consider using animation gifs
+### Consider using animation gifs
 
 A short, nicely crafted animation can be very effective for teaching a user about a feature.
 

--- a/packages/website/docs/getting-started/accessibility.mdx
+++ b/packages/website/docs/getting-started/accessibility.mdx
@@ -5,8 +5,10 @@ sidebar_position: 4
 
 # Accessibility guidelines
 
+```mdx-code-block
 import Link from '@docusaurus/Link';
-import { EuiText } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
+```
 
 :::info Check component-level guidance
 
@@ -43,33 +45,39 @@ You can aid navigation and make pages more accessible for screen reader users by
 
 ### Heading examples
 
-<Guideline type="do" panelPadding="none" text="Descend through headings as you work your way through the document.">
-  ```tsx
-  <EuiText>
-    <h1>Discover your data</h1>
-    <p>Some content</p>
-    <h2>Drill into site metrics</h2>
-    <h3>An important site metric</h3>
-    <h3>Another important site metric</h3>
-  </EuiText>
-  ```
-</Guideline>
-
-<Guideline type="dont" panelPadding="none" text="This heading hierarchy is confusing. Also EuiText is not a good solution when you need to change heading presentation.">
-  ```tsx
-  <EuiText>
-    <EuiScreenReaderOnly>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Descend through headings as you work your way through the document.">
+    ```tsx
+    <EuiText>
       <h1>Discover your data</h1>
-    </EuiScreenReaderOnly>
-    <p>Some content</p>
-    <h2>Discover your data</h2>
-    <!-- Missing h3 header -->
-    <h4 className="myLargeTitle">
-      An important site metric
-    </h4>
-  </EuiText>
-  ```
-</Guideline>
+      <p>Some content</p>
+      <h2>Drill into site metrics</h2>
+      <h3>An important site metric</h3>
+      <h3>Another important site metric</h3>
+    </EuiText>
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="This heading hierarchy is confusing. Also EuiText is not a good solution when you need to change heading presentation.">
+    ```tsx
+    <EuiText>
+      <EuiScreenReaderOnly>
+        <h1>Discover your data</h1>
+      </EuiScreenReaderOnly>
+      <p>Some content</p>
+      <h2>Discover your data</h2>
+      <!-- Missing h3 header -->
+      <h4 className="myLargeTitle">
+        An important site metric
+      </h4>
+    </EuiText>
+    ```
+  </Guideline>
+</EuiFlexGroup>
+
+
+:::tip
+[**EuiTitle**](../components/display/title.mdx) gives you a way to separate your presentation from your semantic markup.
+:::
 
 <Guideline type="do" panelPadding="none" text="This is a good heading hierarchy. Though visible headings are certainly better, sometimes that is difficult to accommodate so hidden headings can give additional context.">
   ```tsx
@@ -80,40 +88,36 @@ You can aid navigation and make pages more accessible for screen reader users by
   ```
 </Guideline>
 
-:::tip
-[**EuiTitle**](../components/display/title.mdx) gives you a way to separate your presentation from your semantic markup.
-:::
-
 **Landmarks** are another way for screen readers to navigate pages. A benefit of landmarks is that they offer more context on the type of content to expect than a heading. This is useful for tech that offers reader modes (e.g., Firefox, Safari, and apps like Pocket) and new form factors (e.g., smartwatches). Many landmarks are mapped to HTML elements, such as `<main>`, `<aside>`, `<article>`; others are exposed through the `role` attribute.
 
 You can implement named landmarks with `aria-label` or `aria-labelledby`. However, having a heading inside of the landmark (even if it is visually hidden) and referenced by `aria-labelledby` is preferred.
 
 ### Landmarks example
 
-<Guideline type="do" panelPadding="none" text="Use HTML5 elements which convey semantic meaning about their purpose. Notice that all of the content is inside of semantic elements.">
-  ```html
-  <body>
-    <header className="appHeader">
-      <!-- content -->
-    </header>
-    <main><!-- content --></main>
-    <footer className="appFooter">
-      <!-- content -->
-    </footer>
-  </body>
-  ```
-</Guideline>
-
-
-<Guideline type="dont" panelPadding="none" text="Classes provide no semantic meaning and not all elements provide semantic meaning either.">
-  ```html
-  <body>
-    <div className="appHeader"></div>
-    <discover-app></discover-app>
-    <ul className="appFooter"></ul>
-  </body>
-  ```
-</Guideline>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Use HTML5 elements which convey semantic meaning about their purpose. Notice that all of the content is inside of semantic elements.">
+    ```tsx
+    <body>
+      <header className="appHeader">
+        <!-- content -->
+      </header>
+      <main><!-- content --></main>
+      <footer className="appFooter">
+        <!-- content -->
+      </footer>
+    </body>
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="Classes provide no semantic meaning and not all elements provide semantic meaning either.">
+    ```tsx
+    <body>
+      <div className="appHeader"></div>
+      <discover-app></discover-app>
+      <ul className="appFooter"></ul>
+    </body>
+    ```
+  </Guideline>
+</EuiFlexGroup>
 
 ### Headings and named landmarks example
 

--- a/packages/website/docs/getting-started/testing/recommendations.mdx
+++ b/packages/website/docs/getting-started/testing/recommendations.mdx
@@ -4,7 +4,10 @@ sidebar_label: Recommendations
 
 # Testing recommendations
 
+```mdx-code-block
 import Link from '@docusaurus/Link';
+import { EuiFlexGroup } from '@elastic/eui';
+```
 
 Our general set of do's and don'ts for testing components and views.
 
@@ -16,21 +19,22 @@ Prioritize accessible and semantic queries (e.g., `[role="dialog"]`) followed by
 
 Check out our component-specific testing docs to find the selectors we officially support.
 
-<Guideline type="do" panelPadding="none" text="Use accessible and semantic queries.">
-  ```tsx
-  screen.getByRole('dialog'); // react-testing-library
-  cy.get('[role="dialog"]'); // cypress
-  driver.findElement(By.cssSelector('[role="dialog"]')); // selenium
-  ```
-</Guideline>
-
-<Guideline type="dont" panelPadding="none" text="Query by internal EUI selectors, especially when better selectors are available.">
-  ```tsx
-  container.querySelector('.euiFlyout'); // react-testing-library
-  cy.get('.euiFlyout'); // cypress
-  driver.findElement(By.cssSelector('.euiFlyout')); // selenium
-  ```
-</Guideline>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Use accessible and semantic queries.">
+    ```tsx
+    screen.getByRole('dialog'); // react-testing-library
+    cy.get('[role="dialog"]'); // cypress
+    driver.findElement(By.cssSelector('[role="dialog"]')); // selenium
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="Query by internal EUI selectors, especially when better selectors are available.">
+    ```tsx
+    container.querySelector('.euiFlyout'); // react-testing-library
+    cy.get('.euiFlyout'); // cypress
+    driver.findElement(By.cssSelector('.euiFlyout')); // selenium
+    ```
+  </Guideline>
+</EuiFlexGroup>
 
 ## Don't use snapshots
 
@@ -40,20 +44,21 @@ Tests should tell a story and be considered an instant red flag whenever they fa
 
 Instead, consider writing simple but precise assertion tests.
 
-<Guideline type="do" panelPadding="none" text="Query and assert on elements you actually want to test">
-  ```tsx
-  const { getByText, getByRole } = render(<MyComponent />);
-  expect(getByText('Hello, World!')).toBeInTheDocument();
-  expect(getByRole('button')).toHaveTextContent('Save');
-  ```
-</Guideline>
-
-<Guideline type="dont" panelPadding="none" text="Snapshot whole components">
-  ```tsx
-  const { container } = render(<MyComponent />); // react-testing-library
-  expect(container).toMatchSnapshot();
-  ```
-</Guideline>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Query and assert on elements you actually want to test">
+    ```tsx
+    const { getByText, getByRole } = render(<MyComponent />);
+    expect(getByText('Hello, World!')).toBeInTheDocument();
+    expect(getByRole('button')).toHaveTextContent('Save');
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="Snapshot whole components">
+    ```tsx
+    const { container } = render(<MyComponent />); // react-testing-library
+    expect(container).toMatchSnapshot();
+    ```
+  </Guideline>
+</EuiFlexGroup>
 
 ## Avoid time-based waits
 
@@ -65,20 +70,21 @@ Sometimes the easiest solution to fixing a test is adding a wait/sleep call. In 
 
 Instead, use the utilities available for every testing framework to wait for elements to appear or for asynchronous operations to finish execution.
 
-<Guideline type="do" panelPadding="none" text="Programmatically await changes to occur">
-  ```tsx
-  screen.getByRole('button', { name: 'Save document' });
-  expect(await screen.findByText('Document saved successfully')).toBeInTheDocument();
-  ```
-</Guideline>
-
-<Guideline type="dont" panelPadding="none" text="Add timeouts and other static waits">
-  ```tsx
-  screen.getByRole('button', { name: 'Save document' });
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  expect(screen.getByText('Document saved successfully')).toBeInTheDocument();
-  ```
-</Guideline>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Programmatically await changes to occur">
+    ```tsx
+    screen.getByRole('button', { name: 'Save document' });
+    expect(await screen.findByText('Document saved successfully')).toBeInTheDocument();
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="Add timeouts and other static waits">
+    ```tsx
+    screen.getByRole('button', { name: 'Save document' });
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    expect(screen.getByText('Document saved successfully')).toBeInTheDocument();
+    ```
+  </Guideline>
+</EuiFlexGroup>
 
 ## Write clear test names
 
@@ -86,43 +92,45 @@ Test cases and suites should have unambiguous names and match the naming convent
 
 We recommend using the third-person singular simple present tense for its short form and ease of reading.
 
-<Guideline type="do" panelPadding="none" text="Use clear and consistent names and test grouping">
-  ```tsx
-  describe('arraySearch()', () => { // use tested function name as the root group name
-    it('accepts object arrays', () => { /* [...] */ });
-    it('accepts string arrays', () => { /* [...] */ });
-    it('throw on non-array inputs', () => { /* [...] */});
-    it('supports the `options.caseSensitive` option', () => { /*[...]*/ });
-  });
-  ```
-</Guideline>
-
-<Guideline type="dont" panelPadding="none" text="Use inconsistent or unclear naming">
-  ```tsx
-  describe('array search', () => { // bad: not pointing to what exactly this group is testing
-    it('object arrays', () => { /* [...] */ }); // bad: not enough context
-    it('arraySearch(["a", "b"])', () => { /* [...] */ }); // bad: function call example may not be easily understandable
-    it('should throw on non-array inputs', () => { /* [...] */ });
-    it('supports options.caseSensitive', () => { /* [...] */ }); // bad: using two different naming conventions; see line above
-  });
-  ```
-</Guideline>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Use clear and consistent names and test grouping">
+    ```tsx
+    describe('arraySearch()', () => { // use tested function name as the root group name
+      it('accepts object arrays', () => { /* [...] */ });
+      it('accepts string arrays', () => { /* [...] */ });
+      it('throw on non-array inputs', () => { /* [...] */});
+      it('supports the `options.caseSensitive` option', () => { /*[...]*/ });
+    });
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="Use inconsistent or unclear naming">
+    ```tsx
+    describe('array search', () => { // bad: not pointing to what exactly this group is testing
+      it('object arrays', () => { /* [...] */ }); // bad: not enough context
+      it('arraySearch(["a", "b"]), () => { /* [...] */ }); // bad: function call example may not be easily understandable
+      it('should throw on non-array inputs', () => { /* [...] */ });
+      it('supports options.caseSensitive', () => { /* [...] */ }); // bad: using two different naming conventions; see line above
+    });
+    ```
+  </Guideline>
+</EuiFlexGroup>
 
 ### Wrap property names and data in  `` ` ``
 
 When including property and argument names in the test name string, wrap them in backticks (`` ` ``) to clearly separate them from the rest of the text.
 
-<Guideline type="do" panelPadding="none" text="Wrap property names in backticks">
-  ```tsx
-  it('returns an empty object when the `value` string is empty');
-  ```
-</Guideline>
-
-<Guideline type="dont" panelPadding="none" text="Have no separation between property names and the rest of the text">
-  ```tsx
-  it('returns an empty object when the value string is empty');
-  ```
-</Guideline>
+<EuiFlexGroup gutterSize="m">
+  <Guideline type="do" panelPadding="none" text="Wrap property names in backticks">
+    ```tsx
+    it('returns an empty object when the `value` string is empty');
+    ```
+  </Guideline>
+  <Guideline type="dont" panelPadding="none" text="Have no separation between property names and the rest of the text">
+    ```tsx
+    it('returns an empty object when the value string is empty');
+    ```
+  </Guideline>
+</EuiFlexGroup>
 
 ## Add debug-friendly comments or error messages
 


### PR DESCRIPTION
## Summary

On this PR, I:

- [fix(website): use h3 for guideline sections in toast and tour](https://github.com/elastic/eui/commit/e3e0340f60ea28a24abbd39b697071576d7cd707)
- [feat(website): render guidelines side-by-side in recommendations](https://github.com/elastic/eui/commit/67d0401500575397febcee68209df3047024e6d5)
- [feat(website): render guidelines side-by-side in accessibility](https://github.com/elastic/eui/commit/7eb00ceecd62ce4618e9010c4fe42cde150cbdbe)

## QA

- [ ] Toast guidelines sections use h3
- [ ] Tour guidelines sections use h3
- [ ] Recommendations page renders guidelines side-by-side
- [ ] Accessibility page renders guidelines side-by-side
