### PR TITLE
chore: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,6 +51,6 @@ Remove or strikethrough items that do not apply to your PR.
 - Release checklist
     - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
     - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
-    - [ ] If the changes unblock an issue in a different repo e.g. Kibana, smoke tested carefully
+    - [ ] If the changes unblock an issue in a different repo, smoke tested carefully (see [Testing EUI features in Kibana ahead of time](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md))
 - Designer checklist
   - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_


### PR DESCRIPTION
## Summary

Updating the PR template to address a common pitfall: forgetting to manually test any fixes that have a direct effect in other repos.

> [!IMPORTANT]
> Take this as a suggestion, I'm happy to close

## Why are we making this change?

To avoid shipping fixes or changes that will look good in isolation, and will include proper automated tests, etc. but still might fail to fully fulfill any external requirements.

A recent example:
- #9059 was shipped and released as a fix for #9019 
  - which in turn was blocking https://github.com/elastic/observability-dev/issues/4787
- it turned out there were 2 other bugs that keep blocking the original issue, that could have been fixed at the same time (see [comment](https://github.com/elastic/eui/issues/9019#issuecomment-3414948359))

It appeared unnecessary to do, and the PR ([#9059](https://github.com/elastic/eui/pull/9059)) was properly reviewed, but some extra smoke testing would have saved some time.