### PR TITLE
[Website] Add page about tree-shaking

### DIFF
--- a/packages/website/docs/getting-started/tree-shaking.mdx
+++ b/packages/website/docs/getting-started/tree-shaking.mdx
@@ -32,11 +32,7 @@ This tells bundlers that all JavaScript modules are side-effect-free and safe to
 
 ## What you need
 
-For tree-shaking to work, your bundler must resolve `@elastic/eui` to the **ES module build** (`es/`). Most bundlers do this automatically via the `module` field. Verify that:
-
-1. Your bundler is running in **production mode** (e.g., `mode: 'production'` in Webpack)
-2. **Minification** is enabled (dead code is only physically removed during minification)
-3. You're importing from the top-level package:
+For tree-shaking to work, your bundler must resolve `@elastic/eui` to the **ES module build** (`es/`). Most bundlers do this automatically via the `module` field. Verify that you're importing from the top-level package:
 
 ```tsx
 import { EuiButton, EuiPanel } from '@elastic/eui';


### PR DESCRIPTION
## Summary

<!--
Provide a detailed summary of your PR. What changed? Explain how you arrived at your solution.

If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
-->

Added "Tree-shaking" page to our docs.

## Why are we making this change?

<!--
Generally, most PRs should have a related issue from the [public EUI repo](https://github.com/elastic/eui) that explain **why** we are making changes.

If this change does *not* have an issue associated with, or it is not clear in the issue, please clearly explain *why* we are making this change. This is valuable context for our changelogs.
-->

We want to highlight that EUI is tree-shakeable and provide guidance on how to configure it.

## QA

- [ ] Verify the page displays correctly
- [ ] Verify external links are correct
- [ ] Verify the information is truthful