### PR TITLE
[EuiWrappingPopover] Migrate from class component to functional component

### DIFF
--- a/packages/eui/changelogs/upcoming/9537.md
+++ b/packages/eui/changelogs/upcoming/9537.md
@@ -1,1 +1,0 @@
-- Updated `wrapping_popover` from class component to functional component (PR #9537).

--- a/packages/eui/changelogs/upcoming/9537.md
+++ b/packages/eui/changelogs/upcoming/9537.md
@@ -1,0 +1,1 @@
+- Updated `wrapping_popover` from class component to functional component (PR #9537).

--- a/packages/eui/src/components/popover/wrapping_popover.tsx
+++ b/packages/eui/src/components/popover/wrapping_popover.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Component } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { EuiPopover, Props as EuiPopoverProps } from './popover';
 import { EuiPortal } from '../portal';
 
@@ -20,43 +20,42 @@ export interface EuiWrappingPopoverProps
  * then the button element is moved into the popover dom.
  * On unmount, the button is moved back to its original location.
  */
-export class EuiWrappingPopover extends Component<EuiWrappingPopoverProps> {
-  private portal: HTMLElement | null = null;
 
-  componentWillUnmount() {
-    if (this.props.button.parentNode) {
-      if (this.portal) {
-        this.portal.insertAdjacentElement('beforebegin', this.props.button);
-      }
+export function EuiWrappingPopover(props: EuiWrappingPopoverProps) {
+  const { button, ...rest } = props;
+
+  const portalRef = useRef<HTMLElement | null>(null);
+
+  const setPortalRef = (node: HTMLElement | null) => {
+    if (node) {
+      portalRef.current = node;
     }
-  }
-
-  setPortalRef = (node: HTMLElement | null) => {
-    this.portal = node;
   };
 
-  setAnchorRef = (node: HTMLElement | null) => {
-    node?.insertAdjacentElement('beforebegin', this.props.button);
+  const setAnchorRef = (node: HTMLElement | null) => {
+    node?.insertAdjacentElement('beforebegin', props.button);
   };
 
-  render() {
-    const { button, ...rest } = this.props;
+  useEffect(() => {
+    // component clean up
+    return () => {
+      if (props.button.parentNode && portalRef.current) {
+        portalRef.current.insertAdjacentElement('beforebegin', props.button);
+      }
+    };
+  }, [props.button]);
 
-    return (
-      <EuiPortal
-        portalRef={this.setPortalRef}
-        insert={{ sibling: this.props.button, position: 'after' }}
-      >
-        <EuiPopover
-          {...rest}
-          button={
-            <div
-              ref={this.setAnchorRef}
-              className="euiWrappingPopover__anchor"
-            />
-          }
-        />
-      </EuiPortal>
-    );
-  }
+  return (
+    <EuiPortal
+      portalRef={setPortalRef}
+      insert={{ sibling: props.button, position: 'after' }}
+    >
+      <EuiPopover
+        {...rest}
+        button={
+          <div ref={setAnchorRef} className="euiWrappingPopover__anchor" />
+        }
+      />
+    </EuiPortal>
+  );
 }

--- a/packages/eui/src/components/popover/wrapping_popover.tsx
+++ b/packages/eui/src/components/popover/wrapping_popover.tsx
@@ -48,7 +48,7 @@ export function EuiWrappingPopover(props: EuiWrappingPopoverProps) {
   return (
     <EuiPortal
       portalRef={setPortalRef}
-      insert={{ sibling: props.button, position: 'after' }}
+      insert={{ sibling: button, position: 'after' }}
     >
       <EuiPopover
         {...rest}

--- a/packages/eui/src/components/popover/wrapping_popover.tsx
+++ b/packages/eui/src/components/popover/wrapping_popover.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useLayoutEffect, useRef } from 'react';
 import { EuiPopover, Props as EuiPopoverProps } from './popover';
 import { EuiPortal } from '../portal';
 
@@ -26,24 +26,24 @@ export function EuiWrappingPopover(props: EuiWrappingPopoverProps) {
 
   const portalRef = useRef<HTMLElement | null>(null);
 
-  const setPortalRef = (node: HTMLElement | null) => {
-    if (node) {
-      portalRef.current = node;
-    }
-  };
+  const setPortalRef = useCallback((node: HTMLElement | null) => {
+    portalRef.current = node;
+  }, []);
 
-  const setAnchorRef = (node: HTMLElement | null) => {
-    node?.insertAdjacentElement('beforebegin', props.button);
-  };
+  const setAnchorRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      node?.insertAdjacentElement('beforebegin', button);
+    },
+    [button]
+  );
 
-  useEffect(() => {
-    // component clean up
+  useLayoutEffect(() => {
     return () => {
-      if (props.button.parentNode && portalRef.current) {
-        portalRef.current.insertAdjacentElement('beforebegin', props.button);
+      if (button.parentNode && portalRef.current) {
+        portalRef.current.insertAdjacentElement('beforebegin', button);
       }
     };
-  }, [props.button]);
+  }, [button]);
 
   return (
     <EuiPortal


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

- **What:** Refactor `EuiWrappingPopover` from class to functional Component.
- **Why:** Resolves [#9471](https://github.com/elastic/eui/issues/9471) raised for migration.
- **How:** By observing the component behavior and did equivalent changes to the file. Tested by executing `yarn test-unit`, `yarn test-unit popover` and through storybook.

### API Changes `none`

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

~~- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~~
~~- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~~
~~- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~~
~~- [ ] 🔧 **Hard to integrate** — If integration is complex, stage commits in Kibana/Cloud UI branches for cherry-picking and link to them below.~~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

~~- [ ] **Documentation:** {link to docs page(s)}~~
~~- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
~~- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
~~- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer
- [x] Run storybook and navigate to `EuiWrappingPopover` to check if the component is working as expected.

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.

  -->

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [X] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
~~- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~~
~~- [ ] **QA:** Tested docs changes~~
~~- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~~
~~- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~~
~~- [ ] **Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [x] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [x] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
