### PR TITLE
Unwrap icon from fragment on external link icon component

### DIFF
--- a/packages/eui/src/components/link/external_link_icon.tsx
+++ b/packages/eui/src/components/link/external_link_icon.tsx
@@ -39,36 +39,38 @@ export const EuiExternalLinkIcon: FunctionComponent<
   const showExternalLinkIcon =
     (target === '_blank' && external !== false) || external === true;
 
+  if (!showExternalLinkIcon) {
+    return null;
+  }
+
   return (
-    showExternalLinkIcon && (
-      <>
-        <EuiIcon
-          css={iconCssStyle}
-          size="s"
-          type="popout"
-          role="presentation"
-          {...rest}
-        />
-        {target === '_blank' ? (
-          <EuiScreenReaderOnly>
-            <span>
-              <EuiI18n
-                token="euiExternalLinkIcon.newTarget.screenReaderOnlyText"
-                default="(external, opens in a new tab or window)"
-              />
-            </span>
-          </EuiScreenReaderOnly>
-        ) : (
-          <EuiScreenReaderOnly>
-            <span>
-              <EuiI18n
-                token="euiExternalLinkIcon.externalTarget.screenReaderOnlyText"
-                default="(external)"
-              />
-            </span>
-          </EuiScreenReaderOnly>
-        )}
-      </>
-    )
+    <>
+      <EuiIcon
+        css={iconCssStyle}
+        size="s"
+        type="popout"
+        role="presentation"
+        {...rest}
+      />
+      {target === '_blank' ? (
+        <EuiScreenReaderOnly>
+          <span>
+            <EuiI18n
+              token="euiExternalLinkIcon.newTarget.screenReaderOnlyText"
+              default="(external, opens in a new tab or window)"
+            />
+          </span>
+        </EuiScreenReaderOnly>
+      ) : (
+        <EuiScreenReaderOnly>
+          <span>
+            <EuiI18n
+              token="euiExternalLinkIcon.externalTarget.screenReaderOnlyText"
+              default="(external)"
+            />
+          </span>
+        </EuiScreenReaderOnly>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## Summary

While reading the source code, I found an opportunity to simplify the external link icon component.

## Why are we making this change?

Just for cleanup. ✌️ 

## Impact to users

Since this is a small code refactor, no impact is expected.