### PR TITLE
[MarkdownEditorHelpButton] Add optional tooltipPosition

### DIFF
--- a/packages/eui/changelogs/upcoming/9546.md
+++ b/packages/eui/changelogs/upcoming/9546.md
@@ -1,1 +1,1 @@
-- Added an optional `tooltipPosition` prop to `EuiMarkdownEditorHelpButton`
+- Added an optional `tooltipProps` prop to `EuiMarkdownEditorHelpButton`

--- a/packages/eui/src/components/markdown_editor/markdown_editor_help_button.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor_help_button.tsx
@@ -21,7 +21,7 @@ import { EuiI18n, useEuiI18n } from '../i18n';
 import { EuiPopover } from '../popover';
 import { EuiText } from '../text';
 import { EuiSpacer } from '../spacer';
-import { EuiToolTip, ToolTipPositions } from '../tool_tip';
+import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 import { EuiHorizontalRule } from '../horizontal_rule';
 import { EuiLink } from '../link';
 import { EuiMarkdownEditorUiPlugin } from './markdown_types';
@@ -32,7 +32,7 @@ import { euiMarkdownEditorHelpButtonStyles } from './markdown_editor_help_button
 
 interface EuiMarkdownEditorHelpButtonProps {
   uiPlugins: EuiMarkdownEditorUiPlugin[];
-  tooltipPosition?: ToolTipPositions;
+  tooltipProps?: Omit<EuiToolTipProps, 'children' | 'content'>;
 }
 
 const mdSyntaxHref = 'https://guides.github.com/features/mastering-markdown/';
@@ -48,7 +48,7 @@ const mdSyntaxLink = (
 
 export const EuiMarkdownEditorHelpButton = ({
   uiPlugins,
-  tooltipPosition,
+  tooltipProps,
 }: EuiMarkdownEditorHelpButtonProps) => {
   const [isShowingHelpModal, setIsShowingHelpModal] = useState(false);
   const [isShowingHelpPopover, setIsShowingHelpPopover] = useState(false);
@@ -73,7 +73,7 @@ export const EuiMarkdownEditorHelpButton = ({
   if (hasUiPluginsWithHelpText) {
     return (
       <>
-        <EuiToolTip content={syntaxTitle} position={tooltipPosition}>
+        <EuiToolTip {...tooltipProps} content={syntaxTitle}>
           <EuiButtonIcon
             size="s"
             css={styles.euiMarkdownEditorFooter__helpButton}


### PR DESCRIPTION
## Summary
Adds an optional `tooltipPosition` to the EuiMarkdownEditorHelpButton.

This is needed for the Dashboard markdown editor, as we put the help button on the header and use a floating Edit/Preview toggle.

In https://github.com/elastic/kibana/issues/253431 we're adding a Settings button, which we can successfully assign `position: bottom`:

<img width="996" height="196" alt="Screenshot 2026-03-31 at 3 10 26 PM" src="https://github.com/user-attachments/assets/c07fbe15-d7e1-431f-b89e-c556de68a806" />

But we can't do the same for the help button:

<img width="265" height="150" alt="Screenshot 2026-03-31 at 3 42 08 PM" src="https://github.com/user-attachments/assets/6274b0d0-3456-45a2-b295-14841f818ef1" />

An undefined `tooltipPosition` defaults to `top`, so this change will have no impact on other uses of the help button.