### PR TITLE
[EuiFlyoutSessionProvider] Fix `onUnmount` handler and `goBack` functionality

### DIFF
--- a/packages/eui/changelogs/upcoming/8846.md
+++ b/packages/eui/changelogs/upcoming/8846.md
@@ -1,0 +1,5 @@
+- Updates to `EuiFlyoutSessionProvider`
+  * Remove the onUnmount callbacks from various flyout configurations
+  * Consolidate unmount behavior with a single onUnmount prop at the provider level.
+  * Removed onCloseFlyout and onCloseChildFlyout from the flyout render context.
+  * Fixed the canGoBack logic in packages/eui/src/components/flyout/sessions/use_eui_flyout.ts.

--- a/packages/eui/src/components/flyout/index.ts
+++ b/packages/eui/src/components/flyout/index.ts
@@ -32,5 +32,6 @@ export type {
   EuiFlyoutSessionOpenMainOptions,
   EuiFlyoutSessionProviderComponentProps,
   EuiFlyoutSessionRenderContext,
+  EuiFlyoutSessionApi,
 } from './sessions';
 export { EuiFlyoutSessionProvider, useEuiFlyoutSession } from './sessions';

--- a/packages/eui/src/components/flyout/sessions/README.md
+++ b/packages/eui/src/components/flyout/sessions/README.md
@@ -29,8 +29,8 @@ The `useEuiFlyoutSession` hook is generic and can be typed to match the `meta` o
 *   `openFlyout(options: EuiFlyoutSessionOpenMainOptions<MetaType>)`: Opens a new main flyout. If a flyout is already open, it adds the new one to a history stack.
 *   `openChildFlyout(options: EuiFlyoutSessionOpenChildOptions<MetaType>)`: Opens a new child flyout to the left of the main flyout.
 *   `openFlyoutGroup(options: EuiFlyoutSessionOpenGroupOptions<MetaType>)`: Opens a group containing a main flyout and a child flyout.
-*   `goBack()`: If there's a previous flyout in the history stack, it will be shown.
 *   `closeChildFlyout()`: Closes the currently open child flyout.
+*   `goBack()`: If there's a previous flyout in the history stack, it will be shown.
 *   `clearHistory()`: Closes all flyouts by clearing the history stack of all flyouts in the session.
 
 ### State Values
