### PR TITLE
[Flyout System] improve size validation flexibility and bidirectionality

### DIFF
--- a/packages/eui/src/components/flyout/README.md
+++ b/packages/eui/src/components/flyout/README.md
@@ -54,8 +54,8 @@ The managed flyout wrapper that integrates with the flyout manager system, handl
 
 ### `src/components/flyout/manager/flyout_validation.ts`
 Validation utilities for managed flyout props:
-- **Named Size Validation**: Managed flyouts must use named sizes (s, m, l). If not provided, defaults to 'm'.
-- **Size Combination Rules**: Parent and child can't both be 'm', parent can't be 'l' with child
+- **Named Size Validation**: Child flyouts must use named sizes (s, m, l, fill). Main flyouts can use named sizes or custom values (e.g., '400px'). If size is not provided, main flyouts default to 'm' and child flyouts default to 's'.
+- **Size Combination Rules**: Parent and child can't both be 'm', parent and child can't both be 'fill', and 'l' can only be used if the other flyout is 'fill'
 - **Title**: Must be provided either through `flyoutMenuProps` or `aria-label`
 - **Error Handling**: Comprehensive error messages for invalid configurations
 

--- a/packages/eui/src/components/flyout/manager/flyout_managed.test.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.test.tsx
@@ -282,7 +282,7 @@ describe('EuiManagedFlyout', () => {
   });
 
   describe('size handling', () => {
-    it('defaults size to "m" when no size is provided', () => {
+    it('defaults main flyout size to "m" when no size is provided', () => {
       // Import the real validation function to test the actual behavior
       const { validateManagedFlyoutSize } = jest.requireActual('./validation');
 
@@ -297,6 +297,31 @@ describe('EuiManagedFlyout', () => {
           level={LEVEL_MAIN}
           onClose={() => {}}
           flyoutMenuProps={{ title: 'Test Flyout' }}
+          // Explicitly not providing size prop
+        />
+      );
+
+      // The flyout should render successfully, indicating the default size worked
+      expect(getByTestSubject('managed-flyout')).toBeInTheDocument();
+
+      // Restore the mock
+      require('./validation').validateManagedFlyoutSize = originalMock;
+    });
+
+    it('defaults child flyout size to "s" when no size is provided', () => {
+      // Import the real validation function to test the actual behavior
+      const { validateManagedFlyoutSize } = jest.requireActual('./validation');
+
+      // Temporarily restore the real validation function for this test
+      const originalMock = require('./validation').validateManagedFlyoutSize;
+      require('./validation').validateManagedFlyoutSize =
+        validateManagedFlyoutSize;
+
+      const { getByTestSubject } = renderInProvider(
+        <EuiManagedFlyout
+          id="default-child-size-test"
+          level={LEVEL_CHILD}
+          onClose={() => {}}
           // Explicitly not providing size prop
         />
       );

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -74,7 +74,7 @@ export const EuiManagedFlyout = ({
   onClose: onCloseProp,
   onActive: onActiveProp,
   level,
-  size = 'm',
+  size: sizeProp,
   css: customCss,
   flyoutMenuProps: _flyoutMenuProps,
   ...props
@@ -88,6 +88,9 @@ export const EuiManagedFlyout = ({
   const parentFlyout = useCurrentMainFlyout();
   const layoutMode = useFlyoutLayoutMode();
   const styles = useEuiMemoizedStyles(euiManagedFlyoutStyles);
+
+  // Set default size based on level: main defaults to 'm', child defaults to 's'
+  const size = sizeProp ?? (level === LEVEL_CHILD ? 's' : 'm');
 
   // Validate size
   const sizeTypeError = validateManagedFlyoutSize(size, flyoutId, level);

--- a/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_manager.stories.tsx
@@ -68,10 +68,10 @@ const meta: Meta<FlyoutChildStoryArgs> = {
   component: EuiFlyoutChild,
   argTypes: {
     childSize: {
-      options: ['s', 'm', 'fill'],
+      options: ['s', 'm', 'l', 'fill'],
       control: { type: 'radio' },
       description:
-        'The size of the child flyout. If the main is `s`, the child can be `s`, or `m`. If the main is `m`, the child can only be `s`.',
+        'The size of the child flyout. Valid combinations: both cannot be "m", both cannot be "fill", and "l" can only be used if the other flyout is "fill".',
     },
     childBackgroundStyle: {
       options: ['default', 'shaded'],
@@ -83,10 +83,10 @@ const meta: Meta<FlyoutChildStoryArgs> = {
       description: 'The maximum width of the child flyout.',
     },
     mainSize: {
-      options: ['s', 'm', 'fill'],
+      options: ['s', 'm', 'l', 'fill', '400px'],
       control: { type: 'radio' },
       description:
-        'The size of the main (parent) flyout. If `m`, the child must be `s`. If `s`, the child can be `s`, or `m`.',
+        'The size of the main (parent) flyout. Can use named sizes (s, m, l, fill) or custom values like "400px". Valid combinations: both cannot be "m", both cannot be "fill", and "l" can only be used if the other flyout is "fill".',
     },
     mainFlyoutType: {
       options: FLYOUT_TYPES,
@@ -269,8 +269,12 @@ const StatefulFlyout: React.FC<FlyoutChildStoryArgs> = ({
                     <p>This is the child flyout content.</p>
                     <p>Size restrictions apply:</p>
                     <ul>
-                      <li>When main panel is 's', child can be 's', or 'm'</li>
-                      <li>When main panel is 'm', child is limited to 's'</li>
+                      <li>Both flyouts cannot be size &quot;m&quot;</li>
+                      <li>Both flyouts cannot be size &quot;fill&quot;</li>
+                      <li>
+                        Size &quot;l&quot; can only be used if the other flyout
+                        is &quot;fill&quot;
+                      </li>
                     </ul>
                     <EuiSpacer />
                     <p>

--- a/packages/eui/src/components/flyout/manager/layout_mode.ts
+++ b/packages/eui/src/components/flyout/manager/layout_mode.ts
@@ -126,7 +126,7 @@ export const useApplyFlyoutLayoutMode = () => {
     let newLayoutMode: EuiFlyoutLayoutMode;
 
     // Handle fill size flyouts: keep layout as side-by-side when fill flyout is present
-    // This allows fill flyouts to dynamically calculate their width based on sibling
+    // This allows fill flyouts to dynamically calculate their width based on the other in the pair
     if (parentFlyout?.size === 'fill' || childFlyout?.size === 'fill') {
       // For fill flyouts, we want to maintain side-by-side layout to enable dynamic width calculation
       // Only stack if the viewport is too small (below the small breakpoint)

--- a/packages/eui/src/components/flyout/manager/validation.ts
+++ b/packages/eui/src/components/flyout/manager/validation.ts
@@ -9,7 +9,7 @@
 import { EuiFlyoutSize, FLYOUT_SIZES } from '../const';
 import { EuiFlyoutComponentProps } from '../flyout.component';
 import { EuiFlyoutMenuProps } from '../flyout_menu';
-import { LEVEL_MAIN } from './const';
+import { LEVEL_CHILD, LEVEL_MAIN } from './const';
 import { EuiFlyoutLevel } from './types';
 
 type FlyoutValidationErrorType =
@@ -42,11 +42,11 @@ export function validateManagedFlyoutSize(
   flyoutId: string,
   level: EuiFlyoutLevel
 ): FlyoutValidationError | null {
-  if (!isNamedSize(size)) {
+  if (level === LEVEL_CHILD && !isNamedSize(size)) {
     const namedSizes = FLYOUT_SIZES.join(', ');
     return {
       type: 'INVALID_SIZE_TYPE',
-      message: `Managed flyouts must use named sizes (${namedSizes}). Received: ${size}`,
+      message: `Child flyouts must use named sizes (${namedSizes}). Received: ${size}`,
       flyoutId,
       level,
       size,
@@ -81,8 +81,10 @@ export function validateSizeCombination(
   parentSize: EuiFlyoutSize,
   childSize: EuiFlyoutSize
 ): FlyoutValidationError | null {
+  const sizes = [parentSize, childSize];
+
   // Parent and child can't both be 'm'
-  if (parentSize === 'm' && childSize === 'm') {
+  if (sizes.every((s) => s === 'm')) {
     return {
       type: 'INVALID_SIZE_COMBINATION',
       message: 'Parent and child flyouts cannot both be size "m"',
@@ -90,18 +92,18 @@ export function validateSizeCombination(
   }
 
   // Parent and child can't both be 'fill'
-  if (parentSize === 'fill' && childSize === 'fill') {
+  if (sizes.every((s) => s === 'fill')) {
     return {
       type: 'INVALID_SIZE_COMBINATION',
       message: 'Parent and child flyouts cannot both be size "fill"',
     };
   }
 
-  // Parent can't be 'l' if there is a child
-  if (parentSize === 'l') {
+  // Flyout can't be 'l' if the other in the pair is not "fill"
+  if (sizes.includes('l') && !sizes.includes('fill')) {
     return {
       type: 'INVALID_SIZE_COMBINATION',
-      message: 'Parent flyouts cannot be size "l" when there is a child flyout',
+      message: 'Flyouts cannot be size "l" unless the other flyout is "fill"',
     };
   }
 


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

- Allow main flyouts to use custom size values (e.g., '400px') while child flyouts must use named sizes
- Update 'l' size validation to be bidirectional: either flyout can be 'l' if the other is 'fill'
- Change the default size of child flyouts to be `s` so that default sizing for both parent and child results in a valid combination
- Refactor validation logic to use array methods for cleaner, more concise code
- Update all tests to reflect new validation rules
- Update documentation and storybook with correct size combination rules
- Add 'l' and '400px' options to flyout manager storybook controls

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

We have to allow flexible sizing options to support existing use cases in Kibana and provide an easy migration path for those flyouts to adopt the Flyout System.

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

Impact to devs: easier migration path to adopt existing flyouts into the Flyout System.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [x] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [x] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
