### PR TITLE
Export `useEuiTimeWindow` hook

### DIFF
--- a/packages/eui/src/components/date_picker/super_date_picker/index.ts
+++ b/packages/eui/src/components/date_picker/super_date_picker/index.ts
@@ -21,5 +21,6 @@ export type { EuiSuperUpdateButtonProps } from './super_update_button';
 export { EuiSuperUpdateButton } from './super_update_button';
 
 export type { EuiTimeWindowButtonsConfig } from './time_window_buttons';
+export { useEuiTimeWindow } from './time_window_buttons';
 
 export { PrettyDuration, usePrettyDuration } from './pretty_duration';


### PR DESCRIPTION
## Summary

Makes the `useEuiTimeWindow` hook available to import from main package `@elastic/eui`.

## Why are we making this change?

In order to be able to reuse the hook, until now it was available only in `EuiSuperDatePicker`.

I'm deliberately not adding a changelog entry yet.

## Impact to users

🟢 None, this is adding a new export.

## QA

* [x] Verify the `useEuiTimeWindow` hook can be imported e.g. `import { useEuiTimeWindow } from '@elastic/eui'`

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
    - [ ] If the changes unblock an issue in a different repo, smoke tested carefully (see [Testing EUI features in Kibana ahead of time](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md))
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
