### PR TITLE
Disable generation of sourcemaps for @elastic/eui-theme-borealis and @elastic/eui-theme-common

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8764.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8764.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed missing source map warnings emitted by some bundlers by excluding source maps from being published
+  - To align with `@elastic/eui` and many other popular packages, we made a call to not ship source maps anymore

--- a/packages/eui-theme-borealis/package.json
+++ b/packages/eui-theme-borealis/package.json
@@ -8,7 +8,7 @@
     "build:clean": "rimraf lib/",
     "build": "yarn build:clean && yarn build:compile && yarn build:compile:cjs && yarn build:types && yarn copy-files",
     "build:compile": "tsc --project ./tsconfig.json",
-    "build:compile:cjs": "NODE_ENV=production NO_COREJS_POLYFILL=true babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx --source-maps=true",
+    "build:compile:cjs": "NODE_ENV=production NO_COREJS_POLYFILL=true babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx",
     "build:types": "NODE_ENV=production tsc --project tsconfig.types.json",
     "build-pack": "yarn build && npm pack",
     "copy-files": "node ./scripts/copy-json-files.js",

--- a/packages/eui-theme-borealis/tsconfig.cjs.json
+++ b/packages/eui-theme-borealis/tsconfig.cjs.json
@@ -11,7 +11,6 @@
     ],
     "moduleResolution": "Node",
     "declaration": true,
-    "sourceMap": true,
     "noEmitHelpers": true,
     "incremental": true,
     "esModuleInterop": true,

--- a/packages/eui-theme-borealis/tsconfig.json
+++ b/packages/eui-theme-borealis/tsconfig.json
@@ -11,7 +11,6 @@
     ],
     "moduleResolution": "Node",
     "declaration": true,
-    "sourceMap": true,
     "noEmitHelpers": true,
     "incremental": true,
     "esModuleInterop": true,

--- a/packages/eui-theme-borealis/tsconfig.types.json
+++ b/packages/eui-theme-borealis/tsconfig.types.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": "lib/cjs",
         "declaration": true,
-        "declarationMap": true,
         "isolatedModules": false,
         "noEmit": false,
         "allowJs": false,

--- a/packages/eui-theme-common/changelogs/upcoming/8764.md
+++ b/packages/eui-theme-common/changelogs/upcoming/8764.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed missing source map warnings emitted by some bundlers by excluding source maps from being published
+  - To align with `@elastic/eui` and many other popular packages, we made a call to not ship source maps anymore

--- a/packages/eui-theme-common/package.json
+++ b/packages/eui-theme-common/package.json
@@ -7,7 +7,7 @@
     "build:clean": "rimraf lib/",
     "build": "yarn build:clean && yarn build:compile && yarn build:compile:cjs && yarn build:types",
     "build:compile": "tsc --project ./tsconfig.json",
-    "build:compile:cjs": "NODE_ENV=production NO_COREJS_POLYFILL=true babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx --source-maps=true",
+    "build:compile:cjs": "NODE_ENV=production NO_COREJS_POLYFILL=true babel src --out-dir=lib/cjs --extensions .js,.ts,.tsx",
     "build:types": "NODE_ENV=production tsc --project tsconfig.types.json",
     "build-pack": "yarn build && npm pack",
     "lint": "yarn tsc --noEmit && yarn lint-es && yarn lint-sass",

--- a/packages/eui-theme-common/tsconfig.cjs.json
+++ b/packages/eui-theme-common/tsconfig.cjs.json
@@ -11,7 +11,6 @@
     ],
     "moduleResolution": "Node",
     "declaration": true,
-    "sourceMap": true,
     "noEmitHelpers": true,
     "incremental": true,
     "esModuleInterop": true,

--- a/packages/eui-theme-common/tsconfig.json
+++ b/packages/eui-theme-common/tsconfig.json
@@ -11,7 +11,6 @@
     ],
     "moduleResolution": "Node",
     "declaration": true,
-    "sourceMap": true,
     "noEmitHelpers": true,
     "incremental": true,
     "esModuleInterop": true,

--- a/packages/eui-theme-common/tsconfig.types.json
+++ b/packages/eui-theme-common/tsconfig.types.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "outDir": "lib/cjs",
         "declaration": true,
-        "declarationMap": true,
         "isolatedModules": false,
         "noEmit": false,
         "allowJs": false,


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/8699

Based on a recent discussion, we've decided not to include sourcemaps in published packages.
The reason is primarily based on the fact that our distribution files aren't minified, and having source maps pointing to TypeScript source files that we don't include in published packages leads to "file not found" warnings reported for some bundler configurations.

## QA

1. Checkout this branch locally
2. Install all dependencies - `yarn`
3. Build related packages - `yarn workspace @elastic/eui-theme-borealis build && yarn workspace @elastic/eui-theme-common build`
4. Confirm the dist directories (`packages/eui-theme-borealis/lib` and `packages/eui-theme-common/lib`) contain no `.map` files

### General checklist

- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
