### PR TITLE
build: Support `workflow_call` in the release workflow and output published packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,29 +28,27 @@ on:
         required: false
         type: string
   workflow_call:
-    release_ref:
-      description: Upstream git ref to create the release from
-      required: true
-      type: string
-    type:
-      description: Release type
-      required: true
-      type: choice
-      options:
-        - snapshot
-        - official
-    workspaces:
-      description: A comma-separated list of workspaces to release
-      required: false
-      type: string
-    dry_run:
-      description: Dry run (do not publish the packages)
-      required: true
-      type: boolean
-    npm_tag:
-      description: "[Custom releases only] npm tag to use"
-      required: false
-      type: string
+    inputs:
+      release_ref:
+        description: Upstream git ref to create the release from
+        required: true
+        type: string
+      type:
+        description: Release type - snapshot or official
+        required: true
+        type: string
+      workspaces:
+        description: A comma-separated list of workspaces to release
+        required: false
+        type: string
+      dry_run:
+        description: Dry run (do not publish the packages)
+        required: true
+        type: boolean
+      npm_tag:
+        description: "[Custom releases only] npm tag to use"
+        required: false
+        type: string
     outputs:
       published_packages_json:
         description: A JSON-formatted list of published packages and their versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
     steps:
       - id: resolver
         run: |
-          PUBLISHED_PACKAGES_JSON_SNAPSHOT="${{ jobs.release_snapshot.outputs.published_packages_json }}"
-          PUBLISHED_PACKAGES_JSON_OFFICIAL="${{ jobs.release_official.outputs.published_packages_json }}"
+          PUBLISHED_PACKAGES_JSON_SNAPSHOT="${{ needs.release_snapshot.outputs.published_packages_json }}"
+          PUBLISHED_PACKAGES_JSON_OFFICIAL="${{ needs.release_official.outputs.published_packages_json }}"
 
           echo "json=${PUBLISHED_PACKAGES_JSON_SNAPSHOT:-$PUBLISHED_PACKAGES_JSON_OFFICIAL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,34 @@ on:
         description: "[Custom releases only] npm tag to use"
         required: false
         type: string
+  workflow_call:
+    release_ref:
+      description: Upstream git ref to create the release from
+      required: true
+      type: string
+    type:
+      description: Release type
+      required: true
+      type: choice
+      options:
+        - snapshot
+        - official
+    workspaces:
+      description: A comma-separated list of workspaces to release
+      required: false
+      type: string
+    dry_run:
+      description: Dry run (do not publish the packages)
+      required: true
+      type: boolean
+    npm_tag:
+      description: "[Custom releases only] npm tag to use"
+      required: false
+      type: string
+    outputs:
+      published_packages_json:
+        description: A JSON-formatted list of published packages and their versions
+        value: ${{ jobs.resolver.outputs.published_packages_json }}
 
 permissions:
   id-token: write # Required for OIDC
@@ -76,6 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.type == 'snapshot' }}
     needs: [ lint_and_unit_tests, cypress_tests ]
