### PR TITLE
[EuiProgress] Handle nodes in label prop

### DIFF
--- a/packages/eui/changelogs/upcoming/8856.md
+++ b/packages/eui/changelogs/upcoming/8856.md
@@ -1,3 +1,4 @@
 **Bug fixes**
 
 - Fixed the screen reader output in `EuiProgress` when a node is passed in the `label` prop
+- Removed unnecessary `title` attributes for `label` and `valueText` in `EuiProgress`

--- a/packages/eui/changelogs/upcoming/8856.md
+++ b/packages/eui/changelogs/upcoming/8856.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed the screen reader output in `EuiProgress` when a node is passed in the `label` prop

--- a/packages/eui/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/packages/eui/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -114,13 +114,12 @@ exports[`EuiProgress has labelProps 1`] = `
   <div
     class="euiProgress__data emotion-euiProgress__data"
   >
-    <span
+    <div
       aria-hidden="true"
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
-      title="150"
     >
       150
-    </span>
+    </div>
   </div>
   <div
     aria-atomic="true"
@@ -128,7 +127,6 @@ exports[`EuiProgress has labelProps 1`] = `
     class="emotion-euiScreenReaderOnly"
   >
     <span>
-       
       150
     </span>
   </div>
@@ -149,9 +147,7 @@ exports[`EuiProgress has max 1`] = `
   aria-live="polite"
   class="emotion-euiScreenReaderOnly"
 >
-  <span>
-     
-  </span>
+  <span />
 </div>
 `;
 
@@ -168,20 +164,18 @@ exports[`EuiProgress has valueText and label 1`] = `
   <div
     class="euiProgress__data emotion-euiProgress__data"
   >
-    <span
+    <div
       aria-hidden="true"
       class="euiProgress__label emotion-euiProgress__label"
-      title="Label"
     >
       Label
-    </span>
-    <span
+    </div>
+    <div
       aria-hidden="true"
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
-      title="150"
     >
       150
-    </span>
+    </div>
   </div>
   <div
     aria-atomic="true"
@@ -212,7 +206,6 @@ exports[`EuiProgress is determinate 1`] = `
   class="emotion-euiScreenReaderOnly"
 >
   <span>
-     
     50
   </span>
 </div>
@@ -263,13 +256,12 @@ exports[`EuiProgress valueText is true 1`] = `
   <div
     class="euiProgress__data emotion-euiProgress__data"
   >
-    <span
+    <div
       aria-hidden="true"
       class="euiProgress__valueText emotion-euiProgress__valueText-success"
-      title="50%"
     >
       50%
-    </span>
+    </div>
   </div>
   <div
     aria-atomic="true"
@@ -277,7 +269,6 @@ exports[`EuiProgress valueText is true 1`] = `
     class="emotion-euiScreenReaderOnly"
   >
     <span>
-       
       50%
     </span>
   </div>

--- a/packages/eui/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/packages/eui/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`EuiProgress has labelProps 1`] = `
     class="emotion-euiScreenReaderOnly"
   >
     <span>
+       
       150
     </span>
   </div>
@@ -148,7 +149,9 @@ exports[`EuiProgress has max 1`] = `
   aria-live="polite"
   class="emotion-euiScreenReaderOnly"
 >
-  <span />
+  <span>
+     
+  </span>
 </div>
 `;
 
@@ -186,7 +189,8 @@ exports[`EuiProgress has valueText and label 1`] = `
     class="emotion-euiScreenReaderOnly"
   >
     <span>
-      Label 
+      Label
+       
       150
     </span>
   </div>
@@ -208,6 +212,7 @@ exports[`EuiProgress is determinate 1`] = `
   class="emotion-euiScreenReaderOnly"
 >
   <span>
+     
     50
   </span>
 </div>
@@ -272,6 +277,7 @@ exports[`EuiProgress valueText is true 1`] = `
     class="emotion-euiScreenReaderOnly"
   >
     <span>
+       
       50%
     </span>
   </div>

