### PR TITLE
[EuiLiveAnnouncer][A11y] Support live announcements on mount

### DIFF
--- a/packages/eui/changelogs/upcoming/8916.md
+++ b/packages/eui/changelogs/upcoming/8916.md
@@ -1,0 +1,5 @@
+**Accessibility**
+
+- Added a new beta `EuiLiveAnnouncer` component which supports `aria-live` announcements on mount
+- Added `announceOnMount` prop on `EuiCallOut` to support announcing its content on mount
+

--- a/packages/eui/src/components/accessibility/index.ts
+++ b/packages/eui/src/components/accessibility/index.ts
@@ -12,3 +12,4 @@ export { EuiScreenReaderOnly, euiScreenReaderOnly } from './screen_reader_only';
 export type { EuiScreenReaderOnlyProps } from './screen_reader_only';
 export { EuiSkipLink } from './skip_link';
 export type { EuiSkipLinkProps } from './skip_link';
+export { type EuiLiveAnnouncerProps, EuiLiveAnnouncer } from './live_announcer';

--- a/packages/eui/src/components/accessibility/live_announcer/__snapshots__/live_announcer.test.tsx.snap
+++ b/packages/eui/src/components/accessibility/live_announcer/__snapshots__/live_announcer.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiLiveAnnouncer renders screen reader content when active 1`] = `
+<div
+  aria-atomic="true"
+  aria-live="polite"
+  class="emotion-euiScreenReaderOnly"
+  role="status"
+>
+  You have new notifications.
+</div>
+`;

--- a/packages/eui/src/components/accessibility/live_announcer/index.ts
+++ b/packages/eui/src/components/accessibility/live_announcer/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export * from './live_announcer';

--- a/packages/eui/src/components/accessibility/live_announcer/live_announcer.stories.tsx
+++ b/packages/eui/src/components/accessibility/live_announcer/live_announcer.stories.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { ReactNode, useEffect, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { EuiLiveAnnouncer, EuiLiveAnnouncerProps } from './live_announcer';
+import { EuiFlexGroup, EuiFlexItem } from '../../flex';
+import { EuiButton } from '../../button';
+import { EuiCodeBlock } from '../../code';
+import { EuiSpacer } from '../../spacer';
+import { EuiCallOut } from '../../call_out';
+import { EuiFlyout, EuiFlyoutBody } from '../../flyout';
+
+const meta: Meta<EuiLiveAnnouncerProps> = {
+  title: 'Utilities/EuiLiveAnnouncer',
+  component: EuiLiveAnnouncer,
+  args: {
+    // Component defaults
+    role: 'status',
+    isActive: true,
+  },
+  parameters: {
+    loki: {
+      // There are no visual elements to test
+      skip: true,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<EuiLiveAnnouncerProps>;
+
+export const Playground: Story = {
+  parameters: {
+    codeSnippet: {
+      snippet: `
+        <EuiLiveAnnouncer {{...STORY_ARGS}}>{message}</EuiLiveAnnouncer>
+      `,
+    },
+  },
+  args: {
+    children: 'You have new notifications',
+  },
+  render: function Render(args) {
+    const { children, ...rest } = args;
+    const [announcement, setAnnouncement] = useState<ReactNode>(children);
+    const [isAnnouncementShown, setAnnouncementShown] = useState(false);
+
+    useEffect(() => {
+      setAnnouncement(children);
+    }, [children]);
+
+    const updateAnnouncement = () => {
+      setAnnouncement(
+        `You have ${Math.floor(Math.random() * 1000)} new notifications.`
+      );
+    };
+
+    return (
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ maxWidth: 300 }}>
+        <EuiFlexItem>
+          <EuiButton onClick={() => setAnnouncementShown((shown) => !shown)}>
+            Toggle announcement
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          {isAnnouncementShown && (
+            <>
+              <EuiButton onClick={updateAnnouncement}>
+                Update announcement
+              </EuiButton>
+              <EuiSpacer size="m" />
+              <EuiCodeBlock>{announcement}</EuiCodeBlock>
+              <EuiLiveAnnouncer {...rest}>{announcement}</EuiLiveAnnouncer>
+            </>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  },
+};
+
+export const WithinFlyouts: Story = {
+  parameters: {
+    codeSnippet: {
+      skip: true,
+    },
+  },
+  args: {
+    children: 'You have new notifications',
+  },
+  render: function Render(args) {
+    const { children, ...rest } = args;
+    const [isFlyoutOpen, setFlyoutOpen] = useState(false);
+    const [announcement, setAnnouncement] = useState<ReactNode>(children);
+    const [isShown, setShown] = useState(false);
+
+    useEffect(() => {
+      setAnnouncement(children);
+    }, [children]);
+
+    const updateAnnouncement = () => {
+      setAnnouncement(
+        `You have ${Math.floor(Math.random() * 1000)} new notifications.`
+      );
+    };
+
+    const content = (
+      <>
+        <div>
+          <EuiButton onClick={updateAnnouncement}>
+            Update announcement
+          </EuiButton>
+          <EuiSpacer size="m" />
+          <EuiCodeBlock>{announcement}</EuiCodeBlock>
+          <EuiLiveAnnouncer {...rest}>{announcement}</EuiLiveAnnouncer>
+        </div>
+        <EuiSpacer size="xl" />
+        <EuiButton onClick={() => setShown((show) => !show)}>
+          Toggle CallOut
+        </EuiButton>
+        {isShown && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              announceOnMount
+              onDismiss={() => setShown(false)}
+              title="Important notification!"
+            >
+              {/* long text is for testing clearTimeout functionality */}
+              <span>
+                Lorem Ipsum is simply dummy text of the printing and typesetting
+                industry. Lorem Ipsum has been the industry's standard dummy
+                text ever since the 1500s, when an unknown printer took a galley
+                of type and scrambled it to make a type specimen book. It has
+                survived not only five centuries, but also the leap into
+                electronic typesetting, remaining essentially unchanged. It was
+                popularised in the 1960s with the release of Letraset sheets
+                containing Lorem Ipsum passages, and more recently with desktop
+                publishing software like Aldus PageMaker including versions of
+                Lorem Ipsum.
+              </span>
+            </EuiCallOut>
+          </>
+        )}
+      </>
+    );
+
+    return (
+      <>
+        <EuiButton onClick={() => setFlyoutOpen((open) => !open)}>
+          Toggle flyout
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={() => setFlyoutOpen(false)}>
+            <EuiFlyoutBody>{content}</EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
+  },
+};

--- a/packages/eui/src/components/accessibility/live_announcer/live_announcer.test.tsx
+++ b/packages/eui/src/components/accessibility/live_announcer/live_announcer.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { ReactElement } from 'react';
+import { act } from '@testing-library/react';
+import { screen, render } from '../../../test/rtl';
+
+import { EuiLiveAnnouncer } from './live_announcer';
+
+const content = 'You have new notifications.';
+
+const renderComponent = (component: ReactElement) => {
+  const testArgs = render(component);
+
+  act(() => {
+    jest.advanceTimersByTime(50);
+  });
+
+  return testArgs;
+};
+
+describe('EuiLiveAnnouncer', () => {
+  jest.useFakeTimers();
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('renders screen reader content when active', () => {
+    const { container } = renderComponent(
+      <EuiLiveAnnouncer isActive={true}>{content}</EuiLiveAnnouncer>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders `children` as string correctly', () => {
+    renderComponent(<EuiLiveAnnouncer>{content}</EuiLiveAnnouncer>);
+
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region).toHaveAttribute('aria-atomic', 'true');
+    expect(region).toHaveTextContent('You have new notifications.');
+  });
+
+  it('renders `children` as ReactNode correctly', () => {
+    renderComponent(<EuiLiveAnnouncer>{content}</EuiLiveAnnouncer>);
+
+    const region = screen.getByRole('status').firstChild;
+    expect(region).toHaveTextContent('You have new notifications.');
+  });
+
+  it('clears the message after `clearAfterMs`', () => {
+    renderComponent(
+      <EuiLiveAnnouncer clearAfterMs={1000}>{content}</EuiLiveAnnouncer>
+    );
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('You have new notifications.');
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(region).toHaveTextContent('');
+  });
+
+  it('does not clear the message if `clearAfterMs=false`', () => {
+    renderComponent(
+      <EuiLiveAnnouncer clearAfterMs={false}>{content}</EuiLiveAnnouncer>
+    );
+    const region = screen.getByRole('status');
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(region).toHaveTextContent('You have new notifications.');
+  });
+
+  it('sets `aria-live` to off when `isActive=false`', () => {
+    renderComponent(
+      <EuiLiveAnnouncer isActive={false}>{content}</EuiLiveAnnouncer>
+    );
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'off');
+  });
+
+  it('sets custom `role` and `aria-live`', () => {
+    renderComponent(
+      <EuiLiveAnnouncer role="alert" aria-live="assertive">
+        {content}
+      </EuiLiveAnnouncer>
+    );
+    const region = screen.getByRole('alert');
+    expect(region).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('updates the message when `children` change', () => {
+    const { rerender } = renderComponent(
+      <EuiLiveAnnouncer>{content}</EuiLiveAnnouncer>
+    );
+    const region = screen.getByRole('status');
+    expect(region).toHaveTextContent('You have new notifications.');
+    rerender(
+      <EuiLiveAnnouncer>You have additional notifications.</EuiLiveAnnouncer>
+    );
+    expect(region).toHaveTextContent('You have additional notifications.');
+  });
+});

--- a/packages/eui/src/components/accessibility/live_announcer/live_announcer.tsx
+++ b/packages/eui/src/components/accessibility/live_announcer/live_announcer.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  FunctionComponent,
+  ReactNode,
+  useEffect,
+  useState,
+  isValidElement,
+} from 'react';
+
+import { EuiScreenReaderOnly } from '../screen_reader_only';
+import { EuiScreenReaderLiveProps } from '../screen_reader_live';
+
+export type EuiLiveAnnouncerProps = Omit<
+  EuiScreenReaderLiveProps,
+  'focusRegionOnTextChange'
+> & {
+  /**
+   * Sets a delay in ms before the live region is cleared.
+   * The message will still be read by screen readers even if it's cleared in between.
+   *
+   * @default 2000
+   */
+  clearAfterMs?: number | false;
+};
+
+export const EuiLiveAnnouncer: FunctionComponent<EuiLiveAnnouncerProps> = ({
+  children,
+  clearAfterMs = 2000,
+  isActive = true,
+  role = 'status',
+  'aria-live': ariaLive = 'polite',
+  ...rest
+}) => {
+  const [content, setContent] = useState<ReactNode>('');
+  const [isMounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (!isMounted) {
+      setTimeout(() => {
+        // set isMounted with a small delay to trigger an render update after first render
+        setMounted(true);
+      }, 50);
+    }
+
+    return () => {
+      setMounted(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout | undefined;
+
+    if (children) {
+      setContent(isValidElement(children) ? children : <>{children}</>);
+    }
+
+    if (clearAfterMs) {
+      timeout = setTimeout(() => {
+        setContent('');
+      }, clearAfterMs);
+    }
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [children, clearAfterMs]);
+
+  return (
+    <EuiScreenReaderOnly>
+      <div
+        role={role}
+        aria-live={isActive ? ariaLive : 'off'}
+        aria-atomic="true"
+        {...rest}
+      >
+        {isMounted && content}
+      </div>
+    </EuiScreenReaderOnly>
+  );
+};

--- a/packages/eui/src/components/accessibility/screen_reader_live/screen_reader_live.stories.tsx
+++ b/packages/eui/src/components/accessibility/screen_reader_live/screen_reader_live.stories.tsx
@@ -6,12 +6,18 @@
  * Side Public License, v 1.
  */
 
+import React, { ReactNode, useEffect, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import {
   EuiScreenReaderLive,
   EuiScreenReaderLiveProps,
 } from './screen_reader_live';
+import { EuiFlexGroup, EuiFlexItem } from '../../flex';
+import { EuiButton } from '../../button';
+import { EuiCodeBlock } from '../../code';
+import { EuiSpacer } from '../../spacer';
+import { EuiFlyout, EuiFlyoutBody } from '../../flyout';
 
 const meta: Meta<EuiScreenReaderLiveProps> = {
   title: 'Utilities/EuiScreenReaderLive',
@@ -34,7 +40,107 @@ export default meta;
 type Story = StoryObj<EuiScreenReaderLiveProps>;
 
 export const Playground: Story = {
+  parameters: {
+    codeSnippet: {
+      snippet: `
+        <EuiScreenReaderLive {{...STORY_ARGS}}>{message}</EuiScreenReaderLive>
+      `,
+    },
+  },
   args: {
     children: 'You have new notifications',
+  },
+  render: function Render(args) {
+    const { children, ...rest } = args;
+    const [announcement, setAnnouncement] = useState<ReactNode>(children);
+    const [isAnnouncementShown, setAnnouncementShown] = useState(false);
+
+    useEffect(() => {
+      setAnnouncement(children);
+    }, [children]);
+
+    const updateAnnouncement = () => {
+      setAnnouncement(
+        `You have ${Math.floor(Math.random() * 1000)} new notifications.`
+      );
+    };
+
+    return (
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ maxWidth: 300 }}>
+        <EuiFlexItem>
+          <EuiButton onClick={() => setAnnouncementShown((shown) => !shown)}>
+            Toggle announcement
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          {isAnnouncementShown && (
+            <>
+              <EuiButton onClick={updateAnnouncement}>
+                Update announcement
+              </EuiButton>
+              <EuiSpacer size="m" />
+              <EuiCodeBlock>{announcement}</EuiCodeBlock>
+              <EuiScreenReaderLive {...rest}>
+                {announcement}
+              </EuiScreenReaderLive>
+            </>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  },
+};
+
+export const WithinFlyouts: Story = {
+  parameters: {
+    codeSnippet: {
+      skip: true,
+    },
+  },
+  args: {
+    children: 'You have new notifications',
+  },
+  render: function Render(args) {
+    const { children, ...rest } = args;
+    const [isFlyoutOpen, setFlyoutOpen] = useState(false);
+    const [announcement, setAnnouncement] = useState<ReactNode>(children);
+
+    useEffect(() => {
+      setAnnouncement(children);
+    }, [children]);
+
+    const updateAnnouncement = () => {
+      setAnnouncement(
+        `You have ${Math.floor(Math.random() * 1000)} new notifications.`
+      );
+    };
+
+    const content = (
+      <>
+        <div>
+          <EuiButton onClick={updateAnnouncement}>
+            Update announcement
+          </EuiButton>
+          <EuiSpacer size="m" />
+          <EuiCodeBlock>{announcement}</EuiCodeBlock>
+          <EuiScreenReaderLive {...rest}>{announcement}</EuiScreenReaderLive>
+        </div>
+      </>
+    );
+
+    return (
+      <>
+        <EuiButton onClick={() => setFlyoutOpen((open) => !open)}>
+          Toggle flyout
+        </EuiButton>
+
+        {isFlyoutOpen && (
+          <EuiFlyout onClose={() => setFlyoutOpen(false)}>
+            <EuiFlyoutBody>{content}</EuiFlyoutBody>
+          </EuiFlyout>
+        )}
+      </>
+    );
   },
 };

--- a/packages/eui/src/components/accessibility/screen_reader_live/screen_reader_live.tsx
+++ b/packages/eui/src/components/accessibility/screen_reader_live/screen_reader_live.tsx
@@ -31,10 +31,14 @@ export interface EuiScreenReaderLiveProps {
    * `role` attribute for both live regions.
    *
    * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#roles_with_implicit_live_region_attributes
+   *
+   * @default 'status'
    */
   role?: HTMLAttributes<HTMLDivElement>['role'];
   /**
    * `aria-live` attribute for both live regions
+   *
+   * @default 'polite'
    */
   'aria-live'?: AriaAttributes['aria-live'];
   /**
@@ -42,6 +46,8 @@ export interface EuiScreenReaderLiveProps {
    * to automatically read out the text content. This prop should primarily be used for
    * navigation or page changes, where programmatically resetting focus location back to
    * a certain part of the page is desired.
+   *
+   * @default false
    */
   focusRegionOnTextChange?: boolean;
 }
@@ -86,6 +92,7 @@ export const EuiScreenReaderLive: FunctionComponent<
           aria-atomic="true"
           // Setting `aria-hidden` and setting `aria-live` to "off" prevents
           // double announcements from VO when `focusRegionOnTextChange` is true
+          // WARNING: This solves the issue in VO/Chrome but results in VO/Safari not reading anything at all
           aria-hidden={toggle ? undefined : 'true'}
           aria-live={!toggle || focusRegionOnTextChange ? 'off' : ariaLive}
         >

--- a/packages/eui/src/components/call_out/call_out.stories.tsx
+++ b/packages/eui/src/components/call_out/call_out.stories.tsx
@@ -6,8 +6,10 @@
  * Side Public License, v 1.
  */
 
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { EuiButton } from '../button';
 import { EuiCallOut, EuiCallOutProps } from './call_out';
 
 const meta: Meta<EuiCallOutProps> = {
@@ -31,5 +33,35 @@ export const Playground: Story = {
   args: {
     title: 'Callout title',
     children: 'Callout text',
+  },
+};
+
+export const AnnounceOnMount: Story = {
+  parameters: {
+    controls: {
+      include: ['children', 'announceOnMount'],
+    },
+    loki: {
+      skip: true,
+    },
+  },
+  args: {
+    title: 'Callout title',
+    children: 'Callout text',
+    announceOnMount: true,
+  },
+  render: function Render() {
+    const [isShown, setShown] = useState(false);
+
+    return (
+      <>
+        <EuiButton onClick={() => setShown(!isShown)}>Toggle CallOut</EuiButton>
+        {isShown && (
+          <EuiCallOut title="Callout title" announceOnMount>
+            Callout text
+          </EuiCallOut>
+        )}
+      </>
+    );
   },
 };

--- a/packages/eui/src/components/call_out/call_out.test.tsx
+++ b/packages/eui/src/components/call_out/call_out.test.tsx
@@ -7,9 +7,9 @@
  */
 
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../test/required_props';
-import { render } from '../../test/rtl';
+import { render, screen } from '../../test/rtl';
 
 import { EuiCallOut, COLORS, HEADINGS } from './call_out';
 
@@ -63,12 +63,60 @@ describe('EuiCallOut', () => {
 
     test('onDismiss', () => {
       const onDismiss = jest.fn();
-      const { getByTestSubject } = render(
-        <EuiCallOut onDismiss={onDismiss}>Content</EuiCallOut>
-      );
+      render(<EuiCallOut onDismiss={onDismiss}>Content</EuiCallOut>);
 
-      fireEvent.click(getByTestSubject('euiDismissCalloutButton'));
+      fireEvent.click(screen.getByTestSubject('euiDismissCalloutButton'));
       expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    describe('announceOnMount', () => {
+      jest.useFakeTimers();
+
+      afterEach(() => {
+        jest.clearAllTimers();
+      });
+
+      it('announces the callout content in an aria-live region when announceOnMount is true', () => {
+        render(
+          <EuiCallOut announceOnMount title="Announcement title">
+            Announcement content
+          </EuiCallOut>
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(50);
+        });
+
+        // The live region should exist and contain the announcement
+        const liveRegion = screen.getByRole('status');
+        expect(liveRegion).toHaveTextContent(
+          'Announcement title, Announcement content'
+        );
+      });
+
+      it('clears the announcement after 2000ms', () => {
+        render(
+          <EuiCallOut announceOnMount title="Announcement title">
+            Announcement content
+          </EuiCallOut>
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(50);
+        });
+
+        // The live region should exist and contain the announcement
+        const liveRegion = screen.getByRole('status');
+        expect(liveRegion).toHaveTextContent(
+          'Announcement title, Announcement content'
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(2000);
+        });
+
+        expect(liveRegion).toHaveTextContent('');
+      });
     });
   });
 });

--- a/packages/eui/src/components/call_out/call_out.tsx
+++ b/packages/eui/src/components/call_out/call_out.tsx
@@ -19,6 +19,7 @@ import { EuiPanel } from '../panel';
 import { EuiSpacer } from '../spacer';
 import { EuiTitle } from '../title';
 import { EuiI18n } from '../i18n';
+import { EuiLiveAnnouncer } from '../accessibility/live_announcer';
 
 import { euiCallOutStyles, euiCallOutHeaderStyles } from './call_out.styles';
 
@@ -51,6 +52,13 @@ export type EuiCallOutProps = CommonProps &
      * removing the callout or other actions.
      */
     onDismiss?: () => void;
+    /**
+     * Enables the content to be read by screen readers on mount.
+     * Use this for callouts that are shown based on a user action.
+     *
+     * @default false
+     */
+    announceOnMount?: boolean;
   };
 
 export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
@@ -64,6 +72,7 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
       className,
       heading = 'p',
       onDismiss,
+      announceOnMount = false,
       ...rest
     },
     ref
@@ -170,6 +179,12 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
             </>
           )
         }
+        {announceOnMount && (title || children) && (
+          <EuiLiveAnnouncer clearAfterMs={2000}>
+            {title && `${title}, `}
+            {children}
+          </EuiLiveAnnouncer>
+        )}
       </EuiPanel>
     );
   }

--- a/packages/eui/src/components/call_out/call_out.tsx
+++ b/packages/eui/src/components/call_out/call_out.tsx
@@ -180,7 +180,7 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
           )
         }
         {announceOnMount && (title || children) && (
-          <EuiLiveAnnouncer clearAfterMs={2000}>
+          <EuiLiveAnnouncer>
             {title && `${title}, `}
             {children}
           </EuiLiveAnnouncer>

--- a/packages/website/docs/components/display/callout.mdx
+++ b/packages/website/docs/components/display/callout.mdx
@@ -241,6 +241,44 @@ export default () => {
 };
 ```
 
