### PR TITLE
[Flyout System] fix imports in flyout management codesandbox

### DIFF
--- a/packages/website/docs/components/containers/flyout/_session_management.mdx
+++ b/packages/website/docs/components/containers/flyout/_session_management.mdx
@@ -13,13 +13,15 @@ simple flyout transitions, state sharing, and more.
 import React, { useState } from "react";
 import {
   EuiButton,
+  EuiCode,
+  EuiFieldText,
   EuiFlyout,
   EuiFlyoutBody,
-  EuiSpacer,
+  EuiFlyoutHeader,
   EuiFormRow,
-  EuiFieldText,
+  EuiSpacer,
   EuiText,
-  EuiCode,
+  EuiTitle,
 } from "@elastic/eui";
 
 export default () => {


### PR DESCRIPTION
## Summary

This PR fixes a runtime error with the Flyout System example for Codesandbox: `EuiFlyoutHeader` and `EuiTitle` component imports were missing.