### PR TITLE
chore: deploy both to root and version subfolder

### DIFF
--- a/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
+++ b/.buildkite/scripts/pipelines/pipeline_deploy_new_docs.sh
@@ -87,11 +87,12 @@ if is_pipeline_trigger_pull_request; then
   echo "Detected a PR preview environment configuration. The built files will be copied to ${bucket_directory}"
 elif is_pipeline_trigger_tag; then
   latest_release_tag_on_main=$(git describe --tags "$(git rev-list --branches=main --tags --max-count=1)")
+  bucket_directory="${BUILDKITE_TAG}/"
+  copy_to_root_directory=false
   if [[ "${BUILDKITE_TAG}" == "${latest_release_tag_on_main}" ]]; then
-    # Deploy to root directory. No trailing slash here
-    bucket_directory=""
+    # Deploy to root directory and version subfolder
     copy_to_root_directory=true
-    echo "Detected a tagged release. The built files will be copied to the root directory"
+    echo "Detected the latest tagged release. The built files will be copied to the root directory and to ${bucket_directory}"
   else
     bucket_directory="${BUILDKITE_TAG}/"
     echo "Detected a tagged release. The built files will be copied to ${bucket_directory}"
@@ -145,11 +146,21 @@ echo "Beginning to copy built files to /${bucket_directory}"
 gcloud storage cp "${GCLOUD_CP_ARGS[@]}" packages/website/build/* "gs://${GCLOUD_BUCKET_FULL}/${bucket_directory}"
 echo "Successfully copied files to /${bucket_directory}"
 
+if [[ "${copy_to_root_directory}" == true ]]; then
+  echo "Also copying built files to the root directory /"
+  gcloud storage cp "${GCLOUD_CP_ARGS[@]}" packages/website/build/* "gs://${GCLOUD_BUCKET_FULL}/"
+  echo "Successfully copied files to the root directory"
+fi
+
 ############################################################
 #                      Step 5 - Notify                     #
 ############################################################
 
 published_website_url="https://eui.elastic.co/${bucket_directory}"
+
+if [[ "${copy_to_root_directory}" == true ]]; then
+  published_website_url="https://eui.elastic.co/ (root) and https://eui.elastic.co/${bucket_directory}"
+fi
 
 # Add an annotation on top of the pipeline
 echo "New documentation website deployed: ${published_website_url}" | buildkite-agent annotate --style "success" --context "deployed"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "build:workspaces": "yarn workspaces foreach -Rpi --topological-dev --from @elastic/eui-website run build",
+    "build:workspaces": "yarn workspaces foreach -Rpi --topological-dev --from @elastic/eui-website --exclude @elastic/eui-website run build",
     "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider docusaurus start",
     "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Summary

On this PR, I:

- [chore: deploy both to root and version subfolder](https://github.com/elastic/eui/commit/948c610319aae63b31798faf7a56702316f7a5d7)
  - The reason why we had previous version deployments missing on the documentation website is because the pipeline logic was: if it's the latest tagged release on main, deploy to root. If it's a tagged release, deploy under a version subfolder. The issue is, what happens when we make the next release? Its files just overwrite the previous version in the root folder but the version subfolder is not created.
  - To fix this, if it's the latest tagged release on main, we will deploy both to the root folder and the version subfolder.
- [chore: deploy Storybook](https://github.com/elastic/eui/commit/00aa74276175e98aeccc2f0d204e0f1f13c1d2fa)
  - I added steps for building and deploying Storybook: if it's the latest tagged release on main, then both in the root folder `eui.elastic.co/storybook` and under version subfolder `eui.elastic.co/vx.y.z/storybook`. If it's a tagged release, then in a version subfolder `eui.elastic.co/vx.y.z/storybook`. If it's triggered by a branch, then in a PR subfolder version subfolder `eui.elastic.co/pr_xxxx/storybook`.

## Why are we making this change?

Relates to https://github.com/elastic/eui-private/issues/326 and https://github.com/elastic/eui/issues/8761, previously opened as https://github.com/elastic/eui/pull/8805

## Impact to users

High impact for users and maintainers. Otherwise, old versions of our documentation page are not available unless uploaded manually to GCP bucket.

## QA

Changes to the pipeline have to be tested off the main branch.

- [ ] Verify that the logic covers all scenarios well:
  - [ ] Docs
    - [ ] if it's the latest tagged release on main, deploy under root and `/vx.y.z/`
    - [ ] if it's a tagged release, deploy under `/vx.y.z/`
    - [ ] if it's triggered by a branch, deploy under `/pr_xxxx/`
  - [ ] Storybook
    - [ ] if it's the latest tagged release on main, deploy under `/storybook/` and `/vx.y.z/storybook/`
    - [ ] if it's a tagged release, deploy under `/vx.y.z/storybook/`
    - [ ] if it's triggered by a branch, deploy under `/pr_xxxx/storybook/`