### PR TITLE
[EuiListItemLayout] Add support for focusable disabled items via `hasAriaDisabled`

### DIFF
--- a/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
+++ b/packages/eui/src/components/combo_box/combo_box_options_list/combo_box_options_list.tsx
@@ -273,7 +273,7 @@ export class EuiComboBoxOptionsList<T> extends Component<
         showIndicator={!!singleSelection}
         textWrap={rowHeight !== 'auto' ? 'truncate' : 'wrap'}
         tooltipProps={
-          toolTipContent
+          toolTipContent && !optionIsDisabled
             ? {
                 ...toolTipProps,
                 content: toolTipContent,

--- a/packages/eui/src/components/list_group/list_group_item.stories.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.stories.tsx
@@ -23,12 +23,20 @@ const meta: Meta<EuiListGroupItemProps> = {
     iconType: {
       control: { type: 'text' },
     },
+    hasAriaDisabled: {
+      description: `NOTE: Beta feature, may be changed or removed in the future.<br/>
+      Changes the native \`disabled\` attribute for \`element="button"\` usages to \`aria-disabled\` to preserve focusability.
+      This results in a semantically disabled button without the default browser handling of the disabled state.<br/>
+      Use e.g. when a disabled button element should have a tooltip.
+      `,
+    },
   },
   args: {
     color: 'text',
     showToolTip: false,
     isActive: false,
     isDisabled: false,
+    hasAriaDisabled: false,
   },
 };
 disableStorybookControls(meta, ['buttonRef']);

--- a/packages/eui/src/components/list_group/list_group_item.test.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.test.tsx
@@ -90,6 +90,26 @@ describe('EuiListGroupItem', () => {
       });
     });
 
