### PR TITLE
[EuiPopover] Reset `isClosing` state on opening a popover

### DIFF
--- a/packages/eui/changelogs/upcoming/8882.md
+++ b/packages/eui/changelogs/upcoming/8882.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiPopover` not closing on outside click after multiple fast clicks on the trigger element
+

--- a/packages/eui/src/components/popover/popover.spec.tsx
+++ b/packages/eui/src/components/popover/popover.spec.tsx
@@ -173,6 +173,48 @@ describe('EuiPopover', () => {
     });
   });
 
+  describe('toggle click behavior', () => {
+    it('closes the popover on outside click after multiple clicks on the trigger', () => {
+      cy.mount(
+        <PopoverComponent initialFocus="#test">
+          <button data-test-subj="popover-toggle">Test</button>
+        </PopoverComponent>
+      );
+
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+
+      cy.get('[data-test-subj="popoverPanel"]').should('exist');
+
+      cy.get('body').click();
+
+      cy.get('[data-test-subj="popoverPanel"]').should('not.exist');
+    });
+
+    it('closes the popover on ESCAPE keypress after multiple clicks on the trigger', () => {
+      cy.mount(
+        <PopoverComponent initialFocus="#test">
+          <button data-test-subj="popover-toggle">Test</button>
+        </PopoverComponent>
+      );
+
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+      cy.get('[data-test-subj="togglePopover"]').click();
+
+      cy.get('[data-test-subj="popoverPanel"]').should('exist');
+
+      cy.focused().type('{esc}');
+
+      cy.get('[data-test-subj="popoverPanel"]').should('not.exist');
+    });
+  });
+
   describe('repositionToCrossAxis', () => {
     beforeEach(() => {
       // Set a forced viewport with not enough room to render the popover vertically

--- a/packages/eui/src/components/popover/popover.tsx
+++ b/packages/eui/src/components/popover/popover.tsx
@@ -406,6 +406,7 @@ export class EuiPopover extends Component<Props, State> {
     this.closingTransitionAnimationFrame = window.requestAnimationFrame(() => {
       this.setState({
         isOpening: true,
+        isClosing: false,
       });
     });
 


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8879

This PR aims to fix an issue on `EuiPopover` where rapid clicking of the popover toggle element would result in the popover not being closable via click outside or `Escape` key press. 
If the click interval is big enough to account for the `closingTransitionTimeout` then the popover would be closable as expected. If the interval is too short though, it would result in both `isOpening` and `isClosing` state being `true`.

https://github.com/user-attachments/assets/8d66c56c-ea2b-45b6-a690-1d628dcb0947

Ensuring that `isClosing` state is reset when opening a popover resolves this issue.

## Why are we making this change?

Fixing a bug on EuiPopover to ensure the popover is always closable.

## Screenshots

| before | after |
|---|---|
| <img width="1471" height="677" alt="Screenshot 2025-07-18 at 16 37 28" src="https://github.com/user-attachments/assets/4f605b76-a1e1-4f88-93e4-bbd47109f782" /> | <img width="1471" height="677" alt="Screenshot 2025-07-18 at 16 37 44" src="https://github.com/user-attachments/assets/a3e96174-05f5-4c4f-b2b7-8d83fab3b9d9" /> |

## Impact to users

🟢 There are no updates needed on consumer side.

## QA

- [x] ci passes and the newly added regression tests succeed
- [x] compare [production](https://eui.elastic.co/storybook/index.html?path=/story/layout-euipopover-euipopover--playground&globals=colorMode:light) and [staging](https://eui.elastic.co/pr_8882/storybook/?path=/story/layout-euipopover-euipopover--playground) behavior and verify that the popover closes as expected

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
