### PR TITLE
[Amsterdam] Update values for `border-strong-*` tokens

### DIFF
--- a/packages/eui/src/themes/amsterdam/_colors_dark.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_dark.scss
@@ -126,7 +126,7 @@ $euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary !default;
 $euiColorBorderStrongNeutral: $euiColorSeverityNeutral !default;
 $euiColorBorderStrongSuccess: $euiColorSuccess !default;
 $euiColorBorderStrongWarning: $euiColorWarning !default;
-$euiColorBorderStrongRisk: $euiColorSeverityRisk !default;
+$euiColorBorderStrongRisk: tint($euiColorSeverityRisk, 0.2) !default;
 $euiColorBorderStrongDanger: $euiColorDanger !default;
 
 // Charts

--- a/packages/eui/src/themes/amsterdam/_colors_dark.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_dark.scss
@@ -120,14 +120,14 @@ $euiColorBorderBaseFloating: $euiColorLightShade !default;
 $euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
 $euiColorBorderBaseFormsControl: tint($euiColorLightestShade, 0.31) !default;
 
-$euiColorBorderStrongPrimary: tint($euiColorPrimary, 0.1) !default;
-$euiColorBorderStrongAccent: tint($euiColorAccent, 0.1) !default;
-$euiColorBorderStrongAccentSecondary: tint($euiColorAccentSecondary, 0.1) !default;
-$euiColorBorderStrongNeutral: tint($euiColorSeverityNeutral, 0.1) !default;
-$euiColorBorderStrongSuccess: tint($euiColorSuccess, 0.1) !default;
-$euiColorBorderStrongWarning: tint($euiColorWarning, 0.1) !default;
-$euiColorBorderStrongRisk: tint($euiColorSeverityRisk, 0.1) !default;
-$euiColorBorderStrongDanger: tint($euiColorDanger, 0.1) !default;
+$euiColorBorderStrongPrimary: $euiColorPrimary !default;
+$euiColorBorderStrongAccent: $euiColorAccent !default;
+$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary !default;
+$euiColorBorderStrongNeutral: $euiColorSeverityNeutral !default;
+$euiColorBorderStrongSuccess: $euiColorSuccess !default;
+$euiColorBorderStrongWarning: $euiColorWarning !default;
+$euiColorBorderStrongRisk: $euiColorSeverityRisk !default;
+$euiColorBorderStrongDanger: $euiColorDanger !default;
 
 // Charts
 $euiColorChartLines: $euiColorLightShade !default;

--- a/packages/eui/src/themes/amsterdam/_colors_dark.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_dark.scss
@@ -120,14 +120,14 @@ $euiColorBorderBaseFloating: $euiColorLightShade !default;
 $euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
 $euiColorBorderBaseFormsControl: tint($euiColorLightestShade, 0.31) !default;
 
-$euiColorBorderStrongPrimary: $euiColorBorderBasePrimary !default;
-$euiColorBorderStrongAccent: $euiColorBorderBaseAccent !default;
-$euiColorBorderStrongAccentSecondary: $euiColorBorderBaseAccentSecondary !default;
-$euiColorBorderStrongNeutral: $euiColorBorderBasePrimary !default;
-$euiColorBorderStrongSuccess: $euiColorBorderBaseSuccess !default;
-$euiColorBorderStrongWarning: $euiColorBorderBaseWarning !default;
-$euiColorBorderStrongRisk: $euiColorBorderBaseWarning !default;
-$euiColorBorderStrongDanger: $euiColorBorderBaseDanger !default;
+$euiColorBorderStrongPrimary: tint($euiColorPrimary, 0.1) !default;
+$euiColorBorderStrongAccent: tint($euiColorAccent, 0.1) !default;
+$euiColorBorderStrongAccentSecondary: tint($euiColorAccentSecondary, 0.1) !default;
+$euiColorBorderStrongNeutral: tint($euiColorSeverityNeutral, 0.1) !default;
+$euiColorBorderStrongSuccess: tint($euiColorSuccess, 0.1) !default;
+$euiColorBorderStrongWarning: tint($euiColorWarning, 0.1) !default;
+$euiColorBorderStrongRisk: tint($euiColorSeverityRisk, 0.1) !default;
+$euiColorBorderStrongDanger: tint($euiColorDanger, 0.1) !default;
 
 // Charts
 $euiColorChartLines: $euiColorLightShade !default;

