### PR TITLE
[Cypress][EuiDataGrid] Fix locally failing test

### DIFF
--- a/packages/eui/src/components/datagrid/body/cell/data_grid_cell.styles.spec.tsx
+++ b/packages/eui/src/components/datagrid/body/cell/data_grid_cell.styles.spec.tsx
@@ -132,6 +132,7 @@ describe('Cell outline styles', () => {
           });
 
         cy.realPress('Enter');
+        cy.wait(50);
         getHeaderCell().then(($el) => {
           expect(getOutlineColor($el[0])).to.eq(EXPECTED_HOVER_COLOR);
         });
@@ -162,6 +163,7 @@ describe('Cell outline styles', () => {
           });
 
         cy.realPress('Enter');
+        cy.wait(50);
         getRowCell().then(($el) => {
           expect(getOutlineColor($el[0])).to.eq(EXPECTED_HOVER_COLOR);
         });


### PR DESCRIPTION
## Summary

This PR updates the `data_grid_cell.styles.spec.tsx` cypress test which would fail when run locally only.
It looks like the call to `getComputedStyle` that gets the style information might happen too early. Adding a `wait()` resolves the issue.

>[!NOTE]
The checks to styles should probably not happen in a cypress test as we're rather verifying functionality in those.
We should consider migrating those tests to VRT instead.

## QA

Checkout this PR and run cypress tests locally in `eui/packages/eui`: `yarn test-cypress-dev` and choose `data_grid_cell.styles.spec.tsx` to run.

- [x] verify no tests fail
  - [x] (optional) compare the behavior when reverting the PR changes - the focus trap tests would fail.