@@ -81,11 +81,11 @@ const FlyoutApp: React.FC = () => {
   // The EuiFlyoutSessionRenderContext is passed to your render prop functions.
   // This can contain a custom `meta` object (set in the `openFlyout` function call)
   // which allows you to customize the content shown in the flyout.
-  const renderMainFlyoutContent = (context: EuiFlyoutSessionRenderContext<{ title: string }>) => (
+  const renderMainFlyoutContent = (flyoutContext: EuiFlyoutSessionRenderContext<{ title: string }>) => (
     <>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle size="s">
-          <h2>{context.meta.title}</h2>
+          <h2>{flyoutContext.meta.title}</h2>
         </EuiTitle>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>

--- a/packages/eui/src/components/flyout/sessions/README.md
+++ b/packages/eui/src/components/flyout/sessions/README.md
@@ -18,7 +18,7 @@ The `EuiFlyoutSessionProvider` is the core stateful component. You must wrap it 
 The `flyoutContext` object passed to your render prop functions is of type `EuiFlyoutSessionRenderContext<MetaType>` and contains the following useful properties:
 
 *   **`meta`**: `MetaType` - The arbitrary data object you passed into the `meta` property when calling `openFlyout` or `openChildFlyout`. This is a generic, allowing you to have type safety for your custom data.
-*   **`activeFlyoutGroup`**: `EuiFlyoutGroup` - The currently active flyout group.
+*   **`activeFlyoutGroup`**: `EuiFlyoutSessionGroup` - The currently active flyout group.
 
 ## `useEuiFlyoutSession` Hook API
 
@@ -26,10 +26,10 @@ The `useEuiFlyoutSession` hook is generic and can be typed to match the `meta` o
 
 ### Methods
 
-*   `openFlyout(options)`: Opens a new main flyout. If a flyout is already open, it adds the new one to a history stack.
-*   `openChildFlyout(options)`: Opens a new child flyout to the left of the main flyout.
-*   `openFlyoutGroup(options)`: Opens a group containing a main flyout and a child flyout.
-*   `closeFlyout()`: Closes the currently open main flyout. If there's a previous flyout in the history stack, it will be shown.
+*   `openFlyout(options: EuiFlyoutSessionOpenMainOptions<MetaType>)`: Opens a new main flyout. If a flyout is already open, it adds the new one to a history stack.
+*   `openChildFlyout(options: EuiFlyoutSessionOpenChildOptions<MetaType>)`: Opens a new child flyout to the left of the main flyout.
+*   `openFlyoutGroup(options: EuiFlyoutSessionOpenGroupOptions<MetaType>)`: Opens a group containing a main flyout and a child flyout.
+*   `goBack()`: If there's a previous flyout in the history stack, it will be shown.
 *   `closeChildFlyout()`: Closes the currently open child flyout.
 *   `clearHistory()`: Closes all flyouts by clearing the history stack of all flyouts in the session.
 
@@ -52,6 +52,8 @@ import {
   EuiButton,
   EuiFlyoutBody,
   EuiText,
+  EuiFlyoutHeader,
+  EuiTitle,
   EuiFlyoutSessionProvider,
   useEuiFlyoutSession,
 } from '@elastic/eui';
@@ -64,6 +66,7 @@ const FlyoutAppControls: React.FC = () => {
     // will add the new flyout to the history stack.
     openFlyout({
       size: 'm',
+      meta: { title: 'My Flyout' },
     });
   };
 
@@ -78,12 +81,19 @@ const FlyoutApp: React.FC = () => {
   // The EuiFlyoutSessionRenderContext is passed to your render prop functions.
   // This can contain a custom `meta` object (set in the `openFlyout` function call)
   // which allows you to customize the content shown in the flyout.
-  const renderMainFlyoutContent = (context: EuiFlyoutSessionRenderContext) => (
-    <EuiFlyoutBody>
-      <EuiText>
-        <p>Simple flyout content</p>
-      </EuiText>
-    </EuiFlyoutBody>
+  const renderMainFlyoutContent = (context: EuiFlyoutSessionRenderContext<{ title: string }>) => (
+    <>
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="s">
+          <h2>{context.meta.title}</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <EuiText>
+          <p>Simple flyout content</p>
+        </EuiText>
+      </EuiFlyoutBody>
+    </>
   );
 
   return (

--- a/packages/eui/src/components/flyout/sessions/README.md
+++ b/packages/eui/src/components/flyout/sessions/README.md
@@ -18,8 +18,7 @@ The `EuiFlyoutSessionProvider` is the core stateful component. You must wrap it 
 The `flyoutContext` object passed to your render prop functions is of type `EuiFlyoutSessionRenderContext<MetaType>` and contains the following useful properties:
 
 *   **`meta`**: `MetaType` - The arbitrary data object you passed into the `meta` property when calling `openFlyout` or `openChildFlyout`. This is a generic, allowing you to have type safety for your custom data.
-*   **`flyoutSize`**: The size of the currently active flyout.
-*   **`flyoutType`**: `'main' | 'child'` - Indicates which flyout the render prop is being called for.
+*   **`activeFlyoutGroup`**: `EuiFlyoutGroup` - The currently active flyout group.
 
 ## `useEuiFlyoutSession` Hook API
 

--- a/packages/eui/src/components/flyout/sessions/README.md
+++ b/packages/eui/src/components/flyout/sessions/README.md
@@ -18,8 +18,6 @@ The `EuiFlyoutSessionProvider` is the core stateful component. You must wrap it 
 The `flyoutContext` object passed to your render prop functions is of type `EuiFlyoutSessionRenderContext<MetaType>` and contains the following useful properties:
 
 *   **`meta`**: `MetaType` - The arbitrary data object you passed into the `meta` property when calling `openFlyout` or `openChildFlyout`. This is a generic, allowing you to have type safety for your custom data.
-*   **`onCloseFlyout`**: `() => void` - A callback function that closes the current main flyout.
-*   **`onCloseChildFlyout`**: `() => void` - A callback function that closes the current child flyout.
 *   **`flyoutSize`**: The size of the currently active flyout.
 *   **`flyoutType`**: `'main' | 'child'` - Indicates which flyout the render prop is being called for.
 

--- a/packages/eui/src/components/flyout/sessions/flyout_provider.stories.tsx
+++ b/packages/eui/src/components/flyout/sessions/flyout_provider.stories.tsx
@@ -84,7 +84,6 @@ const ShoppingCartContent: React.FC<ShoppingCartContentProps> = ({
           closeChildFlyout(); // If we add an onClose handler to the child flyout, we have to call closeChildFlyout within it for the flyout to actually close
         },
       },
-      onUnmount: () => console.log('Unmounted item details child flyout'),
     };
     openChildFlyout(options);
   };
@@ -98,8 +97,6 @@ const ShoppingCartContent: React.FC<ShoppingCartContentProps> = ({
         ...config?.mainFlyoutProps,
         'aria-label': 'Review order',
       },
-      onUnmount: () =>
-        console.log(`Unmounted review order flyout (${reviewFlyoutSize})`),
     };
     openFlyout(options);
   };
@@ -279,7 +276,6 @@ const WithHistoryAppControls: React.FC = () => {
           clearHistory(); // If we add an onClose handler to the main flyout, we have to call clearHistory within it for the flyout to actually close
         },
       },
-      onUnmount: () => console.log('Unmounted shopping cart flyout'),
     };
     openFlyout(options);
   };
