### PR TITLE
fix(website): remove link to an obsolete GH discussion

### DIFF
--- a/packages/website/docs/components/forms/selection/overview.mdx
+++ b/packages/website/docs/components/forms/selection/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Selection controls
+# Component comparison
 
 ```mdx-code-block
 import { EuiIconTip, EuiTable, EuiTableRow, EuiTableHeader, EuiTableBody, EuiTableRowCell, EuiTableHeaderCell } from '@elastic/eui';
@@ -10,32 +10,46 @@ import { EuiIconTip, EuiTable, EuiTableRow, EuiTableHeader, EuiTableBody, EuiTab
 
 EUI currently offers over 4 ways to select an option from a list (6 including checkboxes and radios).
 
-While it can get overwhelming figuring out which component to use, this page should serve as a handy guide to help you make that decision depending on what features you need.
+Choosing the right selection component may seem tricky at first - with so many similar options, it can feel overwhelming figuring out which component to use. This comprehensive guide will help you decide which component to use and when, including detailed explanations and comparisons for each component.
+
+## Summary
+
+When choosing a selection component, consider these key factors:
+
+- **Number of options**: Small sets (\<7) work well with radio/checkbox groups, medium sets (\<12) with [EuiSelect](./select.mdx), and larger sets need search functionality
+- **Selection type**: Single vs. multiple selection requirements
+- **Display needs**: Whether you need custom option rendering or simple text options
+- **User input**: Whether users should be able to add custom values
+- **Accessibility**: Native components ([EuiSelect](./select.mdx), radio/checkbox groups) are generally more accessible
+- **Visual layout**: Horizontal pills ([EuiComboBox](./combo-box.mdx)) vs. vertical lists ([EuiSelectable](./selectable.mdx))
+
+For most use cases, start with the simpler native components ([EuiSelect](./select.mdx), [EuiRadioGroup](./checkboxes-and-radios/index.mdx#radio-group), [EuiCheckboxGroup](./checkboxes-and-radios/index.mdx#checkbox-group)) and only move to more complex components when you need their specific features.
 
 ## Which selection component should I use?
+
+The following decision tree will help you choose the right component based on your specific needs.
 
 ### Single selection
 
 - When you have a small set of options (\<7) and all options are equally important in terms of visibility, use [EuiRadioGroup](./checkboxes-and-radios/index.mdx#radio-group).
 - When you have a small set of options (\<12) and only the current selected option has UI importance, reach for [EuiSelect](./select.mdx) first when possible, over other more complex selection components.
-    - Native form controls tend to have better cross-browser and cross-device affordances (particularly for mobile devices), and are more familiar to end users due to their ubiquity across the internet.
+    - **EuiSelect** renders a basic HTML `<select>` element, providing the best cross-browser and cross-device affordances (particularly for mobile devices)
+    - Native form controls are more familiar to end users due to their ubiquity across the internet
 - When you have a small set of options (\<12) _and_ if you need to customize how the options are rendered and selected, use [EuiSuperSelect](./super-select.mdx).
-    - We recommend reaching for **EuiSuperSelect** only if custom option display is absolutely necessary (e.g. for multi-line option text/descriptions), as **EuiSelect** is natively more accessible.
+    - **EuiSuperSelect** gives you control over option display through the `dropdownDisplay` prop, allowing for multi-line option text or descriptions
+    - We recommend reaching for **EuiSuperSelect** only if custom option display is absolutely necessary, as **EuiSelect** is natively more accessible
 - Large sets of options (\>12) should use a selection component that supports searching/filtering options. This requires the use of one of the more advanced multiselect components with `singleSelection` set.
 
 ### Multiple selections
 
 - When you have a small set of options (\<7), and all options are equally important in terms of visibility, use [EuiCheckboxGroup](./checkboxes-and-radios/index.mdx#checkbox-group).
-
-{/* TODO: Once EuiComboBox is rewritten to dogfood EuiSelectable, the below will no longer be as true, and we can recommend either EuiSelectable or EuiComboBox equally */}
-
 - In general, we recommend using [EuiSelectable](./selectable.mdx) for most multi-selection purposes. It renders a searchable, vertically-oriented list with icons next to the option representing selection state.
-    - **EuiSelectable** can optionally be rendered with a search box for filtering through many options, or as just a list for fewer options.
-    - **EuiSelectable** is by far our most accessible and flexible selection component (although customization may require extra development). It can be used within popovers and flyouts, or as a standalone list.
-    - If you need the ability to exclude options, **EuiSelectable** is the only component that offers that functionality.
+    - **EuiSelectable** can optionally be rendered with a search box for filtering through many options, or as just a list for fewer options
+    - **EuiSelectable** is by far our most accessible and flexible selection component (although customization may require extra development). It can be used within popovers and flyouts, or as a standalone list
+    - If you need the ability to exclude options, **EuiSelectable** is the only component that offers that functionality
 - In general, for multi-select scenarios, we recommend using [EuiComboBox](./combo-box.mdx) over [EuiSelectable](./selectable.mdx) primarily when selections should be immediately visible and unselected options should not. Selections are rendered as a horizontally-oriented list of pills.
-    - **EuiComboBox** also allows users to search through a list of dropdown options. This functionality is core to the component and cannot be removed, unlike **EuiSelectable**.
-    - If you need the ability to dynamically add custom user-generated input outside of the available options, **EuiComboBox** is the only component that offers that functionality.
+    - **EuiComboBox** allows users to search through a list of dropdown options. This functionality is core to the component and cannot be removed, unlike **EuiSelectable**
+    - If you need the ability to dynamically add custom user-generated input outside of the available options, **EuiComboBox** is the only component that offers that functionality
 
 ## Feature comparison chart
 

--- a/packages/website/docs/components/forms/selection/selectable.mdx
+++ b/packages/website/docs/components/forms/selection/selectable.mdx
@@ -5,7 +5,12 @@ keywords: [EuiSelectable, EuiSelectableOption]
 
 # Selectable
 
-**EuiSelectable** aims to make the pattern of a selectable list (with or without search) consistent across implementations. It is the same concept used in [EuiComboBox](./combo-box.mdx) and [EuiFilterGroup](../search-and-filter/filter-group.mdx). **This is not intended for [primary navigation](../../display/list-group.mdx) but can be used to simplify the construction of popover navigational menus; i.e. the spaces menu in the [header](../../layout/header.mdx). See EUI's <a href="https://github.com/elastic/eui/discussions/7049" target="_blank">in-depth guide on which selection component to choose</a> for more information.
+**EuiSelectable** aims to make the pattern of a selectable list (with or without search) consistent across implementations. It is the same concept used in [EuiComboBox](./combo-box.mdx) and [EuiFilterGroup](../search-and-filter/filter-group.mdx).
+
+:::warning It's **not** intended for primary navigation
+
+**EuiSelectable** is not intended for [primary navigation](../../display/list-group.mdx) but can be used to simplify the construction of popover navigational menus; i.e. the spaces menu in the [header](../../layout/header.mdx).
+:::
 
 ## The basics
 


### PR DESCRIPTION
## Summary

On this PR, I:

- [fix(website): remove link to an obsolete GH discussion](https://github.com/elastic/eui/commit/92e14ff06541ed2b93c8c48612ed5b67722c5992)
- [fix(website): improve wording in selection controls overview](https://github.com/elastic/eui/commit/9501262a5b48b621ae9793e862d3515171a27864)

## Why are we making this change?

There was an internal request. A Kibana developer asked about `EuiComboBox` shifting the layout. I suggested to use `EuiSelectable` to work around the issue and when checking out the docs, noticed some lonesome `**`.

After talking to @acstll about the [in-depth guide on choosing the select control](https://github.com/elastic/eui/discussions/7049), I decided to mark it as obsolete, remove the link from `EuiSelectable` and update the overview (the content was already in parity with the GH Discussion).

@acstll also raised the issue that `EuiSelectable` is more discoverable than `EuiSelect` so some developers default to it. That's why I renamed the page to "Component comparison" and added a "Summary" section. 

## Screenshots

### `EuiSelectable` Before (prod)

WIP

### `EuiSelectable` After (staging)

WIP

## Impact to users

🟢 Just a docs change. No impact for users.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- [ ] Verify there are no typos and the content is clear on the EuiSelectable page
- [ ] Verify there are no typos and the content is clear on the Component comparison page
- [ ] Think about what is the most important information and how to highlight it
- [ ] Think about whether the current documentation touches on all important aspects