### PR TITLE
[Fix] Ensure correct file paths in `compile-icons`

### DIFF
--- a/packages/eui/scripts/compile-icons.js
+++ b/packages/eui/scripts/compile-icons.js
@@ -20,7 +20,7 @@ const iconFiles = glob.sync('**/*.svg', { cwd: iconsDir, realpath: true });
 
 iconFiles.forEach((filePath) => {
   const fileName = path.basename(filePath, '.svg');
-  const svgSource = fs.readFileSync(filePath);
+  const svgSource = fs.readFileSync(path.join(iconsDir, filePath));
   const svgString = svgSource.toString();
 
   try {


### PR DESCRIPTION
## Summary

This PR updates the `compile-icons` script to ensure that the svg file paths are correct after an update to the `glob` dependency in [this PR](https://github.com/elastic/eui/pull/8694) ([change](https://github.com/elastic/eui/pull/8694/files#diff-108f1387bbecf39d15ec8e99a63d9a6963acf6c7d4bb8fc01cecb989c4b6c18aR204)).

<img width="625" height="469" alt="Screenshot 2025-07-11 at 10 10 20" src="https://github.com/user-attachments/assets/33affd83-e846-4a6b-8bb4-1f017967cda3" />


## Why are we making this change?

Fixes the currently broken script that compiles icons.

## QA

- checkout this PR and manually add a new icon (e.g. by copying and renaming an existing one) in `/packages/eui/src/components/icon/svgs` and adding it to `/packages/eui/src/components/icon/icon_map.ts`
  - [x] run `yarn compile-icons` in `/packages/eui` and verify that the script succeeds and a new icon `.tsx` file is generated