### PR TITLE
feat(website): add typography utilities documentation

### DIFF
--- a/packages/website/docs/getting-started/theming/utilities/preview_utilities.tsx
+++ b/packages/website/docs/getting-started/theming/utilities/preview_utilities.tsx
@@ -6,11 +6,19 @@ import {
   useEuiTheme,
   EuiTextAlign,
   EuiFlexGrid,
+  EuiFlexGroup,
   EuiFlexItem,
   EuiPanel,
   EuiTextColor,
   EuiCode,
+  EuiText,
+  EuiSpacer,
 } from '@elastic/eui';
+import {
+  euiFontSizeFromScale,
+  euiLineHeightFromBaseline,
+  euiTextShift,
+} from '@elastic/eui/src/global_styling';
 
 const maxWidth = 300;
 const longLink =
@@ -114,26 +122,26 @@ export const NumbersFormatFnPreview = () => {
     <EuiTextAlign textAlign="right">
       <EuiFlexGrid columns={2}>
         <EuiFlexItem>
-          <p>
+          <EuiText>
             <strong>Without function</strong>
-            <br />
+            <EuiSpacer size="s" />
             11317.11
-            <br />
+            <EuiSpacer size="s" />
             0040.900
-          </p>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
-          <p
+          <EuiText
             css={css`
               ${euiNumberFormat(euiTheme)}
             `}
           >
             <strong>With function</strong>
-            <br />
+            <EuiSpacer size="s" />
             11317.11
-            <br />
+            <EuiSpacer size="s" />
             0040.900
-          </p>
+          </EuiText>
         </EuiFlexItem>
       </EuiFlexGrid>
     </EuiTextAlign>
@@ -145,22 +153,22 @@ export const NumbersFormatPreview = () => {
     <EuiTextAlign textAlign="right">
       <EuiFlexGrid columns={2}>
         <EuiFlexItem>
-          <p>
+          <EuiText>
             <strong>Without class</strong>
-            <br />
+            <EuiSpacer size="s" />
             11317.11
-            <br />
+            <EuiSpacer size="s" />
             0040.900
-          </p>
+          </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
-          <p className="eui-textNumber">
+          <EuiText className="eui-textNumber">
             <strong>With class</strong>
-            <br />
+            <EuiSpacer size="s" />
             11317.11
-            <br />
+            <EuiSpacer size="s" />
             0040.900
-          </p>
+          </EuiText>
         </EuiFlexItem>
       </EuiFlexGrid>
     </EuiTextAlign>
@@ -173,5 +181,146 @@ export const ColorInheritPreview = () => {
       <EuiCode className="eui-textInheritColor">I am code</EuiCode> that matches
       the EuiTextColor
     </EuiTextColor>
+  );
+};
+
+export const FontSizeFromScaleFnPreview = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexGrid columns={3}>
+      <EuiFlexItem>
+        <EuiText
+          css={css`
+            font-size: ${euiFontSizeFromScale('s', euiTheme)};
+          `}
+        >
+          <strong>s scale</strong>
+          <EuiSpacer size="s" />
+          This text uses <EuiCode>euiFontSizeFromScale('s')</EuiCode>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText
+          css={css`
+            font-size: ${euiFontSizeFromScale('m', euiTheme)};
+          `}
+        >
+          <strong>m scale</strong>
+          <EuiSpacer size="s" />
+          This text uses <EuiCode>euiFontSizeFromScale('m')</EuiCode>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText
+          css={css`
+            font-size: ${euiFontSizeFromScale('l', euiTheme)};
+          `}
+        >
+          <strong>l scale</strong>
+          <EuiSpacer size="s" />
+          This text uses <EuiCode>euiFontSizeFromScale('l')</EuiCode>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGrid>
+  );
+};
+
+export const LineHeightFromBaselineFnPreview = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexGrid columns={2}>
+      <EuiFlexItem>
+        <EuiText
+          css={css`
+            padding: 0.5em 1em;
+            font-size: ${euiFontSizeFromScale('m', euiTheme)};
+            line-height: 1.5;
+            background-color: rgba(255, 0, 0, 0.1);
+          `}
+        >
+          <strong>Regular line-height: 1.5</strong>
+          <EuiSpacer size="s" />
+          This text uses a regular line-height of 1.5. Notice how it doesn't
+          align to the baseline grid.
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText
+          css={css`
+            padding: 0.5em 1em;
+            font-size: ${euiFontSizeFromScale('m', euiTheme)};
+            line-height: ${euiLineHeightFromBaseline('m', euiTheme)};
+            background-color: rgba(0, 255, 0, 0.1);
+          `}
+        >
+          <strong>Baseline-aligned line-height</strong>
+          <EuiSpacer size="s" />
+          This text uses <EuiCode>euiLineHeightFromBaseline('m')</EuiCode> to
+          align to the baseline grid for consistency.
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGrid>
+  );
+};
+
+export const TextShiftFnPreview = () => {
+  const { euiTheme } = useEuiTheme();
+
+  return (
+    <EuiFlexGrid columns={2}>
+      <EuiFlexItem>
+        <EuiText>
+          Without <EuiCode>euiTextShift</EuiCode>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiPanel
+              paddingSize="s"
+              color="subdued"
+              css={css`
+                cursor: pointer;
+                &:hover {
+                  font-weight: ${euiTheme.font.weight.bold};
+                }
+              `}
+            >
+              Hover me
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiText size="s"> - Notice layout shift on hover</EuiText>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText>
+          With <EuiCode>euiTextShift</EuiCode>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiPanel
+              paddingSize="s"
+              color="subdued"
+              data-text="Hover me" // important for euiTextShift
+              css={css`
+                cursor: pointer;
+
+                ${euiTextShift('bold', 'data-text', euiTheme)}
+                &:hover {
+                  font-weight: ${euiTheme.font.weight.bold};
+                }
+              `}
+            >
+              Hover me
+            </EuiPanel>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText size="s"> - No layout shift on hover</EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGrid>
   );
 };

