### PR TITLE
Chore: update failing time zone snapshot

### DIFF
--- a/packages/eui/src/components/date_picker/super_date_picker/date_popover/__snapshots__/timezone_display.test.tsx.snap
+++ b/packages/eui/src/components/date_picker/super_date_picker/date_popover/__snapshots__/timezone_display.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiTimeZoneDisplay renders 1`] = `
 <div>
   <div
-    aria-label="UTC-7 (America/Los_Angeles)"
+    aria-label="UTC-8 (America/Los_Angeles)"
     class="euiFlexGroup emotion-euiFlexGroup-responsive-xs-flexStart-center-row-euiTimeZoneDisplay"
     data-test-subj="euiTimeZoneDisplay"
   >
@@ -14,7 +14,7 @@ exports[`EuiTimeZoneDisplay renders 1`] = `
     <span
       class="euiText emotion-euiText-s-euiTextColor-subdued"
     >
-      UTC-7 (America/Los_Angeles)
+      UTC-8 (America/Los_Angeles)
     </span>
   </div>
 </div>


### PR DESCRIPTION
## Summary

This PR updates a snapshot in `timezone_display.text.tsx.snap`.

This snapshot was just recently updated [here](https://github.com/elastic/eui/pull/9430/commits/4f987d9cf47fbfad5d30ba1a9ef2990b4daf4469) to account for the updated daylight saving time but the test then was updated in https://github.com/elastic/eui/pull/9433 which stabilized the assertion to `UTC-8` but didn't update the snapshot which resulted in no merge conflicts and hence a still failing snapshot.

## Why are we making this change?

🧹 Cleanup

## Screenshots <a href="#user-content-screenshots" id="screenshots">#</a>

<!--
If this change includes changes to UI, it is important to include screenshots or gif. This helps our users understand what changed when reviewing our changelogs.
-->

## Impact to users

⚪ Internal only.

## QA

- [ ] CI passes

### General checklist

- Browser QA
    - [ ] Checked in both **light and dark** modes
    - [ ] Checked in both [MacOS](https://support.apple.com/lv-lv/guide/mac-help/unac089/mac) and [Windows](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) **high contrast modes**
      - (_[emulate forced colors](https://devtoolstips.org/tips/en/emulate-forced-colors/) if you do not have access to a Windows machine_.)
    - [ ] Checked in **mobile**
    - [ ] Checked in **Chrome**, **Safari**, **Edge**, and **Firefox**
    - [ ] Checked for **accessibility** including keyboard-only and screenreader modes
- Docs site QA
    - [ ] Added **[documentation](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting)**
    - [ ] Props have proper **autodocs** (using `@default` if default values are missing) and **[playground toggles](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/playgrounds.md)**
    - [ ] Checked **[Code Sandbox](https://codesandbox.io/)** works for any docs examples
- Code quality checklist
    - [ ] Added or updated **[jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md) and [cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md) tests**
    - [ ] Updated **[visual regression tests](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)**
- Release checklist
    - [ ] A **[changelog](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)** entry exists and is marked appropriately
    - [ ] If applicable, added the **breaking change** issue label (and filled out the breaking change checklist)
    - [ ] If the changes unblock an issue in a different repo, smoke tested carefully (see [Testing EUI features in Kibana ahead of time](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md))
- Designer checklist
  - [ ] If applicable, [file an issue](https://github.com/elastic/platform-ux-team/issues/new/choose) to update [EUI's Figma library](https://www.figma.com/community/file/964536385682658129) with any corresponding UI changes. _(This is an internal repo, if you are external to Elastic, ask a maintainer to submit this request)_
