### PR TITLE
Remove obsolete `-ms-` CSS prefixes

### DIFF
--- a/packages/docusaurus-theme/src/theme/Navbar/Content/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Navbar/Content/index.tsx
@@ -36,7 +36,6 @@ const DOCS_PATH = '/docs';
 const placeHolderStyles = (content: string) => `
   &::-webkit-input-placeholder { ${content} }
   &::-moz-placeholder { ${content} }
-  &:-ms-input-placeholder { ${content} }
   &:-moz-placeholder { ${content} }
   &::placeholder { ${content} }
 `;
@@ -209,8 +208,8 @@ export default function NavbarContent(): JSX.Element {
 
   return (
     <>
-      {/* adding search styles globally to ensure they are available for usage on 
-      homepage as well without duplication. NOTE: swizzle/wrap does not work for 
+      {/* adding search styles globally to ensure they are available for usage on
+      homepage as well without duplication. NOTE: swizzle/wrap does not work for
       the plugin SearchBar component */}
       <Global styles={styles.search} />
       <NavbarContentLayout

--- a/packages/eui-theme-common/src/global_styling/mixins/_form.scss
+++ b/packages/eui-theme-common/src/global_styling/mixins/_form.scss
@@ -23,7 +23,6 @@
   // Each prefix must be its own content block
   &::-webkit-input-placeholder { @content; opacity: 1; }
   &::-moz-placeholder { @content; opacity: 1; }
-  &:-ms-input-placeholder { @content; opacity: 1; }
   &:-moz-placeholder { @content; opacity: 1; }
   &::placeholder { @content; opacity: 1; }
 }

--- a/packages/eui-theme-common/src/global_styling/mixins/_range.scss
+++ b/packages/eui-theme-common/src/global_styling/mixins/_range.scss
@@ -19,8 +19,6 @@ The following files still use the Sass version:
 @mixin euiRangeTrackPerBrowser {
   &::-webkit-slider-runnable-track { @content; }
   &::-moz-range-track { @content; }
-  &::-ms-fill-lower { @content; }
-  &::-ms-fill-upper { @content; }
 }
 
 @mixin euiRangeThumbBorder {
@@ -52,7 +50,6 @@ The following files still use the Sass version:
 @mixin euiRangeThumbPerBrowser {
   &::-webkit-slider-thumb { @content; }
   &::-moz-range-thumb { @content; }
-  &::-ms-thumb { @content; }
 }
 
 @mixin euiRangeThumbFocus {

--- a/packages/eui-theme-common/src/global_styling/mixins/_typography.scss
+++ b/packages/eui-theme-common/src/global_styling/mixins/_typography.scss
@@ -43,7 +43,6 @@
   font-weight: $euiFontWeightRegular;
   letter-spacing: -.005em;
   -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
   font-kerning: normal;
 }
 

--- a/packages/eui/changelogs/upcoming/8940.md
+++ b/packages/eui/changelogs/upcoming/8940.md
@@ -1,0 +1,1 @@
+- Removed obsolete IE-specific CSS properties

--- a/packages/eui/src/components/date_picker/react-datepicker/src/stylesheets/datepicker.scss
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/stylesheets/datepicker.scss
@@ -1,18 +1,18 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2018 HackerOne Inc and individual contributors
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,7 +20,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  */
 
 @import "variables.scss";
@@ -468,7 +468,6 @@
   &:last-of-type {
     -webkit-user-select: none;
     -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
     border-bottom-left-radius: $datepicker__border-radius;
     border-bottom-right-radius: $datepicker__border-radius;

--- a/packages/eui/src/components/form/field_password/field_password.styles.ts
+++ b/packages/eui/src/components/form/field_password/field_password.styles.ts
@@ -39,6 +39,7 @@ export const euiFieldPasswordStyles = (euiThemeContext: UseEuiTheme) => {
       }
     `,
     // Only remove Edge's internal reveal button if we're providing a custom one
+    // This pseudo-element is still supported in Chromium-based Edge.
     withToggle: css`
       &::-ms-reveal {
         display: none;

--- a/packages/eui/src/components/form/form.styles.test.tsx
+++ b/packages/eui/src/components/form/form.styles.test.tsx
@@ -130,10 +130,6 @@ describe('euiFormControlStyles', () => {
             color: #798EAF;
             opacity: 1;
            }
-        &:-ms-input-placeholder { 
-            color: #798EAF;
-            opacity: 1;
-           }
         &:-moz-placeholder { 
             color: #798EAF;
             opacity: 1;
@@ -174,7 +170,7 @@ describe('euiFormControlStyles', () => {
             --euiFormControlStateColor: #C61E25;
             --euiFormControlStateHoverColor: #DA3737;
             --euiFormControlStateWidth: 1px;
-            
+
             
         position: relative;
         z-index: 1;
@@ -218,10 +214,6 @@ describe('euiFormControlStyles', () => {
             opacity: 1;
            }
         &::-moz-placeholder { 
-            color: #798EAF;
-            opacity: 1;
-           }
-        &:-ms-input-placeholder { 
             color: #798EAF;
             opacity: 1;
            }

--- a/packages/eui/src/components/form/form.styles.ts
+++ b/packages/eui/src/components/form/form.styles.ts
@@ -390,7 +390,7 @@ export const euiFormControlInvalidStyles = (euiThemeContext: UseEuiTheme) => {
           ? euiTheme.border.width.thick
           : euiTheme.border.width.thin
       };
-      
+
       ${euiFormControlHighlightBorderStyles}
       ${euiFormControlShowBackgroundLine(euiThemeContext, invalidColor)}
     `
@@ -578,7 +578,6 @@ export const euiFormControlShowBackgroundLine = (
 const euiPlaceholderPerBrowser = (content: string) => `
   &::-webkit-input-placeholder { ${content} }
   &::-moz-placeholder { ${content} }
-  &:-ms-input-placeholder { ${content} }
   &:-moz-placeholder { ${content} }
   &::placeholder { ${content} }
 `;

--- a/packages/eui/src/components/form/range/range.styles.ts
+++ b/packages/eui/src/components/form/range/range.styles.ts
@@ -80,8 +80,6 @@ export const euiRangeTrackPerBrowser = (content: string) => {
   return `
     &::-webkit-slider-runnable-track { ${content}; }
     &::-moz-range-track { ${content}; }
-    &::-ms-fill-lower {${content}; }
-    &::-ms-fill-upper { ${content}; }
   `;
 };
 
@@ -156,7 +154,6 @@ export const euiRangeThumbPerBrowser = (content: string) => {
   return `
     &::-webkit-slider-thumb { ${content}; }
     &::-moz-range-thumb { ${content}; }
-    &::-ms-thumb {${content}; }
   `;
 };
 

--- a/packages/eui/src/global_styling/mixins/_typography.scss
+++ b/packages/eui/src/global_styling/mixins/_typography.scss
@@ -43,7 +43,6 @@
   font-weight: $euiFontWeightRegular;
   letter-spacing: -.005em;
   -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
   font-kerning: normal;
 }
 

--- a/packages/eui/src/services/emotion/prefixer.ts
+++ b/packages/eui/src/services/emotion/prefixer.ts
@@ -42,53 +42,145 @@ export const euiStylisPrefixer = (element: Element) => {
 
 const prefix = (value: Element['value'], length: Element['length']): string => {
   switch (hash(value, length)) {
-    /**
+    /************************************************************
      * `-webkit` prefixes
+     ************************************************************/
+
+    /**
+     * user-select
+     * Safari needs the -webkit prefix as of August 2025
+     * @see https://caniuse.com/mdn-css_properties_user-select
      */
-    // user-select - https://caniuse.com/mdn-css_properties_user-select - needed by Safari
     case 4246:
-    // text-decoration - https://caniuse.com/text-decoration - iOS Safari is the main one that needs this
+
+    /**
+     * text-decoration
+     * iOS Safari needs the -webkit prefix as of August 2025
+     * @see https://caniuse.com/text-decoration
+     */
     case 5572:
-    // text-size-adjust - https://caniuse.com/text-size-adjust - iOS Safari
+
+    /**
+     * text-size-adjust
+     * iOS Safari needs the -webkit prefix as of August 2025
+     * @see https://caniuse.com/text-size-adjust
+     */
     case 2756:
-    // box-decoration-break - https://caniuse.com/css-boxdecorationbreak - Chrome & Safari
+
+    /**
+     * box-decoration-break
+     * Safari needs the -webkit prefix as of August 2025
+     * @see https://caniuse.com/css-boxdecorationbreak
+     */
     case 3005:
-    // mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite - Chrome
+
+    /**
+     * mask, mask-image, mask-(mode|clip|size), mask-(repeat|origin), mask-position, mask-composite
+     * @see https://caniuse.com/css-masks
+     * TODO: Remove as this is natively supported since November 2023
+     */
     case 6391:
     case 5879:
     case 5623:
     case 6135:
     case 4599:
     case 4855:
-    // print-color-adjust - https://caniuse.com/css-color-adjust - Chrome
+
+    /**
+     * print-color-adjust
+     * Chromium-based browsers need the -webkit prefix as of August 2025
+     * @see https://caniuse.com/css-color-adjust
+     */
     case 2282:
       return WEBKIT + value + value;
 
-    // background-clip - https://caniuse.com/background-clip-text - Chrome, only for `text` value
+    /**
+     * background-clip
+     * @see https://caniuse.com/background-clip-text
+     * TODO: Remove as this is natively supported since November 2023
+     */
     case 4215:
       if (~indexof(value, 'text')) {
         return WEBKIT + value + value;
       }
 
-    /**
+    /************************************************************
      * Intrinsic/extrinsic sizing value prefixes
-     * `stretch` alternatives needed by Chrome & Firefox - https://caniuse.com/intrinsic-width
+     ************************************************************/
+
+    /**
+     * width
+     * @see https://caniuse.com/intrinsic-width
      */
-    // (min|max)?(width|height|inline-size|block-size)
     case 8116:
+
+    /**
+     * height
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 7059:
+
+    /**
+     * inline-size
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5753:
+
+    /**
+     * block-size
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5535:
+
+    /**
+     * min-width
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5445:
+
+    /**
+     * min-height
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5701:
+
+    /**
+     * min-inline-size
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 4933:
+
+    /**
+     * min-block-size
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 4677:
+
+    /**
+     * max-width
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5533:
+
+    /**
+     * max-height
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5789:
+
+    /**
+     * max-inline-size
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 5021:
+
+    /**
+     * max-block-size
+     * @see https://caniuse.com/intrinsic-width
+     */
     case 4765:
       // stretch, max-content, min-content, fill-available
-      if (strlen(value) - 1 - length > 6)
+      if (strlen(value) - 1 - length > 6) {
         switch (charat(value, length + 1)) {
           // (f)ill-available
           case 102:
@@ -113,6 +205,7 @@ const prefix = (value: Element['value'], length: Element['length']): string => {
               );
             }
         }
+      }
       break;
   }
 

--- a/packages/eui/src/themes/amsterdam/global_styling/mixins/_typography.scss
+++ b/packages/eui/src/themes/amsterdam/global_styling/mixins/_typography.scss
@@ -42,7 +42,6 @@
   font-weight: $euiFontWeightRegular;
   letter-spacing: normal;
   -webkit-text-size-adjust: 100%;
-  -ms-text-size-adjust: 100%;
   font-kerning: normal;
 }
 


### PR DESCRIPTION
## Summary

Resolves #8897

This PR removes IE-specific CSS properties, pseudo-elements, and other features. EUI doesn't support any Internet Explorer version anymore, and these `-ms-`-prefixed properties were causing browser errors to be printed out in the console. 

## Why are we making this change?

To reduce the number of errors printed out in the console.

## Impact to users

No user impact expected. EUI doesn't support any Internet Explorer version anymore, and this PR is just a cleanup.

## QA

- [x] Test placeholder styles of EUI input components on Edge

### General checklist

- Browser QA
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