--- a/packages/website/docs/getting-started/theming/utilities/preview_utilities.tsx
+++ b/packages/website/docs/getting-started/theming/utilities/preview_utilities.tsx
@@ -18,7 +18,7 @@ import {
   euiFontSizeFromScale,
   euiLineHeightFromBaseline,
   euiTextShift,
-} from '@elastic/eui/src/global_styling';
+} from '@elastic/eui';
 
 const maxWidth = 300;
 const longLink =

--- a/packages/website/docs/getting-started/theming/utilities/typography.mdx
+++ b/packages/website/docs/getting-started/theming/utilities/typography.mdx
@@ -5,8 +5,11 @@ sidebar_label: Typography
 
 # Typography utilities
 
+```mdx-code-block
+import { css } from '@emotion/react';
 import { Example } from '@site/src/components';
-import { EuiSpacer } from '@elastic/eui';
+import { EuiCallOut, EuiCode, EuiSpacer, EuiText } from '@elastic/eui';
+```
 
 ## Alignment
 
@@ -73,7 +76,9 @@ import { EuiSpacer } from '@elastic/eui';
 
 ## Wrapping
 
+```mdx-code-block
 import { WrappingTextTruncateFnPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -100,7 +105,9 @@ import { WrappingTextTruncateFnPreview } from './preview_utilities';
 
 <EuiSpacer />
 
+```mdx-code-block
 import { WrappingTextTruncatePreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -148,7 +155,9 @@ import { WrappingTextBreakWordFnPreview } from './preview_utilities';
 
 <EuiSpacer />
 
+```mdx-code-block
 import { WrappingTextBreakWordPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -171,7 +180,9 @@ import { WrappingTextBreakWordPreview } from './preview_utilities';
 
 <EuiSpacer />
 
+```mdx-code-block
 import { WrappingTextNoWrapPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -194,7 +205,9 @@ import { WrappingTextNoWrapPreview } from './preview_utilities';
 
 <EuiSpacer />
 
+```mdx-code-block
 import { WrappingTextBreakAllPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -217,7 +230,9 @@ import { WrappingTextBreakAllPreview } from './preview_utilities';
 
 <EuiSpacer />
 
+```mdx-code-block
 import { WrappingTextBreakNormalPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -240,7 +255,9 @@ import { WrappingTextBreakNormalPreview } from './preview_utilities';
 
 ## Numbers
 
+```mdx-code-block
 import { NumbersFormatFnPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -263,7 +280,9 @@ import { NumbersFormatFnPreview } from './preview_utilities';
 
 <EuiSpacer />
 
+```mdx-code-block
 import { NumbersFormatPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -286,7 +305,9 @@ import { NumbersFormatPreview } from './preview_utilities';
 
 ## Color
 
+```mdx-code-block
 import { ColorInheritPreview } from './preview_utilities';
+```
 
 <Example>
   <Example.Description>
@@ -305,6 +326,94 @@ import { ColorInheritPreview } from './preview_utilities';
     <EuiTextColor color="danger">
       <EuiCode className="eui-textInheritColor">I am danger code</EuiCode>
     </EuiTextColor>
+    ```
+  </Example.Snippet>
+</Example>
+
+## Size
+
+```mdx-code-block
+import { FontSizeFromScaleFnPreview } from './preview_utilities';
+```
+
+<Example>
+  <Example.Description>
+    ### `euiFontSizeFromScale(scale, euiTheme, options?)` <Badge color="hollow">function</Badge>
+
+    Calculates font-size values using the theme's scale system for consistent typography.
+
+    Accepts a scale key (`'xxxs'`, `'xxs'`, `'xs'`, `'s'`, `'m'`, `'l'`, `'xl'`, `'xxl'`), the `euiTheme` object, and optional parameters for unit or custom scaling.
+
+  </Example.Description>
+  <Example.Preview>
+    <FontSizeFromScaleFnPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    css`
+      font-size: ${euiFontSizeFromScale('m', euiTheme)};
+    `
+    ```
+  </Example.Snippet>
+</Example>
+
+<EuiSpacer />
+
+```mdx-code-block
+import { LineHeightFromBaselineFnPreview } from './preview_utilities';
+```
+
+<Example>
+  <Example.Description>
+    ### `euiLineHeightFromBaseline(scale, euiTheme, options?)` <Badge color="hollow">function</Badge>
+
+    Calculates line-height values aligned to the baseline grid for consistent vertical rhythm.
+
+    Uses the same scale system as `euiFontSizeFromScale` and automatically adjusts to maintain baseline alignment.
+
+  </Example.Description>
+  <Example.Preview>
+    <LineHeightFromBaselineFnPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    css`
+      line-height: ${euiLineHeightFromBaseline('m', euiTheme)};
+    `
+    ```
+  </Example.Snippet>
+</Example>
+
+<EuiSpacer />
+
+```mdx-code-block
+import { TextShiftFnPreview } from './preview_utilities';
+```
+
+<Example>
+  <Example.Description>
+    ### `euiTextShift(fontWeight?, attribute?, euiTheme)` <Badge color="hollow">function</Badge>
+
+    Prevents layout shift when changing font-weight on hover or focus. Creates an invisible pseudo-element to reserve space for the bold weight.
+
+    Useful for interactive text that changes weight on state changes.
+
+    <EuiCallOut iconType="warning" color="warning" title={<EuiText css={css`display: inline;`}>Remember to pass <EuiCode>data-text</EuiCode> attribute!</EuiText>}>
+      This is important for <EuiCode>euiTextShift</EuiCode> to work correctly.
+    </EuiCallOut>
+
+  </Example.Description>
+  <Example.Preview>
+    <TextShiftFnPreview />
+  </Example.Preview>
+  <Example.Snippet>
+    ```tsx
+    css`
+      ${euiTextShift('bold', 'data-text', euiTheme)}
+      &:hover {
+        font-weight: ${euiTheme.font.weight.bold};
+      }
+    `
     ```
   </Example.Snippet>
 </Example>


### PR DESCRIPTION
## Summary

I'm adding a documentation for:
- `euiFontSizeFromScale`
- `euiLineHeightFromBaseline`
- `euiTextShift`

## Why are we making this change?

There was an internal request from a Kibana developer. They were migrating Sass and wanted to replace `lineHeightFromBaseline` with `euiLineHeightFromBaseline`. 

I noticed that there is no documentation around those utilities we export and they confirmed it would help them if there was documentation.

## Screenshots

<img width="986" height="947" alt="Screenshot 2025-07-25 at 14 37 05" src="https://github.com/user-attachments/assets/cc310b4b-4b3d-4c66-8dea-a92144e361fa" />
<img width="983" height="604" alt="Screenshot 2025-07-25 at 14 37 11" src="https://github.com/user-attachments/assets/51ce3a1a-5f5b-4fce-84b9-d497f3e8553c" />

## Impact to users

🟢 Just a docs change. No impact on users.

## QA

- [x] Verify that all typography utilities are correctly documented in [the new section](https://eui.elastic.co/pr_8913/docs/getting-started/theming/utilities/typography/#size)
