### PR TITLE
Lint (old license snippet)

### DIFF
--- a/packages/eui/src/test/enzyme/enzyme_matchers.ts
+++ b/packages/eui/src/test/enzyme/enzyme_matchers.ts
@@ -1,10 +1,9 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 /* eslint-env jest */

--- a/packages/eui/src/test/enzyme/index.ts
+++ b/packages/eui/src/test/enzyme/index.ts
@@ -1,10 +1,9 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the "Elastic License
- * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
- * Public License v 1"; you may not use this file except in compliance with, at
- * your election, the "Elastic License 2.0", the "GNU Affero General Public
- * License v3.0 only", or the "Server Side Public License, v 1".
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 export {


### PR DESCRIPTION
## Summary

Running `yarn lint-es --fix` would update these 2 files, which had a different license snippet from the one the linter likes.

This PR updates these snippets.

## Why are we making this change?

For ourselves.

## Impact to users

None.

## QA

* [ ] Checkout this PR locally (`gh pr checkout 9277`), run `yarn lint-es --fix` — no files should have been changed.