### PR TITLE
[EuiComboBox] Multiline options

### DIFF
--- a/packages/eui/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
+++ b/packages/eui/src/components/combo_box/__snapshots__/combo_box.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
             data-focus-lock-disabled="disabled"
           >
             <div
-              class="euiComboBoxOptionsList emotion-euiComboBoxOptionList"
+              class="euiComboBoxOptionsList emotion-euiComboBoxOptionList-render"
               data-test-subj="comboBoxOptionsList alsoGetsAppliedToOptionsList-optionsList"
             >
               <div
@@ -191,7 +191,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Titan
                           </span>
@@ -220,7 +220,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Enceladus
                           </span>
@@ -249,7 +249,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Mimas
                           </span>
@@ -278,7 +278,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Dione
                           </span>
@@ -307,7 +307,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Iapetus
                           </span>
@@ -336,7 +336,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Phoebe
                           </span>
@@ -365,7 +365,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Rhea
                           </span>
@@ -394,7 +394,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Pandora is one of Saturn's moons, named for a Titaness of Greek mythology
                           </span>
@@ -423,7 +423,7 @@ exports[`EuiComboBox renders the options list dropdown 1`] = `
                           class="euiComboBoxOption__contentWrapper"
                         >
                           <span
-                            class="euiComboBoxOption__content"
+                            class="euiComboBoxOption__content eui-textTruncate"
                           >
                             Tethys
                           </span>

--- a/packages/eui/src/components/combo_box/combo_box.stories.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.stories.tsx
@@ -20,6 +20,7 @@ import { EuiFlexItem } from '../flex';
 
 import { EuiComboBoxOptionMatcher } from './types';
 import { EuiComboBox, EuiComboBoxProps } from './combo_box';
+import { EuiHighlight } from '../highlight';
 
 const options = [
   { label: 'Item 1' },
@@ -101,6 +102,66 @@ export const WithCustomOptionIds: Story = {
       { id: 'item-9', label: 'Item 9' },
       { id: 'item-10', label: 'Item 10' },
     ],
+  },
+  render: (args) => <StatefulComboBox {...args} />,
+};
+
+export const RowHeightAuto: Story = {
+  parameters: {
+    controls: {
+      include: ['singleSelection', 'options', 'onChange'],
+    },
+  },
+  args: {
+    singleSelection: false,
+    rowHeight: 'auto',
+    selectedOptions: [],
+    options: [
+      { label: 'kibana.task_manager_metrics.metrics.error' },
+      { label: 'kibana.task_manager_metrics.metrics.last_update' },
+      { label: 'kibana.task_manager_metrics.metrics.message' },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.insolence',
+      },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.nudge',
+      },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.advancement',
+      },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.outlaw',
+      },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.representation',
+      },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.tomb',
+      },
+      {
+        label:
+          'kibana.task_manager_metrics.metrics.task_overdue.value.by_type.march',
+      },
+      { label: 'kibana.task_manager_metrics.metrics.task_claim.timestamp' },
+      {
+        label: 'kibana.task_manager_metrics.metrics.task_claim.value.duration',
+      },
+      { label: 'kibana.task_manager_metrics.metrics.task_claim.value.success' },
+      { label: 'kibana.task_manager_metrics.metrics.task_claim.value.total' },
+    ],
+    renderOption: (option, searchValue) => {
+      return (
+        <EuiHighlight search={searchValue} style={{ wordBreak: 'break-word' }}>
+          {option.label}
+        </EuiHighlight>
+      );
+    },
   },
   render: (args) => <StatefulComboBox {...args} />,
 };

--- a/packages/eui/src/components/combo_box/combo_box.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.tsx
@@ -113,9 +113,10 @@ export interface _EuiComboBoxProps<T>
    */
   placeholder?: string;
   /**
-   * Every option must be the same height and must be explicitly set if using a custom render
+   *  The height of each option in pixels. When using a custom render (`renderOption` prop) it's recommended to set it explicitly.
+   * `auto` will disable virtualization, enabling text to wrap onto multiple lines.
    */
-  rowHeight?: number;
+  rowHeight?: number | 'auto';
   /**
    * When `true` only allows the user to select a single option. Set to `{ asPlainText: true }` to not render input selection as pills
    */

--- a/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.styles.ts
+++ b/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.styles.ts
@@ -14,7 +14,6 @@ import {
   mathWithUnits,
   euiScrollBarStyles,
   euiTextBreakWord,
-  euiTextTruncate,
 } from '../../../global_styling';
 import { euiTitle } from '../../title/title.styles';
 
@@ -46,7 +45,6 @@ export const euiComboBoxOptionListStyles = (euiThemeContext: UseEuiTheme) => {
       .euiComboBoxOption__content {
         flex: 1;
         text-align: start;
-        ${euiTextTruncate()}
       }
 
       .euiComboBoxOption__emptyStateText {
@@ -71,6 +69,14 @@ export const euiComboBoxOptionListStyles = (euiThemeContext: UseEuiTheme) => {
         )}
         ${logicalCSS('padding-bottom', euiTheme.size.xs)}
         ${euiTitle(euiThemeContext, 'xxxs')}
+      }
+    `,
+
+    hasRowHeightAuto: css`
+      overflow-block: auto;
+
+      .euiComboBoxOption__contentWrapper {
+        align-items: flex-start;
       }
     `,
 

