### PR TITLE
[Storybook] Always show vrt-only stories in development environment

### DIFF
--- a/packages/eui/.storybook/manager.ts
+++ b/packages/eui/.storybook/manager.ts
@@ -12,13 +12,14 @@ import { ADDON_ID, PANEL_ID } from './addons/code-snippet/constants';
 import { Panel } from './addons/code-snippet/components/panel';
 import { setupCodeSnippetEvents } from './addons/code-snippet/event-handlers/setup';
 
-// filter out stories based on tags that should not
-// be shown in the Storybook sidebar menu
 addons.setConfig({
   sidebar: {
+    // Filter which stories should be visible in the sidebar based on tags
     filters: {
       patterns: (item) => {
-        // Storybook only accepts string literals in the tags
+        // Always show all stories in development mode in the sidebar.
+        if (process.env.NODE_ENV === 'development') return true;
+        // Storybook only accepts string literals in the tags,
         // handling this centrally via a map doesn't work :(
         return !item.tags?.includes('vrt-only');
       },


### PR DESCRIPTION
## Summary

This PR updates the Storybook sidebar config to always show stories with the tag `vrt-only` in development mode.
This makes it more convenient to debug those stories (which are usually specific scenarios or different visual variants) without having to manually show/hide them.

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Development         | Production         |
| -------------- | ------------- |
| <img width="280" height="207" alt="Screenshot 2026-03-17 at 09 36 31" src="https://github.com/user-attachments/assets/4d6c0077-fec8-4deb-8c82-723c1a4f6ca2" /> | <img width="292" height="152" alt="Screenshot 2026-03-17 at 10 00 18" src="https://github.com/user-attachments/assets/a2fcb6c8-2412-4f32-8670-5739a04dc474" /> |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

**Impact level:** 🟢 None - Internal only.

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

🟢 Internal only. Non-release changes.

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [x] compare the local development state of storybook and the [deployed storybook](https://eui.elastic.co/pr_9513/storybook/) and verify that `vrt-only` stories are visible by default locally but hidden in production state

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