--- a/packages/eui/src/themes/amsterdam/_colors_light.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_light.scss
@@ -123,7 +123,7 @@ $euiColorBorderBaseFormsControl: shade($euiColorLightestShade, 0.4) !default;
 $euiColorBorderStrongPrimary: $euiColorPrimary !default;
 $euiColorBorderStrongAccent: $euiColorAccent !default;
 $euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary !default;
-$euiColorBorderStrongNeutral: $euiColorSeverityNeutral !default;
+$euiColorBorderStrongNeutral: shade($euiColorSeverityNeutral, 0.2) !default;
 $euiColorBorderStrongSuccess: $euiColorSuccess !default;
 $euiColorBorderStrongWarning: $euiColorWarning !default;
 $euiColorBorderStrongRisk: $euiColorSeverityRisk !default;

--- a/packages/eui/src/themes/amsterdam/_colors_light.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_light.scss
@@ -120,14 +120,14 @@ $euiColorBorderBaseFloating: 'transparent' !default;
 $euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
 $euiColorBorderBaseFormsControl: shade($euiColorLightestShade, 0.4) !default;
 
-$euiColorBorderStrongPrimary: tint($euiColorPrimary, 0.1) !default;
-$euiColorBorderStrongAccent: tint($euiColorAccent, 0.1) !default;
-$euiColorBorderStrongAccentSecondary: tint($euiColorAccentSecondary, 0.1) !default;
-$euiColorBorderStrongNeutral: tint($euiColorSeverityNeutral, 0.1) !default;
-$euiColorBorderStrongSuccess: tint($euiColorSuccess, 0.1) !default;
-$euiColorBorderStrongWarning: tint($euiColorWarning, 0.1) !default;
-$euiColorBorderStrongRisk: tint($euiColorSeverityRisk, 0.1) !default;
-$euiColorBorderStrongDanger: tint($euiColorDanger, 0.1) !default;
+$euiColorBorderStrongPrimary: $euiColorPrimary !default;
+$euiColorBorderStrongAccent: $euiColorAccent !default;
+$euiColorBorderStrongAccentSecondary: $euiColorAccentSecondary !default;
+$euiColorBorderStrongNeutral: $euiColorSeverityNeutral !default;
+$euiColorBorderStrongSuccess: $euiColorSuccess !default;
+$euiColorBorderStrongWarning: $euiColorWarning !default;
+$euiColorBorderStrongRisk: $euiColorSeverityRisk !default;
+$euiColorBorderStrongDanger: $euiColorDanger !default;
 
 // Charts
 $euiColorChartLines: shade($euiColorLightestShade, 3%) !default;

--- a/packages/eui/src/themes/amsterdam/_colors_light.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_light.scss
@@ -120,14 +120,14 @@ $euiColorBorderBaseFloating: 'transparent' !default;
 $euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
 $euiColorBorderBaseFormsControl: shade($euiColorLightestShade, 0.4) !default;
 
