### PR TITLE
[EuiProgress][A11y] Announce determinate progress update to screen readers

### DIFF
--- a/packages/eui/changelogs/upcoming/8839.md
+++ b/packages/eui/changelogs/upcoming/8839.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Improved the experience of `EuiProgress` by ensuring that determinate updates are read out immediately to screen readers
+

--- a/packages/eui/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/packages/eui/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -115,15 +115,25 @@ exports[`EuiProgress has labelProps 1`] = `
     class="euiProgress__data emotion-euiProgress__data"
   >
     <span
+      aria-hidden="true"
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
       title="150"
     >
       150
     </span>
   </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="emotion-euiScreenReaderOnly"
+  >
+    <span>
+      150
+    </span>
+  </div>
   <progress
-    aria-hidden="false"
     aria-label="aria-label"
+    aria-valuetext="150"
     class="euiProgress testClass1 testClass2 emotion-euiProgress-native-m-static-success-euiTestCss"
     data-test-subj="test subject string"
     max="100"
@@ -133,13 +143,13 @@ exports[`EuiProgress has labelProps 1`] = `
 `;
 
 exports[`EuiProgress has max 1`] = `
-<progress
-  aria-hidden="false"
-  aria-label="aria-label"
-  class="euiProgress testClass1 testClass2 emotion-euiProgress-native-m-static-success-euiTestCss"
-  data-test-subj="test subject string"
-  max="100"
-/>
+<div
+  aria-atomic="true"
+  aria-live="polite"
+  class="emotion-euiScreenReaderOnly"
+>
+  <span />
+</div>
 `;
 
 exports[`EuiProgress has value 1`] = `
@@ -156,21 +166,33 @@ exports[`EuiProgress has valueText and label 1`] = `
     class="euiProgress__data emotion-euiProgress__data"
   >
     <span
+      aria-hidden="true"
       class="euiProgress__label emotion-euiProgress__label"
       title="Label"
     >
       Label
     </span>
     <span
+      aria-hidden="true"
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
       title="150"
     >
       150
     </span>
   </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="emotion-euiScreenReaderOnly"
+  >
+    <span>
+      Label 
+      150
+    </span>
+  </div>
   <progress
-    aria-hidden="true"
     aria-label="aria-label"
+    aria-valuetext="150"
     class="euiProgress testClass1 testClass2 emotion-euiProgress-native-m-static-success-euiTestCss"
     data-test-subj="test subject string"
     max="100"
@@ -180,14 +202,15 @@ exports[`EuiProgress has valueText and label 1`] = `
 `;
 
 exports[`EuiProgress is determinate 1`] = `
-<progress
-  aria-hidden="false"
-  aria-label="aria-label"
-  class="euiProgress testClass1 testClass2 emotion-euiProgress-native-m-static-success-euiTestCss"
-  data-test-subj="test subject string"
-  max="100"
-  value="50"
-/>
+<div
+  aria-atomic="true"
+  aria-live="polite"
+  class="emotion-euiScreenReaderOnly"
+>
+  <span>
+    50
+  </span>
+</div>
 `;
 
 exports[`EuiProgress is indeterminate 1`] = `
