### PR TITLE
[Flyout System] Have EuiFlyoutHeader defer to EuiFlyoutMenu if in managed session

### DIFF
--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -86,6 +86,7 @@
     "unified": "^9.2.2",
     "unist-util-visit": "^2.0.3",
     "url-parse": "^1.5.10",
+    "use-sync-external-store": "^1.6.0",
     "uuid": "^8.3.0",
     "vfile": "^4.2.1"
   },

--- a/packages/eui/src/components/flyout/flyout.tsx
+++ b/packages/eui/src/components/flyout/flyout.tsx
@@ -20,6 +20,7 @@ import {
   useHasActiveSession,
   useIsInManagedFlyout,
 } from './manager';
+import { EuiFlyoutMenuContext } from './flyout_menu_context';
 
 export type {
   EuiFlyoutSize,
@@ -87,6 +88,10 @@ export const EuiFlyout = forwardRef<
   // TODO: if resizeable={true}, render EuiResizableFlyout.
 
   isUnmanagedFlyout.current = true;
-  return <EuiFlyoutComponent {...rest} onClose={onClose} as={as} ref={ref} />;
+  return (
+    <EuiFlyoutMenuContext.Provider value={{ onClose }}>
+      <EuiFlyoutComponent {...rest} onClose={onClose} as={as} ref={ref} />
+    </EuiFlyoutMenuContext.Provider>
+  );
 });
 EuiFlyout.displayName = 'EuiFlyout';

--- a/packages/eui/src/components/flyout/flyout_custom_menu_context.tsx
+++ b/packages/eui/src/components/flyout/flyout_custom_menu_context.tsx
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { createContext, useContext } from 'react';
+
+export interface FlyoutCustomMenuContextValue {
+  hasCustomMenu: boolean;
+  setHasCustomMenu: (hasCustomMenu: boolean) => void;
+}
+
+export const FlyoutCustomMenuContext = createContext<FlyoutCustomMenuContextValue>({
+  hasCustomMenu: false,
+  setHasCustomMenu: () => {},
+});
+
+export const useFlyoutCustomMenuContext = () => useContext(FlyoutCustomMenuContext);

--- a/packages/eui/src/components/flyout/flyout_header.tsx
+++ b/packages/eui/src/components/flyout/flyout_header.tsx
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { useEuiMemoizedStyles } from '../../services';
 import { euiFlyoutHeaderStyles } from './flyout_header.styles';
+import { useHasActiveSession } from './manager';
+import { EuiFlyoutMenuWrapper } from './flyout_menu';
 
 export type EuiFlyoutHeaderProps = FunctionComponent<
   HTMLAttributes<HTMLDivElement> &
