### PR TITLE
[`EuiFlyout`] Add optional menu bar 

### DIFF
--- a/packages/eui/src/components/flyout/__snapshots__/flyout_menu_bar.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout_menu_bar.test.tsx.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiFlyoutMenuBar actions renders action buttons 1`] = `
+<div
+  class="euiFlyoutMenuBar emotion-euiFlyoutMenuBar"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  >
+    <h2
+      class="euiFlyoutMenuBar__title emotion-euiFlyoutMenuBar__title"
+    >
+      Test Title
+    </h2>
+  </div>
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Edit"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="pencil"
+      />
+    </button>
+    <button
+      aria-label="Share"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="share"
+      />
+    </button>
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiFlyoutMenuBar actions renders disabled action buttons 1`] = `
+<div
+  class="euiFlyoutMenuBar emotion-euiFlyoutMenuBar"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  >
+    <h2
+      class="euiFlyoutMenuBar__title emotion-euiFlyoutMenuBar__title"
+    >
+      Test Title
+    </h2>
+  </div>
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Edit"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-disabled-isDisabled"
+      disabled=""
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="pencil"
+      />
+    </button>
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiFlyoutMenuBar exactly 3 actions shows all 3 actions as buttons without overflow 1`] = `
+<div
+  class="euiFlyoutMenuBar emotion-euiFlyoutMenuBar"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  >
+    <h2
+      class="euiFlyoutMenuBar__title emotion-euiFlyoutMenuBar__title"
+    >
+      Test Title
+    </h2>
+  </div>
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Edit"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="pencil"
+      />
+    </button>
+    <button
+      aria-label="Share"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="share"
+      />
+    </button>
+    <button
+      aria-label="Copy"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="copy"
+      />
+    </button>
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiFlyoutMenuBar is rendered 1`] = `
+<div
+  aria-label="aria-label"
+  class="euiFlyoutMenuBar testClass1 testClass2 emotion-euiFlyoutMenuBar-euiTestCss"
+  data-test-subj="test subject string"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  />
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiFlyoutMenuBar overflow menu shows overflow menu when more than 3 actions 1`] = `
+<div
+  class="euiFlyoutMenuBar emotion-euiFlyoutMenuBar"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  >
+    <h2
+      class="euiFlyoutMenuBar__title emotion-euiFlyoutMenuBar__title"
+    >
+      Test Title
+    </h2>
+  </div>
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Edit"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="pencil"
+      />
+    </button>
+    <button
+      aria-label="Share"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="share"
+      />
+    </button>
+    <div
+      class="euiPopover emotion-euiPopover-inline-block"
+    >
+      <button
+        aria-label="More actions"
+        class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+        data-test-subj="euiFlyoutMenuBarOverflowButton"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="euiButtonIcon__icon"
+          color="inherit"
+          data-euiicon-type="boxesVertical"
+        />
+      </button>
+    </div>
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiFlyoutMenuBar props children are rendered and take precedence over title 1`] = `
+<div
+  class="euiFlyoutMenuBar emotion-euiFlyoutMenuBar"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  >
+    <span>
+      Custom Content
+    </span>
+  </div>
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EuiFlyoutMenuBar props title is rendered 1`] = `
+<div
+  class="euiFlyoutMenuBar emotion-euiFlyoutMenuBar"
+>
+  <div
+    class="euiFlyoutMenuBar__content emotion-euiFlyoutMenuBar__content"
+  >
+    <h2
+      class="euiFlyoutMenuBar__title emotion-euiFlyoutMenuBar__title"
+    >
+      Test Title
+    </h2>
+  </div>
+  <div
+    class="euiFlyoutMenuBar__actions emotion-euiFlyoutMenuBar__actions"
+  >
+    <button
+      aria-label="Close this dialog"
+      class="euiButtonIcon emotion-euiButtonIcon-xs-empty-text"
+      data-test-subj="euiFlyoutMenuBarCloseButton"
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        class="euiButtonIcon__icon"
+        color="inherit"
+        data-euiicon-type="cross"
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/packages/eui/src/components/flyout/flyout_menu_bar.stories.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu_bar.stories.tsx
@@ -1,0 +1,367 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiFlyout } from './flyout';
+import { EuiFlyoutBody } from './flyout_body';
+import {
+  EuiFlyoutMenuBar,
+  EuiFlyoutMenuBarProps,
+  EuiFlyoutMenuBarAction,
+} from './flyout_menu_bar';
+import { EuiText } from '../text';
+import { EuiSpacer } from '../spacer';
+import { EuiFlexGroup, EuiFlexItem } from '../flex';
+import { EuiIcon } from '../icon';
+import { EuiButton } from '../button';
+import { LOKI_SELECTORS } from '../../../.storybook/loki';
+
+const meta: Meta<EuiFlyoutMenuBarProps> = {
+  title: 'Layout/EuiFlyout/EuiFlyoutMenuBar',
+  component: EuiFlyoutMenuBar,
+  argTypes: {
+    onClose: { action: 'onClose' },
+  },
+  args: {
+    // Component defaults
+  },
+  parameters: {
+    loki: {
+      // Flyout content is rendered in a portal
+      chromeSelector: LOKI_SELECTORS.portal,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiFlyoutMenuBarProps>;
+
+export const Playground: Story = {
+  args: {
+    title: 'Event details',
+  },
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout} />
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This is a flyout with a menu bar. The menu bar contains a
+                  title and a close button.
+                </p>
+                <EuiSpacer />
+                <p>
+                  Click the close button in the menu bar to close this flyout.
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    title: 'Event details',
+  },
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout with title
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout} />
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This flyout menu bar displays a simple title on the left side
+                  and a close button on the right.
+                </p>
+                <EuiSpacer />
+                <p>
+                  The title will truncate with ellipsis if it's too long to fit
+                  in the available space.
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};
+
+export const WithCustomContent: Story = {
+  args: {},
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout with custom content
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout}>
+              <EuiFlexGroup
+                alignItems="center"
+                gutterSize="s"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
+                  <EuiIcon type="alert" color="warning" />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiText size="s">
+                    <strong>Investigation Status</strong>
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlyoutMenuBar>
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This flyout menu bar displays custom React content instead of
+                  a simple title.
+                </p>
+                <EuiSpacer />
+                <p>
+                  You can include icons, formatted text, or any other React
+                  components in the left content area.
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    title:
+      'This is a very long title that should demonstrate how the menu bar handles text overflow with ellipsis truncation when the content is too wide',
+  },
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout with long title
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout} />
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This story demonstrates how the menu bar handles long titles
+                  by truncating them with ellipsis.
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};
+
+export const EmptyContent: Story = {
+  args: {},
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout with empty content
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout} />
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This flyout menu bar has no title or custom content, showing
+                  just the close button.
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: 'Event details',
+    actions: [
+      {
+        key: 'edit',
+        iconType: 'pencil',
+        'aria-label': 'Edit event',
+        onClick: () => console.log('Edit clicked'),
+        'data-test-subj': 'editButton',
+      },
+      {
+        key: 'share',
+        iconType: 'share',
+        'aria-label': 'Share event',
+        onClick: () => console.log('Share clicked'),
+        'data-test-subj': 'shareButton',
+      },
+    ] as EuiFlyoutMenuBarAction[],
+  },
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout with action buttons
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout} />
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This flyout menu bar includes custom action buttons (Edit and
+                  Share) along with the close button.
+                </p>
+                <EuiSpacer />
+                <p>
+                  All action buttons use the "text" color and are positioned to
+                  the left of the close button.
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};
+
+export const WithManyActions: Story = {
+  args: {
+    title: 'Investigation details',
+    actions: [
+      {
+        key: 'edit',
+        iconType: 'pencil',
+        'aria-label': 'Edit investigation',
+        onClick: () => console.log('Edit clicked'),
+      },
+      {
+        key: 'share',
+        iconType: 'share',
+        'aria-label': 'Share investigation',
+        onClick: () => console.log('Share clicked'),
+      },
+      {
+        key: 'copy',
+        iconType: 'copy',
+        'aria-label': 'Copy investigation',
+        onClick: () => console.log('Copy clicked'),
+      },
+      {
+        key: 'download',
+        iconType: 'download',
+        'aria-label': 'Download investigation',
+        onClick: () => console.log('Download clicked'),
+      },
+      {
+        key: 'delete',
+        iconType: 'trash',
+        'aria-label': 'Delete investigation',
+        onClick: () => console.log('Delete clicked'),
+      },
+    ] as EuiFlyoutMenuBarAction[],
+  },
+  render: function Render({ ...args }) {
+    const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
+
+    const closeFlyout = () => setIsFlyoutOpen(false);
+    const openFlyout = () => setIsFlyoutOpen(true);
+
+    return (
+      <>
+        <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
+          Open flyout with overflow menu
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={closeFlyout} hideCloseButton>
+            <EuiFlyoutMenuBar {...args} onClose={closeFlyout} />
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>
+                  This flyout menu bar demonstrates the overflow functionality
+                  with 5 actions.
+                </p>
+                <EuiSpacer />
+                <p>
+                  Only the first 2 actions (Edit and Share) are visible
+                  directly. The remaining 3 actions (Copy, Download, Delete) are
+                  accessible through the overflow menu (⋮ button).
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};

--- a/packages/eui/src/components/flyout/flyout_menu_bar.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_menu_bar.styles.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { UseEuiTheme } from '../../services';
+import { logicalCSS } from '../../global_styling';
+
+export const euiFlyoutMenuBarStyles = (euiThemeContext: UseEuiTheme) => {
+  const { euiTheme } = euiThemeContext;
+
+  return {
+    euiFlyoutMenuBar: css`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      ${logicalCSS('height', '36px')}
+      ${logicalCSS('padding-horizontal', euiTheme.size.s)}
+      ${logicalCSS('border-bottom', euiTheme.border.thin)}
+      background-color: ${euiTheme.colors.emptyShade};
+      flex-shrink: 0;
+    `,
+
+    euiFlyoutMenuBar__content: css`
+      display: flex;
+      align-items: center;
+      flex: 1;
+      ${logicalCSS('min-width', '0')}/* Allow content to shrink */
+    `,
+
+    euiFlyoutMenuBar__title: css`
+      font-size: ${euiTheme.size.m};
+      font-weight: ${euiTheme.font.weight.semiBold};
+      color: ${euiTheme.colors.title};
+      margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    `,
+
+    euiFlyoutMenuBar__actions: css`
+      display: flex;
+      align-items: center;
+      gap: ${euiTheme.size.xs};
+      flex-shrink: 0;
+    `,
+  };
+};

--- a/packages/eui/src/components/flyout/flyout_menu_bar.test.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu_bar.test.tsx
@@ -1,0 +1,375 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { requiredProps } from '../../test/required_props';
+import { render } from '../../test/rtl';
+
+import { EuiFlyoutMenuBar, EuiFlyoutMenuBarAction } from './flyout_menu_bar';
+
+describe('EuiFlyoutMenuBar', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('is rendered', () => {
+    const { container } = render(
+      <EuiFlyoutMenuBar {...requiredProps} onClose={mockOnClose} />
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('props', () => {
+    test('title is rendered', () => {
+      const { container } = render(
+        <EuiFlyoutMenuBar title="Test Title" onClose={mockOnClose} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('children are rendered and take precedence over title', () => {
+      const { container, getByText } = render(
+        <EuiFlyoutMenuBar title="Test Title" onClose={mockOnClose}>
+          <span>Custom Content</span>
+        </EuiFlyoutMenuBar>
+      );
+
+      expect(getByText('Custom Content')).toBeInTheDocument();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('close button calls onClose when clicked', () => {
+      const { getByLabelText } = render(
+        <EuiFlyoutMenuBar title="Test Title" onClose={mockOnClose} />
+      );
+
+      const closeButton = getByLabelText('Close this dialog');
+      fireEvent.click(closeButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('actions', () => {
+    const mockActions: EuiFlyoutMenuBarAction[] = [
+      {
+        key: 'edit',
+        iconType: 'pencil',
+        'aria-label': 'Edit',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'share',
+        iconType: 'share',
+        'aria-label': 'Share',
+        onClick: jest.fn(),
+      },
+    ];
+
+    test('renders action buttons', () => {
+      const { container, getByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={mockActions}
+        />
+      );
+
+      expect(getByLabelText('Edit')).toBeInTheDocument();
+      expect(getByLabelText('Share')).toBeInTheDocument();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('action buttons call onClick when clicked', () => {
+      const { getByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={mockActions}
+        />
+      );
+
+      const editButton = getByLabelText('Edit');
+      const shareButton = getByLabelText('Share');
+
+      fireEvent.click(editButton);
+      fireEvent.click(shareButton);
+
+      expect(mockActions[0].onClick).toHaveBeenCalledTimes(1);
+      expect(mockActions[1].onClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('renders disabled action buttons', () => {
+      const disabledActions: EuiFlyoutMenuBarAction[] = [
+        {
+          key: 'edit',
+          iconType: 'pencil',
+          'aria-label': 'Edit',
+          onClick: jest.fn(),
+          disabled: true,
+        },
+      ];
+
+      const { container, getByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={disabledActions}
+        />
+      );
+
+      const editButton = getByLabelText('Edit');
+      expect(editButton).toBeDisabled();
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('renders data-test-subj on action buttons', () => {
+      const actionsWithTestSubj: EuiFlyoutMenuBarAction[] = [
+        {
+          key: 'edit',
+          iconType: 'pencil',
+          'aria-label': 'Edit',
+          onClick: jest.fn(),
+          'data-test-subj': 'edit-action',
+        },
+      ];
+
+      const { getByTestSubject } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={actionsWithTestSubj}
+        />
+      );
+
+      expect(getByTestSubject('edit-action')).toBeInTheDocument();
+    });
+  });
+
+  describe('overflow menu', () => {
+    const manyActions: EuiFlyoutMenuBarAction[] = [
+      {
+        key: 'edit',
+        iconType: 'pencil',
+        'aria-label': 'Edit',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'share',
+        iconType: 'share',
+        'aria-label': 'Share',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'copy',
+        iconType: 'copy',
+        'aria-label': 'Copy',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'download',
+        iconType: 'download',
+        'aria-label': 'Download',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'delete',
+        iconType: 'trash',
+        'aria-label': 'Delete',
+        onClick: jest.fn(),
+      },
+    ];
+
+    test('shows overflow menu when more than 3 actions', () => {
+      const { container, getByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={manyActions}
+        />
+      );
+
+      // Should show first 2 actions as buttons
+      expect(getByLabelText('Edit')).toBeInTheDocument();
+      expect(getByLabelText('Share')).toBeInTheDocument();
+
+      // Should show overflow menu button
+      expect(getByLabelText('More actions')).toBeInTheDocument();
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('opens overflow menu when clicked', () => {
+      const { getByLabelText, getByText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={manyActions}
+        />
+      );
+
+      const overflowButton = getByLabelText('More actions');
+      fireEvent.click(overflowButton);
+
+      // Should show overflow menu items
+      expect(getByText('Copy')).toBeInTheDocument();
+      expect(getByText('Download')).toBeInTheDocument();
+      expect(getByText('Delete')).toBeInTheDocument();
+    });
+
+    test('calls action onClick from overflow menu', () => {
+      const { getByLabelText, getByText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={manyActions}
+        />
+      );
+
+      // Open overflow menu
+      const overflowButton = getByLabelText('More actions');
+      fireEvent.click(overflowButton);
+
+      // Click on overflow menu item
+      const copyItem = getByText('Copy');
+      fireEvent.click(copyItem);
+
+      expect(manyActions[2].onClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows disabled state in overflow menu', () => {
+      const actionsWithDisabled = [
+        ...manyActions.slice(0, 4),
+        {
+          key: 'delete',
+          iconType: 'trash',
+          'aria-label': 'Delete',
+          onClick: jest.fn(),
+          disabled: true,
+        },
+      ];
+
+      const { getByLabelText, getByText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={actionsWithDisabled}
+        />
+      );
+
+      // Open overflow menu
+      const overflowButton = getByLabelText('More actions');
+      fireEvent.click(overflowButton);
+
+      // Check disabled item
+      const deleteItem = getByText('Delete');
+      expect(deleteItem.closest('button')).toBeDisabled();
+    });
+  });
+
+  describe('exactly 3 actions', () => {
+    const threeActions: EuiFlyoutMenuBarAction[] = [
+      {
+        key: 'edit',
+        iconType: 'pencil',
+        'aria-label': 'Edit',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'share',
+        iconType: 'share',
+        'aria-label': 'Share',
+        onClick: jest.fn(),
+      },
+      {
+        key: 'copy',
+        iconType: 'copy',
+        'aria-label': 'Copy',
+        onClick: jest.fn(),
+      },
+    ];
+
+    test('shows all 3 actions as buttons without overflow', () => {
+      const { container, getByLabelText, queryByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={threeActions}
+        />
+      );
+
+      // Should show all 3 actions as buttons
+      expect(getByLabelText('Edit')).toBeInTheDocument();
+      expect(getByLabelText('Share')).toBeInTheDocument();
+      expect(getByLabelText('Copy')).toBeInTheDocument();
+
+      // Should NOT show overflow menu button
+      expect(queryByLabelText('More actions')).not.toBeInTheDocument();
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('accessibility', () => {
+    test('close button has proper aria-label', () => {
+      const { getByLabelText } = render(
+        <EuiFlyoutMenuBar title="Test Title" onClose={mockOnClose} />
+      );
+
+      expect(getByLabelText('Close this dialog')).toBeInTheDocument();
+    });
+
+    test('action buttons have proper aria-labels', () => {
+      const actions: EuiFlyoutMenuBarAction[] = [
+        {
+          key: 'edit',
+          iconType: 'pencil',
+          'aria-label': 'Edit document',
+          onClick: jest.fn(),
+        },
+      ];
+
+      const { getByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={actions}
+        />
+      );
+
+      expect(getByLabelText('Edit document')).toBeInTheDocument();
+    });
+
+    test('overflow menu button has proper aria-label', () => {
+      const manyActions: EuiFlyoutMenuBarAction[] = Array.from(
+        { length: 4 },
+        (_, i) => ({
+          key: `action-${i}`,
+          iconType: 'pencil',
+          'aria-label': `Action ${i}`,
+          onClick: jest.fn(),
+        })
+      );
+
+      const { getByLabelText } = render(
+        <EuiFlyoutMenuBar
+          title="Test Title"
+          onClose={mockOnClose}
+          actions={manyActions}
+        />
+      );
+
+      expect(getByLabelText('More actions')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/eui/src/components/flyout/flyout_menu_bar.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu_bar.tsx
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  HTMLAttributes,
+  ReactNode,
+  useState,
+} from 'react';
+import classNames from 'classnames';
+import { CommonProps } from '../common';
+import { useEuiMemoizedStyles } from '../../services';
+import { EuiButtonIcon } from '../button';
+import { EuiPopover } from '../popover';
+import { EuiContextMenu, EuiContextMenuPanelDescriptor } from '../context_menu';
+import { useEuiI18n } from '../i18n';
+import { IconType } from '../icon';
+import { euiFlyoutMenuBarStyles } from './flyout_menu_bar.styles';
+
+export interface EuiFlyoutMenuBarAction {
+  /**
+   * Unique identifier for the action
+   */
+  key: string;
+  /**
+   * Icon type for the action button
+   */
+  iconType: IconType;
+  /**
+   * Aria label for accessibility
+   */
+  'aria-label': string;
+  /**
+   * Click handler for the action
+   */
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /**
+   * Optional disabled state
+   */
+  disabled?: boolean;
+  /**
+   * Optional data-test-subj for testing
+   */
+  'data-test-subj'?: string;
+}
+
+export interface EuiFlyoutMenuBarProps
+  extends HTMLAttributes<HTMLDivElement>,
+    CommonProps {
+  /**
+   * Title text to display on the left side of the menu bar
+   */
+  title?: string;
+  /**
+   * React node to display on the left side instead of title.
+   * Takes precedence over title if both are provided.
+   */
+  children?: ReactNode;
+  /**
+   * Array of action buttons to display. Maximum of 3 visible buttons.
+   * If more than 3 actions are provided, the first 2 will be shown
+   * and the rest will be in an overflow menu.
+   */
+  actions?: EuiFlyoutMenuBarAction[];
+  /**
+   * Callback function called when the close button is clicked
+   *
+   * **Important:** The parent EuiFlyout must have `hideCloseButton={true}`
+   * to prevent showing duplicate close buttons.
+   *
+   * @example
+   * ```tsx
+   * <EuiFlyout hideCloseButton onClose={handleClose}>
+   *   <EuiFlyoutMenuBar
+   *     title="My Title"
+   *     onClose={handleClose}
+   *   />
+   * </EuiFlyout>
+   * ```
+   */
+  onClose: (event: Event) => void;
+}
+
+export const EuiFlyoutMenuBar: FunctionComponent<EuiFlyoutMenuBarProps> = ({
+  title,
+  children,
+  actions = [],
+  onClose,
+  className,
+  ...rest
+}) => {
+  const [isOverflowPopoverOpen, setIsOverflowPopoverOpen] = useState(false);
+
+  const classes = classNames('euiFlyoutMenuBar', className);
+
+  const styles = useEuiMemoizedStyles(euiFlyoutMenuBarStyles);
+  const cssStyles = [styles.euiFlyoutMenuBar];
+
+  const closeAriaLabel = useEuiI18n(
+    'euiFlyoutMenuBar.closeAriaLabel',
+    'Close this dialog'
+  );
+
+  const overflowAriaLabel = useEuiI18n(
+    'euiFlyoutMenuBar.overflowAriaLabel',
+    'More actions'
+  );
+
+  // Determine which actions to show directly and which to put in overflow
+  const maxVisibleActions = 3;
+
+  // If we have more than 3 actions, show only 2 directly and put the rest in overflow
+  const directActions =
+    actions.length > maxVisibleActions
+      ? actions.slice(0, 2)
+      : actions.slice(0, maxVisibleActions);
+  const shouldShowOverflow = actions.length > maxVisibleActions;
+
+  // Render left content - children take precedence over title
+  const leftContent = children ? (
+    <div
+      className="euiFlyoutMenuBar__content"
+      css={styles.euiFlyoutMenuBar__content}
+    >
+      {children}
+    </div>
+  ) : title ? (
+    <div
+      className="euiFlyoutMenuBar__content"
+      css={styles.euiFlyoutMenuBar__content}
+    >
+      <h2
+        className="euiFlyoutMenuBar__title"
+        css={styles.euiFlyoutMenuBar__title}
+      >
+        {title}
+      </h2>
+    </div>
+  ) : (
+    <div
+      className="euiFlyoutMenuBar__content"
+      css={styles.euiFlyoutMenuBar__content}
+    />
+  );
+
+  // Create overflow menu items for context menu
+  const overflowMenuItems = shouldShowOverflow
+    ? actions.slice(2).map((action) => ({
+        name: action['aria-label'],
+        icon: action.iconType,
+        onClick: () => {
+          setIsOverflowPopoverOpen(false);
+          // Create a synthetic event for consistency
+          const syntheticEvent = new MouseEvent('click', {
+            bubbles: true,
+          }) as any;
+          action.onClick(syntheticEvent);
+        },
+        disabled: action.disabled,
+        'data-test-subj': action['data-test-subj'],
+      }))
+    : [];
+
+  const overflowPanels: EuiContextMenuPanelDescriptor[] = [
+    {
+      id: 0,
+      items: overflowMenuItems,
+    },
+  ];
+
+  return (
+    <div className={classes} css={cssStyles} {...rest}>
+      {leftContent}
+
+      <div
+        className="euiFlyoutMenuBar__actions"
+        css={styles.euiFlyoutMenuBar__actions}
+      >
+        {/* Render direct action buttons */}
+        {directActions.map((action) => (
+          <EuiButtonIcon
+            key={action.key}
+            iconType={action.iconType}
+            color="text"
+            aria-label={action['aria-label']}
+            onClick={action.onClick}
+            disabled={action.disabled}
+            data-test-subj={action['data-test-subj']}
+          />
+        ))}
+
+        {/* Render overflow menu if needed */}
+        {shouldShowOverflow && (
+          <EuiPopover
+            button={
+              <EuiButtonIcon
+                iconType="boxesVertical"
+                color="text"
+                aria-label={overflowAriaLabel}
+                onClick={() => setIsOverflowPopoverOpen(!isOverflowPopoverOpen)}
+                data-test-subj="euiFlyoutMenuBarOverflowButton"
+              />
+            }
+            isOpen={isOverflowPopoverOpen}
+            closePopover={() => setIsOverflowPopoverOpen(false)}
+            panelPaddingSize="none"
+            anchorPosition="downRight"
+          >
+            <EuiContextMenu initialPanelId={0} panels={overflowPanels} />
+          </EuiPopover>
+        )}
+
+        {/* Always render close button last */}
+        <EuiButtonIcon
+          iconType="cross"
+          color="text"
+          aria-label={closeAriaLabel}
+          data-test-subj="euiFlyoutMenuBarCloseButton"
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            onClose(e.nativeEvent);
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/eui/src/components/flyout/index.ts
+++ b/packages/eui/src/components/flyout/index.ts
@@ -18,6 +18,12 @@ export { EuiFlyoutFooter } from './flyout_footer';
 export type { EuiFlyoutHeaderProps } from './flyout_header';
 export { EuiFlyoutHeader } from './flyout_header';
 
+export type {
+  EuiFlyoutMenuBarProps,
+  EuiFlyoutMenuBarAction,
+} from './flyout_menu_bar';
+export { EuiFlyoutMenuBar } from './flyout_menu_bar';
+
 export { euiFlyoutSlideInRight, euiFlyoutSlideInLeft } from './flyout.styles';
 
 export type { EuiFlyoutResizableProps } from './flyout_resizable';

--- a/packages/website/docs/components/containers/flyout/_flyout_push.mdx
+++ b/packages/website/docs/components/containers/flyout/_flyout_push.mdx
@@ -1,5 +1,3 @@
-# Push flyouts
-
 Another way to allow for continued interactions of the page content while a flyout is visible is to change the `type` from `overlay` to `push`.
 
 :::warning Push flyouts require manual accessibility management
@@ -75,9 +73,3 @@ export default () => {
   );
 };
 ```
-
-## Props
-
-import flyoutDocgen from '@elastic/eui-docgen/dist/components/flyout/flyout.json';
-
-<PropTable definition={flyoutDocgen.EuiFlyout} />

--- a/packages/website/docs/components/containers/flyout/index.mdx
+++ b/packages/website/docs/components/containers/flyout/index.mdx
@@ -603,6 +603,213 @@ export default () => {
 
 ```
 
+### Menu bar
+
+Use `EuiFlyoutMenuBar` to display actions at the top of a flyout. The menu bar provides a close button on the right and supports optional, custom action buttons. When using `EuiFlyoutMenuBar`, the parent `EuiFlyout` must have `hideCloseButton={true}` to prevent duplicate close buttons.
+
+```tsx interactive
+import React, { useState } from 'react';
+import {
+  EuiFlyout,
+  EuiFlyoutMenuBar,
+  EuiFlyoutBody,
+  EuiButton,
+  EuiText,
+  EuiIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+
+export default () => {
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+
+  const closeFlyout = () => setIsFlyoutVisible(false);
+  const showFlyout = () => setIsFlyoutVisible(true);
+
+  let flyout;
+
+  if (isFlyoutVisible) {
+    flyout = (
+      <EuiFlyout onClose={closeFlyout} hideCloseButton>
+        <EuiFlyoutMenuBar
+          title="Document Settings"
+          onClose={closeFlyout}
+          actions={[
+            {
+              key: 'edit',
+              iconType: 'pencil',
+              'aria-label': 'Edit document',
+              onClick: () => alert('Edit clicked'),
+            },
+            {
+              key: 'share',
+              iconType: 'share',
+              'aria-label': 'Share document',
+              onClick: () => alert('Share clicked'),
+            },
+          ]}
+        />
+        <EuiFlyoutBody>
+          <EuiText>
+            <p>
+              This flyout uses EuiFlyoutMenuBar with a title and action buttons.
+              Notice how the parent EuiFlyout has hideCloseButton=true.
+            </p>
+          </EuiText>
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    );
+  }
+
+  return (
+    <div>
+      <EuiButton onClick={showFlyout}>Show flyout with menu bar</EuiButton>
+      {flyout}
+    </div>
+  );
+};
+```
+
+The menu bar can display either a simple title string or custom React content on the left side.
+
+```tsx interactive
+import React, { useState } from 'react';
+import {
+  EuiFlyout,
+  EuiFlyoutMenuBar,
+  EuiFlyoutBody,
+  EuiButton,
+  EuiText,
+  EuiIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from '@elastic/eui';
+
+export default () => {
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+
+  const closeFlyout = () => setIsFlyoutVisible(false);
+  const showFlyout = () => setIsFlyoutVisible(true);
+
+  let flyout;
+
+  if (isFlyoutVisible) {
+    flyout = (
+      <EuiFlyout onClose={closeFlyout} hideCloseButton>
+        <EuiFlyoutMenuBar onClose={closeFlyout}>
+          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+            <EuiFlexItem grow={false}>
+              <EuiIcon type="alert" color="warning" />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <strong>Custom Content with Icon</strong>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlyoutMenuBar>
+        <EuiFlyoutBody>
+          <EuiText>
+            <p>
+              This flyout uses custom React content in the menu bar instead of a simple title.
+            </p>
+          </EuiText>
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    );
+  }
+
+  return (
+    <div>
+      <EuiButton onClick={showFlyout}>Show flyout with custom menu bar content</EuiButton>
+      {flyout}
+    </div>
+  );
+};
+```
+
+If more than three actions are provided, the first two are shown as buttons and the rest are accessible via an overflow menu. If exactly three actions are provided, all are shown as buttons.
+
+```tsx interactive
+import React, { useState } from 'react';
+import {
+  EuiFlyout,
+  EuiFlyoutMenuBar,
+  EuiFlyoutBody,
+  EuiButton,
+  EuiText,
+} from '@elastic/eui';
+
+export default () => {
+  const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
+
+  const closeFlyout = () => setIsFlyoutVisible(false);
+  const showFlyout = () => setIsFlyoutVisible(true);
+
+  const manyActions = [
+    {
+      key: 'edit',
+      iconType: 'pencil',
+      'aria-label': 'Edit',
+      onClick: () => alert('Edit clicked'),
+    },
+    {
+      key: 'share',
+      iconType: 'share',
+      'aria-label': 'Share',
+      onClick: () => alert('Share clicked'),
+    },
+    {
+      key: 'copy',
+      iconType: 'copy',
+      'aria-label': 'Copy',
+      onClick: () => alert('Copy clicked'),
+    },
+    {
+      key: 'download',
+      iconType: 'download',
+      'aria-label': 'Download',
+      onClick: () => alert('Download clicked'),
+    },
+    {
+      key: 'delete',
+      iconType: 'trash',
+      'aria-label': 'Delete',
+      onClick: () => alert('Delete clicked'),
+      disabled: true,
+    },
+  ];
+
+  let flyout;
+
+  if (isFlyoutVisible) {
+    flyout = (
+      <EuiFlyout onClose={closeFlyout} hideCloseButton>
+        <EuiFlyoutMenuBar
+          title="Many Actions (Overflow Menu)"
+          onClose={closeFlyout}
+          actions={manyActions}
+        />
+        <EuiFlyoutBody>
+          <EuiText>
+            <p>
+              This flyout has more than 3 actions, so the first 2 are shown as buttons
+              and the rest are in an overflow menu. Notice the disabled state is preserved
+              in the overflow menu.
+            </p>
+          </EuiText>
+        </EuiFlyoutBody>
+      </EuiFlyout>
+    );
+  }
+
+  return (
+    <div>
+      <EuiButton onClick={showFlyout}>Show flyout with overflow menu</EuiButton>
+      {flyout}
+    </div>
+  );
+};
+```
+
 ### Banners
 
 To highlight some information at the top of a flyout, you can pass an [EuiCallOut](../../display/callout.mdx) to the `banner` prop available in **EuiFlyoutBody** and its layout will adjust appropriately.
@@ -1017,3 +1224,5 @@ import flyoutDocgen from '@elastic/eui-docgen/dist/components/flyout/flyout.json
 <PropTable definition={docgen.EuiFlyoutResizable} />
 
 <PropTable definition={docgen.EuiFlyoutChild} />
+
+<PropTable definition={docgen.EuiFlyoutMenuBar} />


### PR DESCRIPTION
Closes #8873 

## Summary

Adds support for an optional `EuiFlyoutMenuBar` component (i.e. sub component of `EuiFlyout`).

## Why are we making this change?

There is a pattern of adding a custom menu bar atop flyouts to house related actions. Most notably, this pattern is used for the Security flyout and, therefore, is part of the Flyout System project. Aside from that, it is also useful on any flyout that needs to show extra actions.

Note: this menu bar will be required/enforced for flyouts that opt into using the forthcoming managed state.

## Screenshots

### Example with custom actions
<img width="1642" height="420" alt="CleanShot 2025-07-23 at 13 04 20@2x" src="https://github.com/user-attachments/assets/d82af97e-a4c9-488b-a98e-865f41ca4a40" />

### Basic example with title
<img width="1514" height="432" alt="CleanShot 2025-07-23 at 13 04 50@2x" src="https://github.com/user-attachments/assets/13ddcc0c-1f33-4ec7-8da4-ed1a19b17dca" />

### Minimal example (close required)
<img width="1674" height="328" alt="CleanShot 2025-07-23 at 13 05 22@2x" src="https://github.com/user-attachments/assets/91a9ecb3-27bb-4393-a359-2a75ab672674" />

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
