### PR TITLE
[SCSS] Fix `transparent` variable values

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8966.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8966.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed the syntax of the SCSS variable `$euiColorTransparent` to ensure a valid value
+

--- a/packages/eui-theme-borealis/src/variables/colors/_semantic_colors.scss
+++ b/packages/eui-theme-borealis/src/variables/colors/_semantic_colors.scss
@@ -9,7 +9,7 @@ $euiColorWhite: #FFFFFF !default;
 $euiColorBlack: #000000 !default;
 $euiColorMutedBlack: #0E0F12 !default;
 $euiColorBlueBlack: #050F21 !default;
-$euiColorTransparent: 'transparent' !default;
+$euiColorTransparent: transparent !default;
 
 $euiColorPlainLight: $euiColorWhite !default;
 $euiColorPlainDark: $euiColorBlueBlack !default;

--- a/packages/eui/changelogs/upcoming/8966.md
+++ b/packages/eui/changelogs/upcoming/8966.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed the syntax of the SCSS variable `$euiColorTransparent` to ensure a valid value
+

--- a/packages/eui/src/themes/amsterdam/_colors_dark.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_dark.scss
@@ -121,8 +121,8 @@ $euiColorBorderBaseFloating: $euiColorLightShade !default;
 $euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
 $euiColorBorderBaseFormsControl: tint($euiColorLightestShade, 0.31) !default;
 
-$euiColorBorderInteractiveFormsHoverPlain: 'transparent' !default;
-$euiColorBorderInteractiveFormsHoverDanger: 'transparent' !default;
+$euiColorBorderInteractiveFormsHoverPlain: transparent !default;
+$euiColorBorderInteractiveFormsHoverDanger: transparent !default;
 
 $euiColorBorderStrongPrimary: $euiColorPrimary !default;
 $euiColorBorderStrongAccent: $euiColorAccent !default;

--- a/packages/eui/src/themes/amsterdam/_colors_light.scss
+++ b/packages/eui/src/themes/amsterdam/_colors_light.scss
@@ -117,12 +117,12 @@ $euiColorBorderBaseDanger: tint($euiColorDanger, 0.6) !default;
 $euiColorBorderBasePlain: $euiColorLightShade !default;
 $euiColorBorderBaseSubdued: $euiColorLightShade !default;
 $euiColorBorderBaseDisabled: transparentize(darken($euiColorLightShade, 40%), 0.1) !default;
-$euiColorBorderBaseFloating: 'transparent' !default;
+$euiColorBorderBaseFloating: transparent !default;
 $euiColorBorderBaseFormsColorSwatch: transparentize($euiColorFullShade, 0.1) !default;
 $euiColorBorderBaseFormsControl: shade($euiColorLightestShade, 0.4) !default;
 
-$euiColorBorderInteractiveFormsHoverPlain: 'transparent' !default;
-$euiColorBorderInteractiveFormsHoverDanger: 'transparent' !default;
+$euiColorBorderInteractiveFormsHoverPlain: transparent !default;
+$euiColorBorderInteractiveFormsHoverDanger: transparent !default;
 
 $euiColorBorderStrongPrimary: $euiColorPrimary !default;
 $euiColorBorderStrongAccent: $euiColorAccent !default;


### PR DESCRIPTION
## Summary

This PR fixes invalid `transparent` values in SCSS. The usage of strings `'transparent'` is not correct and leads to invalid css output.

Affected SCSS variables: `$euiColorTransparent`.

## Why are we making this change?

Fixing incorrect SCSS variables to prevent broken style output.

## Screenshots

| before | after |
|---|---|
| <img width="1378" height="199" alt="Screenshot 2025-08-13 at 19 15 35" src="https://github.com/user-attachments/assets/684a2f20-9c9f-47a8-9b02-68a406d3db4d" /> | <img width="1407" height="235" alt="Screenshot 2025-08-13 at 19 23 06" src="https://github.com/user-attachments/assets/4218de19-11b0-47e3-bc41-6191aa57bb7f" /> |

## Impact to users

🟢 There are no updates needed on consumer side

## QA

🔗 [Testing codesandbox](https://codesandbox.io/p/sandbox/agitated-haze-7glrkg)

- [x] verify that the updated EUI variable `$euiColorTransparent` returns valid styles
  - update the `package.json` entires to `latest` to switch back to the previous broken state

### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~Checked in **mobile**~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [ ] ~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~
    - [ ] ~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
