### PR TITLE
[Flyout system] Add `isOpen` prop for better opening and closing animations

### DIFF
--- a/packages/eui-theme-borealis/src/eui_theme_borealis_dark.json
+++ b/packages/eui-theme-borealis/src/eui_theme_borealis_dark.json
@@ -15,7 +15,7 @@
   "euiContrastRatioGraphic": 3,
   "euiContrastRatioDisabled": 2,
   "euiAnimSlightBounce": "cubic-bezier(0.34, 1.61, 0.7, 1)",
-  "euiAnimSlightResistance": "cubic-bezier(0.694, 0.0482, 0.335, 1)",
+  "euiAnimSlightResistance": "cubic-bezier(0.32, 0.72, 0, 1)",
   "euiAnimSpeedExtraFast": "90ms",
   "euiAnimSpeedFast": "150ms",
   "euiAnimSpeedNormal": "250ms",

--- a/packages/eui-theme-borealis/src/eui_theme_borealis_light.json
+++ b/packages/eui-theme-borealis/src/eui_theme_borealis_light.json
@@ -15,7 +15,7 @@
   "euiContrastRatioGraphic": 3,
   "euiContrastRatioDisabled": 2,
   "euiAnimSlightBounce": "cubic-bezier(0.34, 1.61, 0.7, 1)",
-  "euiAnimSlightResistance": "cubic-bezier(0.694, 0.0482, 0.335, 1)",
+  "euiAnimSlightResistance": "cubic-bezier(0.32, 0.72, 0, 1)",
   "euiAnimSpeedExtraFast": "90ms",
   "euiAnimSpeedFast": "150ms",
   "euiAnimSpeedNormal": "250ms",

