### PR TITLE
feat(docusaurus-theme): Support markdown tables

### DIFF
--- a/packages/docusaurus-theme/src/theme/MDXComponents/Table.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/Table.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { JSX, TableHTMLAttributes } from 'react';
+import { EuiTable } from '@elastic/eui';
+
+export const Table = ({
+  children,
+}: TableHTMLAttributes<HTMLTableElement>): JSX.Element => (
+  <EuiTable>{children}</EuiTable>
+);

--- a/packages/docusaurus-theme/src/theme/MDXComponents/TableBody.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/TableBody.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { HTMLAttributes, JSX } from 'react';
+import { EuiTableBody } from '@elastic/eui';
+
+export const TableBody = ({
+  children,
+}: HTMLAttributes<HTMLTableSectionElement>): JSX.Element => (
+  <EuiTableBody>{children}</EuiTableBody>
+);

--- a/packages/docusaurus-theme/src/theme/MDXComponents/TableDataCell.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/TableDataCell.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { JSX, TdHTMLAttributes } from 'react';
+import { EuiTableRowCell, EuiText } from '@elastic/eui';
+
+export const TableDataCell = ({
+  children,
+}: TdHTMLAttributes<HTMLTableCellElement>): JSX.Element => (
+  <EuiTableRowCell>
+    <EuiText size="m" component="span">
+      {children}
+    </EuiText>
+  </EuiTableRowCell>
+);

--- a/packages/docusaurus-theme/src/theme/MDXComponents/TableHeader.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/TableHeader.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { HTMLAttributes, JSX } from 'react';
+import { EuiTableHeader } from '@elastic/eui';
+
+export const TableHeader = ({
+  children,
+}: HTMLAttributes<HTMLTableSectionElement>): JSX.Element => (
+  <EuiTableHeader wrapWithTableRow={false}>{children}</EuiTableHeader>
+);

--- a/packages/docusaurus-theme/src/theme/MDXComponents/TableHeaderCell.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/TableHeaderCell.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { JSX, ThHTMLAttributes } from 'react';
+import { EuiTableHeaderCell, EuiText } from '@elastic/eui';
+
+export const TableHeaderCell = ({
+  children,
+}: ThHTMLAttributes<HTMLTableCellElement>): JSX.Element => (
+  <EuiTableHeaderCell>
+    <EuiText size="m" component="span">
+      {children}
+    </EuiText>
+  </EuiTableHeaderCell>
+);

--- a/packages/docusaurus-theme/src/theme/MDXComponents/TableRow.tsx
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/TableRow.tsx
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { HTMLAttributes, JSX } from 'react';
+import { EuiTableRow } from '@elastic/eui';
+
+export const TableRow = ({
+  children,
+}: HTMLAttributes<HTMLTableRowElement>): JSX.Element => (
+  <EuiTableRow>{children}</EuiTableRow>
+);

--- a/packages/docusaurus-theme/src/theme/MDXComponents/index.ts
+++ b/packages/docusaurus-theme/src/theme/MDXComponents/index.ts
@@ -17,6 +17,12 @@ import { Blockquote } from './Blockquote';
 import { Paragraph } from './Paragraph';
 import { UnorderedList } from './UnorderedList';
 import { OrderedList } from './OrderedList';
