### PR TITLE
Feat/9577 add to dashboard icon

### DIFF
--- a/packages/eui/changelogs/upcoming/9590.md
+++ b/packages/eui/changelogs/upcoming/9590.md
@@ -1,0 +1,1 @@
+- Added `addToDashboard` icon

--- a/packages/eui/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/packages/eui/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -626,16 +626,29 @@ exports[`EuiIcon props type addToDashboard is rendered 1`] = `
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
-    d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
-    fill-rule="evenodd"
+    d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207zM14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
   />
-  <path
-    d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z"
-  />
-  <path
-    class="euiIcon__fillSecondary"
-    d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
-  />
+  <mask
+    height="13"
+    id="add_to_dashboard_generated-id_a"
+    maskUnits="userSpaceOnUse"
+    style="mask-type: alpha;"
+    width="13"
+    x="1"
+    y="1"
+  >
+    <path
+      d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
+      fill-rule="evenodd"
+    />
+  </mask>
+  <g
+    mask="url(#add_to_dashboard_generated-id_a)"
+  >
+    <path
+      d="M1-.083h13.464V9H9v5H1z"
+    />
+  </g>
 </svg>
 `;
 

--- a/packages/eui/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/packages/eui/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -626,30 +626,12 @@ exports[`EuiIcon props type addToDashboard is rendered 1`] = `
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
+    d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
+    fill-rule="evenodd"
+  />
+  <path
     d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z"
   />
-  <mask
-    height="13"
-    id="add_to_dashboard_generated-id_a"
-    maskUnits="userSpaceOnUse"
-    style="mask-type: alpha;"
-    width="13"
-    x="1"
-    y="1"
-  >
-    <path
-      d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
-      fill="#fff"
-      fill-rule="evenodd"
-    />
-  </mask>
-  <g
-    mask="url(#add_to_dashboard_generated-id_a)"
-  >
-    <path
-      d="M1-.083h13.464V9H9v5H1z"
-    />
-  </g>
   <path
     class="euiIcon__fillSecondary"
     d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"

--- a/packages/eui/src/components/icon/__snapshots__/icon.test.tsx.snap
+++ b/packages/eui/src/components/icon/__snapshots__/icon.test.tsx.snap
@@ -614,6 +614,49 @@ exports[`EuiIcon props type addDataApp is rendered 1`] = `
 </svg>
 `;
 
+exports[`EuiIcon props type addToDashboard is rendered 1`] = `
+<svg
+  class="euiIcon emotion-euiIcon-m-isLoaded"
+  data-icon-type="addToDashboard"
+  data-is-loaded="true"
+  height="16"
+  role="presentation"
+  viewBox="0 0 16 16"
+  width="16"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z"
+  />
+  <mask
+    height="13"
+    id="add_to_dashboard_generated-id_a"
+    maskUnits="userSpaceOnUse"
+    style="mask-type: alpha;"
+    width="13"
+    x="1"
+    y="1"
+  >
+    <path
+      d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
+      fill="#fff"
+      fill-rule="evenodd"
+    />
+  </mask>
+  <g
+    mask="url(#add_to_dashboard_generated-id_a)"
+  >
+    <path
+      d="M1-.083h13.464V9H9v5H1z"
+    />
+  </g>
+  <path
+    class="euiIcon__fillSecondary"
+    d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
+  />
+</svg>
+`;
+
 exports[`EuiIcon props type advancedSettingsApp is rendered 1`] = `
 <svg
   class="euiIcon emotion-euiIcon-m-app-isLoaded"

--- a/packages/eui/src/components/icon/assets/add_to_dashboard.tsx
+++ b/packages/eui/src/components/icon/assets/add_to_dashboard.tsx
@@ -10,6 +10,7 @@
 
 import * as React from 'react';
 import type { SVGProps } from 'react';
+import { htmlIdGenerator } from '../../../services';
 interface SVGRProps {
   title?: string;
   titleId?: string;
@@ -18,25 +19,39 @@ const EuiIconAddToDashboard = ({
   title,
   titleId,
   ...props
-}: SVGProps<SVGSVGElement> & SVGRProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width={16}
-    height={16}
-    viewBox="0 0 16 16"
-    aria-labelledby={titleId}
-    {...props}
-  >
-    {title ? <title id={titleId}>{title}</title> : null}
-    <path
-      fillRule="evenodd"
-      d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
-    />
-    <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z" />
-    <path
-      d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
-      className="euiIcon__fillSecondary"
-    />
-  </svg>
-);
+}: SVGProps<SVGSVGElement> & SVGRProps) => {
+  const generateId = htmlIdGenerator('add_to_dashboard');
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={16}
+      height={16}
+      viewBox="0 0 16 16"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207zM14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z" />
+      <mask
+        id={generateId('a')}
+        width={13}
+        height={13}
+        x={1}
+        y={1}
+        maskUnits="userSpaceOnUse"
+        style={{
+          maskType: 'alpha',
+        }}
+      >
+        <path
+          fillRule="evenodd"
+          d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
+        />
+      </mask>
+      <g mask={`url(#${generateId('a')})`}>
+        <path d="M1-.083h13.464V9H9v5H1z" />
+      </g>
+    </svg>
+  );
+};
 export const icon = EuiIconAddToDashboard;

