### PR TITLE
[EuiDataGrid] Fix column reordering

### DIFF
--- a/packages/eui/changelogs/upcoming/9030.md
+++ b/packages/eui/changelogs/upcoming/9030.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `columns` in `EuiDataGrid` not being rendered in the correct order as defined by `columnVisibility.visibleColumns` which resulted in unexpected updates when reordering columns
+

--- a/packages/eui/src/components/datagrid/controls/column_selector.tsx
+++ b/packages/eui/src/components/datagrid/controls/column_selector.tsx
@@ -64,7 +64,12 @@ export const useDataGridColumnSelector = (
 
   const [sortedColumns, setSortedColumns] = useDependentState(() => {
     const availableColumnIds = availableColumns.map(({ id }) => id);
-    const visibleSet = new Set(visibleColumns);
+    const availableSet = new Set(availableColumnIds);
+    // Filter visibleColumns to only include existing columns
+    const validVisibleColumns = visibleColumns.filter((id) =>
+      availableSet.has(id)
+    );
+    const visibleSet = new Set(validVisibleColumns);
 
     const result: string[] = [];
     let visibleIndex = 0;
@@ -72,7 +77,7 @@ export const useDataGridColumnSelector = (
     for (const columnId of availableColumnIds) {
       if (visibleSet.has(columnId)) {
         // Replace with next visible column in order
-        result.push(visibleColumns[visibleIndex++]);
+        result.push(validVisibleColumns[visibleIndex++]);
       } else {
         // Keep hidden column in original position
         result.push(columnId);

--- a/packages/eui/src/components/datagrid/controls/column_selector.tsx
+++ b/packages/eui/src/components/datagrid/controls/column_selector.tsx
@@ -60,12 +60,29 @@ export const useDataGridColumnSelector = (
     'allowReorder'
   );
 
-  const [sortedColumns, setSortedColumns] = useDependentState(
-    () => availableColumns.map(({ id }) => id),
-    [availableColumns]
-  );
-
   const { visibleColumns, setVisibleColumns } = columnVisibility;
+
+  const [sortedColumns, setSortedColumns] = useDependentState(() => {
+    const availableColumnIds = availableColumns.map(({ id }) => id);
+    const visibleSet = new Set(visibleColumns);
+
+    const result: string[] = [];
+    let visibleIndex = 0;
+
+    for (const columnId of availableColumnIds) {
+      if (visibleSet.has(columnId)) {
+        // Replace with next visible column in order
+        result.push(visibleColumns[visibleIndex++]);
+      } else {
+        // Keep hidden column in original position
+        result.push(columnId);
+      }
+    }
+
+    return result;
+    // doesn't depend on visibleColumns on purpose to keep it an initial state
+  }, [availableColumns]);
+
   const visibleColumnIds = useMemo(
     () => new Set(visibleColumns),
     [visibleColumns]


### PR DESCRIPTION
## Summary

closes https://github.com/elastic/eui/issues/8196

This PR fixes a bug in `EuiDataGrid` when the order of `columns` and `columnVisibility.visibleColumns` are not in sync. This resulted in unexpected reordering behavior for columns where the initial `column` order would differ from the internal sorting order. The issue came from the columns selector where the states for rendering the actual `columns` and the state for rendering the column selector list items was using different non-dependent arrays.
This resulted in the columns updating unexpectedly on drag, from the column selector as well as via the cell menu "move left/right" buttons.

Instead, we need to ensure that the order in which `columns` are rendered initially depends on the order provided by `columnVisibility.visibleColumns` to ensure they are in sync.

The update ensures that the initial state is sorted by `visibleColumns` while keeping non-visible items in place to keep the current behavior as is.

## Why are we making this change?

🐛 Bug fix: Fixing a bug that resulted in non-synced column orders between column output and column selector output that would result in unexpected order updates when reordering columns.

Related Kibana issues: 
- https://github.com/elastic/kibana/issues/229352
- https://github.com/elastic/kibana/issues/228397
- https://github.com/elastic/kibana/issues/233096
- https://github.com/elastic/kibana/issues/221757
- https://github.com/elastic/kibana/issues/174713

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

| column selector reordering | column header drag | column action "mode left/right" |
|---|---|---|
| <video src="https://github.com/user-attachments/assets/d67446a6-caeb-4567-93da-5a6b82f62ae8" /> | <video src="https://github.com/user-attachments/assets/a69a907e-eb5b-4d0c-818d-72bfb0f5b8b7" /> | <video src="https://github.com/user-attachments/assets/045762de-4a11-4c76-a0c6-f59728c2187e" /> |

**Kibana use case**

| before | after |
|---|---|
| <video src="https://github.com/user-attachments/assets/0f12d8fe-5985-42ca-a6f4-51869517a9b4" /> | <video src="https://github.com/user-attachments/assets/9658aac5-80d2-48f2-be5c-9dfb89972a14" /> |

## Impact to users

🟢 There are no updates required on consumer side.

## QA

### 💻 Links

- Codesanbox: [original bug sandbox](https://codesandbox.io/p/sandbox/gallant-visvesvaraya-v2lfhw),  [fixed sandbox](https://codesandbox.io/p/devbox/objective-bhabha-wjq58x?workspaceId=ws_3QHkS8M7QbnwRJNYvPkxUw)
- [~Testing story~](https://eui.elastic.co/pr_9030/storybook/?path=/story/tabular-content-euidatagrid--testing-example) [REVERTED]
- [Kibana instance](https://kibana-pr-235177-f25de5.kb.us-west2.gcp.elastic-cloud.com/app/observability/alerts?_a=(controlConfigs:!((exclude:!f,existsSelected:!f,fieldName:kibana.alert.status,hideActionBar:!t,selectedOptions:!(active),title:Status),(exclude:!f,existsSelected:!f,fieldName:kibana.alert.rule.name,hideActionBar:!f,selectedOptions:!(),title:Rule),(exclude:!f,existsSelected:!f,fieldName:kibana.alert.group.value,hideActionBar:!f,selectedOptions:!(),title:Group),(exclude:!f,existsSelected:!f,fieldName:tags,hideActionBar:!f,selectedOptions:!(),title:Tags)),filters:!(),groupings:!(none),kuery:%27%27,rangeFrom:now-24h,rangeTo:now)) ([credentials](https://p.elstc.co/paste/jmvni+e0#7Ao3fKPFhkeG7nV3iM1UAdWV6ALyE8vpbBm3BUtypRR))
  - `Observability > Alerts`

### Criteria

- [ ] review the codesandbox and added Storybook and verify:
  - [ ] the order of columns and column selector list items is identical on mount
  - [ ] updating the order from the column selector list updates the column render correctly
  - [ ] updating the order of columns via drag on the column header updates the order and the order is reflected correctly in the column selector
  - [ ] updating the order from from the cell menu via "move left/right" buttons updates the order correctly and the order is reflected correctly in the column selector
  - [ ] non-visible columns are shown in the column selector and can be toggled to be visible and are rendered in the correct position


### General checklist

- Browser QA
    - [ ] ~Checked in both **light and dark** modes~
    - [ ] ~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [x] Checked in **mobile**
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~Checked for **accessibility** including keyboard-only and screenreader modes~
- Docs site QA
    - [ ] ~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~
    - [ ] ~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~
    - [ ] ~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [x] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [x] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~
- Designer checklist
  - [ ] ~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~
