### PR TITLE
fix(website): update the button icon to align with the guideline

### DIFF
--- a/packages/website/docs/components/navigation/buttons/button.mdx
+++ b/packages/website/docs/components/navigation/buttons/button.mdx
@@ -489,7 +489,7 @@ Extra small applies only to `EuiButtonEmpty` and `EuiButtonIcon`.
         <EuiButton size="m">Button</EuiButton>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon iconType="trash" color="danger" size="m" aria-label="Delete"/>
+        <EuiButtonIcon iconType="gear" color="primary" size="m" aria-label="Settings"/>
       </EuiFlexItem>
     </EuiFlexGroup>
   </Guideline>


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/eui/issues/8855

The guideline example on the Button page didn't align with what the guideline said.

## Why are we making this change?

We are making this change because the current example goes against the guideline:

> Stick to the default pattern: a filled, primary button paired with an empty, but same-colored button.

`EuiButton` uses color `primary` and `EuiButtonIcon` uses color `danger`.

We settled with the designers on changing the icon to `gear` and color to `primary`.

## Screenshots

| Before | After |
| ------ | ------ |
| <img width="819" height="437" alt="Screenshot 2025-07-23 at 11 00 53" src="https://github.com/user-attachments/assets/1c913b97-ef4d-44c6-8aef-ba00e56a7573" /> | <img width="832" height="440" alt="Screenshot 2025-07-23 at 10 59 19" src="https://github.com/user-attachments/assets/c7190d73-4ee5-4f92-8631-e6bbe1229556" /> |

## Impact to users

🟢 Affects our **documentation website**. It's not a breaking change.

## QA

- [ ] [Size guideline example](https://eui.elastic.co/pr_8901/docs/components/navigation/buttons/button/#size) is aligned with the guideline text 
