### PR TITLE
[EuiMarkdownEditor][A11y] Fix invalid nested interactive elements

### DIFF
--- a/packages/eui/changelogs/upcoming/9625.md
+++ b/packages/eui/changelogs/upcoming/9625.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+- Fixed invalid nested interactive elements in `EuiMarkdownEditor` by removing `role` from the drop zone wrapper.

--- a/packages/eui/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
+++ b/packages/eui/src/components/markdown_editor/__snapshots__/markdown_editor.test.tsx.snap
@@ -210,7 +210,6 @@ exports[`EuiMarkdownEditor is rendered 1`] = `
   >
     <div
       class="euiMarkdownEditorDropZone emotion-euiMarkdownEditorDropZone"
-      role="button"
     >
       <textarea
         aria-label="aria-label"
@@ -468,7 +467,6 @@ exports[`EuiMarkdownEditor props autoExpandPreview is rendered with false 1`] = 
   >
     <div
       class="euiMarkdownEditorDropZone emotion-euiMarkdownEditorDropZone"
-      role="button"
     >
       <textarea
         aria-label="aria-label"
@@ -725,7 +723,6 @@ exports[`EuiMarkdownEditor props height is rendered in full mode 1`] = `
   >
     <div
       class="euiMarkdownEditorDropZone emotion-euiMarkdownEditorDropZone"
-      role="button"
     >
       <textarea
         aria-label="aria-label"
@@ -982,7 +979,6 @@ exports[`EuiMarkdownEditor props height is rendered with a custom size 1`] = `
   >
     <div
       class="euiMarkdownEditorDropZone emotion-euiMarkdownEditorDropZone"
-      role="button"
     >
       <textarea
         aria-label="aria-label"
@@ -1239,7 +1235,6 @@ exports[`EuiMarkdownEditor props maxHeight is rendered with a custom size 1`] = 
   >
     <div
       class="euiMarkdownEditorDropZone emotion-euiMarkdownEditorDropZone"
-      role="button"
     >
       <textarea
         aria-label="aria-label"

--- a/packages/eui/src/components/markdown_editor/markdown_editor.stories.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor.stories.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -123,11 +123,15 @@ export const DropZone: Story = {
 };
 
 const StatefulMarkdownEditor = ({
-  value: initialValue,
+  value: _value,
   onChange,
   ...rest
 }: EuiMarkdownEditorProps) => {
-  const [value, setValue] = useState(initialValue);
+  const [value, setValue] = useState(_value);
+
+  useEffect(() => {
+    setValue(_value);
+  }, [_value]);
 
   return (
     <EuiMarkdownEditor

--- a/packages/eui/src/components/markdown_editor/markdown_editor.stories.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor.stories.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -88,4 +88,55 @@ export const CustomToolbarContent: Story = {
       ),
     },
   },
+};
+
+export const DropZone: Story = {
+  parameters: {
+    controls: { include: ['dropHandlers', 'value'] },
+    loki: {
+      // functional test story only
+      skip: true,
+    },
+  },
+  args: {
+    value: initialContent,
+    dropHandlers: [
+      {
+        supportedFiles: ['image/png', 'image/jpeg'],
+        accepts: (type: string) => type.startsWith('image/'),
+        getFormattingForItem: (file: File) =>
+          new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () =>
+              resolve({
+                text: `![${file.name}](${reader.result})`,
+                config: { block: true },
+              });
+            reader.readAsDataURL(file);
+          }),
+      },
+    ],
+  },
+  render: (args: EuiMarkdownEditorProps) => (
+    <StatefulMarkdownEditor {...args} />
+  ),
+};
+
+const StatefulMarkdownEditor = ({
+  value: initialValue,
+  onChange,
+  ...rest
+}: EuiMarkdownEditorProps) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <EuiMarkdownEditor
+      {...rest}
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onChange?.(v);
+      }}
+    />
+  );
 };

--- a/packages/eui/src/components/markdown_editor/markdown_editor.test.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor.test.tsx
@@ -121,6 +121,34 @@ describe('EuiMarkdownEditor', () => {
         expect(container.firstChild).toMatchSnapshot();
       });
     });
+
+    describe('dropHandlers', () => {
+      // A11y: ensure interactive elements aren't nested
+      it('does not have role="button" when dropHandlers are provided', () => {
+        const { container } = render(
+          <EuiMarkdownEditor
+            editorId="editorId"
+            value=""
+            onChange={() => null}
+            dropHandlers={[
+              {
+                supportedFiles: ['image/png'],
+                accepts: (type: string) => type === 'image/png',
+                getFormattingForItem: (file: File) =>
+                  Promise.resolve({
+                    text: `![${file.name}]()`,
+                    config: { block: true },
+                  }),
+              },
+            ]}
+            {...requiredProps}
+          />
+        );
+
+        const dropZone = container.querySelector('.euiMarkdownEditorDropZone');
+        expect(dropZone).not.toHaveAttribute('role', 'button');
+      });
+    });
   });
 
   test('is preview rendered', () => {

--- a/packages/eui/src/components/markdown_editor/markdown_editor_drop_zone.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor_drop_zone.tsx
@@ -214,7 +214,11 @@ export const EuiMarkdownEditorDropZone: FunctionComponent<
   });
 
   const rootProps = { ...getRootProps() };
-  if (readOnly) rootProps.role = undefined; // Unset the default `role="button"` attribute which sets a misleading pointer icon
+  /* Unset the default `role="button"` attribute to prevent invalid nested interactive elements.
+  The dropzone has `noClick=true` and `noKeyboard=true` set via `useDropzone`.
+  Keyboard drop interactions expect the drop zone element to have `role="button` but we're supporting
+  adding files via a standalone footer button instead." */
+  rootProps.role = undefined;
 
   return (
     <div {...rootProps} css={cssStyles} className={classes}>


### PR DESCRIPTION
## Summary

Caused by: https://github.com/elastic/kibana/pull/263605

>The EUI markdown editor's drop zone div gets role="button" from react-dropzone by default, even when no drop handlers are configured. This wraps the textarea in a semantic button, triggering an axe-core "Interactive controls must not be nested" violation (WCAG 4.1.2 Level A).

This PR updates `EuiMarkdownEditor` by removing the added `role="button"` on the drop zone wrapper element.
This would result in invalid nested interactive elements as the button would nest the textarea.

The change removes the `role` completely, considering that the drop zone doesn't actually support keyboard interaction as is (it's also disabled via `noKeyboard` in the drop zone settings). The drop zone basically only works for mouse interaction while we're already making use of a standalone way via a button in the footer to add files instead.

### API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/7f6f1b53-0238-419b-ae62-4994ea9f89c9" /> | <video src="https://github.com/user-attachments/assets/f117a170-eeb8-41cb-b697-b1ed72f950d2" />|


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [x] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 Low 
The removes `role` might require snapshot updates.

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
- [ ] ~~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

💻 [EuiMarkdownEditor storybook](https://eui.elastic.co/pr_9625/storybook/?path=/story/editors-syntax-euimarkdowneditor--playground)

- [x] verify there is no regression with production
- [x] verify adding files is possible via a) dragging files with the mouse OR b) adding them via keyboard using the dedicated upload button

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] ~~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana]~~(https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] ~~**QA:** Tested docs changes~~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~~**Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [x] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [x] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
