### PR TITLE
[Documentation] Fix broken link on the EuiPanel page

### DIFF
--- a/packages/website/docs/components/containers/panel/index.mdx
+++ b/packages/website/docs/components/containers/panel/index.mdx
@@ -68,7 +68,7 @@ export default () => (
 
 ### Shadow and border
 
-**EuiPanel** can give depth to your container with `hasShadow` while `hasBorder` can add containment. Just be sure not to include too many [nested panels](#guidelines with these settings.
+**EuiPanel** can give depth to your container with `hasShadow` while `hasBorder` can add containment. Just be sure not to include too many [nested panels](#guidelines) with these settings.
 
 :::warning Certain allowed combinations of shadow, border, and color depend on the current theme.
 


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

Fix syntax error: `[nested panels](#guidelines`.

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

I noticed there's a broken link on [EuiPanel](https://eui.elastic.co/docs/components/containers/panel/#shadow-and-border) documentation page.

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

<img width="829" height="510" alt="Screenshot 2025-12-12 at 14 56 49" src="https://github.com/user-attachments/assets/01084d31-af9a-41d1-bfd5-07afd55281c0" />

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

🟢 Just a docs change.

## QA

### Specific checklist

- [ ] verify the link is working in staging