-$euiColorBorderStrongPrimary: $euiColorBorderBasePrimary !default;
-$euiColorBorderStrongAccent: $euiColorBorderBaseAccent !default;
-$euiColorBorderStrongAccentSecondary: $euiColorBorderBaseAccentSecondary !default;
-$euiColorBorderStrongNeutral: $euiColorBorderBasePrimary !default;
-$euiColorBorderStrongSuccess: $euiColorBorderBaseSuccess !default;
-$euiColorBorderStrongWarning: $euiColorBorderBaseWarning !default;
-$euiColorBorderStrongRisk: $euiColorBorderBaseWarning !default;
-$euiColorBorderStrongDanger: $euiColorBorderBaseDanger !default;
+$euiColorBorderStrongPrimary: tint($euiColorPrimary, 0.1) !default;
+$euiColorBorderStrongAccent: tint($euiColorAccent, 0.1) !default;
+$euiColorBorderStrongAccentSecondary: tint($euiColorAccentSecondary, 0.1) !default;
+$euiColorBorderStrongNeutral: tint($euiColorSeverityNeutral, 0.1) !default;
+$euiColorBorderStrongSuccess: tint($euiColorSuccess, 0.1) !default;
+$euiColorBorderStrongWarning: tint($euiColorWarning, 0.1) !default;
+$euiColorBorderStrongRisk: tint($euiColorSeverityRisk, 0.1) !default;
+$euiColorBorderStrongDanger: tint($euiColorDanger, 0.1) !default;
 
 // Charts
 $euiColorChartLines: shade($euiColorLightestShade, 3%) !default;

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
@@ -324,9 +324,9 @@ export const border_colors: _EuiThemeBorderColors = {
   borderStrongAccent: computed(([accent]) => accent, ['colors.accent']),
   borderStrongAccentSecondary: computed(
     ([accentSecondary]) => accentSecondary,
-    ['colors.accentSeconday']
+    ['colors.accentSecondary']
   ),
-  borderStrongNeutral: severityColors.neutral,
+  borderStrongNeutral: shade(severityColors.neutral, 0.2).toUpperCase(),
   borderStrongSuccess: computed(([success]) => success, ['colors.success']),
   borderStrongWarning: computed(([warning]) => warning, ['colors.warning']),
   borderStrongRisk: severityColors.risk,
@@ -543,12 +543,12 @@ export const dark_border_colors: _EuiThemeBorderColors = {
   borderStrongAccent: computed(([accent]) => accent, ['colors.accent']),
   borderStrongAccentSecondary: computed(
     ([accentSecondary]) => accentSecondary,
-    ['colors.accentSeconday']
+    ['colors.accentSecondary']
   ),
   borderStrongNeutral: severityColors.neutral,
   borderStrongSuccess: computed(([success]) => success, ['colors.success']),
   borderStrongWarning: computed(([warning]) => warning, ['colors.warning']),
-  borderStrongRisk: tint(severityColors.risk, 0.1),
+  borderStrongRisk: tint(severityColors.risk, 0.2).toUpperCase(),
   borderStrongDanger: computed(([danger]) => danger, ['colors.danger']),
 };
 

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
@@ -320,32 +320,17 @@ export const border_colors: _EuiThemeBorderColors = {
     ['colors.lightestShade']
   ),
 
-  borderStrongPrimary: computed(
-    ([primary]) => primary, // no tint to match and keep previous token usage
-    ['colors.primary']
-  ),
-  borderStrongAccent: computed(
-    ([accent]) => tint(accent, 0.1),
-    ['colors.accent']
-  ),
+  borderStrongPrimary: computed(([primary]) => primary, ['colors.primary']),
+  borderStrongAccent: computed(([accent]) => accent, ['colors.accent']),
   borderStrongAccentSecondary: computed(
-    ([accentSeconday]) => tint(accentSeconday, 0.1),
+    ([accentSecondary]) => accentSecondary,
     ['colors.accentSeconday']
   ),
-  borderStrongNeutral: tint(severityColors.neutral, 0.1),
-  borderStrongSuccess: computed(
-    ([success]) => tint(success, 0.1),
-    ['colors.success']
-  ),
-  borderStrongWarning: computed(
-    ([warning]) => tint(warning, 0.1),
-    ['colors.warning']
-  ),
-  borderStrongRisk: tint(severityColors.risk, 0.1),
-  borderStrongDanger: computed(
-    ([danger]) => tint(danger, 0.1),
-    ['colors.danger']
-  ),
+  borderStrongNeutral: severityColors.neutral,
+  borderStrongSuccess: computed(([success]) => success, ['colors.success']),
+  borderStrongWarning: computed(([warning]) => warning, ['colors.warning']),
+  borderStrongRisk: severityColors.risk,
+  borderStrongDanger: computed(([danger]) => danger, ['colors.danger']),
 };
 
 export const light_colors: _EuiThemeColorsMode = {
@@ -554,32 +539,17 @@ export const dark_border_colors: _EuiThemeBorderColors = {
     ['colors.lightestShade']
   ),
 
-  borderStrongPrimary: computed(
-    ([primary]) => primary, // no tint to match and keep previous token usage
-    ['colors.primary']
-  ),
-  borderStrongAccent: computed(
-    ([accent]) => tint(accent, 0.1),
-    ['colors.accent']
-  ),
+  borderStrongPrimary: computed(([primary]) => primary, ['colors.primary']),
+  borderStrongAccent: computed(([accent]) => accent, ['colors.accent']),
   borderStrongAccentSecondary: computed(
-    ([accentSeconday]) => tint(accentSeconday, 0.1),
+    ([accentSecondary]) => accentSecondary,
     ['colors.accentSeconday']
   ),
-  borderStrongNeutral: tint(severityColors.neutral, 0.1),
-  borderStrongSuccess: computed(
-    ([success]) => tint(success, 0.1),
-    ['colors.success']
-  ),
-  borderStrongWarning: computed(
-    ([warning]) => tint(warning, 0.1),
-    ['colors.warning']
-  ),
+  borderStrongNeutral: severityColors.neutral,
+  borderStrongSuccess: computed(([success]) => success, ['colors.success']),
+  borderStrongWarning: computed(([warning]) => warning, ['colors.warning']),
   borderStrongRisk: tint(severityColors.risk, 0.1),
-  borderStrongDanger: computed(
-    ([danger]) => tint(danger, 0.1),
-    ['colors.danger']
-  ),
+  borderStrongDanger: computed(([danger]) => danger, ['colors.danger']),
 };
 
 export const dark_colors_ams: _EuiThemeColorsMode = {

--- a/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
+++ b/packages/eui/src/themes/amsterdam/global_styling/variables/_colors.ts
@@ -321,36 +321,30 @@ export const border_colors: _EuiThemeBorderColors = {
   ),
 
   borderStrongPrimary: computed(
-    ([borderBasePrimary]) => borderBasePrimary,
-    ['colors.borderBasePrimary']
+    ([primary]) => primary, // no tint to match and keep previous token usage
+    ['colors.primary']
   ),
   borderStrongAccent: computed(
-    ([borderBaseAccent]) => borderBaseAccent,
-    ['colors.borderBaseAccent']
+    ([accent]) => tint(accent, 0.1),
+    ['colors.accent']
   ),
   borderStrongAccentSecondary: computed(
-    ([borderBaseAccentSecondary]) => borderBaseAccentSecondary,
-    ['colors.borderBaseAccentSecondary']
+    ([accentSeconday]) => tint(accentSeconday, 0.1),
+    ['colors.accentSeconday']
   ),
-  borderStrongNeutral: computed(
-    ([borderBaseNeutral]) => borderBaseNeutral,
-    ['colors.borderBaseNeutral']
-  ),
+  borderStrongNeutral: tint(severityColors.neutral, 0.1),
   borderStrongSuccess: computed(
-    ([borderBaseSuccess]) => borderBaseSuccess,
-    ['colors.borderBaseSuccess']
+    ([success]) => tint(success, 0.1),
+    ['colors.success']
   ),
   borderStrongWarning: computed(
-    ([borderBaseWarning]) => borderBaseWarning,
-    ['colors.borderBaseWarning']
+    ([warning]) => tint(warning, 0.1),
+    ['colors.warning']
   ),
-  borderStrongRisk: computed(
-    ([borderBaseRisk]) => borderBaseRisk,
-    ['colors.borderBaseRisk']
-  ),
+  borderStrongRisk: tint(severityColors.risk, 0.1),
   borderStrongDanger: computed(
-    ([borderBaseDanger]) => borderBaseDanger,
-    ['colors.borderBaseDanger']
+    ([danger]) => tint(danger, 0.1),
+    ['colors.danger']
   ),
 };
 
