### PR TITLE
feat: Customise tooltip offset optional prop

### DIFF
--- a/packages/eui/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
+++ b/packages/eui/src/components/tool_tip/__snapshots__/tool_tip.test.tsx.snap
@@ -90,3 +90,45 @@ exports[`EuiToolTip shows tooltip on mouseover and focus 1`] = `
   </div>
 </body>
 `;
+
+exports[`EuiToolTip uses custom offset prop value 1`] = `
+<body
+  class="euiBody-hasPortalContent"
+>
+  <div>
+    <span
+      class="euiToolTipAnchor emotion-euiToolTipAnchor-inlineBlock"
+    >
+      <button
+        aria-describedby="generated-id"
+        data-test-subj="trigger"
+      >
+        Trigger
+      </button>
+    </span>
+  </div>
+  <div
+    data-euiportal="true"
+  >
+    <div
+      aria-label="aria-label"
+      class="euiToolTipPopover euiToolTip testClass1 testClass2 emotion-euiToolTip-top-euiTestCss"
+      data-position="top"
+      data-test-subj="test subject string"
+      id="generated-id"
+      offset="32"
+      position="top"
+      role="tooltip"
+      style="top: -32px; left: -10px;"
+    >
+      <div
+        class="euiToolTip__arrow emotion-euiToolTip__arrow-top"
+        style="left: 3px; top: 100%;"
+      />
+      <div>
+        content
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -47,6 +47,7 @@ const meta: Meta<EuiToolTipProps> = {
     repositionOnScroll: false,
     title: '',
     disableScreenReaderOutput: false,
+    offset: 8,
   },
 };
 enableFunctionToggleControls(meta, ['onMouseOut']);

--- a/packages/eui/src/components/tool_tip/tool_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.test.tsx
@@ -61,6 +61,19 @@ describe('EuiToolTip', () => {
     await waitForEuiToolTipVisible();
   });
 
+  it('uses custom offset prop value', async () => {
+    const offsetValue = 32;
+    const { baseElement, getByTestSubject } = render(
+      <EuiToolTip content="content" offset={offsetValue} {...requiredProps}>
+        <button data-test-subj="trigger">Trigger</button>
+      </EuiToolTip>
+    );
+    // Simulate mouse over to show tooltip
+    fireEvent.mouseOver(getByTestSubject('trigger'));
+    await waitForEuiToolTipVisible();
+    expect(baseElement).toMatchSnapshot();
+  });
+
   test('anchor props are rendered', () => {
     const { baseElement } = render(
       <EuiToolTip

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -121,6 +121,11 @@ export interface EuiToolTipProps extends CommonProps {
    * hidden.
    */
   onMouseOut?: (event: ReactMouseEvent<HTMLSpanElement, MouseEvent>) => void;
+
+  /**
+   * Offset in pixels from the anchor. Defaults to 16.
+   */
+  offset?: number;
 }
 
 interface State {
@@ -220,6 +225,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
 
   positionToolTip = () => {
     const requestedPosition = this.props.position;
+    const offset = this.props.offset ?? 16;
 
     if (!this.anchor || !this.popover) {
       return;
@@ -229,7 +235,7 @@ export class EuiToolTip extends Component<EuiToolTipProps, State> {
       anchor: this.anchor,
       popover: this.popover,
       position: requestedPosition,
-      offset: 16, // offset popover 16px from the anchor
+      offset,
       arrowConfig: {
         arrowWidth: 12,
         arrowBuffer: 4,


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

## Why are we making this change?
 Currently in relation to reworking navigation in Kibana, we faced the need to use custom offset values. So in this PR I am proposing a way to extend this capability and add optional offset prop which is set to default to the value that is used currently.
<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

## Screenshots

https://github.com/user-attachments/assets/84cc1431-d772-40c2-8625-d487df3c21ac


<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users
This is not a breaking change, it is on opt-in basis.
<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [x] Checked in both **light and dark** modes
    - [x] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [x] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
