### PR TITLE
[a11y] Add a rule for conditionally rendered EuiCallOut

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -147,6 +147,10 @@ Ensure `EuiIconTip` is used rather than `<EuiToolTip><EuiIcon/></EuiToolTip>`, a
 
 Ensure that all radio input components (`EuiRadio`, `EuiRadioGroup`) have a `name` attribute. The `name` attribute is required for radio inputs to be grouped correctly, allowing users to select only one option from a set. Without a `name`, radios may not behave as expected and can cause accessibility issues for assistive technologies.
 
+### `@elastic/eui/callout-announce-on-mount`
+
+Ensures that `EuiCallOut` components rendered conditionally have the `announceOnMount` prop for better accessibility. When callouts appear dynamically (e.g., after user interactions, form validation errors, or status changes), screen readers may not announce their content to users. The `announceOnMount` prop ensures these messages are properly announced to users with assistive technologies.
+
 ## Testing
 
 ### Running unit tests

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { CallOutAnnounceOnMount } from './rules/a11y/callout_announce_on_mount';
 import { HrefOnClick } from './rules/href_or_on_click';
 import { NoRestrictedEuiImports } from './rules/no_restricted_eui_imports';
 import { NoCssColor } from './rules/no_css_color';
@@ -37,6 +38,7 @@ const config = {
     'sr-output-disabled-tooltip': ScreenReaderOutputDisabledTooltip,
     'prefer-eui-icon-tip': PreferEuiIconTip,
     'no-unnamed-radio-group' : NoUnnamedRadioGroup,
+    'callout-announce-on-mount': CallOutAnnounceOnMount
   },
   configs: {
     recommended: {
@@ -50,6 +52,7 @@ const config = {
         '@elastic/eui/sr-output-disabled-tooltip': 'warn',
         '@elastic/eui/prefer-eui-icon-tip': 'warn',
         '@elastic/eui/no-unnamed-radio-group': 'warn',
+        '@elastic/eui/callout-announce-on-mount': 'warn',
       },
     },
   },

