### PR TITLE
[EuiInMemoryTable] fire `search.onChange` for plain text (`searchFormat="text"`)

### DIFF
--- a/packages/eui/changelogs/upcoming/9059.md
+++ b/packages/eui/changelogs/upcoming/9059.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiInMemoryTable` not firing the `search.onChange` callback when `searchFormat` equals `text`.

--- a/packages/eui/src/components/basic_table/in_memory_table.test.tsx
+++ b/packages/eui/src/components/basic_table/in_memory_table.test.tsx
@@ -1505,5 +1505,69 @@ describe('EuiInMemoryTable', () => {
       expect(tableContent).toHaveLength(1); // only 1 match
       expect(tableContent[0]).toHaveTextContent(specialCharacterSearch);
     });
+
+    it('fires the onChange callback', () => {
+      const items = [{ title: 'Hello' }, { title: 'Goodbye' }];
+      const columns = [{ field: 'title', name: 'Title' }];
+      const TEXT = 'Hello World!';
+      const mockOnChange = jest.fn();
+
+      const { getByTestSubject, container } = render(
+        <EuiInMemoryTable
+          items={items}
+          searchFormat="text"
+          search={{
+            box: { incremental: true, 'data-test-subj': 'searchbox' },
+            onChange: mockOnChange,
+          }}
+          columns={columns}
+        />
+      );
+
+      fireEvent.keyUp(getByTestSubject('searchbox'), {
+        target: { value: TEXT },
+      });
+
+      const tableContent = container.querySelectorAll(
+        '.euiTableRowCell .euiTableCellContent'
+      );
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith({
+        query: Query.parse(`"${TEXT}"`),
+        queryText: TEXT,
+        error: null,
+      });
+      expect(tableContent).toHaveLength(items.length); // all items
+    });
+
+    it('fires the onChange callback but handles internal state too', () => {
+      const items = [{ title: 'foo' }, { title: 'bar' }, { title: 'baz' }];
+      const columns = [{ field: 'title', name: 'Title' }];
+      const TEXT = 'ba';
+      const mockOnChange = jest.fn();
+      mockOnChange.mockReturnValue(true);
+
+      const { getByTestSubject, container } = render(
+        <EuiInMemoryTable
+          items={items}
+          searchFormat="text"
+          search={{
+            box: { incremental: true, 'data-test-subj': 'searchbox' },
+            onChange: mockOnChange,
+          }}
+          columns={columns}
+        />
+      );
+
+      fireEvent.keyUp(getByTestSubject('searchbox'), {
+        target: { value: TEXT },
+      });
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      const tableContent = container.querySelectorAll(
+        '.euiTableRowCell .euiTableCellContent'
+      );
+      expect(tableContent).toHaveLength(2); // 2 matches for "ba"
+    });
   });
 });

--- a/packages/eui/src/components/basic_table/in_memory_table.tsx
+++ b/packages/eui/src/components/basic_table/in_memory_table.tsx
@@ -543,6 +543,21 @@ export class EuiInMemoryTable<T extends object = object> extends Component<
   onPlainTextSearch = (searchValue: string) => {
     const escapedQueryText = searchValue.replace(/["\\]/g, '\\$&');
     const finalQuery = `"${escapedQueryText}"`;
+    const { search } = this.props;
+
+    if (isEuiSearchBarProps(search)) {
+      if (search.onChange) {
+        const shouldQueryInMemory = search.onChange({
+          query: EuiSearchBar.Query.parse(finalQuery),
+          queryText: escapedQueryText,
+          error: null,
+        });
+        if (!shouldQueryInMemory) {
+          return;
+        }
+      }
+    }
+
     this.setState({
       query: EuiSearchBar.Query.parse(finalQuery),
     });


### PR DESCRIPTION
## Summary

Fixes #9019 

It's possible to control the search logic from outside in `EuiInMemoryTable` by providing a `onChange` callback in the `search` prop. This works as expected by default, for `eql`. But it does not for plain text, that is enabled by passing `searchFormat="text"`.

## Why are we making this change?

To unblock a bug from being fixed (https://github.com/elastic/observability-dev/issues/4787).

Also for correctness.

## Impact to users

💚 No impact, the change should be safe.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] ~~Checked in both **light and dark** modes~~
    - [ ] ~~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~~
      - ~~(_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)~~
    - [ ] ~~Checked in **mobile**~~
    - [ ] ~~Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**~~
    - [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- Docs site QA
    - [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
    - [ ] ~~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    - [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] ~~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist
  - [ ] ~~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~~
