### PR TITLE
[EuiComboBox] Break long strings properly when `rowHeight="auto"`

### DIFF
--- a/packages/eui/src/components/combo_box/combo_box.stories.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.stories.tsx
@@ -20,7 +20,6 @@ import { EuiFlexItem } from '../flex';
 
 import { EuiComboBoxOptionMatcher } from './types';
 import { EuiComboBox, EuiComboBoxProps } from './combo_box';
-import { EuiHighlight } from '../highlight';
 
 const options = [
   { label: 'Item 1' },
@@ -163,13 +162,6 @@ export const RowHeightAuto: Story = {
       },
       { label: 'elastic.task_manager_metrics.metrics.task_claim.value.total' },
     ],
-    renderOption: (option, searchValue) => {
-      return (
-        <EuiHighlight search={searchValue} style={{ wordBreak: 'break-word' }}>
-          {option.label}
-        </EuiHighlight>
-      );
-    },
   },
   render: (args) => <StatefulComboBox {...args} />,
 };

--- a/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.styles.ts
+++ b/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.styles.ts
@@ -45,6 +45,9 @@ export const euiComboBoxOptionListStyles = (euiThemeContext: UseEuiTheme) => {
       .euiComboBoxOption__content {
         flex: 1;
         text-align: start;
+        /* Allow long strings without spaces to break,
+           while keeping regular sentences wrapping as expected */
+        overflow-wrap: anywhere;
       }
 
       .euiComboBoxOption__emptyStateText {


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/elastic/eui/pull/8934

It introduces a tiny update to the styles of the Combobox options, so long string without spaces wrap. Without awkwardly regular sentences as applying `word-space: break-word` would.

That (having long string without spaces wrap) was made possible in #8934 by introducing variable heights in the options list (`rowHeight="auto"`). But a bit of code was required from the consumer side, namely using the `renderOption` prop.

```tsx
renderOption: (option, searchValue) => {
  return (
    <EuiHighlight search={searchValue} style={{ wordBreak: 'break-word' }}>
      {option.label}
    </EuiHighlight>
  );
},
```

## Why are we making this change?

This PR aims to completely fulfill the request made in https://github.com/elastic/eui/issues/7712 without introducing any _breaking_ changes (pun intended).

## Screenshots

> Only `rowHeight="auto"` needed

<img width="597" height="362" alt="image" src="https://github.com/user-attachments/assets/1c90c0c1-3fad-4072-9713-7171b6104c6a" />

## Impact to users

🟢 No impact, changes only affect the new API.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] ~~Checked in both **light and dark** modes~~
    - [ ] ~~Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**~~
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] ~~Checked in **mobile**~~
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] ~~Checked for **accessibility** including keyboard-only and screenreader modes~~
- Docs site QA
    - [ ] ~~Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
    - [ ] ~~Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**~~
    - [ ] ~~Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- Code quality checklist
    - [ ] ~~Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**~~
    - [ ] ~~Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] ~~If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist
  - [ ] ~~If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~~