+### Screen reader announcements
+
+`EuiCallOut` supports announcing its content to screen readers when it first appears using the `announceOnMount` prop. 
+When enabled, the callout's title and content will be announced via an `aria-live` region. The announcement will be cleared after 2 seconds 
+to prevent duplicate DOM content but screen readers will continue reading the message even after it's cleared.
+
+Generally you won't need this prop when a callout is rendered on initial page load, as screen readers will encounter the content during normal page navigation.
+Use `announceOnMount` when the callout appears as the result of a user action or contains information that needs immediate attention.
+
+
+```tsx interactive
+import React, { useState } from 'react';
+import { EuiCallOut, EuiButton, EuiSpacer } from '@elastic/eui';
+
+export default () => {
+  const [isShown, setIsShown] = useState(false);
+
+  return (
+    <>
+      <EuiButton onClick={() => setIsShown(!isShown)}>
+        {isShown ? 'Hide' : 'Show'} callout
+      </EuiButton>
+      <EuiSpacer />
+      {isShown && (
+        <EuiCallOut
+          title="Important notification!"
+          color="accent"
+          announceOnMount
+        >
+          <p>This content will be announced to screen readers when it appears.</p>
+        </EuiCallOut>
+      )}
+    </>
+  );
+};
+```
+
+
 ## Guidelines
 
 **Keep these guidelines in mind:**

