### PR TITLE
build: fix dts-generator directory paths

### DIFF
--- a/packages/eui/scripts/compile-eui.js
+++ b/packages/eui/scripts/compile-eui.js
@@ -229,19 +229,21 @@ async function compileBundle() {
   });
 
   for (const dir of destinationDirs) {
+    const relativeDir = path.relative(packageRootDir, dir);
+
     dtsGenerator({
       prefix: '',
       out: `${dir}/index.d.ts`,
       baseDir: path.resolve(__dirname, '..', 'src/test/'),
       files: ['index.ts'],
       resolveModuleId({ currentModuleId }) {
-        return `@elastic/eui/${dir}${
+        return `@elastic/eui/${relativeDir}${
           currentModuleId !== 'index' ? `/${currentModuleId}` : ''
         }`;
       },
       resolveModuleImport({ currentModuleId, importedModuleId }) {
         if (currentModuleId === 'index') {
-          return `@elastic/eui/${dir}/${importedModuleId.replace('./', '')}`;
+          return `@elastic/eui/${relativeDir}/${importedModuleId.replace('./', '')}`;
         }
         return null;
       },


### PR DESCRIPTION
## Summary

This fixes an issue introduced in my recent https://github.com/elastic/eui/pull/8694 PR causing `dts-generator` to replace imports with an absolute path instead of a path relative to the `src` directory.

## Why are we making this change?

Because of a bug introduced in https://github.com/elastic/eui/pull/8694

## Impact to users

No user-facing impact expected

## QA

- [ ] Compare the contents of `eui.d.ts` from the latest EUI release and this PR and ensure they're equal