### PR TITLE
[Changelog] Update #8725 changelogs

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8725.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8725.md
@@ -1,4 +1,3 @@
-- Renamed `colors.vis.euiColorVisNeutral0` to `euiColorVisBase0`
 - Added new tokens on `colors.vis`:
   -  `euiColorVisNeutral0`
   -  `euiColorVisNeutral1`
@@ -6,6 +5,10 @@
   -  `euiColorVisRisk0`
   -  `euiColorVisRisk1`
 - Updated the value of token `colors.vis.euiColorVisWarning0`
+
+**Breaking changes**
+
+- Renamed `colors.vis.euiColorVisNeutral0` to `euiColorVisBase0`
 
 
 

--- a/packages/eui/changelogs/upcoming/8725.md
+++ b/packages/eui/changelogs/upcoming/8725.md
@@ -2,7 +2,6 @@
   - `euiPaletteSkyBlue`, `useEuiPaletteSkyBlue`
   - `euiPaletteYellow`, `useEuiPaletteYellow`
   - `euiPaletteOrange`, `useEuiPaletteOrange`
-- Renamed `colors.vis.euiColorVisNeutral0` to `euiColorVisBase0`
 - Added new tokens on `colors.vis`:
   -  `euiColorVisNeutral0`
   -  `euiColorVisNeutral1`
@@ -10,6 +9,10 @@
   -  `euiColorVisRisk0`
   -  `euiColorVisRisk1`
 - Updated the value of token `colors.vis.euiColorVisWarning0`
+
+**Breaking changes**
+
+- Renamed `colors.vis.euiColorVisNeutral0` to `euiColorVisBase0`
 
 
 


### PR DESCRIPTION
## Summary

Initially [this PR](https://github.com/elastic/eui/pull/8725) was marked as non-breaking but after discussion we decided to consider those type of visual changes as breaking too.
While the changes are not technically breaking, they require updates to be used the way we intent them to.