### PR TITLE
fix: correct some jsdoc links that pointed to old docs

### DIFF
--- a/packages/eui-theme-common/src/global_styling/variables/typography.ts
+++ b/packages/eui-theme-common/src/global_styling/variables/typography.ts
@@ -138,7 +138,7 @@ export interface _EuiThemeTitle {
 export type _EuiThemeFont = _EuiThemeFontBase & {
   scale: _EuiThemeFontScales;
   /**
-   * See {@link https://eui.elastic.co/#/theming/typography/values%23font-weight | Reference} for more information
+   * See {@link https://eui.elastic.co/docs/getting-started/theming/tokens/typography/font-weight/ | Reference} for more information
    */
   weight: _EuiThemeFontWeights;
   body: _EuiThemeBody;

--- a/packages/eui-theme-common/src/services/theme/types.ts
+++ b/packages/eui-theme-common/src/services/theme/types.ts
@@ -64,7 +64,7 @@ export type EuiThemeShapeBase = {
   /** - Default value: 16 */
   base: _EuiThemeBase;
   /**
-   * See {@link https://eui.elastic.co/#/theming/sizing | Reference} for more information
+   * See {@link https://eui.elastic.co/docs/getting-started/theming/tokens/sizing/ | Reference} for more information
    */
   size: _EuiThemeSizes;
   font: _EuiThemeFont;

--- a/packages/eui/src/components/header/header.stories.tsx
+++ b/packages/eui/src/components/header/header.stories.tsx
@@ -306,7 +306,7 @@ const ElasticNavigationPatternExample = () => {
           <EuiText size="s" color="subdued" style={{ padding: '0 8px 8px' }}>
             <p>
               Please see the component page for{' '}
-              <EuiLink href="https://eui.elastic.co/#/navigation/collapsible-nav">
+              <EuiLink href="https://eui.elastic.co/docs/components/navigation/collapsible-nav/">
                 <strong>EuiCollapsibleNav</strong>
               </EuiLink>{' '}
               on how to configure your navigation.
@@ -358,7 +358,7 @@ const ElasticNavigationPatternExample = () => {
           <EuiText size="s" color="subdued">
             <p>
               Please see the component page for{' '}
-              <EuiLink href="https://eui.elastic.co/#/layout/header#header-notifications">
+              <EuiLink href="https://eui.elastic.co/docs/components/layout/header#header-notifications">
                 <strong>EuiHeaderAlert</strong>
               </EuiLink>{' '}
               on how to configure your alerts.
@@ -396,7 +396,7 @@ const ElasticNavigationPatternExample = () => {
         <EuiText size="s" color="subdued">
           <p>
             Please see the component page for{' '}
-            <EuiLink href="https://eui.elastic.co/#/layout/header">
+            <EuiLink href="https://eui.elastic.co/docs/components/layout/header">
               <strong>EuiHeader</strong>
             </EuiLink>{' '}
             on how to configure your user menu.
@@ -433,7 +433,7 @@ const ElasticNavigationPatternExample = () => {
         <EuiText size="s" color="subdued">
           <p>
             Please see the component page for{' '}
-            <EuiLink href="https://eui.elastic.co/#/layout/header">
+            <EuiLink href="https://eui.elastic.co/docs/components/layout/header">
               <strong>EuiHeader</strong>
             </EuiLink>{' '}
             on how to configure your spaces menu.
@@ -502,7 +502,7 @@ const ElasticNavigationPatternExample = () => {
         <EuiSelectableMessage style={{ minHeight: 300 }}>
           <p>
             Please see the component page for{' '}
-            <EuiLink href="https://eui.elastic.co/#/forms/selectable">
+            <EuiLink href="https://eui.elastic.co/docs/components/forms/selection/selectable/">
               <strong>EuiSelectableTemplateSitewide</strong>
             </EuiLink>{' '}
             on how to configure your sitewide search.


### PR DESCRIPTION
## Summary
Some links in the docs and examples point to the old site. I've found some of them and fixed them. There are more items using relative paths, which I can address in a future PR.

## Why are we making this change?
We need to clean up the code base from broken links.

## Impact to users
Broken links can be frustrating if users looking for information click on them and are redirected to the home page or a 404.
## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
