### PR TITLE
fix(EuiInputPopover): close popover on Tab, not Shift Tab

### DIFF
--- a/packages/eui/changelogs/upcoming/8950.md
+++ b/packages/eui/changelogs/upcoming/8950.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Fixed an issue where pressing Shift + Tab on the last tabbable element inside `EuiInputPopover` popover would close the popover unexpectedly

--- a/packages/eui/src/components/form/range/types.ts
+++ b/packages/eui/src/components/form/range/types.ts
@@ -131,6 +131,7 @@ export interface _SharedRangeInputProps {
     | 'isOpen'
     | 'closePopover'
     | 'disableFocusTrap'
+    | 'ownFocus'
     | 'popoverScreenReaderText'
     | 'fullWidth'
   >;

--- a/packages/eui/src/components/popover/input_popover.spec.tsx
+++ b/packages/eui/src/components/popover/input_popover.spec.tsx
@@ -208,24 +208,6 @@ describe('EuiPopover', () => {
         cy.get('[data-popover-panel]').should('exist');
       });
 
-      // Not sure how much sense this behavior makes, but this logic was
-      // apparently added to EuiInputPopover with EuiDualRange in mind
-      it('automatically closes the popover when users tab from anywhere in the popover', () => {
-        cy.mount(
-          <>
-            <StatefulInputPopover disableFocusTrap={true}>
-              <button data-test-subj="one">one</button>
-              <button data-test-subj="two">two</button>
-            </StatefulInputPopover>
-          </>
-        );
-
-        cy.get('[data-test-subj="one"]').click();
-        cy.realPress('Tab');
-
-        cy.get('[data-popover-panel]').should('not.exist');
-      });
-
       it('behaves with normal popover focus trap/tab behavior if `ownFocus` is set to true', () => {
         cy.mount(
           <>

--- a/packages/eui/src/components/popover/input_popover.spec.tsx
+++ b/packages/eui/src/components/popover/input_popover.spec.tsx
@@ -177,6 +177,22 @@ describe('EuiPopover', () => {
 
         cy.get('[data-popover-panel]').should('not.exist');
       });
+
+      it('does not close the popover when users Shift+Tab from the last item in the popover', () => {
+        cy.mount(
+          <StatefulInputPopover>
+            <button data-test-subj="one">one</button>
+            <button data-test-subj="two">two</button>
+          </StatefulInputPopover>
+        );
+
+        cy.focused().invoke('attr', 'data-test-subj').should('eq', 'one');
+        cy.realPress('Tab');
+        cy.focused().invoke('attr', 'data-test-subj').should('eq', 'two');
+        cy.realPress(['Shift', 'Tab']);
+        cy.focused().invoke('attr', 'data-test-subj').should('eq', 'one');
+        cy.get('[data-popover-panel]').should('exist');
+      });
     });
 
     describe('with focus trap disabled', () => {

--- a/packages/eui/src/components/popover/input_popover.stories.tsx
+++ b/packages/eui/src/components/popover/input_popover.stories.tsx
@@ -17,6 +17,8 @@ import {
 import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { EuiFieldText } from '../form';
 import { EuiInputPopover, EuiInputPopoverProps } from './input_popover';
+import { css } from '@emotion/react';
+import { EuiButton } from '../button';
 
 const meta: Meta<EuiInputPopoverProps> = {
   title: 'Layout/EuiInputPopover',
@@ -130,5 +132,39 @@ export const AnchorPosition: Story = {
     <div css={{ display: 'flex', justifyContent: 'center' }}>
       <StatefulInputPopover {...args} />
     </div>
+  ),
+};
+
+export const InteractiveChildren: Story = {
+  parameters: {
+    controls: { include: ['ownFocus', 'disableFocusTrap'] },
+  },
+  args: {
+    isOpen: true,
+    ownFocus: true,
+    disableFocusTrap: false,
+    input: (
+      <EuiFieldText
+        placeholder="Focus me to toggle an input popover"
+        aria-label="Popover attached to input element"
+      />
+    ),
+  },
+  render: (args) => (
+    <>
+      <StatefulInputPopover {...args}>
+        <div
+          css={({ euiTheme }) => css`
+            display: flex;
+            flex-direction: column;
+            gap: ${euiTheme.size.s};
+          `}
+        >
+          <EuiButton>First button</EuiButton>
+          <EuiButton>Second button</EuiButton>
+          <EuiButton>Third button</EuiButton>
+        </div>
+      </StatefulInputPopover>
+    </>
   ),
 };

--- a/packages/eui/src/components/popover/input_popover.tsx
+++ b/packages/eui/src/components/popover/input_popover.tsx
@@ -153,7 +153,8 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
           const tabbingFromLastItemInPopover =
             document.activeElement === tabbableItems[tabbableItems.length - 1];
 
-          if (tabbingFromLastItemInPopover) {
+          // Only close if Tab (not Shift+Tab) is pressed from the last item
+          if (tabbingFromLastItemInPopover && !event.shiftKey) {
             closePopover();
           }
         }

--- a/packages/eui/src/components/popover/input_popover.tsx
+++ b/packages/eui/src/components/popover/input_popover.tsx
@@ -135,6 +135,28 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
 
   const panelPropsOnKeyDown = props.panelProps?.onKeyDown;
 
+  const handleTabNavigation = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const tabbableItems = tabbable(e.currentTarget).filter(
+        (el) => !el.hasAttribute('data-focus-guard')
+      );
+      if (!tabbableItems.length) return;
+
+      const tabbingFromFirstItemInPopover =
+        document.activeElement === tabbableItems[0];
+      const tabbingFromLastItemInPopover =
+        document.activeElement === tabbableItems[tabbableItems.length - 1];
+
+      if (
+        (tabbingFromFirstItemInPopover && e.shiftKey) ||
+        (tabbingFromLastItemInPopover && !e.shiftKey)
+      ) {
+        closePopover();
+      }
+    },
+    [closePopover]
+  );
+
   const onKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
       panelPropsOnKeyDown?.(event);
@@ -142,25 +164,16 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
       if (event.key === keys.TAB) {
         if (disableFocusTrap) {
           if (!ownFocus) {
-            closePopover();
+            handleTabNavigation(event);
           }
         } else {
-          const tabbableItems = tabbable(event.currentTarget).filter(
-            (el) => !el.hasAttribute('data-focus-guard')
-          );
-          if (!tabbableItems.length) return;
-
-          const tabbingFromLastItemInPopover =
-            document.activeElement === tabbableItems[tabbableItems.length - 1];
-
-          // Only close if Tab (not Shift+Tab) is pressed from the last item
-          if (tabbingFromLastItemInPopover && !event.shiftKey) {
-            closePopover();
+          if (!ownFocus) {
+            handleTabNavigation(event);
           }
         }
       }
     },
-    [disableFocusTrap, ownFocus, closePopover, panelPropsOnKeyDown]
+    [disableFocusTrap, ownFocus, panelPropsOnKeyDown, handleTabNavigation]
   );
 
   /**


### PR DESCRIPTION
## Summary

If `disableFocusTrap` is `false`, regardless of `ownFocus`, the active item is the last tabbable item in the `EuiInputPopover` overlay and if we press <kbd>Shift + Tab</kbd>, the popover will close. It's expected to close only on pressing <kbd>Tab</kbd> because it will mean circling back to the first tabbable element. But in the other direction, it should not close.

## Why are we making this change?

Resolves https://github.com/elastic/eui/issues/8949

This PR comes out of a triage, so I kept the changes to the minimum, only to address the issue that the consumer is struggling with.

That being said, the keyboard navigation in this component feels weird to me. It seems that only some combination of `disableTrapFocus` and `ownFocus` produces the expected result. From my perspective, it's best if the keyboard navigation in this component is reworked.

⚠️ I also noticed on `Esc` nothing happens.

If you have an idea how to best handle the popover, I'm open to suggestions! Otherwise, we can address it separately whenever the time allows 😄 

## Screenshots

|     | [Prod](https://codesandbox.io/p/sandbox/flamboyant-williams-yk9nw4) | Local |
| -- | ----- | ----- |
| `disableTrapFocus={true}`, `ownFocus={true}` | ![prod-true-true](https://github.com/user-attachments/assets/6fa00d79-4c69-4dfb-a25c-ffac1d1598f5) | ![local-true-true](https://github.com/user-attachments/assets/695228bd-2126-4c66-aff4-8b4cc288abb0) |
| `disableTrapFocus={true}`, `ownFocus={false}` | ![prod-true-false](https://github.com/user-attachments/assets/3a238ab6-71bd-4b55-ad25-511fc9c726b0) | ![local-true-false](https://github.com/user-attachments/assets/20f9b3f6-d712-429e-b0a1-6450bb59cc39) |
| `disableTrapFocus={false}`, `ownFocus={true}` | ![prod-false-true](https://github.com/user-attachments/assets/2b8a16ce-6c53-4d6c-973a-ad154a31bfb7) | ![local-false-true](https://github.com/user-attachments/assets/bb5aa40f-e71e-4fb3-bc53-bdc697b5b146) |
| `disableTrapFocus={false}`, `ownFocus={false}` | ![prod-false-false](https://github.com/user-attachments/assets/c600cdd7-0492-4fca-a055-54569dbf9dd4) | ![local-false-false](https://github.com/user-attachments/assets/16038300-3194-41e0-94a0-31a91a743979) |

## Impact to users

🟠 It's **not** a breaking change BUT it's a difference in component behavior which may affect some use cases detrimentally, and especially automated tests.

This change should prompt a cleanup of: https://github.com/elastic/kibana/pull/230852#discussion_r2257920981

## QA

### Specific checklist

- [x] Verify in [Storybook](https://eui.elastic.co/pr_8950/storybook/index.html?path=/story/layout-euiinputpopover--interactive-children) that the `EuiInputPopover` doesn't close on <kbd>Shift</kbd> + <kbd>Tab</kbd> when the last interactive element is active

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - ~(_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, ~**Edge**, and **Firefox**~
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
