### PR TITLE
[EuiBadge] fix iconOnClick styles

### DIFF
--- a/packages/eui/src/components/badge/badge.styles.ts
+++ b/packages/eui/src/components/badge/badge.styles.ts
@@ -170,16 +170,6 @@ export const euiBadgeStyles = (euiThemeContext: UseEuiTheme) => {
       euiBadge__iconButton: css`
         font-size: 0; /* Makes the button only as large as the icon so it aligns vertically better */
 
-        &:focus {
-          background-color: ${euiTheme.components
-            .badgeIconButtonBackgroundHover};
-          color: ${euiTheme.colors.ink};
-          border-radius: ${mathWithUnits(
-            euiTheme.border.radius.small,
-            (x) => x / 2
-          )};
-        }
-
         &:disabled {
           cursor: not-allowed;
         }


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/114017

## Summary

This PR removes the styles that were defined for the iconOnClick case.

## Before
(Styles were applied when iconOnClick was present)

<img width="123" height="40" alt="image" src="https://github.com/user-attachments/assets/15874979-d2d0-4760-8b75-4ea7937e95d6" />

<img width="123" height="40" alt="image" src="https://github.com/user-attachments/assets/5d8c933c-48a3-461b-83f6-dda051f571a7" />


## After 
(Styles are no longer applied, making the code cleaner)

<img width="123" height="40" alt="image" src="https://github.com/user-attachments/assets/8cc4c07e-0323-4ccc-b8c9-d7fec5b81402" />

<img width="123" height="40" alt="image" src="https://github.com/user-attachments/assets/61bd9030-8c9c-4f74-826a-cf800e74b5f0" />

