### PR TITLE
refactor: convert FieldValueToggleFilter to function component

### DIFF
--- a/packages/eui/src/components/search_bar/filters/field_value_toggle_filter.tsx
+++ b/packages/eui/src/components/search_bar/filters/field_value_toggle_filter.tsx
@@ -29,7 +29,9 @@ export interface FieldValueToggleFilterProps {
   onChange: (value: Query) => void;
 }
 
-export const FieldValueToggleFilter: FC<FieldValueToggleFilterProps> = (props) => {
+export const FieldValueToggleFilter: FC<FieldValueToggleFilterProps> = (
+  props
+) => {
   const resolveDisplay = (clause: Clause | undefined) => {
     const { name, negatedName } = props.config;
     if (isNil(clause)) {
@@ -38,10 +40,10 @@ export const FieldValueToggleFilter: FC<FieldValueToggleFilterProps> = (props) =
     return Query.isMust(clause)
       ? { hasActiveFilters: true, name }
       : {
-        hasActiveFilters: true,
-        name: negatedName ? negatedName : `Not ${name}`,
-      };
-  }
+          hasActiveFilters: true,
+          name: negatedName ? negatedName : `Not ${name}`,
+        };
+  };
 
   const valueChanged = (checked: boolean) => {
     const { field, value, operator } = props.config;
@@ -70,8 +72,4 @@ export const FieldValueToggleFilter: FC<FieldValueToggleFilterProps> = (props) =
       {name}
     </EuiFilterButton>
   );
-}
-
-
-
-
+};


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

Convert FieldValueToggleFilter from a class component to a stateless function component.

- Refactored to use `FC<FieldValueToggleFilterProps>` style
- Stateless render-only; no functional changes
- Prettier formatting applied

### API Changes

None — this is an internal component and its API hasn’t changed.

## Screenshots

Not applicable — no visual changes.

## Impact Assessment

- [x] 🔴 Breaking changes — None
- [x] 💅 Visual changes — None
- [x] 🧪 Test impact — All existing tests pass
- [x] 🔧 Hard to integrate — N/A

Impact level: 🟢 None

## Release Readiness

- [x] Documentation — N/A
- [x] Figma — N/A
- [x] Migration guide — N/A
- [x] Adoption plan — N/A

### QA instructions for reviewer

- Verify the FieldValueToggleFilter behaves as before in Storybook and any demo pages
- Confirm that toggling the filter updates the query as expected

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [x] QA: Verified light/dark mode, accessibility, keyboard navigation
- [x] Tests: Existing Jest/Cypress tests pass
- [x] Changelog: Not needed (internal component)
- [x] Breaking changes: None