### PR TITLE
[EuiFlyoutChild] default / shaded background style

### DIFF
--- a/packages/eui/changelogs/upcoming/8847.md
+++ b/packages/eui/changelogs/upcoming/8847.md
@@ -1,0 +1,1 @@
+- Added a new background styling option to the EuiFlyoutChild component.

--- a/packages/eui/src/components/flyout/_flyout_close_button.styles.ts
+++ b/packages/eui/src/components/flyout/_flyout_close_button.styles.ts
@@ -29,8 +29,7 @@ export const euiFlyoutCloseButtonStyles = (euiThemeContext: UseEuiTheme) => {
       z-index: 3;
     `,
     inside: css`
-      background-color: ${euiTheme.components
-        .flyoutCloseButtonInsideBackground};
+      background-color: transparent;
     `,
     outside: css`
       /* Match dropshadow */

--- a/packages/eui/src/components/flyout/flyout_child.stories.tsx
+++ b/packages/eui/src/components/flyout/flyout_child.stories.tsx
@@ -249,7 +249,7 @@ export const WithSmallMainSize: Story = {
   ),
 };
 
-export const WithSmallMainLargeChlld: Story = {
+export const WithSmallMainLargeChild: Story = {
   name: 'Main Size: s, Child Size: m',
   render: (args) => (
     <StatefulFlyout
@@ -258,4 +258,94 @@ export const WithSmallMainLargeChlld: Story = {
       pushMinBreakpoint={args.pushMinBreakpoint}
     />
   ),
+};
+
+const ChildBackgroundStylesFlyout = () => {
+  const [isMainOpen, setIsMainOpen] = useState(true);
+  const [isDefaultChildOpen, setIsDefaultChildOpen] = useState(true);
+  const [isShadedChildOpen, setIsShadedChildOpen] = useState(false);
+
+  const openDefaultChild = () => {
+    setIsDefaultChildOpen(true);
+    setIsShadedChildOpen(false);
+  };
+  const openShadedChild = () => {
+    setIsDefaultChildOpen(false);
+    setIsShadedChildOpen(true);
+  };
+
+  const closeMain = () => {
+    setIsMainOpen(false);
+    setIsDefaultChildOpen(false);
+    setIsShadedChildOpen(false);
+  };
+  const closeChild = () => {
+    setIsDefaultChildOpen(false);
+    setIsShadedChildOpen(false);
+  };
+
+  const ChildFlyoutContent = () => (
+    <EuiFlyoutBody>
+      <EuiText>
+        <p>
+          This is the child flyout content, with a{' '}
+          <b>{isShadedChildOpen ? 'shaded' : 'default'}</b> background.
+        </p>
+      </EuiText>
+    </EuiFlyoutBody>
+  );
+
+  return (
+    <>
+      <EuiText>
+        <EuiButton onClick={openDefaultChild} disabled={isDefaultChildOpen}>
+          Open flyout with <b>default</b> child background
+        </EuiButton>
+        <EuiSpacer />
+        <EuiButton onClick={openShadedChild} disabled={isShadedChildOpen}>
+          Open flyout with <b>shaded</b> child background
+        </EuiButton>
+      </EuiText>
+
+      {isMainOpen && (
+        <EuiFlyout
+          onClose={closeMain}
+          size="s"
+          type="push"
+          pushMinBreakpoint="xs"
+        >
+          <EuiFlyoutBody>
+            <EuiText>
+              <p>This is the main flyout content.</p>
+            </EuiText>
+            <EuiSpacer />
+          </EuiFlyoutBody>
+
+          {isDefaultChildOpen && (
+            <EuiFlyoutChild
+              onClose={closeChild}
+              size="s"
+              backgroundStyle="default"
+            >
+              <ChildFlyoutContent />
+            </EuiFlyoutChild>
+          )}
+          {isShadedChildOpen && (
+            <EuiFlyoutChild
+              onClose={closeChild}
+              size="s"
+              backgroundStyle="shaded"
+            >
+              <ChildFlyoutContent />
+            </EuiFlyoutChild>
+          )}
+        </EuiFlyout>
+      )}
+    </>
+  );
+};
+
+export const WithChildBackgroundStyles: Story = {
+  name: 'Child Background Styles',
+  render: () => <ChildBackgroundStylesFlyout />,
 };

--- a/packages/eui/src/components/flyout/flyout_child.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_child.styles.ts
@@ -25,7 +25,6 @@ export const euiFlyoutChildStyles = (euiThemeContext: UseEuiTheme) => {
       inset-block-start: 0;
       inset-inline-start: 0;
       block-size: 100%;
-      background: ${euiTheme.colors.backgroundBaseSubdued};
       display: flex;
       flex-direction: column;
       ${logicalCSSWithFallback('overflow-y', 'hidden')}
@@ -34,6 +33,13 @@ export const euiFlyoutChildStyles = (euiThemeContext: UseEuiTheme) => {
       border-inline-start: ${euiTheme.border.thin};
 
       ${maxedFlyoutWidth(euiThemeContext)}
+    `,
+
+    backgroundDefault: css`
+      background: ${euiTheme.colors.backgroundBasePlain};
+    `,
+    backgroundShaded: css`
+      background: ${euiTheme.colors.backgroundBaseSubdued};
     `,
 
     // Position variants based on screen size
@@ -53,13 +59,6 @@ export const euiFlyoutChildStyles = (euiThemeContext: UseEuiTheme) => {
 
     m: css`
       ${composeFlyoutSizing(euiThemeContext, 'm')}
-    `,
-
-    closeButton: css`
-      position: absolute;
-      inset-block-start: ${euiTheme.size.s};
-      inset-inline-end: ${euiTheme.size.s};
-      z-index: 1;
     `,
 
     overflow: {

--- a/packages/eui/src/components/flyout/flyout_child.tsx
+++ b/packages/eui/src/components/flyout/flyout_child.tsx
@@ -60,6 +60,10 @@ export interface EuiFlyoutChildProps
    * @default 's'
    */
   size?: 's' | 'm';
+  /*
+   * The background of the child flyout can be optionally shaded. Use `shaded` to add the shading.
+   */
+  backgroundStyle?: 'shaded' | 'default';
   /**
    * Children are implicitly part of FunctionComponent, but good to have if props type is standalone.
    */
@@ -72,6 +76,7 @@ export interface EuiFlyoutChildProps
  */
 export const EuiFlyoutChild: FunctionComponent<EuiFlyoutChildProps> = ({
   children,
+  backgroundStyle = 'default',
   className,
   banner,
   hideCloseButton = false,
@@ -195,6 +200,9 @@ export const EuiFlyoutChild: FunctionComponent<EuiFlyoutChildProps> = ({
 
   const flyoutChildCss = [
     styles.euiFlyoutChild,
+    backgroundStyle === 'shaded'
+      ? styles.backgroundShaded
+      : styles.backgroundDefault,
     size === 's' ? styles.s : styles.m,
     childLayoutMode === 'side-by-side'
       ? styles.sidePosition
@@ -238,7 +246,6 @@ export const EuiFlyoutChild: FunctionComponent<EuiFlyoutChildProps> = ({
         {!hideCloseButton && (
           <EuiFlyoutCloseButton
             className="euiFlyoutChild__closeButton"
-            css={styles.closeButton}
             onClose={handleClose}
             side="right"
             closeButtonPosition="inside"


### PR DESCRIPTION
## Summary

This PR is part of a series of atomic PRs to improve and evolve the EuiFlyoutChild component and its state management. This PR focuses on state management improvements.

This pull request introduces a new background styling option enhancement to the `EuiFlyoutChild` component. 

### Additional changes
* Remove redundant styling.
* Provide storybook example for developers.

### Enhancements to `EuiFlyoutChild` component:

## Why are we making this change?

Part of https://github.com/elastic/kibana-team/issues/1606 - Kibana SharedUX Flyout System. When demoing this project, we had feedback about there not being enough contrast between the child flyout and the underlying page background.

## Screenshots

![flyout-child-background-style](https://github.com/user-attachments/assets/3db63bc5-2e13-48ad-a2e7-10717a522ab1)

## Impact to users

UI of a child flyout can have a background color that serves to better distinguish the flyout with the underlying page.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [X] Checked in both **light and dark** modes
    ~~- [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~~
      ~~- (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~~
    ~~- [ ] Checked in **mobile**~~
    ~~- [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
    ~~- [ ] Checked for **accessibility** including keyboard-only and screenreader modes~~
- Docs site QA
    ~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
    ~~- [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    ~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- Code quality checklist
    ~~- [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~~
    ~~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    ~~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist~~
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
