### PR TITLE
Fix test-env EuiFlyout to use forwardRef to silence Jest warning

### DIFF
--- a/packages/eui/src/components/flyout/flyout.testenv.tsx
+++ b/packages/eui/src/components/flyout/flyout.testenv.tsx
@@ -6,37 +6,45 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
-export const EuiFlyout = ({
-  as = 'div',
-  role = 'dialog',
-  children,
-  closeButtonProps,
-  hideCloseButton,
-  onClose,
-  onKeyDown,
-  'data-test-subj': dataTestSubj,
-}: any) => {
-  const Element = as;
-  return (
-    <Element
-      data-eui="EuiFlyout"
-      data-test-subj={dataTestSubj}
-      role={role}
-      onKeyDown={onKeyDown}
-    >
-      {!hideCloseButton && (
-        <button
-          type="button"
-          data-test-subj="euiFlyoutCloseButton"
-          aria-label="Close this dialog"
-          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-            onClose();
-            closeButtonProps?.onClick && closeButtonProps.onClick(e);
-          }}
-        />
-      )}
-      {children}
-    </Element>
-  );
-};
+import React, { forwardRef } from 'react';
+export const EuiFlyout = forwardRef<any, any>(
+  (
+    {
+      as = 'div',
+      role = 'dialog',
+      children,
+      closeButtonProps,
+      hideCloseButton,
+      onClose,
+      onKeyDown,
+      'data-test-subj': dataTestSubj,
+    },
+    ref
+  ) => {
+    const Element = as;
+    return (
+      <Element
+        ref={ref}
+        data-eui="EuiFlyout"
+        data-test-subj={dataTestSubj}
+        role={role}
+        onKeyDown={onKeyDown}
+      >
+        {!hideCloseButton && (
+          <button
+            type="button"
+            data-test-subj="euiFlyoutCloseButton"
+            aria-label="Close this dialog"
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              onClose();
+              closeButtonProps?.onClick && closeButtonProps.onClick(e);
+            }}
+          />
+        )}
+        {children}
+      </Element>
+    );
+  }
+);
+
+EuiFlyout.displayName = 'EuiFlyout';


### PR DESCRIPTION
## Summary

This PR wraps the `EuiFlyout` component in `flyout.testenv.tsx` with `React.forwardRef()` and assigns a `displayName`, resolving a warning that appears when running tests involving `EuiFlyoutResizable`.

The warning occurred because the test-environment variant of `EuiFlyout` was implemented as a plain function component. However, `EuiFlyoutResizable` attempts to pass a `ref` to `EuiFlyout`, which causes React to emit a warning unless the target component supports refs via `forwardRef()`.

This change aligns the test-environment implementation with the production version (`flyout.tsx`), which already uses `forwardRef`.

## Why are we making this change?

In the test environment, when rendering `EuiFlyoutResizable`, Jest prints the following warning:
'''bash
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
'''

This is caused by the `EuiFlyout` test-env mock not supporting refs. Although this warning does not affect end users, it pollutes the test output and could obscure more meaningful test warnings or errors.

Fixing this helps maintain a clean test environment and ensures consistent internal behavior between test and production code paths.

## Screenshots

_N/A – no visual/UI changes._

## Impact to users

No impact to EUI consumers. This change only affects the `flyout.testenv.tsx` mock used in tests. It prevents a non-breaking warning from appearing in Jest output. No runtime behavior or visual output is affected.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