--- a/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -121,7 +121,8 @@ export class EuiComboBoxOptionsList<T> extends Component<
     if (
       this.listRef &&
       typeof this.props.activeOptionIndex !== 'undefined' &&
-      this.props.activeOptionIndex !== prevProps.activeOptionIndex
+      this.props.activeOptionIndex !== prevProps.activeOptionIndex &&
+      this.props.rowHeight !== 'auto'
     ) {
       this.listRef.scrollToItem(this.props.activeOptionIndex, 'auto');
     }

--- a/packages/eui/src/components/filter_group/filter_select_item.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.tsx
@@ -91,6 +91,14 @@ export class EuiFilterSelectItemClass extends Component<
     return this.state.hasFocus;
   };
 
+  componentDidUpdate(
+    prevProps: Readonly<WithEuiThemeProps<{}> & EuiFilterSelectItemProps>
+  ) {
+    if (this.props.isFocused && !prevProps.isFocused) {
+      this.buttonRef?.scrollIntoView?.({ block: 'nearest' });
+    }
+  }
+
   render() {
     const {
       theme,

--- a/packages/eui/src/components/filter_group/filter_select_item.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.tsx
@@ -26,6 +26,7 @@ export interface EuiFilterSelectItemProps
   checked?: FilterChecked;
   showIcons?: boolean;
   isFocused?: boolean;
+  truncateContent?: boolean;
   toolTipContent?: EuiComboBoxOptionOption['toolTipContent'];
   toolTipProps?: EuiComboBoxOptionOption['toolTipProps'];
   forwardRef?: (ref: HTMLButtonElement | null) => void;
@@ -57,6 +58,7 @@ export class EuiFilterSelectItemClass extends Component<
 > {
   static defaultProps = {
     showIcons: true,
+    truncateContent: true,
   };
 
   buttonRef: HTMLButtonElement | null = null;
@@ -101,6 +103,7 @@ export class EuiFilterSelectItemClass extends Component<
       toolTipContent,
       toolTipProps,
       style,
+      truncateContent,
       forwardRef,
       ...rest
     } = this.props;
@@ -166,7 +169,10 @@ export class EuiFilterSelectItemClass extends Component<
         >
           {iconNode}
           <EuiFlexItem
-            className="euiFilterSelectItem__content eui-textTruncate"
+            className={classNames(
+              'euiFilterSelectItem__content',
+              this.props.truncateContent && 'eui-textTruncate'
+            )}
             component="span"
           >
             {children}

--- a/packages/website/docs/components/forms/selection/combo-box.mdx
+++ b/packages/website/docs/components/forms/selection/combo-box.mdx
@@ -933,6 +933,50 @@ export default () => {
 
 ```
 
+:::warning Setting `rowHeight` to `auto` will cause truncation to be completely disabled
+
+:::
+
+## Multiple lines
+
+Only in the rare case you need text to wrap onto multiple lines instead of being truncated, you can set the `⁠rowHeight` prop to `⁠auto`. This will disable virtualization for the options list. When virtualization is disabled, highlighting will function as expected, but text truncation properties will be ignored.
+
+```tsx interactive
+import React, { useState } from 'react';
+import { EuiComboBox } from '@elastic/eui';
+
+const options = [
+  { label: 'Nam vestibulum, arcu quis gravida tempus, nunc nibh rhoncus tellus' },
+  { label: 'Aliquam placerat augue at dolor interdum, et sodales dui consectetur' },
+  { label: 'Aenean in scelerisque ligula, nec scelerisque metus' },
+  { label: 'Donec iaculis varius massa, ac scelerisque velit facilisis nec' },
+  { label: 'Nulla varius urna lorem, et suscipit nisi scelerisque sed' },
+  { label: 'Phasellus scelerisque laoreet neque, non malesuada neque maximus sed' },
+  { label: 'Maecenas felis eros, mattis eget augue in, euismod tristique arcu' },
+  { label: 'Aliquam ac tristique tortor, commodo rhoncus turpis' },
+];
+
+export default () => {
+  const [selectedOptions, setSelected] = useState([]);
+
+  const onChange = (selectedOptions) => {
+    setSelected(selectedOptions);
+  };
+
+  return (
+    <EuiComboBox
+      aria-label="Accessible screen reader label"
+      placeholder="Long text options onto multiple lines"
+      rowHeight="auto"
+      options={options}
+      selectedOptions={selectedOptions}
+      onChange={onChange}
+    />
+  );
+};
+
+```
+
 ## Groups
 
 You can group options together. The group labels _won’t_ match against the search value.


### PR DESCRIPTION
## Summary

Resolves #7712

This PR adds the possibility to render `EuiComboBox` options in multiple lines instead of having text be truncated.

It's accomplished by disabling virtualization of the list, by allowing to pass `auto` into the `rowHeight` prop.

The first version of the plan can be found in https://github.com/elastic/eui/issues/7712#issuecomment-3117083944

## Why are we making this change?

To fulfill the request in #7712

## Screenshots

<img width="914" height="600" alt="Screenshot 2025-07-31 at 17 16 49" src="https://github.com/user-attachments/assets/12a77bce-4bc2-461c-a7f1-1441726ac566" />

## Impact to users

None. All current usages of the component until now should remain unchanged. The number of changes have been kept to a minimum.

However, this change enables fixing a problem in Kibana that should have a very positive impact.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

\<TODO\>

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