--- a/packages/eui/src/components/progress/progress.a11y.tsx
+++ b/packages/eui/src/components/progress/progress.a11y.tsx
@@ -71,25 +71,25 @@ describe('EuiProgress', () => {
 
     it('displays correct progress values and labels', () => {
       cy.get(
-        'div[data-test-subj="cy-progress-1"] span.euiProgress__valueText'
+        'div[data-test-subj="cy-progress-1"] div.euiProgress__valueText'
       ).contains('0');
       cy.get(
-        'div[data-test-subj="cy-progress-2"] span.euiProgress__valueText'
+        'div[data-test-subj="cy-progress-2"] div.euiProgress__valueText'
       ).contains('33');
       cy.get(
-        'div[data-test-subj="cy-progress-3"] span.euiProgress__valueText'
+        'div[data-test-subj="cy-progress-3"] div.euiProgress__valueText'
       ).contains('66');
       cy.get(
-        'div[data-test-subj="cy-progress-4"] span.euiProgress__valueText'
+        'div[data-test-subj="cy-progress-4"] div.euiProgress__valueText'
       ).contains('100');
       cy.get(
-        'div[data-test-subj="cy-progress-5"] span.euiProgress__label'
+        'div[data-test-subj="cy-progress-5"] div.euiProgress__label'
       ).contains('Basic percentage');
       cy.get(
-        'div[data-test-subj="cy-progress-5"] span.euiProgress__valueText'
+        'div[data-test-subj="cy-progress-5"] div.euiProgress__valueText'
       ).contains('100');
       cy.get(
-        'div[data-test-subj="cy-progress-infinite"] span.euiProgress__valueText'
+        'div[data-test-subj="cy-progress-infinite"] div.euiProgress__valueText'
       ).should('not.exist');
     });
   });