@@ -362,6 +358,7 @@ const WithHistoryApp: React.FC = () => {
     <EuiFlyoutSessionProvider
       renderMainFlyoutContent={renderMainFlyoutContent}
       renderChildFlyoutContent={renderChildFlyoutContent}
+      onUnmount={() => console.log('All flyouts have been unmounted')}
     >
       <WithHistoryAppControls />
     </EuiFlyoutSessionProvider>
@@ -397,7 +394,6 @@ const GroupOpenerControls: React.FC = () => {
           className: 'groupOpenerMainFlyout',
           'aria-label': 'Main flyout',
         },
-        onUnmount: () => console.log('Unmounted main flyout'),
       },
       child: {
         size: 's',
@@ -405,7 +401,6 @@ const GroupOpenerControls: React.FC = () => {
           className: 'groupOpenerChildFlyout',
           'aria-label': 'Child flyout',
         },
-        onUnmount: () => console.log('Unmounted child flyout'),
       },
     };
     openFlyoutGroup(options);

--- a/packages/eui/src/components/flyout/sessions/flyout_provider.stories.tsx
+++ b/packages/eui/src/components/flyout/sessions/flyout_provider.stories.tsx
@@ -258,6 +258,13 @@ const WithHistoryAppControls: React.FC = () => {
     clearHistory,
   } = useEuiFlyoutSession();
 
