### PR TITLE
[Fix] Add missing JSON token exports

### DIFF
--- a/packages/eui/changelogs/upcoming/8819.md
+++ b/packages/eui/changelogs/upcoming/8819.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed missing JSON token exports for `euiColorBackgroundBaseInteractiveSelectHover` and `euiColorBorderStrongText`
+

--- a/packages/eui/src/themes/json/eui_theme_borealis_dark.json
+++ b/packages/eui/src/themes/json/eui_theme_borealis_dark.json
@@ -377,6 +377,7 @@
   "euiColorBackgroundBaseFormsControlDisabled": "#2B394F",
   "euiColorBackgroundBaseInteractiveHover": "rgba(255,255,255, 0.08)",
   "euiColorBackgroundBaseInteractiveSelect": "#0D2F5E",
+  "euiColorBackgroundBaseInteractiveSelectHover": "#123778",
   "euiColorBackgroundBaseInteractiveOverlay": "rgba(43,57,79, 0.7)",
   "euiColorBackgroundBaseSkeletonEdge": "rgba(255,255,255, 0.16)",
   "euiColorBackgroundBaseSkeletonMiddle": "rgba(255,255,255, 0.08)",
@@ -419,5 +420,6 @@
   "euiColorBorderStrongSuccess": "#24C292",
   "euiColorBorderStrongWarning": "#FACB3D",
   "euiColorBorderStrongRisk": "#FC8544",
-  "euiColorBorderStrongDanger": "#F6726A"
+  "euiColorBorderStrongDanger": "#F6726A",
+  "euiColorBorderStrongText": "#8E9FBC"
 }

--- a/packages/eui/src/themes/json/eui_theme_borealis_dark.json.d.ts
+++ b/packages/eui/src/themes/json/eui_theme_borealis_dark.json.d.ts
@@ -378,6 +378,7 @@ declare module '@elastic/eui/dist/eui_theme_borealis_dark.json' {
     euiColorBackgroundBaseFormsControlDisabled: string;
     euiColorBackgroundBaseInteractiveHover: string;
     euiColorBackgroundBaseInteractiveSelect: string;
+    euiColorBackgroundBaseInteractiveSelectHover: string;
     euiColorBackgroundBaseInteractiveOverlay: string;
     euiColorBackgroundBaseSkeletonEdge: string;
     euiColorBackgroundBaseSkeletonMiddle: string;
@@ -421,6 +422,7 @@ declare module '@elastic/eui/dist/eui_theme_borealis_dark.json' {
     euiColorBorderStrongWarning: string;
     euiColorBorderStrongRisk: string;
     euiColorBorderStrongDanger: string;
+    euiColorBorderStrongText: string;
   };
   export default sassVariables;
 }

--- a/packages/eui/src/themes/json/eui_theme_borealis_light.json
+++ b/packages/eui/src/themes/json/eui_theme_borealis_light.json
@@ -377,6 +377,7 @@
   "euiColorBackgroundBaseFormsControlDisabled": "#CAD3E2",
   "euiColorBackgroundBaseInteractiveHover": "rgba(23,80,186, 0.04)",
   "euiColorBackgroundBaseInteractiveSelect": "#E8F1FF",
+  "euiColorBackgroundBaseInteractiveSelectHover": "#D9E8FF",
   "euiColorBackgroundBaseInteractiveOverlay": "rgba(72,89,117, 0.7)",
   "euiColorBackgroundBaseSkeletonEdge": "rgba(72,89,117, 0.16)",
   "euiColorBackgroundBaseSkeletonMiddle": "rgba(72,89,117, 0.04)",
@@ -419,5 +420,6 @@
   "euiColorBorderStrongSuccess": "#09724D",
   "euiColorBorderStrongWarning": "#825803",
   "euiColorBorderStrongRisk": "#9E3A16",
-  "euiColorBorderStrongDanger": "#A71627"
+  "euiColorBorderStrongDanger": "#A71627",
+  "euiColorBorderStrongText": "#5A6D8C"
 }

--- a/packages/eui/src/themes/json/eui_theme_borealis_light.json.d.ts
+++ b/packages/eui/src/themes/json/eui_theme_borealis_light.json.d.ts
@@ -378,6 +378,7 @@ declare module '@elastic/eui/dist/eui_theme_borealis_light.json' {
     euiColorBackgroundBaseFormsControlDisabled: string;
     euiColorBackgroundBaseInteractiveHover: string;
     euiColorBackgroundBaseInteractiveSelect: string;
+    euiColorBackgroundBaseInteractiveSelectHover: string;
     euiColorBackgroundBaseInteractiveOverlay: string;
     euiColorBackgroundBaseSkeletonEdge: string;
     euiColorBackgroundBaseSkeletonMiddle: string;
@@ -421,6 +422,7 @@ declare module '@elastic/eui/dist/eui_theme_borealis_light.json' {
     euiColorBorderStrongWarning: string;
     euiColorBorderStrongRisk: string;
     euiColorBorderStrongDanger: string;
+    euiColorBorderStrongText: string;
   };
   export default sassVariables;
 }


### PR DESCRIPTION
## Summary

This PR is a follow-up fix to [this previous PR](https://github.com/elastic/eui/pull/8769). It adds missing JSON token exports.

## Why are we making this change?

This fixes typescript errors when using the JSON tokens.