@@ -561,36 +555,30 @@ export const dark_border_colors: _EuiThemeBorderColors = {
   ),
 
   borderStrongPrimary: computed(
-    ([borderBasePrimary]) => borderBasePrimary,
-    ['colors.borderBasePrimary']
+    ([primary]) => primary, // no tint to match and keep previous token usage
+    ['colors.primary']
   ),
   borderStrongAccent: computed(
-    ([borderBaseAccent]) => borderBaseAccent,
-    ['colors.borderBaseAccent']
+    ([accent]) => tint(accent, 0.1),
+    ['colors.accent']
   ),
   borderStrongAccentSecondary: computed(
-    ([borderBaseAccentSecondary]) => borderBaseAccentSecondary,
-    ['colors.borderBaseAccentSecondary']
+    ([accentSeconday]) => tint(accentSeconday, 0.1),
+    ['colors.accentSeconday']
   ),
-  borderStrongNeutral: computed(
-    ([borderBaseNeutral]) => borderBaseNeutral,
-    ['colors.borderBaseNeutral']
-  ),
+  borderStrongNeutral: tint(severityColors.neutral, 0.1),
   borderStrongSuccess: computed(
-    ([borderBaseSuccess]) => borderBaseSuccess,
-    ['colors.borderBaseSuccess']
+    ([success]) => tint(success, 0.1),
+    ['colors.success']
   ),
   borderStrongWarning: computed(
-    ([borderBaseWarning]) => borderBaseWarning,
-    ['colors.borderBaseWarning']
+    ([warning]) => tint(warning, 0.1),
+    ['colors.warning']
   ),
-  borderStrongRisk: computed(
-    ([borderBaseRisk]) => borderBaseRisk,
-    ['colors.borderBaseRisk']
-  ),
+  borderStrongRisk: tint(severityColors.risk, 0.1),
   borderStrongDanger: computed(
-    ([borderBaseDanger]) => borderBaseDanger,
-    ['colors.borderBaseDanger']
+    ([danger]) => tint(danger, 0.1),
+    ['colors.danger']
   ),
 };
 

--- a/packages/eui/src/themes/json/eui_theme_amsterdam_dark.json
+++ b/packages/eui/src/themes/json/eui_theme_amsterdam_dark.json
@@ -416,12 +416,12 @@
   "euiColorBorderBaseFloating": "transparent",
   "euiColorBorderBaseFormsColorSwatch": "rgba(255,255,255,0.1)",
   "euiColorBorderBaseFormsControl": "#69696f",
-  "euiColorBorderStrongPrimary": "#164160",
-  "euiColorBorderStrongAccent": "#62394c",
-  "euiColorBorderStrongAccentSecondary": "#325956",
-  "euiColorBorderStrongNeutral": "#4c535b",
-  "euiColorBorderStrongSuccess": "#325956",
-  "euiColorBorderStrongWarning": "#927f44",
-  "euiColorBorderStrongRisk": "#835329",
-  "euiColorBorderStrongDanger": "#632b28"
+  "euiColorBorderStrongPrimary": "#36A2EF",
+  "euiColorBorderStrongAccent": "#F79AC5",
+  "euiColorBorderStrongAccentSecondary": "#8AE1DC",
+  "euiColorBorderStrongNeutral": "#C0D4E6",
+  "euiColorBorderStrongSuccess": "#8AE1DC",
+  "euiColorBorderStrongWarning": "#F4D77F",
+  "euiColorBorderStrongRisk": "#DE9758",
+  "euiColorBorderStrongDanger": "#F97A73"
 }