--- a/packages/eslint-plugin/src/rules/a11y/callout_announce_on_mount.test.ts
+++ b/packages/eslint-plugin/src/rules/a11y/callout_announce_on_mount.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CallOutAnnounceOnMount } from './callout_announce_on_mount';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+const languageOptions = {
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+};
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('callout-announce-on-mount', CallOutAnnounceOnMount, {
+  valid: [
+    {
+      code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Always visible callout">
+            This callout is always rendered
+          </EuiCallOut>
+        )
+      `,
+      languageOptions,
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => (
+          condition && <EuiCallOut announceOnMount title="Error">
+            Something went wrong
+          </EuiCallOut>
+        )
+      `,
+      languageOptions,
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => (
+          condition ? <EuiCallOut announceOnMount title="Success">
+            Operation completed
+          </EuiCallOut> : null
+        )
+      `,
+      languageOptions,
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => {
+          if (condition) {
+            return <EuiCallOut announceOnMount title="Warning">
+              Please check your input
+            </EuiCallOut>
+          }
+          return null;
+        }
+      `,
+      languageOptions,
+    },
+    {
+      code: dedent`
+        const MyComponent = () => (
+          <div>
+            <EuiCallOut title="Static callout">
+              This is not conditionally rendered
+            </EuiCallOut>
+          </div>
+        )
+      `,
+      languageOptions,
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => (
+          condition && <EuiCallOut title="Error">
+            Something went wrong
+          </EuiCallOut>
+        )
+      `,
+      output: dedent`
+        const MyComponent = ({ condition }) => (
+          condition && <EuiCallOut announceOnMount title="Error">
+            Something went wrong
+          </EuiCallOut>
+        )
+      `,
+      languageOptions,
+      errors: [{ messageId: 'missingAnnounceOnMount' }],
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => (
+          condition ? <EuiCallOut title="Success">
+            Operation completed
+          </EuiCallOut> : null
+        )
+      `,
+      output: dedent`
+        const MyComponent = ({ condition }) => (
+          condition ? <EuiCallOut announceOnMount title="Success">
+            Operation completed
+          </EuiCallOut> : null
+        )
+      `,
+      languageOptions,
+      errors: [{ messageId: 'missingAnnounceOnMount' }],
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => {
+          if (condition) {
+            return <EuiCallOut title="Warning">
+              Please check your input
+            </EuiCallOut>
+          }
+          return null;
+        }
+      `,
+      output: dedent`
+        const MyComponent = ({ condition }) => {
+          if (condition) {
+            return <EuiCallOut announceOnMount title="Warning">
+              Please check your input
+            </EuiCallOut>
+          }
+          return null;
+        }
+      `,
+      languageOptions,
+      errors: [{ messageId: 'missingAnnounceOnMount' }],
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ condition }) => (
+          <div>
+            {!condition && <EuiCallOut title="Validation Error">
+              Form contains errors
+            </EuiCallOut>}
+          </div>
+        )
+      `,
+      output: dedent`
+        const MyComponent = ({ condition }) => (
+          <div>
+            {!condition && <EuiCallOut announceOnMount title="Validation Error">
+              Form contains errors
+            </EuiCallOut>}
+          </div>
+        )
+      `,
+      languageOptions,
+      errors: [{ messageId: 'missingAnnounceOnMount' }],
+    },
+    {
+      code: dedent`
+        const MyComponent = ({ status }) => {
+          let notification;
+
+          if (status === 'success') {
+            notification = (
+              <EuiCallOut
+                title="Task completed successfully"
+              />
+            );
+          } else if (status === 'error') {
+            notification = (
+              <EuiCallOut
+                title="Something went wrong"
+              />
+            );
+          }
+
+          return <div>{notification}</div>;
+        }
+      `,
+      output: dedent`
+        const MyComponent = ({ status }) => {
+          let notification;
+
+          if (status === 'success') {
+            notification = (
+              <EuiCallOut announceOnMount
+                title="Task completed successfully"
+              />
+            );
+          } else if (status === 'error') {
+            notification = (
+              <EuiCallOut announceOnMount
+                title="Something went wrong"
+              />
+            );
+          }
+
+          return <div>{notification}</div>;
+        }
+      `,
+      languageOptions,
+      errors: [
+        { messageId: 'missingAnnounceOnMount' },
+        { messageId: 'missingAnnounceOnMount' },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/a11y/callout_announce_on_mount.ts
+++ b/packages/eslint-plugin/src/rules/a11y/callout_announce_on_mount.ts
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { type TSESTree, ESLintUtils } from '@typescript-eslint/utils';
+
+const CALLOUT_COMPONENT = 'EuiCallOut';
+
+export const CallOutAnnounceOnMount = ESLintUtils.RuleCreator.withoutDocs({
+  create(context) {
+    function isInConditionalRendering(node: TSESTree.JSXElement): boolean {
+      let parent: TSESTree.Node | undefined = node.parent;
+      
+      while (parent) {
+        if (parent.type === 'ConditionalExpression' || 
+            parent.type === 'IfStatement' ||
+            (parent.type === 'LogicalExpression' && parent.operator === '&&')) {
+          return true;
+        }
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    return {
+      JSXElement(node) {
+        const { openingElement } = node;
+        if (openingElement.name.type !== 'JSXIdentifier' || 
+            openingElement.name.name !== CALLOUT_COMPONENT) {
+          return;
+        }
+        if (openingElement.attributes.some(attr => 
+          attr.type === 'JSXAttribute' &&
+          attr.name.type === 'JSXIdentifier' &&
+          attr.name.name === 'announceOnMount'
+        )) {
+          return;
+        }
+        if (isInConditionalRendering(node)) {
+          const hasSpread = openingElement.attributes.some(a => a.type === 'JSXSpreadAttribute');
+          
+          context.report({
+            node: openingElement,
+            messageId: 'missingAnnounceOnMount',
+            fix: hasSpread ? undefined : (fixer) => {
+              return fixer.insertTextAfterRange(
+                [openingElement.name.range[1], openingElement.name.range[1]], 
+                ' announceOnMount'
+              );
+            },
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Ensure EuiCallout components that are conditionally rendered have announceOnMount prop for better accessibility'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingAnnounceOnMount: [
+        'EuiCallout should have "announceOnMount" prop when conditionally rendered for better accessibility.',
+        '\n',
+        'When EuiCallout appears dynamically (e.g., after user interaction, form validation, etc.),',
+        'screen readers may not announce its content. Adding "announceOnMount" ensures the callout',
+        'is properly announced to users with assistive technologies.',
+        '\n',
+        'Example:',
+        '  <EuiCallout announceOnMount title="Error" color="danger">',
+        '    This message will be announced when it appears',
+        '  </EuiCallout>',
+      ].join('\n'),
+    },
+  },
+  defaultOptions: [],
+});


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
