### PR TITLE
[Docs] Fix page jump for Empty Prompt page

### DIFF
--- a/packages/website/docs/components/display/empty-prompt/index.mdx
+++ b/packages/website/docs/components/display/empty-prompt/index.mdx
@@ -292,78 +292,83 @@ The following example shows the usage of the [EuiPageTemplate.EmptyPrompt](../..
 
 You can then tie multiple types of empty states together to create a seamless loading to empty or loading to error experience. The following example shows how to incorporate these states with [EuiPageTemplate.EmptyPrompt](../../templates/page-template/index.mdx#empty-pages-or-content).
 
-```tsx interactive
-import React, { useState, useEffect } from 'react';
-import {
-  EuiPageTemplate,
-  EuiLoadingLogo,
-  EuiButton,
-  EuiEmptyPromptProps,
-} from '@elastic/eui';
+{/* Set `minHeight` to avoid jumps on the page as the state changes */}
+<Demo previewWrapper={({ children }) => (
+  <div style={{ minHeight: 292 }}>{children}</div>
+)}>
+  ```tsx
+  import React, { useState, useEffect } from 'react';
+  import {
+    EuiPageTemplate,
+    EuiLoadingLogo,
+    EuiButton,
+    EuiEmptyPromptProps,
+  } from '@elastic/eui';
 
-export default () => {
-  const states = ['loading1', 'error', 'loading2', 'empty'];
+  export default () => {
+    const states = ['loading1', 'error', 'loading2', 'empty'];
 
-  const [currentState, setCurrentState] = useState(states[0]);
+    const [currentState, setCurrentState] = useState(states[0]);
 
-  const searchTimeout = setTimeout(() => {
-    // Cycle through the array of states
-    const index = states.indexOf(currentState);
-    setCurrentState(index < states.length - 1 ? states[index + 1] : states[0]);
-  }, 3000);
+    const searchTimeout = setTimeout(() => {
+      // Cycle through the array of states
+      const index = states.indexOf(currentState);
+      setCurrentState(index < states.length - 1 ? states[index + 1] : states[0]);
+    }, 3000);
 
-  useEffect(() => {
-    return () => {
-      clearTimeout(searchTimeout);
-    };
-  });
-
-  let emptyPromptProps: Partial<EuiEmptyPromptProps>;
-  switch (currentState) {
-    case 'error':
-      emptyPromptProps = {
-        color: 'danger',
-        iconType: 'error',
-        title: <h2>Unable to load your dashboards</h2>,
-        body: (
-          <p>
-            There was an error loading the Dashboard application. Contact your
-            administrator for help.
-          </p>
-        ),
+    useEffect(() => {
+      return () => {
+        clearTimeout(searchTimeout);
       };
-      break;
-    case 'empty':
-      emptyPromptProps = {
-        color: 'plain',
-        iconType: 'dashboardApp',
-        iconColor: 'default',
-        title: <h2>Dashboards</h2>,
-        body: <p>You don&apos;t have any dashboards yet.</p>,
-        actions: [
-          <EuiButton fill iconType="plusInCircleFilled">
-            Create new dashboard
-          </EuiButton>,
-        ],
-      };
-      break;
+    });
 
-    default:
-      emptyPromptProps = {
-        color: 'subdued',
-        icon: <EuiLoadingLogo logo="logoKibana" size="xl" />,
-        title: <h2>Loading Dashboards</h2>,
-      };
-      break;
-  }
+    let emptyPromptProps: Partial<EuiEmptyPromptProps>;
+    switch (currentState) {
+      case 'error':
+        emptyPromptProps = {
+          color: 'danger',
+          iconType: 'error',
+          title: <h2>Unable to load your dashboards</h2>,
+          body: (
+            <p>
+              There was an error loading the Dashboard application. Contact your
+              administrator for help.
+            </p>
+          ),
+        };
+        break;
+      case 'empty':
+        emptyPromptProps = {
+          color: 'plain',
+          iconType: 'dashboardApp',
+          iconColor: 'default',
+          title: <h2>Dashboards</h2>,
+          body: <p>You don&apos;t have any dashboards yet.</p>,
+          actions: [
+            <EuiButton fill iconType="plusInCircleFilled">
+              Create new dashboard
+            </EuiButton>,
+          ],
+        };
+        break;
 
-  return (
-    <EuiPageTemplate minHeight="0">
-      <EuiPageTemplate.EmptyPrompt {...emptyPromptProps} />
-    </EuiPageTemplate>
-  );
-};
-```
+      default:
+        emptyPromptProps = {
+          color: 'subdued',
+          icon: <EuiLoadingLogo logo="logoKibana" size="xl" />,
+          title: <h2>Loading Dashboards</h2>,
+        };
+        break;
+    }
+
+    return (
+      <EuiPageTemplate minHeight={320}>
+        <EuiPageTemplate.EmptyPrompt {...emptyPromptProps} />
+      </EuiPageTemplate>
+    );
+  };
+  ```
+</Demo>
 
 ## Guidelines
 

--- a/packages/website/docs/components/display/empty-prompt/index.mdx
+++ b/packages/website/docs/components/display/empty-prompt/index.mdx
@@ -294,7 +294,7 @@ You can then tie multiple types of empty states together to create a seamless lo
 
 {/* setting a fixed `height` to avoid jumps on the page as the state changes */}
 <Demo previewWrapper={({ children }) => (
-  <div style={{ display: "flex", flexDirection: "column", height: 400 }}>{children}</div>
+  <div style={{ height: 460 }}>{children}</div>
 )}>
   ```tsx
   import React, { useState, useEffect } from 'react';
@@ -362,7 +362,7 @@ You can then tie multiple types of empty states together to create a seamless lo
     }
 
     return (
-      <EuiPageTemplate minHeight={400} grow={false}>
+      <EuiPageTemplate grow={false} css={css`section { max-height: 460px }`}>
         <EuiPageTemplate.EmptyPrompt {...emptyPromptProps} />
       </EuiPageTemplate>
     );

--- a/packages/website/docs/components/display/empty-prompt/index.mdx
+++ b/packages/website/docs/components/display/empty-prompt/index.mdx
@@ -292,9 +292,9 @@ The following example shows the usage of the [EuiPageTemplate.EmptyPrompt](../..
 
 You can then tie multiple types of empty states together to create a seamless loading to empty or loading to error experience. The following example shows how to incorporate these states with [EuiPageTemplate.EmptyPrompt](../../templates/page-template/index.mdx#empty-pages-or-content).
 
-{/* Set `minHeight` to avoid jumps on the page as the state changes */}
+{/* setting a fixed `height` to avoid jumps on the page as the state changes */}
 <Demo previewWrapper={({ children }) => (
-  <div style={{ minHeight: 292 }}>{children}</div>
+  <div style={{ display: "flex", flexDirection: "column", height: 400 }}>{children}</div>
 )}>
   ```tsx
   import React, { useState, useEffect } from 'react';
@@ -362,7 +362,7 @@ You can then tie multiple types of empty states together to create a seamless lo
     }
 
     return (
-      <EuiPageTemplate minHeight={320}>
+      <EuiPageTemplate minHeight={400} grow={false}>
         <EuiPageTemplate.EmptyPrompt {...emptyPromptProps} />
       </EuiPageTemplate>
     );

--- a/packages/website/docs/components/tables/in-memory.mdx
+++ b/packages/website/docs/components/tables/in-memory.mdx
@@ -159,7 +159,7 @@ import InMemoryTableSelection from './table_selection';
 
 ### Search bar
 
-This example shows how to configure **EuiInMemoryTable** to display a search bar by passing the `search` prop. For more detailed information about the syntax and configuration accepted by this prop, see [EuiSearchBar](../../forms/search-and-filter/search-bar.mdx).
+This example shows how to configure **EuiInMemoryTable** to display a search bar by passing the `search` prop. For more detailed information about the syntax and configuration accepted by this prop, see [EuiSearchBar](../forms/search-and-filter/search-bar.mdx).
 
 ```tsx interactive
 import React, { useState } from 'react';


### PR DESCRIPTION
## Summary

An time-based state change in a demo causes a page to jump, below the demo. This PR fixes that by adding a fixed height to the container.

## Screenshots

The bug being fixed:

https://github.com/user-attachments/assets/a4661be5-3b47-4f47-8346-f54f82ed9a74

(thank you @MiriamAparicio)

## QA

* [ ] check the [Empty Prompt](https://eui.elastic.co/pr_8807/docs/components/display/empty-prompt/#using-in-a-page-template) page behaves as expected