--- a/packages/eui/src/components/icon/assets/add_to_dashboard.tsx
+++ b/packages/eui/src/components/icon/assets/add_to_dashboard.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// THIS IS A GENERATED FILE. DO NOT MODIFY MANUALLY. @see scripts/compile-icons.js
+
+import * as React from 'react';
+import type { SVGProps } from 'react';
+import { htmlIdGenerator } from '../../../services';
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const EuiIconAddToDashboard = ({
+  title,
+  titleId,
+  ...props
+}: SVGProps<SVGSVGElement> & SVGRProps) => {
+  const generateId = htmlIdGenerator('add_to_dashboard');
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={16}
+      height={16}
+      viewBox="0 0 16 16"
+      aria-labelledby={titleId}
+      {...props}
+    >
+      {title ? <title id={titleId}>{title}</title> : null}
+      <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z" />
+      <mask
+        id={generateId('a')}
+        width={13}
+        height={13}
+        x={1}
+        y={1}
+        maskUnits="userSpaceOnUse"
+        style={{
+          maskType: 'alpha',
+        }}
+      >
+        <path
+          fill="#fff"
+          fillRule="evenodd"
+          d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
+        />
+      </mask>
+      <g mask={`url(#${generateId('a')})`}>
+        <path d="M1-.083h13.464V9H9v5H1z" />
+      </g>
+      <path
+        d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
+        className="euiIcon__fillSecondary"
+      />
+    </svg>
+  );
+};
+export const icon = EuiIconAddToDashboard;

--- a/packages/eui/src/components/icon/assets/add_to_dashboard.tsx
+++ b/packages/eui/src/components/icon/assets/add_to_dashboard.tsx
@@ -10,7 +10,6 @@
 
 import * as React from 'react';
 import type { SVGProps } from 'react';
-import { htmlIdGenerator } from '../../../services';
 interface SVGRProps {
   title?: string;
   titleId?: string;
@@ -19,44 +18,25 @@ const EuiIconAddToDashboard = ({
   title,
   titleId,
   ...props
-}: SVGProps<SVGSVGElement> & SVGRProps) => {
-  const generateId = htmlIdGenerator('add_to_dashboard');
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={16}
-      height={16}
-      viewBox="0 0 16 16"
-      aria-labelledby={titleId}
-      {...props}
-    >
-      {title ? <title id={titleId}>{title}</title> : null}
-      <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z" />
-      <mask
-        id={generateId('a')}
-        width={13}
-        height={13}
-        x={1}
-        y={1}
-        maskUnits="userSpaceOnUse"
-        style={{
-          maskType: 'alpha',
-        }}
-      >
-        <path
-          fill="#fff"
-          fillRule="evenodd"
-          d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
-        />
-      </mask>
-      <g mask={`url(#${generateId('a')})`}>
-        <path d="M1-.083h13.464V9H9v5H1z" />
-      </g>
-      <path
-        d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
-        className="euiIcon__fillSecondary"
-      />
-    </svg>
-  );
-};
+}: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={16}
+    height={16}
+    viewBox="0 0 16 16"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path
+      fillRule="evenodd"
+      d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"
+    />
+    <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z" />
+    <path
+      d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"
+      className="euiIcon__fillSecondary"
+    />
+  </svg>
+);
 export const icon = EuiIconAddToDashboard;

