### PR TITLE
[EuiCheckableCard] Fix onChange handler being invoked twice

### DIFF
--- a/packages/eui/changelogs/upcoming/8786.md
+++ b/packages/eui/changelogs/upcoming/8786.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `onChange` being triggered twice when the checkbox in `EuiCheckableCard` is clicked
+

--- a/packages/eui/src/components/card/checkable_card/checkable_card.spec.tsx
+++ b/packages/eui/src/components/card/checkable_card/checkable_card.spec.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
+/// <reference types="../../../../cypress/support" />
+
+import React, { FunctionComponent, useState } from 'react';
+
+import { EuiCheckableCard, type EuiCheckableCardProps } from '../index';
+
+describe('EuiCheckableCard', () => {
+  const StatefulCheckableCard: FunctionComponent<
+    Partial<EuiCheckableCardProps>
+  > = ({ checkableType = 'checkbox', ...rest }) => {
+    const [isChecked, setChecked] = useState(false);
+
+    return (
+      <EuiCheckableCard
+        id="checkableCard"
+        label="Checkable card"
+        data-test-subj="checkableCard"
+        checkableType={checkableType}
+        {...rest}
+        checked={isChecked}
+        onChange={() => setChecked((checked) => !checked)}
+      />
+    );
+  };
+
+  describe('Click behavior', () => {
+    it('fired onChange only once when the checkbox is clicked', () => {
+      cy.realMount(<StatefulCheckableCard />);
+
+      cy.get('[data-test-subj=checkableCard]').realClick();
+
+      cy.get('[data-test-subj=checkableCard]').should('be.checked');
+    });
+  });
+});

--- a/packages/eui/src/components/card/checkable_card/checkable_card.tsx
+++ b/packages/eui/src/components/card/checkable_card/checkable_card.tsx
@@ -75,6 +75,7 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
 
   const { id } = rest;
   const labelEl = useRef<HTMLLabelElement>(null);
+  const inputEl = useRef<HTMLInputElement>(null);
   const classes = classNames('euiCheckableCard', className);
 
   let checkableElement;
@@ -88,14 +89,19 @@ export const EuiCheckableCard: FunctionComponent<EuiCheckableCardProps> = ({
     );
   } else {
     checkableElement = (
-      <EuiCheckbox checked={checked} disabled={disabled} {...rest} />
+      <EuiCheckbox
+        inputRef={inputEl}
+        checked={checked}
+        disabled={disabled}
+        {...rest}
+      />
     );
   }
 
   const labelClasses = classNames('euiCheckableCard__label');
 
-  const onChangeAffordance = () => {
-    if (labelEl.current) {
+  const onChangeAffordance = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (labelEl.current && e.target !== inputEl.current) {
       labelEl.current.click();
     }
   };

--- a/packages/eui/src/components/form/checkbox/checkbox.tsx
+++ b/packages/eui/src/components/form/checkbox/checkbox.tsx
@@ -13,6 +13,7 @@ import React, {
   InputHTMLAttributes,
   LabelHTMLAttributes,
   useCallback,
+  Ref,
 } from 'react';
 import classNames from 'classnames';
 
@@ -28,7 +29,7 @@ export interface EuiCheckboxProps
   id: string;
   checked?: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>; // overriding to make it required
-  inputRef?: (element: HTMLInputElement) => void;
+  inputRef?: Ref<HTMLInputElement> | ((element: HTMLInputElement) => void);
   label?: ReactNode;
   disabled?: boolean;
   indeterminate?: boolean;

--- a/packages/website/docs/components/containers/card.mdx
+++ b/packages/website/docs/components/containers/card.mdx
@@ -363,7 +363,7 @@ export default () => {
       checkableType="checkbox"
       value="checkbox1"
       checked={checkbox}
-      onChange={() => setCheckbox(!checkbox)}
+      onChange={() => setCheckbox(checked => !checked)}
     />
   );
 };


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8782

## Why are we making this change?

This PR fixes an unexpected behavior where the `onChange` event would be triggered twice on click of the checkbox within `EuiCheckableCard`. This would result in the checkbox being unchecked instead of checked.

This was due to the wrapper having a separate click handler to enlarge the clickable area. 
The fix applied is to only trigger the wrapper click handler if the wrapper is clicked, not the checkbox.

## Screenshots

Scenario: After a single click on the checkbox:

**before: checkbox is unchecked**

![Screenshot 2025-06-12 at 14 55 41](https://github.com/user-attachments/assets/4ce46fde-1a98-4526-b9c9-c0ce1bcf9def)

**after: checkbox is checked**

![Screenshot 2025-06-12 at 14 55 44](https://github.com/user-attachments/assets/7e09f217-e853-42c9-b132-9cd73a8a987e)


## QA

- [x] newly added cypress regression test passes
- checkout this PR and open the added "TESTING_EXAMPLE" story and:
  - [x] verify the checkbox is checked on a single click to the checkbox
  - [x] verify the checkbox is checked on a click to the area around the checkbox and on the label
  - [x] remove the check on the `e.target` in `checkable_card.tsx` and confirm that previously the checkbox is not checked on a single click

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
