### PR TITLE
Fix typo in EuiBadge reference

### DIFF
--- a/packages/website/docs/components/display/badge/index.mdx
+++ b/packages/website/docs/components/display/badge/index.mdx
@@ -4,7 +4,7 @@ keywords: [EuiBadge, EuiBetaBadge, EuiNotificationBadge]
 
 # Badge
 
-**EuiBadge** is used to focus on important bits of information. Although they will automatically space themselves if you use them in a repetitive fashion it is good form to wrap them using a **EuiBadgeGroup** so that they will wrap when width is constrained (as seen below).
+**EuiBadge** highlights key pieces of information. While badges will space themselves automatically when used repeatedly, it's best practice to wrap them in an **EuiBadgeGroup**. This ensures they wrap properly when space is limited (as shown below).
 
 ## Components
 

--- a/packages/website/docs/components/display/badge/index.mdx
+++ b/packages/website/docs/components/display/badge/index.mdx
@@ -4,7 +4,7 @@ keywords: [EuiBadge, EuiBetaBadge, EuiNotificationBadge]
 
 # Badge
 
-**EuiBadges** are used to focus on important bits of information. Although they will automatically space themselves if you use them in a repetitive fashion it is good form to wrap them using a **EuiBadgeGroup** so that they will wrap when width is constrained (as seen below).
+**EuiBadge** is used to focus on important bits of information. Although they will automatically space themselves if you use them in a repetitive fashion it is good form to wrap them using a **EuiBadgeGroup** so that they will wrap when width is constrained (as seen below).
 
 ## Components
 


### PR DESCRIPTION
## Summary

There is a misleading reference mentioning **EuiBadges** as a countable which actually doesn't exist referred to the React component which is uncountable **EuiBadge**. In order to avoid a weird output like this: **EuiBadge**s (with the "s" not applying the bold style) I suggest to change a bit the sentence to become: 

> EuiBadge is used to focus on important ...


### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
