### PR TITLE
Fix typo in documenting components section

### DIFF
--- a/wiki/contributing-to-eui/documenting/writing-documentation.md
+++ b/wiki/contributing-to-eui/documenting/writing-documentation.md
@@ -4,7 +4,7 @@
 - [Partials](#partials)
 - [Collapsible sidebar items](#collapsible-sidebar-items)
 - [Front matter](#front-matter)
-- [Documeting components](#documenting-components)
+- [Documenting components](#documenting-components)
 - [Custom components available](#custom-components-available)
 - [Writing content](#writing-content)
   - [Headings](#headings)


### PR DESCRIPTION
## Summary

Just fixing a typo that I noticed while checking our documentation wiki. I opened this PR from GitHub UI, hence it's a branch in the original repo.
