### PR TITLE
fix(EuiFieldNumber): update native validity based on isInvalid prop

### DIFF
--- a/packages/eui/src/components/form/field_number/field_number.stories.tsx
+++ b/packages/eui/src/components/form/field_number/field_number.stories.tsx
@@ -13,6 +13,10 @@ import {
 } from '../../../../.storybook/utils';
 
 import { EuiFieldNumber, EuiFieldNumberProps } from './field_number';
+import React, { ChangeEventHandler, useState } from 'react';
+import { EuiForm } from '../form';
+import { EuiFormRow } from '../form_row';
+import { EuiText } from '../../text';
 
 const meta: Meta<EuiFieldNumberProps> = {
   title: 'Forms/EuiFieldNumber',
@@ -89,3 +93,55 @@ moveStorybookControlsToCategory(IconShape, [
   'prepend',
   'append',
 ]);
+
+const FieldNumberValidationComponent = () => {
+  const [value1, setValue1] = useState('5');
+  const [value2, setValue2] = useState('4');
+
+  const onChange1: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const newValue = e.target.value;
+    setValue1(newValue);
+  };
+
+  const onChange2: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const newValue = e.target.value;
+    setValue2(newValue);
+  };
+
+  const isValue2GreaterThanValue1 = value2 > value1;
+
+  return (
+    <EuiForm component="form">
+      <EuiFormRow label="value 1">
+        <EuiFieldNumber
+          placeholder="Placeholder text"
+          value={value1}
+          min={1}
+          onChange={onChange1}
+          aria-label="Use aria labels when no actual label is in use"
+        />
+      </EuiFormRow>
+
+      <EuiFormRow isInvalid={isValue2GreaterThanValue1} label="value 2">
+        <>
+          <EuiFieldNumber
+            isInvalid={isValue2GreaterThanValue1}
+            placeholder="Placeholder text"
+            value={value2}
+            onChange={onChange2}
+            aria-label="Use aria labels when no actual label is in use"
+          />
+          {isValue2GreaterThanValue1 && (
+            <EuiText color="danger" size="s">
+              value2 should be smaller than value1
+            </EuiText>
+          )}
+        </>
+      </EuiFormRow>
+    </EuiForm>
+  );
+};
+
+export const FieldNumberValidation: Story = {
+  render: () => <FieldNumberValidationComponent />,
+};

--- a/packages/eui/src/components/form/field_number/field_number.tsx
+++ b/packages/eui/src/components/form/field_number/field_number.tsx
@@ -132,7 +132,7 @@ export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
     if (_inputRef.current) {
       checkNativeValidity(_inputRef.current);
     }
-  }, [value, min, max, step, checkNativeValidity]);
+  }, [isInvalid, value, min, max, step, checkNativeValidity]);
 
   const classes = classNames('euiFieldNumber', className, {
     'euiFieldNumber-isLoading': isLoading,


### PR DESCRIPTION
## Summary

The issue is consistently reproducible on [this sandbox](https://codesandbox.io/p/sandbox/interesting-platform-37zmtk).

The passed value of `isInvalid` can change but the `isNativelyValid` state doesn't update.

<img width="1395" height="666" alt="Screenshot 2025-08-07 at 18 26 18" src="https://github.com/user-attachments/assets/9456d6a1-4fea-432c-855e-c01d3040ef07" />

There's a special `useEffect` to update it whenever some props change and `isValid` wasn't in the dependency array. Adding it fixes the issue.

## Why are we making this change?

This came out of an internal request by a Kibana developer.

## Screenshots

| Before | After |
| ------- | ----- |
| ![before](https://github.com/user-attachments/assets/c5c88173-3674-4968-ac45-e765533712b1) | ![after](https://github.com/user-attachments/assets/ec56de1e-605d-4cf4-8c1f-65874288d643) |

## Impact to users

🟢 No impact to users

## QA

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - ~(_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, ~**Edge**, and **Firefox**~
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **~[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and~ [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