@@ -236,15 +259,25 @@ exports[`EuiProgress valueText is true 1`] = `
     class="euiProgress__data emotion-euiProgress__data"
   >
     <span
+      aria-hidden="true"
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
       title="50%"
     >
       50%
     </span>
   </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    class="emotion-euiScreenReaderOnly"
+  >
+    <span>
+      50%
+    </span>
+  </div>
   <progress
-    aria-hidden="false"
     aria-label="aria-label"
+    aria-valuetext="50%"
     class="euiProgress testClass1 testClass2 emotion-euiProgress-native-m-static-success-euiTestCss"
     data-test-subj="test subject string"
     max="100"

--- a/packages/eui/src/components/progress/progress.stories.tsx
+++ b/packages/eui/src/components/progress/progress.stories.tsx
@@ -85,7 +85,8 @@ export const DeterminateLoading: Story = {
     max: 100,
   },
   render: function Render(args) {
-    const { value, valueText } = args;
+    const { value, valueText, max } = args;
+    const maxValue = max ?? 100;
     const hasCustomValueText = valueText === 'steps';
 
     const [loading, setLoading] = useState<number>(
@@ -99,16 +100,28 @@ export const DeterminateLoading: Story = {
       undefined
     );
 
-    useEffect(() => {
-      if (loading >= 100 && intervalId !== null) {
-        clearInterval(intervalId);
+    const cleanInterval = (id: NodeJS.Timeout | undefined) => {
+      if (id !== undefined) {
+        clearInterval(id);
         setIntervalId(undefined);
       }
-    }, [intervalId, loading]);
+    };
+
+    useEffect(() => {
+      if (loading >= maxValue) {
+        cleanInterval(intervalId);
+      }
+    }, [intervalId, loading, maxValue]);
+
+    useEffect(() => {
+      return () => {
+        cleanInterval(intervalId);
+      };
+    }, []);
 
     const increment = () => {
       setLoading((prev: number) => {
-        if (prev >= 100) return 0;
+        if (prev >= maxValue) return 0;
 
         return prev + 10;
       });
@@ -137,6 +150,7 @@ export const DeterminateLoading: Story = {
           {/* casting due to ExclusiveUnion complexity */}
           <EuiProgress
             {...(args as typeof EuiProgress)}
+            max={maxValue}
             value={loading}
             valueText={
               hasCustomValueText ? `${loading} ${valueText}` : valueText

--- a/packages/eui/src/components/progress/progress.stories.tsx
+++ b/packages/eui/src/components/progress/progress.stories.tsx
@@ -6,9 +6,12 @@
  * Side Public License, v 1.
  */
 
+import React, { useEffect, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { EuiProgress, COLORS } from './progress';
+import { EuiButton } from '../button';
+import { EuiFlexGroup, EuiFlexItem } from '../flex';
 
 const meta: Meta<typeof EuiProgress> = {
   title: 'Display/EuiProgress',
@@ -18,7 +21,15 @@ const meta: Meta<typeof EuiProgress> = {
     // for quicker/easier QA
     label: { control: 'text' },
     value: { control: 'number' },
-    valueText: { control: 'boolean' },
+    valueText: {
+      control: 'radio',
+      options: ['custom', 'true', 'false'],
+      mapping: {
+        custom: 'steps',
+        true: true,
+        false: false,
+      },
+    },
   },
   args: {
     color: 'success',
@@ -52,5 +63,87 @@ export const HighContrast: Story = {
     ...Determinate.args,
     size: 'xs',
     color: 'primary',
+  },
+  render: (args) => <EuiProgress {...args} />,
+};
+
+export const DeterminateLoading: Story = {
+  parameters: {
+    controls: {
+      include: ['label', 'value', 'valueText', 'max'],
+    },
+    codeSnippet: {
+      resolveStoryElementOnly: true,
+    },
+    loki: {
+      skip: true,
+    },
+  },
+  args: {
+    label: 'Loading',
+    value: 70,
+    max: 100,
+  },
+  render: function Render(args) {
+    const { value, valueText } = args;
+    const hasCustomValueText = valueText === 'steps';
+
+    const [loading, setLoading] = useState<number>(
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+        ? parseInt(value)
+        : 0
+    );
+    const [intervalId, setIntervalId] = useState<NodeJS.Timeout | undefined>(
+      undefined
+    );
+
+    useEffect(() => {
+      if (loading >= 100 && intervalId !== null) {
+        clearInterval(intervalId);
+        setIntervalId(undefined);
+      }
+    }, [intervalId, loading]);
+
+    const increment = () => {
+      setLoading((prev: number) => {
+        if (prev >= 100) return 0;
+
+        return prev + 10;
+      });
+    };
+
+    const startLoading = () => {
+      if (loading === 0 && intervalId === undefined) {
+        const _intervalId = setInterval(() => increment(), 1000);
+
+        setIntervalId(_intervalId);
+      } else {
+        setLoading(0);
+        clearInterval(intervalId);
+        setIntervalId(undefined);
+      }
+    };
+
+    return (
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiButton onClick={startLoading}>
+            {loading === 0 ? 'Start' : 'Reset'}
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          {/* casting due to ExclusiveUnion complexity */}
+          <EuiProgress
+            {...(args as typeof EuiProgress)}
+            value={loading}
+            valueText={
+              hasCustomValueText ? `${loading} ${valueText}` : valueText
+            }
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
   },
 };

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -72,9 +72,15 @@ type Indeterminate = EuiProgressProps & HTMLAttributes<HTMLDivElement>;
 
 type Determinate = EuiProgressProps &
   Omit<ProgressHTMLAttributes<HTMLProgressElement>, 'max'> & {
+    /**
+     * When set, creates determinate progress with a value/max ratio
+     */
     max?: number;
-    /*
-     * If true, will render the percentage, otherwise pass a custom node
+    /**
+     * Displays custom text or percentage
+     * Pass `true` to display the percentage value
+     * Pass a ReactNode for custom text
+     * @default false
      */
     valueText?: boolean | ReactNode;
     label?: ReactNode;

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -105,7 +105,9 @@ export const EuiProgress: FunctionComponent<
   ...rest
 }) => {
   const valueTextRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
+  const labelRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
   const [innerValueText, setInnerValueText] = useState<string | undefined>();
+  const [labelText, setLabelText] = useState<string | undefined>();
 
   const determinate = !isNil(max);
   const isNamedColor = COLORS.includes(color as EuiProgressColor);
@@ -165,6 +167,7 @@ export const EuiProgress: FunctionComponent<
 
   useEffect(() => {
     setInnerValueText(valueTextRef.current?.textContent ?? '');
+    setLabelText(labelRef.current?.textContent ?? '');
   }, [label, valueRender, value]);
 
   // Because of a Firefox animation issue, indeterminate progress needs to not use <progress />.
@@ -180,7 +183,10 @@ export const EuiProgress: FunctionComponent<
                 {(ref, innerText) => (
                   <span
                     title={innerText}
-                    ref={ref}
+                    ref={(node) => {
+                      labelRef.current = node;
+                      ref?.(node);
+                    }}
                     {...labelProps}
                     className={labelClasses}
                     css={labelCssStyles}
@@ -227,6 +233,7 @@ export const EuiProgress: FunctionComponent<
           max={max}
           value={value}
           aria-valuetext={innerValueText || undefined}
+          aria-label={labelText || undefined}
           {...(rest as ProgressHTMLAttributes<HTMLProgressElement>)}
         />
       </>


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8837

This PR updates **EuiProgress** to ensure that progress updates are announces to screen reader users. Previously users would only be able to know the current progress of the element by manually navigating to it in the DOM.

### Changes

- adds a `aria-live` region in **EuiProgress** that mirrors the values of `label` and `value`, reading on progress update e.g. `Loading 10%`
  - ℹ️ Due to the native behavior of `aria-live` with `aria-atomic` the initial value will not be output, only updates will trigger an output. This is expected as we don't want the value to be read on mount but only on update. This means we can support static value display as well as loading states.
- removes the visible `label` and `valueText` output from the accessibility tree with `aria-hidden`:
  - because we're adding an `aria-live` region with the same text, we prevent duplicate content for screen reader users this way
- removes `aria-hidden` on the `<progress>` element:
  - ℹ️  `aria-hidden` was used here previously with the assumption that the `<progress>` element and `valueText` duplicate each other. This is true but having the `<progress>` element available in the DOM has a few benefits:
    - a) the element is perceivable in the DOM on user navigation and provides semantic information on demand next to the automatic updates
    - b) the available `<progress>` element can trigger update sounds (not reading it's value but providing a sound-icon indication of progress) when available
    - c) providing the label and progress aligns the screen reader experience closer with the visual output 

## Why are we making this change?

This update improves the accessibility of the **EuiProgress** component by ensuring that users are receiving updates directly without the need to manually focus the component in the DOM.

[WCAG 4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html)

## Screenshots

| AT | `valueText={false}` | `valueText={true}` | valueText={${value} steps}` |
|---|---|---|---|
| NVDA | <video src="https://github.com/user-attachments/assets/5eeb5123-d627-41a0-86dc-6f5f69dd4af7" /> | <video src="https://github.com/user-attachments/assets/aa38bb20-fbfc-4398-873e-83b4cc1bbe54" /> | <video src="https://github.com/user-attachments/assets/041eeb73-fef0-453d-86f1-f599f79e4857" /> |
| JAWS | <img src="https://github.com/user-attachments/assets/ed4b51a7-3142-4e70-9de5-568f544eb0e5" /> | <img src="https://github.com/user-attachments/assets/02a2627c-1d82-4626-b228-a750c29dded9" /> | <img src="https://github.com/user-attachments/assets/c2f96bf0-4ff2-4a20-b856-c77e97e21d78" /> |

## Impact to users

🟢 This PR does not contain breaking changes nor does it require updates on consumer side.

## QA

- checkout this PR and open the newly added story `EuiProgress > Determinate Loading"
  - [x] verify that the progress updates are correctly announced to the screen reader (NVDA/JAWS, VoiceOver)
  - [ ] verify that navigating the DOM with the screen reader will read the label/status and progress bar

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
