### PR TITLE
[Docs] Add EuiFlyout CSS vars and component default documentation

### DIFF
--- a/packages/website/docs/components/containers/flyout/_flyout_push.mdx
+++ b/packages/website/docs/components/containers/flyout/_flyout_push.mdx
@@ -1,5 +1,3 @@
-# Push flyouts
-
 Another way to allow for continued interactions of the page content while a flyout is visible is to change the `type` from `overlay` to `push`.
 
 :::warning Push flyouts require manual accessibility management
@@ -11,6 +9,22 @@ Please be cautious when using push flyouts, and make sure you are managing your 
 :::
 
 A pushed flyout still positions itself as `fixed`, but adds padding to the document's body element to accommodate for the flyout's width. Because this squishes the page content, the flyout changes back to `overlay` at smaller window widths. You can adjust this minimum breakpoint with `pushMinBreakpoint`.
+
+#### Relative positioning
+
+Push flyouts automatically set global CSS variables that you can use to position other elements in your application relative to the flyout's width:
+
+- `--euiPushFlyoutOffsetInlineStart` (Set when `side="left"`)
+- `--euiPushFlyoutOffsetInlineEnd` (Set when `side="right"`)
+
+These variables are automatically updated when the flyout resizes and are removed when the flyout is closed. 
+
+```css
+.custom-fixed-sidebar {
+  /* Adjust sidebar position when left push flyout is open */
+  inset-inline-start: var(--euiPushFlyoutOffsetInlineStart, 0);
+}
+```
 
 
 ```tsx interactive

--- a/packages/website/docs/utilities/provider.mdx
+++ b/packages/website/docs/utilities/provider.mdx
@@ -106,6 +106,7 @@ All EUI components ship with a set of baseline defaults that can usually be conf
     EuiTablePagination: { itemsPerPage: 20, },
     EuiFocusTrap: { crossFrame: true },
     EuiPortal: { insert },
+    EuiFlyout: { includeSelectorInFocusTrap: ['.custom-selector', '[data-custom-selector]'], includeFixedHeadersInFocusTrap: false }
   }}
 >
   <App />


### PR DESCRIPTION
## Summary

This PR is a follow-up to https://github.com/elastic/eui/pull/8849 and https://github.com/elastic/eui/pull/8872 and adds/updates documentation for:

- `EuiFlyout`'s global CSS variables `--euiPushFlyoutOffsetInlineStart` and `--euiPushFlyoutOffsetInlineEnd`
- `EuiFlyout` specific component defaults on `EuiProvider`

## Why are we making this change?

To ensure available features are documented and discoverable.

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

🟢 There are no updates needed on consumer side. This affects EUI docs only.

## QA

- [x] review the added docs for [EuiFlyout CSS vars](https://eui.elastic.co/pr_9001/docs/components/containers/flyout/#relative-positioning)
- [x] review the updated docs for [EuiFlyout component defaults on EuiProvider ](https://eui.elastic.co/pr_9001/docs/utilities/provider/#component-defaults-)
