### PR TITLE
[Website] Fix unexpected page background styles

### DIFF
--- a/packages/docusaurus-theme/src/theme/infima.styles.ts
+++ b/packages/docusaurus-theme/src/theme/infima.styles.ts
@@ -330,8 +330,8 @@ export const getInfimaStyles = () => css`
   }
 
   html {
-    background-color: var(--ifm-background-color);
-    color: var(--ifm-font-color-base);
+    background-color: var(--ifm-background-color) !important;
+    color: var(--ifm-font-color-base) !important;
     color-scheme: var(--ifm-color-scheme);
     -webkit-font-smoothing: antialiased;
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## Summary

This PR is quick fix follow-up to this [previous PR](https://github.com/elastic/eui/pull/8754) that updated how Emotion styles are applied. The updated Emotion css order had an unexpected impact on the build styles which resulted in `EuiGlobalStyles` overwriting the project global styles. This specifically resulted in the background-color being noticeable changed.

As quick fix this PR ensures the `website` styles are enforced.

💭 Long term we might need to check how to better handle global styles (do we rather disable global styles on the `EuiProvider` with `globalStyles={false}` and provide project internal reset and global styles? Can we inject the `EuiGlobalStyles` in a different way that ensures the correct order? Or do we need to make `EuiGlobalStyles` more customizable?

_before_

![Screenshot 2025-06-10 at 21 16 01](https://github.com/user-attachments/assets/01240dfc-2e62-4223-b0dd-8aa5776e1505)

_after_

![Screenshot 2025-06-10 at 21 16 06](https://github.com/user-attachments/assets/942789cb-b296-45fc-8970-7055a97ed0fd)

## QA

- [ ] verify the that the page background for staging has a background color of  `#0B1628 ` (set as `backgroundBasePlain`) instead of `#07101F` (inherited from EUI `colors.body`)