### PR TITLE
Setup a base Github Actions workflow for automated EUI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release packages (Work in Progress, a dry run only)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workspaces:
+        description: A comma-separated list of workspaces to release
+        required: false
+        type: string
+
+#permissions:
+#  id-token: write # Required for OIDC
+#  contents: read
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Run tests
+        run: yarn workspaces foreach -A run test-ci


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/eui-private/issues/448

This PR adds a base configuration for the new release Github Actions workflow. It needs to be merged to `main` before any test executions can be performed from PRs. In the current shape, the workflow will install dependencies and run tests, but that's primarily to confirm no OS-level dependencies are missing.

This workflow is not triggered automatically and won't impact anything we currently do.

## Why are we making this change?

To unblock further work on automated EUI releases: https://github.com/elastic/eui-private/issues/448

## Impact to users

Infrastructure only. No impact to users.
