### PR TITLE
[Flyout System] Refactor EuiFlyoutMenu to use context

### DIFF
--- a/packages/eui/src/components/flyout/flyout_menu.stories.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.stories.tsx
@@ -6,112 +6,89 @@
  * Side Public License, v 1.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryObj } from '@storybook/react';
-import { EuiButton } from '../button';
-import { EuiSpacer } from '../spacer';
-import { EuiText } from '../text';
-import { EuiFlyout } from './flyout';
-import { EuiFlyoutBody } from './flyout_body';
 import { EuiFlyoutMenu, EuiFlyoutMenuProps } from './flyout_menu';
+import { EuiFlyoutMenuContext } from './flyout_menu_context';
+import { EuiFlyoutManagerContext } from './manager/provider';
+import { LEVEL_MAIN } from './manager/const';
+import { EuiPanel } from '../panel';
 
 interface Args extends EuiFlyoutMenuProps {
   showCustomActions: boolean;
-  showHistoryItems: boolean;
 }
 
 const meta: Meta<Args> = {
   title: 'Layout/EuiFlyout/EuiFlyoutMenu',
   component: EuiFlyoutMenu,
   argTypes: {
-    showBackButton: { control: 'boolean' },
-    showCustomActions: { control: 'boolean' },
     'aria-label': { table: { disable: true } },
-    backButtonProps: { table: { disable: true } },
     customActions: { table: { disable: true } },
-    historyItems: { table: { disable: true } },
+    hideBackButton: { control: 'boolean' },
+    hideCloseButton: { control: 'boolean' },
+    showCustomActions: { control: 'boolean' },
   },
   args: {
+    hideBackButton: false,
     hideCloseButton: false,
-    showBackButton: true,
     showCustomActions: true,
-    showHistoryItems: true,
   },
 };
 
 export default meta;
 
 const MenuBarFlyout = (args: Args) => {
-  const {
-    hideCloseButton,
-    showBackButton,
-    showCustomActions,
-    showHistoryItems,
-  } = args;
+  const { hideCloseButton, hideBackButton, showCustomActions } = args;
 
-  const [isFlyoutOpen, setIsFlyoutOpen] = useState(true);
-  const openFlyout = () => setIsFlyoutOpen(true);
-  const closeFlyout = () => {
-    setIsFlyoutOpen(false);
-  };
-
-  const backButtonProps = {
-    onClick: () => {
-      action('back button')('click');
-    },
-  };
-
-  const historyItems = showHistoryItems
-    ? ['First item', 'Second item', 'Third item'].map((title) => ({
-        title,
+  const customActions = showCustomActions
+    ? ['gear', 'broom'].map((iconType) => ({
+        iconType,
         onClick: () => {
-          action('history item')(`${title} clicked`);
+          action('custom action')(`${iconType} action clicked`);
         },
+        'aria-label': `${iconType} action`,
       }))
     : undefined;
 
-  const customActions = ['gear', 'broom'].map((iconType) => ({
-    iconType,
-    onClick: () => {
-      action('custom action')(`${iconType} action clicked`);
+  // Mock history items for demonstration
+  const mockHistoryItems = ['First item', 'Second item', 'Third item'].map(
+    (title) => ({
+      title,
+      onClick: () => {
+        action('history item')(`${title} clicked`);
+      },
+    })
+  );
+
+  // Mock manager context for story demonstration
+  const mockManagerContext = {
+    historyItems: mockHistoryItems,
+    goBack: () => {
+      action('back button')('clicked');
     },
-    'aria-label': `${iconType} action`,
-  }));
+  } as any;
+
+  // Mock menu context with level set to LEVEL_MAIN so back button shows
+  const mockMenuContext = {
+    level: LEVEL_MAIN as typeof LEVEL_MAIN,
+    onClose: () => action('close')('clicked'),
+  };
 
   return (
-    <>
-      <EuiButton onClick={openFlyout} disabled={isFlyoutOpen}>
-        Open flyout
-      </EuiButton>
-
-      {isFlyoutOpen && (
-        <EuiFlyout
-          onClose={closeFlyout}
-          size="l"
-          id="menu-bar-example-main"
-          type="overlay"
-          outsideClickCloses={false}
-          ownFocus
-          flyoutMenuProps={{
-            title: 'Flyout title',
-            hideCloseButton,
-            showBackButton,
-            backButtonProps,
-            historyItems,
-            customActions: showCustomActions ? customActions : undefined,
-          }}
-        >
-          <EuiFlyoutBody>
-            <EuiText>
-              <p>Simple flyout content.</p>
-              <EuiSpacer size="m" />
-            </EuiText>
-          </EuiFlyoutBody>
-        </EuiFlyout>
-      )}
-    </>
+    <EuiFlyoutManagerContext.Provider value={mockManagerContext}>
+      <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+        <EuiPanel paddingSize="none" hasShadow={false} hasBorder={true}>
+          <EuiFlyoutMenu
+            title="Flyout Menu Example"
+            hideCloseButton={hideCloseButton}
+            hideBackButton={hideBackButton}
+            customActions={customActions}
+          />
+        </EuiPanel>
+      </EuiFlyoutMenuContext.Provider>
+    </EuiFlyoutManagerContext.Provider>
   );
 };
 

--- a/packages/eui/src/components/flyout/flyout_menu.test.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.test.tsx
@@ -1,0 +1,289 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { render, screen } from '../../test/rtl';
+import { requiredProps } from '../../test/required_props';
+
+import { EuiFlyoutMenu } from './flyout_menu';
+import { EuiFlyoutMenuContext } from './flyout_menu_context';
+import { EuiFlyoutManagerContext } from './manager/provider';
+import { LEVEL_MAIN, LEVEL_CHILD } from './manager/const';
+
+describe('EuiFlyoutMenu', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  describe('basic rendering', () => {
+    it('renders without context', () => {
+      const { container } = render(
+        <EuiFlyoutMenu {...requiredProps} title="Test Title" />
+      );
+
+      expect(container.querySelector('.euiFlyoutMenu')).toBeInTheDocument();
+      expect(screen.getByText('Test Title')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /close/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders with a title', () => {
+      render(<EuiFlyoutMenu title="Test Title" />);
+
+      expect(screen.getByText('Test Title')).toBeInTheDocument();
+    });
+
+    it('renders without a title', () => {
+      const { container } = render(<EuiFlyoutMenu />);
+
+      expect(container.querySelector('.euiTitle')).not.toBeInTheDocument();
+    });
+
+    it('renders a close button by default', () => {
+      render(<EuiFlyoutMenu title="Test" />);
+
+      expect(
+        screen.getByRole('button', { name: /close/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('props', () => {
+    it('hides the close button when hideCloseButton is true', () => {
+      render(<EuiFlyoutMenu title="Test" hideCloseButton />);
+
+      expect(
+        screen.queryByRole('button', { name: /close/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders custom actions', () => {
+      const customActions = [
+        {
+          iconType: 'gear',
+          onClick: jest.fn(),
+          'aria-label': 'Settings',
+        },
+        {
+          iconType: 'broom',
+          onClick: jest.fn(),
+          'aria-label': 'Clean',
+        },
+      ];
+
+      render(<EuiFlyoutMenu title="Test" customActions={customActions} />);
+
+      expect(screen.getByLabelText('Settings')).toBeInTheDocument();
+      expect(screen.getByLabelText('Clean')).toBeInTheDocument();
+    });
+
+    it('applies titleId to the title element', () => {
+      const { container } = render(
+        <EuiFlyoutMenu title="Test" titleId="custom-id" />
+      );
+
+      const title = container.querySelector('#custom-id');
+      expect(title).toBeInTheDocument();
+      expect(title).toHaveClass('euiTitle');
+    });
+  });
+
+  describe('context integration', () => {
+    const mockHistoryItems = [
+      { title: 'First', onClick: jest.fn() },
+      { title: 'Second', onClick: jest.fn() },
+      { title: 'Third', onClick: jest.fn() },
+    ];
+
+    const mockManagerContext = {
+      historyItems: mockHistoryItems,
+      goBack: jest.fn(),
+    } as any;
+
+    describe('with main flyout context', () => {
+      it('shows back button when level is LEVEL_MAIN and history items exist', () => {
+        const mockMenuContext = {
+          level: LEVEL_MAIN as typeof LEVEL_MAIN,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutManagerContext.Provider value={mockManagerContext}>
+            <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+              <EuiFlyoutMenu title="Test" />
+            </EuiFlyoutMenuContext.Provider>
+          </EuiFlyoutManagerContext.Provider>
+        );
+
+        expect(screen.getByText('Back')).toBeInTheDocument();
+      });
+
+      it('shows history popover when level is LEVEL_MAIN and history items exist', () => {
+        const mockMenuContext = {
+          level: LEVEL_MAIN as typeof LEVEL_MAIN,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutManagerContext.Provider value={mockManagerContext}>
+            <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+              <EuiFlyoutMenu title="Test" />
+            </EuiFlyoutMenuContext.Provider>
+          </EuiFlyoutManagerContext.Provider>
+        );
+
+        expect(screen.getByLabelText('History')).toBeInTheDocument();
+      });
+
+      it('hides back button when hideBackButton is true', () => {
+        const mockMenuContext = {
+          level: LEVEL_MAIN as typeof LEVEL_MAIN,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutManagerContext.Provider value={mockManagerContext}>
+            <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+              <EuiFlyoutMenu title="Test" hideBackButton />
+            </EuiFlyoutMenuContext.Provider>
+          </EuiFlyoutManagerContext.Provider>
+        );
+
+        expect(screen.queryByText('Back')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('with child flyout context', () => {
+      it('does not show back button when level is LEVEL_CHILD', () => {
+        const mockMenuContext = {
+          level: LEVEL_CHILD as typeof LEVEL_CHILD,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutManagerContext.Provider value={mockManagerContext}>
+            <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+              <EuiFlyoutMenu title="Test" />
+            </EuiFlyoutMenuContext.Provider>
+          </EuiFlyoutManagerContext.Provider>
+        );
+
+        expect(screen.queryByText('Back')).not.toBeInTheDocument();
+      });
+
+      it('does not show history popover when level is LEVEL_CHILD', () => {
+        const mockMenuContext = {
+          level: LEVEL_CHILD as typeof LEVEL_CHILD,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutManagerContext.Provider value={mockManagerContext}>
+            <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+              <EuiFlyoutMenu title="Test" />
+            </EuiFlyoutMenuContext.Provider>
+          </EuiFlyoutManagerContext.Provider>
+        );
+
+        expect(screen.queryByLabelText('History')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('without manager context', () => {
+      it('renders without back button when manager context is null', () => {
+        const mockMenuContext = {
+          level: LEVEL_MAIN as typeof LEVEL_MAIN,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+            <EuiFlyoutMenu title="Test" />
+          </EuiFlyoutMenuContext.Provider>
+        );
+
+        expect(screen.queryByText('Back')).not.toBeInTheDocument();
+      });
+
+      it('renders without history popover when manager context is null', () => {
+        const mockMenuContext = {
+          level: LEVEL_MAIN as typeof LEVEL_MAIN,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+            <EuiFlyoutMenu title="Test" />
+          </EuiFlyoutMenuContext.Provider>
+        );
+
+        expect(screen.queryByLabelText('History')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('without history items', () => {
+      it('does not show back button when history is empty', () => {
+        const emptyManagerContext = {
+          historyItems: [],
+          goBack: jest.fn(),
+        } as any;
+
+        const mockMenuContext = {
+          level: LEVEL_MAIN as typeof LEVEL_MAIN,
+          onClose: mockOnClose,
+        };
+
+        render(
+          <EuiFlyoutManagerContext.Provider value={emptyManagerContext}>
+            <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+              <EuiFlyoutMenu title="Test" />
+            </EuiFlyoutMenuContext.Provider>
+          </EuiFlyoutManagerContext.Provider>
+        );
+
+        expect(screen.queryByText('Back')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('interactions', () => {
+    it('calls onClose from context when close button is clicked', () => {
+      const mockMenuContext = {
+        onClose: mockOnClose,
+      };
+
+      render(
+        <EuiFlyoutMenuContext.Provider value={mockMenuContext}>
+          <EuiFlyoutMenu title="Test" />
+        </EuiFlyoutMenuContext.Provider>
+      );
+
+      screen.getByRole('button', { name: /close/i }).click();
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls custom action onClick when clicked', () => {
+      const customActionClick = jest.fn();
+      const customActions = [
+        {
+          iconType: 'gear',
+          onClick: customActionClick,
+          'aria-label': 'Settings',
+        },
+      ];
+
+      render(<EuiFlyoutMenu title="Test" customActions={customActions} />);
+
+      screen.getByLabelText('Settings').click();
+      expect(customActionClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/eui/src/components/flyout/flyout_menu_context.ts
+++ b/packages/eui/src/components/flyout/flyout_menu_context.ts
@@ -8,8 +8,10 @@
 
 import { createContext } from 'react';
 import { EuiFlyoutProps } from './flyout';
+import { LEVEL_CHILD, LEVEL_MAIN } from './manager/const';
 
 interface EuiFlyoutMenuContextProps {
+  level?: typeof LEVEL_MAIN | typeof LEVEL_CHILD;
   onClose?: EuiFlyoutProps['onClose'];
 }
 

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useEuiMemoizedStyles } from '../../../services';
 import { useResizeObserver } from '../../observer/resize_observer';
 import {
@@ -50,7 +50,7 @@ import {
  */
 export interface EuiManagedFlyoutProps extends EuiFlyoutComponentProps {
   level: EuiFlyoutLevel;
-  flyoutMenuProps?: Omit<EuiFlyoutMenuProps, 'historyItems' | 'showBackButton'>;
+  flyoutMenuProps?: Omit<EuiFlyoutMenuProps, 'historyItems' | 'hideBackButton'>;
   onActive?: () => void;
 }
 
@@ -82,13 +82,7 @@ export const EuiManagedFlyout = ({
   const flyoutId = useFlyoutId(id);
   const flyoutRef = useRef<HTMLDivElement>(null);
 
-  const {
-    addFlyout,
-    closeFlyout,
-    setFlyoutWidth,
-    goBack,
-    historyItems: _historyItems,
-  } = useFlyoutManager();
+  const { addFlyout, closeFlyout, setFlyoutWidth } = useFlyoutManager();
   const parentSize = useParentFlyoutSize(flyoutId);
   const parentFlyout = useCurrentMainFlyout();
   const layoutMode = useFlyoutLayoutMode();
@@ -222,29 +216,14 @@ export const EuiManagedFlyout = ({
     level,
   });
 
-  // Note: history controls are only relevant for main flyouts
-  const historyItems = useMemo(() => {
-    const result = level === LEVEL_MAIN ? _historyItems : undefined;
-    return result;
-  }, [level, _historyItems]);
-
-  const backButtonProps = useMemo(() => {
-    return level === LEVEL_MAIN ? { onClick: goBack } : undefined;
-  }, [level, goBack]);
-
-  const showBackButton = historyItems ? historyItems.length > 0 : false;
-
   const flyoutMenuProps = {
     ..._flyoutMenuProps,
-    historyItems,
-    showBackButton,
-    backButtonProps,
     title,
   };
 
   return (
     <EuiFlyoutIsManagedProvider isManaged={true}>
-      <EuiFlyoutMenuContext.Provider value={{ onClose }}>
+      <EuiFlyoutMenuContext.Provider value={{ level, onClose }}>
         <EuiFlyoutComponent
           id={flyoutId}
           ref={flyoutRef}


### PR DESCRIPTION
## Summary

This change moves the logic for showing the back button to be internal to the flyout menu.

API changes:
* showBackButton => hideBackButton
* removed: backButtonProps
* removed: historyItems

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

Data passed to `EuiFlyoutMenu` needs to be decoupled from props in case we want to use `EuiFlyoutHeader` as a router component that renders the `EuiFlyoutMenu` when the flyout is in a managed context. Without this refactoring, having two places where `EuiFlyoutMenu` is rendered would mean much duplicated code.

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

Internal refactoring change only; no screenshots

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

While the `EuiFlyoutMenu` prop interface has changed, this interface is only used internally so there is no impact to users or developers in this PR.

## QA

Remove or strikethrough items that do not apply to your PR.

### General checklist

- Browser QA
    - [X] Checked in both **light and dark** modes
    - [x] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    ~~- [ ] Checked in **mobile**~~
    - [x] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [X] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    ~~- [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**~~
    - [x] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    ~~- [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples~~
- Code quality checklist
    - [X] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    ~~- [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**~~
- Release checklist
    ~~- [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately.~~
    ~~- [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)~~
- Designer checklist
  ~~- [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_~~
