### PR TITLE
[Wiki] Update guideline for cloud deployments

### DIFF
--- a/wiki/contributing-to-eui/testing/testing-in-kibana.md
+++ b/wiki/contributing-to-eui/testing/testing-in-kibana.md
@@ -84,9 +84,11 @@ After you have created a Kibana PR following the steps above, there are two ways
 - Add the labels `ci:cloud-deploy` and `ci:cloud-persist-deployment` on your PR and ensure the CI pipelines run by checking the "Click to trigger kibana-deploy-cloud-from-pr for this PR!" checkbox in the comment from **elasticmachine**
 - Once the pipelines are finished, **kibanamachine** will post a message with a link to the credentials on Buildkite, there you'll find a link to the deployment e.g. https://kibana-pr-228477.kb.us-west2.gcp.elastic-cloud.com and a command to get the credentials
 - Run the `vault` command to get the credentials in your terminal (if you never used the `vault` CLI, continue reading)
-- To use Hashicorp's `vault` CLI
-  - [Install the CLI](https://developer.hashicorp.com/vault/install), if you're on a Mac you can use [homebrew](https://brew.sh/)
-  - [Login for the Infra Vault (production)](https://docs.elastic.dev/vault/accessing)
+- To use HashiCorp's `vault` CLI
+  - [Install it](https://developer.hashicorp.com/vault/install), if you're on a Mac you can use [homebrew](https://brew.sh/)
+  - Login for the [Infra Vault (production)]((https://docs.elastic.dev/vault/accessing)) by running:
+    - `export VAULT_ADDR=https://secrets.elastic.co:8200`
+    - `vault login -method=oidc`
 
 ##### Using Kibana a la carte
 

--- a/wiki/contributing-to-eui/testing/testing-in-kibana.md
+++ b/wiki/contributing-to-eui/testing/testing-in-kibana.md
@@ -77,9 +77,17 @@ Elastic engineers have the option to deploy a local EUI package in Kibana. To do
 
 #### Deploy the custom EUI package
 
-There are two ways you can deploy your local EUI package in Kibana.
+After you have created a Kibana PR following the steps above, there are two ways you can deploy your local EUI package in Kibana.
 
-1. add the labels `ci:cloud-deploy` and `ci:cloud-persist-deployment` on your PR and ensure the CI pipelines run 
-  - after the pipelines finish the "Build" information will have a link to the cloud deployment and access information ([vault access](https://docs.elastic.dev/vault/infra-vault/accessing) is required)
-2. use [Kibana-a-la-carte](https://kibana-a-la-carte.kbndev.co/) to deploy your PR
+##### Using labels
 
+- Add the labels `ci:cloud-deploy` and `ci:cloud-persist-deployment` on your PR and ensure the CI pipelines run by checking the "Click to trigger kibana-deploy-cloud-from-pr for this PR!" checkbox in the comment from **elasticmachine**
+- Once the pipelines are finished, **kibanamachine** will post a message with a link to the credentials on Buildkite, there you'll find a link to the deployment e.g. https://kibana-pr-228477.kb.us-west2.gcp.elastic-cloud.com and a command to get the credentials
+- Run the `vault` command to get the credentials in your terminal (if you never used the `vault` CLI, continue reading)
+- To use Hashicorp's `vault` CLI
+  - [Install the CLI](https://developer.hashicorp.com/vault/install), if you're on a Mac you can use [homebrew](https://brew.sh/)
+  - [Login for the Infra Vault (production)](https://docs.elastic.dev/vault/accessing)
+
+##### Using Kibana a la carte
+
+Follow the instructions in [Kibana a la carte](https://kibana-a-la-carte.kbndev.co/) to deploy your PR.


### PR DESCRIPTION
## Summary

This PR updates the `testing-in-kibana.md` wiki page, namely the part where it explains how to create cloud deployments for Kibana PRs. The related to the docs for getting the credentials was broken. I made it a bit more foolproof in general.

## Why are we making this change?

To keep internal docs up-to-date.

## Impact to users

Internal, only relevant to contributors.