### PR TITLE
chore(eui): improve EuiCallout `size` prop type

### DIFF
--- a/packages/eui/src/components/call_out/call_out.tsx
+++ b/packages/eui/src/components/call_out/call_out.tsx
@@ -32,9 +32,10 @@ export const COLORS = [
 export type Color = (typeof COLORS)[number];
 
 export const HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'] as const;
-type Heading = (typeof HEADINGS)[number];
+export type Heading = (typeof HEADINGS)[number];
 
-type Size = 's' | 'm';
+export const SIZES = ['s', 'm'] as const;
+export type Size = (typeof SIZES)[number];
 
 export type EuiCallOutProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'title' | 'color'> & {


### PR DESCRIPTION
## Summary

I improved the `size` prop type in `EuiCallout` so that `react-docgen` picks it up correctly, just like for `heading` and `color` which are local types.

## Why are we making this change?

It was an internal request. A Kibana developer raised the issue on Slack.

## Screenshots

| [Prod](https://eui.elastic.co/docs/components/display/callout/#EuiCallOut-prop-size) | [Staging](https://eui.elastic.co/pr_8917/docs/components/display/callout/#EuiCallOut-prop-size) |
| ----- | ------- |
| <img width="833" height="914" alt="Screenshot 2025-07-28 at 14 43 38" src="https://github.com/user-attachments/assets/0c1f2b59-aa80-400e-97ee-125124eefba9" /> | <img width="833" height="914" alt="Screenshot 2025-07-28 at 14 43 44" src="https://github.com/user-attachments/assets/655a9b1e-d8d1-41ef-aee7-567baf4422bc" /> |

## Impact to users

🟢 Just a docs change. No impact for users.

## QA

- [ ] Verify that the `EuiCallout`'s `size` prop lists a union type `"s" | "m"` in the prop table ([staging](https://eui.elastic.co/pr_8917/docs/components/display/callout/#EuiCallOut-prop-size))
