### PR TITLE
[EuiCodeBlock] Add accessible labels for virtualized code blocks

### DIFF
--- a/packages/eui/changelogs/upcoming/8887.md
+++ b/packages/eui/changelogs/upcoming/8887.md
@@ -1,0 +1,4 @@
+**Accessibility**
+
+- Added accessible labels to virtualized `EuiCodeBlock`
+

--- a/packages/eui/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/packages/eui/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`EuiCodeBlock Virtualization renders a virtualized code block 1`] = `
       <div
         class="emotion-euiScreenReaderOnly"
       >
+        aria-label, 
         text code block:
       </div>
       <span
@@ -33,7 +34,6 @@ exports[`EuiCodeBlock Virtualization renders a virtualized code block 1`] = `
         ✄𐘗
       </span>
       <code
-        aria-label="aria-label"
         class="euiCodeBlock__code emotion-euiCodeBlock__code-isVirtualized"
         data-code-language="text"
         data-test-subj="test subject string"
@@ -92,6 +92,7 @@ exports[`EuiCodeBlock renders a code block 1`] = `
     <div
       class="emotion-euiScreenReaderOnly"
     >
+      aria-label, 
       text code block:
     </div>
     <span
@@ -102,7 +103,6 @@ exports[`EuiCodeBlock renders a code block 1`] = `
       ✄𐘗
     </span>
     <code
-      aria-label="aria-label"
       class="euiCodeBlock__code emotion-euiCodeBlock__code"
       data-code-language="text"
       data-test-subj="test subject string"

--- a/packages/eui/src/components/code/__snapshots__/code_block.test.tsx.snap
+++ b/packages/eui/src/components/code/__snapshots__/code_block.test.tsx.snap
@@ -13,6 +13,25 @@ exports[`EuiCodeBlock Virtualization renders a virtualized code block 1`] = `
       style="position: relative; block-size: 600px; inline-size: 600px; overflow: auto; will-change: transform; direction: ltr;"
       tabindex="0"
     >
+      <span
+        aria-hidden="true"
+        class="euiScreenReaderOnly"
+        data-tabular-copy-marker="no-copy"
+      >
+        ✄𐘗
+      </span>
+      <div
+        class="emotion-euiScreenReaderOnly"
+      >
+        text code block:
+      </div>
+      <span
+        aria-hidden="true"
+        class="euiScreenReaderOnly"
+        data-tabular-copy-marker="no-copy"
+      >
+        ✄𐘗
+      </span>
       <code
         aria-label="aria-label"
         class="euiCodeBlock__code emotion-euiCodeBlock__code-isVirtualized"

--- a/packages/eui/src/components/code/code_block.tsx
+++ b/packages/eui/src/components/code/code_block.tsx
@@ -135,6 +135,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
   overflowHeight,
   isVirtualized: _isVirtualized,
   lineNumbers = false,
+  'aria-label': ariaLabel,
   ...rest
 }) => {
   const euiTheme = useEuiTheme();
@@ -278,7 +279,10 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
     <>
       {tabularCopyMarkers.hiddenNoCopyBoundary}
       <EuiScreenReaderOnly>
-        <div>{codeBlockLabel}</div>
+        <div>
+          {ariaLabel ? `${ariaLabel}, ` : undefined}
+          {codeBlockLabel}
+        </div>
       </EuiScreenReaderOnly>
       {tabularCopyMarkers.hiddenNoCopyBoundary}
     </>

--- a/packages/eui/src/components/code/code_block.tsx
+++ b/packages/eui/src/components/code/code_block.tsx
@@ -293,6 +293,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
       {isVirtualized ? (
         <EuiCodeBlockVirtualized
           data={data}
+          label={codeBlockLabelElement}
           rowHeight={fontSizeToRowHeightMap[fontSize]}
           overflowHeight={overflowHeight}
           preProps={preProps}
@@ -314,6 +315,7 @@ export const EuiCodeBlock: FunctionComponent<EuiCodeBlockProps> = ({
           {isVirtualized ? (
             <EuiCodeBlockVirtualized
               data={data}
+              label={codeBlockLabelElement}
               rowHeight={fontSizeToRowHeightMap.l}
               preProps={preFullscreenProps}
               codeProps={codeProps}

--- a/packages/eui/src/components/code/code_block_virtualized.tsx
+++ b/packages/eui/src/components/code/code_block_virtualized.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { HTMLAttributes, forwardRef, useMemo } from 'react';
+import React, { HTMLAttributes, ReactNode, forwardRef, useMemo } from 'react';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { RefractorNode } from 'refractor';
 import { logicalStyles } from '../../global_styling';
@@ -19,12 +19,14 @@ import { nodeToHtml } from './utils';
 
 export const EuiCodeBlockVirtualized = ({
   data,
+  label,
   rowHeight,
   overflowHeight,
   preProps,
   codeProps,
 }: {
   data: RefractorNode[];
+  label: ReactNode;
   rowHeight: number;
   overflowHeight?: number | string;
   preProps: HTMLAttributes<HTMLPreElement>;
@@ -32,10 +34,13 @@ export const EuiCodeBlockVirtualized = ({
 }) => {
   const VirtualizedOuterElement = useMemo(
     () =>
-      forwardRef<any, any>(({ style, ...props }, ref) => (
-        <pre style={logicalStyles(style)} {...props} ref={ref} {...preProps} />
+      forwardRef<any, any>(({ style, children, ...props }, ref) => (
+        <pre style={logicalStyles(style)} {...props} ref={ref} {...preProps}>
+          {label}
+          {children}
+        </pre>
       )),
-    [preProps]
+    [preProps, label]
   );
 
   const VirtualizedInnerElement = useMemo(


### PR DESCRIPTION
## Summary

relates to https://github.com/elastic/kibana/issues/205331#issuecomment-2963080851

This PR adds missing accessible labels for `EuiCodeBlock` when `isVirtualized`. We previously added accessible labels in https://github.com/elastic/eui/issues/8195 but they were not applied to the virtualized output.

## Why are we making this change?

Fixing an Accessibility issue for missing role and name information on `EuiCodeBlock`.

🔗 [WCAG 4.1.2: Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)

## Screenshots

| before | after |
|---|---|
| <video src="https://github.com/user-attachments/assets/92c0ad4e-f13d-4181-a20e-b07329fda902" /> | <video src="https://github.com/user-attachments/assets/9de81d9e-e4ae-4b37-be14-642732e659db" /> |

## Impact to users

🟢 There are no updates required on consumer side.

## QA

- open [Storybook](https://eui.elastic.co/pr_8887/storybook/?path=/story/editors-syntax-euicodeblock--playground) and set `isVirtualized` and `overflowHeight: {number}` (e.g. `100`)
  - [x] verify that the code block label is read when navigating onto EuiCodeBlock in a screen reader (e.g. "text code block")
  - [x] verify that the code block label is read when opening the fullscreen mode and navigating onto EuiCodeBlock in a screen reader (e.g. "text code block")

Example output: `text code block: <p> <!-- Hello world --> </p> group`

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