--- a/packages/eui/src/themes/json/eui_theme_amsterdam_dark.json
+++ b/packages/eui/src/themes/json/eui_theme_amsterdam_dark.json
@@ -422,6 +422,6 @@
   "euiColorBorderStrongNeutral": "#B9CFE3",
   "euiColorBorderStrongSuccess": "#7DDED8",
   "euiColorBorderStrongWarning": "#F3D371",
-  "euiColorBorderStrongRisk": "#DA8B45",
+  "euiColorBorderStrongRisk": "#E1A26A",
   "euiColorBorderStrongDanger": "#F86B63"
 }

--- a/packages/eui/src/themes/json/eui_theme_amsterdam_dark.json
+++ b/packages/eui/src/themes/json/eui_theme_amsterdam_dark.json
@@ -417,11 +417,11 @@
   "euiColorBorderBaseFormsColorSwatch": "rgba(255,255,255,0.1)",
   "euiColorBorderBaseFormsControl": "#69696f",
   "euiColorBorderStrongPrimary": "#36A2EF",
-  "euiColorBorderStrongAccent": "#F79AC5",
-  "euiColorBorderStrongAccentSecondary": "#8AE1DC",
-  "euiColorBorderStrongNeutral": "#C0D4E6",
-  "euiColorBorderStrongSuccess": "#8AE1DC",
-  "euiColorBorderStrongWarning": "#F4D77F",
-  "euiColorBorderStrongRisk": "#DE9758",
-  "euiColorBorderStrongDanger": "#F97A73"
+  "euiColorBorderStrongAccent": "#F68FBE",
+  "euiColorBorderStrongAccentSecondary": "#7DDED8",
+  "euiColorBorderStrongNeutral": "#B9CFE3",
+  "euiColorBorderStrongSuccess": "#7DDED8",
+  "euiColorBorderStrongWarning": "#F3D371",
+  "euiColorBorderStrongRisk": "#DA8B45",
+  "euiColorBorderStrongDanger": "#F86B63"
 }

--- a/packages/eui/src/themes/json/eui_theme_amsterdam_light.json
+++ b/packages/eui/src/themes/json/eui_theme_amsterdam_light.json
@@ -416,12 +416,12 @@
   "euiColorBorderBaseFloating": "transparent",
   "euiColorBorderBaseFormsColorSwatch": "rgba(0,0,0,0.1)",
   "euiColorBorderBaseFormsControl": "#919296",
-  "euiColorBorderStrongPrimary": "#99c9eb",
-  "euiColorBorderStrongAccent": "#f9b8d6",
-  "euiColorBorderStrongAccentSecondary": "#99e5e1",
-  "euiColorBorderStrongNeutral": "#e5ecf4",
-  "euiColorBorderStrongSuccess": "#99e5e1",
-  "euiColorBorderStrongWarning": "#fedc72",
-  "euiColorBorderStrongRisk": "#e9b98f",
-  "euiColorBorderStrongDanger": "#e5a9a5"
+  "euiColorBorderStrongPrimary": "#0077CC",
+  "euiColorBorderStrongAccent": "#F260A2",
+  "euiColorBorderStrongAccentSecondary": "#1AC5BB",
+  "euiColorBorderStrongNeutral": "#C0D4E6",
+  "euiColorBorderStrongSuccess": "#1AC5BB",
+  "euiColorBorderStrongWarning": "#FECB2C",
+  "euiColorBorderStrongRisk": "#DE9758",
+  "euiColorBorderStrongDanger": "#C43D35"
 }