+  const handleCloseOrGoBack = () => {
+    if (canGoBack) {
+      goBack();
+    } else {
+      clearHistory();
+    }
+  };
   const handleOpenShoppingCart = () => {
     const options: EuiFlyoutSessionOpenMainOptions<WithHistoryAppMeta> = {
       size: 'm',
@@ -297,7 +304,11 @@ const WithHistoryAppControls: React.FC = () => {
         Close child flyout
       </EuiButton>
       <EuiSpacer size="s" />
-      <EuiButton onClick={goBack} isDisabled={!canGoBack} color="warning">
+      <EuiButton
+        onClick={handleCloseOrGoBack}
+        isDisabled={!isFlyoutOpen}
+        color="warning"
+      >
         Close/Go back
       </EuiButton>
       <EuiSpacer size="s" />

--- a/packages/eui/src/components/flyout/sessions/flyout_provider.tsx
+++ b/packages/eui/src/components/flyout/sessions/flyout_provider.tsx
@@ -21,6 +21,7 @@ import {
 interface FlyoutSessionContextProps {
   state: EuiFlyoutSessionHistoryState;
   dispatch: React.Dispatch<EuiFlyoutSessionAction>;
+  onUnmount?: EuiFlyoutSessionProviderComponentProps['onUnmount'];
 }
 
 const EuiFlyoutSessionContext = createContext<FlyoutSessionContextProps | null>(
@@ -53,7 +54,12 @@ export const useEuiFlyoutSessionContext = () => {
  */
 export const EuiFlyoutSessionProvider: React.FC<
   EuiFlyoutSessionProviderComponentProps
-> = ({ children, renderMainFlyoutContent, renderChildFlyoutContent }) => {
+> = ({
+  children,
+  renderMainFlyoutContent,
+  renderChildFlyoutContent,
+  onUnmount,
+}) => {
   const [state, dispatch] = useReducer(flyoutReducer, initialFlyoutState);
   const { activeFlyoutGroup } = state;
 
@@ -101,7 +107,7 @@ export const EuiFlyoutSessionProvider: React.FC<
   const flyoutPropsChild = config?.childFlyoutProps || {};
 
   return (
-    <EuiFlyoutSessionContext.Provider value={{ state, dispatch }}>
+    <EuiFlyoutSessionContext.Provider value={{ state, dispatch, onUnmount }}>
       {children}
       {activeFlyoutGroup?.isMainOpen && (
         <EuiFlyout

--- a/packages/eui/src/components/flyout/sessions/flyout_provider.tsx
+++ b/packages/eui/src/components/flyout/sessions/flyout_provider.tsx
@@ -75,8 +75,6 @@ export const EuiFlyoutSessionProvider: React.FC<
       flyoutType: 'main',
       dispatch,
       activeFlyoutGroup,
-      onCloseFlyout: handleClose,
-      onCloseChildFlyout: handleCloseChild,
       meta: activeFlyoutGroup.meta,
     };
     mainFlyoutContentNode = renderMainFlyoutContent(mainRenderContext);
@@ -88,8 +86,6 @@ export const EuiFlyoutSessionProvider: React.FC<
         flyoutType: 'child',
         dispatch,
         activeFlyoutGroup,
-        onCloseFlyout: handleClose,
-        onCloseChildFlyout: handleCloseChild,
         meta: activeFlyoutGroup.meta,
       };
       childFlyoutContentNode = renderChildFlyoutContent(childRenderContext);

--- a/packages/eui/src/components/flyout/sessions/flyout_provider.tsx
+++ b/packages/eui/src/components/flyout/sessions/flyout_provider.tsx
@@ -75,26 +75,14 @@ export const EuiFlyoutSessionProvider: React.FC<
   let childFlyoutContentNode: React.ReactNode = null;
 
   if (activeFlyoutGroup) {
-    const mainRenderContext: EuiFlyoutSessionRenderContext = {
-      flyoutProps: activeFlyoutGroup.config.mainFlyoutProps || {},
-      flyoutSize: activeFlyoutGroup.config.mainSize,
-      flyoutType: 'main',
-      dispatch,
+    const renderContext: EuiFlyoutSessionRenderContext = {
       activeFlyoutGroup,
       meta: activeFlyoutGroup.meta,
     };
-    mainFlyoutContentNode = renderMainFlyoutContent(mainRenderContext);
+    mainFlyoutContentNode = renderMainFlyoutContent(renderContext);
 
     if (activeFlyoutGroup.isChildOpen && renderChildFlyoutContent) {
-      const childRenderContext: EuiFlyoutSessionRenderContext = {
-        flyoutProps: activeFlyoutGroup.config.childFlyoutProps || {},
-        flyoutSize: activeFlyoutGroup.config.childSize,
-        flyoutType: 'child',
-        dispatch,
-        activeFlyoutGroup,
-        meta: activeFlyoutGroup.meta,
-      };
-      childFlyoutContentNode = renderChildFlyoutContent(childRenderContext);
+      childFlyoutContentNode = renderChildFlyoutContent(renderContext);
     } else if (activeFlyoutGroup.isChildOpen && !renderChildFlyoutContent) {
       console.warn(
         'EuiFlyoutSessionProvider: A child flyout is open, but renderChildFlyoutContent was not provided.'

--- a/packages/eui/src/components/flyout/sessions/flyout_reducer.ts
+++ b/packages/eui/src/components/flyout/sessions/flyout_reducer.ts
@@ -64,7 +64,7 @@ export function flyoutReducer<FlyoutMeta>(
 ): EuiFlyoutSessionHistoryState<FlyoutMeta> {
   switch (action.type) {
     case 'OPEN_MAIN_FLYOUT': {
-      const { size, flyoutProps, onUnmount } = action.payload;
+      const { size, flyoutProps } = action.payload;
       const newHistory = [...state.history];
 
       if (state.activeFlyoutGroup) {
@@ -80,8 +80,6 @@ export function flyoutReducer<FlyoutMeta>(
           mainFlyoutProps: flyoutProps,
           childFlyoutProps: {},
         },
-        mainOnUnmount: onUnmount,
-        childOnUnmount: undefined,
         meta:
           action.payload.meta !== undefined
             ? state.activeFlyoutGroup?.meta !== undefined
@@ -104,7 +102,7 @@ export function flyoutReducer<FlyoutMeta>(
         return state;
       }
 
-      const { size, flyoutProps, onUnmount } = action.payload;
+      const { size, flyoutProps } = action.payload;
       const updatedActiveGroup: EuiFlyoutSessionGroup<FlyoutMeta> = {
         ...state.activeFlyoutGroup,
         isChildOpen: true,
@@ -113,7 +111,6 @@ export function flyoutReducer<FlyoutMeta>(
           childSize: size,
           childFlyoutProps: flyoutProps,
         },
-        childOnUnmount: onUnmount,
         meta:
           action.payload.meta !== undefined
             ? state.activeFlyoutGroup.meta !== undefined
@@ -146,8 +143,6 @@ export function flyoutReducer<FlyoutMeta>(
           mainFlyoutProps: main.flyoutProps,
           childFlyoutProps: child.flyoutProps,
         },
-        mainOnUnmount: main.onUnmount,
-        childOnUnmount: child.onUnmount,
         meta,
       };
 
@@ -165,8 +160,6 @@ export function flyoutReducer<FlyoutMeta>(
         return state;
       }
 
-      state.activeFlyoutGroup.childOnUnmount?.();
-
       const updatedActiveGroup: EuiFlyoutSessionGroup<FlyoutMeta> = {
         ...state.activeFlyoutGroup,
         isChildOpen: false,
@@ -174,7 +167,6 @@ export function flyoutReducer<FlyoutMeta>(
           ...state.activeFlyoutGroup.config,
           childFlyoutProps: {},
         },
-        childOnUnmount: undefined,
       };
 
       return {
@@ -186,12 +178,6 @@ export function flyoutReducer<FlyoutMeta>(
     case 'GO_BACK': {
       if (!state.activeFlyoutGroup)
         return initialFlyoutState as EuiFlyoutSessionHistoryState<FlyoutMeta>;
-
-      if (state.activeFlyoutGroup.isChildOpen) {
-        state.activeFlyoutGroup.childOnUnmount?.();
-      }
-
-      state.activeFlyoutGroup.mainOnUnmount?.();
 
       // Restore from history or return to initial state
       if (state.history.length > 0) {
@@ -214,8 +200,7 @@ export function flyoutReducer<FlyoutMeta>(
         return state;
       }
 
-      const { configChanges, newMainOnUnmount, newChildOnUnmount } =
-        action.payload;
+      const { configChanges } = action.payload;
 
       const updatedActiveGroup: EuiFlyoutSessionGroup<FlyoutMeta> = {
         ...state.activeFlyoutGroup,
@@ -223,14 +208,6 @@ export function flyoutReducer<FlyoutMeta>(
           ...state.activeFlyoutGroup.config,
           ...configChanges,
         },
-        mainOnUnmount:
-          newMainOnUnmount !== undefined
-            ? newMainOnUnmount
-            : state.activeFlyoutGroup.mainOnUnmount,
-        childOnUnmount:
-          newChildOnUnmount !== undefined
-            ? newChildOnUnmount
-            : state.activeFlyoutGroup.childOnUnmount,
       };
 
       const finalUpdatedActiveGroup = applySizeConstraints(updatedActiveGroup);

--- a/packages/eui/src/components/flyout/sessions/index.ts
+++ b/packages/eui/src/components/flyout/sessions/index.ts
@@ -21,4 +21,5 @@ export {
   useEuiFlyoutSession,
   type EuiFlyoutSessionOpenChildOptions,
   type EuiFlyoutSessionOpenMainOptions,
+  type EuiFlyoutSessionApi,
 } from './use_eui_flyout';

--- a/packages/eui/src/components/flyout/sessions/types.ts
+++ b/packages/eui/src/components/flyout/sessions/types.ts
@@ -84,10 +84,6 @@ export type EuiFlyoutSessionAction<FlyoutMeta = unknown> =
  * Flyout session context managed by `EuiFlyoutSessionProvider`, and passed to the `renderMainFlyoutContent` and `renderChildFlyoutContent` functions.
  */
 export interface EuiFlyoutSessionRenderContext<FlyoutMeta = unknown> {
-  flyoutProps: Partial<EuiFlyoutProps | EuiFlyoutChildProps>;
-  flyoutSize: EuiFlyoutProps['size'] | EuiFlyoutChildProps['size'];
-  flyoutType: 'main' | 'child';
-  dispatch: React.Dispatch<EuiFlyoutSessionAction<FlyoutMeta>>;
   activeFlyoutGroup: EuiFlyoutSessionGroup<FlyoutMeta> | null;
   meta?: FlyoutMeta;
 }

--- a/packages/eui/src/components/flyout/sessions/types.ts
+++ b/packages/eui/src/components/flyout/sessions/types.ts
@@ -27,8 +27,6 @@ export interface EuiFlyoutSessionGroup<FlyoutMeta> {
   isMainOpen: boolean;
   isChildOpen: boolean;
   config: EuiFlyoutSessionConfig;
-  mainOnUnmount?: () => void;
-  childOnUnmount?: () => void;
   meta?: FlyoutMeta;
 }
 
@@ -46,8 +44,6 @@ export type EuiFlyoutSessionAction<FlyoutMeta = unknown> =
       type: 'UPDATE_ACTIVE_FLYOUT_CONFIG';
       payload: {
         configChanges: Partial<EuiFlyoutSessionConfig>;
-        newMainOnUnmount?: () => void;
-        newChildOnUnmount?: () => void;
       };
     }
   | {
@@ -55,7 +51,6 @@ export type EuiFlyoutSessionAction<FlyoutMeta = unknown> =
       payload: {
         size: EuiFlyoutSize;
         flyoutProps?: Partial<Omit<EuiFlyoutProps, 'children'>>;
-        onUnmount?: () => void;
         meta?: FlyoutMeta;
       };
     }
@@ -64,7 +59,6 @@ export type EuiFlyoutSessionAction<FlyoutMeta = unknown> =
       payload: {
         size: 's' | 'm';
         flyoutProps?: Partial<Omit<EuiFlyoutChildProps, 'children'>>;
-        onUnmount?: () => void;
         meta?: FlyoutMeta;
       };
     }
@@ -74,12 +68,10 @@ export type EuiFlyoutSessionAction<FlyoutMeta = unknown> =
         main: {
           size: EuiFlyoutSize;
           flyoutProps?: Partial<Omit<EuiFlyoutProps, 'children'>>;
-          onUnmount?: () => void;
         };
         child: {
           size: 's' | 'm';
           flyoutProps?: Partial<Omit<EuiFlyoutChildProps, 'children'>>;
-          onUnmount?: () => void;
         };
         meta?: FlyoutMeta;
       };
@@ -105,6 +97,7 @@ export interface EuiFlyoutSessionRenderContext<FlyoutMeta = unknown> {
  */
 export interface EuiFlyoutSessionProviderComponentProps<FlyoutMeta = any> {
   children: React.ReactNode;
+  onUnmount?: () => void;
   renderMainFlyoutContent: (
     context: EuiFlyoutSessionRenderContext<FlyoutMeta>
   ) => React.ReactNode;

--- a/packages/eui/src/components/flyout/sessions/types.ts
+++ b/packages/eui/src/components/flyout/sessions/types.ts
@@ -97,8 +97,6 @@ export interface EuiFlyoutSessionRenderContext<FlyoutMeta = unknown> {
   flyoutType: 'main' | 'child';
   dispatch: React.Dispatch<EuiFlyoutSessionAction<FlyoutMeta>>;
   activeFlyoutGroup: EuiFlyoutSessionGroup<FlyoutMeta> | null;
-  onCloseFlyout: () => void;
-  onCloseChildFlyout: () => void;
   meta?: FlyoutMeta;
 }
 

--- a/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
+++ b/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
@@ -100,7 +100,7 @@ export function useEuiFlyoutSession() {
     dispatch({ type: 'GO_BACK' });
   };
 
-  const canGoBack = !!state.activeFlyoutGroup;
+  const canGoBack = !!state.history.length;
 
   const isFlyoutOpen = !!state.activeFlyoutGroup?.isMainOpen;
 

--- a/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
+++ b/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { useEffect, useRef } from 'react';
 import { EuiFlyoutSize } from '../flyout';
 import { useEuiFlyoutSessionContext } from './flyout_provider';
 import { EuiFlyoutSessionConfig } from './types';
@@ -16,7 +17,6 @@ import { EuiFlyoutSessionConfig } from './types';
 export interface EuiFlyoutSessionOpenMainOptions<Meta = unknown> {
   size: EuiFlyoutSize;
   flyoutProps?: EuiFlyoutSessionConfig['mainFlyoutProps'];
-  onUnmount?: () => void;
   meta?: Meta;
 }
 
@@ -26,7 +26,6 @@ export interface EuiFlyoutSessionOpenMainOptions<Meta = unknown> {
 export interface EuiFlyoutSessionOpenChildOptions<Meta = unknown> {
   size: 's' | 'm';
   flyoutProps?: EuiFlyoutSessionConfig['childFlyoutProps'];
-  onUnmount?: () => void;
   meta?: Meta;
 }
 
@@ -37,12 +36,10 @@ export interface EuiFlyoutSessionOpenGroupOptions<Meta = unknown> {
   main: {
     size: EuiFlyoutSize;
     flyoutProps?: EuiFlyoutSessionConfig['mainFlyoutProps'];
-    onUnmount?: () => void;
   };
   child: {
     size: 's' | 'm';
     flyoutProps?: EuiFlyoutSessionConfig['childFlyoutProps'];
-    onUnmount?: () => void;
   };
   meta?: Meta; // Shared meta for both flyouts
 }
@@ -51,7 +48,18 @@ export interface EuiFlyoutSessionOpenGroupOptions<Meta = unknown> {
  * Hook for accessing the flyout API
  */
 export function useEuiFlyoutSession() {
-  const { state, dispatch } = useEuiFlyoutSessionContext();
+  const { state, dispatch, onUnmount } = useEuiFlyoutSessionContext();
+  const isInitialMount = useRef(true);
+
+  useEffect(() => {
+    // When there is no active flyout, we should call the onUnmount callback.
+    // Ensure this is not called on the initial render, only on subsequent state changes.
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else if (state.activeFlyoutGroup === null) {
+      onUnmount?.();
+    }
+  }, [state.activeFlyoutGroup, onUnmount]);
 
   const openFlyout = (options: EuiFlyoutSessionOpenMainOptions) => {
     dispatch({
@@ -80,12 +88,10 @@ export function useEuiFlyoutSession() {
         main: {
           size: options.main.size,
           flyoutProps: options.main.flyoutProps,
-          onUnmount: options.main.onUnmount,
         },
         child: {
           size: options.child.size,
           flyoutProps: options.child.flyoutProps,
-          onUnmount: options.child.onUnmount,
         },
         meta: options.meta,
       },

--- a/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
+++ b/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
@@ -44,11 +44,23 @@ export interface EuiFlyoutSessionOpenGroupOptions<Meta = unknown> {
   meta?: Meta; // Shared meta for both flyouts
 }
 
+export interface EuiFlyoutSessionApi {
+  openFlyout: (options: EuiFlyoutSessionOpenMainOptions) => void;
+  openChildFlyout: (options: EuiFlyoutSessionOpenChildOptions) => void;
+  openFlyoutGroup: (options: EuiFlyoutSessionOpenGroupOptions) => void;
+  closeChildFlyout: () => void;
+  goBack: () => void;
+  clearHistory: () => void;
+  isFlyoutOpen: boolean;
+  isChildFlyoutOpen: boolean;
+  canGoBack: boolean;
+}
+
 /**
  * Hook for accessing the flyout API
  * @public
  */
-export function useEuiFlyoutSession() {
+export function useEuiFlyoutSession(): EuiFlyoutSessionApi {
   const { state, dispatch, onUnmount } = useEuiFlyoutSessionContext();
   const isInitialMount = useRef(true);
 
@@ -107,15 +119,15 @@ export function useEuiFlyoutSession() {
     dispatch({ type: 'GO_BACK' });
   };
 
-  const canGoBack = !!state.history.length;
+  const clearHistory = () => {
+    dispatch({ type: 'CLEAR_HISTORY' });
+  };
 
   const isFlyoutOpen = !!state.activeFlyoutGroup?.isMainOpen;
 
   const isChildFlyoutOpen = !!state.activeFlyoutGroup?.isChildOpen;
 
-  const clearHistory = () => {
-    dispatch({ type: 'CLEAR_HISTORY' });
-  };
+  const canGoBack = !!state.history.length;
 
   return {
     openFlyout,
@@ -123,9 +135,9 @@ export function useEuiFlyoutSession() {
     openFlyoutGroup,
     closeChildFlyout,
     goBack,
-    canGoBack,
+    clearHistory,
     isFlyoutOpen,
     isChildFlyoutOpen,
-    clearHistory,
+    canGoBack,
   };
 }

--- a/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
+++ b/packages/eui/src/components/flyout/sessions/use_eui_flyout.ts
@@ -46,6 +46,7 @@ export interface EuiFlyoutSessionOpenGroupOptions<Meta = unknown> {
 
 /**
  * Hook for accessing the flyout API
+ * @public
  */
 export function useEuiFlyoutSession() {
   const { state, dispatch, onUnmount } = useEuiFlyoutSessionContext();


### PR DESCRIPTION
## Summary
This PR is part of a series of atomic PRs to improve and evolve the `EuiFlyoutChild` component and its state management. This PR focuses on state management improvements.

These changes refactor the `EuiFlyoutSessionProvider` component and related files to ensure that unserializable data does not pollute the provider's state.
* Remove the `onUnmount` callbacks from various flyout configurations
* Consolidate unmount behavior with a single `onUnmount` prop at the provider level.

The changes are not considered breaking since the flyout state management is a non-public preview component for Kibana purposes only.

### Additional changes
* Removed `onCloseFlyout` and `onCloseChildFlyout` from the flyout render context.
* Fixed the `canGoBack` logic in `packages/eui/src/components/flyout/sessions/use_eui_flyout.ts`.
* Clean up the `EuiFlyoutSessionRenderContext` interface
* Updated `packages/eui/src/components/flyout/sessions/use_eui_flyout.test.tsx` unit tests.

## Why are we making this change?

Part of https://github.com/elastic/kibana-team/issues/1606 - Kibana SharedUX Flyout System. These issues were discovered while working on further enhancements of the system.

## Screenshots

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

No changes to UI.

## Impact to users

Better cleanup when flyouts are closed using the state management system, improved navigation when "going back" to previous flyouts in history.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    ~~- [ ] Checked in both **light and dark** modes~~
    ~~- [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~~
      ~~- (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~~
    ~~- [ ] Checked in **mobile**~~
    ~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
    ~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- Docs site QA
    - [X] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    ~~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    ~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- Code quality checklist
    - [X] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    ~~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist
  ~~- [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~~
