### PR TITLE
[Website] Fix EuiFlyout JSDoc docs link

### DIFF
--- a/packages/eui/src/components/flyout/flyout.tsx
+++ b/packages/eui/src/components/flyout/flyout.tsx
@@ -46,7 +46,7 @@ export type EuiFlyoutProps<T extends ElementType = 'div' | 'nav'> = Omit<
    * When the `session` prop is undefined (not set), the flyout will automatically inherit from
    * a parent flyout if it's nested inside one. Otherwise, it defaults to `never`.
    *
-   * Check out [EuiFlyout session management](https://eui.elastic.co/docs/components/containers/flyout/session-management)
+   * Check out [EuiFlyout session management](https://eui.elastic.co/docs/components/containers/flyout/#flyout-session-management)
    * documentation to learn more.
    * @default undefined (auto-inherit when nested, otherwise 'never')
    */


### PR DESCRIPTION
The ["EuiFlyout session management" link](https://eui.elastic.co/docs/components/containers/flyout/#EuiFlyout-prop-session) doesn't work. It redirects to `docs/components/containers/flyout/session-management` that doesn't exist. Instead, `_session_management.mdx` is a partial within the same page and can be navigated to using `docs/components/containers/flyout/#flyout-session-management` anchor.

The fix is to use that anchor in the JSDoc in `EuiFlyout`. Simple.

Raised internally.

https://github.com/user-attachments/assets/a8645a10-34e2-44b2-bb3a-48810e9c0220

## QA

- [ ] Verify the link in staging redirects to the proper heading