### PR TITLE
fix(website): fix EuiTour page typo

### DIFF
--- a/packages/website/docs/components/display/tour/index.mdx
+++ b/packages/website/docs/components/display/tour/index.mdx
@@ -82,7 +82,7 @@ export default () => {
   return (
     <div>
       <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenRef(true); setIsOpenSelector(false); }}>
-        Beign tour
+        Begin tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
       <EuiTourStep
@@ -114,7 +114,7 @@ export default () => {
       <EuiSpacer size="xxl" />
 
       <EuiButtonEmpty size="s" flush="left" iconType="refresh" onClick={() => { setIsOpenSelector(true); setIsOpenRef(false); }}>
-        Beign tour
+        Begin tour
       </EuiButtonEmpty>
       <EuiSpacer size="m" />
       <EuiTourStep


### PR DESCRIPTION
## Summary

I noticed this typo when debugging `EuiTour` in [our docs](https://eui.elastic.co/docs/components/display/tour/). No testing needed. Simple change.
