### PR TITLE
feat(website): add size="s" to all content EuiText wrappers

### DIFF
--- a/packages/website/docs/components/display/tour/index.mdx
+++ b/packages/website/docs/components/display/tour/index.mdx
@@ -149,7 +149,7 @@ export default () => {
 
 ### Guided tour
 
-Uers proceed through tour steps without needing to complete actions on the underlying page. In this scenario, consider showing both **Close tour** and **Next** buttons.
+Users proceed through tour steps without needing to complete actions on the underlying page. In this scenario, consider showing both **Close tour** and **Next** buttons.
 
 ```tsx interactive
 import React, { useEffect, useState } from 'react';

--- a/packages/website/docs/components/display/tour/index.mdx
+++ b/packages/website/docs/components/display/tour/index.mdx
@@ -7,7 +7,7 @@ keywords: [EuiTour, EuiTourStep, useEuiTour]
 The tour components provided by EUI allow for a flexible and customizable way to showcase items on a page in an ordered manner by augmenting existing elements on the page without altering functionality.
 
 :::note
-Examples on this page use localStorage to persist state.
+Examples on this page use `localStorage` to persist state.
 :::
 
 ## Usage
@@ -37,7 +37,7 @@ export default () => {
       <EuiSpacer size="m" />
       <EuiTourStep
         content={
-          <EuiText>
+          <EuiText size="s">
             <p>The tour step content.</p>
           </EuiText>
         }
@@ -88,7 +88,7 @@ export default () => {
       <EuiTourStep
         anchor={() => anchorRef.current}
         content={
-          <EuiText>
+          <EuiText size="s">
             <p>
               Popover is attached to the <EuiCode>anchorRef</EuiCode> button
             </p>
@@ -120,7 +120,7 @@ export default () => {
       <EuiTourStep
         anchor="#anchorTarget"
         content={
-          <EuiText>
+          <EuiText size="s">
             <p>
               Popover is attached to the <EuiCode>#anchorTarget</EuiCode> button
             </p>
@@ -162,34 +162,35 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiButtonIcon,
+  EuiText,
 } from '@elastic/eui';
 
 const demoTourSteps = [
   {
     step: 1,
     title: 'Preview mode',
-    content: <p>See what your project looks like.</p>,
+    content: <EuiText size="s"><p>See what your project looks like.</p></EuiText>,
     anchorRef: 'notActionDrivenStep1',
     iconType: 'eye',
   },
   {
     step: 2,
     title: 'Build Mode',
-    content: <p>Build your project.</p>,
+    content: <EuiText size="s"><p>Build your project.</p></EuiText>,
     anchorRef: 'notActionDrivenStep2',
     iconType: 'code',
   },
   {
     step: 3,
     title: 'Comment mode',
-    content: <p>Collaborate with your colleagues.</p>,
+    content: <EuiText size="s"><p>Collaborate with your colleagues.</p></EuiText>,
     anchorRef: 'notActionDrivenStep3',
     iconType: 'comment',
   },
   {
     step: 2,
     title: 'Share',
-    content: <p>Share your project.</p>,
+    content: <EuiText size="s"><p>Share your project.</p></EuiText>,
     anchorRef: 'notActionDrivenStep4',
     iconType: 'share',
   },
@@ -316,6 +317,7 @@ import {
   EuiSpacer,
   EuiTextArea,
   EuiTourStep,
+  EuiText,
 } from '@elastic/eui';
 
 const demoTourSteps = [
@@ -323,20 +325,19 @@ const demoTourSteps = [
     step: 1,
     title: 'Step 1',
     content: (
-      <span>
+      <EuiText size="s">
         <p>Copy and paste this sample query.</p>
-        <EuiSpacer />
         <EuiCodeBlock language="html" paddingSize="s" isCopyable>
-          {'SELECT email FROM “kibana_sample_data_ecommerce”'}
+          {'SELECT email FROM "kibana_sample_data_ecommerce"'}
         </EuiCodeBlock>
-      </span>
+      </EuiText>
     ),
     anchorRef: 'tourStep2',
   },
   {
     step: 2,
     title: 'Step 2',
-    content: <p>Save your changes.</p>,
+    content: <EuiText size="s"><p>Save your changes.</p></EuiText>,
     anchorRef: 'tourStep1',
   },
 ];
@@ -469,6 +470,7 @@ import {
   EuiTextArea,
   EuiTourStep,
   useEuiTour,
+  EuiText,
 } from '@elastic/eui';
 
 const demoTourSteps = [
@@ -476,20 +478,19 @@ const demoTourSteps = [
     step: 1,
     title: 'Step 1',
     content: (
-      <span>
+      <EuiText size="s">
         <p>Copy and paste this sample query.</p>
-        <EuiSpacer />
         <EuiCodeBlock language="html" paddingSize="s" isCopyable>
-          {'SELECT email FROM “kibana_sample_data_ecommerce”'}
+          {'SELECT email FROM "kibana_sample_data_ecommerce"'}
         </EuiCodeBlock>
-      </span>
+      </EuiText>
     ),
     anchorPosition: 'rightUp',
   },
   {
     step: 2,
     title: 'Step 2',
-    content: <p>Save your changes.</p>,
+    content: <EuiText size="s"><p>Save your changes.</p></EuiText>,
     anchorPosition: 'rightUp',
   },
 ];
@@ -585,6 +586,7 @@ import {
   EuiTextArea,
   EuiTour,
   EuiTourStep,
+  EuiText,
 } from '@elastic/eui';
 
 const demoTourSteps = [
@@ -592,20 +594,19 @@ const demoTourSteps = [
     step: 1,
     title: 'Step 1',
     content: (
-      <span>
+      <EuiText size="s">
         <p>Copy and paste this sample query.</p>
-        <EuiSpacer />
         <EuiCodeBlock language="html" paddingSize="s" isCopyable>
-          {'SELECT email FROM “kibana_sample_data_ecommerce”'}
+          {'SELECT email FROM "kibana_sample_data_ecommerce"'}
         </EuiCodeBlock>
-      </span>
+      </EuiText>
     ),
     anchorPosition: 'rightUp',
   },
   {
     step: 2,
     title: 'Step 2',
-    content: <p>Save your changes.</p>,
+    content: <EuiText size="s"><p>Save your changes.</p></EuiText>,
     anchorPosition: 'rightUp',
   },
 ];
@@ -703,6 +704,7 @@ import {
   EuiTextArea,
   EuiTourStep,
   useEuiTour,
+  EuiText,
 } from '@elastic/eui';
 
 const demoTourSteps = [
@@ -714,12 +716,12 @@ const demoTourSteps = [
     step: 2,
     title: 'Step 2',
     anchorPosition: 'upCenter',
-    content: <p>What is your favorite color?</p>,
+    content: <EuiText size="s"><p>What is your favorite color?</p></EuiText>,
   },
   {
     step: 3,
     title: 'Step 3',
-    content: <p>Click here for more cool things.</p>,
+    content: <EuiText size="s"><p>Click here for more cool things.</p></EuiText>,
     anchorPosition: 'downRight',
     minWidth: 'auto',
   },
@@ -778,13 +780,12 @@ export default () => {
             {...euiTourStepOne}
             zIndex={1}
             content={
-              <div>
+              <EuiText size="s">
                 <p>This is a neat thing. You enter queries here.</p>
-                <EuiSpacer />
                 <EuiButton color="primary" onClick={actions.incrementStep}>
                   Ok, got it.
                 </EuiButton>
-              </div>
+              </EuiText>
             }
           >
             <EuiTextArea
@@ -840,13 +841,12 @@ export default () => {
             {...euiTourStepFour}
             zIndex={1}
             content={
-              <div>
+              <EuiText size="s">
                 <p>That about does it.</p>
-                <EuiSpacer />
                 <EuiButton color="primary" onClick={onReset}>
                   Take me to the start.
                 </EuiButton>
-              </div>
+              </EuiText>
             }
           >
             <div>


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

Change the `EuiTour` docs examples to use `EuiText` as a `content` wrapper and set `size="s"`.

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

We want the `content` in `EuiTour` to use this composition:

```tsx
<EuiText>
  <p>
    {content}
  </p>
</EuiText>
```

as outlined by [our docs](https://eui.elastic.co/v106.6.0/docs/components/display/text/index.html):

> **EuiText** is a generic catchall wrapper that will apply our standard typography styling and spacing to naked HTML.

That composition yields undesirable `font-size`, specifically `16px`. The hierarchy between the title and the content seems off:

<img width="1252" height="532" alt="image" src="https://github.com/user-attachments/assets/8755b619-ae08-42c0-96c5-94c19b364391" />

Therefore, we want all our docs examples to use `size="s"`:

```tsx
<EuiText size="s">
  <p>
    {content}
  </p>
</EuiText>
```

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

🟢 None. It's a website change.

## QA

### Specific checklist

- [ ] Verify that all examples on the [EuiTour docs page](http://eui.elastic.co/pr_9078/docs/components/display/tour/) render correctly (the content is `14px`)
