### PR TITLE
[Flyout System] Improve validation and error logging

### DIFF
--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -33,7 +33,7 @@ import {
   useIsFlyoutActive,
   useParentFlyoutSize,
 } from './hooks';
-import { useIsFlyoutRegistered } from './selectors';
+import { useCurrentMainFlyout, useIsFlyoutRegistered } from './selectors';
 import type { EuiFlyoutLevel } from './types';
 import {
   createValidationErrorMessage,
@@ -86,6 +86,7 @@ export const EuiManagedFlyout = ({
   const { addFlyout, closeFlyout, setFlyoutWidth, goBack, getHistoryItems } =
     useFlyoutManager();
   const parentSize = useParentFlyoutSize(flyoutId);
+  const parentFlyout = useCurrentMainFlyout();
   const layoutMode = useFlyoutLayoutMode();
   const styles = useEuiMemoizedStyles(euiManagedFlyoutStyles);
 
@@ -105,6 +106,7 @@ export const EuiManagedFlyout = ({
     const combinationError = validateSizeCombination(parentSize, size);
     if (combinationError) {
       combinationError.flyoutId = flyoutId;
+      combinationError.parentFlyoutId = parentFlyout?.flyoutId;
       combinationError.level = level;
       throw new Error(createValidationErrorMessage(combinationError));
     }

--- a/packages/eui/src/components/flyout/manager/validation.ts
+++ b/packages/eui/src/components/flyout/manager/validation.ts
@@ -9,7 +9,7 @@
 import { EuiFlyoutSize, FLYOUT_SIZES } from '../const';
 import { EuiFlyoutComponentProps } from '../flyout.component';
 import { EuiFlyoutMenuProps } from '../flyout_menu';
-import { LEVEL_CHILD, LEVEL_MAIN } from './const';
+import { LEVEL_MAIN } from './const';
 import { EuiFlyoutLevel } from './types';
 
 type FlyoutValidationErrorType =
@@ -21,8 +21,10 @@ export interface FlyoutValidationError {
   type: FlyoutValidationErrorType;
   message: string;
   flyoutId?: string;
+  parentFlyoutId?: string;
   level?: EuiFlyoutLevel;
-  size?: string; // Allow any string for error reporting
+  size?: string | number;
+  parentSize?: string | number;
 }
 
 /**
@@ -47,7 +49,7 @@ export function validateManagedFlyoutSize(
       message: `Managed flyouts must use named sizes (${namedSizes}). Received: ${size}`,
       flyoutId,
       level,
-      size: `${size}`,
+      size,
     };
   }
   return null;
@@ -84,7 +86,6 @@ export function validateSizeCombination(
     return {
       type: 'INVALID_SIZE_COMBINATION',
       message: 'Parent and child flyouts cannot both be size "m"',
-      size: childSize,
     };
   }
 
@@ -93,7 +94,6 @@ export function validateSizeCombination(
     return {
       type: 'INVALID_SIZE_COMBINATION',
       message: 'Parent and child flyouts cannot both be size "fill"',
-      size: childSize,
     };
   }
 
@@ -102,36 +102,7 @@ export function validateSizeCombination(
     return {
       type: 'INVALID_SIZE_COMBINATION',
       message: 'Parent flyouts cannot be size "l" when there is a child flyout',
-      size: parentSize,
     };
-  }
-
-  return null;
-}
-
-/**
- * Comprehensive validation for flyout size rules
- */
-export function validateFlyoutSize(
-  size: EuiFlyoutComponentProps['size'],
-  flyoutId: string,
-  level: EuiFlyoutLevel,
-  parentSize?: EuiFlyoutSize
-): FlyoutValidationError | null {
-  // First validate that managed flyouts use named sizes
-  const sizeTypeError = validateManagedFlyoutSize(size, flyoutId, level);
-  if (sizeTypeError) {
-    return sizeTypeError;
-  }
-
-  // If this is a child flyout and we have parent size, validate combination
-  if (level === LEVEL_CHILD && parentSize && isNamedSize(size)) {
-    const combinationError = validateSizeCombination(parentSize, size);
-    if (combinationError) {
-      combinationError.flyoutId = flyoutId;
-      combinationError.level = level;
-      return combinationError;
-    }
   }
 
   return null;
@@ -143,16 +114,15 @@ export function validateFlyoutSize(
 export function createValidationErrorMessage(
   error: FlyoutValidationError
 ): string {
-  const prefix = `EuiFlyout validation error: `;
+  console.error(error);
+  const prefix = `EuiFlyout validation error`;
 
   switch (error.type) {
     case 'INVALID_SIZE_TYPE':
-      return `${prefix}${error.message}`;
     case 'INVALID_SIZE_COMBINATION':
-      return `${prefix}${error.message}`;
     case 'INVALID_FLYOUT_MENU_TITLE':
-      return `${prefix}${error.message}`;
+      return `${prefix}: ${error.message}`;
     default:
-      return `${prefix}Unknown validation error`;
+      return `${prefix}: Unknown validation error`;
   }
 }


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

## Why are we making this change?

This allows developers using the Flyout System to better understand why validation errors occur, and to be able to correlate the message to their code. 

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

No impact to end users. Use cases that would throw validation errors should be fixed before the code is released.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