--- a/packages/eui/src/components/icon/icon_map.ts
+++ b/packages/eui/src/components/icon/icon_map.ts
@@ -9,6 +9,7 @@
 export const typeToPathMap = {
   accessibility: () => import('./assets/accessibility'),
   addDataApp: () => import('./assets/app_add_data'),
+  addToDashboard: () => import('./assets/add_to_dashboard'),
   advancedSettingsApp: () => import('./assets/app_advanced_settings'),
   agentApp: () => import('./assets/app_fleet'),
   aggregate: () => import('./assets/aggregate'),

--- a/packages/eui/src/components/icon/svgs/add_to_dashboard.svg
+++ b/packages/eui/src/components/icon/svgs/add_to_dashboard.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z"/>
+  <mask id="add-to-dashboard-mask" width="13" height="13" x="1" y="1" maskUnits="userSpaceOnUse" style="mask-type:alpha">
+    <path fill="#fff" fill-rule="evenodd" d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"/>
+  </mask>
+  <g mask="url(#add-to-dashboard-mask)">
+    <path d="M1-.083h13.464V9H9v5H1z"/>
+  </g>
+  <path class="euiIcon__fillSecondary" d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"/>
+</svg>

--- a/packages/eui/src/components/icon/svgs/add_to_dashboard.svg
+++ b/packages/eui/src/components/icon/svgs/add_to_dashboard.svg
@@ -1,10 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"/>
   <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z"/>
-  <mask id="add-to-dashboard-mask" width="13" height="13" x="1" y="1" maskUnits="userSpaceOnUse" style="mask-type:alpha">
-    <path fill="#fff" fill-rule="evenodd" d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"/>
-  </mask>
-  <g mask="url(#add-to-dashboard-mask)">
-    <path d="M1-.083h13.464V9H9v5H1z"/>
-  </g>
   <path class="euiIcon__fillSecondary" d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"/>
 </svg>

--- a/packages/eui/src/components/icon/svgs/add_to_dashboard.svg
+++ b/packages/eui/src/components/icon/svgs/add_to_dashboard.svg
@@ -1,5 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"/>
-  <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207z"/>
-  <path class="euiIcon__fillSecondary" d="M14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"/>
+  <path d="m8.5 9.207 3.854-3.853-.708-.708L8.5 7.793l-2-2-3.854 3.853.708.708L6.5 7.207zM14 13h2v1h-2v2h-1v-2h-2v-1h2v-2h1z"/>
+  <mask id="a" width="13" height="13" x="1" y="1" maskUnits="userSpaceOnUse" style="mask-type:alpha">
+    <path fill-rule="evenodd" d="M13.072 1c.464 0 .928.542.928 1.083v10.834c0 .541-.464 1.083-.929 1.083H1.931C1.464 14 1 13.567 1 12.917V2.083C1 1.542 1.467 1 1.93 1zM1.93 12.917h11.14V2.083H1.932z"/>
+  </mask>
+  <g mask="url(#a)">
+    <path d="M1-.083h13.464V9H9v5H1z"/>
+  </g>
 </svg>

--- a/packages/website/docs/components/display/icons/icon_types.ts
+++ b/packages/website/docs/components/display/icons/icon_types.ts
@@ -2,6 +2,7 @@ import { IconType } from '@elastic/eui';
 
 export const iconTypes: Array<IconType> = [
   'accessibility',
+  'addToDashboard',
   'aggregate',
   'alignBottom',
   'alignBottomLeft',


### PR DESCRIPTION
## Summary

- **What:** Added the `addToDashboard` icon, registered it in `icon_map`, documented it in the website icon types list, and updated Jest snapshots.
- **Why:** Provides a dedicated glyph for “add to dashboard” actions so product UIs can avoid ambiguous reuse of generic `plus` / `plusInCircle` icons or `dashboardApp` alone, as described in the issue.
- **How:** New artwork depicting a dashboard motif with a small “+” sub-glyph.

Fixes https://github.com/elastic/eui/issues/9577

### API Changes
| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiIcon`          | `type`       | Added  | `addToDashboard` |
## Screenshots
| Before | After |
| ------ | ----- |
| _(no `addToDashboard` type)_ | ![11](https://github.com/user-attachments/assets/52f19b54-ed23-4d81-a229-796575772e1b)|
## Impact Assessment
- [ ] Breaking changes
- [x] Visual changes — New optional `EuiIcon` type only; existing icons unchanged.
- [x] Test impact — `EuiIcon` snapshot updates for the new type.
- [ ] Hard to integrate
**Impact level:** Low
## Release Readiness
- [x] **Documentation:** Listed in website icon types / icons docs once merged.
- [ ] **Figma:** Tracked via [#9577](https://github.com/elastic/eui/issues/9577); further visual tuning in Figma if needed.
- [ ] **Migration guide:** N/A
- [x] **Adoption plan:** Discover / Kibana (and similar flows) can switch to `type="addToDashboard"` where the action needs a distinct icon.
### QA instructions for reviewer
- [ ] Confirm `addToDashboard` appears in the Icons docs and Storybook icon listing.
- [ ] Confirm the glyph is clear at 16×16 in light and dark mode (frame, chart, and + read as one concept).
### Checklist before marking Ready for Review
- [x] Filled out sections above (per template).
- [x] **QA:** Light/dark, high contrast.
- [ ] **QA:** CodeSandbox / Kibana (optional for icon-only change).
- [x] **QA:** Docs/types updated for the new icon name, added to Figma file
- [x] **Tests:** Jest snapshots updated (including after SVG simplification).
- [x] **Changelog:** `packages/eui/changelo