### PR TITLE
[Flyout System] Add the flyout overlay mask back

### DIFF
--- a/packages/eui/src/components/flyout/_flyout_overlay.tsx
+++ b/packages/eui/src/components/flyout/_flyout_overlay.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { PropsWithChildren } from 'react';
+import type { EuiFlyoutComponentProps } from './flyout.component';
+import { EuiOverlayMask } from '../overlay_mask';
+import { EuiPortal } from '../portal';
+import { useEuiTheme } from '../../services';
+
+export interface EuiFlyoutOverlayProps extends PropsWithChildren {
+  hasOverlayMask: boolean;
+  maskProps: EuiFlyoutComponentProps['maskProps'];
+  isPushed: boolean;
+}
+
+/**
+ * Light wrapper for conditionally rendering portals or overlay masks:
+ *  - If ownFocus is set, wrap with an overlay and allow the user to click it to close it.
+ *  - Otherwise still wrap within an EuiPortal so it appends to the bottom of the window.
+ * Push flyouts have no overlay OR portal behavior.
+ *
+ * @internal
+ */
+export const EuiFlyoutOverlay = ({
+  children,
+  isPushed,
+  maskProps,
+  hasOverlayMask,
+}: EuiFlyoutOverlayProps) => {
+  const { euiTheme } = useEuiTheme();
+  let content = children;
+
+  if (!isPushed || hasOverlayMask) {
+    content = <EuiPortal>{content}</EuiPortal>;
+  }
+
+  // TODO(tkajtoch): This should likely depend on maskProps.headerZIndexLocation
+  // in cases where the mask has z-index 6000
+  const maskLevel = Number(euiTheme.levels.flyout) - 1;
+
+  return (
+    <>
+      {hasOverlayMask && (
+        <EuiOverlayMask
+          {...maskProps}
+          // This needs to be a string due to the logic inside EuiOverlayMask.
+          // It can't be a `css` prop either
+          style={`z-index: ${maskLevel}`}
+        />
+      )}
+      {content}
+    </>
+  );
+};

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -20,7 +20,6 @@ import React, {
   ElementType,
   FunctionComponent,
   MutableRefObject,
-  ReactNode,
   JSX,
   AnimationEventHandler,
 } from 'react';
@@ -49,7 +48,6 @@ import type { EuiOverlayMaskProps } from '../overlay_mask';
 import type { EuiButtonIconPropsForButton } from '../button';
 import { EuiI18n } from '../i18n';
 import { useResizeObserver } from '../observer/resize_observer';
-import { EuiPortal } from '../portal';
 import { EuiScreenReaderOnly } from '../accessibility';
 
 import { EuiFlyoutCloseButton } from './_flyout_close_button';
@@ -69,6 +67,7 @@ import {
 } from './const';
 import { useIsPushed } from './hooks';
 import { EuiFlyoutMenu, EuiFlyoutMenuProps } from './flyout_menu';
