### PR TITLE
[Docs] Add documentation about `EuiFormRow` controlling its child `id`

### DIFF
--- a/packages/website/docs/components/forms/layouts/_form_row_callout.mdx
+++ b/packages/website/docs/components/forms/layouts/_form_row_callout.mdx
@@ -1,5 +1,6 @@
 :::tip Wrap your form controls in a form row
 
 Use the [EuiFormRow](./row.mdx) component to easily and accessibly associate form components with labels, help text, and error text.
+Keep in mind that **EuiFormRow** controls the `id` of its wrapped child form component to associate it with the label and help text.
 
 :::

--- a/packages/website/docs/components/forms/layouts/row.mdx
+++ b/packages/website/docs/components/forms/layouts/row.mdx
@@ -5,11 +5,17 @@ keywords: [EuiFormRow]
 
 # Form rows
 
-Use the **EuiFormRow** component to easily associate form components with labels, help text, and error text. Use the **EuiForm** component to group **EuiFormRows**. By default, **EuiForm** will render as a simple div unless you pass `component="form"`.
+Use the **EuiFormRow** component to easily associate form components with labels, help text, and error text. 
+Use the **EuiForm** component to group **EuiFormRows**. By default, **EuiForm** will render as a simple div unless you pass `component="form"`.
+
+:::warning **EuiFormRow** controls the child `id`
+**EuiFormRow** composes related ids for the associated labels and help texts based on the `id` passed on **EuiFormRow** and passes it down to the child form element.
+:::
 
 :::info Accessibility requirement
 Whenever possible, pass a `label` to **EuiFormRow**. If not using the `label` prop, you must instead apply an `aria-label` directly to the wrapped form control, or an `aria-labelledby` with the text node ID of an external label.
 :::
+
 
 ```tsx interactive
 import React, { useState } from 'react';


### PR DESCRIPTION
## Summary

This PR adds documentation about `EuiFormRow` controlling the `id` of the nested form component.

## Why are we making this change?

🧠 Clarification: Prevent confusion about the `id` prop of form components not being applied when used within `EuiFormRow`.

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<img width="849" height="436" alt="Screenshot 2025-10-17 at 14 45 24" src="https://github.com/user-attachments/assets/fde72a1c-78c8-499d-914c-da09b8e17658" />
<img width="853" height="297" alt="Screenshot 2025-10-17 at 14 45 16" src="https://github.com/user-attachments/assets/7e7ed869-6a87-43fd-9936-96fc3d25ebe0" />


## Impact to users

🟢 No impact to users as these changes apply to the EUI documentation only.

## QA

- [ ] review the added documentation and confirm it's clear and correct ([EuiFormRow](https://eui.elastic.co/pr_9127/docs/components/forms/layouts/row), child example: [text controls](https://eui.elastic.co/pr_9127/docs/components/forms/text))