### PR TITLE
chore: close comment in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 ---
 
 **Describe the bug**
-<!-- A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **Impact and severity**
 <!-- Is there an end-user impact caused by this bug? If so, how severe is it? Is there a known workaround? Understanding the impact and severity will help us determine the priority. -->


### PR DESCRIPTION
## Summary

Something I noticed during [Strict Mode epic](https://github.com/elastic/eui/issues/7774) refining is that the bug template has one comment that is not closed, and so `**Impact and severity**` don't appear.

Personally, I remove the comments but someone might not, and not notice that they have the "Impact and severity" section commented out.