--- a/packages/eui/src/components/progress/progress.test.tsx
+++ b/packages/eui/src/components/progress/progress.test.tsx
@@ -81,9 +81,9 @@ describe('EuiProgress', () => {
   });
 
   test('handles node in label', () => {
-    const { container } = render(
+    const { container, getByTestSubject } = render(
       <EuiProgress
-        label={<span data-unique>Label text</span>}
+        label={<span data-test-subj="progress-label">Label text</span>}
         valueText={true}
         value={50}
         max={100}
@@ -91,7 +91,7 @@ describe('EuiProgress', () => {
       />
     );
 
-    const labelElement = container.querySelector('[data-unique]');
+    const labelElement = getByTestSubject('progress-label');
     expect(labelElement).toBeInTheDocument();
     expect(labelElement).toHaveTextContent('Label text');
     expect(container.querySelector('[aria-live]')).toHaveTextContent(

--- a/packages/eui/src/components/progress/progress.test.tsx
+++ b/packages/eui/src/components/progress/progress.test.tsx
@@ -83,7 +83,7 @@ describe('EuiProgress', () => {
   test('handles node in label', () => {
     const { container } = render(
       <EuiProgress
-        label={<span>Label text</span>}
+        label={<span data-unique>Label text</span>}
         valueText={true}
         value={50}
         max={100}
@@ -91,9 +91,9 @@ describe('EuiProgress', () => {
       />
     );
 
-    expect(container.querySelector('.euiProgress__label')).toHaveTextContent(
-      'Label text'
-    );
+    const labelElement = container.querySelector('[data-unique]');
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement).toHaveTextContent('Label text');
     expect(container.querySelector('[aria-live]')).toHaveTextContent(
       'Label text'
     );

--- a/packages/eui/src/components/progress/progress.test.tsx
+++ b/packages/eui/src/components/progress/progress.test.tsx
@@ -80,6 +80,25 @@ describe('EuiProgress', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('handles node in label', () => {
+    const { container } = render(
+      <EuiProgress
+        label={<span>Label text</span>}
+        valueText={true}
+        value={50}
+        max={100}
+        {...requiredProps}
+      />
+    );
+
+    expect(container.querySelector('.euiProgress__label')).toHaveTextContent(
+      'Label text'
+    );
+    expect(container.querySelector('[aria-live]')).toHaveTextContent(
+      'Label text'
+    );
+  });
+
   test('has labelProps', () => {
     const { container } = render(
       <EuiProgress

--- a/packages/eui/src/components/progress/progress.test.tsx
+++ b/packages/eui/src/components/progress/progress.test.tsx
@@ -99,6 +99,22 @@ describe('EuiProgress', () => {
     );
   });
 
+  test('has screen reader only output', () => {
+    const { container } = render(
+      <EuiProgress
+        label={<span>Label text</span>}
+        valueText={true}
+        value={50}
+        max={100}
+        {...requiredProps}
+      />
+    );
+
+    expect(container.querySelector('[aria-live]')?.innerHTML).toBe(
+      '<span>Label text 50%</span>'
+    );
+  });
+
   test('has labelProps', () => {
     const { container } = render(
       <EuiProgress

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -221,7 +221,8 @@ export const EuiProgress: FunctionComponent<
         <EuiScreenReaderOnly>
           <div aria-live="polite" aria-atomic="true">
             <span>
-              {label && `${label} `}
+              {label && <>{label}</>}
+              {` `}
               {valueRender || value}
             </span>
           </div>

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -103,137 +103,137 @@ export const EuiProgress: FunctionComponent<
   labelProps,
   ...rest
 }) => {
-    const valueTextRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
-    const labelRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
-    const [innerValueText, setInnerValueText] = useState<string | undefined>();
-    const [labelText, setLabelText] = useState<string | undefined>();
+  const valueTextRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
+  const labelRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
+  const [innerValueText, setInnerValueText] = useState<string | undefined>();
+  const [labelText, setLabelText] = useState<string | undefined>();
 
-    const determinate = !isNil(max);
-    const isNamedColor = COLORS.includes(color as EuiProgressColor);
+  const determinate = !isNil(max);
+  const isNamedColor = COLORS.includes(color as EuiProgressColor);
 
-    const euiTheme = useEuiTheme();
-    const customColorStyles = !isNamedColor ? { color } : {};
-    const customTextColorStyles = !isNamedColor
-      ? { color: makeHighContrastColor(color)(euiTheme.euiTheme) }
-      : {};
+  const euiTheme = useEuiTheme();
+  const customColorStyles = !isNamedColor ? { color } : {};
+  const customTextColorStyles = !isNamedColor
+    ? { color: makeHighContrastColor(color)(euiTheme.euiTheme) }
+    : {};
 
-    const styles = euiProgressStyles(euiTheme, determinate);
-    const cssStyles = [
-      styles.euiProgress,
-      determinate && styles.native,
-      !determinate && styles.indeterminate,
-      styles[size],
-      styles[position],
-      isNamedColor ? styles[color as EuiProgressColor] : styles.customColor,
-    ];
+  const styles = euiProgressStyles(euiTheme, determinate);
+  const cssStyles = [
+    styles.euiProgress,
+    determinate && styles.native,
+    !determinate && styles.indeterminate,
+    styles[size],
+    styles[position],
+    isNamedColor ? styles[color as EuiProgressColor] : styles.customColor,
+  ];
 
-    const dataStyles = euiProgressDataStyles(euiTheme);
-    const dataCssStyles = [
-      dataStyles.euiProgress__data,
-      size === 'l' && dataStyles[size],
-    ];
-    const labelCssStyles = [
-      euiProgressLabelStyles.euiProgress__label,
-      labelProps?.css,
-    ];
-    const valueTextStyles = euiProgressValueTextStyles(euiTheme);
-    const valueTextCssStyles = [
-      valueTextStyles.euiProgress__valueText,
-      isNamedColor
-        ? valueTextStyles[color as EuiProgressColor]
-        : styles.customColor,
-    ];
+  const dataStyles = euiProgressDataStyles(euiTheme);
+  const dataCssStyles = [
+    dataStyles.euiProgress__data,
+    size === 'l' && dataStyles[size],
+  ];
+  const labelCssStyles = [
+    euiProgressLabelStyles.euiProgress__label,
+    labelProps?.css,
+  ];
+  const valueTextStyles = euiProgressValueTextStyles(euiTheme);
+  const valueTextCssStyles = [
+    valueTextStyles.euiProgress__valueText,
+    isNamedColor
+      ? valueTextStyles[color as EuiProgressColor]
+      : styles.customColor,
+  ];
 
-    const classes = classNames('euiProgress', className);
-    const labelClasses = classNames('euiProgress__label', labelProps?.className);
+  const classes = classNames('euiProgress', className);
+  const labelClasses = classNames('euiProgress__label', labelProps?.className);
 
-    let valueRender: ReactNode;
-    if (valueText === true) {
-      // valueText is true
-      valueRender = (
-        <EuiI18n
-          token="euiProgress.valueText"
-          default="{value}%"
-          values={{
-            value,
-          }}
-        />
-      );
-    } else if (valueText) {
-      // valueText exists
-      valueRender = valueText;
-    }
+  let valueRender: ReactNode;
+  if (valueText === true) {
+    // valueText is true
+    valueRender = (
+      <EuiI18n
+        token="euiProgress.valueText"
+        default="{value}%"
+        values={{
+          value,
+        }}
+      />
+    );
+  } else if (valueText) {
+    // valueText exists
+    valueRender = valueText;
+  }
 
-    useEffect(() => {
-      setInnerValueText(valueTextRef.current?.textContent ?? '');
-      setLabelText(labelRef.current?.textContent ?? '');
-    }, [label, valueRender, value]);
+  useEffect(() => {
+    setInnerValueText(valueTextRef.current?.textContent ?? '');
+    setLabelText(labelRef.current?.textContent ?? '');
+  }, [label, valueRender, value]);
 
-    // Because of a Firefox animation issue, indeterminate progress needs to not use <progress />.
-    // See https://css-tricks.com/html5-progress-element/
+  // Because of a Firefox animation issue, indeterminate progress needs to not use <progress />.
+  // See https://css-tricks.com/html5-progress-element/
 
-    if (determinate) {
-      return (
-        <>
-          {label || valueText ? (
-            <div css={dataCssStyles} className="euiProgress__data">
-              {label && (
-                <div
-                  ref={(node) => {
-                    labelRef.current = node;
-                  }}
-                  {...labelProps}
-                  className={labelClasses}
-                  css={labelCssStyles}
-                  aria-hidden="true"
-                >
-                  {label}
-                </div>
-              )}
-              {valueRender && (
-                <div
-                  ref={(node) => {
-                    valueTextRef.current = node;
-                  }}
-                  style={customTextColorStyles}
-                  css={valueTextCssStyles}
-                  className="euiProgress__valueText"
-                  aria-hidden="true"
-                >
-                  {valueRender}
-                </div>
-              )}
-            </div>
-          ) : undefined}
-          <EuiScreenReaderOnly>
-            <div aria-live="polite" aria-atomic="true">
-              <span>
-                {label && <>{label}</>}
-                {label && ' '}
-                {valueRender || value}
-              </span>
-            </div>
-          </EuiScreenReaderOnly>
-          <progress
-            css={cssStyles}
-            className={classes}
-            style={customColorStyles}
-            max={max}
-            value={value}
-            aria-valuetext={innerValueText || undefined}
-            aria-label={labelText || undefined}
-            {...(rest as ProgressHTMLAttributes<HTMLProgressElement>)}
-          />
-        </>
-      );
-    } else {
-      return (
-        <div
+  if (determinate) {
+    return (
+      <>
+        {label || valueText ? (
+          <div css={dataCssStyles} className="euiProgress__data">
+            {label && (
+              <div
+                ref={(node) => {
+                  labelRef.current = node;
+                }}
+                {...labelProps}
+                className={labelClasses}
+                css={labelCssStyles}
+                aria-hidden="true"
+              >
+                {label}
+              </div>
+            )}
+            {valueRender && (
+              <div
+                ref={(node) => {
+                  valueTextRef.current = node;
+                }}
+                style={customTextColorStyles}
+                css={valueTextCssStyles}
+                className="euiProgress__valueText"
+                aria-hidden="true"
+              >
+                {valueRender}
+              </div>
+            )}
+          </div>
+        ) : undefined}
+        <EuiScreenReaderOnly>
+          <div aria-live="polite" aria-atomic="true">
+            <span>
+              {label && <>{label}</>}
+              {label && ' '}
+              {valueRender || value}
+            </span>
+          </div>
+        </EuiScreenReaderOnly>
+        <progress
           css={cssStyles}
-          style={customColorStyles}
           className={classes}
-          {...(rest as HTMLAttributes<HTMLDivElement>)}
+          style={customColorStyles}
+          max={max}
+          value={value}
+          aria-valuetext={innerValueText || undefined}
+          aria-label={labelText || undefined}
+          {...(rest as ProgressHTMLAttributes<HTMLProgressElement>)}
         />
-      );
-    }
-  };
+      </>
+    );
+  } else {
+    return (
+      <div
+        css={cssStyles}
+        style={customColorStyles}
+        className={classes}
+        {...(rest as HTMLAttributes<HTMLDivElement>)}
+      />
+    );
+  }
+};

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -208,8 +208,7 @@ export const EuiProgress: FunctionComponent<
         <EuiScreenReaderOnly>
           <div aria-live="polite" aria-atomic="true">
             <span>
-              {label && <>{labelText}</>}
-              {label && valueRender && ' '}
+              {label && <>{labelText} </>}
               {valueRender || value}
             </span>
           </div>

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -19,7 +19,6 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { EuiI18n } from '../i18n';
-import { EuiInnerText } from '../inner_text';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { isNil } from '../../services/predicate';
 
@@ -104,149 +103,137 @@ export const EuiProgress: FunctionComponent<
   labelProps,
   ...rest
 }) => {
-  const valueTextRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
-  const labelRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
-  const [innerValueText, setInnerValueText] = useState<string | undefined>();
-  const [labelText, setLabelText] = useState<string | undefined>();
+    const valueTextRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
+    const labelRef: MutableRefObject<HTMLSpanElement | null> = useRef(null);
+    const [innerValueText, setInnerValueText] = useState<string | undefined>();
+    const [labelText, setLabelText] = useState<string | undefined>();
 
-  const determinate = !isNil(max);
-  const isNamedColor = COLORS.includes(color as EuiProgressColor);
+    const determinate = !isNil(max);
+    const isNamedColor = COLORS.includes(color as EuiProgressColor);
 
-  const euiTheme = useEuiTheme();
-  const customColorStyles = !isNamedColor ? { color } : {};
-  const customTextColorStyles = !isNamedColor
-    ? { color: makeHighContrastColor(color)(euiTheme.euiTheme) }
-    : {};
+    const euiTheme = useEuiTheme();
+    const customColorStyles = !isNamedColor ? { color } : {};
+    const customTextColorStyles = !isNamedColor
+      ? { color: makeHighContrastColor(color)(euiTheme.euiTheme) }
+      : {};
 
-  const styles = euiProgressStyles(euiTheme, determinate);
-  const cssStyles = [
-    styles.euiProgress,
-    determinate && styles.native,
-    !determinate && styles.indeterminate,
-    styles[size],
-    styles[position],
-    isNamedColor ? styles[color as EuiProgressColor] : styles.customColor,
-  ];
+    const styles = euiProgressStyles(euiTheme, determinate);
+    const cssStyles = [
+      styles.euiProgress,
+      determinate && styles.native,
+      !determinate && styles.indeterminate,
+      styles[size],
+      styles[position],
+      isNamedColor ? styles[color as EuiProgressColor] : styles.customColor,
+    ];
 
-  const dataStyles = euiProgressDataStyles(euiTheme);
-  const dataCssStyles = [
-    dataStyles.euiProgress__data,
-    size === 'l' && dataStyles[size],
-  ];
-  const labelCssStyles = [
-    euiProgressLabelStyles.euiProgress__label,
-    labelProps?.css,
-  ];
-  const valueTextStyles = euiProgressValueTextStyles(euiTheme);
-  const valueTextCssStyles = [
-    valueTextStyles.euiProgress__valueText,
-    isNamedColor
-      ? valueTextStyles[color as EuiProgressColor]
-      : styles.customColor,
-  ];
+    const dataStyles = euiProgressDataStyles(euiTheme);
+    const dataCssStyles = [
+      dataStyles.euiProgress__data,
+      size === 'l' && dataStyles[size],
+    ];
+    const labelCssStyles = [
+      euiProgressLabelStyles.euiProgress__label,
+      labelProps?.css,
+    ];
+    const valueTextStyles = euiProgressValueTextStyles(euiTheme);
+    const valueTextCssStyles = [
+      valueTextStyles.euiProgress__valueText,
+      isNamedColor
+        ? valueTextStyles[color as EuiProgressColor]
+        : styles.customColor,
+    ];
 
-  const classes = classNames('euiProgress', className);
-  const labelClasses = classNames('euiProgress__label', labelProps?.className);
+    const classes = classNames('euiProgress', className);
+    const labelClasses = classNames('euiProgress__label', labelProps?.className);
 
-  let valueRender: ReactNode;
-  if (valueText === true) {
-    // valueText is true
-    valueRender = (
-      <EuiI18n
-        token="euiProgress.valueText"
-        default="{value}%"
-        values={{
-          value,
-        }}
-      />
-    );
-  } else if (valueText) {
-    // valueText exists
-    valueRender = valueText;
-  }
-
-  useEffect(() => {
-    setInnerValueText(valueTextRef.current?.textContent ?? '');
-    setLabelText(labelRef.current?.textContent ?? '');
-  }, [label, valueRender, value]);
-
-  // Because of a Firefox animation issue, indeterminate progress needs to not use <progress />.
-  // See https://css-tricks.com/html5-progress-element/
-
-  if (determinate) {
-    return (
-      <>
-        {label || valueText ? (
-          <div css={dataCssStyles} className="euiProgress__data">
-            {label && (
-              <EuiInnerText>
-                {(ref, innerText) => (
-                  <span
-                    title={innerText}
-                    ref={(node) => {
-                      labelRef.current = node;
-                      ref?.(node);
-                    }}
-                    {...labelProps}
-                    className={labelClasses}
-                    css={labelCssStyles}
-                    aria-hidden="true"
-                  >
-                    {label}
-                  </span>
-                )}
-              </EuiInnerText>
-            )}
-            {valueRender && (
-              <EuiInnerText>
-                {(ref, innerText) => (
-                  <span
-                    title={innerText}
-                    ref={(node) => {
-                      valueTextRef.current = node;
-                      ref?.(node);
-                    }}
-                    style={customTextColorStyles}
-                    css={valueTextCssStyles}
-                    className="euiProgress__valueText"
-                    aria-hidden="true"
-                  >
-                    {valueRender}
-                  </span>
-                )}
-              </EuiInnerText>
-            )}
-          </div>
-        ) : undefined}
-        <EuiScreenReaderOnly>
-          <div aria-live="polite" aria-atomic="true">
-            <span>
-              {label && <>{label}</>}
-              {` `}
-              {valueRender || value}
-            </span>
-          </div>
-        </EuiScreenReaderOnly>
-        <progress
-          css={cssStyles}
-          className={classes}
-          style={customColorStyles}
-          max={max}
-          value={value}
-          aria-valuetext={innerValueText || undefined}
-          aria-label={labelText || undefined}
-          {...(rest as ProgressHTMLAttributes<HTMLProgressElement>)}
+    let valueRender: ReactNode;
+    if (valueText === true) {
+      // valueText is true
+      valueRender = (
+        <EuiI18n
+          token="euiProgress.valueText"
+          default="{value}%"
+          values={{
+            value,
+          }}
         />
-      </>
-    );
-  } else {
-    return (
-      <div
-        css={cssStyles}
-        style={customColorStyles}
-        className={classes}
-        {...(rest as HTMLAttributes<HTMLDivElement>)}
-      />
-    );
-  }
-};
+      );
+    } else if (valueText) {
+      // valueText exists
+      valueRender = valueText;
+    }
+
+    useEffect(() => {
+      setInnerValueText(valueTextRef.current?.textContent ?? '');
+      setLabelText(labelRef.current?.textContent ?? '');
+    }, [label, valueRender, value]);
+
+    // Because of a Firefox animation issue, indeterminate progress needs to not use <progress />.
+    // See https://css-tricks.com/html5-progress-element/
+
+    if (determinate) {
+      return (
+        <>
+          {label || valueText ? (
+            <div css={dataCssStyles} className="euiProgress__data">
+              {label && (
+                <div
+                  ref={(node) => {
+                    labelRef.current = node;
+                  }}
+                  {...labelProps}
+                  className={labelClasses}
+                  css={labelCssStyles}
+                  aria-hidden="true"
+                >
+                  {label}
+                </div>
+              )}
+              {valueRender && (
+                <div
+                  ref={(node) => {
+                    valueTextRef.current = node;
+                  }}
+                  style={customTextColorStyles}
+                  css={valueTextCssStyles}
+                  className="euiProgress__valueText"
+                  aria-hidden="true"
+                >
+                  {valueRender}
+                </div>
+              )}
+            </div>
+          ) : undefined}
+          <EuiScreenReaderOnly>
+            <div aria-live="polite" aria-atomic="true">
+              <span>
+                {label && <>{label}</>}
+                {label && ' '}
+                {valueRender || value}
+              </span>
+            </div>
+          </EuiScreenReaderOnly>
+          <progress
+            css={cssStyles}
+            className={classes}
+            style={customColorStyles}
+            max={max}
+            value={value}
+            aria-valuetext={innerValueText || undefined}
+            aria-label={labelText || undefined}
+            {...(rest as ProgressHTMLAttributes<HTMLProgressElement>)}
+          />
+        </>
+      );
+    } else {
+      return (
+        <div
+          css={cssStyles}
+          style={customColorStyles}
+          className={classes}
+          {...(rest as HTMLAttributes<HTMLDivElement>)}
+        />
+      );
+    }
+  };

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -208,8 +208,8 @@ export const EuiProgress: FunctionComponent<
         <EuiScreenReaderOnly>
           <div aria-live="polite" aria-atomic="true">
             <span>
-              {label && <>{label}</>}
-              {label && ' '}
+              {label && <>{labelText}</>}
+              {label && valueRender && ' '}
               {valueRender || value}
             </span>
           </div>


### PR DESCRIPTION
## Summary

When passing a node e.g. `<EuiText>Label<EuiText>` in the `label` prop in `EuiProgress`, the text is not correctly rendered in the screen-reader-only output e.g. `[object Object]`.

This PR also removes `title` attribute for both label and value text. They're not needed for accessibility and can cause trouble (like when using a delayed tooltip, e.g. https://github.com/elastic/kibana/pull/226882#discussion_r2201246292)

## Why are we making this change?

It's a bug fix. Related to https://github.com/elastic/eui/pull/8829

## Screenshots

<img width="1734" height="888" alt="Screenshot 2025-07-10 at 12 18 37" src="https://github.com/user-attachments/assets/1d67ede2-bff0-4b17-b00b-42bae46f9cc5" />

## Impact to users

No visual changes and no breaking changes. This change ensure the screen reader output works as well when passing something different than plain text into the `label` prop of `EuiProgress`.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] ~~Checked in both **light and dark** modes~~
    - [ ] ~~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~~
      - ~~(_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~~
    - [ ] ~~Checked in **mobile**~~
    - [ ] ~~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
    - [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- Docs site QA
    - [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
    - [ ] ~~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    - [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist~~
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist
  - [ ] ~~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~~