+    describe('hasAriaDisabled', () => {
+      it('renders interactive items with `aria-disabled` when `isDisabled=true`', () => {
+        const { getByTestSubject } = render(
+          <EuiListGroupItem
+            label="Label"
+            hasAriaDisabled
+            isDisabled
+            onClick={() => {}}
+            data-test-subj="euiListGroupItem"
+          />
+        );
+
+        const button = getByTestSubject('euiListGroupItem');
+
+        expect(button).toBeEuiDisabled();
+        expect(button).toHaveAttribute('aria-disabled', 'true');
+        expect(button).not.toHaveAttribute('disabled');
+      });
+    });
+
     describe('iconType', () => {
       test('is rendered', () => {
         const { container } = render(

--- a/packages/eui/src/components/list_group/list_group_item.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.tsx
@@ -21,6 +21,7 @@ import {
   getSecureRelForTarget,
   useEuiMemoizedStyles,
   cloneElementWithCss,
+  EuiDisabledProps,
 } from '../../services';
 import { validateHref } from '../../services/security/href_validator';
 import { ExclusiveUnion, CommonProps } from '../common';
@@ -58,7 +59,8 @@ export type EuiListGroupItemProps = CommonProps &
       HTMLAttributes<HTMLSpanElement>
     >,
     'onClick' | 'color' | 'target' | 'rel'
-  > & {
+  > &
+  EuiDisabledProps & {
     /**
      * By default the item will get the color `text`.
      * You can customize the color of the item by passing a color name.
@@ -75,11 +77,6 @@ export type EuiListGroupItemProps = CommonProps &
      * Apply styles indicating an item is active
      */
     isActive?: boolean;
-
-    /**
-     * Apply styles indicating an item is disabled
-     */
-    isDisabled?: boolean;
 
     /**
      * Make the list item label a link.

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.stories.tsx
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.stories.tsx
@@ -125,6 +125,13 @@ const meta: Meta<EuiListItemLayoutProps> = {
     role: {
       control: 'text',
     },
+    hasAriaDisabled: {
+      description: `NOTE: Beta feature, may be changed or removed in the future.<br/>
+      Changes the native \`disabled\` attribute for \`element="button"\` usages to \`aria-disabled\` to preserve focusability.
+      This results in a semantically disabled button without the default browser handling of the disabled state.<br/>
+      Use e.g. when a disabled button element should have a tooltip.
+      `,
+    },
   },
   args: {
     element: 'li',
@@ -132,6 +139,7 @@ const meta: Meta<EuiListItemLayoutProps> = {
     prepend: undefined,
     append: undefined,
     isDisabled: false,
+    hasAriaDisabled: false,
     isFocused: false,
     isSelected: false,
     isSingleSelection: false,
@@ -205,12 +213,19 @@ export const TooltipProps: Story = {
   name: 'tooltipProps (prop)',
   parameters: {
     controls: {
-      include: ['element', 'tooltipProps', 'isFocused', 'children'],
+      include: [
+        'element',
+        'tooltipProps',
+        'isFocused',
+        'children',
+        'isDisabled',
+        'hasAriaDisabled',
+      ],
     },
   },
   args: {
     children: 'List item',
-    component: 'button',
+    element: 'button',
     isFocused: true,
     tooltipProps: {
       title: 'Tooltip',
@@ -301,7 +316,13 @@ export const KitchenSink: Story = {
   tags: ['vrt-only'],
   parameters: {
     controls: {
-      include: ['isDisabled', 'isFocused', 'isSelected', 'children'],
+      include: [
+        'isDisabled',
+        'hasAriaDisabled',
+        'isFocused',
+        'isSelected',
+        'children',
+      ],
     },
   },
   args: {

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.styles.ts
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.styles.ts
@@ -137,6 +137,17 @@ export const euiListItemLayoutStyles = (euiThemeContext: UseEuiTheme) => {
       cursor: not-allowed;
       background-color: transparent;
     `,
+    buttonIsDisabled: css`
+      /* prevent user (mouse) interactions for custom disabled buttons.
+      Covers user interaction only. Programmatic event handling is done in the \`useEuiDisabledElement\` hook */
+      &[aria-disabled='true'] {
+        pointer-events: none;
+
+        > * {
+          pointer-events: none;
+        }
+      }
+    `,
     isFocused: css`
       ${highlightedStyles}
     `,
@@ -168,6 +179,11 @@ export const euiListItemLayoutStyles = (euiThemeContext: UseEuiTheme) => {
           .backgroundBaseInteractiveSelectHover};
       }
     `,
+    tooltip: {
+      isDisabled: css`
+        cursor: not-allowed;
+      `,
+    },
   };
 };
 

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.test.tsx
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.test.tsx
@@ -571,6 +571,36 @@ describe('EuiListItemLayout', () => {
       });
     });
 
+    describe('hasAriaDisabled', () => {
+      it('renders `aria-disabled` when `isDisabled=true` for `element="button"`', () => {
+        const { getByTestSubject } = render(
+          <EuiListItemLayout element="button" isDisabled hasAriaDisabled>
+            Option
+          </EuiListItemLayout>
+        );
+
+        const button = getByTestSubject('euiListItemLayout');
+
+        expect(button).toBeEuiDisabled();
+        expect(button).toHaveAttribute('aria-disabled', 'true');
+        expect(button).not.toHaveAttribute('disabled');
+      });
+
+      it('renders `aria-disabled` when `isDisabled=true` for `element="a"`', () => {
+        const { getByTestSubject } = render(
+          <EuiListItemLayout element="a" isDisabled hasAriaDisabled>
+            Option
+          </EuiListItemLayout>
+        );
+
+        const button = getByTestSubject('euiListItemLayout');
+
+        expect(button).toBeEuiDisabled();
+        expect(button).toHaveAttribute('aria-disabled', 'true');
+        expect(button).not.toHaveAttribute('disabled');
+      });
+    });
+
     describe('checked', () => {
       it('applies a checked state for multi-selection items when `checked="on"`', () => {
         const { getByTestSubject } = render(

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.tsx
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.tsx
@@ -20,7 +20,12 @@ import React, {
 import { createElement } from '@emotion/react';
 import classNames from 'classnames';
 
-import { useEuiMemoizedStyles } from '../../services';
+import {
+  EuiDisabledProps,
+  useCombinedRefs,
+  useEuiDisabledElement,
+  useEuiMemoizedStyles,
+} from '../../services';
 import { CommonProps, ExclusiveUnion } from '../common';
 import {
   euiListItemLayoutStyles,
@@ -29,6 +34,7 @@ import {
 import { EuiToolTip, EuiToolTipProps } from '../tool_tip';
 import { EuiCheckboxControl } from '../form';
 import { EuiIcon, IconColor, IconType } from '../icon';
+import { isButtonDisabled } from '../button/button_display/_button_display';
 
 export const OPTION_CHECKED_STATES = ['on', 'off', 'mixed', undefined] as const;
 export type EuiListItemLayoutCheckedType =
@@ -54,104 +60,104 @@ const ROLES_THAT_CAN_USE_ARIA_SELECTED = [
   'treeitem',
 ];
 
-export type EuiListItemLayoutSharedProps = CommonProps & {
-  children?: ReactNode;
-  /**
-   * Slot for prepended content (icons)
-   */
-  prepend?: ReactNode;
-  /**
-   * Slot for additional appended content (e.g. badges)
-   * Use extraAction instead for interactive elements.
-   */
-  append?: ReactNode;
-  /**
-   * Slot for additional interactive appended content (extra actions)
-   */
-  extraAction?: ReactNode;
-  /**
-   * Set to manually define the wrapping element for navigational items (`component=button/a`).
-   * This has no effect when `component=li/div`.
-   * @default 'li'
-   */
-  wrapperElement?: 'li' | 'div';
-  /**
-   * Props applied to the wrapper.
-   * Applies only for `component=button/a` if `wrapperElement` is defined or `extraAction` is passed.
-   */
-  wrapperProps?: CommonProps;
-  /**
-   * Props applied to the content wrapper element.
-   */
-  contentProps?: CommonProps;
-  /**
-   * Props applied to the label text element.
-   */
-  textProps?: CommonProps;
-  prependProps?: CommonProps;
-  appendProps?: CommonProps;
-  tooltipProps?: Omit<EuiToolTipProps, 'children'>;
-  /**
-   * Controls the item checked indicator and applies a semantic `aria-checked` attribute.
-   * Ensure to pass an appropriate `role` for the item that supports semantic
-   * `checked` state. For no/other role(s) `checked` only controls the visual checked indicator.
-   *
-   * Leave `undefined` to indicate not selected. Pass a string of
-   * 'on' to indicate inclusion, 'off' to indicate exclusion,
-   * or 'mixed' to indicate inclusion for some.
-   *
-   * When using `singleSelection=true` it's expected to only use the values `on` or `undefined`
-   * to toggle between checked and not checked.
-   */
-  checked?: EuiListItemLayoutCheckedType;
-  /**
-   * Controls the item selection state within a list (not the checked indicator).
-   * It applies an `aria-selected` or `aria-current` attributes depending on `component` and `role`.
-   * It adds a visual selected style when `isSingleSelection=true` or `showIndicator=false`.
-   */
-  isSelected?: boolean;
-  /**
-   * Highlights the item as currently navigated item within a listbox.
-   * The item is not actually focused, it will only be styled as active.
-   */
-  isFocused?: boolean;
-  isDisabled?: boolean;
-  /**
-   * Toggles between multi-selection (renders checkbox indicators) and
-   * single-selection (renders icon indicators).
-   * @default true
-   */
-  isSingleSelection?: boolean;
-  /**
-   * Manually overrides the selection type (checkbox vs selection) for checkable/selectable roles.
-   * This controls whether `aria-checked` or `aria-selected` attributes are set.
-   * For no `role` or unsupported roles, this has no effect and `aria-current` is applied.
-   *
-   * By default when unset, it's handled internally based on `isSingleSelection`
-   * and applies `aria-checked` to multi-selection and `aria-selected` to single-selection.
-   *
-   * Use only when you need to manually adjust this, e.g. for a single-selection
-   * multi-state checkbox item (supports exclusion or indeterminate).
-   */
-  selectionMode?: 'checked' | 'selected';
-  /**
-   * Controls the visibility of the indicator.
-   * @default true
-   */
-  showIndicator?: boolean;
-  /**
-   * Native `role` attribute.
-   * If you pass a custom role make sure to align `selectionMode` where needed as well.
-   * Set it to `checked` when the role natively supports checked states and to `selected` otherwise.
-   */
-  role?: HTMLAttributes<HTMLElement>['role'];
+export type EuiListItemLayoutSharedProps = CommonProps &
+  EuiDisabledProps & {
+    children?: ReactNode;
+    /**
+     * Slot for prepended content (icons)
+     */
+    prepend?: ReactNode;
+    /**
+     * Slot for additional appended content (e.g. badges)
+     * Use extraAction instead for interactive elements.
+     */
+    append?: ReactNode;
+    /**
+     * Slot for additional interactive appended content (extra actions)
+     */
+    extraAction?: ReactNode;
+    /**
+     * Set to manually define the wrapping element for navigational items (`component=button/a`).
+     * This has no effect when `component=li/div`.
+     * @default 'li'
+     */
+    wrapperElement?: 'li' | 'div';
+    /**
+     * Props applied to the wrapper.
+     * Applies only for `component=button/a` if `wrapperElement` is defined or `extraAction` is passed.
+     */
+    wrapperProps?: CommonProps;
+    /**
+     * Props applied to the content wrapper element.
+     */
+    contentProps?: CommonProps;
+    /**
+     * Props applied to the label text element.
+     */
+    textProps?: CommonProps;
+    prependProps?: CommonProps;
+    appendProps?: CommonProps;
+    tooltipProps?: Omit<EuiToolTipProps, 'children'>;
+    /**
+     * Controls the item checked indicator and applies a semantic `aria-checked` attribute.
+     * Ensure to pass an appropriate `role` for the item that supports semantic
+     * `checked` state. For no/other role(s) `checked` only controls the visual checked indicator.
+     *
+     * Leave `undefined` to indicate not selected. Pass a string of
+     * 'on' to indicate inclusion, 'off' to indicate exclusion,
+     * or 'mixed' to indicate inclusion for some.
+     *
+     * When using `singleSelection=true` it's expected to only use the values `on` or `undefined`
+     * to toggle between checked and not checked.
+     */
+    checked?: EuiListItemLayoutCheckedType;
+    /**
+     * Controls the item selection state within a list (not the checked indicator).
+     * It applies an `aria-selected` or `aria-current` attributes depending on `component` and `role`.
+     * It adds a visual selected style when `isSingleSelection=true` or `showIndicator=false`.
+     */
+    isSelected?: boolean;
+    /**
+     * Highlights the item as currently navigated item within a listbox.
+     * The item is not actually focused, it will only be styled as active.
+     */
+    isFocused?: boolean;
+    /**
+     * Toggles between multi-selection (renders checkbox indicators) and
+     * single-selection (renders icon indicators).
+     * @default true
+     */
+    isSingleSelection?: boolean;
+    /**
+     * Manually overrides the selection type (checkbox vs selection) for checkable/selectable roles.
+     * This controls whether `aria-checked` or `aria-selected` attributes are set.
+     * For no `role` or unsupported roles, this has no effect and `aria-current` is applied.
+     *
+     * By default when unset, it's handled internally based on `isSingleSelection`
+     * and applies `aria-checked` to multi-selection and `aria-selected` to single-selection.
+     *
+     * Use only when you need to manually adjust this, e.g. for a single-selection
+     * multi-state checkbox item (supports exclusion or indeterminate).
+     */
+    selectionMode?: 'checked' | 'selected';
+    /**
+     * Controls the visibility of the indicator.
+     * @default true
+     */
+    showIndicator?: boolean;
+    /**
+     * Native `role` attribute.
+     * If you pass a custom role make sure to align `selectionMode` where needed as well.
+     * Set it to `checked` when the role natively supports checked states and to `selected` otherwise.
+     */
+    role?: HTMLAttributes<HTMLElement>['role'];
 
-  /**
-   * How to handle long text within the item.
-   * @default 'truncate'
-   */
-  textWrap?: 'truncate' | 'wrap';
-};
+    /**
+     * How to handle long text within the item.
+     * @default 'truncate'
+     */
+    textWrap?: 'truncate' | 'wrap';
+  };
 
 export type EuiListItemLayoutAsLi = {
   element: 'li';
@@ -206,6 +212,7 @@ export const EuiListItemLayout = forwardRef<
       tooltipProps: _tooltipProps,
       checked,
       isDisabled,
+      hasAriaDisabled = false,
       isFocused,
       isSelected,
       isSingleSelection = true,
@@ -227,7 +234,22 @@ export const EuiListItemLayout = forwardRef<
       props as AnchorHTMLAttributes<HTMLAnchorElement>;
 
     const component = _element === 'a' && isDisabled ? 'button' : _element;
-    const hasToolTip = !!_tooltipProps && !isDisabled;
+
+    const buttonIsDisabled = isButtonDisabled({
+      href,
+      isDisabled: component === 'button' && isDisabled,
+    });
+
+    const { ref: disabledRef, ...disabledButtonProps } =
+      useEuiDisabledElement<HTMLButtonElement>({
+        isDisabled: buttonIsDisabled,
+        hasAriaDisabled,
+        onKeyDown: rest.onKeyDown,
+      });
+
+    const setCombinedRef = useCombinedRefs([disabledRef, ref]);
+
+    const hasToolTip = !!_tooltipProps;
 
     const isNonInteractiveComponent = ['li', 'div'].includes(component);
     const isInteractiveComponent =
@@ -321,6 +343,10 @@ export const EuiListItemLayout = forwardRef<
       !isDisabled && !hasWrapper && interactiveStyles,
       !hasWrapper && css,
       isDisabled && styles.isDisabled,
+      hasAriaDisabled &&
+        buttonIsDisabled &&
+        hasToolTip &&
+        styles.buttonIsDisabled,
     ];
 
     // Manually trigger the tooltip on keyboard focus
@@ -415,10 +441,12 @@ export const EuiListItemLayout = forwardRef<
         : {};
 
     const disabledProps = isDisabled
-      ? {
-          disabled: component === 'button' ? isDisabled : undefined,
-          'aria-disabled': component !== 'button' ? isDisabled : undefined,
-        }
+      ? buttonIsDisabled
+        ? disabledButtonProps
+        : {
+            disabled: component === 'button' ? isDisabled : undefined,
+            'aria-disabled': component !== 'button' ? isDisabled : undefined,
+          }
       : {};
 
     const wrapperProps = {
@@ -428,9 +456,20 @@ export const EuiListItemLayout = forwardRef<
       css: [wrapperCssStyles, _wrapperProps?.css],
     };
 
+    const tooltipProps = {
+      ..._tooltipProps,
+      anchorProps: {
+        ..._tooltipProps?.anchorProps,
+        css: [
+          isDisabled && styles.tooltip.isDisabled,
+          _tooltipProps?.anchorProps?.css,
+        ],
+      },
+    };
+
     const hasInternalTooltip = isNonInteractiveComponent && hasToolTip;
     const elementProps = {
-      ref,
+      ref: setCombinedRef,
       role,
       className: classes,
       css: cssStyles,
@@ -529,9 +568,9 @@ export const EuiListItemLayout = forwardRef<
     const content = hasInternalTooltip ? (
       <EuiToolTip
         ref={setTooltipRef}
-        content={_tooltipProps?.content}
+        content={tooltipProps?.content}
         anchorClassName="eui-fullWidth"
-        {..._tooltipProps}
+        {...tooltipProps}
       >
         {innerContent}
       </EuiToolTip>
@@ -548,9 +587,9 @@ export const EuiListItemLayout = forwardRef<
       !isNonInteractiveComponent && hasToolTip ? (
         <EuiToolTip
           ref={setTooltipRef}
-          content={_tooltipProps?.content}
+          content={tooltipProps?.content}
           anchorClassName="eui-fullWidth"
-          {..._tooltipProps}
+          {...tooltipProps}
         >
           {innerElement}
         </EuiToolTip>

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.tsx
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.tsx
@@ -247,7 +247,9 @@ export const EuiListItemLayout = forwardRef<
         onKeyDown: rest.onKeyDown,
       });
 
-    const setCombinedRef = useCombinedRefs([disabledRef, ref]);
+    const setCombinedRef = useCombinedRefs(
+      useMemo(() => [disabledRef, ref], [disabledRef, ref])
+    );
 
     const hasToolTip = !!_tooltipProps;
 


### PR DESCRIPTION
## Summary

>[!important]
This PR merges into a [feature branch](https://github.com/elastic/eui/tree/feat/selectable-ui-enhancements)

This PR updates `EuiListItemLayout` by adding `hasAriaDisabled` prop to enable support for focusable disabled items. This uses the same functionality implemented in button components (Beta feature).

The main intention here is to support adding tooltips in different scenarios, enabled items as well as disabled ones. Besides that, we'd want to (at least for now) keep parity for `EuiListGroupItem` which applies tooltips without restriction (besides via `showTooltip`) as it can be used as visual alternative when items are truncated ([EUI docs](https://eui.elastic.co/docs/components/display/list-group/#text-wrapping-and-tooltips)).
This behavior to show tooltips previously only worked for mouse interactions. By supporting focusable disabled elements via `hasAriaDisabled` we'll extend the functionality to ensure keyboard navigation can also be supported.

>[!NOTE]
`hasAriaDisabled` is an opt-in feature.

### Changes

- Adds `hasAriaDisabled` prop on `EuiListItemLayout`
- Removes the `isDisabled` condition for showing tooltips in `EuiListItemLayout`
- Adds `hasAriaDisabled` prop on `EuiListGroupItem`
- Adds manual disabled condition on `EuiComboBox` list item tooltips (to keep current behavior and align with `EuiSelectableListItem`; once we decide to make options focusable we can change this easily (see https://github.com/elastic/eui/issues/8869))

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiListItemLayout` (Internal component) | `hasAriaDisabled` | Added | Default: `false`; Enables focusable disabled interactive list items |
| `EuiListGroupItem` | `hasAriaDisabled` | Added | Default: `false`; Enables focusable disabled interactive list items |

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/af6a0d8c-0388-4ed4-901e-0354b01418b8" /> | <video src="https://github.com/user-attachments/assets/fdbfaac4-32e6-46f2-9dc9-3c0436e7d3fb" /> |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None - opt-in feature

ℹ️ The changes were tested in Kibana CI in combination with the changes from https://github.com/elastic/eui/pull/9579. (🟢  [CI build](https://buildkite.com/elastic/kibana-pull-request/builds/424798#019d7295-0e8d-46bb-a0ba-c56d78e44879))

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
- [ ] ~~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

💻 [EuiListItemLayout storybook]()

- [ ] verify that `hasAriaDisabled=true` on `EuiListItemLayout` results in interactive list items (`element=button/a`) being focusable when `IsDisabled=true`
- [ ] verify that `hasAriaDisabled=true` on `EuiListGroupItem` results in interactive items (`onClick` or `href`) being focusable when `IsDisabled=true`
- [ ] verify that disabled `EuiListItemLayout` and `EuiListGroupItem` items can show tooltips on hover and on focus (with `hasAriaDisabled=true`
- [ ] verify that `EuiSelectableListItem` and `EuiComboBox` list items do not support tooltips on disabled items
- [ ] verify there is no unexpected regression

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [x] **QA:** Tested in ~~[CodeSandbox](https://codesandbox.io/) and~~ [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] ~~**QA:** Tested docs changes~~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~~**Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
