### PR TITLE
fix(EuiDataGrid): Don't scroll into view on middle mouse button click

### DIFF
--- a/packages/eui/changelogs/upcoming/9613.md
+++ b/packages/eui/changelogs/upcoming/9613.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed a bug in EuiDataGrid that caused the scroll position to reset when using middle mouse button to scroll the container.

--- a/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { act } from '@testing-library/react';
 import { render, renderHook } from '../../../test/rtl';
 import { DataGridCellPopoverContext } from '../body/cell';
@@ -28,15 +28,50 @@ const createPointerEvent = (
 };
 
 describe('useScroll', () => {
-  it('ignores deferred scrolling on non-primary mouse pointerup events', () => {
-    const scrollTo = jest.fn();
-    const scrollToItem = jest.fn();
-    const outerGrid = document.createElement('div');
-    const pointerTarget = document.createElement('div');
+  const scrollTo = jest.fn();
+  const scrollToItem = jest.fn();
+  let outerGrid: HTMLDivElement;
+  let pointerTarget: HTMLDivElement;
+  let focusedCell: [number, number] | undefined;
+  let args: Parameters<typeof useScroll>[0];
+
+  const focusContext = {
+    setFocusedCell: jest.fn(),
+    setIsFocusedCellInView: jest.fn(),
+    onFocusUpdate: () => () => {},
+    focusFirstVisibleInteractiveCell: jest.fn(),
+  };
+
+  const popoverContext = {
+    popoverIsOpen: false,
+    cellLocation: { rowIndex: 0, colIndex: 0 },
+    openCellPopover: jest.fn(),
+    closeCellPopover: jest.fn(),
+    setPopoverAnchor: jest.fn(),
+    setPopoverAnchorPosition: jest.fn(),
+    setPopoverContent: jest.fn(),
+    setCellPopoverProps: jest.fn(),
+  };
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <DataGridFocusContext.Provider value={{ ...focusContext, focusedCell }}>
+      <DataGridCellPopoverContext.Provider value={popoverContext}>
+        {children}
+      </DataGridCellPopoverContext.Provider>
+    </DataGridFocusContext.Provider>
+  );
+
+  beforeEach(() => {
+    scrollTo.mockReset();
+    scrollToItem.mockReset();
+    focusedCell = undefined;
+
+    outerGrid = document.createElement('div');
+    pointerTarget = document.createElement('div');
     outerGrid.appendChild(pointerTarget);
     document.body.appendChild(outerGrid);
 
-    const args = {
+    args = {
       gridRef: { current: { scrollTo, scrollToItem } as any },
       outerGridRef: {
         current: {
@@ -60,63 +95,70 @@ describe('useScroll', () => {
       visibleRowCount: 20,
       hasStickyFooter: false,
     };
+  });
 
-    const focusContext = {
-      setFocusedCell: jest.fn(),
-      setIsFocusedCellInView: jest.fn(),
-      onFocusUpdate: () => () => {},
-      focusFirstVisibleInteractiveCell: jest.fn(),
-    };
-    const popoverContext = {
-      popoverIsOpen: false,
-      cellLocation: { rowIndex: 0, colIndex: 0 },
-      openCellPopover: jest.fn(),
-      closeCellPopover: jest.fn(),
-      setPopoverAnchor: jest.fn(),
-      setPopoverAnchorPosition: jest.fn(),
-      setPopoverContent: jest.fn(),
-      setCellPopoverProps: jest.fn(),
-    };
+  afterEach(() => {
+    outerGrid.remove();
+  });
 
-    const HookConsumer = () => {
-      useScroll(args);
-      return null;
-    };
+  it('scrolls the focused cell into view on primary (left) pointerup after deferred focus', () => {
+    jest.spyOn(window, 'getSelection').mockReturnValue({
+      type: 'Caret',
+    } as Selection);
 
-    const Component = ({ focusedCell }: { focusedCell?: [number, number] }) => (
-      <DataGridFocusContext.Provider value={{ ...focusContext, focusedCell }}>
-        <DataGridCellPopoverContext.Provider value={popoverContext}>
-          <HookConsumer />
-        </DataGridCellPopoverContext.Provider>
-      </DataGridFocusContext.Provider>
-    );
+    const { rerender } = renderHook(() => useScroll(args), {
+      wrapper,
+    });
 
-    const { rerender, unmount } = render(<Component />);
+    act(() => {
+      pointerTarget.dispatchEvent(
+        createPointerEvent('pointerdown', {
+          button: 0,
+        })
+      );
+    });
+
+    focusedCell = [1, 1];
+    rerender();
+
+    act(() => {
+      document.dispatchEvent(
+        createPointerEvent('pointerup', {
+          button: 0,
+        })
+      );
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({ scrollLeft: 150, scrollTop: 0 });
+    expect(scrollToItem).not.toHaveBeenCalled();
+  });
+
+  it('ignores deferred scrolling on non-primary mouse pointerup events', () => {
+    const { rerender } = renderHook(() => useScroll(args), {
+      wrapper,
+    });
 
     act(() => {
       pointerTarget.dispatchEvent(
         createPointerEvent('pointerdown', {
           button: 1,
-          pointerType: 'mouse',
         })
       );
     });
 
-    rerender(<Component focusedCell={[1, 1]} />);
+    focusedCell = [1, 1];
+    rerender();
 
     act(() => {
       document.dispatchEvent(
         createPointerEvent('pointerup', {
           button: 1,
-          pointerType: 'mouse',
         })
       );
     });
 
     expect(scrollTo).not.toHaveBeenCalled();
-
-    unmount();
-    outerGrid.remove();
+    expect(scrollToItem).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.test.tsx
@@ -7,10 +7,118 @@
  */
 
 import React from 'react';
+import { act } from '@testing-library/react';
 import { render, renderHook } from '../../../test/rtl';
-import { useScrollCellIntoView, useScrollBars } from './scrolling';
+import { DataGridCellPopoverContext } from '../body/cell';
+import { useScroll, useScrollCellIntoView, useScrollBars } from './scrolling';
+import { DataGridFocusContext } from './focus';
 
 // see scrolling.spec.tsx for E2E useScroll tests
+
+const createPointerEvent = (
+  type: string,
+  init: PointerEventInit = {}
+): MouseEvent => {
+  const event = new MouseEvent(type, { bubbles: true, ...init });
+  Object.defineProperty(event, 'pointerType', {
+    configurable: true,
+    value: init.pointerType ?? 'mouse',
+  });
+  return event;
+};
+
+describe('useScroll', () => {
+  it('ignores deferred scrolling on non-primary mouse pointerup events', () => {
+    const scrollTo = jest.fn();
+    const scrollToItem = jest.fn();
+    const outerGrid = document.createElement('div');
+    const pointerTarget = document.createElement('div');
+    outerGrid.appendChild(pointerTarget);
+    document.body.appendChild(outerGrid);
+
+    const args = {
+      gridRef: { current: { scrollTo, scrollToItem } as any },
+      outerGridRef: {
+        current: {
+          scrollTop: 0,
+          scrollLeft: 0,
+          clientHeight: 100,
+          clientWidth: 100,
+          querySelector: () =>
+            ({
+              parentNode: { offsetTop: 0 },
+              offsetLeft: 150,
+              offsetWidth: 100,
+              offsetHeight: 20,
+            } as any),
+          contains: outerGrid.contains.bind(outerGrid),
+        } as any,
+      },
+      hasGridScrolling: true,
+      headerRowHeight: 0,
+      footerRowHeight: 0,
+      visibleRowCount: 20,
+      hasStickyFooter: false,
+    };
+
+    const focusContext = {
+      setFocusedCell: jest.fn(),
+      setIsFocusedCellInView: jest.fn(),
+      onFocusUpdate: () => () => {},
+      focusFirstVisibleInteractiveCell: jest.fn(),
+    };
+    const popoverContext = {
+      popoverIsOpen: false,
+      cellLocation: { rowIndex: 0, colIndex: 0 },
+      openCellPopover: jest.fn(),
+      closeCellPopover: jest.fn(),
+      setPopoverAnchor: jest.fn(),
+      setPopoverAnchorPosition: jest.fn(),
+      setPopoverContent: jest.fn(),
+      setCellPopoverProps: jest.fn(),
+    };
+
+    const HookConsumer = () => {
+      useScroll(args);
+      return null;
+    };
+
+    const Component = ({ focusedCell }: { focusedCell?: [number, number] }) => (
+      <DataGridFocusContext.Provider value={{ ...focusContext, focusedCell }}>
+        <DataGridCellPopoverContext.Provider value={popoverContext}>
+          <HookConsumer />
+        </DataGridCellPopoverContext.Provider>
+      </DataGridFocusContext.Provider>
+    );
+
+    const { rerender, unmount } = render(<Component />);
+
+    act(() => {
+      pointerTarget.dispatchEvent(
+        createPointerEvent('pointerdown', {
+          button: 1,
+          pointerType: 'mouse',
+        })
+      );
+    });
+
+    rerender(<Component focusedCell={[1, 1]} />);
+
+    act(() => {
+      document.dispatchEvent(
+        createPointerEvent('pointerup', {
+          button: 1,
+          pointerType: 'mouse',
+        })
+      );
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    unmount();
+    outerGrid.remove();
+  });
+});
 
 describe('useScrollCellIntoView', () => {
   const scrollToItem = jest.fn();

--- a/packages/eui/src/components/datagrid/utils/scrolling.tsx
+++ b/packages/eui/src/components/datagrid/utils/scrolling.tsx
@@ -73,10 +73,16 @@ export const useScroll = (args: Dependencies) => {
   }, [focusedCell, scrollCellIntoView, isPointerDownRef]);
 
   useEffect(() => {
-    const handlePointerUp = () => {
+    const handlePointerUp = (event: PointerEvent) => {
       if (!pendingScrollRef.current || !focusedCell) return;
 
       pendingScrollRef.current = false;
+
+      // The pointerup event can come from any mouse button, not only the left
+      // click. We only care about the primary (usually left) mouse button
+      // clicks, and specifically have to ignore middle mouse button clicks,
+      // which indicate scrolling on Windows.
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
 
       // Skip if the interaction resulted in text being selected
       if (window?.getSelection()?.type === 'Range') return;


### PR DESCRIPTION
## Summary

This PR addresses an externally reported bug that causes cell focus return/reset when using the middle mouse button scrolling on Windows.

### API Changes

N/A

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| https://github.com/user-attachments/assets/d18e0790-bfc5-485c-abff-ed8660ab9d64 | https://github.com/user-attachments/assets/1c610b98-0079-4217-a55b-093e39af685e |

## Impact Assessment

No negative impact expected.

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer



### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