--- a/packages/eui-theme-borealis/src/variables/_animation.ts
+++ b/packages/eui-theme-borealis/src/variables/_animation.ts
@@ -22,7 +22,7 @@ export const animation_speed: _EuiThemeAnimationSpeeds = {
 
 export const animation_ease: _EuiThemeAnimationEasings = {
   bounce: 'cubic-bezier(.34, 1.61, .7, 1)',
-  resistance: 'cubic-bezier(.694, .0482, .335, 1)',
+  resistance: 'cubic-bezier(.32, .72, 0, 1)',
 };
 
 export const animation: _EuiThemeAnimation = {

--- a/packages/eui-theme-common/src/global_styling/variables/_animations.scss
+++ b/packages/eui-theme-common/src/global_styling/variables/_animations.scss
@@ -1,7 +1,7 @@
 // Animations
 
 $euiAnimSlightBounce: cubic-bezier(.34, 1.61, .7, 1) !default;
-$euiAnimSlightResistance: cubic-bezier(.694, .0482, .335, 1) !default;
+$euiAnimSlightResistance: cubic-bezier(.32, .72, 0, 1) !default;
 
 $euiAnimSpeedExtraFast: 90ms !default;
 $euiAnimSpeedFast: 150ms !default;

--- a/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EuiCollapsibleNav close button can be hidden 1`] = `
       <nav
         aria-describedby="generated-id"
         aria-modal="true"
-        class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
         role="dialog"
@@ -69,7 +69,7 @@ exports[`EuiCollapsibleNav is rendered 1`] = `
         aria-describedby="generated-id"
         aria-label="aria-label"
         aria-modal="true"
-        class="euiFlyout euiCollapsibleNav testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay-euiTestCss"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay-euiTestCss"
         data-autofocus="true"
         data-test-subj="test subject string"
         id="id"
@@ -110,51 +110,53 @@ exports[`EuiCollapsibleNav is rendered 1`] = `
 
 exports[`EuiCollapsibleNav props accepts EuiFlyout props 1`] = `
 <div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-  <div
-    data-focus-lock-disabled="false"
-  >
-    <nav
-      aria-describedby="generated-id"
-      aria-modal="true"
-      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
-      data-autofocus="true"
-      id="id"
-      role="dialog"
-      style="inline-size: 240px;"
+  <div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
       tabindex="0"
+    />
+    <div
+      data-focus-lock-disabled="false"
     >
-      <p
-        class="emotion-euiScreenReaderOnly"
-        id="generated-id"
+      <nav
+        aria-describedby="generated-id"
+        aria-modal="true"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
+        data-autofocus="true"
+        id="id"
+        role="dialog"
+        style="inline-size: 240px;"
+        tabindex="0"
       >
-        You are in a non-modal dialog. To close the dialog, press Escape.
-         
-      </p>
-      <button
-        aria-label="Close this dialog"
-        class="euiButtonIcon euiFlyout__closeButton emotion-euiButtonIcon-xs-fill-text-euiFlyout__closeButton-outside-left"
-        data-test-subj="euiFlyoutCloseButton"
-        type="button"
-      >
-        <span
-          aria-hidden="true"
-          class="euiButtonIcon__icon"
-          color="inherit"
-          data-euiicon-type="cross"
-        />
-      </button>
-    </nav>
+        <p
+          class="emotion-euiScreenReaderOnly"
+          id="generated-id"
+        >
+          You are in a non-modal dialog. To close the dialog, press Escape.
+           
+        </p>
+        <button
+          aria-label="Close this dialog"
+          class="euiButtonIcon euiFlyout__closeButton emotion-euiButtonIcon-xs-fill-text-euiFlyout__closeButton-outside-left"
+          data-test-subj="euiFlyoutCloseButton"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="euiButtonIcon__icon"
+            color="inherit"
+            data-euiicon-type="cross"
+          />
+        </button>
+      </nav>
+    </div>
+    <div
+      data-focus-guard="true"
+      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+      tabindex="0"
+    />
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
 </div>
 `;
 
@@ -177,7 +179,7 @@ exports[`EuiCollapsibleNav props button 1`] = `
       <nav
         aria-describedby="generated-id"
         aria-modal="true"
-        class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
         role="dialog"
@@ -229,7 +231,7 @@ exports[`EuiCollapsibleNav props dockedBreakpoint 1`] = `
       <nav
         aria-describedby="generated-id"
         aria-modal="true"
-        class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
         role="dialog"
@@ -278,7 +280,7 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <nav
-      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
+      class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px;"
     />
@@ -305,7 +307,7 @@ exports[`EuiCollapsibleNav props onClose 1`] = `
       <nav
         aria-describedby="generated-id"
         aria-modal="true"
-        class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
         role="dialog"
@@ -359,7 +361,7 @@ exports[`EuiCollapsibleNav props showButtonIfDocked 1`] = `
     data-focus-lock-disabled="disabled"
   >
     <nav
-      class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
+      class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px;"
     />
@@ -386,7 +388,7 @@ exports[`EuiCollapsibleNav props size 1`] = `
       <nav
         aria-describedby="generated-id"
         aria-modal="true"
-        class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-overlay-left-left-euiCollapsibleNav-overlay"
         data-autofocus="true"
         id="id"
         role="dialog"

--- a/packages/eui/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/__snapshots__/collapsible_nav_beta.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`EuiCollapsibleNavBeta renders 1`] = `
     >
       <nav
         aria-label="aria-label"
-        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNavBeta-left-isPush-euiTestCss"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav euiCollapsibleNavBeta testClass1 testClass2 emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNavBeta-left-isPush-euiTestCss"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
         style="inline-size: 248px;"
@@ -89,7 +89,7 @@ exports[`EuiCollapsibleNavBeta renders initialIsCollapsed 1`] = `
     >
       <nav
         aria-label="Site menu"
-        class="euiFlyout euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNavBeta-left-isPush-isPushCollapsed"
+        class="euiFlyout euiFlyout--open euiCollapsibleNav euiCollapsibleNavBeta emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNavBeta-left-isPush-isPushCollapsed"
         data-test-subj="nav"
         id="generated-id_euiCollapsibleNav"
         style="inline-size: 48px;"

--- a/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -598,49 +598,51 @@ exports[`EuiFlyout props ownFocus can be false 1`] = `
   style=""
 >
   <div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
+    <div>
       <div
-        aria-describedby="generated-id"
-        aria-modal="true"
-        class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
-        data-autofocus="true"
-        role="dialog"
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
         tabindex="0"
+      />
+      <div
+        data-focus-lock-disabled="false"
       >
-        <p
-          class="emotion-euiScreenReaderOnly"
-          id="generated-id"
+        <div
+          aria-describedby="generated-id"
+          aria-modal="true"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          data-autofocus="true"
+          role="dialog"
+          tabindex="0"
         >
-          You are in a non-modal dialog. To close the dialog, press Escape.
-           
-        </p>
-        <button
-          aria-label="Close this dialog"
-          class="euiButtonIcon euiFlyout__closeButton emotion-euiButtonIcon-xs-empty-text-euiFlyout__closeButton-inside"
-          data-test-subj="euiFlyoutCloseButton"
-          type="button"
-        >
-          <span
-            aria-hidden="true"
-            class="euiButtonIcon__icon"
-            color="inherit"
-            data-euiicon-type="cross"
-          />
-        </button>
+          <p
+            class="emotion-euiScreenReaderOnly"
+            id="generated-id"
+          >
+            You are in a non-modal dialog. To close the dialog, press Escape.
+             
+          </p>
+          <button
+            aria-label="Close this dialog"
+            class="euiButtonIcon euiFlyout__closeButton emotion-euiButtonIcon-xs-empty-text-euiFlyout__closeButton-inside"
+            data-test-subj="euiFlyoutCloseButton"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="euiButtonIcon__icon"
+              color="inherit"
+              data-euiicon-type="cross"
+            />
+          </button>
+        </div>
       </div>
+      <div
+        data-focus-guard="true"
+        style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        tabindex="0"
+      />
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </body>
 `;

--- a/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`EuiFlyout is rendered 1`] = `
           aria-describedby="generated-id"
           aria-label="aria-label"
           aria-modal="true"
-          class="euiFlyout testClass1 testClass2 emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right-euiTestCss"
+          class="euiFlyout euiFlyout--open testClass1 testClass2 emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right-euiTestCss"
           data-autofocus="true"
           data-test-subj="test subject string"
           role="dialog"
@@ -73,7 +73,7 @@ exports[`EuiFlyout props accepts div props 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           id="imaflyout"
           role="dialog"
@@ -128,7 +128,7 @@ exports[`EuiFlyout props closeButtonPosition can be outside 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -182,7 +182,7 @@ exports[`EuiFlyout props closeButtonProps 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -236,7 +236,7 @@ exports[`EuiFlyout props hideCloseButton 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -278,7 +278,7 @@ exports[`EuiFlyout props is rendered as nav 1`] = `
         <nav
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -333,7 +333,7 @@ exports[`EuiFlyout props maxWidth can be set to a custom number 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           style="max-inline-size: 1024px;"
@@ -389,7 +389,7 @@ exports[`EuiFlyout props maxWidth can be set to a custom value and measurement 1
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           style="max-inline-size: 24rem;"
@@ -445,7 +445,7 @@ exports[`EuiFlyout props maxWidth can be set to a default 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -500,7 +500,7 @@ exports[`EuiFlyout props outsideClickCloses 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -555,7 +555,7 @@ exports[`EuiFlyout props ownFocus can alter mask props with maskProps without th
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -609,7 +609,7 @@ exports[`EuiFlyout props ownFocus can be false 1`] = `
       <div
         aria-describedby="generated-id"
         aria-modal="true"
-        class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+        class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
         data-autofocus="true"
         role="dialog"
         tabindex="0"
@@ -663,7 +663,7 @@ exports[`EuiFlyout props paddingSize l is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -718,7 +718,7 @@ exports[`EuiFlyout props paddingSize m is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-m-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-m-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -773,7 +773,7 @@ exports[`EuiFlyout props paddingSize none is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-none-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-none-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -828,7 +828,7 @@ exports[`EuiFlyout props paddingSize s is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-s-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-s-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -867,7 +867,7 @@ exports[`EuiFlyout props paddingSize s is rendered 1`] = `
 
 exports[`EuiFlyout props push flyouts renders 1`] = `
 <div
-  class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-push-right-noAnimation-right"
+  class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-push-right-noAnimation-right"
   data-test-subj="flyout"
 >
   <button
@@ -903,7 +903,7 @@ exports[`EuiFlyout props sides left is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-left-left"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-left-left"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -957,7 +957,7 @@ exports[`EuiFlyout props sides right is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -1012,7 +1012,7 @@ exports[`EuiFlyout props size accepts custom number 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           style="inline-size: 500px;"
@@ -1068,7 +1068,7 @@ exports[`EuiFlyout props size fill is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-fill-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-fill-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -1123,7 +1123,7 @@ exports[`EuiFlyout props size l is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-l-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-l-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -1178,7 +1178,7 @@ exports[`EuiFlyout props size m is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -1233,7 +1233,7 @@ exports[`EuiFlyout props size s is rendered 1`] = `
         <div
           aria-describedby="generated-id"
           aria-modal="true"
-          class="euiFlyout emotion-euiFlyout-l-s-noMaxWidth-overlay-right-right"
+          class="euiFlyout euiFlyout--open emotion-euiFlyout-l-s-noMaxWidth-overlay-right-right"
           data-autofocus="true"
           role="dialog"
           tabindex="0"
@@ -1293,7 +1293,7 @@ exports[`EuiFlyout renders extra screen reader instructions when fixed EuiHeader
           aria-describedby="generated-id"
           aria-label="aria-label"
           aria-modal="true"
-          class="euiFlyout testClass1 testClass2 emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right-euiTestCss"
+          class="euiFlyout euiFlyout--open testClass1 testClass2 emotion-euiFlyout-l-m-noMaxWidth-overlay-right-right-euiTestCss"
           data-autofocus="true"
           data-test-subj="test subject string"
           role="dialog"

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -45,7 +45,7 @@ import {
 
 import { CommonProps, PropsOfElement } from '../common';
 import { EuiFocusTrap, EuiFocusTrapProps } from '../focus_trap';
-import { EuiOverlayMaskProps } from '../overlay_mask';
+import type { EuiOverlayMaskProps } from '../overlay_mask';
 import type { EuiButtonIconPropsForButton } from '../button';
 import { EuiI18n } from '../i18n';
 import { useResizeObserver } from '../observer/resize_observer';
@@ -663,11 +663,15 @@ const EuiFlyoutComponentWrapper: FunctionComponent<{
   hasOverlayMask: boolean;
   maskProps: EuiFlyoutComponentProps['maskProps'];
   isPortalled: boolean;
-}> = ({ children, isPortalled }) => {
+}> = ({ children, hasOverlayMask, isPortalled }) => {
   // TODO(tkajtoch): Add EuiOverlayMask again
 
-  if (isPortalled) {
-    return <EuiPortal>{children}</EuiPortal>;
+  if (isPortalled || hasOverlayMask) {
+    return (
+      <EuiPortal>
+        <div>{children}</div>
+      </EuiPortal>
+    );
   } else {
     return <>{children}</>;
   }

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -22,6 +22,7 @@ import React, {
   MutableRefObject,
   ReactNode,
   JSX,
+  AnimationEventHandler,
 } from 'react';
 import classnames from 'classnames';
 
@@ -258,12 +259,17 @@ export const EuiFlyoutComponent = forwardRef(
       onResize,
       isOpen,
       onClosing,
+      onAnimationEnd: _onAnimationEnd,
       ...rest
     } = usePropsWithComponentDefaults('EuiFlyout', props);
 
     const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
 
-    const { openState, onAnimationEnd, closeFlyout } = useEuiFlyoutOpenState({
+    const {
+      openState,
+      onAnimationEnd: onAnimationEndFlyoutOpenState,
+      closeFlyout,
+    } = useEuiFlyoutOpenState({
       isOpen,
       onClose,
       onClosing,
@@ -566,6 +572,14 @@ export const EuiFlyoutComponent = forwardRef(
     );
 
     const maskCombinedRefs = useCombinedRefs([maskProps?.maskRef, maskRef]);
+
+    const onAnimationEnd = useCallback<AnimationEventHandler>(
+      (event) => {
+        onAnimationEndFlyoutOpenState(event);
+        _onAnimationEnd?.(event);
+      },
+      [_onAnimationEnd, onAnimationEndFlyoutOpenState]
+    );
 
     if (openState === 'closed') {
       // Render null only if the flyout is completely closed

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -257,7 +257,7 @@ export const EuiFlyoutComponent = forwardRef(
       resizable = false,
       minWidth,
       onResize,
-      isOpen,
+      isOpen = true,
       onClosing,
       onAnimationEnd: _onAnimationEnd,
       ...rest

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -44,7 +44,7 @@ import {
 
 import { CommonProps, PropsOfElement } from '../common';
 import { EuiFocusTrap, EuiFocusTrapProps } from '../focus_trap';
-import { EuiOverlayMask, EuiOverlayMaskProps } from '../overlay_mask';
+import { EuiOverlayMaskProps } from '../overlay_mask';
 import type { EuiButtonIconPropsForButton } from '../button';
 import { EuiI18n } from '../i18n';
 import { useResizeObserver } from '../observer/resize_observer';
@@ -69,9 +69,23 @@ import {
 import { useIsPushed } from './hooks';
 import { EuiFlyoutResizeButton } from './_flyout_resize_button';
 import { useEuiFlyoutResizable } from './use_flyout_resizable';
+import {
+  useEuiFlyoutOpenState,
+  type EuiFlyoutOpenState,
+} from './use_open_state';
 
 interface _EuiFlyoutComponentProps {
-  onClose: (event: MouseEvent | TouchEvent | KeyboardEvent) => void;
+  /**
+   * Whether the flyout is open (visible) or closed (hidden).
+   * It defaults to `true` for backwards compatibility.
+   * @default true
+   */
+  isOpen?: boolean;
+  /**
+   *
+   */
+  onClose: (event?: MouseEvent | TouchEvent | KeyboardEvent) => void;
+  onClosing?: (event?: MouseEvent | TouchEvent | KeyboardEvent) => void;
   /**
    * Defines the width of the panel.
    * Pass a predefined size of `s | m | l`, or pass any number/string compatible with the CSS `width` attribute
@@ -188,6 +202,14 @@ interface _EuiFlyoutComponentProps {
 
 const defaultElement = 'div';
 
+const openStateToClassNameMap: Record<EuiFlyoutOpenState, string> = {
+  opening: 'euiFlyout--opening',
+  open: 'euiFlyout--open',
+  closing: 'euiFlyout--closing',
+  // No special class needed for the closed state
+  closed: '',
+};
+
 type Props<T extends ElementType> = CommonProps & {
   /**
    * Sets the HTML element for `EuiFlyout`
@@ -234,10 +256,18 @@ export const EuiFlyoutComponent = forwardRef(
       resizable = false,
       minWidth,
       onResize,
+      isOpen,
+      onClosing,
       ...rest
     } = usePropsWithComponentDefaults('EuiFlyout', props);
 
     const { setGlobalCSSVariables } = useEuiThemeCSSVariables();
+
+    const { openState, onAnimationEnd, closeFlyout } = useEuiFlyoutOpenState({
+      isOpen,
+      onClose,
+      onClosing,
+    });
 
     const Element = as || defaultElement;
     const maskRef = useRef<HTMLDivElement>(null);
@@ -376,10 +406,10 @@ export const EuiFlyoutComponent = forwardRef(
       (event: KeyboardEvent) => {
         if (!isPushed && event.key === keys.ESCAPE && shouldCloseOnEscape) {
           event.preventDefault();
-          onClose(event);
+          closeFlyout(event);
         }
       },
-      [onClose, isPushed, shouldCloseOnEscape]
+      [closeFlyout, isPushed, shouldCloseOnEscape]
     );
 
     const siblingFlyoutWidth = useFlyoutWidth(siblingFlyoutId);
@@ -418,7 +448,11 @@ export const EuiFlyoutComponent = forwardRef(
       styles[side],
     ];
 
-    const classes = classnames('euiFlyout', className);
+    const classes = classnames(
+      'euiFlyout',
+      openStateToClassNameMap[openState],
+      className
+    );
 
     const flyoutToggle = useRef<Element | null>(document.activeElement);
     const [focusTrapShards, setFocusTrapShards] = useState<HTMLElement[]>([]);
@@ -520,23 +554,30 @@ export const EuiFlyoutComponent = forwardRef(
         if (outsideClickCloses === false) return undefined;
         if (hasOverlayMask) {
           // The overlay mask is present, so only clicks on the mask should close the flyout, regardless of outsideClickCloses
-          if (event.target === maskRef.current) return onClose(event);
+          if (event.target === maskRef.current) return closeFlyout(event);
         } else {
           // No overlay mask is present, so any outside clicks should close the flyout
-          if (outsideClickCloses === true) return onClose(event);
+          if (outsideClickCloses === true) return closeFlyout(event);
         }
         // Otherwise if ownFocus is false and outsideClickCloses is undefined, outside clicks should not close the flyout
         return undefined;
       },
-      [onClose, hasOverlayMask, outsideClickCloses]
+      [closeFlyout, hasOverlayMask, outsideClickCloses]
     );
+
+    const maskCombinedRefs = useCombinedRefs([maskProps?.maskRef, maskRef]);
+
+    if (openState === 'closed') {
+      // Render null only if the flyout is completely closed
+      return null;
+    }
 
     return (
       <EuiFlyoutComponentWrapper
         hasOverlayMask={hasOverlayMask}
         maskProps={{
           ...maskProps,
-          maskRef: useCombinedRefs([maskProps?.maskRef, maskRef]),
+          maskRef: maskCombinedRefs,
         }}
         isPortalled={!isPushed}
       >
@@ -560,12 +601,13 @@ export const EuiFlyoutComponent = forwardRef(
             tabIndex={!isPushed ? 0 : rest.tabIndex}
             aria-describedby={!isPushed ? ariaDescribedBy : _ariaDescribedBy}
             data-autofocus={!isPushed || undefined}
+            onAnimationEnd={onAnimationEnd}
           >
             {!isPushed && screenReaderDescription}
-            {!hideCloseButton && onClose && (
+            {!hideCloseButton && (
               <EuiFlyoutCloseButton
                 {...closeButtonProps}
-                onClose={onClose}
+                onClose={closeFlyout}
                 closeButtonPosition={closeButtonPosition}
                 side={side}
               />
@@ -607,19 +649,10 @@ const EuiFlyoutComponentWrapper: FunctionComponent<{
   hasOverlayMask: boolean;
   maskProps: EuiFlyoutComponentProps['maskProps'];
   isPortalled: boolean;
-}> = ({ children, hasOverlayMask, maskProps, isPortalled }) => {
-  // TODO: @tkajtoch - this is causing all kinds of issues with animations if a
-  // main flyout is opened with ownFocus={true}.  Since the logic is to _change_
-  // ownFocus to false if a child is rendered, the component remounts, spinning all
-  // of the animations into a tailspin.  One option would be to flat-out _hide_ this
-  // mask. :shrug:
-  if (hasOverlayMask) {
-    return (
-      <EuiOverlayMask headerZindexLocation="below" {...maskProps}>
-        {children}
-      </EuiOverlayMask>
-    );
-  } else if (isPortalled) {
+}> = ({ children, isPortalled }) => {
+  // TODO(tkajtoch): Add EuiOverlayMask again
+
+  if (isPortalled) {
     return <EuiPortal>{children}</EuiPortal>;
   } else {
     return <>{children}</>;

--- a/packages/eui/src/components/flyout/flyout.stories.tsx
+++ b/packages/eui/src/components/flyout/flyout.stories.tsx
@@ -54,6 +54,8 @@ type Story = StoryObj<EuiFlyoutProps>;
 
 const onClose = action('onClose');
 
+const onClosing = action('onClosing');
+
 const StatefulFlyout = (
   props: Partial<
     EuiFlyoutProps & { isOpen: boolean; onToggle: (open: boolean) => void }
@@ -72,15 +74,15 @@ const StatefulFlyout = (
       <EuiButton size="s" onClick={() => handleToggle(!_isOpen)}>
         Toggle flyout
       </EuiButton>
-      {_isOpen && (
-        <EuiFlyout
-          {...props}
-          onClose={() => {
-            handleToggle(false);
-            onClose();
-          }}
-        />
-      )}
+      <EuiFlyout
+        {...props}
+        isOpen={_isOpen}
+        onClose={() => {
+          handleToggle(false);
+          onClose();
+        }}
+        onClosing={onClosing}
+      />
     </>
   );
 };

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -32,7 +32,7 @@ export const euiFlyoutSlideInRight = keyframes`
     opacity: 0;
     transform: translateX(100%);
   }
-  85%, to {
+  to {
     opacity: 1;
     transform: translateX(0%);
   }
@@ -43,7 +43,7 @@ export const euiFlyoutSlideOutRight = keyframes`
     opacity: 1;
     transform: translateX(0%);
   }
-  85%, to {
+  to {
     opacity: 0;
     transform: translateX(100%);
   }
@@ -54,7 +54,7 @@ export const euiFlyoutSlideInLeft = keyframes`
     opacity: 0;
     transform: translateX(-100%);
   }
-  85%, to {
+  to {
     opacity: 1;
     transform: translateX(0%);
   }
@@ -65,7 +65,7 @@ export const euiFlyoutSlideOutLeft = keyframes`
     opacity: 1;
     transform: translateX(0);
   }
-  85%, to {
+  to {
     opacity: 0;
     transform: translateX(-100%);
   }

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -28,35 +28,46 @@ import { euiFormMaxWidth } from '../form/form.styles';
 export const FLYOUT_BREAKPOINT = 'm' as const;
 
 export const euiFlyoutSlideInRight = keyframes`
-  0% {
+  from {
     opacity: 0;
     transform: translateX(100%);
   }
-  75% {
+  85%, to {
     opacity: 1;
     transform: translateX(0%);
   }
 `;
 
 export const euiFlyoutSlideOutRight = keyframes`
-  0% {
+  from {
     opacity: 1;
     transform: translateX(0%);
   }
-  75% {
+  85%, to {
     opacity: 0;
     transform: translateX(100%);
   }
 `;
 
 export const euiFlyoutSlideInLeft = keyframes`
-  0% {
+  from {
     opacity: 0;
     transform: translateX(-100%);
   }
-  75% {
+  85%, to {
     opacity: 1;
     transform: translateX(0%);
+  }
+`;
+
+export const euiFlyoutSlideOutLeft = keyframes`
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  85%, to {
+    opacity: 0;
+    transform: translateX(-100%);
   }
 `;
 
@@ -145,9 +156,26 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('left', 0)}
       clip-path: polygon(0 0, 150% 0, 150% 100%, 0 100%);
 
-      ${euiCanAnimate} {
-        animation: ${euiFlyoutSlideInLeft} ${euiTheme.animation.normal}
-          ${euiTheme.animation.resistance};
+      &.euiFlyout--opening {
+        // Jump animation states immediately unless
+        // prefers-reduced-motion: reduce is *not* set
+        animation: ${euiFlyoutSlideInLeft} 0s ${euiTheme.animation.resistance}
+          forwards;
+
+        ${euiCanAnimate} {
+          animation-duration: ${euiTheme.animation.normal};
+        }
+      }
+
+      &.euiFlyout--closing {
+        // Jump animation states immediately unless
+        // prefers-reduced-motion: reduce is *not* set
+        animation: ${euiFlyoutSlideOutLeft} 0s ${euiTheme.animation.resistance}
+          forwards;
+
+        ${euiCanAnimate} {
+          animation-duration: ${euiTheme.animation.normal};
+        }
       }
     `,
 

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -14,7 +14,6 @@ import {
   EuiFlyoutSize,
   isEuiFlyoutSizeNamed,
 } from './const';
-import { PROPERTY_FLYOUT } from './manager/const';
 import {
   euiCanAnimate,
   euiMaxBreakpoint,
@@ -36,6 +35,17 @@ export const euiFlyoutSlideInRight = keyframes`
   75% {
     opacity: 1;
     transform: translateX(0%);
+  }
+`;
+
+export const euiFlyoutSlideOutRight = keyframes`
+  0% {
+    opacity: 1;
+    transform: translateX(0%);
+  }
+  75% {
+    opacity: 0;
+    transform: translateX(100%);
   }
 `;
 
@@ -104,13 +114,25 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       clip-path: polygon(-50% 0, 100% 0, 100% 100%, -50% 100%);
       ${logicalCSS('right', 0)}
 
-      /* Unmanaged flyouts: always play initial opening animation */
-      &:not([${PROPERTY_FLYOUT}]) {
+      &.euiFlyout--opening {
+        // Jump animation states immediately unless
+        // prefers-reduced-motion: reduce is *not* set
+        animation: ${euiFlyoutSlideInRight} 0s ${euiTheme.animation.resistance}
+          forwards;
+
         ${euiCanAnimate} {
-          animation: ${euiFlyoutSlideInRight} ${euiTheme.animation.normal}
-            ${euiTheme.animation.resistance} forwards;
-          animation-fill-mode: forwards;
-          animation-iteration-count: 1;
+          animation-duration: ${euiTheme.animation.normal};
+        }
+      }
+
+      &.euiFlyout--closing {
+        // Jump animation states immediately unless
+        // prefers-reduced-motion: reduce is *not* set
+        animation: ${euiFlyoutSlideOutRight} 0s ${euiTheme.animation.resistance}
+          forwards;
+
+        ${euiCanAnimate} {
+          animation-duration: ${euiTheme.animation.normal};
         }
       }
 
@@ -123,14 +145,9 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('left', 0)}
       clip-path: polygon(0 0, 150% 0, 150% 100%, 0 100%);
 
-      /* Unmanaged flyouts: always play initial opening animation */
-      &:not([${PROPERTY_FLYOUT}]) {
-        ${euiCanAnimate} {
-          animation: ${euiFlyoutSlideInLeft} ${euiTheme.animation.normal}
-            ${euiTheme.animation.resistance} forwards;
-          animation-fill-mode: forwards;
-          animation-iteration-count: 1;
-        }
+      ${euiCanAnimate} {
+        animation: ${euiFlyoutSlideInLeft} ${euiTheme.animation.normal}
+          ${euiTheme.animation.resistance};
       }
     `,
 

--- a/packages/eui/src/components/flyout/flyout.test.tsx
+++ b/packages/eui/src/components/flyout/flyout.test.tsx
@@ -31,9 +31,11 @@ jest.mock('../portal', () => ({
 }));
 
 describe('EuiFlyout', () => {
+  // TODO: Add `maskProps` to `childProps` again when EuiOverlayMask
+  // is added back
   shouldRenderCustomStyles(
     <EuiFlyout {...requiredProps} onClose={() => {}} />,
-    { childProps: ['closeButtonProps', 'maskProps'] }
+    { childProps: ['closeButtonProps'] }
   );
 
   test('is rendered', () => {

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -107,6 +107,7 @@ export const EuiManagedFlyout = ({
     }
 
     addFlyout(flyoutId, level, size as string);
+
     return () => {
       closeFlyout(flyoutId);
     };
@@ -118,7 +119,7 @@ export const EuiManagedFlyout = ({
     'width'
   );
 
-  const onClose = (event: MouseEvent | TouchEvent | KeyboardEvent) => {
+  const onClose = (event?: MouseEvent | TouchEvent | KeyboardEvent) => {
     onCloseProp(event);
     closeFlyout(flyoutId);
   };

--- a/packages/eui/src/components/flyout/use_open_state.ts
+++ b/packages/eui/src/components/flyout/use_open_state.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { AnimationEventHandler, useCallback, useEffect, useState } from 'react';
+import { EuiFlyoutProps } from './flyout';
+
+export type EuiFlyoutOpenState = 'opening' | 'open' | 'closing' | 'closed';
+
+interface UseEuiFlyoutOpenStateArgs {
+  isOpen: EuiFlyoutProps['isOpen'];
+  onClose: EuiFlyoutProps['onClose'];
+  onClosing: EuiFlyoutProps['onClosing'];
+}
+
+export const useEuiFlyoutOpenState = ({
+  isOpen,
+  onClose,
+  onClosing,
+}: UseEuiFlyoutOpenStateArgs) => {
+  const [openState, setOpenState] = useState<EuiFlyoutOpenState>(
+    isOpen ? 'open' : 'closed'
+  );
+
+  useEffect(() => {
+    // Check for matching state
+    if (
+      (isOpen && openState === 'open') ||
+      (!isOpen && openState === 'closed')
+    ) {
+      return;
+    }
+
+    if (isOpen && (openState === 'closing' || openState === 'closed')) {
+      setOpenState('opening');
+    }
+
+    if (!isOpen && (openState === 'opening' || openState === 'open')) {
+      setOpenState('closing');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (openState === 'closed') {
+      onClose();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openState]);
+
+  const onAnimationEnd = useCallback<AnimationEventHandler>(() => {
+    if (openState === 'closing') {
+      setOpenState('closed');
+    }
+
+    if (openState === 'opening') {
+      setOpenState('open');
+    }
+  }, [openState, setOpenState]);
+
+  const closeFlyout = useCallback(
+    (event?: MouseEvent | TouchEvent | KeyboardEvent) => {
+      if (openState === 'closed' || openState === 'closing') {
+        return;
+      }
+
+      onClosing?.(event);
+
+      setOpenState('closing');
+
+      // onClose() will be called by the effect above when openState === 'closed'
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [openState, setOpenState]
+  );
+
+  return {
+    openState,
+    onAnimationEnd,
+    closeFlyout,
+  };
+};


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/8896

This PR improves the existing opening animation and introduces a new closing animation when the new optional `isOpen` prop is used.

## Why are we making this change?

This work is needed for the flyout system initiative and is a prerequisite to the managed flyout changes in this PR: https://github.com/elastic/eui/pull/9015

## Impact to users

The added `isOpen` and `onClosing` props are optional, and the changes should have no impact to end users. There's a small snapshot difference because of the new class names, but it should be very easy to sort out by consumers who use snapshot tests.

## QA

- [ ] Confirm the CI is passing
- [ ] Confirm the EuiFlyout story is animating opening and closing of the flyout when clicking the toggle button

Please note that these changes do not affect managed flyouts since managed flyouts are not aware of the new `isOpen` prop needed for the closing animation to work. This work is included in https://github.com/elastic/eui/pull/9015.

### General checklist

- Browser QA
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
- Docs site QA
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