@@ -25,9 +27,14 @@ export const EuiFlyoutHeader: EuiFlyoutHeaderProps = ({
   hasBorder = false,
   ...rest
 }) => {
-  const classes = classNames('euiFlyoutHeader', className);
-
   const styles = useEuiMemoizedStyles(euiFlyoutHeaderStyles);
+
+  const isInManagedFlyout = useHasActiveSession();
+  if (isInManagedFlyout) {
+    return <EuiFlyoutMenuWrapper {...rest}>{children}</EuiFlyoutMenuWrapper>;
+  }
+
+  const classes = classNames('euiFlyoutHeader', className);
   const cssStyles = [styles.euiFlyoutHeader, hasBorder && styles.hasBorder];
 
   return (

--- a/packages/eui/src/components/flyout/flyout_header.tsx
+++ b/packages/eui/src/components/flyout/flyout_header.tsx
@@ -12,7 +12,7 @@ import { CommonProps } from '../common';
 import { useEuiMemoizedStyles } from '../../services';
 import { euiFlyoutHeaderStyles } from './flyout_header.styles';
 import { useHasActiveSession } from './manager';
-import { EuiFlyoutMenuWrapper } from './flyout_menu';
+import { EuiFlyoutMenu } from './flyout_menu';
 import { useFlyoutCustomMenuContext } from './flyout_custom_menu_context';
 
 export type EuiFlyoutHeaderProps = FunctionComponent<
@@ -42,7 +42,11 @@ export const EuiFlyoutHeader: EuiFlyoutHeaderProps = ({
   }, [isInManagedFlyout, setHasCustomMenu]);
 
   if (isInManagedFlyout) {
-    return <EuiFlyoutMenuWrapper {...rest}>{children}</EuiFlyoutMenuWrapper>;
+    return (
+      <EuiFlyoutMenu asWrapper {...rest}>
+        {children}
+      </EuiFlyoutMenu>
+    );
   }
 
   const classes = classNames('euiFlyoutHeader', className);

--- a/packages/eui/src/components/flyout/flyout_header.tsx
+++ b/packages/eui/src/components/flyout/flyout_header.tsx
@@ -6,13 +6,14 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, HTMLAttributes } from 'react';
+import React, { FunctionComponent, HTMLAttributes, useEffect } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 import { useEuiMemoizedStyles } from '../../services';
 import { euiFlyoutHeaderStyles } from './flyout_header.styles';
 import { useHasActiveSession } from './manager';
 import { EuiFlyoutMenuWrapper } from './flyout_menu';
+import { useFlyoutCustomMenuContext } from './flyout_custom_menu_context';
 
 export type EuiFlyoutHeaderProps = FunctionComponent<
   HTMLAttributes<HTMLDivElement> &
@@ -30,6 +31,16 @@ export const EuiFlyoutHeader: EuiFlyoutHeaderProps = ({
   const styles = useEuiMemoizedStyles(euiFlyoutHeaderStyles);
 
   const isInManagedFlyout = useHasActiveSession();
+  const { setHasCustomMenu } = useFlyoutCustomMenuContext();
+
+  // Signal that we're providing a custom menu
+  useEffect(() => {
+    if (isInManagedFlyout) {
+      setHasCustomMenu(true);
+      return () => setHasCustomMenu(false);
+    }
+  }, [isInManagedFlyout, setHasCustomMenu]);
+
   if (isInManagedFlyout) {
     return <EuiFlyoutMenuWrapper {...rest}>{children}</EuiFlyoutMenuWrapper>;
   }

--- a/packages/eui/src/components/flyout/flyout_menu.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_menu.styles.ts
@@ -7,6 +7,7 @@
  */
 
 import { css } from '@emotion/react';
+import { euiFontSize } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
 
 export const euiFlyoutMenuStyles = (euiThemeContext: UseEuiTheme) => {
@@ -30,6 +31,11 @@ export const euiFlyoutMenuStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     euiFlyoutMenu__actions: css`
       block-size: calc(${euiTheme.size.m} * 1.8);
+    `,
+    euiFlyoutMenu__wrapper_title: css`
+      h2 {
+        ${euiFontSize(euiThemeContext, 's', { unit: 'rem' })};
+      }
     `,
   };
 };

--- a/packages/eui/src/components/flyout/flyout_menu.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.tsx
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { css } from '@emotion/react';
 import classNames from 'classnames';
 import React, {
   FunctionComponent,
@@ -322,19 +321,7 @@ export const EuiFlyoutMenuWrapper: FunctionComponent<
           </EuiFlexItem>
         )}
 
-        <EuiFlexItem
-          grow={false}
-          css={css`
-            * {
-              /* Emulate "EuiTitle size=xxs" styles */
-              overflow-wrap: break-word !important;
-              word-break: break-word;
-              font-size: 1rem;
-              line-height: 1.4286rem;
-              font-weight: 600;
-            }
-          `}
-        >
+        <EuiFlexItem grow={false} css={styles.euiFlyoutMenu__wrapper_title}>
           <>{children /* title element */}</>
         </EuiFlexItem>
 

--- a/packages/eui/src/components/flyout/flyout_menu.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.tsx
@@ -52,7 +52,7 @@ const useFlyoutMenuProps = () => {
     return undefined;
   }
 
-  const { state, goBack, getHistoryItems } = manager;
+  const { state, goBack, historyItems: managerHistoryItems } = manager;
   const currentSession = state.sessions[state.sessions.length - 1];
 
   if (!currentSession) {
@@ -74,7 +74,7 @@ const useFlyoutMenuProps = () => {
   const title = currentSession.title;
 
   // Calculate menu props based on level
-  const historyItems = level === LEVEL_MAIN ? getHistoryItems() : undefined;
+  const historyItems = level === LEVEL_MAIN ? managerHistoryItems : undefined;
   const backButtonProps =
     level === LEVEL_MAIN ? { onClick: goBack } : undefined;
   const showBackButton = historyItems ? historyItems.length > 0 : false;

--- a/packages/eui/src/components/flyout/flyout_menu.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.tsx
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { css } from '@emotion/react';
 import classNames from 'classnames';
 import React, {
   FunctionComponent,
@@ -26,6 +27,9 @@ import { euiFlyoutMenuStyles } from './flyout_menu.styles';
 import { EuiFlyoutMenuContext } from './flyout_menu_context';
 import type { EuiFlyoutCloseEvent } from './types';
 import { EuiI18n, useEuiI18n } from '../i18n';
+import { useHasActiveSession } from './manager';
+import { useFlyoutManager } from './manager/hooks';
+import { LEVEL_MAIN } from './manager/const';
 
 type EuiFlyoutMenuBackButtonProps = Pick<
   PropsForAnchor<EuiButtonProps>,
@@ -35,6 +39,53 @@ type EuiFlyoutMenuBackButtonProps = Pick<
 type EuiFlyoutHistoryItem = {
   title: string;
   onClick: () => void;
+};
+
+/**
+ * Hook that provides flyout menu props based on the current managed flyout context.
+ * Returns undefined if not in a managed flyout context.
+ */
+const useFlyoutMenuProps = () => {
+  const hasActiveSession = useHasActiveSession();
+  const manager = useFlyoutManager();
+
+  if (!hasActiveSession || !manager) {
+    return undefined;
+  }
+
+  const { state, goBack, getHistoryItems } = manager;
+  const currentSession = state.sessions[state.sessions.length - 1];
+
+  if (!currentSession) {
+    return undefined;
+  }
+
+  // Get the current flyout's level and title from the manager state
+  const currentFlyout = state.flyouts.find(
+    (f: any) =>
+      f.flyoutId === currentSession.mainFlyoutId ||
+      f.flyoutId === currentSession.childFlyoutId
+  );
+
+  if (!currentFlyout) {
+    return undefined;
+  }
+
+  const level = currentFlyout.level;
+  const title = currentSession.title;
+
+  // Calculate menu props based on level
+  const historyItems = level === LEVEL_MAIN ? getHistoryItems() : undefined;
+  const backButtonProps =
+    level === LEVEL_MAIN ? { onClick: goBack } : undefined;
+  const showBackButton = historyItems ? historyItems.length > 0 : false;
+
+  return {
+    historyItems,
+    backButtonProps,
+    showBackButton,
+    title,
+  };
 };
 
 export type EuiFlyoutMenuProps = CommonProps &
@@ -106,15 +157,29 @@ const HistoryPopover: React.FC<{
 export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
   titleId,
   className,
-  title,
+  title: titleProp,
   hideCloseButton,
-  historyItems = [],
-  showBackButton,
-  backButtonProps,
+  historyItems: historyItemsProp = [],
+  showBackButton: showBackButtonProp,
+  backButtonProps: backButtonPropsProp,
   customActions,
   ...rest
 }) => {
   const { onClose } = useContext(EuiFlyoutMenuContext);
+
+  // Get menu props from context (if in managed flyout)
+  const contextMenuProps = useFlyoutMenuProps();
+
+  // Use context values as defaults, allow props to override
+  const title = titleProp ?? contextMenuProps?.title;
+  const historyItems =
+    historyItemsProp.length > 0
+      ? historyItemsProp
+      : contextMenuProps?.historyItems ?? [];
+  const backButtonProps =
+    backButtonPropsProp ?? contextMenuProps?.backButtonProps;
+  const showBackButton =
+    showBackButtonProp ?? contextMenuProps?.showBackButton ?? false;
 
   const styles = useEuiMemoizedStyles(euiFlyoutMenuStyles);
   const classes = classNames('euiFlyoutMenu', className);
@@ -148,7 +213,7 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
         gutterSize="none"
         responsive={false}
       >
-        {showBackButton && (
+        {showBackButton && backButtonProps && (
           <EuiFlexItem grow={false}>
             <BackButton {...backButtonProps} />
           </EuiFlexItem>
@@ -161,6 +226,117 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
         )}
 
         {titleNode && <EuiFlexItem grow={false}>{titleNode}</EuiFlexItem>}
+
+        <EuiFlexItem grow={true}></EuiFlexItem>
+
+        {customActions &&
+          customActions.map((action, actionIndex) => (
+            <EuiFlexItem
+              grow={false}
+              key={`action-index-flex-item-${actionIndex}`}
+              css={styles.euiFlyoutMenu__actions}
+            >
+              <EuiButtonIcon
+                key={`action-index-icon-${actionIndex}`}
+                aria-label={action['aria-label']}
+                iconType={action.iconType}
+                onClick={action.onClick}
+                color="text"
+                size="s"
+              />
+            </EuiFlexItem>
+          ))}
+
+        {/* spacer to give custom actions room around the close button */}
+        {!hideCloseButton && (
+          <EuiFlexItem grow={false} css={styles.euiFlyoutMenu__spacer} />
+        )}
+      </EuiFlexGroup>
+      {!hideCloseButton && closeButton}
+    </div>
+  );
+};
+
+export type EuiFlyoutMenuWrapperProps = CommonProps &
+  HTMLAttributes<HTMLDivElement> & {
+    children: React.ReactNode;
+    hideCloseButton?: boolean;
+    // Props that can override context values
+    customActions?: Array<{
+      iconType: string;
+      onClick: () => void;
+      'aria-label': string;
+    }>;
+  };
+
+export const EuiFlyoutMenuWrapper: FunctionComponent<
+  EuiFlyoutMenuWrapperProps
+> = ({
+  children,
+  className,
+  hideCloseButton = false,
+  customActions,
+  ...rest
+}) => {
+  const { onClose } = useContext(EuiFlyoutMenuContext);
+  const styles = useEuiMemoizedStyles(euiFlyoutMenuStyles);
+  const classes = classNames('euiFlyoutMenuWrapper', className);
+
+  // Get menu props from context (if in managed flyout)
+  const contextMenuProps = useFlyoutMenuProps();
+
+  // Use context values as defaults, allow props to override
+  const historyItems = contextMenuProps?.historyItems;
+  const backButtonProps = contextMenuProps?.backButtonProps;
+  const showBackButton = contextMenuProps?.showBackButton ?? false;
+
+  const handleClose = (event: EuiFlyoutCloseEvent | undefined) => {
+    onClose?.(event);
+  };
+
+  const closeButton = (
+    <EuiFlyoutCloseButton
+      onClose={handleClose}
+      side="right"
+      closeButtonPosition="inside"
+    />
+  );
+
+  return (
+    <div className={classes} css={styles.euiFlyoutMenu__container} {...rest}>
+      <EuiFlexGroup
+        alignItems="center"
+        justifyContent="spaceBetween"
+        gutterSize="none"
+        responsive={false}
+      >
+        {showBackButton && backButtonProps && (
+          <EuiFlexItem grow={false}>
+            <BackButton {...backButtonProps} />
+          </EuiFlexItem>
+        )}
+
+        {historyItems && historyItems.length > 0 && (
+          <EuiFlexItem grow={false}>
+            <HistoryPopover items={historyItems} />
+          </EuiFlexItem>
+        )}
+
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            * {
+              /* Emulate "EuiTitle size=xxs" styles */
+              overflow-wrap: break-word !important;
+              word-break: break-word;
+              font-size: 1rem;
+              line-height: 1.4286rem;
+              font-weight: 600;
+            }
+          `}
+        >
+          <>{children /* title element */}</>
+        </EuiFlexItem>
 
         <EuiFlexItem grow={true}></EuiFlexItem>
 

--- a/packages/eui/src/components/flyout/flyout_menu.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.tsx
@@ -101,6 +101,8 @@ export type EuiFlyoutMenuProps = CommonProps &
       onClick: () => void;
       'aria-label': string;
     }>;
+    /* When true, renders children as title content instead of using title prop */
+    asWrapper?: boolean;
   };
 
 const BackButton: React.FC<EuiFlyoutMenuBackButtonProps> = (props) => {
@@ -153,15 +155,34 @@ const HistoryPopover: React.FC<{
   );
 };
 
-export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
+// Internal unified component with branched logic
+const EuiFlyoutMenuInternal: FunctionComponent<{
+  titleId?: string;
+  className?: string;
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+  hideCloseButton?: boolean;
+  historyItems?: EuiFlyoutHistoryItem[];
+  showBackButton?: boolean;
+  backButtonProps?: EuiFlyoutMenuBackButtonProps;
+  customActions?: Array<{
+    iconType: string;
+    onClick: () => void;
+    'aria-label': string;
+  }>;
+  asWrapper?: boolean;
+  [key: string]: any;
+}> = ({
   titleId,
   className,
   title: titleProp,
+  children,
   hideCloseButton,
   historyItems: historyItemsProp = [],
   showBackButton: showBackButtonProp,
   backButtonProps: backButtonPropsProp,
   customActions,
+  asWrapper = false,
   ...rest
 }) => {
   const { onClose } = useContext(EuiFlyoutMenuContext);
@@ -181,14 +202,28 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
     showBackButtonProp ?? contextMenuProps?.showBackButton ?? false;
 
   const styles = useEuiMemoizedStyles(euiFlyoutMenuStyles);
-  const classes = classNames('euiFlyoutMenu', className);
+  const classes = classNames(
+    asWrapper ? 'euiFlyoutMenuWrapper' : 'euiFlyoutMenu',
+    className
+  );
 
+  // Determine title content based on mode
   let titleNode;
-  if (title) {
+  if (asWrapper && children) {
+    // Wrapper mode: render children as title
     titleNode = (
-      <EuiTitle size="xxs" id={titleId}>
-        <h3>{title}</h3>
-      </EuiTitle>
+      <EuiFlexItem grow={false} css={styles.euiFlyoutMenu__wrapper_title}>
+        <>{children}</>
+      </EuiFlexItem>
+    );
+  } else if (title) {
+    // Menu mode: render title in EuiTitle
+    titleNode = (
+      <EuiFlexItem grow={false}>
+        <EuiTitle size="xxs" id={titleId}>
+          <h3>{title}</h3>
+        </EuiTitle>
+      </EuiFlexItem>
     );
   }
 
@@ -224,7 +259,7 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
           </EuiFlexItem>
         )}
 
-        {titleNode && <EuiFlexItem grow={false}>{titleNode}</EuiFlexItem>}
+        {titleNode}
 
         <EuiFlexItem grow={true}></EuiFlexItem>
 
@@ -256,101 +291,6 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
   );
 };
 
-export type EuiFlyoutMenuWrapperProps = CommonProps &
-  HTMLAttributes<HTMLDivElement> & {
-    children: React.ReactNode;
-    hideCloseButton?: boolean;
-    // Props that can override context values
-    customActions?: Array<{
-      iconType: string;
-      onClick: () => void;
-      'aria-label': string;
-    }>;
-  };
-
-export const EuiFlyoutMenuWrapper: FunctionComponent<
-  EuiFlyoutMenuWrapperProps
-> = ({
-  children,
-  className,
-  hideCloseButton = false,
-  customActions,
-  ...rest
-}) => {
-  const { onClose } = useContext(EuiFlyoutMenuContext);
-  const styles = useEuiMemoizedStyles(euiFlyoutMenuStyles);
-  const classes = classNames('euiFlyoutMenuWrapper', className);
-
-  // Get menu props from context (if in managed flyout)
-  const contextMenuProps = useFlyoutMenuProps();
-
-  // Use context values as defaults, allow props to override
-  const historyItems = contextMenuProps?.historyItems;
-  const backButtonProps = contextMenuProps?.backButtonProps;
-  const showBackButton = contextMenuProps?.showBackButton ?? false;
-
-  const handleClose = (event: EuiFlyoutCloseEvent | undefined) => {
-    onClose?.(event);
-  };
-
-  const closeButton = (
-    <EuiFlyoutCloseButton
-      onClose={handleClose}
-      side="right"
-      closeButtonPosition="inside"
-    />
-  );
-
-  return (
-    <div className={classes} css={styles.euiFlyoutMenu__container} {...rest}>
-      <EuiFlexGroup
-        alignItems="center"
-        justifyContent="spaceBetween"
-        gutterSize="none"
-        responsive={false}
-      >
-        {showBackButton && backButtonProps && (
-          <EuiFlexItem grow={false}>
-            <BackButton {...backButtonProps} />
-          </EuiFlexItem>
-        )}
-
-        {historyItems && historyItems.length > 0 && (
-          <EuiFlexItem grow={false}>
-            <HistoryPopover items={historyItems} />
-          </EuiFlexItem>
-        )}
-
-        <EuiFlexItem grow={false} css={styles.euiFlyoutMenu__wrapper_title}>
-          <>{children /* title element */}</>
-        </EuiFlexItem>
-
-        <EuiFlexItem grow={true}></EuiFlexItem>
-
-        {customActions &&
-          customActions.map((action, actionIndex) => (
-            <EuiFlexItem
-              grow={false}
-              key={`action-index-flex-item-${actionIndex}`}
-              css={styles.euiFlyoutMenu__actions}
-            >
-              <EuiButtonIcon
-                key={`action-index-icon-${actionIndex}`}
-                aria-label={action['aria-label']}
-                iconType={action.iconType}
-                onClick={action.onClick}
-                color="text"
-                size="s"
-              />
-            </EuiFlexItem>
-          ))}
-
-        {/* spacer to give custom actions room around the close button */}
-        {!hideCloseButton && (
-          <EuiFlexItem grow={false} css={styles.euiFlyoutMenu__spacer} />
-        )}
-      </EuiFlexGroup>
-      {!hideCloseButton && closeButton}
-    </div>
-  );
+export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = (props) => {
+  return <EuiFlyoutMenuInternal {...props} />;
 };

--- a/packages/eui/src/components/flyout/manager/actions.ts
+++ b/packages/eui/src/components/flyout/manager/actions.ts
@@ -35,6 +35,8 @@ export const ACTION_SET_ACTIVITY_STAGE = `${PREFIX}/setActivityStage` as const;
 export const ACTION_GO_BACK = `${PREFIX}/goBack` as const;
 /** Dispatched to navigate to a specific flyout (remove all sessions after it). */
 export const ACTION_GO_TO_FLYOUT = `${PREFIX}/goToFlyout` as const;
+/** Dispatched to update a flyout's title in the manager state. */
+export const ACTION_UPDATE_TITLE = `${PREFIX}/updateTitle` as const;
 
 /**
  * Add a flyout to manager state. The manager will create or update
@@ -91,6 +93,13 @@ export interface GoToFlyoutAction extends BaseAction {
   flyoutId: string;
 }
 
+/** Update a flyout's title in the manager state. */
+export interface UpdateTitleAction extends BaseAction {
+  type: typeof ACTION_UPDATE_TITLE;
+  flyoutId: string;
+  title: string;
+}
+
 /** Union of all flyout manager actions. */
 export type Action =
   | AddFlyoutAction
@@ -100,7 +109,8 @@ export type Action =
   | SetLayoutModeAction
   | SetActivityStageAction
   | GoBackAction
-  | GoToFlyoutAction;
+  | GoToFlyoutAction
+  | UpdateTitleAction;
 
 /**
  * Register a flyout with the manager.
@@ -172,4 +182,14 @@ export const goBack = (): GoBackAction => ({
 export const goToFlyout = (flyoutId: string): GoToFlyoutAction => ({
   type: ACTION_GO_TO_FLYOUT,
   flyoutId,
+});
+
+/** Update a flyout's title in the manager state. */
+export const updateFlyoutTitle = (
+  flyoutId: string,
+  title: string
+): UpdateTitleAction => ({
+  type: ACTION_UPDATE_TITLE,
+  flyoutId,
+  title,
 });

--- a/packages/eui/src/components/flyout/manager/flyout_main.test.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_main.test.tsx
@@ -29,19 +29,16 @@ jest.mock('./flyout_managed', () => ({
 
 // Keep layout/ID hooks deterministic
 jest.mock('./hooks', () => ({
-  useFlyoutManagerReducer: () => ({
+  useFlyoutManager: () => ({
     state: { sessions: [], flyouts: [], layoutMode: 'side-by-side' },
     dispatch: jest.fn(),
     addFlyout: jest.fn(),
     closeFlyout: jest.fn(),
     setActiveFlyout: jest.fn(),
     setFlyoutWidth: jest.fn(),
-  }),
-  useFlyoutManager: () => ({
-    state: { sessions: [], flyouts: [], layoutMode: 'side-by-side' },
-    addFlyout: jest.fn(),
-    closeFlyout: jest.fn(),
-    setFlyoutWidth: jest.fn(),
+    goBack: jest.fn(),
+    goToFlyout: jest.fn(),
+    historyItems: [],
   }),
   useHasChildFlyout: () => false,
   useFlyoutId: (id?: string) => id ?? 'generated-id',

--- a/packages/eui/src/components/flyout/manager/flyout_managed.test.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.test.tsx
@@ -59,15 +59,11 @@ const createMockFunctions = () => ({
   setFlyoutWidth: jest.fn(),
   goBack: jest.fn(),
   goToFlyout: jest.fn(),
-  getHistoryItems: jest.fn(() => []),
+  historyItems: [],
 });
 
 // Mock hooks that would otherwise depend on ResizeObserver or animation timing
 jest.mock('./hooks', () => ({
-  useFlyoutManagerReducer: () => ({
-    state: createMockState(),
-    ...createMockFunctions(),
-  }),
   useFlyoutManager: () => ({
     state: createMockState(),
     ...createMockFunctions(),

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -83,8 +83,13 @@ export const EuiManagedFlyout = ({
   const flyoutId = useFlyoutId(id);
   const flyoutRef = useRef<HTMLDivElement>(null);
 
-  const { addFlyout, closeFlyout, setFlyoutWidth, goBack, getHistoryItems } =
-    useFlyoutManager();
+  const {
+    addFlyout,
+    closeFlyout,
+    setFlyoutWidth,
+    goBack,
+    historyItems: _historyItems,
+  } = useFlyoutManager();
   const parentSize = useParentFlyoutSize(flyoutId);
   const layoutMode = useFlyoutLayoutMode();
   const styles = useEuiMemoizedStyles(euiManagedFlyoutStyles);
@@ -214,8 +219,9 @@ export const EuiManagedFlyout = ({
 
   // Note: history controls are only relevant for main flyouts
   const historyItems = useMemo(() => {
-    return level === LEVEL_MAIN ? getHistoryItems() : undefined;
-  }, [level, getHistoryItems]);
+    const result = level === LEVEL_MAIN ? _historyItems : undefined;
+    return result;
+  }, [level, _historyItems]);
 
   const backButtonProps = useMemo(() => {
     return level === LEVEL_MAIN ? { onClick: goBack } : undefined;

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -89,6 +89,7 @@ export const EuiManagedFlyout = ({
     setFlyoutWidth,
     goBack,
     historyItems: _historyItems,
+    updateFlyoutTitle,
   } = useFlyoutManager();
   const parentSize = useParentFlyoutSize(flyoutId);
   const layoutMode = useFlyoutLayoutMode();
@@ -134,9 +135,10 @@ export const EuiManagedFlyout = ({
       const domEl = document.getElementById(labelledBy);
       if (domEl) {
         // get the visible text from the element
-        setTitle(title);
-
-        // FIXME: call an action to update the title's name in the manager state
+        const discoveredTitle =
+          domEl.textContent || domEl.innerText || 'Untitled';
+        setTitle(discoveredTitle);
+        updateFlyoutTitle(flyoutId, discoveredTitle);
       }
     }
   }
@@ -145,7 +147,7 @@ export const EuiManagedFlyout = ({
   const titleError = validateFlyoutTitle(title, flyoutId, level);
   if (titleError) {
     console.warn(titleError.message);
-    setTitle('Untitled flyout'); // FIXME: translate
+    setTitle('Untitled flyout');
   }
 
   const isActive = useIsFlyoutActive(flyoutId);

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -8,6 +8,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useEuiMemoizedStyles } from '../../../services';
 import { useResizeObserver } from '../../observer/resize_observer';
+import { useInnerText } from '../../inner_text/inner_text';
 import {
   EuiFlyoutComponent,
   EuiFlyoutComponentProps,
@@ -120,34 +121,94 @@ export const EuiManagedFlyout = ({
     _flyoutMenuProps?.title || props['aria-label']
   );
 
-  if (!title) {
-    const labelledBy = props['aria-labelledby'];
-    if (labelledBy) {
-      /*
-       * Notes
-       * - value could be a space-separated list of ids
-       * - element might not be rendered yet
-       * - element might not have any text content
-       * - element might change over time
-       * - element might not be visible
-       * - this is only a fallback, prefer explicit title or aria-label
-       */
-      const domEl = document.getElementById(labelledBy);
-      if (domEl) {
-        // get the visible text from the element
-        const discoveredTitle =
-          domEl.textContent || domEl.innerText || 'Untitled';
-        setTitle(discoveredTitle);
-        updateFlyoutTitle(flyoutId, discoveredTitle);
+  // Use useInnerText to observe title changes from aria-labelledby element
+  const [setLabelledByRef, labelledByText] = useInnerText();
+
+  // Set up the ref for the aria-labelledby element when it's available
+  const ariaLabelledBy = props['aria-labelledby'];
+  useEffect(() => {
+    // Only try to find the element when the flyout is open
+    if (ariaLabelledBy && isOpen) {
+      const tryFindElement = () => {
+        const domEl = document.getElementById(ariaLabelledBy);
+        if (domEl) {
+          setLabelledByRef(domEl);
+          return true;
+        }
+        return false;
+      };
+
+      // Try immediately first
+      if (!tryFindElement()) {
+        // Retry after a short delay to allow for DOM rendering
+        retryTimerRef.current = setTimeout(() => {
+          if (!tryFindElement()) {
+            // Element not found after retry - this is expected in some cases
+          }
+        }, 500); // Delay to allow for flyout content rendering
+
+        return () => {
+          if (retryTimerRef.current) {
+            clearTimeout(retryTimerRef.current);
+            retryTimerRef.current = null;
+          }
+        };
       }
     }
-  }
+  }, [ariaLabelledBy, setLabelledByRef, flyoutId, isOpen]);
+
+  // Update title when labelledByText changes
+  // Use aria-labelledby as fallback when no explicit title is provided
+  const ariaLabel = props['aria-label'];
+  const explicitTitle = _flyoutMenuProps?.title;
+
+  // Track the last processed title to prevent infinite loops
+  const lastProcessedTitleRef = useRef<string | null>(null);
+
+  // Track retry timer to clear it when text changes
+  const retryTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    // Clear retry timer if we got text (element was found and is being observed)
+    if (labelledByText && retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+
+    // Only update if we have new text and haven't processed this exact title before
+    if (
+      labelledByText &&
+      !explicitTitle &&
+      !ariaLabel &&
+      labelledByText !== lastProcessedTitleRef.current
+    ) {
+      const discoveredTitle = labelledByText || 'Untitled';
+
+      // Mark this title as processed to prevent re-processing
+      lastProcessedTitleRef.current = labelledByText;
+
+      setTitle(discoveredTitle);
+      updateFlyoutTitle(flyoutId, discoveredTitle);
+    }
+  }, [
+    labelledByText,
+    explicitTitle,
+    ariaLabel,
+    flyoutId,
+    updateFlyoutTitle,
+    title,
+    manager,
+  ]);
 
   // Validate title
   const titleError = validateFlyoutTitle(title, flyoutId, level);
   if (titleError) {
-    console.warn(titleError.message);
-    setTitle('Untitled flyout');
+    console.warn('⚠️ Title validation error:', {
+      flyoutId,
+      level,
+      title,
+      error: titleError.message,
+    });
   }
 
   const isActive = useIsFlyoutActive(flyoutId);
@@ -175,9 +236,9 @@ export const EuiManagedFlyout = ({
   // Register with flyout manager context when open, remove when closed
   useEffect(() => {
     if (isOpen) {
-      addFlyout(flyoutId, title!, level, size as string);
+      addFlyout?.(flyoutId, title!, level, size as string);
     } else {
-      closeFlyout(flyoutId);
+      closeFlyout?.(flyoutId);
       // Reset navigation tracking when explicitly closed via isOpen=false
       wasRegisteredRef.current = false;
     }
@@ -218,7 +279,7 @@ export const EuiManagedFlyout = ({
   useEffect(() => {
     return () => {
       // Only remove from manager on component unmount, don't trigger close callback
-      closeFlyout(flyoutId);
+      closeFlyout?.(flyoutId);
     };
   }, [closeFlyout, flyoutId]);
 
@@ -236,7 +297,7 @@ export const EuiManagedFlyout = ({
   // Update width in manager state when it changes
   useEffect(() => {
     if (isActive && width) {
-      setFlyoutWidth(flyoutId, width);
+      setFlyoutWidth?.(flyoutId, width);
     }
   }, [flyoutId, level, isActive, width, setFlyoutWidth]);
 

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -84,14 +84,8 @@ export const EuiManagedFlyout = ({
   const flyoutId = useFlyoutId(id);
   const flyoutRef = useRef<HTMLDivElement>(null);
 
-  const {
-    addFlyout,
-    closeFlyout,
-    setFlyoutWidth,
-    goBack,
-    historyItems: _historyItems,
-    updateFlyoutTitle,
-  } = useFlyoutManager();
+  const { addFlyout, closeFlyout, setFlyoutWidth, updateFlyoutTitle } =
+    useFlyoutManager();
   const parentSize = useParentFlyoutSize(flyoutId);
   const layoutMode = useFlyoutLayoutMode();
   const styles = useEuiMemoizedStyles(euiManagedFlyoutStyles);
@@ -197,7 +191,6 @@ export const EuiManagedFlyout = ({
     flyoutId,
     updateFlyoutTitle,
     title,
-    manager,
   ]);
 
   // Validate title
@@ -306,25 +299,14 @@ export const EuiManagedFlyout = ({
     level,
   });
 
-  // Note: history controls are only relevant for main flyouts
-  const historyItems = useMemo(() => {
-    const result = level === LEVEL_MAIN ? _historyItems : undefined;
-    return result;
-  }, [level, _historyItems]);
-
-  const backButtonProps = useMemo(() => {
-    return level === LEVEL_MAIN ? { onClick: goBack } : undefined;
-  }, [level, goBack]);
-
-  const showBackButton = historyItems ? historyItems.length > 0 : false;
-
-  const flyoutMenuProps = {
-    ..._flyoutMenuProps,
-    historyItems,
-    showBackButton,
-    backButtonProps,
-    title,
-  };
+  // Pass through the basic flyout menu props - the menu component will handle
+  // history and back button logic internally via context
+  const flyoutMenuProps = _flyoutMenuProps
+    ? {
+        ..._flyoutMenuProps,
+        title,
+      }
+    : undefined;
 
   return (
     <EuiFlyoutIsManagedProvider isManaged={true}>

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -15,6 +15,7 @@ import {
 } from '../flyout.component';
 import { EuiFlyoutMenuProps } from '../flyout_menu';
 import { EuiFlyoutMenuContext } from '../flyout_menu_context';
+import { FlyoutCustomMenuContext } from '../flyout_custom_menu_context';
 import type { EuiFlyoutCloseEvent } from '../types';
 import { useFlyoutActivityStage } from './activity_stage';
 import {
@@ -299,9 +300,12 @@ export const EuiManagedFlyout = ({
     level,
   });
 
+  // Check if a custom menu is being provided via context
+  const [hasCustomMenu, setHasCustomMenu] = useState(false);
+
   // Pass through the basic flyout menu props - the menu component will handle
   // history and back button logic internally via context
-  const flyoutMenuProps = _flyoutMenuProps
+  const flyoutMenuProps = !hasCustomMenu
     ? {
         ..._flyoutMenuProps,
         title,
@@ -310,28 +314,32 @@ export const EuiManagedFlyout = ({
 
   return (
     <EuiFlyoutIsManagedProvider isManaged={true}>
-      <EuiFlyoutMenuContext.Provider value={{ onClose }}>
-        <EuiFlyoutComponent
-          id={flyoutId}
-          ref={flyoutRef}
-          css={[
-            styles.managedFlyout,
-            customCss,
-            styles.stage(activityStage, props.side, level),
-          ]}
-          {...{
-            ...props,
-            onClose,
-            size,
-            flyoutMenuProps,
-            onAnimationEnd,
-            isOpen,
-            [PROPERTY_FLYOUT]: true,
-            [PROPERTY_LAYOUT_MODE]: layoutMode,
-            [PROPERTY_LEVEL]: level,
-          }}
-        />
-      </EuiFlyoutMenuContext.Provider>
+      <FlyoutCustomMenuContext.Provider
+        value={{ hasCustomMenu, setHasCustomMenu }}
+      >
+        <EuiFlyoutMenuContext.Provider value={{ onClose }}>
+          <EuiFlyoutComponent
+            id={flyoutId}
+            ref={flyoutRef}
+            css={[
+              styles.managedFlyout,
+              customCss,
+              styles.stage(activityStage, props.side, level),
+            ]}
+            {...{
+              ...props,
+              onClose,
+              size,
+              flyoutMenuProps,
+              onAnimationEnd,
+              isOpen,
+              [PROPERTY_FLYOUT]: true,
+              [PROPERTY_LAYOUT_MODE]: layoutMode,
+              [PROPERTY_LEVEL]: level,
+            }}
+          />
+        </EuiFlyoutMenuContext.Provider>
+      </FlyoutCustomMenuContext.Provider>
     </EuiFlyoutIsManagedProvider>
   );
 };

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useEuiMemoizedStyles } from '../../../services';
 import { useResizeObserver } from '../../observer/resize_observer';
 import {
@@ -115,11 +115,37 @@ export const EuiManagedFlyout = ({
     }
   }
 
+  const [title, setTitle] = useState(
+    _flyoutMenuProps?.title || props['aria-label']
+  );
+
+  if (!title) {
+    const labelledBy = props['aria-labelledby'];
+    if (labelledBy) {
+      /*
+       * Notes
+       * - value could be a space-separated list of ids
+       * - element might not be rendered yet
+       * - element might not have any text content
+       * - element might change over time
+       * - element might not be visible
+       * - this is only a fallback, prefer explicit title or aria-label
+       */
+      const domEl = document.getElementById(labelledBy);
+      if (domEl) {
+        // get the visible text from the element
+        setTitle(title);
+
+        // FIXME: call an action to update the title's name in the manager state
+      }
+    }
+  }
+
   // Validate title
-  const title = _flyoutMenuProps?.title || props['aria-label'];
   const titleError = validateFlyoutTitle(title, flyoutId, level);
   if (titleError) {
-    throw new Error(createValidationErrorMessage(titleError));
+    console.warn(titleError.message);
+    setTitle('Untitled flyout'); // FIXME: translate
   }
 
   const isActive = useIsFlyoutActive(flyoutId);

--- a/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
@@ -473,7 +473,9 @@ export const FlyoutChildDemo: Story = {
         </p>
       </EuiText>
       <EuiSpacer size="l" />
-      <FlyoutWithMenuProps {...args} /> <FlyoutWithHeader {...args} />
+      <FlyoutWithMenuProps {...args} />
+      <EuiSpacer size="xs" />
+      <FlyoutWithHeader {...args} />
     </>
   ),
 };

--- a/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
@@ -170,7 +170,7 @@ type Story = StoryObj<FlyoutChildStoryArgs>;
  * A shared helper component used to demo management of internal state. It keeps internal state of
  * the selected flyout type (overlay/push) and the open/closed state of child flyout.
  */
-const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
+const FlyoutWithMenuProps: React.FC<FlyoutChildStoryArgs> = ({
   mainSize,
   childSize,
   childBackgroundStyle,
@@ -183,7 +183,7 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
   childFlyoutResizable,
   ...args
 }) => {
-  const [isMainOpen, setIsMainOpen] = useState(true);
+  const [isMainOpen, setIsMainOpen] = useState(false);
 
   /* TODO: Allow child to be open automatically on initial render. Currently,
    * this is not supported due to the child not having a reference to the
@@ -212,33 +212,27 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
 
   return (
     <>
-      <EuiText>
-        <p>
-          This is the main page content. Watch how it behaves when the flyout
-          type changes.
-        </p>
-        <p>
-          <strong>Current layout mode: {layoutMode}</strong>
-        </p>
-      </EuiText>
-      <EuiSpacer size="l" />
       {isMainOpen ? (
-        <EuiButton onClick={closeMain}>Close Main Flyout</EuiButton>
+        <EuiButton onClick={closeMain}>Close with flyoutMenuProps</EuiButton>
       ) : (
-        <EuiButton onClick={openMain}>Open Main Flyout</EuiButton>
+        <EuiButton onClick={openMain}>
+          Open Flyout with flyoutMenuProps
+        </EuiButton>
       )}
 
       <EuiFlyout
         isOpen={isMainOpen}
         session={true}
-        id="flyout-manager-playground-main"
+        id="flyout-with-menu-props-main"
         size={mainSize}
         type={mainFlyoutType}
         pushMinBreakpoint={pushMinBreakpoint}
         maxWidth={mainMaxWidth}
         ownFocus={false}
         resizable={mainFlyoutResizable}
-        aria-label={`Main Flyout Menu (${mainSize})`}
+        flyoutMenuProps={{
+          title: `Main Flyout with flyoutMenuProps (${mainSize})`,
+        }}
         {...args}
         onClose={closeMain}
       >
@@ -250,6 +244,9 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
               neque sequi illo, cum rerum quia ab animi velit sit incidunt
               inventore temporibus eaque nam veritatis amet maxime maiores optio
               quam?
+            </p>
+            <p>
+              <strong>Current layout mode: {layoutMode}</strong>
             </p>
           </EuiText>
           <EuiSpacer />
@@ -268,7 +265,9 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
             ownFocus={false}
             resizable={childFlyoutResizable}
             {...args}
-            aria-label={`Child Flyout Panel (${childSize})`}
+            flyoutMenuProps={{
+              title: `Child Flyout with flyoutMenuProps (${childSize})`,
+            }}
             onClose={closeChild}
           >
             <EuiFlyoutBody>
@@ -285,6 +284,159 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
                   Dolorum neque sequi illo, cum rerum quia ab animi velit sit
                   incidunt inventore temporibus eaque nam veritatis amet maxime
                   maiores optio quam?
+                </p>
+                <p>
+                  <strong>Current layout mode: {layoutMode}</strong>
+                </p>
+              </EuiText>
+            </EuiFlyoutBody>
+            {showFooter && (
+              <EuiFlyoutFooter>
+                <EuiText>
+                  <p>Child flyout footer</p>
+                </EuiText>
+              </EuiFlyoutFooter>
+            )}
+            {/* Footer is optional */}
+          </EuiFlyout>
+        </EuiFlyoutBody>
+        {showFooter && (
+          <EuiFlyoutFooter>
+            <EuiText>
+              <p>Main flyout footer</p>
+            </EuiText>
+          </EuiFlyoutFooter>
+        )}
+      </EuiFlyout>
+    </>
+  );
+};
+
+const FlyoutWithHeader: React.FC<FlyoutChildStoryArgs> = ({
+  mainSize,
+  childSize,
+  childBackgroundStyle,
+  mainFlyoutType,
+  pushMinBreakpoint,
+  mainMaxWidth,
+  childMaxWidth,
+  showFooter,
+  mainFlyoutResizable,
+  childFlyoutResizable,
+  ...args
+}) => {
+  const [isMainOpen, setIsMainOpen] = useState(false);
+
+  /* TODO: Allow child to be open automatically on initial render. Currently,
+   * this is not supported due to the child not having a reference to the
+   * session context */
+  const [isChildOpen, setIsChildOpen] = useState(false);
+
+  const openMain = () => {
+    setIsMainOpen(true);
+    playgroundActions.log('Parent flyout opened');
+  };
+  const closeMain = () => {
+    setIsMainOpen(false);
+    setIsChildOpen(false);
+    playgroundActions.log('Parent flyout closed');
+  };
+  const openChild = () => {
+    setIsChildOpen(true);
+    playgroundActions.log('Child flyout opened');
+  };
+  const closeChild = () => {
+    setIsChildOpen(false);
+    playgroundActions.log('Child flyout closed');
+  };
+
+  const layoutMode = useFlyoutLayoutMode();
+
+  return (
+    <>
+      {isMainOpen ? (
+        <EuiButton onClick={closeMain}>Close with EuiFlyoutHeader</EuiButton>
+      ) : (
+        <EuiButton onClick={openMain}>
+          Open Flyout with EuiFlyoutHeader
+        </EuiButton>
+      )}
+
+      <EuiFlyout
+        isOpen={isMainOpen}
+        session={true}
+        id="flyout-with-header-main"
+        size={mainSize}
+        type={mainFlyoutType}
+        pushMinBreakpoint={pushMinBreakpoint}
+        maxWidth={mainMaxWidth}
+        ownFocus={false}
+        resizable={mainFlyoutResizable}
+        aria-labelledby="flyoutWithHeaderTitle"
+        {...args}
+        onClose={closeMain}
+      >
+        <EuiFlyoutHeader>
+          <EuiTitle size="m">
+            <h2 id="flyoutWithHeaderTitle">
+              Main Flyout with EuiFlyoutHeader ({mainSize})
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiText>
+            <p>
+              A flyout that has an <EuiCode>EuiFlyoutHeader</EuiCode> child and{' '}
+              <EuiCode>session=true</EuiCode>
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum
+              neque sequi illo, cum rerum quia ab animi velit sit incidunt
+              inventore temporibus eaque nam veritatis amet maxime maiores optio
+              quam?
+            </p>
+            <p>
+              <strong>Current layout mode: {layoutMode}</strong>
+            </p>
+          </EuiText>
+          <EuiSpacer />
+
+          {!isChildOpen ? (
+            <EuiButton onClick={openChild}>Open child panel</EuiButton>
+          ) : (
+            <EuiButton onClick={closeChild}>Close child panel</EuiButton>
+          )}
+          <EuiFlyout
+            isOpen={isChildOpen}
+            id="flyout-manager-playground-child"
+            size={childSize}
+            backgroundStyle={childBackgroundStyle}
+            maxWidth={childMaxWidth}
+            ownFocus={false}
+            resizable={childFlyoutResizable}
+            {...args}
+            flyoutMenuProps={{
+              title: `Child Flyout with flyoutMenuProps (${childSize})`,
+            }}
+            onClose={closeChild}
+          >
+            <EuiFlyoutBody>
+              <EuiText>
+                <p>This is the child flyout content.</p>
+                <p>Size restrictions apply:</p>
+                <ul>
+                  <li>When main panel is 's', child can be 's', or 'm'</li>
+                  <li>When main panel is 'm', child is limited to 's'</li>
+                </ul>
+                <EuiSpacer />
+                <p>
+                  Lorem ipsum dolor sit amet consectetur adipisicing elit.
+                  Dolorum neque sequi illo, cum rerum quia ab animi velit sit
+                  incidunt inventore temporibus eaque nam veritatis amet maxime
+                  maiores optio quam?
+                </p>
+                <p>
+                  <strong>Current layout mode: {layoutMode}</strong>
                 </p>
               </EuiText>
             </EuiFlyoutBody>
@@ -312,7 +464,18 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
 
 export const FlyoutChildDemo: Story = {
   name: 'Playground',
-  render: (args) => <StatefulFlyout {...args} />,
+  render: (args) => (
+    <>
+      <EuiText>
+        <p>
+          This is the main page content. Watch how it behaves when the flyout
+          type changes.
+        </p>
+      </EuiText>
+      <EuiSpacer size="l" />
+      <FlyoutWithMenuProps {...args} /> <FlyoutWithHeader {...args} />
+    </>
+  ),
 };
 
 const ExternalRootFlyout: React.FC<{ id: string }> = ({ id }) => {

--- a/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
@@ -15,7 +15,7 @@ import type { Root } from 'react-dom/client';
 import { LOKI_SELECTORS } from '../../../../.storybook/loki';
 import { EuiBreakpointSize } from '../../../services';
 import { EuiButton } from '../../button';
-import { EuiCodeBlock } from '../../code';
+import { EuiCode, EuiCodeBlock } from '../../code';
 import { EuiFlexGroup, EuiFlexItem } from '../../flex';
 import { EuiPanel } from '../../panel';
 import { EuiProvider } from '../../provider';
@@ -27,6 +27,7 @@ import { EuiFlyoutBody } from '../flyout_body';
 import { EuiFlyoutFooter } from '../flyout_footer';
 import { EuiFlyoutChild, EuiFlyoutChildProps } from './flyout_child';
 import { useFlyoutLayoutMode, useFlyoutManager } from './hooks';
+import { EuiFlyoutHeader } from '../flyout_header';
 
 type EuiFlyoutChildActualProps = Pick<
   EuiFlyoutChildProps,
@@ -553,7 +554,7 @@ const MultiRootFlyoutDemo: React.FC<FlyoutChildStoryArgs> = (args) => {
         <h3>Primary React root</h3>
       </EuiTitle>
       <EuiSpacer size="m" />
-      <StatefulFlyout
+      <FlyoutWithMenuProps
         {...args}
         mainSize="m"
         childSize="s"

--- a/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
@@ -258,7 +258,7 @@ const FlyoutWithMenuProps: React.FC<FlyoutChildStoryArgs> = ({
           )}
           <EuiFlyout
             isOpen={isChildOpen}
-            id="flyout-manager-playground-child"
+            id="flyout-with-menu-props-child"
             size={childSize}
             backgroundStyle={childBackgroundStyle}
             maxWidth={childMaxWidth}
@@ -408,7 +408,7 @@ const FlyoutWithHeader: React.FC<FlyoutChildStoryArgs> = ({
           )}
           <EuiFlyout
             isOpen={isChildOpen}
-            id="flyout-manager-playground-child"
+            id="flyout-with-header-child"
             size={childSize}
             backgroundStyle={childBackgroundStyle}
             maxWidth={childMaxWidth}

--- a/packages/eui/src/components/flyout/manager/hooks.test.tsx
+++ b/packages/eui/src/components/flyout/manager/hooks.test.tsx
@@ -7,9 +7,7 @@
  */
 
 import { renderHook } from '../../../test/rtl';
-import { act } from '@testing-library/react';
-import { useFlyoutManagerReducer, useFlyoutId } from './hooks';
-import { LEVEL_MAIN, LEVEL_CHILD } from './const';
+import { useFlyoutId } from './hooks';
 
 // Mock the warnOnce service but keep other actual exports (e.g., useGeneratedHtmlId)
 jest.mock('../../../services', () => {
@@ -20,352 +18,35 @@ jest.mock('../../../services', () => {
   };
 });
 
-// Mock the useFlyout selector
-jest.mock('./selectors', () => ({
-  useFlyout: jest.fn(),
-  useIsFlyoutRegistered: jest.fn(),
-}));
+describe('useFlyoutId', () => {
+  it('should return a stable ID when no id is provided', () => {
+    const { result, rerender } = renderHook(() => useFlyoutId());
 
-describe('flyout manager hooks', () => {
-  const {
-    useFlyout: mockUseFlyout,
-    useIsFlyoutRegistered: mockUseIsFlyoutRegistered,
-  } = jest.requireMock('./selectors');
+    const firstId = result.current;
+    rerender();
+    const secondId = result.current;
 
-  beforeEach(() => {
-    mockUseFlyout.mockClear();
-    mockUseIsFlyoutRegistered.mockClear();
+    expect(firstId).toBe(secondId);
+    expect(typeof firstId).toBe('string');
+    expect(firstId).toMatch(/^flyout-_generated-id-\d+$/);
   });
 
-  describe('useFlyoutManagerReducer', () => {
-    it('should return initial state and bound action creators', () => {
-      const { result } = renderHook(() => useFlyoutManagerReducer());
+  it('should return the provided id when given', () => {
+    const customId = 'my-custom-flyout-id';
+    const { result } = renderHook(() => useFlyoutId(customId));
 
-      expect(result.current.state).toEqual({
-        sessions: [],
-        flyouts: [],
-        layoutMode: 'side-by-side',
-      });
-      expect(typeof result.current.dispatch).toBe('function');
-      expect(typeof result.current.addFlyout).toBe('function');
-      expect(typeof result.current.closeFlyout).toBe('function');
-      expect(typeof result.current.setActiveFlyout).toBe('function');
-      expect(typeof result.current.setFlyoutWidth).toBe('function');
-    });
-
-    it('should accept custom initial state', () => {
-      const customInitialState = {
-        sessions: [],
-        flyouts: [],
-        layoutMode: 'stacked' as const,
-      };
-
-      const { result } = renderHook(() =>
-        useFlyoutManagerReducer(customInitialState)
-      );
-
-      expect(result.current.state.layoutMode).toBe('stacked');
-    });
-
-    it('should dispatch actions correctly', () => {
-      const { result } = renderHook(() => useFlyoutManagerReducer());
-
-      act(() => {
-        result.current.addFlyout('main-1', 'main', LEVEL_MAIN, 'l');
-      });
-
-      expect(result.current.state.flyouts).toHaveLength(1);
-      expect(result.current.state.flyouts[0]).toEqual({
-        flyoutId: 'main-1',
-        level: LEVEL_MAIN,
-        size: 'l',
-        activityStage: 'opening',
-      });
-      expect(result.current.state.sessions).toHaveLength(1);
-    });
-
-    it('should handle multiple actions in sequence', () => {
-      const { result } = renderHook(() => useFlyoutManagerReducer());
-
-      act(() => {
-        result.current.addFlyout('main-1', 'main', LEVEL_MAIN);
-        result.current.addFlyout('child-1', 'child', LEVEL_CHILD);
-        result.current.setActiveFlyout('child-1');
-        result.current.setFlyoutWidth('main-1', 600);
-        result.current.setFlyoutWidth('child-1', 400);
-      });
-
-      expect(result.current.state.flyouts).toHaveLength(2);
-      expect(result.current.state.sessions[0].childFlyoutId).toBe('child-1');
-      expect(result.current.state.flyouts[0].width).toBe(600);
-      expect(result.current.state.flyouts[1].width).toBe(400);
-    });
-
-    it('should maintain action creator stability across renders', () => {
-      const { result, rerender } = renderHook(() => useFlyoutManagerReducer());
-
-      const initialAddFlyout = result.current.addFlyout;
-      const initialCloseFlyout = result.current.closeFlyout;
-
-      rerender();
-
-      expect(result.current.addFlyout).toBe(initialAddFlyout);
-      expect(result.current.closeFlyout).toBe(initialCloseFlyout);
-    });
-
-    it('should handle complex state transitions', () => {
-      const { result } = renderHook(() => useFlyoutManagerReducer());
-
-      // Create a complex scenario
-      act(() => {
-        // Add main flyout
-        result.current.addFlyout('main-1', 'main', LEVEL_MAIN, 'l');
-        // Add child flyout
-        result.current.addFlyout('child-1', 'child', LEVEL_CHILD, 'm');
-        // Set child as active
-        result.current.setActiveFlyout('child-1');
-        // Update widths
-        result.current.setFlyoutWidth('main-1', 600);
-        result.current.setFlyoutWidth('child-1', 400);
-        // Close child flyout
-        result.current.closeFlyout('child-1');
-        // Close main flyout
-        result.current.closeFlyout('main-1');
-      });
-
-      expect(result.current.state.flyouts).toHaveLength(0);
-      expect(result.current.state.sessions).toHaveLength(0);
-    });
+    expect(result.current).toBe(customId);
   });
 
-  describe('useFlyoutId', () => {
-    it('should return provided flyout ID when it is not registered', () => {
-      mockUseIsFlyoutRegistered.mockReturnValue(false); // ID is available
-      const { result } = renderHook(() => useFlyoutId('existing-id'));
+  it('should return a stable ID when id is provided', () => {
+    const customId = 'my-custom-flyout-id';
+    const { result, rerender } = renderHook(() => useFlyoutId(customId));
 
-      expect(mockUseIsFlyoutRegistered).toHaveBeenCalledWith('existing-id');
-      expect(result.current).toBe('existing-id');
-    });
+    const firstId = result.current;
+    rerender();
+    const secondId = result.current;
 
-    it('should generate deterministic ID when no ID is provided', () => {
-      const { result } = renderHook(() => useFlyoutId());
-
-      expect(result.current).toMatch(/^flyout-/);
-      expect(typeof result.current).toBe('string');
-    });
-
-    it('should generate deterministic ID when provided ID is empty', () => {
-      const { result } = renderHook(() => useFlyoutId(''));
-
-      expect(result.current).toMatch(/^flyout-/);
-    });
-
-    it('should generate deterministic ID when provided ID is undefined', () => {
-      const { result } = renderHook(() => useFlyoutId(undefined));
-
-      expect(result.current).toMatch(/^flyout-/);
-    });
-
-    it('should maintain ID consistency across renders', () => {
-      mockUseIsFlyoutRegistered.mockReturnValue(false); // ID is available
-      const { result, rerender } = renderHook(() => useFlyoutId('stable-id'));
-
-      const initialId = result.current;
-      rerender();
-      rerender();
-
-      expect(result.current).toBe(initialId);
-    });
-
-    it('should handle different IDs for different components', () => {
-      mockUseIsFlyoutRegistered.mockReturnValue(false); // IDs are available
-      const { result: result1 } = renderHook(() => useFlyoutId('id-1'));
-      const { result: result2 } = renderHook(() => useFlyoutId('id-2'));
-
-      expect(result1.current).toBe('id-1');
-      expect(result2.current).toBe('id-2');
-    });
-
-    it('should handle generated IDs for different components', () => {
-      const { result: result1 } = renderHook(() => useFlyoutId());
-      const { result: result2 } = renderHook(() => useFlyoutId());
-
-      expect(result1.current).not.toBe(result2.current);
-      expect(result1.current).toMatch(/^flyout-/);
-      expect(result2.current).toMatch(/^flyout-/);
-    });
-
-    it('should handle ID conflicts gracefully', () => {
-      // Mock that the ID is already registered (conflict)
-      mockUseIsFlyoutRegistered.mockReturnValue(true);
-
-      const { result } = renderHook(() => useFlyoutId('conflict-id'));
-
-      expect(result.current).toMatch(/^flyout-/);
-      expect(result.current).not.toBe('conflict-id');
-    });
-
-    it('should handle multiple ID conflicts', () => {
-      // Mock multiple conflicts
-      mockUseIsFlyoutRegistered.mockReturnValue(true);
-
-      const { result } = renderHook(() => useFlyoutId('conflict-1'));
-
-      expect(result.current).toMatch(/^flyout-/);
-      expect(result.current).not.toBe('conflict-1');
-    });
-
-    it('should handle special characters in provided IDs', () => {
-      mockUseIsFlyoutRegistered.mockReturnValue(false); // IDs are available
-      const specialIds = [
-        'flyout-1',
-        'flyout_2',
-        'flyout.3',
-        'flyout-4',
-        'FLYOUT-5',
-        'Flyout-6',
-      ];
-
-      specialIds.forEach((id) => {
-        const { result } = renderHook(() => useFlyoutId(id));
-        expect(result.current).toBe(id);
-      });
-    });
-
-    it('should handle very long IDs', () => {
-      mockUseIsFlyoutRegistered.mockReturnValue(false); // ID is available
-      const longId = 'a'.repeat(1000);
-      const { result } = renderHook(() => useFlyoutId(longId));
-
-      expect(result.current).toBe(longId);
-    });
-
-    it('should handle empty string IDs', () => {
-      const { result } = renderHook(() => useFlyoutId(''));
-
-      expect(result.current).toMatch(/^flyout-/);
-    });
-
-    it('should handle null IDs', () => {
-      const { result } = renderHook(() => useFlyoutId(null as any));
-
-      expect(result.current).toMatch(/^flyout-/);
-    });
-
-    it('should maintain ID stability when input changes', () => {
-      // First call with no ID - generates one
-      const { result, rerender } = renderHook(() => useFlyoutId());
-      const firstId = result.current;
-
-      // Re-render with same input (no ID)
-      rerender();
-      expect(result.current).toBe(firstId);
-
-      // Re-render with different input (still no ID)
-      rerender();
-      expect(result.current).toBe(firstId);
-    });
-
-    it('should not change ID when provided ID changes', () => {
-      const { result, rerender } = renderHook(({ id }) => useFlyoutId(id), {
-        initialProps: { id: undefined as string | undefined },
-      });
-
-      const generatedId = result.current;
-      expect(generatedId).toMatch(/^flyout-/);
-
-      // Change to provided ID
-      mockUseIsFlyoutRegistered.mockReturnValue(false);
-      rerender({ id: 'provided-id' });
-
-      expect(result.current).toBe(generatedId);
-      expect(result.current).not.toBe('provided-id');
-    });
-  });
-
-  describe('hook integration', () => {
-    it('should work together with reducer', () => {
-      mockUseIsFlyoutRegistered.mockReturnValue(false); // ID is available
-      const { result: reducerResult } = renderHook(() =>
-        useFlyoutManagerReducer()
-      );
-      const { result: idResult } = renderHook(() => useFlyoutId('test-id'));
-
-      act(() => {
-        reducerResult.current.addFlyout(idResult.current, 'main', LEVEL_MAIN);
-      });
-
-      expect(reducerResult.current.state.flyouts).toHaveLength(1);
-      expect(reducerResult.current.state.flyouts[0].flyoutId).toBe('test-id');
-    });
-
-    it('should handle multiple flyouts with generated IDs', () => {
-      const { result: reducerResult } = renderHook(() =>
-        useFlyoutManagerReducer()
-      );
-      const { result: idResult1 } = renderHook(() => useFlyoutId());
-      const { result: idResult2 } = renderHook(() => useFlyoutId());
-
-      act(() => {
-        reducerResult.current.addFlyout(idResult1.current, 'main', LEVEL_MAIN);
-        reducerResult.current.addFlyout(
-          idResult2.current,
-          'child',
-          LEVEL_CHILD
-        );
-      });
-
-      expect(reducerResult.current.state.flyouts).toHaveLength(2);
-      expect(reducerResult.current.state.sessions).toHaveLength(1);
-      expect(reducerResult.current.state.sessions[0].childFlyoutId).toBe(
-        idResult2.current
-      );
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle rapid state changes', () => {
-      const { result } = renderHook(() => useFlyoutManagerReducer());
-
-      act(() => {
-        // Rapidly add and remove flyouts
-        for (let i = 0; i < 10; i++) {
-          result.current.addFlyout(`flyout-${i}`, 'main', LEVEL_MAIN);
-          result.current.closeFlyout(`flyout-${i}`);
-        }
-      });
-
-      expect(result.current.state.flyouts).toHaveLength(0);
-      expect(result.current.state.sessions).toHaveLength(0);
-    });
-
-    it('should handle concurrent ID generation', () => {
-      const results = [];
-      for (let i = 0; i < 5; i++) {
-        const { result } = renderHook(() => useFlyoutId());
-        results.push(result.current);
-      }
-
-      // All IDs should be unique
-      const uniqueIds = new Set(results);
-      expect(uniqueIds.size).toBe(5);
-
-      // All IDs should follow the pattern
-      results.forEach((id) => {
-        expect(id).toMatch(/^flyout-/);
-      });
-    });
-
-    it('should handle undefined initial state gracefully', () => {
-      const { result } = renderHook(() =>
-        useFlyoutManagerReducer(undefined as any)
-      );
-
-      expect(result.current.state).toEqual({
-        sessions: [],
-        flyouts: [],
-        layoutMode: 'side-by-side',
-      });
-    });
+    expect(firstId).toBe(secondId);
+    expect(firstId).toBe(customId);
   });
 });

--- a/packages/eui/src/components/flyout/manager/hooks.ts
+++ b/packages/eui/src/components/flyout/manager/hooks.ts
@@ -6,26 +6,11 @@
  * Side Public License, v 1.
  */
 
-import { useCallback, useContext, useReducer, useRef } from 'react';
+import { useContext, useRef } from 'react';
 
 import { warnOnce, useGeneratedHtmlId } from '../../../services';
 
-import { flyoutManagerReducer, initialState } from './reducer';
-import {
-  addFlyout as addFlyoutAction,
-  closeFlyout as closeFlyoutAction,
-  setActiveFlyout as setActiveFlyoutAction,
-  setFlyoutWidth as setFlyoutWidthAction,
-  goBack as goBackAction,
-  goToFlyout as goToFlyoutAction,
-} from './actions';
-import {
-  type EuiFlyoutLevel,
-  type EuiFlyoutManagerState,
-  type FlyoutManagerApi,
-} from './types';
 import { EuiFlyoutManagerContext } from './provider';
-import { LEVEL_MAIN } from './const';
 import { useIsFlyoutRegistered } from './selectors';
 
 // Ensure uniqueness across multiple hook instances, including in test envs
@@ -48,67 +33,6 @@ export { useIsInManagedFlyout } from './context';
 
 // Convenience selector for a flyout's activity stage
 export type { EuiFlyoutActivityStage } from './types';
-
-/**
- * Hook that provides the flyout manager reducer and bound action creators.
- * Accepts an optional initial state (mainly for tests or custom setups).
- */
-export function useFlyoutManagerReducer(
-  initial: EuiFlyoutManagerState = initialState
-): FlyoutManagerApi {
-  const [state, dispatch] = useReducer(flyoutManagerReducer, initial);
-
-  const addFlyout = useCallback(
-    (
-      flyoutId: string,
-      title: string,
-      level: EuiFlyoutLevel = LEVEL_MAIN,
-      size?: string
-    ) => dispatch(addFlyoutAction(flyoutId, title, level, size)),
-    []
-  );
-  const closeFlyout = useCallback(
-    (flyoutId: string) => dispatch(closeFlyoutAction(flyoutId)),
-    []
-  );
-  const setActiveFlyout = useCallback(
-    (flyoutId: string | null) => dispatch(setActiveFlyoutAction(flyoutId)),
-    []
-  );
-  const setFlyoutWidth = useCallback(
-    (flyoutId: string, width: number) =>
-      dispatch(setFlyoutWidthAction(flyoutId, width)),
-    []
-  );
-  const goBack = useCallback(() => dispatch(goBackAction()), []);
-  const goToFlyout = useCallback(
-    (flyoutId: string) => dispatch(goToFlyoutAction(flyoutId)),
-    []
-  );
-  const getHistoryItems = useCallback(() => {
-    const currentSessionIndex = state.sessions.length - 1;
-    const previousSessions = state.sessions.slice(0, currentSessionIndex);
-
-    return previousSessions
-      .reverse()
-      .map(({ title, mainFlyoutId: mainFlyoutId }) => ({
-        title: title,
-        onClick: () => goToFlyout(mainFlyoutId),
-      }));
-  }, [state.sessions, goToFlyout]);
-
-  return {
-    state,
-    dispatch,
-    addFlyout,
-    closeFlyout,
-    setActiveFlyout,
-    setFlyoutWidth,
-    goBack,
-    goToFlyout,
-    getHistoryItems,
-  };
-}
 
 /** Access the flyout manager context (state and actions). */
 export const useFlyoutManager = () => useContext(EuiFlyoutManagerContext);

--- a/packages/eui/src/components/flyout/manager/provider.tsx
+++ b/packages/eui/src/components/flyout/manager/provider.tsx
@@ -6,10 +6,11 @@
  * Side Public License, v 1.
  */
 
-import React, { createContext, useContext } from 'react';
-import { useFlyoutManagerReducer } from './hooks';
+import React, { createContext, useContext, useMemo } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { useApplyFlyoutLayoutMode } from './layout_mode';
 import { FlyoutManagerApi } from './types';
+import { getFlyoutManagerStore } from './store';
 
 /**
  * React context that exposes the Flyout Manager API (state + actions).
@@ -24,7 +25,26 @@ export const EuiFlyoutManagerContext = createContext<FlyoutManagerApi | null>(
 export const EuiFlyoutManager: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const api = useFlyoutManagerReducer();
+  const { getState, subscribe, goToFlyout, ...rest } = getFlyoutManagerStore();
+
+  const state = useSyncExternalStore(subscribe, getState);
+
+  const api: FlyoutManagerApi = useMemo(
+    () => ({
+      state,
+      ...rest,
+      goToFlyout,
+      getHistoryItems: () => {
+        const currentSessionIndex = state.sessions.length - 1;
+        const previousSessions = state.sessions.slice(0, currentSessionIndex);
+        return previousSessions.reverse().map(({ title, mainFlyoutId }) => ({
+          title,
+          onClick: () => goToFlyout(mainFlyoutId),
+        }));
+      },
+    }),
+    [state, goToFlyout, rest]
+  );
   return (
     <EuiFlyoutManagerContext.Provider value={api}>
       <EuiFlyoutManagerContainer>{children}</EuiFlyoutManagerContainer>

--- a/packages/eui/src/components/flyout/manager/provider.tsx
+++ b/packages/eui/src/components/flyout/manager/provider.tsx
@@ -27,13 +27,12 @@ export const EuiFlyoutManager: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const { getState, subscribe, ...rest } = getFlyoutManagerStore();
   const state = useSyncExternalStore(subscribe, getState);
-  const api: FlyoutManagerApi = useMemo(() => {
-    const result = {
-      state,
-      ...rest,
-    };
-    return result;
-  }, [state, rest]);
+
+  const api: FlyoutManagerApi = useMemo(
+    () => ({ state, ...rest }),
+    [state, rest]
+  );
+
   return (
     <EuiFlyoutManagerContext.Provider value={api}>
       <EuiFlyoutManagerContainer>{children}</EuiFlyoutManagerContainer>

--- a/packages/eui/src/components/flyout/manager/provider.tsx
+++ b/packages/eui/src/components/flyout/manager/provider.tsx
@@ -25,26 +25,15 @@ export const EuiFlyoutManagerContext = createContext<FlyoutManagerApi | null>(
 export const EuiFlyoutManager: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const { getState, subscribe, goToFlyout, ...rest } = getFlyoutManagerStore();
-
+  const { getState, subscribe, ...rest } = getFlyoutManagerStore();
   const state = useSyncExternalStore(subscribe, getState);
-
-  const api: FlyoutManagerApi = useMemo(
-    () => ({
+  const api: FlyoutManagerApi = useMemo(() => {
+    const result = {
       state,
       ...rest,
-      goToFlyout,
-      getHistoryItems: () => {
-        const currentSessionIndex = state.sessions.length - 1;
-        const previousSessions = state.sessions.slice(0, currentSessionIndex);
-        return previousSessions.reverse().map(({ title, mainFlyoutId }) => ({
-          title,
-          onClick: () => goToFlyout(mainFlyoutId),
-        }));
-      },
-    }),
-    [state, goToFlyout, rest]
-  );
+    };
+    return result;
+  }, [state, rest]);
   return (
     <EuiFlyoutManagerContext.Provider value={api}>
       <EuiFlyoutManagerContainer>{children}</EuiFlyoutManagerContainer>

--- a/packages/eui/src/components/flyout/manager/reducer.ts
+++ b/packages/eui/src/components/flyout/manager/reducer.ts
@@ -15,6 +15,7 @@ import {
   ACTION_SET_ACTIVITY_STAGE,
   ACTION_GO_BACK,
   ACTION_GO_TO_FLYOUT,
+  ACTION_UPDATE_TITLE,
   Action,
 } from './actions';
 import { LAYOUT_MODE_SIDE_BY_SIDE, LEVEL_MAIN, STAGE_OPENING } from './const';
@@ -255,6 +256,29 @@ export function flyoutManagerReducer(
       const newSessions = state.sessions.slice(0, targetSessionIndex + 1);
 
       return { ...state, sessions: newSessions, flyouts: newFlyouts };
+    }
+
+    // Update a flyout's title in the current session
+    case ACTION_UPDATE_TITLE: {
+      const { flyoutId, title } = action;
+
+      // Find the session containing this flyout
+      const sessionIndex = state.sessions.findIndex(
+        (session) => session.mainFlyoutId === flyoutId
+      );
+
+      if (sessionIndex === -1) {
+        return state; // Flyout not found in any session
+      }
+
+      // Update the session title
+      const updatedSessions = [...state.sessions];
+      updatedSessions[sessionIndex] = {
+        ...updatedSessions[sessionIndex],
+        title,
+      };
+
+      return { ...state, sessions: updatedSessions };
     }
 
     default:

--- a/packages/eui/src/components/flyout/manager/selectors.test.tsx
+++ b/packages/eui/src/components/flyout/manager/selectors.test.tsx
@@ -9,26 +9,13 @@
 import React from 'react';
 import { renderHook } from '../../../test/rtl';
 import {
-  useSession,
-  useHasActiveSession,
-  useIsFlyoutActive,
-  useFlyout,
-  useCurrentSession,
-  useCurrentMainFlyout,
-  useCurrentChildFlyout,
   useFlyoutWidth,
   useParentFlyoutSize,
   useHasChildFlyout,
 } from './selectors';
-import { EuiFlyoutManager, useFlyoutManager } from './provider';
-import { useFlyoutManagerReducer } from './hooks';
+import { useFlyoutManager } from './provider';
 
 import { LEVEL_MAIN, LEVEL_CHILD } from './const';
-
-// Mock the hooks module to avoid circular dependencies
-jest.mock('./hooks', () => ({
-  useFlyoutManagerReducer: jest.fn(),
-}));
 
 // Mock the provider context
 jest.mock('./provider', () => ({
@@ -36,520 +23,164 @@ jest.mock('./provider', () => ({
   useFlyoutManager: jest.fn(),
 }));
 
-// Test wrapper component
-const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  return <EuiFlyoutManager>{children}</EuiFlyoutManager>;
-};
+const mockUseFlyoutManager = useFlyoutManager as jest.MockedFunction<
+  typeof useFlyoutManager
+>;
 
-// Mock data
-const mockState = {
-  sessions: [
-    { mainFlyoutId: 'main-1', childFlyoutId: 'child-1' },
-    { mainFlyoutId: 'main-2', childFlyoutId: null },
-  ],
-  flyouts: [
-    { flyoutId: 'main-1', level: LEVEL_MAIN, size: 'l', width: 600 },
-    { flyoutId: 'child-1', level: LEVEL_CHILD, size: 'm', width: 400 },
-    { flyoutId: 'main-2', level: LEVEL_MAIN, size: 's', width: 300 },
-  ],
-  layoutMode: 'side-by-side' as const,
-};
-
-const mockApi = {
-  state: mockState,
-  dispatch: jest.fn(),
-  addFlyout: jest.fn(),
-  closeFlyout: jest.fn(),
-  setActiveFlyout: jest.fn(),
-  setFlyoutWidth: jest.fn(),
-};
-
-describe('flyout manager selectors', () => {
+describe('Flyout Manager Selectors', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    const mockUseFlyoutManagerReducer = useFlyoutManagerReducer as jest.Mock;
-    const mockUseFlyoutManager = useFlyoutManager as jest.Mock;
-    mockUseFlyoutManagerReducer.mockReturnValue(mockApi);
-    mockUseFlyoutManager.mockReturnValue(mockApi);
-  });
-
-  describe('useSession', () => {
-    it('should return session when flyout ID matches main', () => {
-      const { result } = renderHook(() => useSession('main-1'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        mainFlyoutId: 'main-1',
-        childFlyoutId: 'child-1',
-      });
-    });
-
-    it('should return session when flyout ID matches child', () => {
-      const { result } = renderHook(() => useSession('child-1'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        mainFlyoutId: 'main-1',
-        childFlyoutId: 'child-1',
-      });
-    });
-
-    it('should return null when flyout ID does not match any session', () => {
-      const { result } = renderHook(() => useSession('non-existent'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-
-    it('should return null when no flyout ID is provided', () => {
-      const { result } = renderHook(() => useSession(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-
-    it('should return null when flyout ID is null', () => {
-      const { result } = renderHook(() => useSession(null), {
-        wrapper: TestWrapper,
-      });
-
-      // The selector treats null as a literal value to search for
-      // It finds the session where childFlyoutId: null matches flyoutId: null
-      expect(result.current).toEqual({
-        mainFlyoutId: 'main-2',
-        childFlyoutId: null,
-      });
-    });
-  });
-
-  describe('useHasActiveSession', () => {
-    it('should return true when there are active sessions', () => {
-      const { result } = renderHook(() => useHasActiveSession(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBe(true);
-    });
-
-    it('should return false when there are no sessions', () => {
-      const emptyState = { ...mockState, sessions: [] };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-
-      const { result } = renderHook(() => useHasActiveSession(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBe(false);
-    });
-  });
-
-  describe('useIsFlyoutActive', () => {
-    it('should return true when flyout is main in current session', () => {
-      const { result } = renderHook(() => useIsFlyoutActive('main-2'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBe(true);
-    });
-
-    it('should return true when flyout is child in current session', () => {
-      const { result } = renderHook(() => useIsFlyoutActive('child-1'), {
-        wrapper: TestWrapper,
-      });
-
-      // child-1 is not in the current session (main-2 with no child)
-      // It's in the previous session (main-1 with child-1)
-      expect(result.current).toBe(false);
-    });
-
-    it('should return false when flyout is not in current session', () => {
-      const { result } = renderHook(() => useIsFlyoutActive('non-existent'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBe(false);
-    });
-
-    it('should return false when flyout is in previous session', () => {
-      const { result } = renderHook(() => useIsFlyoutActive('main-1'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBe(false);
-    });
-  });
-
-  describe('useFlyout', () => {
-    it('should return flyout when ID exists', () => {
-      const { result } = renderHook(() => useFlyout('main-1'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        flyoutId: 'main-1',
-        level: LEVEL_MAIN,
-        size: 'l',
-        width: 600,
-      });
-    });
-
-    it('should return null when flyout ID does not exist', () => {
-      const { result } = renderHook(() => useFlyout('non-existent'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-
-    it('should return null when no flyout ID is provided', () => {
-      const { result } = renderHook(() => useFlyout(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-
-    it('should return null when flyout ID is null', () => {
-      const { result } = renderHook(() => useFlyout(null), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-  });
-
-  describe('useCurrentSession', () => {
-    it('should return the most recent session', () => {
-      const { result } = renderHook(() => useCurrentSession(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        mainFlyoutId: 'main-2',
-        childFlyoutId: null,
-      });
-    });
-
-    it('should return null when no sessions exist', () => {
-      const emptyState = { ...mockState, sessions: [] };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-
-      const { result } = renderHook(() => useCurrentSession(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-  });
-
-  describe('useCurrentMainFlyout', () => {
-    it('should return the main flyout of current session', () => {
-      const { result } = renderHook(() => useCurrentMainFlyout(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        flyoutId: 'main-2',
-        level: LEVEL_MAIN,
-        size: 's',
-        width: 300,
-      });
-    });
-
-    it('should return null when no current session exists', () => {
-      const emptyState = { ...mockState, sessions: [] };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-
-      const { result } = renderHook(() => useCurrentMainFlyout(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-  });
-
-  describe('useCurrentChildFlyout', () => {
-    it('should return the child flyout of current session', () => {
-      // Change current session to one with a child
-      const stateWithChildCurrent = {
-        ...mockState,
-        sessions: [
-          { mainFlyoutId: 'main-2', childFlyoutId: null },
-          { mainFlyoutId: 'main-1', childFlyoutId: 'child-1' }, // Make this the current session
-        ],
-      };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: stateWithChildCurrent,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: stateWithChildCurrent,
-      });
-
-      const { result } = renderHook(() => useCurrentChildFlyout(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        flyoutId: 'child-1',
-        level: LEVEL_CHILD,
-        size: 'm',
-        width: 400,
-      });
-    });
-
-    it('should return null when current session has no child', () => {
-      const { result } = renderHook(() => useCurrentChildFlyout(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
-
-    it('should return null when no current session exists', () => {
-      const emptyState = { ...mockState, sessions: [] };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-
-      const { result } = renderHook(() => useCurrentChildFlyout(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeNull();
-    });
+    mockUseFlyoutManager.mockClear();
   });
 
   describe('useFlyoutWidth', () => {
-    it('should return flyout width when it exists', () => {
-      const { result } = renderHook(() => useFlyoutWidth('main-1'), {
-        wrapper: TestWrapper,
+    it('should return undefined when flyout is not found', () => {
+      mockUseFlyoutManager.mockReturnValue({
+        state: {
+          sessions: [],
+          flyouts: [],
+          layoutMode: 'side-by-side',
+        },
+        dispatch: jest.fn(),
+        addFlyout: jest.fn(),
+        closeFlyout: jest.fn(),
+        setActiveFlyout: jest.fn(),
+        setFlyoutWidth: jest.fn(),
+        goBack: jest.fn(),
+        goToFlyout: jest.fn(),
+        historyItems: [],
       });
 
-      expect(result.current).toBe(600);
-    });
-
-    it('should return undefined when flyout has no width', () => {
-      const stateWithoutWidth = {
-        ...mockState,
-        flyouts: [{ flyoutId: 'main-1', level: LEVEL_MAIN, size: 'l' }],
-      };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: stateWithoutWidth,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: stateWithoutWidth,
-      });
-
-      const { result } = renderHook(() => useFlyoutWidth('main-1'), {
-        wrapper: TestWrapper,
-      });
+      const { result } = renderHook(() =>
+        useFlyoutWidth('non-existent-flyout')
+      );
 
       expect(result.current).toBeUndefined();
     });
 
-    it('should return undefined when flyout does not exist', () => {
-      const { result } = renderHook(() => useFlyoutWidth('non-existent'), {
-        wrapper: TestWrapper,
+    it('should return the width when flyout exists', () => {
+      mockUseFlyoutManager.mockReturnValue({
+        state: {
+          sessions: [],
+          flyouts: [
+            {
+              flyoutId: 'test-flyout',
+              level: LEVEL_MAIN,
+              size: 'm',
+              activityStage: 'active',
+              width: 500,
+            },
+          ],
+          layoutMode: 'side-by-side',
+        },
+        dispatch: jest.fn(),
+        addFlyout: jest.fn(),
+        closeFlyout: jest.fn(),
+        setActiveFlyout: jest.fn(),
+        setFlyoutWidth: jest.fn(),
+        goBack: jest.fn(),
+        goToFlyout: jest.fn(),
+        historyItems: [],
       });
 
-      expect(result.current).toBeUndefined();
-    });
+      const { result } = renderHook(() => useFlyoutWidth('test-flyout'));
 
-    it('should return undefined when no flyout ID is provided', () => {
-      const { result } = renderHook(() => useFlyoutWidth(), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeUndefined();
+      expect(result.current).toBe(500);
     });
   });
 
   describe('useParentFlyoutSize', () => {
-    it('should return parent flyout size for child flyout', () => {
-      const { result } = renderHook(() => useParentFlyoutSize('child-1'), {
-        wrapper: TestWrapper,
+    it('should return undefined when no parent flyout exists', () => {
+      mockUseFlyoutManager.mockReturnValue({
+        state: {
+          sessions: [],
+          flyouts: [],
+          layoutMode: 'side-by-side',
+        },
+        dispatch: jest.fn(),
+        addFlyout: jest.fn(),
+        closeFlyout: jest.fn(),
+        setActiveFlyout: jest.fn(),
+        setFlyoutWidth: jest.fn(),
+        goBack: jest.fn(),
+        goToFlyout: jest.fn(),
+        historyItems: [],
       });
 
-      expect(result.current).toBe('l');
-    });
-
-    it('should return undefined when child flyout has no parent', () => {
-      const { result } = renderHook(() => useParentFlyoutSize('non-existent'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toBeUndefined();
-    });
-
-    it('should return undefined when parent flyout has no size', () => {
-      const stateWithoutSize = {
-        ...mockState,
-        flyouts: [
-          { flyoutId: 'main-1', level: LEVEL_MAIN },
-          { flyoutId: 'child-1', level: LEVEL_CHILD },
-        ],
-      };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: stateWithoutSize,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: stateWithoutSize,
-      });
-
-      const { result } = renderHook(() => useParentFlyoutSize('child-1'), {
-        wrapper: TestWrapper,
-      });
+      const { result } = renderHook(() => useParentFlyoutSize('child-flyout'));
 
       expect(result.current).toBeUndefined();
     });
   });
 
   describe('useHasChildFlyout', () => {
-    it('should return true when main flyout has a child', () => {
-      const { result } = renderHook(() => useHasChildFlyout('main-1'), {
-        wrapper: TestWrapper,
+    it('should return false when no child flyout exists', () => {
+      mockUseFlyoutManager.mockReturnValue({
+        state: {
+          sessions: [],
+          flyouts: [
+            {
+              flyoutId: 'parent-flyout',
+              level: LEVEL_MAIN,
+              size: 'm',
+              activityStage: 'active',
+            },
+          ],
+          layoutMode: 'side-by-side',
+        },
+        dispatch: jest.fn(),
+        addFlyout: jest.fn(),
+        closeFlyout: jest.fn(),
+        setActiveFlyout: jest.fn(),
+        setFlyoutWidth: jest.fn(),
+        goBack: jest.fn(),
+        goToFlyout: jest.fn(),
+        historyItems: [],
       });
 
-      expect(result.current).toBe(true);
-    });
-
-    it('should return false when main flyout has no child', () => {
-      const { result } = renderHook(() => useHasChildFlyout('main-2'), {
-        wrapper: TestWrapper,
-      });
+      const { result } = renderHook(() => useHasChildFlyout('parent-flyout'));
 
       expect(result.current).toBe(false);
     });
 
-    it('should return false when flyout ID does not exist', () => {
-      const { result } = renderHook(() => useHasChildFlyout('non-existent'), {
-        wrapper: TestWrapper,
+    it('should return true when child flyout exists', () => {
+      mockUseFlyoutManager.mockReturnValue({
+        state: {
+          sessions: [
+            {
+              mainFlyoutId: 'parent-flyout',
+              childFlyoutId: 'child-flyout',
+              title: 'Parent Flyout',
+            },
+          ],
+          flyouts: [
+            {
+              flyoutId: 'parent-flyout',
+              level: LEVEL_MAIN,
+              size: 'm',
+              activityStage: 'active',
+            },
+            {
+              flyoutId: 'child-flyout',
+              level: LEVEL_CHILD,
+              size: 'm',
+              activityStage: 'active',
+            },
+          ],
+          layoutMode: 'side-by-side',
+        },
+        dispatch: jest.fn(),
+        addFlyout: jest.fn(),
+        closeFlyout: jest.fn(),
+        setActiveFlyout: jest.fn(),
+        setFlyoutWidth: jest.fn(),
+        goBack: jest.fn(),
+        goToFlyout: jest.fn(),
+        historyItems: [],
       });
 
-      expect(result.current).toBe(false);
-    });
+      const { result } = renderHook(() => useHasChildFlyout('parent-flyout'));
 
-    it('should return false when flyout is not a main flyout', () => {
-      const { result } = renderHook(() => useHasChildFlyout('child-1'), {
-        wrapper: TestWrapper,
-      });
-
-      // The selector checks if the flyout ID has a session with a child
-      // Since child-1 is in a session with childFlyoutId: 'child-1', it returns true
       expect(result.current).toBe(true);
-    });
-  });
-
-  describe('edge cases and error handling', () => {
-    it('should handle empty flyouts array', () => {
-      const emptyState = { ...mockState, flyouts: [] };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: emptyState,
-      });
-
-      const { result: flyoutResult } = renderHook(() => useFlyout('main-1'), {
-        wrapper: TestWrapper,
-      });
-      const { result: widthResult } = renderHook(
-        () => useFlyoutWidth('main-1'),
-        {
-          wrapper: TestWrapper,
-        }
-      );
-
-      expect(flyoutResult.current).toBeNull();
-      expect(widthResult.current).toBeUndefined();
-    });
-
-    it('should handle malformed flyout data gracefully', () => {
-      const malformedState = {
-        ...mockState,
-        flyouts: [
-          { flyoutId: 'main-1' }, // Missing required properties
-        ],
-      };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: malformedState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: malformedState,
-      });
-
-      const { result } = renderHook(() => useFlyout('main-1'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({ flyoutId: 'main-1' });
-    });
-
-    it('should handle sessions with missing flyout references', () => {
-      const invalidState = {
-        ...mockState,
-        sessions: [
-          { mainFlyoutId: 'main-1', childFlyoutId: 'non-existent-child' },
-        ],
-        flyouts: [{ flyoutId: 'main-1', level: LEVEL_MAIN }],
-      };
-      (useFlyoutManagerReducer as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: invalidState,
-      });
-      (useFlyoutManager as jest.Mock).mockReturnValue({
-        ...mockApi,
-        state: invalidState,
-      });
-
-      const { result } = renderHook(() => useSession('non-existent-child'), {
-        wrapper: TestWrapper,
-      });
-
-      expect(result.current).toEqual({
-        mainFlyoutId: 'main-1',
-        childFlyoutId: 'non-existent-child',
-      });
     });
   });
 });

--- a/packages/eui/src/components/flyout/manager/store.ts
+++ b/packages/eui/src/components/flyout/manager/store.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { EuiFlyoutLevel, EuiFlyoutManagerState } from './types';
+import type { Action } from './actions';
+import {
+  addFlyout as addFlyoutAction,
+  closeFlyout as closeFlyoutAction,
+  setActiveFlyout as setActiveFlyoutAction,
+  setFlyoutWidth as setFlyoutWidthAction,
+  goBack as goBackAction,
+  goToFlyout as goToFlyoutAction,
+} from './actions';
+import { flyoutManagerReducer, initialState } from './reducer';
+
+type Listener = () => void;
+
+export interface FlyoutManagerStore {
+  getState: () => EuiFlyoutManagerState;
+  subscribe: (listener: Listener) => () => void;
+  dispatch: (action: Action) => void;
+  // Convenience bound action creators
+  addFlyout: (
+    flyoutId: string,
+    title: string,
+    level?: EuiFlyoutLevel,
+    size?: string
+  ) => void;
+  closeFlyout: (flyoutId: string) => void;
+  setActiveFlyout: (flyoutId: string | null) => void;
+  setFlyoutWidth: (flyoutId: string, width: number) => void;
+  goBack: () => void;
+  goToFlyout: (flyoutId: string) => void;
+}
+
+function createStore(
+  initial: EuiFlyoutManagerState = initialState
+): FlyoutManagerStore {
+  let currentState: EuiFlyoutManagerState = initial;
+  const listeners = new Set<Listener>();
+
+  const getState = () => currentState;
+
+  const subscribe = (listener: Listener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const dispatch = (action: Action) => {
+    const nextState = flyoutManagerReducer(currentState, action);
+    if (nextState !== currentState) {
+      currentState = nextState;
+      listeners.forEach((l) => l());
+    }
+  };
+
+  return {
+    getState,
+    subscribe,
+    dispatch,
+    addFlyout: (flyoutId, title, level, size) =>
+      dispatch(addFlyoutAction(flyoutId, title, level, size)),
+    closeFlyout: (flyoutId) => dispatch(closeFlyoutAction(flyoutId)),
+    setActiveFlyout: (flyoutId) => dispatch(setActiveFlyoutAction(flyoutId)),
+    setFlyoutWidth: (flyoutId, width) =>
+      dispatch(setFlyoutWidthAction(flyoutId, width)),
+    goBack: () => dispatch(goBackAction()),
+    goToFlyout: (flyoutId) => dispatch(goToFlyoutAction(flyoutId)),
+  };
+}
+
+// Module-level singleton.  A necessary trade-off to avoid global namespace pollution or the need for a third-party library.
+let storeInstance: FlyoutManagerStore | null = null;
+
+/**
+ * Returns a singleton store instance shared across all React roots within the same JS context.
+ * Uses module-level singleton to ensure deduplication even if modules are loaded twice.
+ */
+export function getFlyoutManagerStore(): FlyoutManagerStore {
+  if (!storeInstance) {
+    storeInstance = createStore();
+  }
+  return storeInstance;
+}
+
+/**
+ * For testing purposes - allows resetting the store
+ */
+export function _resetFlyoutManagerStore(): void {
+  storeInstance = null;
+}

--- a/packages/eui/src/components/flyout/manager/store.ts
+++ b/packages/eui/src/components/flyout/manager/store.ts
@@ -58,15 +58,7 @@ function createStore(
   const subscribe = (listener: Listener) => {
     listeners.add(listener);
     return () => {
-      // Use React's scheduler to defer cleanup until after current render
-      if (typeof requestIdleCallback !== 'undefined') {
-        requestIdleCallback(() => listeners.delete(listener));
-      } else if (typeof requestAnimationFrame !== 'undefined') {
-        requestAnimationFrame(() => listeners.delete(listener));
-      } else {
-        // Fallback to setTimeout for older environments
-        setTimeout(() => listeners.delete(listener), 0);
-      }
+      listeners.delete(listener);
     };
   };
 

--- a/packages/eui/src/components/flyout/manager/store.ts
+++ b/packages/eui/src/components/flyout/manager/store.ts
@@ -15,6 +15,7 @@ import {
   setFlyoutWidth as setFlyoutWidthAction,
   goBack as goBackAction,
   goToFlyout as goToFlyoutAction,
+  updateFlyoutTitle as updateFlyoutTitleAction,
 } from './actions';
 import { flyoutManagerReducer, initialState } from './reducer';
 
@@ -36,6 +37,7 @@ export interface FlyoutManagerStore {
   setFlyoutWidth: (flyoutId: string, width: number) => void;
   goBack: () => void;
   goToFlyout: (flyoutId: string) => void;
+  updateFlyoutTitle: (flyoutId: string, title: string) => void;
   historyItems: Array<{
     title: string;
     onClick: () => void;
@@ -114,6 +116,8 @@ function createStore(
       dispatch(setFlyoutWidthAction(flyoutId, width)),
     goBack: () => dispatch(goBackAction()),
     goToFlyout: (flyoutId) => dispatch(goToFlyoutAction(flyoutId)),
+    updateFlyoutTitle: (flyoutId, title) =>
+      dispatch(updateFlyoutTitleAction(flyoutId, title)),
 
     // Getter ensures fresh data on each access while maintaining React reactivity
     get historyItems() {

--- a/packages/eui/src/components/flyout/manager/types.ts
+++ b/packages/eui/src/components/flyout/manager/types.ts
@@ -80,6 +80,7 @@ export interface FlyoutManagerApi {
   setFlyoutWidth: (flyoutId: string, width: number) => void;
   goBack: () => void;
   goToFlyout: (flyoutId: string) => void;
+  updateFlyoutTitle: (flyoutId: string, title: string) => void;
   historyItems: Array<{
     title: string;
     onClick: () => void;

--- a/packages/eui/src/components/flyout/manager/types.ts
+++ b/packages/eui/src/components/flyout/manager/types.ts
@@ -80,7 +80,7 @@ export interface FlyoutManagerApi {
   setFlyoutWidth: (flyoutId: string, width: number) => void;
   goBack: () => void;
   goToFlyout: (flyoutId: string) => void;
-  getHistoryItems: () => Array<{
+  historyItems: Array<{
     title: string;
     onClick: () => void;
   }>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7493,6 +7493,7 @@ __metadata:
     unified: "npm:^9.2.2"
     unist-util-visit: "npm:^2.0.3"
     url-parse: "npm:^1.5.10"
+    use-sync-external-store: "npm:^1.6.0"
     uuid: "npm:^8.3.0"
     vfile: "npm:^4.2.1"
     webpack: "npm:^5.74.0"
@@ -40851,6 +40852,15 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10c0/ac4814e5592524f242921157e791b022efe36e451fe0d4fd4d204322d5433a4fc300d63b0ade5185f8e0735ded044c70bcf6d2352db0f74d097a238cebd2da02
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/35e1179f872a53227bdf8a827f7911da4c37c0f4091c29b76b1e32473d1670ebe7bcd880b808b7549ba9a5605c233350f800ffab963ee4a4ee346ee983b6019b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
