### PR TITLE
[Theme] Fix typography scss order

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8922.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8922.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Updated shared theme SCSS imports to ensure expected results for the SCSS function `lineHeightFromBaseline`
+

--- a/packages/eui-theme-borealis/src/variables/_index.scss
+++ b/packages/eui-theme-borealis/src/variables/_index.scss
@@ -4,14 +4,14 @@
 // package instead of the common one 
 
 @import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/size';
+@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/responsive';
+@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/typography';
+
 // borders are used in the common package, to define them on theme level we require the size variables first
 @import 'borders';
-@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/responsive';
 @import 'states';
-
 @import './colors/colors_severity';
 @import 'form';
 @import 'page';
 @import 'font_weight';
-@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/typography';
 @import 'typography';

--- a/packages/eui-theme-borealis/src/variables/_index.scss
+++ b/packages/eui-theme-borealis/src/variables/_index.scss
@@ -6,11 +6,12 @@
 @import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/size';
 // borders are used in the common package, to define them on theme level we require the size variables first
 @import 'borders';
-@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/index';
+@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/responsive';
 @import 'states';
 
 @import './colors/colors_severity';
 @import 'form';
 @import 'page';
 @import 'font_weight';
+@import 'node_modules/@elastic/eui-theme-common/src/global_styling/variables/typography';
 @import 'typography';

--- a/packages/eui-theme-common/changelogs/upcoming/8922.md
+++ b/packages/eui-theme-common/changelogs/upcoming/8922.md
@@ -1,0 +1,16 @@
+**Breaking changes**
+
+- Removed obsolete SCSS typography definitions - use the definitions from the themes directly
+  - $euiFontFamily
+  - $euiTextScale
+  - $euiFontSize
+  - $euiFontSizeXS
+  - $euiFontSizeS
+  - $euiFontSizeM
+  - $euiFontSizeL
+  - $euiFontSizeXL
+  - $euiFontSizeXXL
+  - $euiBodyLineHeight
+  - $euiTitles
+  - convertToRem()
+  - lineHeightFromBaseline()

--- a/packages/eui-theme-common/src/global_styling/variables/_typography.scss
+++ b/packages/eui-theme-common/src/global_styling/variables/_typography.scss
@@ -1,75 +1,8 @@
 // Families
-$euiFontFamily: 'Inter', BlinkMacSystemFont, Helvetica, Arial, sans-serif !default;
 $euiCodeFontFamily: 'Roboto Mono', Menlo, Courier, monospace !default;
 
 // Careful using ligatures. Code editors like ACE will often error because of width calculations
 $euiFontFeatureSettings: 'calt' 1, 'kern' 1, 'liga' 1 !default;
 
-// Font sizes -- scale is loosely based on Major Third (1.250)
-$euiTextScale:      2.25, 1.75, 1.25, 1.125, 1, .875, .75 !default;
-
-$euiFontSize:       $euiSize !default; // 5th position in scale
-$euiFontSizeXS:     $euiFontSize * nth($euiTextScale, 7) !default; // 12px
-$euiFontSizeS:      $euiFontSize * nth($euiTextScale, 6) !default; // 14px
-$euiFontSizeM:      $euiFontSize * nth($euiTextScale, 4) !default; // 18px
-$euiFontSizeL:      $euiFontSize * nth($euiTextScale, 3) !default; // 20px
-$euiFontSizeXL:     $euiFontSize * nth($euiTextScale, 2) !default; // 28px
-$euiFontSizeXXL:    $euiFontSize * nth($euiTextScale, 1) !default; // 36px
-
 // Line height
 $euiLineHeight:     1.5 !default;