+import { Table } from './Table';
+import { TableBody } from './TableBody';
+import { TableHeader } from './TableHeader';
+import { TableHeaderCell } from './TableHeaderCell';
+import { TableRow } from './TableRow';
+import { TableDataCell } from './TableDataCell';
 import { Guideline, GuidelineText } from '../../components';
 
 const MDXComponents = {
@@ -27,6 +33,14 @@ const MDXComponents = {
   ul: UnorderedList,
   ol: OrderedList,
   blockquote: Blockquote,
+
+  // Tables
+  table: Table,
+  tbody: TableBody,
+  thead: TableHeader,
+  tr: TableRow,
+  th: TableHeaderCell,
+  td: TableDataCell,
 
   // Custom components
   Badge,

--- a/packages/website/docs/components/forms/selection/overview.mdx
+++ b/packages/website/docs/components/forms/selection/overview.mdx
@@ -4,7 +4,9 @@ sidebar_position: 1
 
 # Selection controls
 
-import { EuiIconTip } from '@elastic/eui';
+```mdx-code-block
+import { EuiIconTip, EuiTable, EuiTableRow, EuiTableHeader, EuiTableBody, EuiTableRowCell, EuiTableHeaderCell } from '@elastic/eui';
+```
 
 EUI currently offers over 4 ways to select an option from a list (6 including checkboxes and radios).
 
@@ -39,23 +41,112 @@ While it can get overwhelming figuring out which component to use, this page sho
 
 Below is a handy reference for comparing the selection components.
 
+```mdx-code-block
 export const tooltipProps = {
   anchorProps: { css: { position: 'absolute', marginBlockStart: -1 } },
   color: 'subdued',
 };
+```
 
-{/* TODO: Convert to basic table with borders */}
-
-| Feature | &emsp;[EuiSelect](./select.mdx)&emsp; | &emsp;[EuiSuperSelect](./super-select.mdx)&emsp; | &emsp;[EuiSelectable](./selectable.mdx)&emsp; | &emsp;[EuiComboBox](./combo-box.mdx)&emsp; |
-|:---|:---:|:---:|:---:|:---:|
-| Select a single option | ✅ | ✅ | ✅ | ✅ |
-| Select multiple options | ❌ | ❌ | ✅ | ✅ |
-| Accepts custom values from user input | ❌ | ❌ | ❌ | ✅ |
-| Option exclusion | ❌ | ❌ | ✅ | ❌ |
-| Customizable option display | ❌ | ✅ | ✅ | ✅ |
-| Customizable loading/error messages | ❌ | ❌ | ✅ | ❌ |
-| Searchable | ❌ <EuiIconTip type="info" content="Native select behavior will jump to options based on user typing" {...tooltipProps} /> | ❌ | ✅ | ✅ |
-| `disabled` state | ✅ <EuiIconTip type="info" content="Disables whole component" {...tooltipProps} /> | ✅ <EuiIconTip type="info" content="Disables individual option" {...tooltipProps} /> | ✅ <EuiIconTip type="info" content="Disables individual option" {...tooltipProps} /> | ✅ <EuiIconTip type="info" content="Disables whole component" {...tooltipProps} /> |
-| `readOnly` state | ❌ | ✅ | ❌ | ❌ |
-| Built in utility function for clearing user input | ❌ | ❌ | ✅ <EuiIconTip type="info" content="Clears search input" {...tooltipProps} /> | ✅ <EuiIconTip type="info" content="Clears all selections" {...tooltipProps} /> |
-| Supports virtualization | ❌ | ❌ | ✅ | ✅ |
+<EuiTable>
+  <EuiTableHeader>
+    <EuiTableHeaderCell>Feature</EuiTableHeaderCell>
+    <EuiTableHeaderCell align="center">[EuiSelect](./select.mdx)</EuiTableHeaderCell>
+    <EuiTableHeaderCell align="center">[EuiSuperSelect](./super-select.mdx)</EuiTableHeaderCell>
+    <EuiTableHeaderCell align="center">[EuiSelectable](./selectable.mdx)</EuiTableHeaderCell>
+    <EuiTableHeaderCell align="center">[EuiComboBox](./combo-box.mdx)</EuiTableHeaderCell>
+  </EuiTableHeader>
+  <EuiTableBody>
+    <EuiTableRow>
+      <EuiTableRowCell>Select a single option</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Select multiple options</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Accepts custom values from user input</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Option exclusion</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Customizable option display</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Customizable loading/error messages</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Searchable</EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ❌&nbsp;<EuiIconTip type="info" content="Native select behavior will jump to options based on user typing" {...tooltipProps} />
+      </EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>`disabled` state</EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ✅&nbsp;<EuiIconTip type="info" content="Disables whole component" {...tooltipProps} />
+      </EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ✅&nbsp;<EuiIconTip type="info" content="Disables individual option" {...tooltipProps} />
+      </EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ✅&nbsp;<EuiIconTip type="info" content="Disables individual option" {...tooltipProps} />
+      </EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ✅&nbsp;<EuiIconTip type="info" content="Disables whole component" {...tooltipProps} />
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>`readOnly` state</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Built in utility function for clearing user input</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ✅&nbsp;<EuiIconTip type="info" content="Clears search input" {...tooltipProps} />
+      </EuiTableRowCell>
+      <EuiTableRowCell align="center">
+        ✅&nbsp;<EuiIconTip type="info" content="Clears all selections" {...tooltipProps} />
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
+      <EuiTableRowCell>Supports virtualization</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+      <EuiTableRowCell align="center">✅</EuiTableRowCell>
+    </EuiTableRow>
+  </EuiTableBody>
+</EuiTable>

--- a/wiki/contributing-to-eui/documenting/writing-documentation.md
+++ b/wiki/contributing-to-eui/documenting/writing-documentation.md
@@ -247,7 +247,16 @@ The story's `id` can be found in the URL. It's the part after `/index.html?path=
 
 ### Tables
 
-The preferred way to display content in tables is by leveraging [EuiBasicTable](https://eui.elastic.co/docs/components/tables/basic-tables) and not Markdown tables.
+There are two supported ways to create tables in MDX - using Markdown tables syntax or using the EUI table components
+like [`EuiTable`](https://eui.elastic.co/docs/components/tables/custom)
+or [`EuiBasicTable`](https://eui.elastic.co/docs/components/tables/basic):
+
+* **Markdown tables** syntax should only be used for simple, text-only tables. The Markdown representation of a table must
+    be easily readable.
+* **[EuiTable](https://eui.elastic.co/docs/components/tables/custom)** components should be used for longer
+    and more complex tables
+* **[EuiBasicTable](https://eui.elastic.co/docs/components/tables/basic)** should be used for multi-column tables,
+    when the data comes from JS objects or isn't easily readable when directly defined using MDX syntax.
 
 Just like with [partials](#partials), the code for the table can be separated in its own file and imported into the MDX document where it'll be displayed. For example:
 


### PR DESCRIPTION
## Summary

Resolves #8682
Resolves https://github.com/elastic/eui-private/issues/224
Resolves https://github.com/elastic/eui-private/issues/287

This PR adds custom table components to `MDXComponents` so that markdown tables can be rendered using `EuiTable`.

## Why are we making this change?

Because the native look and feel of the tables doesn't look very good.

## Screenshots

<img width="1064" height="861" alt="Screenshot 2025-07-12 at 01 41 43" src="https://github.com/user-attachments/assets/1038dab9-8ba9-410d-b910-ff1c02bd17ee" />

## Impact to users

Native markdown tables will be rendered using EUI components making them more readable and look similar to the rest of the site.

## QA

- [ ] Go to the documentation website and confirm the markdown tables look as expected