### PR TITLE
Changelog entry missing for `eui-theme-borealis` in #8983

### DIFF
--- a/packages/eui-theme-borealis/changelogs/upcoming/8983.md
+++ b/packages/eui-theme-borealis/changelogs/upcoming/8983.md
@@ -1,0 +1,6 @@
+- Updated values for component tokens
+  - `dataGridRowStripesBackgroundHover`
+  - `dataGridRowStripesBackgroundStripedHover`
+  - `dataGridRowStripesBackgroundSelectHover`
+  - `dataGridRowStripesBackgroundHover`
+  - `dataGridRowStripesBackgroundStripedHover`


### PR DESCRIPTION
#8983 made updates to component tokens in the `@elastic/eui-theme-borealis` package, but the changelog entry was missing and the expected release was not triggered. This PR fixes part of that.