+import { EuiFlyoutOverlay } from './_flyout_overlay';
 import { EuiFlyoutResizeButton } from './_flyout_resize_button';
 import { useEuiFlyoutResizable } from './use_flyout_resizable';
 import {
@@ -627,13 +626,13 @@ export const EuiFlyoutComponent = forwardRef(
     }
 
     return (
-      <EuiFlyoutComponentWrapper
+      <EuiFlyoutOverlay
         hasOverlayMask={hasOverlayMask}
+        isPushed={isPushed}
         maskProps={{
           ...maskProps,
           maskRef: maskCombinedRefs,
         }}
-        isPortalled={!isPushed}
       >
         <EuiWindowEvent event="keydown" handler={onKeyDown} />
         <EuiFocusTrap
@@ -684,7 +683,7 @@ export const EuiFlyoutComponent = forwardRef(
             {children}
           </Element>
         </EuiFocusTrap>
-      </EuiFlyoutComponentWrapper>
+      </EuiFlyoutOverlay>
     );
   }
   // React.forwardRef interferes with the inferred element type
@@ -695,28 +694,3 @@ export const EuiFlyoutComponent = forwardRef(
 ) => JSX.Element;
 // Recast to allow `displayName`
 (EuiFlyoutComponent as FunctionComponent).displayName = 'EuiFlyoutComponent';
-
-/**
- * Light wrapper for conditionally rendering portals or overlay masks:
- *  - If ownFocus is set, wrap with an overlay and allow the user to click it to close it.
- *  - Otherwise still wrap within an EuiPortal so it appends to the bottom of the window.
- * Push flyouts have no overlay OR portal behavior.
- */
-const EuiFlyoutComponentWrapper: FunctionComponent<{
-  children: ReactNode;
-  hasOverlayMask: boolean;
-  maskProps: EuiFlyoutComponentProps['maskProps'];
-  isPortalled: boolean;
-}> = ({ children, hasOverlayMask, isPortalled }) => {
-  // TODO(tkajtoch): Add EuiOverlayMask again
-
-  if (isPortalled || hasOverlayMask) {
-    return (
-      <EuiPortal>
-        <div>{children}</div>
-      </EuiPortal>
-    );
-  } else {
-    return <>{children}</>;
-  }
-};

--- a/packages/eui/src/components/flyout/manager/flyout_sessions.stories.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_sessions.stories.tsx
@@ -41,6 +41,7 @@ interface FlyoutSessionProps {
   childMaxWidth?: number;
   flyoutType: 'overlay' | 'push';
   childBackgroundShaded?: boolean;
+  ownFocus?: boolean;
 }
 
 const FlyoutSession: React.FC<FlyoutSessionProps> = React.memo((props) => {
@@ -51,6 +52,7 @@ const FlyoutSession: React.FC<FlyoutSessionProps> = React.memo((props) => {
     mainMaxWidth,
     childMaxWidth,
     flyoutType,
+    ownFocus = false,
   } = props;
 
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);
@@ -104,7 +106,7 @@ const FlyoutSession: React.FC<FlyoutSessionProps> = React.memo((props) => {
         size={mainSize}
         maxWidth={mainMaxWidth}
         type={flyoutType}
-        ownFocus={false}
+        ownFocus={ownFocus}
         pushAnimation={true}
         onActive={mainFlyoutOnActive}
         onClose={mainFlyoutOnClose}
@@ -264,6 +266,18 @@ const ExampleComponent = () => {
             mainSize="fill"
             mainMaxWidth={1000}
             childSize="s"
+          />
+        ),
+      },
+      {
+        title: 'Session H: main size = s, child size = s, ownFocus = true',
+        description: (
+          <FlyoutSession
+            flyoutType={flyoutType}
+            title="Session H"
+            mainSize="s"
+            childSize="s"
+            ownFocus
           />
         ),
       },


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/8989

This PR reintroduces the previously removed overlay mask to the flyout component. The `EuiOverlayMask` was temporarily removed to simplify the development of other features and to be able to fix its buggy behavior separately.

The flyout elements are now rendered outside the overlay mask, which allows managed flyouts to render without unexpected flashes when updating the `ownFocus` prop or rerendering for other business logic reasons.

Note that **this PR is marked as draft** as the change to `z-index` values needs to be tested against Kibana. Other than a slight change to that value this PR should not change much.

## Why are we making this change?

It's part of the Flyout System M1 work. See the [issue this resolves](https://github.com/elastic/eui/issues/8989) and the [epic](https://github.com/elastic/kibana-team/issues/1844) for more details.

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

The change may affect `z-index` positioning of custom consumer-created elements if using values that aren't in line with what EUI expects.

The old logic included a behavior I was unaware of that used `z-index: 6000` for flyouts when they were rendered with the overlay mask. The usual `z-index` value for flyouts is `1000`. We're testing if changing the `flyout` `z-index`/level would have any negative impact on Kibana as this value would make way more sense semantically.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
