### PR TITLE
[EuiListItemLayout] Add hover styles only on interactive items

### DIFF
--- a/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav_beta/_kibana_solution/__snapshots__/collapsible_nav_kibana_solution.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`KibanaCollapsibleNavSolution renders docked icons: popover 1`] = `
         data-test-subj="kibanaSolutionSwitcherList"
       >
         <li
-          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
           data-test-subj="test-solution"
         >
           <span
@@ -113,7 +113,7 @@ exports[`KibanaCollapsibleNavSolution renders docked icons: popover 1`] = `
         class="euiListGroup emotion-euiListGroup-maxWidthDefault-euiCollapsibleNavKibanaSolution__secondaryItems"
       >
         <li
-          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
           data-test-subj="euiListItemLayout"
         >
           <span
@@ -220,7 +220,7 @@ exports[`KibanaCollapsibleNavSolution renders with a solution switcher: popover 
         data-test-subj="kibanaSolutionSwitcherList"
       >
         <li
-          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
           data-test-subj="test-solution"
         >
           <span
@@ -239,7 +239,7 @@ exports[`KibanaCollapsibleNavSolution renders with a solution switcher: popover 
         class="euiListGroup emotion-euiListGroup-maxWidthDefault-euiCollapsibleNavKibanaSolution__secondaryItems"
       >
         <li
-          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+          class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
           data-test-subj="euiListItemLayout"
         >
           <span

--- a/packages/eui/src/components/list_group/__snapshots__/list_group.test.tsx.snap
+++ b/packages/eui/src/components/list_group/__snapshots__/list_group.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`EuiListGroup listItems is rendered 1`] = `
   class="euiListGroup emotion-euiListGroup-maxWidthDefault"
 >
   <li
-    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
     data-test-subj="euiListItemLayout"
   >
     <span
@@ -37,7 +37,7 @@ exports[`EuiListGroup listItems is rendered 1`] = `
     </span>
   </li>
   <li
-    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
     data-test-subj="euiListItemLayout"
   >
     <span
@@ -137,7 +137,7 @@ exports[`EuiListGroup listItems is rendered with color 1`] = `
   class="euiListGroup emotion-euiListGroup-maxWidthDefault"
 >
   <li
-    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-primary"
+    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-primary"
     data-test-subj="euiListItemLayout"
   >
     <span
@@ -161,7 +161,7 @@ exports[`EuiListGroup listItems is rendered with color 1`] = `
     </span>
   </li>
   <li
-    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-primary"
+    class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-primary"
     data-test-subj="euiListItemLayout"
   >
     <span

--- a/packages/eui/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
+++ b/packages/eui/src/components/list_group/__snapshots__/list_group_item.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiListGroupItem is rendered 1`] = `
 <li
   aria-label="aria-label"
-  class="euiListItemLayout euiListGroupItem testClass1 testClass2 euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text-euiTestCss"
+  class="euiListItemLayout euiListGroupItem testClass1 testClass2 euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text-euiTestCss"
   data-test-subj="test subject string"
 >
   <span
@@ -21,7 +21,7 @@ exports[`EuiListGroupItem is rendered 1`] = `
 
 exports[`EuiListGroupItem props color primary is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-primary"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-primary"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -39,7 +39,7 @@ exports[`EuiListGroupItem props color primary is rendered 1`] = `
 
 exports[`EuiListGroupItem props color subdued is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-subdued"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-subdued"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -57,7 +57,7 @@ exports[`EuiListGroupItem props color subdued is rendered 1`] = `
 
 exports[`EuiListGroupItem props color text is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -75,7 +75,7 @@ exports[`EuiListGroupItem props color text is rendered 1`] = `
 
 exports[`EuiListGroupItem props extraAction is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -180,7 +180,7 @@ exports[`EuiListGroupItem props href is rendered with rel 1`] = `
 
 exports[`EuiListGroupItem props icon is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -205,7 +205,7 @@ exports[`EuiListGroupItem props icon is rendered 1`] = `
 
 exports[`EuiListGroupItem props iconType is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -233,7 +233,7 @@ exports[`EuiListGroupItem props iconType is rendered 1`] = `
 exports[`EuiListGroupItem props isActive is rendered 1`] = `
 <li
   aria-current="true"
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-isSelected-euiListGroupItem-euiListGroupItem__inner"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isSelected-euiListGroupItem-euiListGroupItem__inner"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -295,7 +295,7 @@ exports[`EuiListGroupItem props onClick is rendered 1`] = `
 exports[`EuiListGroupItem props showToolTip is rendered 1`] = `
 <li
   aria-describedby="generated-id"
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -317,7 +317,7 @@ exports[`EuiListGroupItem props showToolTip is rendered 1`] = `
 
 exports[`EuiListGroupItem props style is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
   style="color: red;"
 >
@@ -336,7 +336,7 @@ exports[`EuiListGroupItem props style is rendered 1`] = `
 
 exports[`EuiListGroupItem props wrapText is rendered 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -403,7 +403,7 @@ exports[`EuiListGroupItem renders a disabled button even if provided an href 2`]
 
 exports[`EuiListGroupItem throws a warning if both iconType and icon are provided but still renders 1`] = `
 <li
-  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+  class="euiListItemLayout euiListGroupItem euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
   data-test-subj="euiListItemLayout"
 >
   <span

--- a/packages/eui/src/components/list_group/pinnable_list_group/__snapshots__/pinnable_list_group.test.tsx.snap
+++ b/packages/eui/src/components/list_group/pinnable_list_group/__snapshots__/pinnable_list_group.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
   data-test-subj="test subject string"
 >
   <li
-    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
     data-test-subj="euiListItemLayout"
   >
     <span
@@ -44,7 +44,7 @@ exports[`EuiPinnableListGroup can have custom pin icon titles 1`] = `
     </span>
   </li>
   <li
-    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
     data-test-subj="euiListItemLayout"
   >
     <span
@@ -207,7 +207,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
   data-test-subj="test subject string"
 >
   <li
-    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
     data-test-subj="euiListItemLayout"
   >
     <span
@@ -244,7 +244,7 @@ exports[`EuiPinnableListGroup is rendered 1`] = `
     </span>
   </li>
   <li
-    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-isInteractive-euiListGroupItem-euiListGroupItem__inner-text"
+    class="euiListItemLayout euiListGroupItem euiPinnableListGroup__item euiListGroupItem__text emotion-euiListItemLayout-euiListGroupItem-euiListGroupItem__inner-text"
     data-test-subj="euiListItemLayout"
   >
     <span

--- a/packages/eui/src/components/list_item_layout/__snapshots__/_list_item_layout.test.tsx.snap
+++ b/packages/eui/src/components/list_item_layout/__snapshots__/_list_item_layout.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`EuiListItemLayout is rendered as button element 1`] = `
 
 exports[`EuiListItemLayout is rendered as div element 1`] = `
 <div
-  class="euiListItemLayout emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
 >
   <span
@@ -68,7 +68,7 @@ exports[`EuiListItemLayout is rendered as div element 1`] = `
 
 exports[`EuiListItemLayout is rendered as li element 1`] = `
 <li
-  class="euiListItemLayout emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
 >
   <span

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.stories.tsx
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.stories.tsx
@@ -181,6 +181,21 @@ export const Playground: Story = {
   },
 };
 
+export const Interactive: Story = {
+  tags: ['vrt-only'], // remove story from sidebar in production
+  parameters: {
+    loki: {
+      // VRT looks the same as the Playground story
+      skip: true,
+    },
+  },
+  ...Playground,
+  args: {
+    children: 'List item',
+    onClick: () => {},
+  },
+};
+
 export const Role: Story = {
   tags: ['vrt-only'],
   parameters: {

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.styles.ts
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.styles.ts
@@ -47,7 +47,6 @@ const listItemCommonStyles = (euiThemeContext: UseEuiTheme) => {
     line-height: ${euiFontSize(euiThemeContext, 's').lineHeight};
     font-size: ${euiFontSize(euiThemeContext, 's').fontSize};
     color: ${euiTheme.colors.textParagraph};
-    cursor: pointer;
     overflow: hidden;
   `;
 };
@@ -128,6 +127,8 @@ export const euiListItemLayoutStyles = (euiThemeContext: UseEuiTheme) => {
       ${sharedFlexStyles}
     `,
     isInteractive: css`
+      cursor: pointer;
+
       &:hover {
         ${highlightedStyles}
       }

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.styles.ts
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.styles.ts
@@ -100,7 +100,8 @@ export const euiListItemLayoutStyles = (euiThemeContext: UseEuiTheme) => {
       text-align: start;
 
       /* Workaround for decent alingment for custom flex wrapper content */
-      > *:only-child {
+      > *:only-child,
+      > *:first-child {
         vertical-align: middle;
       }
 

--- a/packages/eui/src/components/list_item_layout/_list_item_layout.tsx
+++ b/packages/eui/src/components/list_item_layout/_list_item_layout.tsx
@@ -223,6 +223,7 @@ export const EuiListItemLayout = forwardRef<
       'aria-selected': _ariaSelected,
       'aria-checked': _ariaChecked,
       'data-test-subj': dataTestSubj = 'euiListItemLayout',
+      onClick,
       ...props
     },
     ref
@@ -257,6 +258,7 @@ export const EuiListItemLayout = forwardRef<
     const isInteractiveComponent =
       ['button', 'a'].includes(component) ||
       ['button', 'link'].includes(role ?? '');
+    const isInteractive = isInteractiveComponent || !!onClick;
     /* Multi-action: component is interactive (button/a) and has an additional action passed via `extraAction`,
     which requires to not nest interactive elements. The wrapper is the outermost styled container and owns
     hover/focus/selected styles.
@@ -323,7 +325,7 @@ export const EuiListItemLayout = forwardRef<
     const styles = useEuiMemoizedStyles(euiListItemLayoutStyles);
 
     const interactiveStyles = [
-      styles.isInteractive,
+      isInteractive && styles.isInteractive,
       isFocused && styles.isFocused,
       (isSingleSelection || !showIndicator) && isSelected && styles.isSelected,
       (isSingleSelection || !showIndicator) &&
@@ -483,6 +485,7 @@ export const EuiListItemLayout = forwardRef<
         ? ariaDescribedBy
         : _ariaDescribedBy,
       'data-test-subj': dataTestSubj,
+      onClick,
       ...rest,
     };
 

--- a/packages/eui/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
+++ b/packages/eui/src/components/selectable/selectable_list/__snapshots__/selectable_list_item.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
 <li
   aria-label="aria-label"
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem testClass1 testClass2 emotion-euiListItemLayout-isInteractive-euiTestCss"
+  class="euiListItemLayout euiSelectableListItem testClass1 testClass2 emotion-euiListItemLayout-euiTestCss"
   data-test-subj="test subject string"
   role="option"
 >
@@ -26,7 +26,7 @@ exports[`EuiSelectableListItem is rendered 1`] = `
 exports[`EuiSelectableListItem props append 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -53,7 +53,7 @@ exports[`EuiSelectableListItem props append 1`] = `
 exports[`EuiSelectableListItem props checked & allowExclusions mixed 1`] = `
 <li
   aria-checked="mixed"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive-isSelected"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isSelected"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -86,7 +86,7 @@ exports[`EuiSelectableListItem props checked & allowExclusions mixed 1`] = `
 exports[`EuiSelectableListItem props checked & allowExclusions off 1`] = `
 <li
   aria-checked="true"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive-isSelected"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isSelected"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -117,7 +117,7 @@ exports[`EuiSelectableListItem props checked & allowExclusions off 1`] = `
 exports[`EuiSelectableListItem props checked & allowExclusions on 1`] = `
 <li
   aria-checked="true"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive-isSelected"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isSelected"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -148,7 +148,7 @@ exports[`EuiSelectableListItem props checked & allowExclusions on 1`] = `
 exports[`EuiSelectableListItem props checked & allowExclusions undefined 1`] = `
 <li
   aria-checked="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -177,7 +177,7 @@ exports[`EuiSelectableListItem props checked & allowExclusions undefined 1`] = `
 exports[`EuiSelectableListItem props checked & searchable on 1`] = `
 <li
   aria-selected="true"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive-isSelected"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isSelected"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -208,7 +208,7 @@ exports[`EuiSelectableListItem props checked & searchable on 1`] = `
 exports[`EuiSelectableListItem props checked & searchable undefined 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -237,7 +237,7 @@ exports[`EuiSelectableListItem props checked & searchable undefined 1`] = `
 exports[`EuiSelectableListItem props checked mixed 1`] = `
 <li
   aria-checked="mixed"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive-isSelected"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isSelected"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -270,7 +270,7 @@ exports[`EuiSelectableListItem props checked mixed 1`] = `
 exports[`EuiSelectableListItem props checked on 1`] = `
 <li
   aria-selected="true"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive-isSelected"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isSelected"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -299,7 +299,7 @@ exports[`EuiSelectableListItem props checked on 1`] = `
 exports[`EuiSelectableListItem props checked undefined 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -344,7 +344,7 @@ exports[`EuiSelectableListItem props disabled 1`] = `
 exports[`EuiSelectableListItem props isFocused 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem euiSelectableListItem-isFocused emotion-euiListItemLayout-isInteractive-isFocused"
+  class="euiListItemLayout euiSelectableListItem euiSelectableListItem-isFocused emotion-euiListItemLayout-isFocused"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -366,7 +366,7 @@ exports[`EuiSelectableListItem props isFocused 1`] = `
 exports[`EuiSelectableListItem props onFocusBadge can be custom 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -388,7 +388,7 @@ exports[`EuiSelectableListItem props onFocusBadge can be custom 1`] = `
 exports[`EuiSelectableListItem props onFocusBadge can be true 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -410,7 +410,7 @@ exports[`EuiSelectableListItem props onFocusBadge can be true 1`] = `
 exports[`EuiSelectableListItem props prepend 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -437,7 +437,7 @@ exports[`EuiSelectableListItem props prepend 1`] = `
 exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -454,7 +454,7 @@ exports[`EuiSelectableListItem props showIcons can be turned off 1`] = `
 exports[`EuiSelectableListItem props textWrap can be "wrap" 1`] = `
 <li
   aria-selected="false"
-  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+  class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
   data-test-subj="euiListItemLayout"
   role="option"
 >
@@ -481,7 +481,7 @@ exports[`EuiSelectableListItem props tooltip behavior on mouseover 1`] = `
     <li
       aria-describedby="generated-id"
       aria-selected="false"
-      class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout-isInteractive"
+      class="euiListItemLayout euiSelectableListItem emotion-euiListItemLayout"
       data-test-subj="euiListItemLayout"
       role="option"
     >
@@ -544,7 +544,7 @@ exports[`EuiSelectableListItem props tooltip behavior when isFocused 1`] = `
     <li
       aria-describedby="generated-id"
       aria-selected="false"
-      class="euiListItemLayout euiSelectableListItem euiSelectableListItem-isFocused emotion-euiListItemLayout-isInteractive-isFocused"
+      class="euiListItemLayout euiSelectableListItem euiSelectableListItem-isFocused emotion-euiListItemLayout-isFocused"
       data-test-subj="euiListItemLayout"
       role="option"
     >


### PR DESCRIPTION
>[!important]
This PR merges into a [feature branch](https://github.com/elastic/eui/tree/feat/selectable-ui-enhancements)


## Summary

This PR updates `EuiListItemLayout` to fix the appliance of hover styles. Initially the styles were always applied, assuming that list items are always interactive or used as `option` within a listbox.
While not that common, they can also be used as non-interactive list item via `EuiListGroup`/`EuiListGroup` and for that we should not apply a hover style if the items are not actually interactive.

### API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/5f67321e-2471-49a5-b8bc-c001d167d3e3" /> | <video src="https://github.com/user-attachments/assets/055201f2-643b-4216-ad7a-149f13c26f37" /> |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
- [ ] ~~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

Checkout the PR (`EuiListItemLayout` is an internal component and not visible with controls in production storybook) and:

- [x] verify that `EuiListItemLayout` with `element=li/div` without `onClick` don't have a hover style applied
- [x] verify that `EuiListItemLayout` with `element=button/a` have a hover style applied
- [x] verify that `EuiListItemLayout` with `element=li/div` and an interactive `role` (e.g. "link" or "button") have a hover style applied

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] ~~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~~
- [ ] ~~**QA:** Tested docs changes~~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] ~~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~~
- [ ] ~~**Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [x] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [x] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
