### PR TITLE
[Website] Fix all broken CodeSandbox examples

### DIFF
--- a/packages/docusaurus-theme/src/components/demo/actions_bar/actions_bar.tsx
+++ b/packages/docusaurus-theme/src/components/demo/actions_bar/actions_bar.tsx
@@ -23,6 +23,7 @@ export interface DemoActionsBarProps {
   activeSource: DemoSourceMeta | null;
   sources: DemoSourceMeta[];
   extraFiles?: ExtraFiles;
+  previewWrapperSource?: string;
   isSourceOpen: boolean;
   setSourceOpen(isOpen: boolean): void;
   onClickReloadExample(): void;
@@ -55,6 +56,7 @@ export const DemoActionsBar = ({
   activeSource,
   sources,
   extraFiles,
+  previewWrapperSource,
   onClickReloadExample,
   onClickCopyToClipboard,
 }: DemoActionsBarProps) => {
@@ -76,6 +78,7 @@ export const DemoActionsBar = ({
           key={ActionComponent.displayName ?? ActionComponent.name}
           sources={sources}
           extraFiles={extraFiles}
+          previewWrapperSource={previewWrapperSource}
           activeSource={activeSource}
         />
       ))}

--- a/packages/docusaurus-theme/src/components/demo/actions_bar/actions_bar.tsx
+++ b/packages/docusaurus-theme/src/components/demo/actions_bar/actions_bar.tsx
@@ -73,6 +73,7 @@ export const DemoActionsBar = ({
       </EuiButton>
       {extraActions.map((ActionComponent) => (
         <ActionComponent
+          key={ActionComponent.displayName ?? ActionComponent.name}
           sources={sources}
           extraFiles={extraFiles}
           activeSource={activeSource}

--- a/packages/docusaurus-theme/src/components/demo/codesandbox/open_action.tsx
+++ b/packages/docusaurus-theme/src/components/demo/codesandbox/open_action.tsx
@@ -69,7 +69,24 @@ export type Options = {
 const processTsxSource = (source: string) => {
   // jsxImportSource pragma is needed in CodeSandbox as it doesn't seem
   // to support that setting via tsconfig.json
-  return `/** @jsxImportSource @emotion/react */\n${source}`;
+  let processed = `/** @jsxImportSource @emotion/react */\n${source}`;
+
+  // Inject `@elastic/charts` CSS for demos that use the charts library,
+  // since CodeSandbox doesn't load it globally unlike the docs site
+  if (source.includes('@elastic/charts')) {
+    // Match the closing line of the @elastic/charts import (handles both
+    // single-line and multi-line imports, and both quote styles)
+    processed = processed.replace(
+      /^(.*from ['"]@elastic\/charts['"];)$/m,
+      [
+        '$1',
+        "import '@elastic/charts/dist/theme_only_light.css';",
+        "import '@elastic/charts/dist/theme_only_dark.css';",
+      ].join('\n')
+    );
+  }
+
+  return processed;
 };
 
 export const createOpenInCodeSandboxAction =

--- a/packages/docusaurus-theme/src/components/demo/codesandbox/open_action.tsx
+++ b/packages/docusaurus-theme/src/components/demo/codesandbox/open_action.tsx
@@ -34,7 +34,8 @@ const indexTsxSource = dedent`
     <EuiProvider cache={cache}>
       <Demo />
     </EuiProvider>
-  );`;
+  );
+`;
 
 const publicIndexHtmlSource = dedent`
   <head>
@@ -91,7 +92,7 @@ const processTsxSource = (source: string) => {
 
 export const createOpenInCodeSandboxAction =
   ({ files = {}, dependencies }: Options): ActionComponent =>
-  ({ extraFiles, activeSource }) => {
+  ({ extraFiles, activeSource, previewWrapperSource }) => {
     const parameters: string = useMemo(() => {
       const source = activeSource?.code || '';
 
@@ -110,6 +111,24 @@ export const createOpenInCodeSandboxAction =
       return getParameters({
         files: {
           ...defaultCodeSandboxParameters.files,
+          ...(previewWrapperSource
+            ? {
+                'index.tsx': {
+                  content: indexTsxSource
+                    .replace(
+                      "import Demo from './demo';",
+                      "import Demo from './demo';\nimport PreviewWrapper from './preview_wrapper';"
+                    )
+                    .replace(
+                      '<Demo />',
+                      '<PreviewWrapper>\n      <Demo />\n    </PreviewWrapper>'
+                    ),
+                },
+                'preview_wrapper.tsx': {
+                  content: processTsxSource(previewWrapperSource),
+                },
+              }
+            : {}),
           'demo.tsx': {
             content: processTsxSource(source),
           },
@@ -124,7 +143,7 @@ export const createOpenInCodeSandboxAction =
           ...codeSandboxFiles,
         },
       } as any);
-    }, [activeSource, extraFiles]);
+    }, [activeSource, extraFiles, previewWrapperSource]);
 
     return (
       <form

--- a/packages/docusaurus-theme/src/components/demo/demo.tsx
+++ b/packages/docusaurus-theme/src/components/demo/demo.tsx
@@ -79,6 +79,7 @@ export interface DemoProps extends PropsWithChildren {
   extraFiles?: ExtraFiles;
   previewPadding?: DemoPreviewProps['padding'];
   previewWrapper?: DemoPreviewProps['wrapperComponent'];
+  previewWrapperSource?: string;
 }
 
 const getDemoStyles = (euiTheme: UseEuiTheme) => ({
@@ -100,6 +101,7 @@ export const Demo = ({
   isSourceOpen: _isSourceOpen = false,
   previewPadding,
   previewWrapper,
+  previewWrapperSource,
 }: DemoProps) => {
   const styles = useEuiMemoizedStyles(getDemoStyles);
   const [sources, setSources] = useState<DemoSourceMeta[]>([]);
@@ -153,6 +155,7 @@ export const Demo = ({
             activeSource={activeSource}
             extraFiles={extraFiles}
             sources={sources}
+            previewWrapperSource={previewWrapperSource}
             onClickCopyToClipboard={onClickCopyToClipboard}
             onClickReloadExample={onClickReloadExample}
           />

--- a/packages/docusaurus-theme/src/theme/Demo/actions.tsx
+++ b/packages/docusaurus-theme/src/theme/Demo/actions.tsx
@@ -14,6 +14,7 @@ export type ActionComponentProps = {
   activeSource: DemoSourceMeta | null;
   sources: DemoSourceMeta[];
   extraFiles?: ExtraFiles;
+  previewWrapperSource?: string;
 };
 
 export type ActionComponent = ComponentType<ActionComponentProps>;

--- a/packages/docusaurus-theme/src/theme/theme.d.ts
+++ b/packages/docusaurus-theme/src/theme/theme.d.ts
@@ -594,6 +594,7 @@ declare module '@theme/Demo/actions' {
     activeSource: DemoSourceMeta;
     sources: DemoSourceMeta[];
     extraFiles?: ExtraFiles;
+    previewWrapperSource?: string;
   };
 
   export type ActionComponent = ComponentType<ActionComponentProps>;

--- a/packages/website/docs/components/display/empty-prompt/_guidelines.mdx
+++ b/packages/website/docs/components/display/empty-prompt/_guidelines.mdx
@@ -6,16 +6,7 @@ A useful empty state will let the user know what's happening, why it's happening
 
 To make the empty state clear, follow this pattern:
 
-import { EuiAspectRatio } from '@elastic/eui';
-
-<EuiAspectRatio width={16} height={9}>
-  <iframe
-    title="Anatomy of an empty state"
-    width="1200"
-    height="550"
-    src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FRzfYLj2xmH9K7gQtbSKygn%2FElastic-UI%3Fnode-id%3D22764%253A276515"
-  />
-</EuiAspectRatio>
+<FigmaEmbed url="https://www.figma.com/file/FHys7gLzyvD1gc9DrJM6D8/Elastic-UI--Borealis-?node-id=17578-2472" title="Anatomy of an empty state" />
 
 1. **Icon or illustration (optional):** A meaningful representation of the the solution or context.
 2. **Title:** Answers the question "What's happening?". Is it an error? Is it loading?

--- a/packages/website/docs/components/display/empty-prompt/_multiple_types.tsx
+++ b/packages/website/docs/components/display/empty-prompt/_multiple_types.tsx
@@ -4,110 +4,174 @@ import { EuiSelect, useEuiTheme } from '@elastic/eui';
 
 import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
+// @ts-ignore - webpack url-loader
+import pageNotFoundDarkUrl from '!url-loader!../../../../static/images/empty_prompt/pageNotFound--dark.png';
+// @ts-ignore - webpack url-loader
+import pageNotFoundLightUrl from '!url-loader!../../../../static/images/empty_prompt/pageNotFound--light.png';
+// @ts-ignore - webpack url-loader
+import accessDeniedDarkUrl from '!url-loader!../../../../static/images/empty_prompt/accessDenied--dark.png';
+// @ts-ignore - webpack url-loader
+import accessDeniedLightUrl from '!url-loader!../../../../static/images/empty_prompt/accessDenied--light.png';
+
 const types: Array<{
   value: string;
   text: string;
-  code: (colorMode: 'DARK' | 'LIGHT') => string;
+  code: string;
+  scope: Record<string, unknown>;
+  extraFiles: Record<string, string>;
 }> = [
   {
     value: 'errorPages',
     text: 'Page not found',
-    code: (colorMode) => `<EuiEmptyPrompt
-  color="subdued"
-  icon={
-    <EuiImage
-      size="fullWidth"
-      src="${
-        colorMode === 'DARK'
-          ? '/images/empty_prompt/pageNotFound--dark.png'
-          : '/images/empty_prompt/pageNotFound--light.png'
-      }"
-      alt="An outer space illustration. In the background is a large moon and two planets. In the foreground is an astronaut floating in space and the numbers '404'."
+    scope: {
+      pageNotFoundDark: pageNotFoundDarkUrl,
+      pageNotFoundLight: pageNotFoundLightUrl,
+    },
+    extraFiles: {
+      'pageNotFound--dark.ts': `export default "${pageNotFoundDarkUrl}";`,
+      'pageNotFound--light.ts': `export default "${pageNotFoundLightUrl}";`,
+    },
+    code: `import React from 'react';
+import {
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiImage,
+  useEuiTheme,
+} from '@elastic/eui';
+import pageNotFoundDark from './pageNotFound--dark';
+import pageNotFoundLight from './pageNotFound--light';
+
+export default () => {
+  const { colorMode } = useEuiTheme();
+  return (
+    <EuiEmptyPrompt
+      color="subdued"
+      icon={
+        <EuiImage
+          size="fullWidth"
+          src={colorMode === 'DARK' ? pageNotFoundDark : pageNotFoundLight}
+          alt="An outer space illustration. In the background is a large moon and two planets. In the foreground is an astronaut floating in space and the numbers '404'."
+        />
+      }
+      title={<h2>Page not found</h2>}
+      layout="vertical"
+      body={
+        <p>
+          We can&apos;t find the page you&apos;re looking for. It might have
+          been removed, renamed, or it didn&apos;t exist in the first place.
+        </p>
+      }
+      actions={[
+        <EuiButton color="primary" fill>
+          Home
+        </EuiButton>,
+        <EuiButtonEmpty iconType="chevronSingleLeft" flush="both">
+          Go back
+        </EuiButtonEmpty>,
+      ]}
     />
-  }
-  title={<h2>Page not found</h2>}
-  layout="vertical"
-  body={
-    <p>
-      We can&apos;t find the page you&apos;re looking for. It might have
-      been removed, renamed, or it didn&apos;t exist in the first place.
-    </p>
-  }
-  actions={[
-    <EuiButton color="primary" fill>
-      Home
-    </EuiButton>,
-    <EuiButtonEmpty iconType="chevronSingleLeft" flush="both">
-      Go back
-    </EuiButtonEmpty>,
-  ]}
-/>`,
+  );
+};`,
   },
   {
     value: 'noPrivileges',
     text: 'No permission',
-    code: (colorMode) => `<EuiEmptyPrompt
-  color="subdued"
-  icon={
-    <EuiImage
-      size="fullWidth"
-      src="${
-        colorMode === 'DARK'
-          ? '/images/empty_prompt/accessDenied--dark.png'
-          : '/images/empty_prompt/accessDenied--light.png'
-      }"
-      alt=""
+    scope: {
+      accessDeniedDark: accessDeniedDarkUrl,
+      accessDeniedLight: accessDeniedLightUrl,
+    },
+    extraFiles: {
+      'accessDenied--dark.ts': `export default "${accessDeniedDarkUrl}";`,
+      'accessDenied--light.ts': `export default "${accessDeniedLightUrl}";`,
+    },
+    code: `import React from 'react';
+import {
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiImage,
+  useEuiTheme,
+} from '@elastic/eui';
+import accessDeniedDark from './accessDenied--dark';
+import accessDeniedLight from './accessDenied--light';
+
+export default () => {
+  const { colorMode } = useEuiTheme();
+  return (
+    <EuiEmptyPrompt
+      color="subdued"
+      icon={
+        <EuiImage
+          size="fullWidth"
+          src={colorMode === 'DARK' ? accessDeniedDark : accessDeniedLight}
+          alt=""
+        />
+      }
+      title={<h2>Access denied</h2>}
+      layout="vertical"
+      body={
+        <p>
+          Sorry to rain on your parade, but you don't have permissions to access
+          this page.
+        </p>
+      }
+      actions={[
+        <EuiButton color="primary" fill>
+          Home
+        </EuiButton>,
+        <EuiButtonEmpty iconType="chevronSingleLeft" flush="both">
+          Go back
+        </EuiButtonEmpty>,
+      ]}
     />
-  }
-  title={<h2>Access denied</h2>}
-  layout="vertical"
-  body={
-    <p>
-      Sorry to rain on your parade, but you don't have permissions to access
-      this page.
-    </p>
-  }
-  actions={[
-    <EuiButton color="primary" fill>
-      Home
-    </EuiButton>,
-    <EuiButtonEmpty iconType="chevronSingleLeft" flush="both">
-      Go back
-    </EuiButtonEmpty>,
-  ]}
-/>`,
+  );
+};`,
   },
   {
     value: 'licenseUpgrade',
     text: 'License upgrade',
-    code: () => `<EuiEmptyPrompt
-  color="subdued"
-  iconType="logoKibana"
-  title={<h2>Do more with Kibana!</h2>}
-  layout="vertical"
-  hasBorder
-  body={
-    <p>
-      Start a free trial or upgrade your license to use anomaly detection.
-    </p>
-  }
-  actions={[
-    <EuiButton color="primary" fill>
-      Upgrade
-    </EuiButton>,
-    <EuiButtonEmpty>Start a free trial</EuiButtonEmpty>,
-  ]}
-  footer={
-    <>
-      <EuiTitle size="xxs">
-        <h3>Want to learn more?</h3>
-      </EuiTitle>
-      <EuiLink href="#" target="_blank">
-        Read the docs
-      </EuiLink>
-    </>
-  }
-/>`,
+    scope: {},
+    extraFiles: {},
+    code: `import React from 'react';
+import {
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiTitle,
+  EuiLink,
+} from '@elastic/eui';
+
+export default () => (
+  <EuiEmptyPrompt
+    color="subdued"
+    iconType="logoKibana"
+    title={<h2>Do more with Kibana!</h2>}
+    layout="vertical"
+    hasBorder
+    body={
+      <p>
+        Start a free trial or upgrade your license to use anomaly detection.
+      </p>
+    }
+    actions={[
+      <EuiButton color="primary" fill>
+        Upgrade
+      </EuiButton>,
+      <EuiButtonEmpty>Start a free trial</EuiButtonEmpty>,
+    ]}
+    footer={
+      <>
+        <EuiTitle size="xxs">
+          <h3>Want to learn more?</h3>
+        </EuiTitle>
+        <EuiLink href="#" target="_blank">
+          Read the docs
+        </EuiLink>
+      </>
+    }
+  />
+);`,
   },
 ];
 
@@ -136,8 +200,12 @@ export default () => {
         aria-label="Empty prompt examples"
       />
 
-      <Demo key={`${selectedType.value}--${colorMode}`}>
-        {selectedType.code(colorMode)}
+      <Demo
+        key={`${selectedType.value}--${colorMode}`}
+        scope={selectedType.scope}
+        extraFiles={selectedType.extraFiles}
+      >
+        {selectedType.code}
       </Demo>
     </>
   );

--- a/packages/website/docs/components/display/empty-prompt/index.mdx
+++ b/packages/website/docs/components/display/empty-prompt/index.mdx
@@ -4,7 +4,6 @@ keywords: [EuiEmptyPrompt]
 
 # Empty prompt
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import illustrationUrl from '!url-loader!../../../../static/images/empty_prompt/illustration.svg';
 import illustrationSource from '!raw-loader!../../../../static/images/empty_prompt/illustration.svg';
 

--- a/packages/website/docs/components/display/empty-prompt/index.mdx
+++ b/packages/website/docs/components/display/empty-prompt/index.mdx
@@ -5,6 +5,8 @@ keywords: [EuiEmptyPrompt]
 # Empty prompt
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import illustrationUrl from '!url-loader!../../../../static/images/empty_prompt/illustration.svg';
+import illustrationSource from '!raw-loader!../../../../static/images/empty_prompt/illustration.svg';
 
 The **EuiEmptyPrompt** is the building block to create an empty state. You can use it as a placeholder for any type of empty content. They are especially helpful for replacing entire pages or parts of a product that contain no content.
 
@@ -173,7 +175,7 @@ You can supply a `layout` of either `"horizontal"` or `"vertical"` with the defa
 
 When you have longer body text with multiple calls to action, you can use the `horizontal` layout. This layout works best when you can provide a larger graphic like an illustration as the `icon`. For consistency, we recommend providing the illustration using a [EuiImage](../image.mdx) with `size="fullWidth"`.
 
-<Demo scope={{ useBaseUrl }}>
+<Demo scope={{ illustration: illustrationUrl }} extraFiles={{ 'illustration.svg': illustrationSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -183,12 +185,13 @@ When you have longer body text with multiple calls to action, you can use the `h
     EuiLink,
     EuiImage,
   } from '@elastic/eui';
+  import illustration from './illustration.svg';
 
   export default () => {
     return (
       <>
         <EuiEmptyPrompt
-          icon={<EuiImage size="fullWidth" src={useBaseUrl('/images/empty_prompt/illustration.svg')} alt="" />}
+          icon={<EuiImage size="fullWidth" src={illustration} alt="" />}
           title={<h2>Create your first visualization</h2>}
           layout="horizontal"
           color="plain"
@@ -240,7 +243,7 @@ When using a **EuiEmptyPrompt** in a [EuiPageTemplate](../../templates/page-temp
 
 The following example shows the usage of the [EuiPageTemplate.EmptyPrompt](../../templates/page-template/index.mdx#empty-pages-or-content) namespaced component.
 
-<Demo scope={{ useBaseUrl }}>
+<Demo scope={{ illustration: illustrationUrl }} extraFiles={{ 'illustration.svg': illustrationSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -250,12 +253,13 @@ The following example shows the usage of the [EuiPageTemplate.EmptyPrompt](../..
     EuiLink,
     EuiImage,
   } from '@elastic/eui';
+  import illustration from './illustration.svg';
 
   export default () => (
     <EuiPageTemplate minHeight="0">
       <EuiPageTemplate.EmptyPrompt
         title={<h2>Create your first visualization</h2>}
-        icon={<EuiImage size="fullWidth" src={useBaseUrl('/images/empty_prompt/illustration.svg')} alt="" />}
+        icon={<EuiImage size="fullWidth" src={illustration} alt="" />}
         color="plain"
         layout="horizontal"
         body={
@@ -298,6 +302,7 @@ You can then tie multiple types of empty states together to create a seamless lo
 )}>
   ```tsx
   import React, { useState, useEffect } from 'react';
+  import { css } from '@emotion/react';
   import {
     EuiPageTemplate,
     EuiLoadingLogo,

--- a/packages/website/docs/components/display/empty-prompt/types_of_empty_states/empty_snippet.tsx
+++ b/packages/website/docs/components/display/empty-prompt/types_of_empty_states/empty_snippet.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import {
   EuiPageTemplate,
@@ -11,6 +10,7 @@ import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';
+import { USE_CASE_IMAGE_URLS } from './use_case_images';
 
 type Props = {
   radioUseCaseId: string;
@@ -22,10 +22,10 @@ export const EmptySnippet = ({ radioUseCaseId }: Props) => {
 
   const { example } = TYPES_OF_USE_CASES[radioUseCaseId];
 
-  const src = useBaseUrl(isDarkTheme ? example.iconDark : example.iconLight);
-  const src2x = useBaseUrl(
-    isDarkTheme ? example.iconDark2x : example.iconLight2x
-  );
+  const iconPath = isDarkTheme ? example.iconDark : example.iconLight;
+  const icon2xPath = isDarkTheme ? example.iconDark2x : example.iconLight2x;
+  const src = iconPath ? USE_CASE_IMAGE_URLS[iconPath as string] : undefined;
+  const src2x = icon2xPath ? USE_CASE_IMAGE_URLS[icon2xPath as string] : undefined;
 
   // Conditionally set the `icon` prop if a non-standard icon is needed
   // See EuiEmptyPrompt docs to learn more about custom icon usage
@@ -37,8 +37,8 @@ export const EmptySnippet = ({ radioUseCaseId }: Props) => {
       <EuiImage
         size="fullWidth"
         alt={example.alt ?? ''}
-        src={src}
-        srcSet={`${src} 1x, ${src2x} 2x`}
+        src={src ?? ''}
+        srcSet={src2x ? `${src} 1x, ${src2x} 2x` : undefined}
       />
     )
   }
@@ -60,9 +60,30 @@ export const EmptySnippet = ({ radioUseCaseId }: Props) => {
     </EuiPageTemplate>
   );
 
+  const code = `import React from 'react';
+import {
+  EuiPageTemplate,
+  EuiImage,
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiLoadingLogo,
+  EuiTitle,
+  EuiLink,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+} from '@elastic/eui';
+
+export default () => (
+  ${snippet}
+);`;
+
   return (
     <Demo key={`${radioUseCaseId}-${colorMode}`} previewPadding="s">
-      {snippet}
+      {code}
     </Demo>
   );
 };

--- a/packages/website/docs/components/display/empty-prompt/types_of_empty_states/multiple_snippet.tsx
+++ b/packages/website/docs/components/display/empty-prompt/types_of_empty_states/multiple_snippet.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
-import useBaseUrl from '@docusaurus/useBaseUrl';
+// @ts-ignore - webpack url-loader
+import contentCenter from '!url-loader!../../../../../static/images/empty_prompt/content_center.svg';
 
 import {
   EuiPageTemplate,
@@ -15,6 +16,7 @@ import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';
+import { USE_CASE_IMAGE_URLS } from './use_case_images';
 
 type Props = {
   radioUseCaseId: string;
@@ -26,12 +28,10 @@ export const MultipleSnippet = ({ radioUseCaseId }: Props) => {
 
   const { example } = TYPES_OF_USE_CASES[radioUseCaseId];
 
-  const contentCenter = useBaseUrl('/images/empty_prompt/content_center.svg');
-
-  const src = useBaseUrl(isDarkTheme ? example.iconDark : example.iconLight);
-  const src2x = useBaseUrl(
-    isDarkTheme ? example.iconDark2x : example.iconLight2x
-  );
+  const iconPath = isDarkTheme ? example.iconDark : example.iconLight;
+  const icon2xPath = isDarkTheme ? example.iconDark2x : example.iconLight2x;
+  const src = iconPath ? USE_CASE_IMAGE_URLS[iconPath as string] : undefined;
+  const src2x = icon2xPath ? USE_CASE_IMAGE_URLS[icon2xPath as string] : undefined;
 
   // Conditionally set the `icon` prop if a non-standard icon is needed
   // See EuiEmptyPrompt docs to learn more about custom icon usage
@@ -43,8 +43,8 @@ export const MultipleSnippet = ({ radioUseCaseId }: Props) => {
       <EuiImage
         size="fullWidth"
         alt={example.alt ?? ''}
-        src={src}
-        srcSet={`${src} 1x, ${src2x} 2x`}
+        src={src ?? ''}
+        srcSet={src2x ? `${src} 1x, ${src2x} 2x` : undefined}
       />
     )
   }
@@ -84,9 +84,32 @@ export const MultipleSnippet = ({ radioUseCaseId }: Props) => {
     </EuiPageTemplate>
   );
 
+  const code = `import React from 'react';
+import {
+  EuiPageTemplate,
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiPanel,
+  EuiImage,
+  EuiEmptyPrompt,
+  EuiLoadingSpinner,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiLoadingLogo,
+  EuiTitle,
+  EuiLink,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+} from '@elastic/eui';
+
+export default () => (
+  ${snippet}
+);`;
+
   return (
     <Demo key={`${radioUseCaseId}-${colorMode}`} previewPadding="s">
-      {snippet}
+      {code}
     </Demo>
   );
 };

--- a/packages/website/docs/components/display/empty-prompt/types_of_empty_states/sidebar_snippet.tsx
+++ b/packages/website/docs/components/display/empty-prompt/types_of_empty_states/sidebar_snippet.tsx
@@ -1,5 +1,8 @@
 import { ReactNode } from 'react';
-import useBaseUrl from '@docusaurus/useBaseUrl';
+// @ts-ignore - webpack url-loader
+import single from '!url-loader!../../../../../static/images/single.svg';
+// @ts-ignore - webpack url-loader
+import sideNav from '!url-loader!../../../../../static/images/empty_prompt/side_nav.svg';
 
 import {
   EuiPageTemplate,
@@ -12,6 +15,7 @@ import { Demo } from '@elastic/eui-docusaurus-theme/components';
 
 import { TYPES_OF_USE_CASES } from './use_cases';
 import { convertToJsxString } from './utils';
+import { USE_CASE_IMAGE_URLS } from './use_case_images';
 
 type Props = {
   radioUseCaseId: string;
@@ -25,13 +29,10 @@ export const SidebarSnippet = ({ radioUseCaseId }: Props) => {
 
   const { example } = TYPES_OF_USE_CASES[radioUseCaseId];
 
-  const single = useBaseUrl('/images/single.svg');
-  const sideNav = useBaseUrl('/images/empty_prompt/side_nav.svg');
-
-  const src = useBaseUrl(isDarkTheme ? example.iconDark : example.iconLight);
-  const src2x = useBaseUrl(
-    isDarkTheme ? example.iconDark2x : example.iconLight2x
-  );
+  const iconPath = isDarkTheme ? example.iconDark : example.iconLight;
+  const icon2xPath = isDarkTheme ? example.iconDark2x : example.iconLight2x;
+  const src = iconPath ? USE_CASE_IMAGE_URLS[iconPath as string] : undefined;
+  const src2x = icon2xPath ? USE_CASE_IMAGE_URLS[icon2xPath as string] : undefined;
 
   // Conditionally set the `icon` prop if a non-standard icon is needed
   // See EuiEmptyPrompt docs to learn more about custom icon usage
@@ -43,8 +44,8 @@ export const SidebarSnippet = ({ radioUseCaseId }: Props) => {
       <EuiImage
         size="fullWidth"
         alt={example.alt ?? ''}
-        src={src}
-        srcSet={`${src} 1x, ${src2x} 2x`}
+        src={src ?? ''}
+        srcSet={src2x ? `${src} 1x, ${src2x} 2x` : undefined}
       />
     )
   }
@@ -73,12 +74,33 @@ export const SidebarSnippet = ({ radioUseCaseId }: Props) => {
     </EuiPageTemplate>
   );
 
+  const code = `import React from 'react';
+import {
+  EuiPageTemplate,
+  EuiImage,
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiLoadingLogo,
+  EuiTitle,
+  EuiLink,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+} from '@elastic/eui';
+
+export default () => (
+  ${snippet}
+);`;
+
   return (
     <Demo
       key={`${radioUseCaseId}-${colorMode}`}
       previewPadding="s"
     >
-      {snippet}
+      {code}
     </Demo>
   );
 };

--- a/packages/website/docs/components/display/empty-prompt/types_of_empty_states/use_case_images.ts
+++ b/packages/website/docs/components/display/empty-prompt/types_of_empty_states/use_case_images.ts
@@ -1,0 +1,21 @@
+// @ts-ignore - webpack url-loader
+import noResultsLight from '!url-loader!../../../../../static/images/empty_prompt/no-results--light.svg';
+// @ts-ignore - webpack url-loader
+import noResultsDark from '!url-loader!../../../../../static/images/empty_prompt/no-results--dark.svg';
+// @ts-ignore - webpack url-loader
+import pageNotFoundLight from '!url-loader!../../../../../static/images/empty_prompt/pageNotFound--light.png';
+// @ts-ignore - webpack url-loader
+import pageNotFoundDark from '!url-loader!../../../../../static/images/empty_prompt/pageNotFound--dark.png';
+// @ts-ignore - webpack url-loader
+import pageNotFoundLight2x from '!url-loader!../../../../../static/images/empty_prompt/pageNotFound--light@2x.png';
+// @ts-ignore - webpack url-loader
+import pageNotFoundDark2x from '!url-loader!../../../../../static/images/empty_prompt/pageNotFound--dark@2x.png';
+
+export const USE_CASE_IMAGE_URLS: Record<string, string> = {
+  '/images/empty_prompt/no-results--light.svg': noResultsLight,
+  '/images/empty_prompt/no-results--dark.svg': noResultsDark,
+  '/images/empty_prompt/pageNotFound--light.png': pageNotFoundLight,
+  '/images/empty_prompt/pageNotFound--dark.png': pageNotFoundDark,
+  '/images/empty_prompt/pageNotFound--light@2x.png': pageNotFoundLight2x,
+  '/images/empty_prompt/pageNotFound--dark@2x.png': pageNotFoundDark2x,
+};

--- a/packages/website/docs/components/display/icons/index.mdx
+++ b/packages/website/docs/components/display/icons/index.mdx
@@ -11,7 +11,10 @@ import { EuiCodeBlock, EuiSpacer, EuiSplitPanel, EuiToken } from '@elastic/eui';
 ## Component
 
 ```tsx interactive
-<EuiIcon type="grid" />
+import React from 'react';
+import { EuiIcon } from '@elastic/eui';
+
+export default () => <EuiIcon type="grid" />;
 ```
 
 :::accessibility Accessibility recommendation
@@ -25,29 +28,37 @@ If possible, provide a descriptive title based on the icon use. If no title is p
 Use the `size` prop to automatically size your icons. Medium is the default, and will output a `16x16` icon.
 
 import { iconSizes, iconSizesText } from './icon_sizes';
+import iconSizeSource from '!raw-loader!./icon_sizes';
 
-<Demo scope={{ iconSizes, iconSizesText }}>
+<Demo scope={{ iconSizes, iconSizesText }} extraFiles={{ 'icon_sizes.ts': iconSizeSource }}>
   ```tsx
-  <>
-    <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
-      {'<EuiIcon type="logoElasticsearch" size="xl" />'}
-    </EuiCodeBlock>
-    <EuiSpacer />
-    <EuiFlexGrid direction="row" columns={3}>
-      {iconSizes.map((size, index) => (
-        <EuiFlexItem key={size}>
-          <EuiCopy textToCopy={size} afterMessage={`${size} copied`} tooltipProps={{ display: 'block' }}>
-            {(copy) => (
-              <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
-                <EuiIcon className="eui-alignMiddle" type="logoElasticsearch" size={size} /> &emsp;{' '}
-                <small>{iconSizesText[index]}</small>
-              </EuiPanel>
-            )}
-          </EuiCopy>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  </>
+  import React from 'react';
+  import { css } from '@emotion/react';
+  import { EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiIcon } from '@elastic/eui';
+  import { iconSizes, iconSizesText } from './icon_sizes';
+
+  export default () => (
+    <div css={css`height: fit-content;`}>
+      <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
+        {'<EuiIcon type="logoElasticsearch" size="xl" />'}
+      </EuiCodeBlock>
+      <EuiSpacer />
+      <EuiFlexGrid direction="row" columns={3}>
+        {iconSizes.map((size, index) => (
+          <EuiFlexItem key={size}>
+            <EuiCopy textToCopy={size} afterMessage={`${size} copied`} tooltipProps={{ display: 'block' }}>
+              {(copy) => (
+                <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
+                  <EuiIcon className="eui-alignMiddle" type="logoElasticsearch" size={size} /> &emsp;{' '}
+                  <small>{iconSizesText[index]}</small>
+                </EuiPanel>
+              )}
+            </EuiCopy>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGrid>
+    </div>
+  );
   ```
 </Demo>
 
@@ -58,34 +69,42 @@ The default behavior of icons is to inherit from the text color. You can use the
 Two-tone icons, like our app style icons, will behave similarly to normal glyphs when provided a specific color by applying the color to **all** the shapes within. You can force the icon to match the parent's text color by passing `color="inherit"` to the icon.
 
 import { iconColors } from './icon_colors.ts'
+import iconColorsSource from '!raw-loader!./icon_colors';
 
-<Demo scope={{ iconColors }}>
+<Demo scope={{ iconColors }} extraFiles={{ 'icon_colors.ts': iconColorsSource }}>
   ```tsx
-  <>
-    <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
-      {'<EuiIcon type="brush" color="primary" />'}
-    </EuiCodeBlock>
-    <EuiSpacer />
-    <EuiFlexGrid direction="row" columns={3}>
-      {iconColors.map((color) => (
-        <EuiFlexItem key={color}>
-          <EuiCopy textToCopy={color} afterMessage={`${color} copied`} tooltipProps={{ display: 'block' }}>
-            {(copy) => {
-              const panel = (
-                <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
-                  <EuiIcon className="eui-alignMiddle" type="brush" color={color} /> &emsp;{' '}
-                  <small>{color}</small>
-                </EuiPanel>
-              );
-              return color === 'ghost'
-                ? <EuiThemeProvider colorMode="DARK">{panel}</EuiThemeProvider>
-                : panel;
-            }}
-          </EuiCopy>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  </>
+  import React from 'react';
+  import { css } from '@emotion/react';
+  import { EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiIcon, EuiThemeProvider } from '@elastic/eui';
+  import { iconColors } from './icon_colors';
+
+  export default () => (
+    <div css={css`height: fit-content;`}>
+      <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
+        {'<EuiIcon type="brush" color="primary" />'}
+      </EuiCodeBlock>
+      <EuiSpacer />
+      <EuiFlexGrid direction="row" columns={3}>
+        {iconColors.map((color) => (
+          <EuiFlexItem key={color}>
+            <EuiCopy textToCopy={color} afterMessage={`${color} copied`} tooltipProps={{ display: 'block' }}>
+              {(copy) => {
+                const panel = (
+                  <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
+                    <EuiIcon className="eui-alignMiddle" type="brush" color={color} /> &emsp;{' '}
+                    <small>{color}</small>
+                  </EuiPanel>
+                );
+                return color === 'ghost'
+                  ? <EuiThemeProvider colorMode="DARK">{panel}</EuiThemeProvider>
+                  : panel;
+              }}
+            </EuiCopy>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGrid>
+    </div>
+  );
   ```
 </Demo>
 
@@ -96,29 +115,37 @@ Glyphs are small, monochromatic icons that typically should always use the defau
 If you would like to contribute to our growing list of glyphs, you can follow [these guidelines](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/developing/creating-icons.md).
 
 import { iconTypes } from './icon_types';
+import iconTypesSource from '!raw-loader!./icon_types';
 
-<Demo scope={{ iconTypes }}>
+<Demo scope={{ iconTypes }} extraFiles={{ 'icon_types.ts': iconTypesSource }}>
   ```tsx
-  <>
-    <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
-      {'<EuiIcon type="warning" />'}
-    </EuiCodeBlock>
-    <EuiSpacer />
-    <EuiFlexGrid direction="row" columns={3}>
-      {iconTypes.map((iconType) => (
-        <EuiFlexItem key={iconType}>
-          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
-            {(copy) => (
-              <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
-                <EuiIcon className="eui-alignMiddle" type={iconType} /> &emsp;{' '}
-                <small>{iconType}</small>
-              </EuiPanel>
-            )}
-          </EuiCopy>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  </>
+  import React from 'react';
+  import { css } from '@emotion/react';
+  import { EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiIcon } from '@elastic/eui';
+  import { iconTypes } from './icon_types';
+
+  export default () => (
+    <div css={css`height: fit-content;`}>
+      <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
+        {'<EuiIcon type="warning" />'}
+      </EuiCodeBlock>
+      <EuiSpacer />
+      <EuiFlexGrid direction="row" columns={3}>
+        {iconTypes.map((iconType) => (
+          <EuiFlexItem key={iconType}>
+            <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
+              {(copy) => (
+                <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
+                  <EuiIcon className="eui-alignMiddle" type={iconType} /> &emsp;{' '}
+                  <small>{iconType}</small>
+                </EuiPanel>
+              )}
+            </EuiCopy>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGrid>
+    </div>
+  );
   ```
 </Demo>
 
@@ -127,9 +154,15 @@ import { iconTypes } from './icon_types';
 These logos are restricted in use to Elastic products or when referencing Elastic products. They are multi-color with some internal paths having a class of `.euiIcon__fillNegative` to handle flipping colors for dark mode. The only other colors most of them support are ghost and text which turn them into a solid shape.
 
 import { iconTypesLogos } from './icon_types_logos';
+import iconTypesLogosSource from '!raw-loader!./icon_types_logos';
 
-<Demo scope={{ iconTypes: iconTypesLogos }} previewPadding="none">
+<Demo scope={{ iconTypes: iconTypesLogos }} previewPadding="none" extraFiles={{ 'icon_types_logos.ts': iconTypesLogosSource }}>
   ```tsx
+  import React, { useState } from 'react';
+  import { css } from '@emotion/react';
+  import { EuiButtonGroup, EuiSplitPanel, EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiIcon, UseEuiTheme, useEuiMemoizedStyles } from '@elastic/eui';
+  import { iconTypesLogos as iconTypes } from './icon_types_logos';
+
   const allowedColors = ['multi', 'ghost', 'text'];
   const getPanelGhostStyles = ({ euiTheme }: UseEuiTheme) => css`
     color: ${euiTheme.colors.textGhost};
@@ -199,29 +232,37 @@ App logos are logos for Elastic Apps, and can contain multiple colors. Normally 
 Our set of App Icons are a subset of what the [Elastic Design team provides](https://brand.elastic.co/302f66895/p/031452-icons). If you require an icon from that set which EUI does not currently provide, please open a [Feature Request](https://github.com/elastic/eui/issues) for the EUI team to add it.
 
 import { iconTypesApps } from './icon_types_apps';
+import iconTypesAppsSource from '!raw-loader!./icon_types_apps';
 
-<Demo scope={{ iconTypes: iconTypesApps }}>
+<Demo scope={{ iconTypes: iconTypesApps }} extraFiles={{ 'icon_types_apps.ts': iconTypesAppsSource }}>
   ```tsx
-  <>
-    <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
-      {'<EuiIcon type="addDataApp" size="xl" />'}
-    </EuiCodeBlock>
-    <EuiSpacer />
-    <EuiFlexGrid direction="row" columns={3}>
-      {iconTypes.map((iconType) => (
-        <EuiFlexItem key={iconType}>
-          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
-            {(copy) => (
-              <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
-                <EuiIcon className="eui-alignMiddle" type={iconType} size="xl" /> &emsp;{' '}
-                <small>{iconType}</small>
-              </EuiPanel>
-            )}
-          </EuiCopy>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  </>
+  import React from 'react';
+  import { css } from '@emotion/react';
+  import { EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiIcon } from '@elastic/eui';
+  import { iconTypesApps as iconTypes } from './icon_types_apps';
+
+  export default () => (
+    <div css={css`height: fit-content;`}>
+      <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
+        {'<EuiIcon type="addDataApp" size="xl" />'}
+      </EuiCodeBlock>
+      <EuiSpacer />
+      <EuiFlexGrid direction="row" columns={3}>
+        {iconTypes.map((iconType) => (
+          <EuiFlexItem key={iconType}>
+            <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
+              {(copy) => (
+                <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
+                  <EuiIcon className="eui-alignMiddle" type={iconType} size="xl" /> &emsp;{' '}
+                  <small>{iconType}</small>
+                </EuiPanel>
+              )}
+            </EuiCopy>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGrid>
+    </div>
+  );
   ```
 </Demo>
 
@@ -230,29 +271,37 @@ import { iconTypesApps } from './icon_types_apps';
 Machine learning has some specific icons for job creation. Again, these are made for `32x32`.
 
 import { iconTypesML } from './icon_types_ml';
+import iconTypesMLSource from '!raw-loader!./icon_types_ml';
 
-<Demo scope={{ iconTypes: iconTypesML }}>
+<Demo scope={{ iconTypes: iconTypesML }} extraFiles={{ 'icon_types_ml.ts': iconTypesMLSource }}>
   ```tsx
-  <>
-    <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
-      {'<EuiIcon type="addDataApp" size="xl" />'}
-    </EuiCodeBlock>
-    <EuiSpacer />
-    <EuiFlexGrid direction="row" columns={3}>
-      {iconTypes.map((iconType) => (
-        <EuiFlexItem key={iconType}>
-          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
-            {(copy) => (
-              <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
-                <EuiIcon className="eui-alignMiddle" type={iconType} size="xl" /> &emsp;{' '}
-                <small>{iconType}</small>
-              </EuiPanel>
-            )}
-          </EuiCopy>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  </>
+  import React from 'react';
+  import { css } from '@emotion/react';
+  import { EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiIcon } from '@elastic/eui';
+  import { iconTypesML as iconTypes } from './icon_types_ml';
+
+  export default () => (
+    <div css={css`height: fit-content;`}>
+      <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
+        {'<EuiIcon type="addDataApp" size="xl" />'}
+      </EuiCodeBlock>
+      <EuiSpacer />
+      <EuiFlexGrid direction="row" columns={3}>
+        {iconTypes.map((iconType) => (
+          <EuiFlexItem key={iconType}>
+            <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
+              {(copy) => (
+                <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
+                  <EuiIcon className="eui-alignMiddle" type={iconType} size="xl" /> &emsp;{' '}
+                  <small>{iconType}</small>
+                </EuiPanel>
+              )}
+            </EuiCopy>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGrid>
+    </div>
+  );
   ```
 </Demo>
 
@@ -261,29 +310,37 @@ import { iconTypesML } from './icon_types_ml';
 Tokens are most commonly used to visually signify field or code types. An **EuiToken** accepts any valid **EuiIcon** as its `iconType` property. However, icons designed specifically for use in the **EuiToken** are prefixed with "token" in their name and have pre-defined styles.
 
 import { iconTypesTokens } from './icon_types_tokens';
+import iconTypesTokensSource from '!raw-loader!./icon_types_tokens';
 
-<Demo scope={{ iconTypes: iconTypesTokens }}>
+<Demo scope={{ iconTypes: iconTypesTokens }} extraFiles={{ 'icon_types_tokens.ts': iconTypesTokensSource }}>
   ```tsx
-  <>
-    <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
-      {'<EuiToken iconType="tokenAlias" />'}
-    </EuiCodeBlock>
-    <EuiSpacer />
-    <EuiFlexGrid direction="row" columns={3}>
-      {iconTypes.map((iconType) => (
-        <EuiFlexItem key={iconType}>
-          <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
-            {(copy) => (
-              <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
-                <EuiToken className="eui-alignMiddle" iconType={iconType} /> &emsp;{' '}
-                <small>{iconType}</small>
-              </EuiPanel>
-            )}
-          </EuiCopy>
-        </EuiFlexItem>
-      ))}
-    </EuiFlexGrid>
-  </>
+  import React from 'react';
+  import { css } from '@emotion/react';
+  import { EuiCodeBlock, EuiSpacer, EuiFlexGrid, EuiFlexItem, EuiCopy, EuiPanel, EuiToken } from '@elastic/eui';
+  import { iconTypesTokens as iconTypes } from './icon_types_tokens';
+
+  export default () => (
+    <div css={css`height: fit-content;`}>
+      <EuiCodeBlock language="tsx" isCopyable paddingSize="m">
+        {'<EuiToken iconType="tokenAlias" />'}
+      </EuiCodeBlock>
+      <EuiSpacer />
+      <EuiFlexGrid direction="row" columns={3}>
+        {iconTypes.map((iconType) => (
+          <EuiFlexItem key={iconType}>
+            <EuiCopy textToCopy={iconType} afterMessage={`${iconType} copied`} tooltipProps={{ display: 'block' }}>
+              {(copy) => (
+                <EuiPanel hasShadow={false} hasBorder={false} onClick={copy} paddingSize="s">
+                  <EuiToken className="eui-alignMiddle" iconType={iconType} /> &emsp;{' '}
+                  <small>{iconType}</small>
+                </EuiPanel>
+              )}
+            </EuiCopy>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGrid>
+    </div>
+  );
   ```
 </Demo>
 
@@ -364,8 +421,9 @@ When importing an SVG as a component like `import { ReactComponent as ReactLogo 
 :::
 
 import customSvg from '!url-loader!./custom.svg';
+import customSvgSource from '!raw-loader!./custom.svg';
 
-<Demo scope={{ customSvg }}>
+<Demo scope={{ customSvg }} extraFiles={{ 'custom.svg': customSvgSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -378,6 +436,7 @@ import customSvg from '!url-loader!./custom.svg';
     EuiSplitPanel,
     EuiCodeBlock,
   } from '@elastic/eui';
+  import customSvg from './custom.svg';
 
   export default () => (
     <div>

--- a/packages/website/docs/components/editors-and-syntax/markdown/editor.mdx
+++ b/packages/website/docs/components/editors-and-syntax/markdown/editor.mdx
@@ -120,11 +120,7 @@ export default () => {
 
 The `errors` prop allows you to pass an array of errors if syntax is malformed. The below example starts with an incomplete tooltip tag, showing this error message by default. These errors are meant to be ephemeral and part of the editing experience. They should not be a substitute for [form validation](../../forms/layouts/validation.mdx).
 
-```mdx-code-block
-import Link from '@docusaurus/Link';
-```
-
-<Demo scope={{ Link }}>
+<Demo>
 ```tsx interactive
 import React, { useCallback, useState, useRef } from 'react';
 import {
@@ -133,6 +129,7 @@ import {
   EuiCodeBlock,
   EuiButton,
   EuiFormErrorText,
+  EuiLink,
   htmlIdGenerator,
 } from '@elastic/eui';
 
@@ -175,7 +172,7 @@ export default () => {
       >
         Utilize error text or{' '}
         <strong>
-          <Link to="/docs/forms/validation">EuiFormRow</Link>
+          <EuiLink href="/docs/forms/validation">EuiFormRow</EuiLink>
         </strong>{' '}
         for more permanent error feedback
       </EuiFormErrorText>

--- a/packages/website/docs/components/editors-and-syntax/markdown/plugins.mdx
+++ b/packages/website/docs/components/editors-and-syntax/markdown/plugins.mdx
@@ -425,7 +425,7 @@ import * as ElasticCharts from '@elastic/charts';
 
 <Demo scope={{ ...ElasticCharts }}>
   ```tsx
-  import React, { useCallback, useState } from 'react';
+  import React, { useCallback, useState } from "react";
   import {
     getDefaultEuiMarkdownParsingPlugins,
     getDefaultEuiMarkdownProcessingPlugins,
@@ -459,7 +459,7 @@ import * as ElasticCharts from '@elastic/charts';
     euiPaletteOrange,
     euiPaletteWarm,
     getDefaultEuiMarkdownUiPlugins,
-  } from '@elastic/eui';
+  } from "@elastic/eui";
   import {
     Chart,
     Settings,
@@ -468,7 +468,7 @@ import * as ElasticCharts from '@elastic/charts';
     DataGenerator,
     LIGHT_THEME,
     DARK_THEME,
-  } from '@elastic/charts';
+  } from "@elastic/charts";
 
   const paletteData = {
     euiPaletteForStatus,
@@ -490,15 +490,15 @@ import * as ElasticCharts from '@elastic/charts';
   const generateData = (categories) => dg.generateGroupedSeries(10, categories);
 
   const chartDemoPlugin = {
-    name: 'chartDemoPlugin',
+    name: "chartDemoPlugin",
     button: {
-      label: 'Chart',
-      iconType: 'visBarVerticalStacked',
+      label: "Chart",
+      iconType: "visBarVerticalStacked",
     },
     helpText: (
       <div>
         <EuiCodeBlock language="md" fontSize="l" paddingSize="s" isCopyable>
-          {'!{chart{options}}'}
+          {"!{chart{options}}"}
         </EuiCodeBlock>
         <EuiSpacer size="s" />
         <EuiText size="xs" style={{ marginLeft: 16 }}>
@@ -516,7 +516,7 @@ import * as ElasticCharts from '@elastic/charts';
       </div>
     ),
     editor: function ChartEditor({ node, onSave, onCancel }) {
-      const [palette, setPalette] = useState((node && node.palette) || '1');
+      const [palette, setPalette] = useState((node && node.palette) || "1");
       const [categories, setCategories] = useState(5);
 
       const onChange = (e) => {
@@ -528,7 +528,7 @@ import * as ElasticCharts from '@elastic/charts';
           value: String(index + 1),
           title: paletteName,
           palette: paletteData[paletteNames[index]](categories),
-          type: 'fixed',
+          type: "fixed",
         };
       });
 
@@ -596,33 +596,33 @@ import * as ElasticCharts from '@elastic/charts';
     const methods = Parser.prototype.blockMethods;
 
     function tokenizeChart(eat, value, silent) {
-      if (value.startsWith('!{chart') === false) return false;
+      if (value.startsWith("!{chart") === false) return false;
 
       const nextChar = value[7];
 
-      if (nextChar !== '{' && nextChar !== '}') return false; // this isn't actually a chart
+      if (nextChar !== "{" && nextChar !== "}") return false; // this isn't actually a chart
 
       if (silent) {
         return true;
       }
 
       // is there a configuration?
-      const hasConfiguration = nextChar === '{';
+      const hasConfiguration = nextChar === "{";
 
-      let match = '!{chart';
+      let match = "!{chart";
       let configuration = {};
 
       if (hasConfiguration) {
-        let configurationString = '';
+        let configurationString = "";
 
         let openObjects = 0;
 
         for (let i = 7; i < value.length; i++) {
           const char = value[i];
-          if (char === '{') {
+          if (char === "{") {
             openObjects++;
             configurationString += char;
-          } else if (char === '}') {
+          } else if (char === "}") {
             openObjects--;
             if (openObjects === -1) {
               break;
@@ -645,22 +645,22 @@ import * as ElasticCharts from '@elastic/charts';
         }
       }
 
-      match += '}';
+      match += "}";
 
       return eat(match)({
-        type: 'chartDemoPlugin',
+        type: "chartDemoPlugin",
         ...configuration,
       });
     }
 
     tokenizers.chart = tokenizeChart;
-    methods.splice(methods.indexOf('text'), 0, 'chart');
+    methods.splice(methods.indexOf("text"), 0, "chart");
   }
 
   // receives the configuration from the parser and renders
   const ChartMarkdownRenderer = ({ palette, categories }) => {
     const { colorMode } = useEuiTheme();
-    const chartBaseTheme = colorMode === 'DARK' ? DARK_THEME : LIGHT_THEME;
+    const chartBaseTheme = colorMode === "DARK" ? DARK_THEME : LIGHT_THEME;
     const customColors = {
       colors: {
         vizColors: paletteData[paletteNames[palette - 1]](categories),
@@ -678,10 +678,10 @@ import * as ElasticCharts from '@elastic/charts';
           id="status"
           name="Status"
           data={generateData(categories)}
-          xAccessor={'x'}
-          yAccessors={['y']}
-          splitSeriesAccessors={['g']}
-          stackAccessors={['g']}
+          xAccessor={"x"}
+          yAccessors={["y"]}
+          splitSeriesAccessors={["g"]}
+          stackAccessors={["g"]}
         />
         <Axis id="bottom-axis" position="bottom" showGridLines />
         <Axis
@@ -739,11 +739,11 @@ import * as ElasticCharts from '@elastic/charts';
         <div className="eui-textRight">
           <EuiButton
             size="s"
-            iconType={isAstShowing ? 'eyeClosed' : 'eye'}
+            iconType={isAstShowing ? "eyeClosed" : "eye"}
             onClick={() => setIsAstShowing(!isAstShowing)}
             fill={isAstShowing}
           >
-            {isAstShowing ? 'Hide editor AST' : 'Show editor AST'}
+            {isAstShowing ? "Hide editor AST" : "Show editor AST"}
           </EuiButton>
         </div>
         {isAstShowing && <EuiCodeBlock language="json">{ast}</EuiCodeBlock>}

--- a/packages/website/docs/components/editors-and-syntax/markdown/plugins.mdx
+++ b/packages/website/docs/components/editors-and-syntax/markdown/plugins.mdx
@@ -425,7 +425,7 @@ import * as ElasticCharts from '@elastic/charts';
 
 <Demo scope={{ ...ElasticCharts }}>
   ```tsx
-  import React, { useCallback, useState } from "react";
+  import React, { useCallback, useState } from 'react';
   import {
     getDefaultEuiMarkdownParsingPlugins,
     getDefaultEuiMarkdownProcessingPlugins,
@@ -459,7 +459,7 @@ import * as ElasticCharts from '@elastic/charts';
     euiPaletteOrange,
     euiPaletteWarm,
     getDefaultEuiMarkdownUiPlugins,
-  } from "@elastic/eui";
+  } from '@elastic/eui';
   import {
     Chart,
     Settings,
@@ -468,7 +468,7 @@ import * as ElasticCharts from '@elastic/charts';
     DataGenerator,
     LIGHT_THEME,
     DARK_THEME,
-  } from "@elastic/charts";
+  } from '@elastic/charts';
 
   const paletteData = {
     euiPaletteForStatus,
@@ -490,15 +490,15 @@ import * as ElasticCharts from '@elastic/charts';
   const generateData = (categories) => dg.generateGroupedSeries(10, categories);
 
   const chartDemoPlugin = {
-    name: "chartDemoPlugin",
+    name: 'chartDemoPlugin',
     button: {
-      label: "Chart",
-      iconType: "visBarVerticalStacked",
+      label: 'Chart',
+      iconType: 'visBarVerticalStacked',
     },
     helpText: (
       <div>
         <EuiCodeBlock language="md" fontSize="l" paddingSize="s" isCopyable>
-          {"!{chart{options}}"}
+          {'!{chart{options}}'}
         </EuiCodeBlock>
         <EuiSpacer size="s" />
         <EuiText size="xs" style={{ marginLeft: 16 }}>
@@ -516,7 +516,7 @@ import * as ElasticCharts from '@elastic/charts';
       </div>
     ),
     editor: function ChartEditor({ node, onSave, onCancel }) {
-      const [palette, setPalette] = useState((node && node.palette) || "1");
+      const [palette, setPalette] = useState((node && node.palette) || '1');
       const [categories, setCategories] = useState(5);
 
       const onChange = (e) => {
@@ -528,7 +528,7 @@ import * as ElasticCharts from '@elastic/charts';
           value: String(index + 1),
           title: paletteName,
           palette: paletteData[paletteNames[index]](categories),
-          type: "fixed",
+          type: 'fixed',
         };
       });
 
@@ -596,33 +596,33 @@ import * as ElasticCharts from '@elastic/charts';
     const methods = Parser.prototype.blockMethods;
 
     function tokenizeChart(eat, value, silent) {
-      if (value.startsWith("!{chart") === false) return false;
+      if (value.startsWith('!{chart') === false) return false;
 
       const nextChar = value[7];
 
-      if (nextChar !== "{" && nextChar !== "}") return false; // this isn't actually a chart
+      if (nextChar !== '{' && nextChar !== '}') return false; // this isn't actually a chart
 
       if (silent) {
         return true;
       }
 
       // is there a configuration?
-      const hasConfiguration = nextChar === "{";
+      const hasConfiguration = nextChar === '{';
 
-      let match = "!{chart";
+      let match = '!{chart';
       let configuration = {};
 
       if (hasConfiguration) {
-        let configurationString = "";
+        let configurationString = '';
 
         let openObjects = 0;
 
         for (let i = 7; i < value.length; i++) {
           const char = value[i];
-          if (char === "{") {
+          if (char === '{') {
             openObjects++;
             configurationString += char;
-          } else if (char === "}") {
+          } else if (char === '}') {
             openObjects--;
             if (openObjects === -1) {
               break;
@@ -645,22 +645,22 @@ import * as ElasticCharts from '@elastic/charts';
         }
       }
 
-      match += "}";
+      match += '}';
 
       return eat(match)({
-        type: "chartDemoPlugin",
+        type: 'chartDemoPlugin',
         ...configuration,
       });
     }
 
     tokenizers.chart = tokenizeChart;
-    methods.splice(methods.indexOf("text"), 0, "chart");
+    methods.splice(methods.indexOf('text'), 0, 'chart');
   }
 
   // receives the configuration from the parser and renders
   const ChartMarkdownRenderer = ({ palette, categories }) => {
     const { colorMode } = useEuiTheme();
-    const chartBaseTheme = colorMode === "DARK" ? DARK_THEME : LIGHT_THEME;
+    const chartBaseTheme = colorMode === 'DARK' ? DARK_THEME : LIGHT_THEME;
     const customColors = {
       colors: {
         vizColors: paletteData[paletteNames[palette - 1]](categories),
@@ -678,10 +678,10 @@ import * as ElasticCharts from '@elastic/charts';
           id="status"
           name="Status"
           data={generateData(categories)}
-          xAccessor={"x"}
-          yAccessors={["y"]}
-          splitSeriesAccessors={["g"]}
-          stackAccessors={["g"]}
+          xAccessor="x"
+          yAccessors={['y']}
+          splitSeriesAccessors={['g']}
+          stackAccessors={['g']}
         />
         <Axis id="bottom-axis" position="bottom" showGridLines />
         <Axis
@@ -739,11 +739,11 @@ import * as ElasticCharts from '@elastic/charts';
         <div className="eui-textRight">
           <EuiButton
             size="s"
-            iconType={isAstShowing ? "eyeClosed" : "eye"}
+            iconType={isAstShowing ? 'eyeClosed' : 'eye'}
             onClick={() => setIsAstShowing(!isAstShowing)}
             fill={isAstShowing}
           >
-            {isAstShowing ? "Hide editor AST" : "Show editor AST"}
+            {isAstShowing ? 'Hide editor AST' : 'Show editor AST'}
           </EuiButton>
         </div>
         {isAstShowing && <EuiCodeBlock language="json">{ast}</EuiCodeBlock>}

--- a/packages/website/docs/components/forms/date-and-time/date-picker-range.mdx
+++ b/packages/website/docs/components/forms/date-and-time/date-picker-range.mdx
@@ -3,14 +3,18 @@ sidebar_position: 2
 keywords: [EuiDatePickerRange]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Date picker range
 
 To create a single date range control, use **EuiDatePickerRange** and pass individual [EuiDatePicker](./date-picker.mdx) components into the `startDateControl` and `endDateControl` props. You can control the state of both inputs as direct props on **EuiDatePickerRange** as well as control each individually. Date specific props need to applied to the individual components.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiDatePicker, EuiDatePickerRange } from '@elastic/eui';
 import moment from 'moment';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [startDate, setStartDate] = useState(moment());
@@ -45,6 +49,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 :::tip
 If you need even more functionality such as relative time, suggested date ranges, and refresh intervals, consider using [EuiSuperDatePicker](./super-date-picker.mdx).
@@ -54,6 +59,7 @@ If you need even more functionality such as relative time, suggested date ranges
 
 Use the `inline` prop to display the date picker directly in the page instead of inside a popover. If you do not need the default inline shadow effect, apply the `shadow={false}` prop.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import {
@@ -64,6 +70,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import moment from 'moment';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [shadow, setShadow] = useState(true);
@@ -117,6 +124,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ### Dynamic `minDate` and `maxDate`
 

--- a/packages/website/docs/components/forms/date-and-time/date-picker.mdx
+++ b/packages/website/docs/components/forms/date-and-time/date-picker.mdx
@@ -3,6 +3,8 @@ sidebar_position: 1
 keywords: [EuiDatePicker]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Date picker
 
 **EuiDatePicker** is the foundational component that all other EUI date and time controls are built upon. It itself depends upon <a href="https://momentjs.com/docs/" target="_blank">moment</a> for all of its formatting, and a forked and modified version of <a href="https://github.com/Hacker0x01/react-datepicker/tree/v2.0.0" target="_blank">react-datepicker</a> for accessibility.
@@ -33,9 +35,11 @@ export default () => {
 
 Examples of how the input can appear within a form. This should match our other form styles.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiDatePicker, EuiSpacer, EuiFormRow } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [startDate, setStartDate] = useState(null);
@@ -86,6 +90,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Time selection
 
@@ -425,6 +430,7 @@ export default () => {
 
 Use the `inline` prop to display the date picker directly in the page instead of inside a popover. If you do not need the default inline shadow effect, apply the `shadow={false}` prop.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import {
@@ -434,6 +440,7 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import moment from 'moment';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [shadow, setShadow] = useState(true);
@@ -470,6 +477,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Custom classes
 

--- a/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
+++ b/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
@@ -387,7 +387,13 @@ import React, { useState } from 'react';
 import {
   EuiSuperDatePicker,
   EuiSuperDatePickerProps,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSelect,
+  EuiSwitch,
+  EuiSpacer,
   OnTimeChangeProps,
+  useEuiTheme,
 } from '@elastic/eui';
 
 export default () => {
@@ -435,7 +441,7 @@ export default () => {
         width={width}
         compressed={compressed}
       />
-    </EuiSpacer>
+    </>
   );
 };
 ```

--- a/packages/website/docs/components/forms/layouts/form_control_buttons.mdx
+++ b/packages/website/docs/components/forms/layouts/form_control_buttons.mdx
@@ -21,43 +21,31 @@ Set `isDropdown` on **EuiFormControlLayout** to indicate a dropdown toggle that 
 :::
 
 ```tsx interactive
-import React, { useState } from 'react';
+import React, { useState, type ChangeEvent } from "react";
 import {
-	EuiFieldSearch,
-	EuiForm,
-	EuiFormControlLayout,
+  EuiFormRow,
+  EuiFieldSearch,
+  EuiForm,
+  EuiFormControlLayout,
   EuiFormControlButton,
-	EuiInputPopover,
+  EuiInputPopover,
   EuiNotificationBadge,
   EuiFlexGroup,
-	EuiSelectable,
-	EuiSwitch,
-	EuiSpacer,
-	type EuiSelectableOption,
-} from '@elastic/eui';
+  EuiSelectable,
+  EuiSwitch,
+  EuiSpacer,
+  EuiBadge,
+  type EuiSelectableOption,
+} from "@elastic/eui";
 
 const _options: EuiSelectableOption[] = [
-  {
-    label: 'Titan',
-  },
-  {
-    label: 'Enceladus',
-  },
-  {
-    label: 'Mimas',
-  },
-  {
-    label: 'Dione',
-  },
-  {
-    label: 'Iapetus',
-  },
-  {
-    label: 'Phoebe',
-  },
-  {
-    label: 'Rhea',
-  },
+  { label: "Titan" },
+  { label: "Enceladus" },
+  { label: "Mimas" },
+  { label: "Dione" },
+  { label: "Iapetus" },
+  { label: "Phoebe" },
+  { label: "Rhea" },
 ];
 
 export default () => {
@@ -66,64 +54,64 @@ export default () => {
   const [isInvalid, setInvalid] = useState(false);
   const [isDropdown, setDropdown] = useState(false);
   const [isClearable, setClearable] = useState(false);
-  
-	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-	const [searchValue, setSearchValue] = useState('');
-    const [options, setOptions] = useState(_options);
-    const [selectedOptions, setSelectedOptions] = useState<
-      EuiSelectableOption[]
-    >([]);
-    const [buttonLabel, setButtonLabel] = useState('');
 
-	const formLayoutProps = {
-		compressed: isCompressed,
-		isDisabled,
-		isInvalid,
-		isDropdown,
-		clear: isClearable && { onClick: () => {} },
-	}
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState("");
+  const [options, setOptions] = useState(_options);
+  const [selectedOptions, setSelectedOptions] = useState<EuiSelectableOption[]>(
+    []
+  );
+  const [buttonLabel, setButtonLabel] = useState("");
 
-	const formButtonProps = {
-		compressed: isCompressed,
-		isDisabled,
-		isInvalid,
-	}
+  const formLayoutProps = {
+    compressed: isCompressed,
+    isDisabled,
+    isInvalid,
+    isDropdown,
+    clear: isClearable && { onClick: () => {} },
+  };
 
-	const popoverId = 'popover-id';
-	const panelTitle = 'popover-panel-title';
+  const formButtonProps = {
+    compressed: isCompressed,
+    isDisabled,
+    isInvalid,
+  };
 
-	const handleOnSearch = (e: ChangeEvent<HTMLInputElement>) => {
-		setSearchValue(e.target.value);
+  const popoverId = "popover-id";
+  const panelTitle = "popover-panel-title";
 
-		const filteredOptions = _options.filter((opt) => {
-			return opt.label.toLowerCase().includes(e.target.value);
-		});
+  const handleOnSearch = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
 
-		setOptions(filteredOptions);
-	};
+    const filteredOptions = _options.filter((opt) => {
+      return opt.label.toLowerCase().includes(e.target.value);
+    });
 
-	const handleOnChange = (options: EuiSelectableOption[]) => {
-		setOptions(options);
-		const _selectedOptions = getSelectedOptions(options);
-		setSelectedOptions(_selectedOptions);
-		setButtonLabel(_selectedOptions.map((opt) => opt.label).join(', '));
-	};
+    setOptions(filteredOptions);
+  };
 
-	const handleOnClear = () => {
-		setOptions(_options);
-		setSelectedOptions([]);
-		setButtonLabel('');
-	};
+  const handleOnChange = (options: EuiSelectableOption[]) => {
+    setOptions(options);
+    const _selectedOptions = getSelectedOptions(options);
+    setSelectedOptions(_selectedOptions);
+    setButtonLabel(_selectedOptions.map((opt) => opt.label).join(", "));
+  };
 
-	const getSelectedOptions = (options: EuiSelectableOption[]) => {
-		return options
-			.map((option) => (option.checked === 'on' ? option : null))
-			.filter((option) => option !== null);
-	};
+  const handleOnClear = () => {
+    setOptions(_options);
+    setSelectedOptions([]);
+    setButtonLabel("");
+  };
+
+  const getSelectedOptions = (options: EuiSelectableOption[]) => {
+    return options
+      .map((option) => (option.checked === "on" ? option : null))
+      .filter((option) => option !== null);
+  };
 
   return (
-		<>
-			<EuiFlexGroup responsive={false} wrap>
+    <>
+      <EuiFlexGroup responsive={false} wrap>
         <EuiSwitch
           label="compressed"
           checked={isCompressed}
@@ -139,12 +127,12 @@ export default () => {
           checked={isInvalid}
           onChange={(e) => setInvalid(e.target.checked)}
         />
-				<EuiSwitch
+        <EuiSwitch
           label="isDropdown"
           checked={isDropdown}
           onChange={(e) => setDropdown(e.target.checked)}
         />
-				<EuiSwitch
+        <EuiSwitch
           label="clear"
           checked={isClearable}
           onChange={(e) => setClearable(e.target.checked)}
@@ -153,111 +141,104 @@ export default () => {
 
       <EuiSpacer />
 
-			<EuiForm>
-				<EuiFormRow label="Example: placeholder only">
-					<EuiFormControlLayout
-						{...formLayoutProps}
-					>
-						<EuiFormControlButton
-							placeholder="Placeholder text"
-							{...formButtonProps}
-						/>
-					</EuiFormControlLayout>
-				</EuiFormRow>
+      <EuiForm>
+        <EuiFormRow label="Example: placeholder only">
+          <EuiFormControlLayout {...formLayoutProps}>
+            <EuiFormControlButton
+              placeholder="Placeholder text"
+              {...formButtonProps}
+            />
+          </EuiFormControlLayout>
+        </EuiFormRow>
 
-				<EuiFormRow label="Example: value only">
-					<EuiFormControlLayout
-						{...formLayoutProps}
-					>
-						<EuiFormControlButton
-							value="Button value"
-							{...formButtonProps}
-						/>
-					</EuiFormControlLayout>
-				</EuiFormRow>
+        <EuiFormRow label="Example: value only">
+          <EuiFormControlLayout {...formLayoutProps}>
+            <EuiFormControlButton value="Button value" {...formButtonProps} />
+          </EuiFormControlLayout>
+        </EuiFormRow>
 
-				<EuiFormRow label="Example: value with icon and additional content">
-					<EuiFormControlLayout
-						{...formLayoutProps}
-					>
-						<EuiFormControlButton
-							{...formButtonProps}
-							value="Button value"
-							iconType="gear"
-						>
-							<EuiBadge>Active</EuiBadge>
-						</EuiFormControlButton>
-					</EuiFormControlLayout>
-				</EuiFormRow>
+        <EuiFormRow label="Example: value with icon and additional content">
+          <EuiFormControlLayout {...formLayoutProps}>
+            <EuiFormControlButton
+              {...formButtonProps}
+              value="Button value"
+              iconType="gear"
+            >
+              <EuiBadge>Active</EuiBadge>
+            </EuiFormControlButton>
+          </EuiFormControlLayout>
+        </EuiFormRow>
 
-				<EuiFormRow label="Example: Popover with filter selection">
-					<EuiFormControlLayout
-						{...formLayoutProps}
-						clear={isClearable && { onClick: handleOnClear }}
-					>
-						<EuiInputPopover
-							ownFocus
-							input={(
-								<EuiFormControlButton
-									value={buttonLabel ?? ''}
-									placeholder="Placeholder"
-									role="combobox"
-									onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-									aria-expanded={isPopoverOpen}
-									aria-controls={popoverId}
-									{...formButtonProps}
-								>
-									{(selectedOptions.length > 0 || options.length > 0) && (
-										<EuiNotificationBadge
-											color={
-												selectedOptions.length > 0 && !isDisabled ? 'success' : 'subdued'
-											}
-										>
-											{selectedOptions.length > 0
-												? selectedOptions.length
-												: options.length}
-										</EuiNotificationBadge>
-									)}
-								</EuiFormControlButton>
-							)}
-							hasArrow={false}
-							repositionOnScroll
-							isOpen={isPopoverOpen}
-							panelPaddingSize="none"
-							panelMinWidth={200}
-							initialFocus={'[data-test-subj=panel-search-input]'}
-							closePopover={() => setIsPopoverOpen(false)}
-							panelProps={{
-								title: panelTitle,
-								'aria-label': panelTitle,
-							}}
-						>
-							<EuiFieldSearch
-								fullWidth
-								onChange={handleOnSearch}
-								value={searchValue}
-								data-test-subj="panel-search-input"
-								placeholder="search field"
-							/>
+        <EuiFormRow label="Example: Popover with filter selection">
+          <EuiFormControlLayout
+            {...formLayoutProps}
+            clear={isClearable && { onClick: handleOnClear }}
+          >
+            <EuiInputPopover
+              ownFocus
+              input={
+                <EuiFormControlButton
+                  value={buttonLabel ?? ""}
+                  placeholder="Placeholder"
+                  role="combobox"
+                  onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                  aria-expanded={isPopoverOpen}
+                  aria-controls={popoverId}
+                  {...formButtonProps}
+                >
+                  {(selectedOptions.length > 0 || options.length > 0) && (
+                    <EuiNotificationBadge
+                      color={
+                        selectedOptions.length > 0 && !isDisabled
+                          ? "success"
+                          : "subdued"
+                      }
+                    >
+                      {selectedOptions.length > 0
+                        ? selectedOptions.length
+                        : options.length}
+                    </EuiNotificationBadge>
+                  )}
+                </EuiFormControlButton>
+              }
+              hasArrow={false}
+              repositionOnScroll
+              isOpen={isPopoverOpen}
+              panelPaddingSize="none"
+              panelMinWidth={200}
+              initialFocus={"[data-test-subj=panel-search-input]"}
+              closePopover={() => setIsPopoverOpen(false)}
+              panelProps={{
+                title: panelTitle,
+                "aria-label": panelTitle,
+              }}
+            >
+              <EuiFieldSearch
+                fullWidth
+                onChange={handleOnSearch}
+                value={searchValue}
+                data-test-subj="panel-search-input"
+                placeholder="search field"
+              />
 
-							<EuiSelectable
-								options={options}
-								onChange={handleOnChange}
-								id={popoverId}
-							>
-								{(list, search) => (
-									<>
-										{search}
-										{list}
-									</>
-								)}
-							</EuiSelectable>
-						</EuiInputPopover>
-					</EuiFormControlLayout>
-				</EuiFormRow>
-			</EuiForm>
-		</>
-	);
+              <EuiSelectable
+                options={options}
+                onChange={handleOnChange}
+                id={popoverId}
+              >
+                {(list, search) => (
+                  <>
+                    {search}
+                    {list}
+                  </>
+                )}
+              </EuiSelectable>
+            </EuiInputPopover>
+          </EuiFormControlLayout>
+        </EuiFormRow>
+      </EuiForm>
+    </>
+  );
 };
 ```
 

--- a/packages/website/docs/components/forms/layouts/form_control_buttons.mdx
+++ b/packages/website/docs/components/forms/layouts/form_control_buttons.mdx
@@ -21,7 +21,7 @@ Set `isDropdown` on **EuiFormControlLayout** to indicate a dropdown toggle that 
 :::
 
 ```tsx interactive
-import React, { useState, type ChangeEvent } from "react";
+import React, { useState, type ChangeEvent } from 'react';
 import {
   EuiFormRow,
   EuiFieldSearch,
@@ -36,16 +36,16 @@ import {
   EuiSpacer,
   EuiBadge,
   type EuiSelectableOption,
-} from "@elastic/eui";
+} from '@elastic/eui';
 
 const _options: EuiSelectableOption[] = [
-  { label: "Titan" },
-  { label: "Enceladus" },
-  { label: "Mimas" },
-  { label: "Dione" },
-  { label: "Iapetus" },
-  { label: "Phoebe" },
-  { label: "Rhea" },
+  { label: 'Titan' },
+  { label: 'Enceladus' },
+  { label: 'Mimas' },
+  { label: 'Dione' },
+  { label: 'Iapetus' },
+  { label: 'Phoebe' },
+  { label: 'Rhea' },
 ];
 
 export default () => {
@@ -56,12 +56,12 @@ export default () => {
   const [isClearable, setClearable] = useState(false);
 
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const [searchValue, setSearchValue] = useState("");
+  const [searchValue, setSearchValue] = useState('');
   const [options, setOptions] = useState(_options);
   const [selectedOptions, setSelectedOptions] = useState<EuiSelectableOption[]>(
     []
   );
-  const [buttonLabel, setButtonLabel] = useState("");
+  const [buttonLabel, setButtonLabel] = useState('');
 
   const formLayoutProps = {
     compressed: isCompressed,
@@ -77,8 +77,8 @@ export default () => {
     isInvalid,
   };
 
-  const popoverId = "popover-id";
-  const panelTitle = "popover-panel-title";
+  const popoverId = 'popover-id';
+  const panelTitle = 'popover-panel-title';
 
   const handleOnSearch = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);
@@ -95,17 +95,17 @@ export default () => {
     setOptions(options);
     const _selectedOptions = getSelectedOptions(options);
     setSelectedOptions(_selectedOptions);
-    setButtonLabel(_selectedOptions.map((opt) => opt.label).join(", "));
+    setButtonLabel(_selectedOptions.map((opt) => opt.label).join(', '));
   };
 
   const handleOnClear = () => {
     setOptions(_options);
     setSelectedOptions([]);
-    setButtonLabel("");
+    setButtonLabel('');
   };
 
   const getSelectedOptions = (options: EuiSelectableOption[]) => {
-    return options.filter((option) => option.checked === "on");
+    return options.filter((option) => option.checked === 'on');
   };
 
   return (
@@ -177,7 +177,7 @@ export default () => {
               ownFocus
               input={
                 <EuiFormControlButton
-                  value={buttonLabel ?? ""}
+                  value={buttonLabel ?? ''}
                   placeholder="Placeholder"
                   role="combobox"
                   onClick={() => setIsPopoverOpen(!isPopoverOpen)}
@@ -189,8 +189,8 @@ export default () => {
                     <EuiNotificationBadge
                       color={
                         selectedOptions.length > 0 && !isDisabled
-                          ? "success"
-                          : "subdued"
+                          ? 'success'
+                          : 'subdued'
                       }
                     >
                       {selectedOptions.length > 0
@@ -205,11 +205,11 @@ export default () => {
               isOpen={isPopoverOpen}
               panelPaddingSize="none"
               panelMinWidth={200}
-              initialFocus={"[data-test-subj=panel-search-input]"}
+              initialFocus="[data-test-subj=panel-search-input]"
               closePopover={() => setIsPopoverOpen(false)}
               panelProps={{
                 title: panelTitle,
-                "aria-label": panelTitle,
+                'aria-label': panelTitle,
               }}
             >
               <EuiFieldSearch

--- a/packages/website/docs/components/forms/layouts/form_control_buttons.mdx
+++ b/packages/website/docs/components/forms/layouts/form_control_buttons.mdx
@@ -83,8 +83,9 @@ export default () => {
   const handleOnSearch = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);
 
+    const search = e.target.value.toLowerCase();
     const filteredOptions = _options.filter((opt) => {
-      return opt.label.toLowerCase().includes(e.target.value);
+      return opt.label.toLowerCase().includes(search);
     });
 
     setOptions(filteredOptions);
@@ -104,9 +105,7 @@ export default () => {
   };
 
   const getSelectedOptions = (options: EuiSelectableOption[]) => {
-    return options
-      .map((option) => (option.checked === "on" ? option : null))
-      .filter((option) => option !== null);
+    return options.filter((option) => option.checked === "on");
   };
 
   return (

--- a/packages/website/docs/components/forms/numeric/basic.mdx
+++ b/packages/website/docs/components/forms/numeric/basic.mdx
@@ -4,6 +4,8 @@ sidebar_label: Number
 keywords: [EuiFieldNumber]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Basic number field
 
 import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
@@ -12,9 +14,11 @@ import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
 
 Use a **EuiFieldNumber** to allow users to enter numbers. This component renders a basic HTML `<input type="number">` element.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiFieldNumber } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [value, setValue] = useState('');
@@ -36,6 +40,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Native validation
 

--- a/packages/website/docs/components/forms/numeric/range-sliders.mdx
+++ b/packages/website/docs/components/forms/numeric/range-sliders.mdx
@@ -2,6 +2,8 @@
 keywords: [EuiRange, EuiDualRange]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Range sliders
 
 :::tip Understanding precision
@@ -554,6 +556,7 @@ export default () => {
 
 Passing `showInput="inputWithPopover"` instead of a boolean will only display the inputs until the input is interacted with in which case a dropdown will appear displaying the actual slider.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import {
@@ -564,6 +567,7 @@ import {
   EuiDualRangeProps,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [value, setValue] = useState<EuiRangeProps['value']>('20');
@@ -623,11 +627,13 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Kitchen sink
 
 Other alterations you can add to the range are `fullWidth`, and `disabled`.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import {
@@ -637,6 +643,7 @@ import {
   EuiDualRangeProps,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [value, setValue] = useState('20');
@@ -706,6 +713,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Props
 

--- a/packages/website/docs/components/forms/other/color-picker.mdx
+++ b/packages/website/docs/components/forms/other/color-picker.mdx
@@ -3,6 +3,8 @@ sidebar_position: 2
 keywords: [EuiColorPicker]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Color picker
 
 Color input component allowing for multiple methods of entry and selection.
@@ -33,8 +35,10 @@ Use the `palettes` prop to pass your palettes as an array `strings` or an array 
 
 Each of the `palettes`, excluding `type='text'` palettes, can use the `append` prop to append an element to the right of the title.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { css } from '@emotion/react';
 import {
   euiPaletteColorBlind,
   euiPaletteForStatus,
@@ -42,11 +46,13 @@ import {
   EuiSwitch,
   EuiSpacer,
   EuiCode,
+  EuiText,
   EuiColorPalettePicker,
-  EuiFlexGroup
-  EUI_VIS_COLOR_STORE
+  EuiFlexGroup,
+  EUI_VIS_COLOR_STORE,
 } from '@elastic/eui';
 import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
+import { DisplayToggles } from './display_toggles';
 
 const getPalettes = (appendTitles) => [
   {
@@ -192,6 +198,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Color palette display
 
@@ -796,9 +803,11 @@ export default () => {
 
 ## Option toggling
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React from 'react';
 import { EuiColorPicker, useColorPickerState } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [color, setColor] = useColorPickerState('#D36086');
@@ -811,6 +820,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Props
 

--- a/packages/website/docs/components/forms/other/file-picker.mdx
+++ b/packages/website/docs/components/forms/other/file-picker.mdx
@@ -108,12 +108,12 @@ import {
 } from '@elastic/eui';
 
 export default () => {
-  const [files, setFiles] = useState({});
+  const [files, setFiles] = useState(null);
   const filePickerRef = useRef();
   const removeFilePickerId = useGeneratedHtmlId({ prefix: 'removeFilePicker' });
 
   const onChange = (files) => {
-    setFiles(files.length > 0 ? files : {});
+    setFiles(files);
   };
 
   return (
@@ -135,7 +135,7 @@ export default () => {
             <EuiButton
               color="danger"
               iconType="trash"
-              disabled={files.length > 0 ? false : true}
+              disabled={!files}
               onClick={() => filePickerRef.current.removeFiles()}
             >
               <h3>Remove files</h3>

--- a/packages/website/docs/components/forms/other/file-picker.mdx
+++ b/packages/website/docs/components/forms/other/file-picker.mdx
@@ -3,10 +3,13 @@ sidebar_position: 1
 keywords: [EuiFilePicker]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # File picker
 
 **EuiFilePicker** is a stylized, but generic HTML `<input type="file">` tag. It supports drag and drop as well as on click style selection of files. The example below shows how to grab the files using the <a href="https://developer.mozilla.org/en-US/docs/Web/API/FileList" target="_blank">FileList API</a>. Like other form elements, you can wrap it in an [EuiFormRow](../layouts/row.mdx) to apply a label.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import {
@@ -18,6 +21,7 @@ import {
   EuiSwitch,
   useGeneratedHtmlId,
 } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [files, setFiles] = useState({});
@@ -87,6 +91,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Removing files programmatically
 

--- a/packages/website/docs/components/forms/other/palette-picker.mdx
+++ b/packages/website/docs/components/forms/other/palette-picker.mdx
@@ -3,6 +3,8 @@ sidebar_position: 3
 keywords: [EuiColorPalettePicker, EuiColorPaletteDisplay]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Color palette picker
 
 Use **EuiColorPalettePicker** to select palettes to apply colors to data visualization like maps and charts.
@@ -11,6 +13,7 @@ Use the `palettes` prop to pass your palettes as an array `strings` or an array 
 
 Each of the `palettes`, excluding `type='text'` palettes, can use the `append` prop to append an element to the right of the title.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import {
@@ -23,6 +26,7 @@ import {
   EuiColorPalettePicker,
   EuiFlexGroup
 } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 const getPalettes = (appendTitles) => [
   {
@@ -154,6 +158,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Color palette display
 

--- a/packages/website/docs/components/forms/search-and-filter/search.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search.mdx
@@ -4,6 +4,8 @@ sidebar_label: Search
 keywords: [EuiFieldSearch]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Basic search field
 
 Use **EuiFieldSearch** to allow users to enter search queries. This component renders a basic HTML `<input type="search">` element.
@@ -12,9 +14,11 @@ import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
 
 <EuiFormRowCallout />
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiFieldSearch, EuiSwitch } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [isClearable, setIsClearable] = useState(true);
@@ -51,6 +55,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Searching on enter key
 

--- a/packages/website/docs/components/forms/search-and-filter/search.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search.mdx
@@ -99,7 +99,7 @@ To search as the user types into the field, set the `incremental` prop to `true`
 
 ```tsx interactive
 import React, { useState } from 'react';
-import { EuiFieldSearch, EuiSwitch } from '@elastic/eui';
+import { EuiFieldSearch, EuiFormRow, EuiSpacer } from '@elastic/eui';
 
 export default () => {
   const [searchValue, setSearchValue] = useState('');

--- a/packages/website/docs/components/forms/selection/basic-select.mdx
+++ b/packages/website/docs/components/forms/selection/basic-select.mdx
@@ -3,6 +3,8 @@ sidebar_position: 2
 keywords: [EuiSelect]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Basic select
 
 ```mdx-code-block
@@ -13,9 +15,11 @@ import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
 
 Use **EuiSelect** to allow users to choose from a list of 7 to 12 options. When there are less than 7 options consider using a [EuiRadioGroup](./radio-and-radio-group.mdx#radio-group). For more details on which selection component to use, see the [Component comparison](./overview.mdx).
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiSelect, useGeneratedHtmlId } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const options = [
@@ -46,6 +50,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 <EuiFormRowCallout />
 

--- a/packages/website/docs/components/forms/selection/checkbox-and-checkbox-group.mdx
+++ b/packages/website/docs/components/forms/selection/checkbox-and-checkbox-group.mdx
@@ -3,6 +3,8 @@ sidebar_position: 6
 keywords: [EuiCheckbox, EuiCheckboxGroup]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Checkbox and Checkbox group
 
 ```mdx-code-block
@@ -94,9 +96,11 @@ When the individual labels for each radio do not provide a sufficient descriptio
 
 Use the `compressed` prop to tighten up the spacing between checkbox rows.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiCheckboxGroup, useGeneratedHtmlId } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const checkboxGroupItemId__1 = useGeneratedHtmlId({
@@ -160,6 +164,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Usage
 

--- a/packages/website/docs/components/forms/selection/combo-box.mdx
+++ b/packages/website/docs/components/forms/selection/combo-box.mdx
@@ -3,6 +3,8 @@ sidebar_position: 4
 keywords: [EuiComboBox]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Combo box
 
 ```mdx-code-block
@@ -19,9 +21,11 @@ Use **EuiComboBox** when:
 
 For more details on which selection component to use, see the [Component comparison](./overview.mdx).
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiComboBox } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 const optionsStatic = [
   {
@@ -108,6 +112,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 <EuiFormRowCallout />
 
@@ -415,9 +420,11 @@ export default () => {
 
 Useful for visualization or tagging systems. You can also pass a color in your option list. The color can be a hex value (like `#000`) or any other named color value accepted by the [**EuiBadge**](../../display/badge/index.mdx) component.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState, useEffect } from 'react';
 import { EuiComboBox, useEuiPaletteColorBlindBehindText } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 const getOptionsStatic = (visColorsBehindText) => [
   {
@@ -524,6 +531,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Option rendering
 
@@ -612,7 +620,7 @@ You can use the `value` prop of the `option` object to store metadata about the 
 **Note:** virtualization (above) requires that each option have the same height. Ensure that you render the options so that wrapping text is truncated instead of causing the height of the option to change.
 
 ```tsx interactive
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   EuiComboBox,
   EuiHighlight,
@@ -1075,9 +1083,11 @@ export default () => {
 
 To only allow the user to select a single option, provide the `singleSelection` prop. You may want to render the selected option as plain text instead of pill form. To do this, pass `singleSelection={{ asPlainText: true }}`
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiComboBox } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 const options = [
   {
@@ -1144,6 +1154,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ### Single selection with prepended label
 

--- a/packages/website/docs/components/forms/selection/radio-and-radio-group.mdx
+++ b/packages/website/docs/components/forms/selection/radio-and-radio-group.mdx
@@ -3,6 +3,8 @@ sidebar_position: 7
 keywords: [EuiRadio, EuiRadioGroup]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Radio and Radio group
 
 ```mdx-code-block
@@ -77,9 +79,11 @@ Use a **EuiRadioGroup** when you want to generate a group of radio buttons by pa
 
 When the individual labels for each radio do not provide a sufficient description, pass a `legend` to the group.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiRadioGroup, useGeneratedHtmlId } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const radioGroupItemId__1 = useGeneratedHtmlId({
@@ -138,6 +142,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 ## Usage
 

--- a/packages/website/docs/components/forms/selection/super-select.mdx
+++ b/packages/website/docs/components/forms/selection/super-select.mdx
@@ -3,6 +3,8 @@ sidebar_position: 3
 keywords: [EuiSuperSelect]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Super select
 
 ```mdx-code-block
@@ -150,9 +152,11 @@ export default () => {
 
 You can pass the same props as you normally would to **EuiSelect** like disabled, isLoading, compressed, etc.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiSuperSelect } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const options = [
@@ -193,6 +197,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 import FormUsage from '../_partials/form-usage.mdx';
 
 <FormUsage />

--- a/packages/website/docs/components/forms/selection/switch.mdx
+++ b/packages/website/docs/components/forms/selection/switch.mdx
@@ -3,6 +3,8 @@ sidebar_position: 8
 keywords: [EuiSwitch]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Switch
 
 ```mdx-code-block
@@ -11,9 +13,11 @@ import { EuiBasicTable, EuiFlexGrid, EuiFormRow, EuiSwitch, useEuiTheme } from '
 
 An **EuiSwitch** can be substituted for an **EuiCheckbox** when the semantics of the label dictate a true on/off state.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiSwitch } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [checked, setChecked] = useState(false);
@@ -39,6 +43,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 Make sure to pass a `label` to ensure a larger clickable area and ensure that screen readers will read out the label when the user is focused on the input.
 

--- a/packages/website/docs/components/forms/text/basic.mdx
+++ b/packages/website/docs/components/forms/text/basic.mdx
@@ -4,6 +4,8 @@ sidebar_label: Text
 keywords: [EuiFieldText, EuiTextArea]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Basic text controls
 
 import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
@@ -14,9 +16,11 @@ import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
 
 Use a **EuiFieldText** to allow users to enter or edit text. This component renders a basic HTML `<input type="text">` element.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiFieldText } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default function () {
   const [value, setValue] = useState('');
@@ -38,14 +42,17 @@ export default function () {
   );
 }
 ```
+</Demo>
 
 ## Textarea
 
 Use **EuiTextArea** to allow users to enter multi-line text. This component renders a basic HTML `<textarea />` element.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiTextArea } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default () => {
   const [value, setValue] = useState('');
@@ -67,6 +74,7 @@ export default () => {
   );
 };
 ```
+</Demo>
 
 import FormUsage from '../_partials/form-usage.mdx';
 

--- a/packages/website/docs/components/forms/text/password.mdx
+++ b/packages/website/docs/components/forms/text/password.mdx
@@ -2,6 +2,8 @@
 keywords: [EuiFieldPassword]
 ---
 
+import displayTogglesSource from '!raw-loader!../../../../src/components/display_toggles/display_toggles';
+
 # Password field
 
 import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
@@ -10,9 +12,11 @@ import EuiFormRowCallout from '../layouts/_form_row_callout.mdx';
 
 Use a **EuiFieldPassword** to allow users to enter a password. By default, it renders a basic HTML `<input type="password">` where the content is obfuscated. When users type in the field the characters are presented as asterisks.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiFieldPassword } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default function () {
   const [value, setValue] = useState('');
@@ -33,14 +37,17 @@ export default function () {
   );
 }
 ```
+</Demo>
 
 ## Showing passwords
 
 You can allow users to toggle between showing and obfuscating the password by passing the `type="dual"` prop. This option makes the experience more user-friendly and accessible.
 
+<Demo extraFiles={{ 'display_toggles.tsx': displayTogglesSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 import { EuiFieldPassword } from '@elastic/eui';
+import { DisplayToggles } from './display_toggles';
 
 export default function () {
   const [value, setValue] = useState('');
@@ -62,6 +69,7 @@ export default function () {
   );
 }
 ```
+</Demo>
 import FormUsage from '../_partials/form-usage.mdx';
 
 <FormUsage />

--- a/packages/website/docs/components/layout/flex/flex_preview_wrapper.tsx
+++ b/packages/website/docs/components/layout/flex/flex_preview_wrapper.tsx
@@ -1,6 +1,10 @@
 import { PropsWithChildren } from 'react';
 import { css } from '@emotion/react';
-import { transparentize, useEuiMemoizedStyles, type UseEuiTheme } from '@elastic/eui';
+import {
+  transparentize,
+  useEuiMemoizedStyles,
+  type UseEuiTheme,
+} from '@elastic/eui';
 
 const getFlexPreviewWrapperStyles = ({ euiTheme }: UseEuiTheme) => css`
   .euiFlexItem {
@@ -9,12 +13,10 @@ const getFlexPreviewWrapperStyles = ({ euiTheme }: UseEuiTheme) => css`
   }
 `;
 
-export const FlexPreviewWrapper = ({ children }: PropsWithChildren) => {
+const FlexPreviewWrapper = ({ children }: PropsWithChildren) => {
   const styles = useEuiMemoizedStyles(getFlexPreviewWrapperStyles);
 
-  return (
-    <div css={styles}>
-      {children}
-    </div>
-  );
+  return <div css={styles}>{children}</div>;
 };
+
+export default FlexPreviewWrapper;

--- a/packages/website/docs/components/layout/flex/grid.mdx
+++ b/packages/website/docs/components/layout/flex/grid.mdx
@@ -87,7 +87,7 @@ The `gutterSize` prop can be applied to a parent **EuiFlexGrid** to adjust the s
 <FlexDemo>
   ```tsx
   import React, { Fragment } from 'react';
-  import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+  import { EuiFlexGrid, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 
   const gutterSizes = {
     'none': 'None',
@@ -107,7 +107,7 @@ The `gutterSize` prop can be applied to a parent **EuiFlexGrid** to adjust the s
             <EuiFlexItem>{text}</EuiFlexItem>
             <EuiFlexItem>{text}</EuiFlexItem>
             <EuiFlexItem>{text}</EuiFlexItem>
-          </EuiFlexGroup>
+          </EuiFlexGrid>
           <EuiSpacer size="m" />
         </Fragment>
       ))}

--- a/packages/website/docs/components/layout/flex/grid.mdx
+++ b/packages/website/docs/components/layout/flex/grid.mdx
@@ -5,13 +5,16 @@ keywords: [EuiFlexGrid]
 
 # Flex grids
 
+```mdx-code-block
 import { createDemo } from '@elastic/eui-docusaurus-theme/components';
-import { FlexPreviewWrapper } from './flex_preview_wrapper';
+import FlexPreviewWrapper from './flex_preview_wrapper';
+import flexPreviewWrapperSource from '!raw-loader!./flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 
-export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper });
+export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper, previewWrapperSource: flexPreviewWrapperSource });
 
 <DemoNote />
+```
 
 **EuiFlexGrid** is a more rigid component, used for repeatable rows of same-width items. You can set a `columns` prop to specify anywhere between 1-4 columns. Any more would likely break on laptop screens.
 

--- a/packages/website/docs/components/layout/flex/group.mdx
+++ b/packages/website/docs/components/layout/flex/group.mdx
@@ -5,13 +5,16 @@ keywords: [EuiFlexGroup]
 
 # Flex groups
 
+```mdx-code-block
 import { createDemo } from '@elastic/eui-docusaurus-theme/components';
-import { FlexPreviewWrapper } from './flex_preview_wrapper';
+import FlexPreviewWrapper from './flex_preview_wrapper';
+import flexPreviewWrapperSource from '!raw-loader!./flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 
-export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper });
+export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper, previewWrapperSource: flexPreviewWrapperSource });
 
 <DemoNote />
+```
 
 **EuiFlexGroup** is useful for setting up layouts for a single row of content. By default, any [EuiFlexItem](./item.mdx) within **EuiFlexGroup** will stretch and grow to match their siblings.
 

--- a/packages/website/docs/components/layout/flex/index.mdx
+++ b/packages/website/docs/components/layout/flex/index.mdx
@@ -1,8 +1,11 @@
 # Flex
 
+```mdx-code-block
 import { createDemo } from '@elastic/eui-docusaurus-theme/components';
-import { FlexPreviewWrapper } from './flex_preview_wrapper';
+import FlexPreviewWrapper from './flex_preview_wrapper';
+import flexPreviewWrapperSource from '!raw-loader!./flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
+```
 
 ## Use cases
 
@@ -12,9 +15,11 @@ import DemoNote from './_flex_preview_note.mdx';
 
 ## Shared behavior
 
-export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper });
+```mdx-code-block
+export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper, previewWrapperSource: flexPreviewWrapperSource });
 
 <DemoNote />
+```
 
 ### Nesting flex layouts
 

--- a/packages/website/docs/components/layout/flex/item.mdx
+++ b/packages/website/docs/components/layout/flex/item.mdx
@@ -48,7 +48,7 @@ Alternatively, you can sometimes opt to omit **EuiFlexItem** completely.
 <FlexDemo>
   ```tsx
   import React from 'react';
-  import { EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
+  import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiPanel } from '@elastic/eui';
 
   export default () => (
     <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">

--- a/packages/website/docs/components/layout/flex/item.mdx
+++ b/packages/website/docs/components/layout/flex/item.mdx
@@ -9,13 +9,16 @@ keywords: [EuiFlexItem]
 To work correctly, **EuiFlexItem** must be a **direct child** of [EuiFlexGroup](./group.mdx) or [EuiFlexGrid](./grid.mdx). You cannot have any intermediate HTML wrappers between them.
 :::
 
+```mdx-code-block
 import { createDemo } from '@elastic/eui-docusaurus-theme/components';
-import { FlexPreviewWrapper } from './flex_preview_wrapper';
+import FlexPreviewWrapper from './flex_preview_wrapper';
+import flexPreviewWrapperSource from '!raw-loader!./flex_preview_wrapper';
 import DemoNote from './_flex_preview_note.mdx';
 
-export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper });
+export const FlexDemo = createDemo({ previewWrapper: FlexPreviewWrapper, previewWrapperSource: flexPreviewWrapperSource });
 
 <DemoNote />
+```
 
 ## Flex items are also flex
 

--- a/packages/website/docs/components/layout/page_components/index.mdx
+++ b/packages/website/docs/components/layout/page_components/index.mdx
@@ -13,6 +13,9 @@ import fakeParagraph from '!url-loader!./fake_paragraph.svg';
 import { PageComponentsPreviewWrapper, FixedHeightPreviewWrapper } from './_preview_wrapper';
 ```
 
+import fakeSidebarSource from '!raw-loader!./fake_sidebar.svg';
+import fakeParagraphSource from '!raw-loader!./fake_paragraph.svg';
+
 Page layouts are modular and fit together in a precise manner, though certain parts can also be added or removed as needed. EUI provides both the **individual page components** and an [over-arching template](../../templates/page-template/index.mdx) for easily creating some pre-defined layouts.
 
 ## Components
@@ -29,7 +32,7 @@ If you're looking for full page layout examples, we recommend using the [EuiPage
 
 **EuiPageSidebar** doesn't contain many configurations itself, but it does dictate how the rest of the page contents should be displayed. Typically you'll want to wrap all your page contents in **EuiPageBody** and set `panelled={true}` when you have a side bar.
 
-<Demo scope={{ fakeParagraph, fakeSidebar }} previewPadding="none" previewWrapper={FixedHeightPreviewWrapper}>
+<Demo scope={{ fakeParagraph, fakeSidebar }} previewPadding="none" previewWrapper={FixedHeightPreviewWrapper} extraFiles={{ 'fake_sidebar.svg': fakeSidebarSource, 'fake_paragraph.svg': fakeParagraphSource }}>
 
   ```tsx
   import React, { useState } from 'react';
@@ -45,6 +48,8 @@ If you're looking for full page layout examples, we recommend using the [EuiPage
     EuiSwitch,
     useEuiTheme,
   } from '@elastic/eui';
+  import fakeSidebar from './fake_sidebar.svg';
+  import fakeParagraph from './fake_paragraph.svg';
 
   export default () => {
     const { euiTheme } = useEuiTheme();
@@ -119,11 +124,13 @@ If you're looking for full page layout examples, we recommend using the [EuiPage
 
 To create dividers between contents, use the `bottomBorder` prop. The `'extended'` version ensures the border touches the sides of the parent. It also supports `restrictWidth` and `alignment` to align with common usages.
 
-<Demo scope={{ fakeParagraph }} previewPadding="none" previewWrapper={PageComponentsPreviewWrapper}>
+<Demo scope={{ fakeParagraph }} previewPadding="none" previewWrapper={PageComponentsPreviewWrapper} extraFiles={{ 'fake_paragraph.svg': fakeParagraphSource }}>
   ```tsx interactive
   import React, { useState } from 'react';
+  import { css } from '@emotion/react';
 
-  import { EuiPageHeader, EuiPageSection, useEuiTheme } from '@elastic/eui';
+  import { EuiFlexGroup, EuiSwitch, EuiImage, EuiPageHeader, EuiPageSection, useEuiTheme } from '@elastic/eui';
+  import fakeParagraph from './fake_paragraph.svg';
 
   export default () => {
     const { euiTheme } = useEuiTheme();
@@ -204,7 +211,7 @@ import { ConfigurationsTable } from './configurations_table';
 Reminder: [EuiPageTemplate](../../templates/page-template/index.mdx) can handle all these configurations for you.
 :::
 
-<Demo scope={{ fakeParagraph, fakeSidebar }} previewPadding="none" previewWrapper={PageComponentsPreviewWrapper}>
+<Demo scope={{ fakeParagraph, fakeSidebar }} previewPadding="none" previewWrapper={PageComponentsPreviewWrapper} extraFiles={{ 'fake_sidebar.svg': fakeSidebarSource, 'fake_paragraph.svg': fakeParagraphSource }}>
   ```tsx
   import React, { ReactElement, useState } from 'react';
   import { css } from '@emotion/react';
@@ -221,6 +228,8 @@ Reminder: [EuiPageTemplate](../../templates/page-template/index.mdx) can handle 
     EuiSwitch,
     useEuiTheme,
   } from '@elastic/eui';
+  import fakeSidebar from './fake_sidebar.svg';
+  import fakeParagraph from './fake_paragraph.svg';
 
   export default () => {
     const { euiTheme } = useEuiTheme();

--- a/packages/website/docs/components/navigation/buttons/button.mdx
+++ b/packages/website/docs/components/navigation/buttons/button.mdx
@@ -458,7 +458,7 @@ import React, { useState } from 'react';
 
 import {
   EuiButton,
-  EuiButtonIcon
+  EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';

--- a/packages/website/docs/components/navigation/buttons/group.mdx
+++ b/packages/website/docs/components/navigation/buttons/group.mdx
@@ -288,7 +288,7 @@ Read more about [custom disabled behavior](./button.mdx#disabled-and-focusable-)
 ```tsx interactive
 import React, { useState } from 'react';
 
-import { EuiButtonGroup } from '@elastic/eui';
+import { EuiButtonGroup, EuiSwitch, EuiSpacer, EuiFormRow } from '@elastic/eui';
 
 export default () => {
   const toggleButtons = [

--- a/packages/website/docs/components/navigation/facet.mdx
+++ b/packages/website/docs/components/navigation/facet.mdx
@@ -210,7 +210,7 @@ import {
   EuiFacetGroup,
   EuiIcon,
   EuiAvatar,
-  euiPaletteColorBlind,
+  useEuiPaletteColorBlind,
 } from '@elastic/eui';
 
 export default () => {

--- a/packages/website/docs/components/tables/basic.mdx
+++ b/packages/website/docs/components/tables/basic.mdx
@@ -41,7 +41,7 @@ for (let i = 0; i < 10; i++) {
     id: faker.string.uuid(),
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
-    github: faker.internet.userName(),
+    github: faker.internet.username(),
     dateOfBirth: faker.date.past(),
     online: faker.datatype.boolean(),
   });
@@ -727,7 +727,7 @@ for (let i = 0; i < 5; i++) {
     id: faker.string.uuid(),
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
-    github: faker.internet.userName(),
+    github: faker.internet.username(),
     dateOfBirth: faker.date.past(),
     online: i === 0 ? true : faker.datatype.boolean(),
   });
@@ -792,7 +792,6 @@ export default () => {
   ];
 
   const getRowProps = (user: User) => {
-    const { id } = user;
     return {
       className: user.online ? 'euiTableRow--marked' : ''
     };
@@ -966,7 +965,6 @@ type User = {
   firstName: string | null | undefined;
   lastName: string;
   github: string;
-  dateOfBirth: Date;
   jobTitle: string;
   address: string;
 };
@@ -978,7 +976,7 @@ for (let i = 0; i < 10; i++) {
     id: i + 1,
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
-    github: faker.internet.userName(),
+    github: faker.internet.username(),
     jobTitle: faker.person.jobTitle(),
     address: `${faker.location.streetAddress()} ${faker.location.city()} ${faker.location.state(
       { abbreviated: true }
@@ -1093,8 +1091,8 @@ export default () => {
 
   const onTableLayoutChange = (id: string, value: string) => {
     setTableLayout(id);
-    columns[4].width = value === 'custom' ? '100px' : undefined;
-    columns[5].width = value === 'custom' ? '20%' : undefined;
+    columns[3].width = value === 'custom' ? '100px' : undefined;
+    columns[4].width = value === 'custom' ? '20%' : undefined;
   };
 
   const onVAlignChange = (id: string, value: 'top' | 'middle' | 'bottom') => {
@@ -1178,12 +1176,8 @@ To customize how your cells look in mobile vs. desktop view, use the `mobileOpti
 import React, { useState } from 'react';
 import {
   formatDate,
-  Comparators,
   EuiBasicTable,
   EuiBasicTableColumn,
-  EuiTableSelectionType,
-  EuiTableSortingType,
-  Criteria,
   EuiLink,
   EuiHealth,
   EuiFlexGroup,
@@ -1213,7 +1207,7 @@ for (let i = 0; i < 3; i++) {
     id: i + 1,
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
-    github: faker.internet.userName(),
+    github: faker.internet.username(),
     dateOfBirth: faker.date.past(),
     online: faker.datatype.boolean(),
     location: {
@@ -1246,6 +1240,7 @@ export default () => {
    */
   const [customHeader, setCustomHeader] = useState(true);
   const [isResponsive, setIsResponsive] = useState(true);
+  const [selectedItems, setSelectedItems] = useState<User[]>([]);
 
   const columns: Array<EuiBasicTableColumn<User>> = [
     {

--- a/packages/website/docs/components/templates/page-template/guidelines.mdx
+++ b/packages/website/docs/components/templates/page-template/guidelines.mdx
@@ -12,11 +12,15 @@ Try to use as much of the namespaced (e.g. `<EuiPageTemplate.Header />`) as much
 
 import contentCenterSvg from '!url-loader!./content_center.svg';
 import singleSvg from '!url-loader!./content_single.svg';
+import contentCenterSvgSource from '!raw-loader!./content_center.svg';
+import singleSvgSource from '!raw-loader!./content_single.svg';
 
-<Demo scope={{ singleSvg, contentCenterSvg }}>
+<Demo scope={{ singleSvg, contentCenterSvg }} extraFiles={{ 'content_single.svg': singleSvgSource, 'content_center.svg': contentCenterSvgSource }}>
   ```tsx
   import React from 'react';
   import { EuiPageTemplate, EuiPageSection, EuiImage } from '@elastic/eui';
+  import singleSvg from './content_single.svg';
+  import contentCenterSvg from './content_center.svg';
 
   export default () => {
     return (

--- a/packages/website/docs/components/templates/sitewide-search/index.mdx
+++ b/packages/website/docs/components/templates/sitewide-search/index.mdx
@@ -397,6 +397,9 @@ import { Example } from '@site/src/components';
 </Example.Snippet>
 
 ```tsx interactive
+import React from 'react';
+import { EuiSelectableTemplateSitewide } from '@elastic/eui';
+
 export default () => {
   return (
     <EuiSelectableTemplateSitewide

--- a/packages/website/docs/dataviz/accessibility-features.mdx
+++ b/packages/website/docs/dataviz/accessibility-features.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 3
 ---
 
+import useChartBaseThemeSource from '!raw-loader!./use_chart_base_theme';
+
 # Accessibility features
 
 import VersionBadge from './version_badge';
@@ -102,11 +104,13 @@ In version 64.1.0, data tables are only available for **partition charts**.
 Partition charts include: sunburst, treemap, icicle, flame, mosaic, and waffle.
 :::
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiTitle, EuiSpacer, htmlIdGenerator } from '@elastic/eui';
   import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const chartBaseTheme = useChartBaseTheme();
@@ -217,7 +221,7 @@ In version 64.1.0, texture fills are only available for **XY charts**.
 XY charts include: area, bar, and histogram.
 :::
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiSpacer, EuiTitle, htmlIdGenerator } from '@elastic/eui';
@@ -229,6 +233,8 @@ XY charts include: area, bar, and histogram.
     Axis,
     Position,
   } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   const SAMPLE_SMALL_DATA = [
     { x: 0, y: 10.934269 },
@@ -337,7 +343,7 @@ You can add meaning to your color segments by using the `bandLabels` prop.
 In version 64.1.0, semantic groupings are only available for **goal and gauge charts**.
 :::
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -350,6 +356,8 @@ In version 64.1.0, semantic groupings are only available for **goal and gauge ch
     useEuiTheme,
   } from '@elastic/eui';
   import { Chart, Settings, Goal } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const id = htmlIdGenerator()();

--- a/packages/website/docs/dataviz/sizing.mdx
+++ b/packages/website/docs/dataviz/sizing.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 5
 ---
 
+import useChartBaseThemeSource from '!raw-loader!./use_chart_base_theme';
+
 # Sizing
 
 import VersionBadge from './version_badge';
@@ -50,7 +52,7 @@ import * as ElasticCharts from '@elastic/charts';
 import { useChartBaseTheme } from './use_chart_base_theme';
 ```
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -72,6 +74,8 @@ import { useChartBaseTheme } from './use_chart_base_theme';
     AreaSeries,
     PartialTheme,
   } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   /**
    * Example sparkline styles to match `ThemeService.useSparklineOverrides` from kibana `charts` plugin

--- a/packages/website/docs/dataviz/theming.mdx
+++ b/packages/website/docs/dataviz/theming.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 6
 ---
 
+import useChartBaseThemeSource from '!raw-loader!./use_chart_base_theme';
+
 # Theming
 
 import VersionBadge from './version_badge';
@@ -53,7 +55,7 @@ const MyChart = () => {
 
 You'll find an example of these in the demo below.
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React, { useState } from 'react';
   import {
@@ -81,6 +83,7 @@ You'll find an example of these in the demo below.
     DataGenerator,
   } from '@elastic/charts';
   import { VIS_COLOR_STORE_EVENTS } from '@elastic/eui-theme-common';
+  import { useChartBaseTheme } from './use_chart_base_theme';
 
   const getPaletteData = () => ({
   euiPaletteColorBlind,

--- a/packages/website/docs/dataviz/types/metric-chart.mdx
+++ b/packages/website/docs/dataviz/types/metric-chart.mdx
@@ -2,6 +2,8 @@
 sidebar_position: 4
 ---
 
+import useChartBaseThemeSource from '!raw-loader!../use_chart_base_theme';
+
 # Metric chart
 
 import VersionBadge from '../version_badge';
@@ -59,11 +61,13 @@ The `color` attribute can be used to render a color background. Such color can b
 
 If the passed `value` is a `Number` then you must provide a `valueFormatter`, if instead is a `String` then the `valueFormatter` is not required.
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React, { useState } from 'react';
   import { EuiFlexGroup, EuiFlexItem, EuiPanel, EuiRange } from '@elastic/eui';
   import { Chart, Metric, Settings } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const chartBaseTheme = useChartBaseTheme();
@@ -187,11 +191,13 @@ If your metric chart could display negative values (such as temperature, variati
 
 To use this progress bar, your data should adhere to the `MetricWProgress` type. In particular, in addition to the already required properties you have to specify the maximum value the progress bar can reach through the `domainMax` prop and you have to specify a progress bar direction via `progressBarDirection`.
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiFlexGroup, EuiFlexItem, EuiPanel } from '@elastic/eui';
   import { Chart, LayoutDirection, Metric, Settings } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const chartBaseTheme = useChartBaseTheme();
@@ -278,11 +284,13 @@ The trend is then rendered following these principles:
 *   the horizontal space represents the range from the minimum to the maximum `x` value
 *   the trend height is limited to 50% of the overall Metric height, so the maximum `y` value always touches the vertical middle of the metric chart.
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiPanel } from '@elastic/eui';
   import { Chart, Metric, Settings } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const chartBaseTheme = useChartBaseTheme();
@@ -338,11 +346,13 @@ Providing the following data structure `data={[[{col1}, {col2}, {col3}]]}`you wi
 
 You can align vertically the progress bars' directions to compare values using `LayoutDirection.Vertical`
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiPanel } from '@elastic/eui';
   import { Chart, LayoutDirection, Metric, Settings } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const chartBaseTheme = useChartBaseTheme();
@@ -395,11 +405,13 @@ Providing the following data structure `data={[[{col1}], [{col2}], [{col3}]]}`yo
 
 You can align horizontally the progress bars directions to compare values using `LayoutDirection.Horizontal`
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiPanel } from '@elastic/eui';
   import { Chart, LayoutDirection, Metric, Settings } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   export default () => {
     const chartBaseTheme = useChartBaseTheme();
@@ -456,11 +468,13 @@ You can mix columns and rows in the `data` array to create a grid. The grid is f
 
 Different types of metrics can be mixed together.
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import { EuiIcon, EuiPanel } from '@elastic/eui';
   import { Chart, Metric, MetricSpec, Settings } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   const osTrend = Array.from({ length: 30 }).map((d, i) => ({
     x: i,

--- a/packages/website/docs/dataviz/types/part-to-whole-comparisons.mdx
+++ b/packages/website/docs/dataviz/types/part-to-whole-comparisons.mdx
@@ -2,6 +2,9 @@
 sidebar_position: 3
 ---
 
+import useChartBaseThemeSource from '!raw-loader!../use_chart_base_theme';
+import dataSource from '!raw-loader!../data';
+
 # Part to whole comparisons
 
 import VersionBadge from '../version_badge';
@@ -24,7 +27,7 @@ import { useChartBaseTheme } from '../use_chart_base_theme';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 ```
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -41,6 +44,8 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
     PartitionLayout,
     PartialTheme,
   } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
 
   const STATUS_DATA = [
     {
@@ -173,7 +178,7 @@ Below are some basic examples and how EUI supports them with theming. However, t
 import { GITHUB_DATASET_MOD } from '../data';
 ```
 
-<Demo scope={{ ...ElasticCharts, useChartBaseTheme, GITHUB_DATASET_MOD }}>
+<Demo scope={{ ...ElasticCharts, useChartBaseTheme, GITHUB_DATASET_MOD }} extraFiles={{ 'use_chart_base_theme.ts': useChartBaseThemeSource, 'data.tsx': dataSource }}>
   ```tsx
   import React from 'react';
   import {
@@ -184,6 +189,9 @@ import { GITHUB_DATASET_MOD } from '../data';
     useEuiPaletteColorBlind,
   } from '@elastic/eui';
   import { Chart, Partition, Settings, PartitionLayout } from '@elastic/charts';
+  import { useChartBaseTheme } from './use_chart_base_theme';
+
+  import { GITHUB_DATASET_MOD } from './data';
 
 
   type DataType = (typeof GITHUB_DATASET_MOD)[0];

--- a/packages/website/docs/utilities/accessibility/index.mdx
+++ b/packages/website/docs/utilities/accessibility/index.mdx
@@ -18,16 +18,21 @@ Using `EuiScreenReaderOnly` hides the wrapped element from the page, but keeps i
 
 <Demo>
   ```tsx
-  <EuiText>
-    <p>This is the first paragraph. It is visible to all.</p>
-    <EuiScreenReaderOnly>
-      <p>
-      This is the second paragraph. It is hidden for sighted users but visible
-      to screen readers.
-      </p>
-    </EuiScreenReaderOnly>
-    <p>This is the third paragraph. It is visible to all.</p>
-  </EuiText>
+  import React from 'react';
+  import { EuiText, EuiScreenReaderOnly } from '@elastic/eui';
+
+  export default () => (
+    <EuiText>
+      <p>This is the first paragraph. It is visible to all.</p>
+      <EuiScreenReaderOnly>
+        <p>
+        This is the second paragraph. It is hidden for sighted users but visible
+        to screen readers.
+        </p>
+      </EuiScreenReaderOnly>
+      <p>This is the third paragraph. It is visible to all.</p>
+    </EuiText>
+  );
   ```
 </Demo>
 
@@ -39,24 +44,29 @@ If the wrapped element is **focusable**, you must use the `showOnFocus` prop to 
 
 <Demo>
   ```tsx
-  <EuiText>
-    <p>
-      This link is visible to all on focus:{' '}
-      <EuiScreenReaderOnly showOnFocus>
-        <EuiLink href="./utilities/accessibility">Link text</EuiLink>
-      </EuiScreenReaderOnly>
-    </p>
-    <p>
-      This tooltip + button is visible on focus within:{' '}
-      <EuiScreenReaderOnly showOnFocus>
-        <span>
-          <EuiToolTip content="Information">
-            <EuiButtonIcon iconType="info" aria-label="Information" />
-          </EuiToolTip>
-        </span>
-      </EuiScreenReaderOnly>
-    </p>
-  </EuiText>
+  import React from 'react';
+  import { EuiText, EuiScreenReaderOnly, EuiLink, EuiToolTip, EuiButtonIcon } from '@elastic/eui';
+
+  export default () => (
+    <EuiText>
+      <p>
+        This link is visible to all on focus:{' '}
+        <EuiScreenReaderOnly showOnFocus>
+          <EuiLink href="./utilities/accessibility">Link text</EuiLink>
+        </EuiScreenReaderOnly>
+      </p>
+      <p>
+        This tooltip + button is visible on focus within:{' '}
+        <EuiScreenReaderOnly showOnFocus>
+          <span>
+            <EuiToolTip content="Information">
+              <EuiButtonIcon iconType="info" aria-label="Information" />
+            </EuiToolTip>
+          </span>
+        </EuiScreenReaderOnly>
+      </p>
+    </EuiText>
+  );
   ```
 </Demo>
 
@@ -218,7 +228,7 @@ announcements and duplicated DOM content for screen reader users. Screen readers
 <Demo>
   ```tsx
   import { useState } from 'react';
-  import { EuiButton, EuiLiveAnnouncer, EuiSpacer } from '@elastic/eui';
+  import { EuiButton, EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiLiveAnnouncer, EuiSpacer } from '@elastic/eui';
 
   export default () => {
     const [announcement, setAnnouncement] = useState('No notifications.');

--- a/packages/website/docs/utilities/color-palettes/index.mdx
+++ b/packages/website/docs/utilities/color-palettes/index.mdx
@@ -1,6 +1,7 @@
 # Color palettes
 
 import { ColorPaletteCopyCode, ColorPaletteFlexItem } from './color_palettes_components';
+import colorPaletteComponentsSource from '!raw-loader!./color_palettes_components';
 
 EUI provides a base set of color palettes that return an array of hexadecimal color for use in other EUI components or charts.
 
@@ -12,9 +13,11 @@ This palette is restricted to only 10 colors. However, you can add more groups o
 
 These colors are meant to be used as graphics and contrasted against the value of `euiColorEmptyShade` for the current theme. When placing text on top of these colors, use the `euiPaletteColorBlindBehindText()` variant. It is a brightened version of the base palette to create better contrast with text.
 
-<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }}>
+<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }} extraFiles={{ 'color_palettes_components.tsx': colorPaletteComponentsSource }}>
   ```tsx
-  import React, { Fragment } from 'react';
+  import React, { Fragment, useState, useEffect } from 'react';
+  import { css } from '@emotion/react';
+  import { ColorPaletteCopyCode, ColorPaletteFlexItem } from './color_palettes_components';
 
   import {
     EuiBadge,
@@ -158,9 +161,11 @@ For usages in React we recommend using the respective <a href="https://github.co
 The palette for status is the only palette that has proper contrast ratios. When using the other palettes, consider adding another form of the data for screen readers.
 :::
 
-<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }}>
+<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }} extraFiles={{ 'color_palettes_components.tsx': colorPaletteComponentsSource }}>
   ```tsx interactive
   import React, { Fragment, useState } from 'react';
+  import { css } from '@emotion/react';
+  import { ColorPaletteCopyCode, ColorPaletteFlexItem } from './color_palettes_components';
 
   import {
     EuiFlexGroup,
@@ -253,9 +258,11 @@ The palette for status is the only palette that has proper contrast ratios. When
 
 Use the `colorPalette` service to generate a custom, gradiated palette array of any length from one or more hexadecimal color codes. The third parameter `divergent`, will interpolate between the two halves of the spectrums separately. If a middle point is not provided, it will graduate to light gray.
 
-<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }}>
+<Demo scope={{ ColorPaletteCopyCode, ColorPaletteFlexItem }} extraFiles={{ 'color_palettes_components.tsx': colorPaletteComponentsSource }}>
   ```tsx interactive
   import React, { Fragment, useState } from 'react';
+  import { css } from '@emotion/react';
+  import { ColorPaletteCopyCode, ColorPaletteFlexItem } from './color_palettes_components';
 
   import {
     EuiFlexGroup,

--- a/packages/website/docs/utilities/focus-trap/index.mdx
+++ b/packages/website/docs/utilities/focus-trap/index.mdx
@@ -13,8 +13,9 @@ For components that project content in a React portal, **EuiFocusTrap** will mai
 * Use `crossFrame={true}` when focus should not be allowed on other iframes on the page.
 
 import FormExample from './form_compressed';
+import formCompressedSource from '!raw-loader!./form_compressed';
 
-<Demo scope={{ FormExample }}>
+<Demo scope={{ FormExample }} extraFiles={{ 'form_compressed.tsx': formCompressedSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 
@@ -26,6 +27,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import FormExample from './form_compressed';
 
 export default () => {
   const [isDisabled, changeDisabled] = useState(true);

--- a/packages/website/docs/utilities/text-truncation.mdx
+++ b/packages/website/docs/utilities/text-truncation.mdx
@@ -286,6 +286,9 @@ These functionalities can cause performance issues if the component is rendered 
 ```tsx interactive
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { css } from '@emotion/react';
+import { FixedSizeList } from 'react-window';
+import { faker } from '@faker-js/faker';
+import { throttle } from 'lodash';
 
 import {
   EuiFlexGroup,

--- a/packages/website/docs/utilities/window-events/index.mdx
+++ b/packages/website/docs/utilities/window-events/index.mdx
@@ -1,6 +1,7 @@
 # Window events
 
 import { ModalExample } from './modal_example';
+import modalExampleSource from '!raw-loader!./modal_example';
 
 ## Basic example: closing a modal on escape
 
@@ -8,7 +9,7 @@ Use an **EuiWindowEvent** to safely and declaratively manage adding and auto-rem
 
 This modal example registers a listener on the `keydown` event and listens for ESC key presses, which closes the open modal.
 
-<Demo scope={{ ModalExample }}>
+<Demo scope={{ ModalExample }} extraFiles={{ 'modal_example.tsx': modalExampleSource }}>
 ```tsx interactive
 import React from 'react';
 
@@ -18,6 +19,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
 } from '@elastic/eui';
+import { ModalExample } from './modal_example';
 
 const BasicModal = ({ onClose }) => (
   <EuiModal onClose={onClose} style={{ width: '800px' }}>
@@ -45,7 +47,7 @@ Since window event listeners are global, they can conflict with other event list
 
 The safest and best way to avoid these conflicts is to use `event.stopPropagation()` at the lowest, most specific level where you are responding to a DOM event. This will prevent the event from bubbling up to the window, and the **EuiWindowEvent** listener will never be triggered, avoiding the conflict.
 
-<Demo scope={{ ModalExample }}>
+<Demo scope={{ ModalExample }} extraFiles={{ 'modal_example.tsx': modalExampleSource }}>
 ```tsx interactive
 import React, { useState } from 'react';
 
@@ -58,6 +60,7 @@ import {
   EuiSpacer,
   keys,
 } from '@elastic/eui';
+import { ModalExample } from './modal_example';
 
 const ConflictModal = (props) => {
   const [inputValue, setInputValue] = useState('');

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -31,7 +31,7 @@
     "@elastic/eui-theme-common": "workspace:^",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.4",
-    "@faker-js/faker": "^8.4.1",
+    "@faker-js/faker": "^10.3.0",
     "@mdx-js/react": "^3.0.0",
     "@types/lodash": "^4.14.202",
     "chroma-js": "^3.1.2",

--- a/packages/website/src/theme/Demo/actions.tsx
+++ b/packages/website/src/theme/Demo/actions.tsx
@@ -20,6 +20,7 @@ export const extraActions = [
       '@emotion/react': 'latest',
       '@emotion/css': 'latest',
       'moment': 'latest',
+      'moment-timezone': 'latest',
       '@elastic/datemath': 'latest',
       '@elastic/eui': 'latest',
       '@elastic/eui-theme-borealis': 'latest',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7299,7 +7299,7 @@ __metadata:
     "@elastic/eui-theme-common": "workspace:^"
     "@emotion/css": "npm:^11.11.2"
     "@emotion/react": "npm:^11.11.4"
-    "@faker-js/faker": "npm:^8.4.1"
+    "@faker-js/faker": "npm:^10.3.0"
     "@mdx-js/react": "npm:^3.0.0"
     "@types/lodash": "npm:^4.14.202"
     "@types/react": "npm:^18.3.3"
@@ -8044,17 +8044,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "@faker-js/faker@npm:10.3.0"
+  checksum: 10c0/5a4688f8a040366bda83e6c7f144f9db9bef1d44f7c5b43fcee15c8def07463fcdcb572458b0d14072aca58c14321f1195e11d8664ce094266e29eb4d2a70ac4
+  languageName: node
+  linkType: hard
+
 "@faker-js/faker@npm:^8.0.2":
   version: 8.0.2
   resolution: "@faker-js/faker@npm:8.0.2"
   checksum: 10c0/a7851d4abfcd93c8c9d40ca7f1a7ad2218b9dcac1b11afe9dcf0fe38f5c1d91610e56bcedf5193a5b178dc10e052baab35977853342e84ec12b1fb27b425b356
-  languageName: node
-  linkType: hard
-
-"@faker-js/faker@npm:^8.4.1":
-  version: 8.4.1
-  resolution: "@faker-js/faker@npm:8.4.1"
-  checksum: 10c0/4f2aecddcfdc2cc8b50b2d15d1e37302a7c7a5bbd184ae910a9d271bc11248533ca74dcdd4a9ccbe20410553e7af0f6a4d334c5b955635e09a32ddf4a64942d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!TIP]
> I recommend reviewing this PR by [commits](https://github.com/elastic/eui/pull/9516/commits). 

<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui#how-to-ensure-the-timely-review-of-pull-requests) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Resolves https://github.com/elastic/eui/issues/9320

Many CodeSandbox examples were broken. This PR fixes all of them.

- Updated `@faker-js/faker` to `^10.3.0` to align the docs preview with CodeSandbox, which resolves latest, and updated `faker.internet.userName()` calls to `faker.internet.username()` (renamed in v9).
- Fixed broken CodeSandbox examples by adding missing import React and component imports, converting raw JSX fragments to full export default components.
- Fixed broken CodeSandbox examples caused by Docusaurus-specific APIs (`useBaseUrl`, `useChartBaseTheme`) not being available in CodeSandbox - replaced with self-contained alternatives.
- Fixed broken image references in CodeSandbox by embedding images as base64 data URLs via `url-loader`, passing them through `scope` (`react-live`) and `extraFiles` (CodeSandbox).
- Added charts CSS loading to the Docusaurus theme so chart-based demos render correctly in the docs preview.
- Fixed several demos in icons, forms, layout, navigation, templates, utilities, and display pages that had syntax errors or missing imports.

## Impact Assessment

**Impact level:** 🟢 None

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Test [all broken examples](https://github.com/elastic/eui/issues/9320). If you feel up for it, you could test all examples.

## Update `@faker-js/faker` to latest

- [x] [Table row classes](https://eui.elastic.co/pr_9516/docs/components/tables/basic/#table-row-classes)
- [x] [Table layout](https://eui.elastic.co/pr_9516/docs/components/tables/basic/#table-layout)
- [x] [Responsive tables](https://eui.elastic.co/pr_9516/docs/components/tables/basic/#responsive-tables)

## Replace `Link` with `EuiLink`

- [x] [Error handling and feedback](https://eui.elastic.co/pr_9516/docs/components/editors-and-syntax/markdown/editor/#error-handling-and-feedback)

## Add charts CSS imports

- [x] [Putting it all together: a simple chart plugin](https://eui.elastic.co/pr_9516/docs/components/editors-and-syntax/markdown/plugins/#putting-it-all-together-a-simple-chart-plugin)
- [x] [Accessibility features](https://eui.elastic.co/pr_9516/docs/dataviz/accessibility-features/)
- [x] [Part-to-whole comparisons](https://eui.elastic.co/pr_9516/docs/dataviz/types/part-to-whole-comparisons/)
- [x] [Metric chart](https://eui.elastic.co/pr_9516/docs/dataviz/types/metric-chart/)
- [x] [Sizing](https://eui.elastic.co/pr_9516/docs/dataviz/sizing/)

## Simple cases (missing import, syntax error)

- [x] [Flex items are also flex](https://eui.elastic.co/pr_9516/docs/components/layout/flex/item/#flex-items-are-also-flex) (2nd example)
- [x] [Gutter sizing](https://eui.elastic.co/pr_9516/docs/components/layout/flex/grid/#gutter-sizing)
- [x] [Page components](https://eui.elastic.co/pr_9516/docs/layout/page-components/) (all 3 examples)
- [x] [Button text color variant](https://eui.elastic.co/pr_9516/docs/components/navigation/buttons/button/#text-color-variant)
- [x] [Button group tooltips](https://eui.elastic.co/pr_9516/docs/components/navigation/buttons/group/#button-group-tooltips)
- [x] [Facet horizontal and large gutter](https://eui.elastic.co/pr_9516/docs/components/navigation/facet/#horizontal-and-large-gutter)
- [ ] [Empty prompt: using in a page template](https://eui.elastic.co/pr_9516/docs/components/display/empty-prompt/#using-in-a-page-template) (2 examples)
- [ ] [Empty prompt: layout](https://eui.elastic.co/pr_9516/docs/components/display/empty-prompt/#layout)
- [x] [Icons](https://eui.elastic.co/pr_9516/docs/components/display/icons/) (all examples)
- [x] [EuiFormControlButton](https://eui.elastic.co/pr_9516/docs/components/forms/layouts/form_control_buttons/#euiformcontrolbutton)
- [x] [Text](https://eui.elastic.co/pr_9516/docs/components/forms/text/) (2 examples)
- [x] [Password](https://eui.elastic.co/pr_9516/docs/components/forms/text/password/)
- [x] [Numeric](https://eui.elastic.co/pr_9516/docs/components/forms/numeric/) (1st example)
- [x] [Range sliders: inputs with range in a dropdown](https://eui.elastic.co/pr_9516/docs/components/forms/numeric/range-sliders/#inputs-with-range-in-a-dropdown)
- [x] [Range sliders: kitchen sink](https://eui.elastic.co/pr_9516/docs/components/forms/numeric/range-sliders/#kitchen-sink)
- [x] [Basic select](https://eui.elastic.co/pr_9516/docs/components/forms/selection/basic-select/)
- [x] [Super select: states](https://eui.elastic.co/pr_9516/docs/components/forms/selection/super-select/#states)
- [x] [Combo box](https://eui.elastic.co/pr_9516/docs/components/forms/selection/combo-box/) (1st example)
- [x] [Combo box: pill colors](https://eui.elastic.co/pr_9516/docs/components/forms/selection/combo-box/#pill-colors)
- [x] [Combo box: single selection](https://eui.elastic.co/pr_9516/docs/components/forms/selection/combo-box/#single-selection)
- [x] [Combo box: custom dropdown content](https://eui.elastic.co/pr_9516/docs/components/forms/selection/combo-box/#custom-dropdown-content)
- [x] [Checkbox group](https://eui.elastic.co/pr_9516/docs/components/forms/selection/checkbox-and-checkbox-group/#checkbox-group)
- [x] [Radio group](https://eui.elastic.co/pr_9516/docs/components/forms/selection/radio-and-radio-group/#radio-group)
- [x] [Switch](https://eui.elastic.co/pr_9516/docs/components/forms/selection/switch/) (1st example)
- [x] [Search](https://eui.elastic.co/pr_9516/docs/components/forms/search-and-filter/search/)
- [x] [Date picker: states](https://eui.elastic.co/pr_9516/docs/components/forms/date-and-time/date-picker/#date-picker-states)
- [x] [Date picker: inline display](https://eui.elastic.co/pr_9516/docs/components/forms/date-and-time/date-picker/#inline-display)
- [x] [Date picker range](https://eui.elastic.co/pr_9516/docs/components/forms/date-and-time/date-picker-range/) (1st example)
- [x] [Date picker range: inline display](https://eui.elastic.co/pr_9516/docs/components/forms/date-and-time/date-picker-range/#inline-display)
- [x] [Super date picker: sizing](https://eui.elastic.co/pr_9516/docs/components/forms/date-and-time/super-date-picker/#sizing)
- [x] [File picker](https://eui.elastic.co/pr_9516/docs/components/forms/other/file-picker/)
- [x] [Color picker: option toggling](https://eui.elastic.co/pr_9516/docs/components/forms/other/color-picker/#option-toggling)
- [x] [Color palette picker](https://eui.elastic.co/pr_9516/docs/components/forms/other/color-picker/#color-palette-picker)
- [x] [Palette picker](https://eui.elastic.co/pr_9516/docs/components/forms/other/palette-picker/) (1st example)
- [x] [Sitewide search: color modes](https://eui.elastic.co/pr_9516/docs/components/templates/sitewide-search/#colormodes)
- [x] [Accessibility: screen reader only](https://eui.elastic.co/pr_9516/docs/utilities/accessibility/#screen-reader-only)
- [x] [Accessibility: showing on focus](https://eui.elastic.co/pr_9516/docs/utilities/accessibility/#showing-on-focus)
- [x] [Accessibility: auto-focusing the live region on text change](https://eui.elastic.co/pr_9516/docs/utilities/accessibility/#auto-focusing-the-live-region-on-text-change)
- [x] [Accessibility: main difference](https://eui.elastic.co/pr_9516/docs/utilities/accessibility/#main-difference)
- [x] [Color palettes](https://eui.elastic.co/pr_9516/docs/utilities/color-palettes/)
- [x] [Focus trap](https://eui.elastic.co/pr_9516/docs/utilities/focus-trap/)
- [x] [Text truncation: performance](https://eui.elastic.co/pr_9516/docs/utilities/text-truncation/#performance)
- [x] [Window events: closing a modal on escape](https://eui.elastic.co/pr_9516/docs/utilities/window-events/#basic-example-closing-a-modal-on-escape)
- [x] [Window events: avoiding event conflicts](https://eui.elastic.co/pr_9516/docs/utilities/window-events/#avoiding-event-conflicts)

## Complex cases

- [ ] [Empty prompt: more types of empty states](https://eui.elastic.co/pr_9516/docs/components/display/empty-prompt/#more-types-of-empty-states)
- [ ] [Empty prompt: empty state types, goals and recommendations](https://eui.elastic.co/pr_9516/docs/components/display/empty-prompt/#empty-state-types-goals-and-recommendations)

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [x] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [x] **QA:** Tested docs changes
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [ ] ~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~