--- a/packages/eui/src/themes/json/eui_theme_amsterdam_light.json
+++ b/packages/eui/src/themes/json/eui_theme_amsterdam_light.json
@@ -419,7 +419,7 @@
   "euiColorBorderStrongPrimary": "#0077CC",
   "euiColorBorderStrongAccent": "#F04E98",
   "euiColorBorderStrongAccentSecondary": "#00BFB3",
-  "euiColorBorderStrongNeutral": "#B9CFE3",
+  "euiColorBorderStrongNeutral": "#94A6B6",
   "euiColorBorderStrongSuccess": "#00BFB3",
   "euiColorBorderStrongWarning": "#FEC514",
   "euiColorBorderStrongRisk": "#DA8B45",

--- a/packages/eui/src/themes/json/eui_theme_amsterdam_light.json
+++ b/packages/eui/src/themes/json/eui_theme_amsterdam_light.json
@@ -417,11 +417,11 @@
   "euiColorBorderBaseFormsColorSwatch": "rgba(0,0,0,0.1)",
   "euiColorBorderBaseFormsControl": "#919296",
   "euiColorBorderStrongPrimary": "#0077CC",
-  "euiColorBorderStrongAccent": "#F260A2",
-  "euiColorBorderStrongAccentSecondary": "#1AC5BB",
-  "euiColorBorderStrongNeutral": "#C0D4E6",
-  "euiColorBorderStrongSuccess": "#1AC5BB",
-  "euiColorBorderStrongWarning": "#FECB2C",
-  "euiColorBorderStrongRisk": "#DE9758",
-  "euiColorBorderStrongDanger": "#C43D35"
+  "euiColorBorderStrongAccent": "#F04E98",
+  "euiColorBorderStrongAccentSecondary": "#00BFB3",
+  "euiColorBorderStrongNeutral": "#B9CFE3",
+  "euiColorBorderStrongSuccess": "#00BFB3",
+  "euiColorBorderStrongWarning": "#FEC514",
+  "euiColorBorderStrongRisk": "#DA8B45",
+  "euiColorBorderStrongDanger": "#BD271E"
 }

--- a/packages/website/docs/getting-started/theming/tokens/colors/border_colors_table.tsx
+++ b/packages/website/docs/getting-started/theming/tokens/colors/border_colors_table.tsx
@@ -9,10 +9,6 @@ export const BorderColorsTable = () => {
       sampleType="swatch"
       colors={[
         {
-          value: euiTheme.colors.backgroundBasePrimary,
-          token: 'colors.backgroundBasePrimary',
-        },
-        {
           value: euiTheme.colors.borderBasePrimary,
           token: 'colors.borderBasePrimary',
         },


### PR DESCRIPTION
## Summary

In https://github.com/elastic/eui/pull/8769 there was the need to update the color token used for the selected outline in the Data Grid, to be `border-strong-primary`. In order to make this work in Amsterdam, the value for the token also had to be updated.

In this PR all `border-strong-*` tokens get an adequate value so they could actually useful beyond the change in the [aforementioned PR](https://github.com/elastic/eui/pull/8769).

## Why are we making this change?

Because it's needed for https://github.com/elastic/eui/pull/8769 and it made sense to make a separate PR.

## Screenshots

The [codesandbox](https://codesandbox.io/p/sandbox/naughty-sea-wkcxj8) used to generate and "test" the colors.

The `border-strong` color is the second in each block e.g. `tint(accent, 0.1)`.

| Light | Dark |
| ----- | ---- |
| ![Capture-2025-06-12-231519](https://github.com/user-attachments/assets/30bac2b8-aad0-4545-81b4-c1d9528f30f8) | ![Capture-2025-06-12-231536](https://github.com/user-attachments/assets/904390f6-e4e5-441b-85bf-77dbd3db53d6) |

## Impact to users

Minimal to none because these tokens didn't exist previously in Amsterdam, before Borealis.

## QA

* [ ] check color selection is appropriate
* [ ] check there are no typos, etc.
* [ ] check new token values are displayed correctly in the docs
