### PR TITLE
fix(website): improve modal overview wording

### DIFF
--- a/packages/website/docs/components/containers/modal/index.mdx
+++ b/packages/website/docs/components/containers/modal/index.mdx
@@ -6,17 +6,17 @@ keywords: [EuiModal, EuiModalBody, EuiModalFooter, EuiModalHeader, EuiModalHeade
 
 # Modal
 
-A modal works best for focusing users' attention on a **short** amount of content and getting them to make a decision, such as a [confirmation](#confirm-modal). Use it to temporarily interrupt a user’s current task and block interactions to the content below it.
+A modal is best for focusing the user's attention on a **small** amount of content and prompting a decision, such as a [confirmation](#confirm-modal). Use it to temporarily interrupt the current task and block interaction with the content below.
 
-If your modal content is more complex, or requires considerable time to complete, consider using an [EuiFlyout](../flyout/index.mdx) instead.
+If your modal content is complex or takes a long time to complete, consider using an [EuiFlyout](../flyout/index.mdx) instead.
 
-Each **EuiModal** requires a specific set of nested child components. They can be omitted if necessary, but the order cannot be changed or interrupted.
+Each **EuiModal** needs a specific set of nested child components. You can omit some if needed, but do not change their order.
 
 ## Components
 
 ### Default
 
-Modals come a wrapping **EuiOverlayMask** to obscure the content beneath, but unlike flyouts, modals cannot be dismissed by clicking on the overlay mask. This is inline with our [modal usage guidelines](#guidelines) which requires there to be a primary action button, even if that button simply closes the modal.
+Modals use an **EuiOverlayMask** to obscure content beneath. Unlike flyouts, modals can't be dismissed by clicking the mask. This follows our [modal usage guidelines](#guidelines), which require a primary action button, even if it just closes the modal.
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/containers/modal/index.mdx
+++ b/packages/website/docs/components/containers/modal/index.mdx
@@ -8,15 +8,23 @@ keywords: [EuiModal, EuiModalBody, EuiModalFooter, EuiModalHeader, EuiModalHeade
 
 A modal is best for focusing the user's attention on a **small** amount of content and prompting a decision, such as a [confirmation](#confirm-modal). Use it to temporarily interrupt the current task and block interaction with the content below.
 
-If your modal content is complex or takes a long time to complete, consider using an [EuiFlyout](../flyout/index.mdx) instead.
-
 Each **EuiModal** needs a specific set of nested child components. You can omit some if needed, but do not change their order.
+
+:::tip Modal vs flyout
+
+If your modal content is complex or takes a long time to complete, consider using an [EuiFlyout](../flyout/index.mdx) instead.
+:::
 
 ## Components
 
 ### Default
 
-Modals use an **EuiOverlayMask** to obscure content beneath. Unlike flyouts, modals can't be dismissed by clicking the mask. This follows our [modal usage guidelines](#guidelines), which require a primary action button, even if it just closes the modal.
+Modals use an **EuiOverlayMask** to obscure content beneath.
+
+:::warning Modals **can't** be dismissed by clicking outside
+
+Unlike flyouts, modals can't be dismissed by clicking on the mask. This follows our [modal usage guidelines](#guidelines), which require a primary action button, even if it just closes the modal.
+:::
 
 ```tsx interactive
 import React, { useState } from 'react';


### PR DESCRIPTION
## Summary

I updated the wording on the [EuiModal page](https://eui.elastic.co/pr_8905/docs/containers/modal) and highlighted that it cannot be dismissed by clicking outside (by design).

## Why are we making this change?

There was an internal request. Kibana developer asked about creating a custom positioned overlay and wanted to use `EuiModal` as one of the options, and was asking how we can dismiss it on clicking outside.

I think it's useful to highlight that by design, modals cannot be dismissed that way.

## Screenshots

### Before ([prod](https://eui.elastic.co/docs/containers/modal/#default))

<img width="838" height="552" alt="Screenshot 2025-07-24 at 12 58 39" src="https://github.com/user-attachments/assets/3fd73b28-d8fb-429c-a4a4-4deb997e113e" />

### After ([staging](https://eui.elastic.co/pr_8905/docs/containers/modal))

<img width="988" height="602" alt="Screenshot 2025-07-24 at 13 17 44" src="https://github.com/user-attachments/assets/8ad51828-7b94-4939-bb55-30f5748500b1" />

## Impact to users

🟢 Just a docs fix. No impact on the library users.

## QA

- [ ] Verify there are no types and text is clear in [EuiModal page](https://eui.elastic.co/pr_8905/docs/containers/modal)
- [ ] Think about what is the most important information and how it can be highlighted