--- a/packages/website/docs/utilities/accessibility/index.mdx
+++ b/packages/website/docs/utilities/accessibility/index.mdx
@@ -190,6 +190,81 @@ This is primarily useful for announcing navigation or page changes, when program
   ```
 </Demo>
 
+import { EuiBetaBadge } from '@elastic/eui';
+
+## Live announcer region <EuiBetaBadge label="Beta" color="accent" />
+
+:::warning `EuiLiveAnnouncer` is a new, experimental alternative to `EuiScreenReaderLive` for screen reader live region announcements. 
+Its API and behavior may change based on feedback and testing.
+:::
+
+Both `EuiLiveAnnouncer` and `EuiScreenReaderLive` are designed for the **same use cases**: to announce dynamic content, such as nodifications or status changes based on user interaction.
+The main drawback for live regions is that they must be present on initial page load before reading content updates. `EuiLiveAnnouncer` addresses this 
+by updating the content after the initial render to ensure an announcement is made when mounting a component.
+
+Same as for `EuiScreenReaderLive`, `EuiLiveAnnouncer` supports configurable `role` and `aria-live` props which default to `status` and `polite` respectively for non-intrusive but timely update announcements. 
+If you're not using the default values, be sure to follow [ARIA guidelines](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) for `role` to `aria-live` mapping.
+
+### Main difference
+
+- **`EuiLiveAnnouncer`** will announce the message **when the component mounts** (e.g., when it first appears in the DOM), as well as when the message changes.
+- **`EuiScreenReaderLive`** will only announce when the message changes, and will not announce the initial message on mount.
+
+This means `EuiLiveAnnouncer` is especially useful for scenarios where you want to ensure an announcement is made immediately when a component is mounted, e.g. showing a notification or alert based on user interaction.
+
+An additional difference is that `EuiLiveAnnouncer` can clear its message after a configurable timeout via `clearAfterMs`, which prevents stale 
+announcements and duplicated DOM content for screen reader users. Screen readers will continue reading the message even if it was already cleared.
+
+<Demo>
+  ```tsx
+  import { useState } from 'react';
+  import { EuiButton, EuiLiveAnnouncer, EuiSpacer } from '@elastic/eui';
+
+  export default () => {
+    const [announcement, setAnnouncement] = useState('No notifications.');
+    const [isShown, setIsShown] = useState(false);
+
+    return (
+      <EuiFlexGroup direction="column" gutterSize="m" css={{ maxWidth: 300 }}>
+        <EuiFlexItem>
+          <EuiButton onClick={() => setIsShown((shown) => !shown)}>
+            Toggle announcement
+          </EuiButton>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          {isShown && (
+            <>
+              <EuiButton onClick={() => setAnnouncement(`You have ${Math.floor(Math.random() * 1000)} new notifications.`)}>
+                Update announcement
+              </EuiButton>
+              <EuiSpacer size="m" />
+              <EuiCodeBlock>{announcement}</EuiCodeBlock>
+              <EuiLiveAnnouncer>
+                {announcement}
+              </EuiLiveAnnouncer>
+            </>
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  };
+  ```
+</Demo>
+
+### Key differences between `EuiLiveAnnouncer` and `EuiScreenReaderLive`
+
+| Feature                        | `EuiLiveAnnouncer`       | `EuiScreenReaderLive`           |
+|--------------------------------|:---------------------------------:|:-------------------------------:|
+| **Auto-clear message**         | Yes, after configurable timeout (`clearAfterMs`) | No                    |
+| **Announce on mount**          | Yes                                | No                    |
+| **Announce on message change** | Yes                                | Yes                   |
+| **Focus on message change**    | No                                 | Yes (`focusRegionOnTextChange` prop) |
+| **Handles rapid updates**      | Yes                                | Yes                   |
+| **Output consistency**         | High                               | Medium                   |
+| **API stability**              | Beta/experimental                  | Stable                |
+
+
 ## Skip link
 
 The `EuiSkipLink` component allows users to bypass navigation, or ornamental elements, and quickly reach the main content of the page. It requires a `destinationId` which should match the `id` of your main content. If your ID does not correspond to a valid element, the skip link will fall back to focusing the `<main>` tag on your page, if it exists.
@@ -288,4 +363,5 @@ import docgen from '@elastic/eui-docgen/dist/components';
 
 <PropTable definition={docgen.EuiScreenReaderOnly} />
 <PropTable definition={docgen.EuiScreenReaderLive} />
+<PropTable definition={docgen.EuiLiveAnnouncer} />
 <PropTable definition={docgen.EuiSkipLink} />


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8821

This PR introduces a new component: `EuiLiveAnnouncer`. This component aims to provide an alternative way (to `EuiScreenReaderLive`) of handling live region announcements.

### Information about the testing scope

It's not feasible for us to test all possible screen reader and browser combinations but we can determine a set that covers the majority of users. Based on the [latest screen reader survey](https://webaim.org/projects/screenreadersurvey10/#browsers) we can make some generic assumptions:

If we test the following combinations we can cover ~ 74% of usages:

- JAWS/Chrome
- NVDA/Chrome
- JAWS/Edge (Chromium based)
- NVDA/Firefox
- VoiceOver/Safari

<img width="846" height="602" alt="Screenshot 2025-07-28 at 09 48 27" src="https://github.com/user-attachments/assets/3894ae20-50cc-482a-b629-ddfcb11166e6" />

### The Problem(s)

The limitation of `aria-live` regions is that they have to be loaded and available in the DOM before content changes are being read out by screen readers. This means that the available component `EuiScreenReaderLive` currently only reads content updates, but it does not read the content on mount.

`EuiScreenReaderLive` relies on two sibling `aria-live` regions which receive content updates in turn. This pattern aims to ensure predictable output even if announcements happen in rapid succession or identical content is passed.
Unfortunately this implementation showed flaws when testing. Especially the oscillating `aria-hidden` and `aria-live` attributes ([code](https://github.com/elastic/eui/blob/main/packages/eui/src/components/accessibility/screen_reader_live/screen_reader_live.tsx#L89)) cause varying output behaviors across different screen reader and browser combinations. It leads to announcements being skipped at time or not being read at all in some testing scenarios.

🚫 **The current implementation results in no content being read at all in VoiceOver/Safari.**

### The proposed solution(s)

`EuiLiveAnnouncer` aims to provide support for announcements on mount, e.g. when showing UI based on user interaction. Additionally `EuiLiveAnnouncer` proposes a different approach to handling `aria-live` announcements to improve the output support and consistency across screen reader and browser combinations.

>[!IMPORTANT]
`EuiLiveAnnouncer` is being added as standalone component next to `EuiScreenReaderLive` to test it while being in Beta status. This way we can adjust and compare behaviors. If the component proves to behave better than `EuiScreenReaderLive` across the board, the plan would be to replace `EuiScreenReaderLive` with `EuiLiveAnnouncer`.

### How it's done

1. Announcements on mount

`EuiLiveAnnouncer` utilizes a minimal timeout on mount of the component to set the passed content. This means initially the DOM element renders without content and is being updated shortly after with the expected content. This ensures the content is read as an update to the DOM element happened.

2. Improve consistency of announcements

Instead of using two sibling elements that alternate being updated with content, `EuiLiveAnnouncer` uses a single DOM element and utilizes React state to set content and trigger re-renders.
Additionally it clears the content after a configurable timeout which ensures that duplicate content can be read as well as preventing duplicate content being available in the DOM for screen reader users to navigate.

>[!NOTE]
Clearing the content did not result in any issues when testing. A message that a screen reader started to read, was being read even after the content was cleared.

### Component comparison

| Feature                        | `EuiLiveAnnouncer`       | `EuiScreenReaderLive`           |
|--------------------------------|:---------------------------------:|:-------------------------------:|
| **Auto-clear message**         | Yes, after configurable timeout (`clearAfterMs`) | No                    |
| **Announce on mount**          | Yes                                | No                    |
| **Announce on message change** | Yes                                | Yes                   |
| **Focus on message change**    | No (could be added)                                 | Yes (`focusRegionOnTextChange` prop) |
| **Handles rapid updates**      | Yes                                | Yes                   |
| **Output consistency**              | High                 | Medium                |
| **API stability**              | Beta/experimental                  | Stable                |

### Known limitations and issues

#### Generic
  - 🤷‍♀️ VoiceOver will at times read announcements twice in default Storybook view (it works as expected when viewing stories in standalone page view or actual implementations)

#### `EuiLiveAnnouncer`
  
| Issue | screen reader | recordings |
|---|---|---|
| ⚠️ Announcements on mount are at times skipped on opening a dialog | VoiceOver | <video src="https://github.com/user-attachments/assets/a271ed04-64e0-423e-bf4a-b782207b76c7" /> |
  
#### `EuiScreenReaderLive`
  
| Issue | screen reader | recordings |
|---|---|---|
| ⚠️ Announcements are sometimes skipped | All | <video src="https://github.com/user-attachments/assets/226b4c52-86ea-46e0-bf02-8a654a27fed8" /> |
| 🚫 Announcements not read on mount or change | VoiceOver/Safari | <video src="https://github.com/user-attachments/assets/77192d76-79f7-4fec-ac3e-c29bfae63ab0" /> |


## Why are we making this change?

The new component aims to provide a solution to a missing functionality (live announcements on mount) as well as providing a more consistent live region announcement experience.

## Screenshots

<details>
<summary>Screen recordings</summary>

| combinations | mount & update | mount & update in a portalled scope |
|---|---|---|
| JAWS/Chromium (Chrome & Edge) | <video src="https://github.com/user-attachments/assets/01ad3c89-ccd1-45c3-b58f-a76d2ec4c1bc" /> | <video src="https://github.com/user-attachments/assets/66511934-9470-4f11-b153-8fb80801153c" /> |
| NVDA/Chrome | <video src="https://github.com/user-attachments/assets/cfce092b-6258-4469-a381-941a6f97a7ec" /> | <video src="https://github.com/user-attachments/assets/5b691e2e-f92b-4bcf-a8cd-7a61246f17e3" /> |
| NVDA/Firefox | <video src="https://github.com/user-attachments/assets/655abd0d-2715-4856-aa3b-a6ec160241a6" /> | <video src="https://github.com/user-attachments/assets/589dc9f8-f845-4f5d-ab86-e8fe4067401e" /> |
| VoiceOver/Safari | <video src="https://github.com/user-attachments/assets/d6213b0d-7b80-4dac-87a4-f3c0d3768cfc" /> | <video src="https://github.com/user-attachments/assets/45da77d6-ecf9-4bf9-ba44-b1a849dca3d9" /> |
</details>

## Impact to users

🟢 There are no updates needed by consumers.

## QA

Test stories:

- [EuiLiveAnnouncer](https://eui.elastic.co/pr_8916/storybook/?path=/story/utilities-euiliveannouncer--playground) 
- [EuiLiveAnnouncer in Flyout](https://eui.elastic.co/pr_8916/storybook/?path=/story/utilities-euiliveannouncer--within-flyouts)
- [EuiScreenReaderLive](https://eui.elastic.co/pr_8916/storybook/?path=/story/utilities-euiscreenreaderlive--playground)
- [EuiScreenReaderLive in flyout](https://eui.elastic.co/pr_8916/storybook/?path=/story/utilities-euiscreenreaderlive--within-flyouts)
- [EuiCallOut](https://eui.elastic.co/pr_8916/storybook/?path=/story/display-euicallout--announce-on-mount)

Added documentation:

- [EuiLiveAnnouncer](https://eui.elastic.co/pr_8916/docs/utilities/accessibility/#live-announcer-region-)
- [EuiCallOut](https://eui.elastic.co/pr_8916/docs/components/display/callout/#screen-reader-announcements)

---

- [x] added unit tests succeed
- test `EuiLiveAnnouncer` in different testing scenarios (as mentioned above) and verify that:
  - [x] announcements happen on component mount
  - [x] announcements happen on content update
  - [x] messages are cleared if `clearAfterMs` is set which means there is no duplicate content in the DOM after the content being cleared
- compare the behavior of `EuiLiveAnnouncer` with `EuiScreenReaderLive`
  - [x] verify that the overall behavior of announcements on content change is the same
  - [x] verify that announcements are more consistent
- [x] verify that `EuiCallOut` with `announceOnMount` is being read on mount
- [x] verify that `EuiCallOut` that the screen reader only text added with `announceOnMount` is being cleared to prevent duplicate DOM content

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
  
  ### Todo
  
  - [x] add note about Beta component in Deprecations/Beta document https://github.com/elastic/eui/issues/1469
    - added Beta tracking issue https://github.com/elastic/eui/issues/8933
