### PR TITLE
[Docs] Separate component and global css cache to ensure expected Emotion style injection order

### DIFF
--- a/packages/docusaurus-theme/src/components/theme_context/index.tsx
+++ b/packages/docusaurus-theme/src/components/theme_context/index.tsx
@@ -7,9 +7,11 @@ import {
 } from 'react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
 import {
   EUI_THEME,
   EuiProvider,
+  EuiScreenReaderOnly,
   EuiThemeAmsterdam,
   EuiThemeColorMode,
 } from '@elastic/eui';
@@ -55,6 +57,12 @@ Emotion style tags dev mode are in an expected order (global css before componen
 This only applies for @emotion/react css styles, @emotion/css styles are separate  */
 const cssCache = createCache({
   key: 'website-css',
+  prepend: false,
+});
+
+export const cssGlobalCache = createCache({
+  key: 'website-css',
+  prepend: true,
 });
 
 export const AppThemeContext = createContext<AppThemeContextData>(defaultState);
@@ -119,9 +127,12 @@ export const AppThemeProvider: FunctionComponent<PropsWithChildren> = ({
         colorMode={colorMode}
         theme={theme.provider}
         highContrastMode={highContrastMode}
-        cache={cssCache}
+        cache={{
+          default: cssCache,
+          global: cssGlobalCache,
+        }}
       >
-        {children}
+        <CacheProvider value={cssCache}>{children}</CacheProvider>
       </EuiProvider>
     </AppThemeContext.Provider>
   );

--- a/packages/docusaurus-theme/src/theme/Root.tsx
+++ b/packages/docusaurus-theme/src/theme/Root.tsx
@@ -14,10 +14,10 @@ import {
 } from 'react';
 import Head from '@docusaurus/Head';
 import { Props } from '@theme/Root';
-import { css, Global } from '@emotion/react';
+import { CacheProvider, css, Global } from '@emotion/react';
 import { useEuiTheme } from '@elastic/eui';
 
-import { AppThemeProvider } from '../components/theme_context';
+import { AppThemeProvider, cssGlobalCache } from '../components/theme_context';
 import { getGlobalStyles } from './Root.styles';
 import { getResetStyles } from './reset.styles';
 import { getInfimaStyles } from './infima.styles';
@@ -57,7 +57,9 @@ const _Root: FunctionComponent<PropsWithChildren> = ({ children }) => {
           rel="stylesheet"
         />
       </Head>
-      <Global styles={[resetStyles, infimaStyles, globalStyles]} />
+      <CacheProvider value={cssGlobalCache}>
+        <Global styles={[resetStyles, infimaStyles, globalStyles]} />
+      </CacheProvider>
       <div style={!mounted ? { display: 'none' } : undefined} css={styles.root}>
         {children}
       </div>

--- a/packages/docusaurus-theme/src/theme/infima.styles.ts
+++ b/packages/docusaurus-theme/src/theme/infima.styles.ts
@@ -330,8 +330,8 @@ export const getInfimaStyles = () => css`
   }
 
   html {
-    background-color: var(--ifm-background-color) !important;
-    color: var(--ifm-font-color-base) !important;
+    background-color: var(--ifm-background-color);
+    color: var(--ifm-font-color-base);
     color-scheme: var(--ifm-color-scheme);
     -webkit-font-smoothing: antialiased;
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8707

This PR is a follow-up to these previous two PRs:
- https://github.com/elastic/eui/pull/8754
- https://github.com/elastic/eui/pull/8779

This previous PR (https://github.com/elastic/eui/pull/8754) already introduced a standalone cache for the website project to try and adjust style injection order. But that setup wasn't quite enough yet to consistently ensure the correct injected style order.

This current PR adds an additional global css cache with `prepend: true` which ensures it's loaded before the regular (component) css. Additionally this PR ensures that the website global styles are loaded in the correct css cache provider.

ℹ️ The Emotion style injection order can be influenced altered by: 
- using `prepend` - `true` will mean the cache is prepended as first element in the `head` (multiple caches with that setting potentially compete on that position) while `false` means it's appended as the last element in the `head`
- location of the nearest cache provider

ℹ️ CSS styles added via `@emotion/css` instead of `@emotion/react` are not handled by the same cache and are added separately. This issue will be resolved once we migrate all component styles to `@emotion/react`.

This update resolved the need of adding `!important` to the background color token (as added [here](https://github.com/elastic/eui/pull/8779)) and it solves the [issue](https://github.com/elastic/eui/issues/8707) that **EuiColorSwatch** used as examples in the docs aren't displayed with correct styles.

## Screenshots

| before | after |
|---|---|
| ![Screenshot 2025-06-26 at 13 46 23](https://github.com/user-attachments/assets/ca951af4-48b7-42b7-b761-1e2b76d327fc) | ![Screenshot 2025-06-26 at 13 46 11](https://github.com/user-attachments/assets/07030d21-8d04-4dfe-a942-a6b90beeabdd) |
