### PR TITLE
[EuiDataGrid] Enable row background color on hover for `stripes={true}`

### DIFF
--- a/packages/eui-theme-borealis/src/variables/_components.ts
+++ b/packages/eui-theme-borealis/src/variables/_components.ts
@@ -156,25 +156,20 @@ const component_colors: _EuiThemeComponentColors = {
     ([backgroundBasePlain]) => backgroundBasePlain,
     ['colors.backgroundBasePlain']
   ),
-  dataGridRowStripesBackgroundHover: computed(
-    ([backgroundBasePlain]) => backgroundBasePlain,
-    ['colors.backgroundBasePlain']
-  ),
+  dataGridRowStripesBackgroundHover: SEMANTIC_COLORS.shade15,
   dataGridRowStripesBackgroundStriped: computed(
     ([backgroundBaseSubdued]) => backgroundBaseSubdued,
     ['colors.backgroundBaseSubdued']
   ),
-  dataGridRowStripesBackgroundStripedHover: computed(
-    ([backgroundBaseSubdued]) => backgroundBaseSubdued,
-    ['colors.backgroundBaseSubdued']
-  ),
+  dataGridRowStripesBackgroundStripedHover: SEMANTIC_COLORS.shade15,
   dataGridRowStripesBackgroundSelect: computed(
     ([backgroundBaseInteractiveSelect]) => backgroundBaseInteractiveSelect,
     ['colors.backgroundBaseInteractiveSelect']
   ),
   dataGridRowStripesBackgroundSelectHover: computed(
-    ([backgroundBaseInteractiveSelect]) => backgroundBaseInteractiveSelect,
-    ['colors.backgroundBaseInteractiveSelect']
+    ([backgroundBaseInteractiveSelectHover]) =>
+      backgroundBaseInteractiveSelectHover,
+    ['colors.backgroundBaseInteractiveSelectHover']
   ),
 
   dragDropDraggingBackground: computed(
@@ -381,6 +376,8 @@ export const components: _EuiThemeComponents = {
 
     buttonGroupFocusColor: SEMANTIC_COLORS.plainLight,
 
+    dataGridRowStripesBackgroundHover: SEMANTIC_COLORS.shade130,
+    dataGridRowStripesBackgroundStripedHover: SEMANTIC_COLORS.shade130,
     dataGridRowBackgroundMarked: SEMANTIC_COLORS.warning140,
     dataGridRowBackgroundMarkedHover: SEMANTIC_COLORS.warning130,
 

--- a/packages/eui/changelogs/upcoming/8983.md
+++ b/packages/eui/changelogs/upcoming/8983.md
@@ -1,0 +1,2 @@
+- Updated `EuiDataGrid` hover styles when `stripes={true}`. Now there is a background color change on hover.
+

--- a/packages/eui/changelogs/upcoming/8983.md
+++ b/packages/eui/changelogs/upcoming/8983.md
@@ -1,2 +1,2 @@
-- Updated `EuiDataGrid` hover styles when `stripes={true}`. Now there is a background color change on hover.
+- Updated `EuiDataGrid` hover styles when `stripes={true}` to ensure a visible background color change on hover
 

--- a/packages/eui/src/components/datagrid/data_grid.styles.ts
+++ b/packages/eui/src/components/datagrid/data_grid.styles.ts
@@ -87,7 +87,7 @@ export const euiDataGridStyles = (euiThemeContext: UseEuiTheme) => {
       /* The euiDataGridRow--selected and euiDataGridRow--marked classes are not used internally,
        * they're there for convenience, to be used by consumers */
 
-      *:where(&:not(.euiDataGrid--stripes) .euiDataGridRow--selected) {
+      *:where(& .euiDataGridRow--selected) {
         background-color: ${euiTheme.components.dataGridRowBackgroundSelect};
       }
 
@@ -103,7 +103,7 @@ export const euiDataGridStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
 
-      *:where(&:not(.euiDataGrid--stripes) .euiDataGridRow--marked) {
+      *:where(&.euiDataGrid--rowHoverHighlight .euiDataGridRow--marked) {
         &:hover {
           background-color: ${euiTheme.components
             .dataGridRowBackgroundMarkedHover};


### PR DESCRIPTION
## Summary

This PR adds a visual change to EuiDataGrid related to the background color of rows on hover, specifically when using stripes (`stripes` prop equals `true`).

The original design spec within the Visual Refresh effort removed the hover state color change for stripes. After further alignment with teams, this has been ~~reverted~~ reworked.

## Why are we making this change?

To make sure the design spec is implemented equally and consistently.

Related PRs:
- https://github.com/elastic/kibana/pull/229928
- https://github.com/elastic/eui/pull/8769
- https://github.com/elastic/eui-private/issues/360 🔒 

## Screenshots

<details>
<summary>Hover states for striped data grids, in light and dark mode.</summary>


<img width="2272" height="1750" alt="Screenshot 2025-08-27 at 10 49 48" src="https://github.com/user-attachments/assets/661554f2-50a5-4cd9-a04c-d5f25206348f" />

<img width="2272" height="1750" alt="Screenshot 2025-08-27 at 10 49 45" src="https://github.com/user-attachments/assets/6aeebfb2-5c3d-45d7-8cef-61a68fdaa6c7" />

<img width="2272" height="1750" alt="Screenshot 2025-08-27 at 10 50 21" src="https://github.com/user-attachments/assets/2fd92f60-75ea-4014-9e70-f3b00a34e06b" />

<img width="2272" height="1750" alt="Screenshot 2025-08-27 at 10 50 09" src="https://github.com/user-attachments/assets/65866a02-139e-4c2b-bc24-9b994cc74522" />

</details>

## Impact to users

🟢 No direct impact. These visual changes ensure UI remains almost the same while encouraging consistency.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [ ] ~~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~~
      - ~~(_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~~
    - [ ] ~~Checked in **mobile**~~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- Docs site QA
    - [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
    - [ ] ~~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    - [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- Code quality checklist
    - [ ] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~~
    - [ ] ~~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~ (not needed)
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist
  - [ ] ~~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~~
