### PR TITLE
fix(website): remove skip ci from update `versions.json`

### DIFF
--- a/packages/website/scripts/update-versions.js
+++ b/packages/website/scripts/update-versions.js
@@ -56,7 +56,7 @@ const updateVersions = async () => {
 
     // Add and commit the file
     exec(
-      `git add ${versionsFile} && git commit -m "chore: update versions.json [skip ci]"`,
+      `git add ${versionsFile} && git commit -m "chore: update versions.json"`,
       (err) => {
         if (err) {
           console.error('Error committing the file:', err);


### PR DESCRIPTION
## Summary

I remove `[skip ci]` from `chore: update versions.json [skip ci]` commit message to trigger the `eui-deploy-docs` pipeline and fix main documentation release.

## Why are we making this change?

The `versions.json` version append was automated on https://github.com/elastic/eui/pull/8895. The message includes `[skip ci]` so the documentation website is not released. See `eui-deploy-docs` [main history](https://buildkite.com/elastic/eui-deploy-docs/builds?branch=main&query=).

We do want the CI to run on that commit: `chore: update versions.json [skip ci]`.

For the last 2 versions that are missing, I will retroactively add it.

## QA

You can run the similar steps as on the PR ☝🏻 as a sanity check:

1. cd `eui/packages/eui`
2. Temporarily change `@elastic/eui` version: `npm version 106.1.1 --no-git-tag-version`
3. cd `../website`
4. node `./scripts/update-versions.js`
5. Verify `versions.json` file content and `git log` the latest commit should be: `chore: update versions.json [skip ci]`

To test whether this actually works we need to merge the PR and see how it behaves with the next release.