### PR TITLE
[Chore] Fix changelog GH workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 2
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
       - name: Check changelogs
         run: |
           ./scripts/check_changelogs.sh \

--- a/scripts/check_changelogs.sh
+++ b/scripts/check_changelogs.sh
@@ -10,6 +10,9 @@
 
 set -e
 
+# Enable corepack to expose the correct yarn cli command
+corepack enable
+
 # Pull request ID
 PR_NUMBER="$1"
 # Pipe-separated PR labels


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

Added `setup-node@v6` step that reuses `.nvmrc` and `corepack enable` in the bash script.

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

I noticed that the change from `ubuntu-latest` to `ubuntu-slim` (while forgetting to setup Node and enabling corepack) caused the script to fail with `yarn command not found`. ([example 1](https://github.com/elastic/eui/actions/runs/20057201440/job/57525111787?pr=9259), [example 2](https://github.com/elastic/eui/actions/runs/20059769662/job/57533564031?pr=9236))

`ubuntu-latest` ✨ just works ✨ but [ubuntu-slim](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) enables us to save on CI resources (especially for a quick and simple action like this one).

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

<img width="1304" height="329" alt="Screenshot 2026-01-07 at 18 53 36" src="https://github.com/user-attachments/assets/14a89a49-9fc0-4ec7-b045-7106730377e9" />

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

🟢 No impact to users. CI change.

## QA

### Specific checklist

- [ ] Verify that adding any EUI change ([example](https://github.com/elastic/eui/actions/runs/20791092890/job/59713183495?pr=9297)) results in check failing

> [!NOTE]
> The script has been previously tested thoroughly on https://github.com/elastic/eui/pull/9249
