### PR TITLE
[Theme][EuiVisColorStore] Fix wrong initial `hasVisColorAdjustment` value

### DIFF
--- a/packages/eui/src/services/color/eui_palettes.test.ts
+++ b/packages/eui/src/services/color/eui_palettes.test.ts
@@ -93,6 +93,13 @@ describe('euiPaletteForDarkBackground', () => {
 });
 
 describe('euiPaletteForStatus', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteForStatus(6, { colors });
+
+    expect(resultLong[2]).toEqual('#c8e3b8');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -107,6 +114,13 @@ describe('euiPaletteForStatus', () => {
 });
 
 describe('euiPaletteForTemperature', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteForTemperature(6, { colors });
+
+    expect(resultLong[2]).toEqual('#e8f1ff');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -121,6 +135,13 @@ describe('euiPaletteForTemperature', () => {
 });
 
 describe('euiPaletteComplementary', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteComplementary(6, { colors });
+
+    expect(resultLong[2]).toEqual('#c4dcfd');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -135,6 +156,13 @@ describe('euiPaletteComplementary', () => {
 });
 
 describe('euiPaletteRed', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteRed(6, { colors });
+
+    expect(resultLong[2]).toEqual('#feb7b0');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -149,6 +177,13 @@ describe('euiPaletteRed', () => {
 });
 
 describe('euiPaletteGreen', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteGreen(6, { colors });
+
+    expect(resultLong[2]).toEqual('#9fdfc6');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -163,6 +198,13 @@ describe('euiPaletteGreen', () => {
 });
 
 describe('euiPaletteSkyBlue', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteSkyBlue(6, { colors });
+
+    expect(resultLong[2]).toEqual('#a6d8ec');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -177,6 +219,13 @@ describe('euiPaletteSkyBlue', () => {
 });
 
 describe('euiPaletteYellow', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteYellow(6, { colors });
+
+    expect(resultLong[2]).toEqual('#f9d290');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -191,6 +240,13 @@ describe('euiPaletteYellow', () => {
 });
 
 describe('euiPaletteOrange', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteOrange(6, { colors });
+
+    expect(resultLong[2]).toEqual('#ffc1a1');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -205,6 +261,13 @@ describe('euiPaletteOrange', () => {
 });
 
 describe('euiPaletteCool', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteCool(6, { colors });
+
+    expect(resultLong[2]).toEqual('#a8caff');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -219,6 +282,13 @@ describe('euiPaletteCool', () => {
 });
 
 describe('euiPaletteWarm', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteWarm(6, { colors });
+
+    expect(resultLong[2]).toEqual('#ffafa6');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {
@@ -233,6 +303,13 @@ describe('euiPaletteWarm', () => {
 });
 
 describe('euiPaletteGray', () => {
+  it('should return correct colors', () => {
+    const colors = colorVis;
+    const resultLong = euiPaletteGray(6, { colors });
+
+    expect(resultLong[2]).toEqual('#7b8aa4');
+  });
+
   it('should return custom colors', () => {
     const customColor = '#00ff00';
     const colors = {

--- a/packages/eui/src/services/color/vis_color_store.ts
+++ b/packages/eui/src/services/color/vis_color_store.ts
@@ -11,4 +11,4 @@ import { colorVis } from '@elastic/eui-theme-borealis';
 
 // initialsetup of Vis color storage with default colors
 export const EUI_VIS_COLOR_STORE: _EuiVisColorStore =
-  EuiVisColorStore.getInstance(colorVis, true);
+  EuiVisColorStore.getInstance(colorVis, false);


### PR DESCRIPTION
## Summary

This PR fixes the initial value for the static initialized `EUI_VIS_COLOR_STORE`. When we updated the default theme from Amsterdam to Borealis, we missed updating this flag value.

This resulted in wrong initial values for eui color palette calculations which surfaced specifically in tests that use static euiPalette functions and would not be updated due to a React component render.

This PR also updates the palette function tests to assert a calculated color which would catch regression issues based on those theme flags.

## Why are we making this change?

Fixing unexpected initial color palette values.

## Screenshots

ℹ️ The screenshots show:
- `euiPaletteForTemperature(6)`
- `useEuiPaletteForTemperature(6)`

| before | after |
|---|---|
| ![Screenshot 2025-07-07 at 11 43 26](https://github.com/user-attachments/assets/ac4dd6c7-dc7f-412f-b7d1-8d80d0861074) | ![Screenshot 2025-07-07 at 11 44 02](https://github.com/user-attachments/assets/a4751f12-ccac-4fc3-aa35-90dfbbaed7da) |


## Impact to users

⚠️  This is not a breaking change but it likely results in test/snapshot failures on Kibana side when tests assert based on static color palettes. This is expected and would have happened earlier if we wouldn't have missed this flag update.

## QA

- [ ] CI passes
- checkout this PR and run Storybook
  - [ ] log the values of e.g. `euiColorPaletteTemperatur(6)` and `useEuiColorPaletteTemperatur(6)` and verify both have the same values (previously the static palette function would differ) 

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
