### PR TITLE
fix(eslint-plugin): remove duplicate rules key

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -46,7 +46,6 @@ const config = {
         '@elastic/eui/require-aria-label-for-modals': 'warn',
         '@elastic/eui/consistent-is-invalid-props': 'warn',
         '@elastic/eui/sr-output-disabled-tooltip': 'warn',
-        '@elastic/eui/no-css_color': 'warn',
         '@elastic/eui/prefer-eui-icon-tip': 'warn',
       },
     },

--- a/packages/eui/changelogs/upcoming/8888.md
+++ b/packages/eui/changelogs/upcoming/8888.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Removed `no-css_color` entry which mapped to a duplicate `no-css-color` rule
+


### PR DESCRIPTION
## Summary

On the previous PR (https://github.com/elastic/eui/pull/8877), an issue was introduced into the ESLint plugin. An entry was added to `rules`: `no-css_color`.

I caught it on https://github.com/elastic/kibana/pull/228828.