+    outputs:
+      published_packages_json: ${{ steps.published_packages_info.outputs.json }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -131,11 +161,20 @@ jobs:
           result-encoding: string
       - name: Release
         run: yarn release run snapshot --skip-prompts --skip-auth-check --use-auth-token --allow-custom ${{ inputs.dry_run && '--dry-run' || ''}} ${{ steps.prepare_npm_tag_arg.outputs.result }} ${{ steps.prepare_workspaces_arg.outputs.result }}
+      - name: Output published packages info
+        id: published_packages_info
+        # language=bash
+        run: |
+          # minify JSON content for easier handling
+          file_content=$(jq -c . .release/published_packages.json)
+          echo "json=$file_content" >> "$GITHUB_OUTPUT"
   release_official:
     name: Create an official release
     runs-on: ubuntu-latest
     if: ${{ inputs.type == 'official' }}
     needs: [ lint_and_unit_tests, cypress_tests ]
+    outputs:
+      published_packages_json: ${{ steps.published_packages_info.outputs.json }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -195,3 +234,27 @@ jobs:
           result-encoding: string
       - name: Release
         run: yarn release run official --skip-prompts --skip-auth-check --use-auth-token --allow-custom --skip-update-versions ${{ inputs.dry_run && '--dry-run' || ''}} ${{ steps.prepare_npm_tag_arg.outputs.result }} ${{ steps.prepare_workspaces_arg.outputs.result }}
+      - name: Output published packages info
+        id: published_packages_info
+        # language=bash
+        run: |
+          # minify JSON content for easier handling
+          file_content=$(jq -c . .release/published_packages.json)
+          echo "json=$file_content" >> "$GITHUB_OUTPUT"
+  resolver:
+    name: Resolve outputs
+    needs: [release_snapshot, release_official]
+    runs-on: ubuntu-latest
+    outputs:
+      published_packages_json: ${{ steps.resolver.outputs.published_packages.json }}
+    if: |
+      always() &&
+      (needs.release_snapshot.result == 'success' || needs.release_snapshot.result == 'skipped') &&
+      (needs.release_official.result == 'success' || needs.release_official.result == 'skipped')
+    steps:
+      - id: resolver
+        run: |
+          PUBLISHED_PACKAGES_JSON_SNAPSHOT="${{ jobs.release_snapshot.outputs.published_packages_json }}"
+          PUBLISHED_PACKAGES_JSON_OFFICIAL="${{ jobs.release_official.outputs.published_packages_json }}"
+
+          echo "json=${PUBLISHED_PACKAGES_JSON_SNAPSHOT:-$PUBLISHED_PACKAGES_JSON_OFFICIAL}" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ WARP.md
 
 # Build artifacts
 package.tgz
+
+# Release metadata directory
+.release

--- a/packages/release-cli/src/published_packages_file.ts
+++ b/packages/release-cli/src/published_packages_file.ts
@@ -28,7 +28,7 @@ export const emitPublishedPackagesFile = async (packages: PublishedPackages) => 
     PUBLISHED_PACKAGES_FILE_NAME
   );
 
-  await fs.mkdir(releaseDir);
+  await fs.mkdir(releaseDir, { recursive: true });
 
   const fileContent = JSON.stringify(packages, null, 2);
   await fs.writeFile(publishedPackagesFile, fileContent, 'utf8');

--- a/packages/release-cli/src/published_packages_file.ts
+++ b/packages/release-cli/src/published_packages_file.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { getRootWorkspaceDir } from './workspace';
+
+export interface PublishedPackage {
+  name: string;
+  version: string;
+}
+
+export type PublishedPackages = PublishedPackage[];
+
+const RELEASE_DIR_NAME = '.release';
+const PUBLISHED_PACKAGES_FILE_NAME = 'published_packages.json';
+
+export const emitPublishedPackagesFile = async (packages: PublishedPackages) => {
+  const rootDir = getRootWorkspaceDir();
+  const releaseDir = path.join(rootDir, RELEASE_DIR_NAME);
+  const publishedPackagesFile = path.join(
+    releaseDir,
+    PUBLISHED_PACKAGES_FILE_NAME
+  );
+
+  await fs.mkdir(releaseDir);
+
+  const fileContent = JSON.stringify(packages, null, 2);
+  await fs.writeFile(publishedPackagesFile, fileContent, 'utf8');
+};

--- a/packages/release-cli/src/steps/publish.ts
+++ b/packages/release-cli/src/steps/publish.ts
@@ -13,10 +13,7 @@ import { type ReleaseOptions } from '../release';
 import { getRootWorkspaceDir, getWorkspacePackageJson } from '../workspace';
 import { yarnPack, YarnWorkspace } from '../yarn_utils';
 import { npmExecPublish } from '../npm_utils';
-
-interface PublishedWorkspace extends YarnWorkspace {
-  version: string;
-}
+import { emitPublishedPackagesFile, type PublishedPackages } from '../published_packages_file';
 
 /**
  * Publish changed packages to the registry
@@ -33,7 +30,7 @@ export const stepPublish = async (
     return;
   }
 
-  const publishedWorkspaces: Array<PublishedWorkspace> = [];
+  const publishedPackages: PublishedPackages = [];
 
   for (const workspace of workspacesToPublish) {
     const workspaceDir = path.join(rootWorkspaceDir, workspace.location);
@@ -75,10 +72,10 @@ export const stepPublish = async (
       logger.error(err);
       logger.error(chalk.red(`[${workspace.name}] Failed to publish package`));
 
-      if (publishedWorkspaces.length) {
+      if (publishedPackages.length) {
         const remainingPackages = workspacesToPublish.filter(
           (workspaceToPublish) => {
-            return !!publishedWorkspaces.find(
+            return !!publishedPackages.find(
               (publishedWorkspace) =>
                 publishedWorkspace.name === workspaceToPublish.name
             );
@@ -87,7 +84,7 @@ export const stepPublish = async (
 
         logger.error(
           chalk.red(
-            `${publishedWorkspaces.length} out of ` +
+            `${publishedPackages.length} out of ` +
               `${workspacesToPublish.length} packages were already published.`
           )
         );
@@ -100,7 +97,7 @@ export const stepPublish = async (
           `Otherwise, deprecate just published versions of the following ` +
             `packages if they are strictly dependent on remaining ` +
             `packages' updates:\n` +
-            `  ${publishedWorkspaces
+            `  ${publishedPackages
               .map((workspace) => workspace.name)
               .join(' ')}`
         );
@@ -111,14 +108,16 @@ export const stepPublish = async (
       return;
     }
 
-    publishedWorkspaces.push({
-      ...workspace,
+    publishedPackages.push({
+      name: workspace.name,
       version: packageJson.version,
     });
     logger.info(
       `[${workspace.name}] Successfully published ${workspace.name}@${packageJson.version} to npmjs - https://npmjs.com/package/${workspace.name}`
     );
   }
+
+  await emitPublishedPackagesFile(publishedPackages);
 
   logger.info('Publishing packages finished 🎉');
 };


### PR DESCRIPTION
## Summary

This PR updates the `release-cli` to output published packages to `.release/published_packages.json`, so that it can be read from the release workflow. The release workflow is updated to support `workflow_call` triggers (triggers from other workflows) with the same inputs, and with the added `published_packages_json` output read from the `.release/published_packages.json` file.

Release workflow changes:

* `release_official` and `release_snapshot` both have a new step that reads the minified `.release/published_packages.json` contents and passes it as `published_packages_json` job output
* A new `resolver` job is added to conditionally return the `published_packages_json` job output from either the `release_official` or `release_snapshot`, depending on which was run
* `workflow_call` trigger method is now allowed with inputs mirrored with the usual `workflow_dispatch` method.
* `workflow_call`'s `type` input is updated to `string` because the type `choice` is not supported in `workflow_call` inputs

### API Changes

N/A

## Screenshots

N/A

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [x] Checkout this PR, run `yarn && yarn workspace @elastic/eui-release-cli build && yarn release run snapshot --dry-run --allow-custom --skip-auth-check --use-auth-token --workspaces @elastic/eui` and confirm the `.release/published_packages.json` is created and has one entry for `@elastic/eui`
- [ ] Confirm the workflow changes look correct - there's no way to test `workflow_call` before merging to `main` as far as I'm aware

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] ~**QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [ ] ~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
