### PR TITLE
fix: exclude `EuiButtonEmpty` from the `@elastic/eui/no-unnamed-interactive-element` rule.

### DIFF
--- a/packages/eslint-plugin/changelogs/upcoming/9046.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9046.md
@@ -1,0 +1,1 @@
+- exclude `EuiButtonEmpty` from the `no-unnamed-interactive-element` rule.

--- a/packages/eslint-plugin/src/rules/a11y/no_unnamed_interactive_element.test.ts
+++ b/packages/eslint-plugin/src/rules/a11y/no_unnamed_interactive_element.test.ts
@@ -35,7 +35,6 @@ ruleTester.run('NoUnnamedInteractiveElement', NoUnnamedInteractiveElement, {
   valid: [
     // Components with allowed a11y props
     { code: '<EuiBetaBadge aria-label="Beta badge" />', languageOptions },
-    { code: '<EuiButtonEmpty aria-labelledby="btnLabel" />', languageOptions },
     { code: '<EuiButtonIcon aria-label="Icon" />', languageOptions },
     { code: '<EuiComboBox aria-label="Combo label" />', languageOptions },
     { code: '<EuiSelect aria-label="Select label" />', languageOptions },
@@ -70,11 +69,6 @@ ruleTester.run('NoUnnamedInteractiveElement', NoUnnamedInteractiveElement, {
     // Missing a11y prop for interactive components
     {
       code: '<EuiBetaBadge />',
-      languageOptions,
-      errors: [{ messageId: 'missingA11y' }],
-    },
-    {
-      code: '<EuiButtonEmpty />',
       languageOptions,
       errors: [{ messageId: 'missingA11y' }],
     },

--- a/packages/eslint-plugin/src/rules/a11y/no_unnamed_interactive_element.ts
+++ b/packages/eslint-plugin/src/rules/a11y/no_unnamed_interactive_element.ts
@@ -27,7 +27,6 @@ import { hasA11yPropForComponent } from '../../utils/has_a11y_prop_for_component
 
 const interactiveComponents = [
   'EuiBetaBadge',
-  'EuiButtonEmpty',
   'EuiButtonIcon',
   'EuiComboBox',
   'EuiSelect',


### PR DESCRIPTION
This rule was originally introduced in #8973. 

However, `EuiButtonEmpty` already receives meaningful content as a child, which effectively serves the purpose of a role or `aria-label`. Therefore, explicitly requiring an additional accessibility attribute is unnecessary in this case.

## Example of using `EuiButtonEmpty`

```tsx
 <EuiButtonEmpty
    color="text"
    onClick={handleCancelOnClick}
    data-test-subj="protectionUpdatesCancelButton"
    disabled={isUpdating}
  >
    <FormattedMessage
      id="xpack.securitySolution.endpoint.protectionUpdates.cancel"
      defaultMessage="Cancel"
    />
  </EuiButtonEmpty>
````
## Tests

<img width="666" height="378" alt="image" src="https://github.com/user-attachments/assets/a4a551cd-d721-45b6-9df4-630db8b0e6c3" />


