### PR TITLE
Add missing changelog for #9379

### DIFF
--- a/packages/eui/changelogs/upcoming/9379.md
+++ b/packages/eui/changelogs/upcoming/9379.md
@@ -1,0 +1,5 @@
+- Added `textInk` and `textGhost` color tokens for text and icon colors that should always remain dark or light regardless of color mode.
+
+**Breaking changes**
+
+- Removed `ink` and `ghost` theme tokens. Use `textInk` / `textGhost` for text and icon colors or `plainDark` /`plainLight` for non-text use cases.


### PR DESCRIPTION
## Summary

This PR adds a missing changelog for the previously merged https://github.com/elastic/eui/pull/9379

## Why are we making this change?

This ensures that the token changes are communicated in the changelog for the `eui` package

## Impact to users

🟢 No impact.

