### PR TITLE
Migrate/euiwrappingpopover funcional component

### DIFF
--- a/packages/eui/changelogs/upcoming/9537.md
+++ b/packages/eui/changelogs/upcoming/9537.md
@@ -1,1 +1,0 @@
-- Updated `wrapping_popover` from class component to functional component (PR #9537).


### PR DESCRIPTION
resolve nits-
1. use destructured button instead of props.button
2. remove changelog for wrapping_popover