### PR TITLE
chore(website): stage and commit versions.json file

### DIFF
--- a/packages/website/scripts/update-versions.js
+++ b/packages/website/scripts/update-versions.js
@@ -54,16 +54,21 @@ const updateVersions = async () => {
     // Write the updated JSON back to the file
     fs.writeFileSync(versionsFile, JSON.stringify(jsonData, null, 2));
 
-    // Stage the file for commit
-    exec(`git add ${versionsFile}`, (err) => {
-      if (err) {
-        throw new Error('Error staging the file:', err);
-      } else {
-        console.log('Version added and file staged successfully');
+    // Add and commit the file
+    exec(
+      `git add ${versionsFile} && git commit -m "chore: update versions.json [skip ci]"`,
+      (err) => {
+        if (err) {
+          console.error('Error committing the file:', err);
+          process.exit(1);
+        } else {
+          console.log('Version added and committed successfully');
+        }
       }
-    });
+    );
   } catch (error) {
-    throw new Error('Error updating versions:', err);
+    console.error('Error updating versions:', error);
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
## Summary

After merge, I will update [release process wiki](https://github.com/elastic/eui-private/wiki/Release-process#elasticeui).

## QA

1. cd `eui/packages/eui`
2. Temporarily change `@elastic/eui` version: `npm version 106.1.1 --no-git-tag-version`
3. cd `../website`
4. node `./scripts/update-versions.js`
5. Verify `versions.json` file content and `git log` the latest commit should be: `chore: update versions.json [skip ci]`
 