### PR TITLE
[dtsgenerator] Exclude cypress and storybook directories

### DIFF
--- a/packages/eui/scripts/dtsgenerator.js
+++ b/packages/eui/scripts/dtsgenerator.js
@@ -40,6 +40,8 @@ const generator = dtsGenerator({
     'src/test/**/*', // Separate d.ts files are generated for test utils
     '**/*.docgen.tsx', // Don't include "components" generated just for react-docgen
     '**/*.mdx', // Don't include storybook mdx files
+    'cypress/**/*',
+    '.storybook/**/*',
   ],
   resolveModuleId(params) {
     if (


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

Adds `cypress` and `.storybook` directories to `exclude` array in `dtsgenerator.js` because those are internally used tools and should not be expected on the consumer side.

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

It was raised on Slack that when experimenting with `dts-bundle-generator` for flattening Kibana plugin types into a public-facing declaration file (https://github.com/elastic/kibana/pull/248932), following errors were reported by TS:

```
../../../../../node_modules/@elastic/eui/eui.d.ts(26824,36): error TS2307: Cannot find module '@storybook/csf' or its corresponding type declarations.
../../../../../node_modules/@elastic/eui/eui.d.ts(32857,2): error TS2439: Import or export declaration in an ambient module declaration cannot reference module through relative module name.
../../../../../node_modules/@elastic/eui/eui.d.ts(32857,35): error TS2307: Cannot find module '../../../src' or its corresponding type declarations.
../../../../../node_modules/@elastic/eui/eui.d.ts(32858,29): error TS2307: Cannot find module '@cypress/react18' or its corresponding type declarations.
../../../../../node_modules/@elastic/eui/eui.d.ts(32868,2): error TS2439: Import or export declaration in an ambient module declaration cannot reference module through relative module name.
../../../../../node_modules/@elastic/eui/eui.d.ts(32869,2): error TS2439: Import or export declaration in an ambient module declaration cannot reference module through relative module name.
../../../../../node_modules/@elastic/eui/eui.d.ts(32869,31): error TS2307: Cannot find module './mount' or its corresponding type declarations.
../../../../../node_modules/@elastic/eui/eui.d.ts(32877,2): error TS2439: Import or export declaration in an ambient module declaration cannot reference module through relative module name.
../../../../../node_modules/@elastic/eui/eui.d.ts(32877,36): error TS2307: Cannot find module './setup/mount' or its corresponding type declarations.
../../../../../node_modules/@elastic/eui/eui.d.ts(32878,2): error TS2439: Import or export declaration in an ambient module declaration cannot reference module through relative module name.
../../../../../node_modules/@elastic/eui/eui.d.ts(32878,40): error TS2307: Cannot find module './setup/realMount' or its corresponding type declarations.
```

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

🟢 It's a DX, type-related improvement only.

## QA

- [x] CI passes (would be worthwhile to investigate if the output is exactly as expected)
- [x] When the new `eui.d.ts` is used on the above-mentioned branch, the errors are not reported anymore (Tested by Clint, no errors appear anymore)