-$euiBodyLineHeight: 1 !default;
-
-// Normally functions are imported before variables in `_index.scss` files
-// But because they need to consume some typography variables they need to live here
-@function convertToRem($size) {
-  @return #{$size / $euiFontSize}rem;
-}
-
-// Our base gridline is at 1/2 the font-size, ensure line-heights stay on that gridline.
-// EX: A proper line-height for text is 1.5 times the font-size.
-//     If our base font size (euiFontSize) is 16, our baseline is 8 (16*1.5 / 3). To ensure the
-//     text stays on the baseline, we pass a multiplier to calculate a line-height in rems.
-@function lineHeightFromBaseline($multiplier: 3) {
-  @return convertToRem(($euiFontSize / 2) * $multiplier);
-}
-
-// Titles map
-// Lists all the properties per EuiTitle size that then gets looped through to create the selectors.
-// The map allows for tokenization and easier customization per theme, otherwise you'd have to override the selectors themselves
-$euiTitles: (
-  'xxxs': (
-    'font-size': $euiFontSizeXS,
-    'line-height': lineHeightFromBaseline(3),
-    'font-weight': $euiFontWeightBold,
-  ),
-  'xxs': (
-    'font-size': $euiFontSizeS,
-    'line-height': lineHeightFromBaseline(3),
-    'font-weight': $euiFontWeightBold,
-  ),
-  'xs': (
-    'font-size': $euiFontSize,
-    'line-height': lineHeightFromBaseline(3),
-    'font-weight': $euiFontWeightSemiBold,
-    'letter-spacing': -.02em,
-  ),
-  's': (
-    'font-size': $euiFontSizeL,
-    'line-height': lineHeightFromBaseline(4),
-    'font-weight': $euiFontWeightMedium,
-    'letter-spacing': -.025em,
-  ),
-  'm': (
-    'font-size': $euiFontSizeXL,
-    'line-height': lineHeightFromBaseline(5),
-    'font-weight': $euiFontWeightLight,
-    'letter-spacing': -.04em,
-  ),
-  'l': (
-    'font-size': $euiFontSizeXXL,
-    'line-height': lineHeightFromBaseline(6),
-    'font-weight': $euiFontWeightLight,
-    'letter-spacing': -.03em,
-  ),
-) !default;

--- a/packages/eui/changelogs/upcoming/8922.md
+++ b/packages/eui/changelogs/upcoming/8922.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed unexpected results for the SCSS function `lineHeightFromBaseline`
+


### PR DESCRIPTION
## Summary

This PR updates the shared  SCSS typography definitions in `eui-theme-common` and how they are imported in `eui-theme-borealis`.

>[!IMPORTANT]
EUI does not officially support SCSS styling anymore. The existing files remain to support Kibana while it migrates off SCSS.

### Problem

Based on the import order and variable definition the previous setup would result in the function `lineHeightFromBaseline` to return unexpected values. This was due to the dependency function `convertToRem` relying on `$euiFontSize` which is defined in the same file combined with the order of imports of the SCSS files.

## Proposed solution

- remove duplicated shared typography SCSS in `eui-theme-common` which is defined specifically per theme in the themes themselves
- leave only actually shared typography SCSS
- ensure shared typography SCSS is loaded before theme typography SCSS in `eui-theme-borealis`

With this update the output matches the results of the CSS-in-JS equivalent `euiLineHeightFromBaseline `.

```scss
// before - $euiFontSize = 16px from eui-theme-common
line-height: lineHeightFromBaseline(2); // results in 1rem

// after - $euiFontSize = 14px from eui-theme-borealis
line-height: lineHeightFromBaseline(2); // results in 1.1429rem
```

## Why are we making this change?

Ensuring that lecagy usages of `lineHeightFromBaseline` work as expected.

## Screenshots

**before**

<img width="1272" height="546" alt="Screenshot 2025-07-29 at 11 28 59" src="https://github.com/user-attachments/assets/544b2de1-291c-44e4-8151-453640c8ee5d" />


**after**

<img width="1272" height="546" alt="Screenshot 2025-07-29 at 11 07 32" src="https://github.com/user-attachments/assets/02452bab-d5a4-4ac9-862b-d3fb4dc52f2c" />


## Impact to users

🟢 There are no changes needed on consumer side.

## QA

ℹ️ Testing this requires a SCSS setup. You can either checkout an older EUI tag (e.g. `v100.0.0`) that still includes the old EUI docs, setup a small CRA project or use Kibana.

🔗 The changes have been tested in Kibana [here](https://kibana-pr-228578.kb.us-west2.gcp.elastic-cloud.com/app/dev_tools#/console/shell).
login: https://p.elstc.co/paste/Cl3Ucde+#3Y5wj2XV9c4LQ047r9nsM7M8v6ILnAVtCASYPCQx20u

- [ ] verify that `lineHeightFromBaseline(2)` results in `1.1429rem` instead of `1rem`

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
