### PR TITLE
Linked specific meta issue for Next.js support

### DIFF
--- a/packages/website/docs/getting-started/setup.mdx
+++ b/packages/website/docs/getting-started/setup.mdx
@@ -97,6 +97,13 @@ import { css } from '@emotion/react';
       </EuiTableRowCell>
     </EuiTableRow>
     <EuiTableRow>
+      <EuiTableRowCell>Next.js</EuiTableRowCell>
+      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell>
+        Not supported (<Link href="https://github.com/elastic/eui/issues/8881">details</Link>)
+      </EuiTableRowCell>
+    </EuiTableRow>
+    <EuiTableRow>
       <EuiTableRowCell>Server-side Rendering</EuiTableRowCell>
       <EuiTableRowCell align="center">⚠️</EuiTableRowCell>
       <EuiTableRowCell>

--- a/packages/website/docs/getting-started/setup.mdx
+++ b/packages/website/docs/getting-started/setup.mdx
@@ -98,9 +98,9 @@ import { css } from '@emotion/react';
     </EuiTableRow>
     <EuiTableRow>
       <EuiTableRowCell>Next.js</EuiTableRowCell>
-      <EuiTableRowCell align="center">❌</EuiTableRowCell>
+      <EuiTableRowCell align="center">⚠️</EuiTableRowCell>
       <EuiTableRowCell>
-        Not supported (<Link href="https://github.com/elastic/eui/issues/8881">details</Link>)
+        Supported with caveats (<Link href="https://github.com/elastic/eui/issues/8881">details</Link>)
       </EuiTableRowCell>
     </EuiTableRow>
     <EuiTableRow>


### PR DESCRIPTION
## Summary

I created a Meta issue for Next.js js support and linked it in the Supported Environments section in our docs.

## Why are we making this change?

There is recurring interest in Next.js support, and we needed a clear way to communicate that we don't explicitly support it, as well as a Meta issue to explain why we do not currently support it and progress toward support.

## Impact to users

Docs only, no impact.

## QA

Check the docs preview generated by this PR.

### General checklist

- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples