### PR TITLE
[EuiTreeView] Fix support for `css` key in Node

### DIFF
--- a/packages/eui/changelogs/upcoming/8864.md
+++ b/packages/eui/changelogs/upcoming/8864.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed support for `css` key in items object passed to `EuiTreeView`

--- a/packages/eui/src/components/tree_view/tree_view.stories.tsx
+++ b/packages/eui/src/components/tree_view/tree_view.stories.tsx
@@ -73,6 +73,7 @@ export const Playground: Story = {
                 label: "I'm a Bug",
                 id: 'item_bug',
                 icon: <EuiToken iconType="tokenEnum" />,
+                css: ({ euiTheme }) => `color: ${euiTheme.colors.textDanger}`,
               },
             ],
           },

--- a/packages/eui/src/components/tree_view/tree_view.tsx
+++ b/packages/eui/src/components/tree_view/tree_view.tsx
@@ -64,6 +64,9 @@ export interface Node {
   /** Optional class to throw on the node
    */
   className?: string;
+  /** Optional styles
+   */
+  css?: CommonProps['css'];
   /** Function to call when the item is clicked.
    The open state of the item will always be toggled.
    */
@@ -327,6 +330,7 @@ export class EuiTreeViewClass extends Component<
                 key={buttonId + index}
                 id={buttonId}
                 className={node.className}
+                css={node.css}
                 buttonRef={(ref) => this.setButtonRef(ref, index)}
                 aria-controls={node.children ? wrappingId : undefined}
                 label={node.label}


### PR DESCRIPTION
## Summary

This PR makes it possible to add a `css` key to any node in the `items` object passed to `EuiTreeView`.

The `EuiTreeViewItem` component that renders each node, supports the `css` prop (and this is in fact [documented](https://eui.elastic.co/docs/components/navigation/tree-view/#EuiTreeViewItem)) but the prop was not being passed down.

## Why are we making this change?

This is a bug fix.

## Impact to users

No action required, it will just work as expected.
