### PR TITLE
Use fake timers in super date picker timezone display

### DIFF
--- a/packages/eui/src/components/date_picker/super_date_picker/date_popover/__snapshots__/timezone_display.test.tsx.snap
+++ b/packages/eui/src/components/date_picker/super_date_picker/date_popover/__snapshots__/timezone_display.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EuiTimeZoneDisplay renders 1`] = `
+<div>
+  <div
+    aria-label="UTC-8 (America/Los_Angeles)"
+    class="euiFlexGroup emotion-euiFlexGroup-responsive-xs-flexStart-center-row-euiTimeZoneDisplay"
+    data-test-subj="euiTimeZoneDisplay"
+  >
+    <span
+      color="subdued"
+      data-euiicon-type="globe"
+    />
+    <span
+      class="euiText emotion-euiText-s-euiTextColor-subdued"
+    >
+      UTC-8 (America/Los_Angeles)
+    </span>
+  </div>
+</div>
+`;

--- a/packages/eui/src/components/date_picker/super_date_picker/date_popover/timezone_display.test.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/date_popover/timezone_display.test.tsx
@@ -18,13 +18,11 @@ describe('EuiTimeZoneDisplay', () => {
   it('renders', () => {
     jest.useFakeTimers().setSystemTime(new Date('2025-01-15T12:00:00Z'));
 
-    const { getByTestSubject } = render(
+    const { container } = render(
       <EuiTimeZoneDisplay timeZone="America/Los_Angeles" />
     );
 
-    expect(getByTestSubject('euiTimeZoneDisplay')).toHaveTextContent(
-      'UTC-8 (America/Los_Angeles)'
-    );
+    expect(container).toMatchSnapshot();
 
     jest.useRealTimers();
   });


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

Used `jest.useFakeTimers()` in `packages/eui/src/components/date_picker/super_date_picker/date_popover/timezone_display.test.tsx` to avoid timezone-related flakiness.

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

CI is failing: https://buildkite.com/elastic/eui-pull-request-test/builds/5864

`America/Los_Angeles` is UTC-8 in winter, UTC-7 in summer. The offset comes from `new Date()` at runtime, so the snapshot breaks when the season changes.

## Impact to users

<!--
How will this change impact EUI users? If it's a breaking change, what will they need to do to handle this change when upgrading? Take a moment to look at usage in Kibana and consider how many usages this will impact and note it here.

Even if it is not a breaking change, how significant is the visual change? Is it a large enough visual change that we would want them advise them to test it?
-->

🟢 

## QA

- [ ] CI passes