### PR TITLE
[EuiComboBox] Ensure `aria-describedby` is applied on the input

### DIFF
--- a/packages/eui/src/components/combo_box/combo_box.stories.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.stories.tsx
@@ -20,6 +20,7 @@ import { EuiFlexItem } from '../flex';
 
 import { EuiComboBoxOptionMatcher } from './types';
 import { EuiComboBox, EuiComboBoxProps } from './combo_box';
+import { EuiFormRow } from '../form';
 
 const options = [
   { label: 'Item 1' },
@@ -195,6 +196,18 @@ export const NestedOptionsGroups: Story = {
     autoFocus: true,
   },
   render: (args) => <StatefulComboBox {...args} />,
+};
+
+export const TESTING_EXAMPLE: Story = {
+  render: (args) => {
+    return (
+      <>
+        <EuiFormRow isInvalid error={['This is an error!']}>
+          <StatefulComboBox {...args} isInvalid />
+        </EuiFormRow>
+      </>
+    );
+  },
 };
 
 /**

--- a/packages/eui/src/components/combo_box/combo_box.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.tsx
@@ -755,6 +755,7 @@ export class EuiComboBox<T> extends Component<
       optionMatcher,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledby,
+      'aria-describedby': ariaDescribedby,
       ...rest
     } = this.props;
     const {
@@ -909,6 +910,7 @@ export class EuiComboBox<T> extends Component<
                     autoFocus={autoFocus}
                     aria-label={ariaLabel}
                     aria-labelledby={ariaLabelledby}
+                    aria-describedby={ariaDescribedby}
                   />
                 }
               >

--- a/packages/eui/src/components/combo_box/combo_box_input/combo_box_input.tsx
+++ b/packages/eui/src/components/combo_box/combo_box_input/combo_box_input.tsx
@@ -70,6 +70,7 @@ export interface EuiComboBoxInputProps<T> extends CommonProps {
   autoFocus?: boolean;
   'aria-label'?: string;
   'aria-labelledby'?: string;
+  'aria-describedby'?: string;
 }
 
 interface EuiComboBoxInputState {
@@ -249,6 +250,7 @@ export class EuiComboBoxInput<T> extends Component<
       autoFocus,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledby,
+      'aria-describedby': ariaDescribedby,
     } = this.props;
 
     let removeOptionMessage: ReactNode;
@@ -378,6 +380,7 @@ export class EuiComboBoxInput<T> extends Component<
                     aria-expanded={isListOpen}
                     aria-label={ariaLabel}
                     aria-labelledby={ariaLabelledby}
+                    aria-describedby={ariaDescribedby}
                     aria-invalid={isInvalid}
                     aria-haspopup="listbox"
                     css={styles.euiComboBoxInput}


### PR DESCRIPTION
## Summary

This PR fixes an Accessibility bug, where the `aria-describedby` passed from a wrapping `EuiFormRow` would not be applied on the input element of the `EuiComboBox` but instead on the outer wrapper. This would result in the errors not being read by screen readers when the input is focused.

## Why are we making this change?

This change fixes an WCAG Level A Accessibility issue with `EuiComboBox`. The update ensures that related form error messages are read by screen readers when the combobox input is focused.

[WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html)

## Screenshots

**before**

![Screenshot 2025-06-13 at 17 35 35](https://github.com/user-attachments/assets/639985ca-6072-4327-b09c-94e7d4c3d86f)

![Screenshot 2025-06-13 at 18 03 40](https://github.com/user-attachments/assets/ff77ecec-ea6e-4df9-8e05-a3442d40a456)


**after**

![Screenshot 2025-06-13 at 18 00 03](https://github.com/user-attachments/assets/d132ae90-f2ec-4a65-8b1d-999a8dab47a1)

![Screenshot 2025-06-13 at 18 02 42](https://github.com/user-attachments/assets/16c6e60d-542b-4043-b59d-e2254d611568)


## Impact to users

🟢 This is a bug fix only. There are no visual or breaking changes.

## QA

- checkout this PR and open the added "TESTING_EXAMPLE" story:
  - [ ] verify that the `aria-describedby` is applied on the combobox input and read by screen readers

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
