### PR TITLE
[EuiToolTip] Remove delay and update animation

### DIFF
--- a/packages/eui/changelogs/upcoming/9626.md
+++ b/packages/eui/changelogs/upcoming/9626.md
@@ -1,0 +1,10 @@
+- Updated `EuiToolTip` show animation to opacity-only with a 150ms grace period delay, preventing visual flickering when quickly hovering over multiple tooltip triggers
+
+**Bug fixes**
+
+- Fixed `EuiToolTip` self-hiding when the mouse moves over child elements within the trigger
+
+**Breaking changes**
+
+- Removed `delay` prop and `ToolTipDelay` type from `EuiToolTip` and `EuiIconTip`
+- Removed `waitForEuiToolTipVisible` and `waitForEuiToolTipHidden` RTL test helpers; tooltip show/hide is now synchronous so direct assertions can be used instead

--- a/packages/eui/src/components/basic_table/collapsed_item_actions.test.tsx
+++ b/packages/eui/src/components/basic_table/collapsed_item_actions.test.tsx
@@ -12,8 +12,6 @@ import {
   render,
   waitForEuiPopoverOpen,
   waitForEuiPopoverClose,
-  waitForEuiToolTipVisible,
-  waitForEuiToolTipHidden,
 } from '../../test/rtl';
 
 import { CollapsedItemActions } from './collapsed_item_actions';
@@ -80,7 +78,6 @@ describe('CollapsedItemActions', () => {
     expect(getByTestSubject('xyz-link')).toHaveAttribute('href', '#/xyz');
     expect(getByTestSubject('xyz-link')).toHaveTextContent('name xyz');
     fireEvent.mouseEnter(getByTestSubject('xyz-link'));
-    await waitForEuiToolTipVisible();
     expect(getByText('description xyz')).toBeInTheDocument();
 
     fireEvent.click(getByTestSubject('defaultAction'));
@@ -229,7 +226,6 @@ describe('CollapsedItemActions', () => {
 
     const actionDifferent = getByTestSubject('different');
     fireEvent.mouseOver(actionDifferent);
-    await waitForEuiToolTipVisible();
     const tooltipDifferent = getByRole('tooltip');
     expect(tooltipDifferent).toHaveTextContent('different');
     expect(actionDifferent).toHaveAttribute('aria-describedby');
@@ -237,11 +233,9 @@ describe('CollapsedItemActions', () => {
       tooltipDifferent.id
     );
     fireEvent.mouseOut(actionDifferent);
-    await waitForEuiToolTipHidden();
 
     const actionSame = getByTestSubject('same');
     fireEvent.mouseOver(actionSame);
-    await waitForEuiToolTipVisible();
     const tooltipSame = getByRole('tooltip');
     expect(tooltipSame).toHaveTextContent('same');
     expect(actionSame).not.toHaveAttribute('aria-describedby');

--- a/packages/eui/src/components/basic_table/collapsed_item_actions.tsx
+++ b/packages/eui/src/components/basic_table/collapsed_item_actions.tsx
@@ -115,7 +115,6 @@ export const CollapsedItemActions = <T extends {}>({
             }}
             toolTipContent={toolTipContent}
             toolTipProps={{
-              delay: 'long',
               // Avoid screen-readers announcing the same text twice
               disableScreenReaderOutput:
                 typeof buttonContent === 'string' &&
@@ -148,9 +147,7 @@ export const CollapsedItemActions = <T extends {}>({
   );
 
   const withTooltip = !actionsDisabled && (
-    <EuiToolTip content={allActionsTooltip} delay="long">
-      {popoverButton}
-    </EuiToolTip>
+    <EuiToolTip content={allActionsTooltip}>{popoverButton}</EuiToolTip>
   );
 
   return (

--- a/packages/eui/src/components/basic_table/default_item_action.test.tsx
+++ b/packages/eui/src/components/basic_table/default_item_action.test.tsx
@@ -8,11 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import {
-  render,
-  waitForEuiToolTipVisible,
-  waitForEuiToolTipHidden,
-} from '../../test/rtl';
+import { render } from '../../test/rtl';
 
 import { DefaultItemAction } from './default_item_action';
 import {
@@ -79,7 +75,7 @@ describe('DefaultItemAction', () => {
     expect(container.querySelector('.euiButtonEmpty')).toBeInTheDocument();
   });
 
-  test('props that can be functions', async () => {
+  test('props that can be functions', () => {
     const action: EmptyButtonAction<Item> = {
       name: ({ id }) =>
         id === 'hello' ? <span>Hello</span> : <span>world</span>,
@@ -113,17 +109,14 @@ describe('DefaultItemAction', () => {
     expect(secondAction).toHaveAttribute('href', '#/world');
 
     fireEvent.mouseOver(firstAction);
-    await waitForEuiToolTipVisible();
     expect(getByText('hello tooltip')).toBeInTheDocument();
     fireEvent.mouseOut(firstAction);
-    await waitForEuiToolTipHidden();
 
     fireEvent.mouseOver(secondAction);
-    await waitForEuiToolTipVisible();
     expect(getByText('goodbye tooltip')).toBeInTheDocument();
   });
 
-  it('is described by the tooltip via aria-describedby', async () => {
+  it('is described by the tooltip via aria-describedby', () => {
     const actionWithDifferentNameAndDescription: EmptyButtonAction<Item> = {
       name: 'same',
       description: 'different',
@@ -141,7 +134,6 @@ describe('DefaultItemAction', () => {
 
     const action = getByTestSubject('different');
     fireEvent.mouseOver(action);
-    await waitForEuiToolTipVisible();
     const tooltip = getByRole('tooltip');
     expect(tooltip).toHaveTextContent('different');
     expect(tooltip).toBeInTheDocument();
@@ -151,7 +143,7 @@ describe('DefaultItemAction', () => {
 
   // If `name` and `description` are exactly the same
   // we don't want screen readers announcing the same text twice
-  it('has visual-only tooltip when `name` equals `description`', async () => {
+  it('has visual-only tooltip when `name` equals `description`', () => {
     const actionWithEqualNameAndDescription: EmptyButtonAction<Item> = {
       name: 'same',
       description: 'same',
@@ -169,7 +161,6 @@ describe('DefaultItemAction', () => {
 
     const action = getByTestSubject('same');
     fireEvent.mouseOver(action);
-    await waitForEuiToolTipVisible();
     const tooltip = getByRole('tooltip');
     expect(tooltip).toBeInTheDocument();
     expect(tooltip).toHaveTextContent('same');

--- a/packages/eui/src/components/basic_table/default_item_action.tsx
+++ b/packages/eui/src/components/basic_table/default_item_action.tsx
@@ -60,7 +60,6 @@ export const DefaultItemAction = <T extends object>({
   const tooltipContent = callWithItemIfFunction(item)(action.description);
   const tooltipProps: Omit<EuiToolTipProps, 'position' | 'children'> = {
     content: tooltipContent,
-    delay: 'long',
     // Avoid screen-readers announcing the same text twice
     disableScreenReaderOutput:
       typeof actionContent === 'string' && actionContent === tooltipContent,

--- a/packages/eui/src/components/basic_table/table_types.ts
+++ b/packages/eui/src/components/basic_table/table_types.ts
@@ -46,8 +46,7 @@ export type EuiTableColumnNameTooltipProps = {
   /** Additional props for EuiIcon */
   iconProps?: EuiIconTipProps['iconProps'];
   /** Additional props for the EuiToolip */
-  tooltipProps?: Omit<EuiToolTipProps, 'children' | 'delay' | 'position'> & {
-    delay?: EuiToolTipProps['delay'];
+  tooltipProps?: Omit<EuiToolTipProps, 'children' | 'position'> & {
     position?: EuiToolTipProps['position'];
   };
 };

--- a/packages/eui/src/components/basic_table/table_types.ts
+++ b/packages/eui/src/components/basic_table/table_types.ts
@@ -45,7 +45,7 @@ export type EuiTableColumnNameTooltipProps = {
   icon?: IconType;
   /** Additional props for EuiIcon */
   iconProps?: EuiIconTipProps['iconProps'];
-  /** Additional props for the EuiToolip */
+  /** Additional props for the EuiToolTip */
   tooltipProps?: Omit<EuiToolTipProps, 'children' | 'position'> & {
     position?: EuiToolTipProps['position'];
   };

--- a/packages/eui/src/components/button/button_group/button_group.stories.tsx
+++ b/packages/eui/src/components/button/button_group/button_group.stories.tsx
@@ -12,7 +12,6 @@ import { disableStorybookControls } from '../../../../.storybook/utils';
 
 import { LOKI_SELECTORS } from '../../../../.storybook/loki';
 import { EuiSpacer } from '../../spacer';
-import { ToolTipDelay } from '../../tool_tip/tool_tip';
 import {
   EuiButtonGroup,
   EuiButtonGroupProps,
@@ -145,18 +144,14 @@ export const WithTooltips: Story = {
         label: 'Standard tooltip',
         toolTipContent: 'Hello world',
         autoFocus: true, // dev-only usage to showcase tooltip on load
-        toolTipProps: {
-          delay: 'none' as ToolTipDelay, // passing a (not-yet) supported value to hackishly force a lower delay for VRT
-        },
       } as EuiButtonGroupOptionProps,
       {
         id: 'customToolTipProps',
         iconType: 'securitySignalDetected',
         label: 'Custom tooltip',
-        toolTipContent: 'Custom tooltip position and delay',
+        toolTipContent: 'Custom tooltip position',
         toolTipProps: {
           position: 'right',
-          delay: 'long',
           title: 'Hello world',
         },
         // Consumers could also opt to hide titles if preferred

--- a/packages/eui/src/components/button/button_group/button_group.test.tsx
+++ b/packages/eui/src/components/button/button_group/button_group.test.tsx
@@ -9,12 +9,7 @@
 import React from 'react';
 import { css } from '@emotion/react';
 import { fireEvent } from '@testing-library/react';
-import {
-  render,
-  waitForEuiToolTipHidden,
-  waitForEuiToolTipVisible,
-  focusEuiToolTipTrigger,
-} from '../../../test/rtl';
+import { render, focusEuiToolTipTrigger } from '../../../test/rtl';
 import { requiredProps as commonProps } from '../../../test';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 
@@ -262,19 +257,15 @@ describe('EuiButtonGroup', () => {
         />
       );
       fireEvent.mouseOver(getByTestSubject('buttonWithTooltip'));
-      await waitForEuiToolTipVisible();
 
       expect(getByRole('tooltip')).toHaveTextContent('I am a tooltip');
 
       fireEvent.mouseOut(getByTestSubject('buttonWithTooltip'));
-      await waitForEuiToolTipHidden();
 
       const cleanup = focusEuiToolTipTrigger(
         getByTestSubject('buttonWithTooltip')
       );
-      await waitForEuiToolTipVisible();
       fireEvent.blur(getByTestSubject('buttonWithTooltip'));
-      await waitForEuiToolTipHidden();
       cleanup();
     });
 
@@ -299,23 +290,19 @@ describe('EuiButtonGroup', () => {
       // NOTE: uses `parentElement` as the hover event is triggered on the tooltip wrapper.
       // The button itself doesn't allow mouse events when disabled.
       fireEvent.mouseOver(getByTestSubject('buttonWithTooltip').parentElement!);
-      await waitForEuiToolTipVisible();
 
       expect(await findByRole('tooltip')).toHaveTextContent('I am a tooltip');
 
       fireEvent.mouseOut(getByTestSubject('buttonWithTooltip').parentElement!);
-      await waitForEuiToolTipHidden();
 
       const cleanup = focusEuiToolTipTrigger(
         getByTestSubject('buttonWithTooltip')
       );
-      await waitForEuiToolTipVisible();
       fireEvent.blur(getByTestSubject('buttonWithTooltip'));
-      await waitForEuiToolTipHidden();
       cleanup();
     });
 
-    it('allows customizing the tooltip via `toolTipProps`', async () => {
+    it('allows customizing the tooltip via `toolTipProps`', () => {
       const { getByTestSubject } = render(
         <EuiButtonGroup
           {...requiredMultiProps}
@@ -328,7 +315,7 @@ describe('EuiButtonGroup', () => {
               toolTipContent: 'I am a tooltip',
               toolTipProps: {
                 position: 'right',
-                delay: 'regular',
+
                 'data-test-subj': 'toolTipTest',
               },
             },
@@ -336,7 +323,6 @@ describe('EuiButtonGroup', () => {
         />
       );
       fireEvent.mouseOver(getByTestSubject('buttonWithTooltip'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('toolTipTest')).toHaveAttribute(
         'data-position',

--- a/packages/eui/src/components/button/split_button/split_button.stories.tsx
+++ b/packages/eui/src/components/button/split_button/split_button.stories.tsx
@@ -16,7 +16,6 @@ import { EuiSpacer } from '../../spacer';
 import { EuiFlexGroup } from '../../flex';
 import { EuiWrappingPopover } from '../../popover';
 import { EuiContextMenu } from '../../context_menu';
-import { ToolTipDelay } from '../../tool_tip/tool_tip';
 import { EuiSplitButton, EuiSplitButtonProps } from './split_button';
 
 const decorators: Meta<EuiSplitButtonProps>['decorators'] = [
@@ -90,7 +89,6 @@ export const WithTooltip: Story = {
         aria-label="Secondary action"
         tooltipProps={{
           content: 'Tooltip content',
-          delay: 'none' as ToolTipDelay, // passing a not (yet) supported value to hackishly force a lower delay for VRT
         }}
         autoFocus={true} // VRT-only workaround to ensure an opened tooltip
       />,

--- a/packages/eui/src/components/button/split_button/split_button.test.tsx
+++ b/packages/eui/src/components/button/split_button/split_button.test.tsx
@@ -9,11 +9,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 
-import {
-  render,
-  waitForEuiToolTipHidden,
-  waitForEuiToolTipVisible,
-} from '../../../test/rtl';
+import { render } from '../../../test/rtl';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 import { EuiToolTip } from '../../tool_tip';
 import { EuiSplitButton, EuiSplitButtonProps } from './split_button';
@@ -294,7 +290,7 @@ describe('EuiSplitButton', () => {
         consoleErrorSpy.mockRestore();
       });
 
-      it('renders a tooltip', async () => {
+      it('renders a tooltip', () => {
         const { getByTestSubject } = render(
           <EuiSplitButton size="s">
             <EuiSplitButton.ActionPrimary
@@ -315,15 +311,12 @@ describe('EuiSplitButton', () => {
         );
 
         fireEvent.mouseOver(getByTestSubject('primary-action'));
-        await waitForEuiToolTipVisible();
 
         expect(getByTestSubject('primary-action-tooltip')).toBeInTheDocument();
 
         fireEvent.mouseLeave(getByTestSubject('primary-action'));
-        await waitForEuiToolTipHidden();
 
         fireEvent.mouseOver(getByTestSubject('secondary-action'));
-        await waitForEuiToolTipVisible();
 
         expect(
           getByTestSubject('secondary-action-tooltip')

--- a/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.test.tsx
+++ b/packages/eui/src/components/collapsible_nav_beta/collapsible_nav_item/collapsed/collapsed_nav_button.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { render, waitForEuiToolTipVisible } from '../../../../test/rtl';
+import { render } from '../../../../test/rtl';
 import { shouldRenderCustomStyles } from '../../../../test/internal';
 import { requiredProps } from '../../../../test';
 
@@ -19,17 +19,17 @@ describe('EuiCollapsedNavButton', () => {
     childProps: ['linkProps'],
   });
 
-  it('renders a tooltip around the icon button', async () => {
+  it('renders a tooltip around the icon button', () => {
     const { baseElement, getByTestSubject } = render(
       <EuiCollapsedNavButton {...requiredProps} title="Nav item" />
     );
+
     fireEvent.mouseOver(getByTestSubject('euiCollapsedNavButton'));
-    await waitForEuiToolTipVisible();
 
     expect(baseElement).toMatchSnapshot();
   });
 
-  it('renders isSelected', async () => {
+  it('renders isSelected', () => {
     const { container } = render(
       <EuiCollapsedNavButton title="Nav item" href="#" isSelected={true} />
     );

--- a/packages/eui/src/components/color_picker/color_picker_swatch.test.tsx
+++ b/packages/eui/src/components/color_picker/color_picker_swatch.test.tsx
@@ -10,13 +10,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
-import {
-  render,
-  waitForEuiToolTipHidden,
-  waitForEuiToolTipVisible,
-  focusEuiToolTipTrigger,
-} from '../../test/rtl';
-
+import { render, focusEuiToolTipTrigger } from '../../test/rtl';
 import { EuiColorPickerSwatch } from './color_picker_swatch';
 
 describe('EuiColorPickerSwatch', () => {
@@ -29,7 +23,7 @@ describe('EuiColorPickerSwatch', () => {
   });
 
   describe('showToolTip', () => {
-    test('it renders a color label tooltip on hover', async () => {
+    test('it renders a color label tooltip on hover', () => {
       const { getByTestSubject, getByText } = render(
         <EuiColorPickerSwatch
           {...requiredProps}
@@ -42,16 +36,12 @@ describe('EuiColorPickerSwatch', () => {
 
       fireEvent.mouseOver(swatchElement);
 
-      await waitForEuiToolTipVisible();
-
       expect(getByText('#000000')).toBeInTheDocument();
 
       fireEvent.mouseLeave(swatchElement);
-
-      await waitForEuiToolTipHidden();
     });
 
-    test('it renders a color label tooltip on focus', async () => {
+    test('it renders a color label tooltip on focus', () => {
       const { getByTestSubject, getByText } = render(
         <EuiColorPickerSwatch
           {...requiredProps}
@@ -64,17 +54,14 @@ describe('EuiColorPickerSwatch', () => {
 
       const cleanup = focusEuiToolTipTrigger(swatchElement);
 
-      await waitForEuiToolTipVisible();
-
       expect(getByText('#000000')).toBeInTheDocument();
 
       fireEvent.blur(swatchElement);
 
-      await waitForEuiToolTipHidden();
       cleanup();
     });
 
-    test('it does not render a color label tooltip when `showToolTip` is `false`', async () => {
+    test('it does not render a color label tooltip when `showToolTip` is `false`', () => {
       const { getByTestSubject } = render(
         <EuiColorPickerSwatch
           {...requiredProps}
@@ -88,11 +75,7 @@ describe('EuiColorPickerSwatch', () => {
 
       fireEvent.mouseOver(swatchElement);
 
-      await waitForEuiToolTipHidden();
-
       fireEvent.focus(swatchElement);
-
-      await waitForEuiToolTipHidden();
     });
   });
 });

--- a/packages/eui/src/components/color_picker/color_picker_swatch.tsx
+++ b/packages/eui/src/components/color_picker/color_picker_swatch.tsx
@@ -27,7 +27,7 @@ export type EuiColorPickerSwatchProps = CommonProps &
      */
     showToolTip?: boolean;
 
-    /** Additional props for the EuiToolip when `showToolTip={true}` */
+    /** Additional props for the EuiToolTip when `showToolTip={true}` */
     toolTipProps?: Omit<EuiToolTipProps, 'children' | 'position'> & {
       position?: EuiToolTipProps['position'];
     };

--- a/packages/eui/src/components/color_picker/color_picker_swatch.tsx
+++ b/packages/eui/src/components/color_picker/color_picker_swatch.tsx
@@ -28,8 +28,7 @@ export type EuiColorPickerSwatchProps = CommonProps &
     showToolTip?: boolean;
 
     /** Additional props for the EuiToolip when `showToolTip={true}` */
-    toolTipProps?: Omit<EuiToolTipProps, 'children' | 'delay' | 'position'> & {
-      delay?: EuiToolTipProps['delay'];
+    toolTipProps?: Omit<EuiToolTipProps, 'children' | 'position'> & {
       position?: EuiToolTipProps['position'];
     };
   };

--- a/packages/eui/src/components/color_picker/hue.test.tsx
+++ b/packages/eui/src/components/color_picker/hue.test.tsx
@@ -9,12 +9,7 @@
 import React from 'react';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
-import {
-  render,
-  waitForEuiToolTipHidden,
-  waitForEuiToolTipVisible,
-  focusEuiToolTipTrigger,
-} from '../../test/rtl';
+import { render, focusEuiToolTipTrigger } from '../../test/rtl';
 
 import { EuiHue } from './hue';
 import { fireEvent } from '@testing-library/react';
@@ -57,7 +52,7 @@ describe('EuiHue', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('it renders a color label tooltip on hover', async () => {
+  test('it renders a color label tooltip on hover', () => {
     const { getByText } = render(
       <EuiHue hue={180} hex="#00FFFF" onChange={onChange} {...requiredProps} />
     );
@@ -66,16 +61,12 @@ describe('EuiHue', () => {
 
     fireEvent.mouseOver(thumbElement);
 
-    await waitForEuiToolTipVisible();
-
     expect(getByText('#00FFFF')).toBeInTheDocument();
 
     fireEvent.mouseLeave(thumbElement);
-
-    await waitForEuiToolTipHidden();
   });
 
-  test('it renders a color label tooltip on focus', async () => {
+  test('it renders a color label tooltip on focus', () => {
     const { getByText } = render(
       <EuiHue hue={180} hex="#00FFFF" onChange={onChange} {...requiredProps} />
     );
@@ -84,13 +75,10 @@ describe('EuiHue', () => {
 
     const cleanup = focusEuiToolTipTrigger(thumbElement);
 
-    await waitForEuiToolTipVisible();
-
     expect(getByText('#00FFFF')).toBeInTheDocument();
 
     fireEvent.blur(thumbElement);
 
-    await waitForEuiToolTipHidden();
     cleanup();
   });
 });

--- a/packages/eui/src/components/color_picker/saturation.test.tsx
+++ b/packages/eui/src/components/color_picker/saturation.test.tsx
@@ -9,12 +9,7 @@
 import React from 'react';
 import { requiredProps } from '../../test/required_props';
 import { shouldRenderCustomStyles } from '../../test/internal';
-import {
-  render,
-  waitForEuiToolTipHidden,
-  waitForEuiToolTipVisible,
-  focusEuiToolTipTrigger,
-} from '../../test/rtl';
+import { render, focusEuiToolTipTrigger } from '../../test/rtl';
 
 import { EuiSaturation } from './saturation';
 import { fireEvent } from '@testing-library/react';
@@ -46,7 +41,7 @@ describe('EuiSaturation', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('it renders a color label tooltip on hover', async () => {
+  test('it renders a color label tooltip on hover', () => {
     const { getByText } = render(
       <EuiSaturation onChange={onChange} {...requiredProps} hex="#000000" />
     );
@@ -55,16 +50,12 @@ describe('EuiSaturation', () => {
 
     fireEvent.mouseOver(thumbElement);
 
-    await waitForEuiToolTipVisible();
-
     expect(getByText('#000000')).toBeInTheDocument();
 
     fireEvent.mouseLeave(thumbElement);
-
-    await waitForEuiToolTipHidden();
   });
 
-  test('it renders a color label tooltip on focus', async () => {
+  test('it renders a color label tooltip on focus', () => {
     const { getByText } = render(
       <EuiSaturation onChange={onChange} {...requiredProps} hex="#000000" />
     );
@@ -73,13 +64,10 @@ describe('EuiSaturation', () => {
 
     const cleanup = focusEuiToolTipTrigger(thumbElement);
 
-    await waitForEuiToolTipVisible();
-
     expect(getByText('#000000')).toBeInTheDocument();
 
     fireEvent.blur(thumbElement);
 
-    await waitForEuiToolTipHidden();
     cleanup();
   });
 });

--- a/packages/eui/src/components/combo_box/combo_box.test.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.test.tsx
@@ -8,11 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import {
-  render,
-  showEuiComboBoxOptions,
-  waitForEuiToolTipVisible,
-} from '../../test/rtl';
+import { render, showEuiComboBoxOptions } from '../../test/rtl';
 import {
   shouldRenderCustomStyles,
   testOnReactVersion,
@@ -246,7 +242,6 @@ describe('EuiComboBox', () => {
         await showEuiComboBoxOptions();
 
         fireEvent.mouseOver(getByTestSubject('titanOption'));
-        await waitForEuiToolTipVisible();
 
         expect(getByTestSubject('optionToolTip')).toBeInTheDocument();
         expect(getByTestSubject('optionToolTip')).toHaveTextContent(
@@ -277,8 +272,6 @@ describe('EuiComboBox', () => {
 
         const input = getByTestSubject('comboBoxSearchInput');
         fireEvent.keyDown(input, { key: keys.ARROW_DOWN });
-
-        await waitForEuiToolTipVisible();
 
         expect(getByTestSubject('optionToolTip')).toBeInTheDocument();
         expect(getByTestSubject('optionToolTip')).toHaveTextContent(

--- a/packages/eui/src/components/context_menu/context_menu_item.test.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { render, waitForEuiToolTipVisible } from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
 
@@ -22,9 +22,8 @@ describe('EuiContextMenuItem', () => {
     {
       childProps: ['toolTipProps', 'toolTipProps.anchorProps'],
       skip: { parentTest: true },
-      renderCallback: async ({ getByTestSubject }) => {
+      renderCallback: ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
       },
     }
   );
@@ -154,18 +153,17 @@ describe('EuiContextMenuItem', () => {
     });
   });
 
-  test('tooltip behavior', async () => {
+  test('tooltip behavior', () => {
     const { getByRole, baseElement } = render(
       <EuiContextMenuItem
         toolTipContent="tooltip content"
-        toolTipProps={{ title: 'Test', position: 'top', delay: 'long' }}
+        toolTipProps={{ title: 'Test', position: 'top' }}
       >
         Hello
       </EuiContextMenuItem>
     );
 
     fireEvent.mouseOver(getByRole('button'));
-    await waitForEuiToolTipVisible();
 
     expect(baseElement).toMatchSnapshot();
   });

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -8,11 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import {
-  waitForEuiToolTipVisible,
-  waitForEuiToolTipHidden,
-  render,
-} from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 
 import { EuiCopy } from './copy';
@@ -44,7 +40,7 @@ describe('EuiCopy', () => {
   });
 
   describe('props', () => {
-    it('beforeMessage', async () => {
+    it('beforeMessage', () => {
       const beforeMessage = 'copy this';
       const { getByRole, getByText } = render(
         <EuiCopy textToCopy="some text" beforeMessage={beforeMessage}>
@@ -57,14 +53,13 @@ describe('EuiCopy', () => {
       );
       // Simulate mouse over to show the tooltip
       fireEvent.mouseOver(getByRole('button'));
-      await waitForEuiToolTipVisible();
+
       // The beforeMessage should be shown in the tooltip
       expect(getByText(beforeMessage)).toBeInTheDocument();
       fireEvent.mouseOut(getByRole('button'));
-      await waitForEuiToolTipHidden();
     });
 
-    it('afterMessage', async () => {
+    it('afterMessage', () => {
       const afterMessage = 'successfully copied';
       const { getByRole, getByText } = render(
         <EuiCopy textToCopy="some text" afterMessage={afterMessage}>
@@ -79,14 +74,13 @@ describe('EuiCopy', () => {
       // Simulate a click to copy the text
       fireEvent.click(getByRole('button'));
       fireEvent.mouseOver(getByRole('button'));
-      await waitForEuiToolTipVisible();
+
       // The afterMessage should be shown after the copy action
       expect(getByText(afterMessage)).toBeInTheDocument();
       fireEvent.mouseOut(getByRole('button'));
-      await waitForEuiToolTipHidden();
     });
 
-    it('tooltipProps', async () => {
+    it('tooltipProps', () => {
       const tooltipProps = {
         'data-test-subj': 'customTooltip',
         className: 'myTooltipClass',
@@ -107,13 +101,12 @@ describe('EuiCopy', () => {
       );
       // Simulate mouse over to show the tooltip
       fireEvent.mouseOver(getByRole('button'));
-      await waitForEuiToolTipVisible();
+
       // The tooltip portalled, so search the global document
       const tooltip = getByTestSubject('customTooltip');
       expect(tooltip).toBeInTheDocument();
       expect(tooltip?.className).toContain('myTooltipClass');
       fireEvent.mouseOut(getByRole('button'));
-      await waitForEuiToolTipHidden();
     });
   });
 });

--- a/packages/eui/src/components/datagrid/controls/display_selector.tsx
+++ b/packages/eui/src/components/datagrid/controls/display_selector.tsx
@@ -425,7 +425,7 @@ export const useDataGridDisplaySelector = (
         panelProps={{ css: logicalStyle('width', popoverWidth) }}
         panelClassName="euiDataGrid__displayPopoverPanel"
         button={
-          <EuiToolTip content={buttonLabel} delay="long">
+          <EuiToolTip content={buttonLabel}>
             <EuiButtonIcon
               size="xs"
               iconType="controls"

--- a/packages/eui/src/components/datagrid/controls/fullscreen_selector.tsx
+++ b/packages/eui/src/components/datagrid/controls/fullscreen_selector.tsx
@@ -62,7 +62,6 @@ export const useDataGridFullScreenSelector = (
             fullScreenButton
           )
         }
-        delay="long"
       >
         <EuiButtonIcon
           size="xs"

--- a/packages/eui/src/components/datagrid/controls/keyboard_shortcuts.tsx
+++ b/packages/eui/src/components/datagrid/controls/keyboard_shortcuts.tsx
@@ -37,7 +37,7 @@ export const useDataGridKeyboardShortcuts = (): {
         anchorPosition="downRight"
         panelPaddingSize="none"
         button={
-          <EuiToolTip content={title} delay="long">
+          <EuiToolTip content={title}>
             <EuiButtonIcon
               size="xs"
               iconType="keyboard"

--- a/packages/eui/src/components/date_picker/super_date_picker/super_update_button.test.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_update_button.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { render, waitForEuiToolTipVisible, within } from '../../../test/rtl';
+import { render, within } from '../../../test/rtl';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiSuperUpdateButton } from './super_update_button';
@@ -24,14 +24,13 @@ describe('EuiSuperUpdateButton', () => {
       data-test-subj="trigger"
       showTooltip
       needsUpdate
-      toolTipProps={{ children: <>Test</>, delay: 'regular', position: 'top' }} // React throws a `Failed prop type` error without this
+      toolTipProps={{ children: <>Test</>, position: 'top' }} // React throws a `Failed prop type` error without this
     />,
     {
       childProps: ['toolTipProps'],
       skip: { parentTest: true },
-      renderCallback: async ({ getByTestSubject }) => {
+      renderCallback: ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
       },
     }
   );

--- a/packages/eui/src/components/filter_group/filter_select_item.test.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.test.tsx
@@ -7,11 +7,7 @@
  */
 
 import React from 'react';
-import {
-  render,
-  waitForEuiToolTipVisible,
-  waitForEuiToolTipHidden,
-} from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -35,7 +31,7 @@ describe('EuiFilterSelectItem', () => {
     // `toggleToolTip` is called in `componentDidUpdate`; on initial mount `tooltipRef.current`
     // is null because `EuiToolTip` hasn't committed its ref yet, so a re-render is required
     // to trigger `showToolTip`/`hideToolTip`.
-    it('shows tooltip when `isFocused` becomes true', async () => {
+    it('shows tooltip when `isFocused` becomes true', () => {
       const { rerender, getByTestSubject } = render(
         <EuiFilterSelectItem {...tooltipProps} isFocused={false}>
           <span>Item</span>
@@ -48,11 +44,10 @@ describe('EuiFilterSelectItem', () => {
         </EuiFilterSelectItem>
       );
 
-      await waitForEuiToolTipVisible();
       expect(getByTestSubject('filterItemToolTip')).toBeInTheDocument();
     });
 
-    it('hides tooltip when `isFocused` becomes false', async () => {
+    it('hides tooltip when `isFocused` becomes false', () => {
       const { rerender, queryByRole } = render(
         <EuiFilterSelectItem {...tooltipProps} isFocused={false}>
           <span>Item</span>
@@ -65,7 +60,6 @@ describe('EuiFilterSelectItem', () => {
         </EuiFilterSelectItem>
       );
 
-      await waitForEuiToolTipVisible();
       expect(queryByRole('tooltip')).toBeInTheDocument();
 
       rerender(
@@ -74,7 +68,6 @@ describe('EuiFilterSelectItem', () => {
         </EuiFilterSelectItem>
       );
 
-      await waitForEuiToolTipHidden();
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
   });

--- a/packages/eui/src/components/filter_group/filter_select_item.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.tsx
@@ -92,11 +92,27 @@ export class EuiFilterSelectItemClass extends Component<
     return this.state.hasFocus;
   };
 
+  componentDidMount() {
+    const { isFocused, toolTipContent, disabled, children } = this.props;
+    if (React.isValidElement(children) && !disabled && toolTipContent) {
+      this.toggleToolTip(isFocused ?? false);
+    }
+  }
+
   componentDidUpdate(
     prevProps: Readonly<WithEuiThemeProps<{}> & EuiFilterSelectItemProps>
   ) {
     if (this.props.isFocused && !prevProps.isFocused) {
       this.buttonRef?.scrollIntoView?.({ block: 'nearest' });
+    }
+    const { isFocused, toolTipContent, disabled, children } = this.props;
+    if (
+      React.isValidElement(children) &&
+      !disabled &&
+      toolTipContent &&
+      isFocused !== prevProps.isFocused
+    ) {
+      this.toggleToolTip(isFocused ?? false);
     }
   }
 
@@ -143,8 +159,6 @@ export class EuiFilterSelectItemClass extends Component<
             style: anchorStyles,
           }
         : { style };
-
-      this.toggleToolTip(isFocused ?? false);
     }
 
     let iconNode;

--- a/packages/eui/src/components/filter_group/filter_select_item.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.tsx
@@ -6,7 +6,12 @@
  * Side Public License, v 1.
  */
 
-import React, { ButtonHTMLAttributes, Component, createRef } from 'react';
+import React, {
+  ButtonHTMLAttributes,
+  Component,
+  createRef,
+  isValidElement,
+} from 'react';
 import classNames from 'classnames';
 
 import { withEuiTheme, WithEuiThemeProps } from '../../services';
@@ -94,7 +99,7 @@ export class EuiFilterSelectItemClass extends Component<
 
   componentDidMount() {
     const { isFocused, toolTipContent, disabled, children } = this.props;
-    if (React.isValidElement(children) && !disabled && toolTipContent) {
+    if (isValidElement(children) && !disabled && toolTipContent) {
       this.toggleToolTip(isFocused ?? false);
     }
   }
@@ -107,7 +112,7 @@ export class EuiFilterSelectItemClass extends Component<
     }
     const { isFocused, toolTipContent, disabled, children } = this.props;
     if (
-      React.isValidElement(children) &&
+      isValidElement(children) &&
       !disabled &&
       toolTipContent &&
       isFocused !== prevProps.isFocused
@@ -144,7 +149,7 @@ export class EuiFilterSelectItemClass extends Component<
     const hasToolTip =
       // we're using isValidElement here as EuiToolTipAnchor uses
       // cloneElement to enhance the element with required attributes
-      React.isValidElement(children) && !disabled && toolTipContent;
+      isValidElement(children) && !disabled && toolTipContent;
 
     let anchorProps = undefined;
 

--- a/packages/eui/src/components/key_pad_menu/key_pad_menu_item.test.tsx
+++ b/packages/eui/src/components/key_pad_menu/key_pad_menu_item.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { render, waitForEuiToolTipVisible } from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -29,9 +29,8 @@ describe('EuiKeyPadMenuItem', () => {
     {
       skip: { parentTest: true },
       childProps: ['betaBadgeTooltipProps'],
-      renderCallback: async ({ getByTestSubject }) => {
+      renderCallback: ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
       },
     }
   );

--- a/packages/eui/src/components/key_pad_menu/key_pad_menu_item.tsx
+++ b/packages/eui/src/components/key_pad_menu/key_pad_menu_item.tsx
@@ -83,9 +83,7 @@ type EuiKeyPadMenuItemPropsForUncheckable = {
   /**
    * Extends the wrapping EuiToolTip props when `betaBadgeLabel` is provided
    */
-  betaBadgeTooltipProps?: Partial<
-    Omit<EuiToolTipProps, 'title' | 'content' | 'delay'>
-  >;
+  betaBadgeTooltipProps?: Partial<Omit<EuiToolTipProps, 'title' | 'content'>>;
   /**
    * Use `onClick` instead when the item is not `checkable`
    */
@@ -321,7 +319,6 @@ export const EuiKeyPadMenuItem: FunctionComponent<EuiKeyPadMenuItemProps> = ({
       {...betaBadgeTooltipProps}
       title={betaBadgeLabel}
       content={betaBadgeTooltipContent}
-      delay="long"
     >
       {button}
     </EuiToolTip>

--- a/packages/eui/src/components/list_group/list_group_item.test.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
-import { render, waitForEuiToolTipVisible } from '../../test/rtl';
+import { render } from '../../test/rtl';
 
 import { EuiListGroupItem, SIZES, COLORS } from './list_group_item';
 
@@ -38,9 +38,8 @@ describe('EuiListGroupItem', () => {
     {
       childProps: ['toolTipProps', 'toolTipProps.anchorProps'],
       skip: { parentTest: true },
-      renderCallback: async ({ getByTestSubject }) => {
+      renderCallback: ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
       },
     }
   );
@@ -255,7 +254,7 @@ describe('EuiListGroupItem', () => {
     });
 
     describe('toolTipProps', () => {
-      test('renders custom tooltip props', async () => {
+      test('renders custom tooltip props', () => {
         const { getByTestSubject } = render(
           <EuiListGroupItem
             label="Label"
@@ -268,7 +267,6 @@ describe('EuiListGroupItem', () => {
           />
         );
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
         expect(getByTestSubject('tooltip')).toBeInTheDocument();
       });
     });

--- a/packages/eui/src/components/list_group/list_group_item.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.tsx
@@ -350,7 +350,6 @@ export const EuiListGroupItem: FunctionComponent<EuiListGroupItemProps> = ({
         <EuiToolTip
           content={toolTipText ?? label}
           position="right"
-          delay="long"
           {...toolTipProps}
           anchorClassName={anchorClasses}
           anchorProps={anchorPropsAndCss}

--- a/packages/eui/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -178,7 +178,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
           className="euiMarkdownEditorToolbar__buttons"
         >
           {boldItalicButtons.map((item) => (
-            <EuiToolTip key={item.id} content={item.label} delay="long">
+            <EuiToolTip key={item.id} content={item.label}>
               <EuiMarkdownEditorToolbarButton
                 selectedNode={selectedNode}
                 handleMdButtonClick={handleMdButtonClick}
@@ -195,7 +195,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
             className="euiMarkdownEditorToolbar__divider"
           />
           {listButtons.map((item) => (
-            <EuiToolTip key={item.id} content={item.label} delay="long">
+            <EuiToolTip key={item.id} content={item.label}>
               <EuiMarkdownEditorToolbarButton
                 selectedNode={selectedNode}
                 handleMdButtonClick={handleMdButtonClick}
@@ -212,7 +212,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
             className="euiMarkdownEditorToolbar__divider"
           />
           {quoteCodeLinkButtons.map((item) => (
-            <EuiToolTip key={item.id} content={item.label} delay="long">
+            <EuiToolTip key={item.id} content={item.label}>
               <EuiMarkdownEditorToolbarButton
                 selectedNode={selectedNode}
                 handleMdButtonClick={handleMdButtonClick}
@@ -233,7 +233,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
               />
               {uiPlugins.map(({ name, button }) => {
                 return (
-                  <EuiToolTip key={name} content={button.label} delay="long">
+                  <EuiToolTip key={name} content={button.label}>
                     <EuiMarkdownEditorToolbarButton
                       selectedNode={selectedNode}
                       handleMdButtonClick={handleMdButtonClick}

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list_item.test.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list_item.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { render, waitForEuiToolTipVisible } from '../../../test/rtl';
+import { render } from '../../../test/rtl';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 import { requiredProps } from '../../../test/required_props';
 
@@ -167,14 +167,14 @@ describe('EuiSelectableListItem', () => {
       });
     });
 
-    test('tooltip behavior on mouseover', async () => {
+    test('tooltip behavior on mouseover', () => {
       const { baseElement, getByTestSubject } = render(
         <EuiSelectableListItem
           toolTipContent="I am a tooltip!"
           toolTipProps={{
             title: 'Test',
             position: 'top',
-            delay: 'long',
+
             'data-test-subj': 'listItemToolTip',
           }}
         >
@@ -184,20 +184,19 @@ describe('EuiSelectableListItem', () => {
 
       const tooltipAnchor = baseElement.querySelector('.euiToolTipAnchor');
       fireEvent.mouseOver(tooltipAnchor!);
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('listItemToolTip')).toBeInTheDocument();
       expect(baseElement).toMatchSnapshot();
     });
 
-    test('tooltip behavior when isFocused', async () => {
+    test('tooltip behavior when isFocused', () => {
       const { baseElement, getByTestSubject } = render(
         <EuiSelectableListItem
           toolTipContent="I am a tooltip!"
           toolTipProps={{
             title: 'Test',
             position: 'top',
-            delay: 'long',
+
             'data-test-subj': 'listItemToolTip',
           }}
           isFocused
@@ -205,8 +204,6 @@ describe('EuiSelectableListItem', () => {
           Item content
         </EuiSelectableListItem>
       );
-
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('listItemToolTip')).toBeInTheDocument();
       expect(baseElement).toMatchSnapshot();

--- a/packages/eui/src/components/table/table_header_cell.test.tsx
+++ b/packages/eui/src/components/table/table_header_cell.test.tsx
@@ -8,7 +8,7 @@
 
 import React, { PropsWithChildren, ReactElement } from 'react';
 import { requiredProps } from '../../test/required_props';
-import { render, waitForEuiToolTipVisible } from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { fireEvent } from '@testing-library/react';
 
 import { RIGHT_ALIGNMENT, CENTER_ALIGNMENT } from '../../services';
@@ -257,7 +257,7 @@ describe('EuiTableHeaderCell', () => {
   });
 
   describe('tooltip', () => {
-    it('renders an icon with tooltip', async () => {
+    it('renders an icon with tooltip', () => {
       const { getByTestSubject } = renderInTableHeader(
         <EuiTableHeaderCell
           tooltipProps={{
@@ -281,14 +281,13 @@ describe('EuiTableHeaderCell', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('icon'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('tooltip')).toHaveTextContent(
         'This is the content of the tooltip'
       );
     });
 
-    it('renders a tooltip on the cell if sortable', async () => {
+    it('renders a tooltip on the cell if sortable', () => {
       const { getByTestSubject } = renderInTableHeader(
         <EuiTableHeaderCell
           tooltipProps={{
@@ -313,7 +312,6 @@ describe('EuiTableHeaderCell', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('tableHeaderSortButton'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('tooltip')).toHaveTextContent(
         'This is the content of the tooltip'

--- a/packages/eui/src/components/tool_tip/icon_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/icon_tip.stories.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../.storybook/utils';
 import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { EuiFlexGroup } from '../flex';
-import { ToolTipDelay } from './tool_tip';
 import { EuiIconTip, EuiIconTipProps } from './icon_tip';
 
 const meta: Meta<EuiIconTipProps> = {
@@ -43,7 +42,6 @@ const meta: Meta<EuiIconTipProps> = {
   args: {
     type: 'question',
     position: 'top',
-    delay: 'regular',
     display: 'inlineBlock',
     // set up for easier testing/QA
     anchorClassName: '',
@@ -79,6 +77,5 @@ export const Playground: Story = {
       // @ts-ignore - temp. solution for storybook VRT testing
       autofocus: 'true',
     },
-    delay: 'none' as ToolTipDelay, // passing a (not-yet) supported value to hackishly force a lower delay for VRT
   },
 };

--- a/packages/eui/src/components/tool_tip/icon_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/icon_tip.test.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../test';
-import { render, waitForEuiToolTipVisible } from '../../test/rtl';
+import { render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
 import { EuiIconTip } from './icon_tip';
@@ -19,9 +19,8 @@ describe('EuiIconTip', () => {
     <EuiIconTip content="test" iconProps={{ 'data-test-subj': 'trigger' }} />,
     {
       childProps: ['iconProps'],
-      renderCallback: async ({ getByTestSubject }) => {
+      renderCallback: ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
       },
     }
   );
@@ -89,13 +88,12 @@ describe('EuiIconTip', () => {
     });
   });
 
-  it('shows tooltip content on hover', async () => {
+  it('shows tooltip content on hover', () => {
     const { container, getByRole } = render(
       <EuiIconTip content="Tooltip content" />
     );
 
     fireEvent.mouseOver(container.querySelector('[data-euiicon-type]')!);
-    await waitForEuiToolTipVisible();
 
     expect(getByRole('tooltip')).toHaveTextContent('Tooltip content');
   });

--- a/packages/eui/src/components/tool_tip/icon_tip.tsx
+++ b/packages/eui/src/components/tool_tip/icon_tip.tsx
@@ -5,6 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+/* eslint-disable @elastic/eui/prefer-eui-icon-tip */
 
 import React, { FunctionComponent } from 'react';
 
@@ -13,10 +14,7 @@ import { useEuiI18n } from '../i18n';
 import { EuiIcon, IconSize, IconType } from '../icon';
 import { EuiToolTip, EuiToolTipProps } from './tool_tip';
 
-export type EuiIconTipProps = Omit<
-  EuiToolTipProps,
-  'children' | 'delay' | 'position'
-> & {
+export type EuiIconTipProps = Omit<EuiToolTipProps, 'children' | 'position'> & {
   /**
    * Children are not allowed as they are built using the icon props
    */
@@ -44,9 +42,7 @@ export type EuiIconTipProps = Omit<
   // iconProps; however, due to TS's bivariant function arguments `type` could be
   // passed without any error/feedback so we explicitly set it to `never` type
   iconProps?: Omit<PropsOf<typeof EuiIcon>, 'type'> & { type?: never };
-  // This are copied from EuiToolTipProps, but made optional. Defaults
-  // are applied below.
-  delay?: EuiToolTipProps['delay'];
+  // Copied from EuiToolTipProps, but made optional. Default applied below.
   position?: EuiToolTipProps['position'];
 };
 
@@ -57,13 +53,12 @@ export const EuiIconTip: FunctionComponent<EuiIconTipProps> = ({
   size,
   iconProps,
   position = 'top',
-  delay = 'regular',
   ...rest
 }) => {
   const defaultAriaLabel = useEuiI18n('euiIconTip.defaultAriaLabel', 'Info');
 
   return (
-    <EuiToolTip position={position} delay={delay} {...rest}>
+    <EuiToolTip position={position} {...rest}>
       <EuiIcon
         tabIndex={0}
         type={type}

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -44,7 +44,6 @@ const meta: Meta<EuiToolTipProps> = {
   ],
   args: {
     position: 'top',
-    delay: 'regular',
     display: 'inlineBlock',
     // set up for easier testing/QA
     anchorClassName: '',

--- a/packages/eui/src/components/tool_tip/tool_tip.styles.ts
+++ b/packages/eui/src/components/tool_tip/tool_tip.styles.ts
@@ -6,8 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { css } from '@emotion/react';
-import { euiShadow } from '@elastic/eui-theme-common';
+import { css, keyframes } from '@emotion/react';
+import { euiCanAnimate, euiShadow } from '@elastic/eui-theme-common';
 
 import { logicalCSS, euiFontSize } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
@@ -19,6 +19,11 @@ export const euiToolTipBackgroundColor = (euiTheme: UseEuiTheme['euiTheme']) =>
 
 export const euiToolTipBorderColor = (euiTheme: UseEuiTheme['euiTheme']) =>
   euiTheme.components.tooltipBorder;
+
+const euiToolTipAnimation = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
 
 export const euiToolTipStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme, highContrastMode } = euiThemeContext;
@@ -47,6 +52,11 @@ export const euiToolTipStyles = (euiThemeContext: UseEuiTheme) => {
 
       [class*='euiHorizontalRule'] {
         background-color: ${euiToolTipBorderColor(euiTheme)};
+      }
+
+      ${euiCanAnimate} {
+        animation: ${euiToolTipAnimation} ${euiTheme.animation.extraFast}
+          ease-out ${euiTheme.animation.fast} both;
       }
     `,
     // Positions - kept for component compatibility. Animation is in the base style.

--- a/packages/eui/src/components/tool_tip/tool_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.test.tsx
@@ -7,8 +7,13 @@
  */
 
 import React, { createRef, StrictMode, useRef } from 'react';
-import { fireEvent } from '@testing-library/react';
-import { render, focusEuiToolTipTrigger } from '../../test/rtl';
+import { act, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  render,
+  focusEuiToolTipTrigger,
+  simulateFocusVisible,
+} from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -55,7 +60,7 @@ describe('EuiToolTip', () => {
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('shows on initial autoFocus in StrictMode', () => {
+    it('shows on initial `autoFocus` in StrictMode', () => {
       const originalMatches = Element.prototype.matches;
       const spy = jest
         .spyOn(Element.prototype, 'matches')
@@ -97,15 +102,20 @@ describe('EuiToolTip', () => {
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
       const trigger = getByTestSubject('trigger');
-      fireEvent.keyPress(trigger, { key: 'Tab' });
+      const cleanup = simulateFocusVisible(trigger);
 
+      act(() => {
+        userEvent.tab();
+      });
       expect(queryByRole('tooltip')).toBeInTheDocument();
 
       fireEvent.blur(trigger);
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
+
+      cleanup();
     });
 
-    it('persists tooltip on mouseout when trigger was keyboard-focused', () => {
+    it('persists on mouseout when trigger was keyboard-focused', () => {
       const { getByTestSubject, queryByRole } = render(
         <EuiToolTip content="Tooltip content">
           <button data-test-subj="trigger">Trigger</button>
@@ -123,7 +133,7 @@ describe('EuiToolTip', () => {
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('hides tooltip on mouseout when trigger was mouse-click focused', () => {
+    it('hides on mouseout when trigger was mouse-click focused', () => {
       const { getByTestSubject, queryByRole } = render(
         <EuiToolTip content="Tooltip content">
           <button data-test-subj="trigger">Trigger</button>
@@ -167,7 +177,7 @@ describe('EuiToolTip', () => {
   });
 
   describe('props', () => {
-    it('applies anchorClassName and anchorProps to the anchor wrapper', () => {
+    it('applies `anchorClassName` and `anchorProps` to the anchor wrapper', () => {
       const { container } = render(
         <EuiToolTip
           content="content"
@@ -183,7 +193,7 @@ describe('EuiToolTip', () => {
       expect(anchor).toHaveAttribute('data-test-subj', 'anchor');
     });
 
-    it('display="block" applies a different CSS class than display="inlineBlock"', () => {
+    it('`display="block"` applies a different CSS class than `display="inlineBlock"`', () => {
       const { container: blockContainer } = render(
         <EuiToolTip content="content" display="block">
           <button>Trigger</button>
@@ -201,7 +211,7 @@ describe('EuiToolTip', () => {
       expect(blockAnchor.className).not.toEqual(inlineBlockAnchor.className);
     });
 
-    it('calls the onMouseOut prop callback on mouseout', () => {
+    it('calls the `onMouseOut` prop callback on mouseout', () => {
       const onMouseOut = jest.fn();
       const { getByTestSubject } = render(
         <EuiToolTip content="content" onMouseOut={onMouseOut}>
@@ -353,11 +363,11 @@ describe('EuiToolTip', () => {
   });
 
   describe('ref', () => {
-    describe('showToolTip / hideToolTip', () => {
+    describe('`showToolTip` / `hideToolTip`', () => {
       // Although we don't publicly recommend it, consumers may need to reach into EuiToolTip
       // to manually control visibility state via `show/hideToolTip`, exposed via `useImperativeHandle`.
 
-      test('showToolTip', () => {
+      test('`showToolTip`', () => {
         const ConsumerToolTip = () => {
           const toolTipRef = useRef<EuiToolTipRef>(null);
 
@@ -390,7 +400,7 @@ describe('EuiToolTip', () => {
         expect(getByRole('tooltip')).toBeInTheDocument();
       });
 
-      test('hideToolTip', () => {
+      test('`hideToolTip`', () => {
         // Consumers appear to mostly want this after modal/flyout/focus trap close, when
         // focus is returned to toggling buttons with a tooltip, & said tooltip blocks UI
         // @see https://github.com/elastic/eui/issues/5883#issuecomment-1120908605 for example
@@ -423,7 +433,7 @@ describe('EuiToolTip', () => {
     });
 
     describe('id', () => {
-      it('exposes the id prop value', () => {
+      it('exposes the `id` prop value', () => {
         const ref = createRef<EuiToolTipRef>();
         render(
           <EuiToolTip content="content" id="custom-id" ref={ref}>
@@ -433,7 +443,7 @@ describe('EuiToolTip', () => {
         expect(ref.current?.id).toBe('custom-id');
       });
 
-      it('exposes a generated id when no id prop is provided', () => {
+      it('exposes a generated id when no `id` prop is provided', () => {
         const ref = createRef<EuiToolTipRef>();
         render(
           <EuiToolTip content="content" ref={ref}>

--- a/packages/eui/src/components/tool_tip/tool_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.test.tsx
@@ -7,13 +7,8 @@
  */
 
 import React, { createRef, StrictMode, useRef } from 'react';
-import { act, fireEvent } from '@testing-library/react';
-import {
-  render,
-  waitForEuiToolTipVisible,
-  waitForEuiToolTipHidden,
-  focusEuiToolTipTrigger,
-} from '../../test/rtl';
+import { fireEvent } from '@testing-library/react';
+import { render, focusEuiToolTipTrigger } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
 
@@ -27,9 +22,8 @@ describe('EuiToolTip', () => {
     </EuiToolTip>,
     {
       childProps: ['anchorProps'],
-      renderCallback: async ({ getByTestSubject }) => {
+      renderCallback: ({ getByTestSubject }) => {
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
       },
     }
   );
@@ -45,11 +39,7 @@ describe('EuiToolTip', () => {
   });
 
   describe('visibility', () => {
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
-    it('shows on mouseover and hides on mouseout', async () => {
+    it('shows on mouseover and hides on mouseout', () => {
       const { getByTestSubject, queryByRole } = render(
         <EuiToolTip content="Tooltip content">
           <button data-test-subj="trigger">Trigger</button>
@@ -59,15 +49,13 @@ describe('EuiToolTip', () => {
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
       fireEvent.mouseOver(getByTestSubject('trigger'));
-      await waitForEuiToolTipVisible();
       expect(queryByRole('tooltip')).toBeInTheDocument();
 
       fireEvent.mouseOut(getByTestSubject('trigger'));
-      await waitForEuiToolTipHidden();
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('shows on initial autoFocus in StrictMode', async () => {
+    it('shows on initial autoFocus in StrictMode', () => {
       const originalMatches = Element.prototype.matches;
       const spy = jest
         .spyOn(Element.prototype, 'matches')
@@ -88,51 +76,37 @@ describe('EuiToolTip', () => {
           </StrictMode>
         );
 
-        await waitForEuiToolTipVisible();
         expect(queryByRole('tooltip')).toBeInTheDocument();
 
         fireEvent.blur(getByTestSubject('trigger'));
-        await waitForEuiToolTipHidden();
         expect(queryByRole('tooltip')).not.toBeInTheDocument();
       } finally {
         spy.mockRestore();
       }
     });
 
-    it('shows on keyboard focus and hides on blur', async () => {
+    it('shows on keyboard focus and hides on blur', () => {
       const { getByTestSubject, queryByRole } = render(
-        <EuiToolTip content="Tooltip content">
-          <button data-test-subj="trigger">Trigger</button>
-        </EuiToolTip>
+        <StrictMode>
+          <EuiToolTip content="Tooltip content">
+            <button data-test-subj="trigger" autoFocus>
+              Trigger
+            </button>
+          </EuiToolTip>
+        </StrictMode>
       );
 
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
       const trigger = getByTestSubject('trigger');
-      const cleanup = focusEuiToolTipTrigger(trigger);
-      await waitForEuiToolTipVisible();
+      focusEuiToolTipTrigger(trigger);
       expect(queryByRole('tooltip')).toBeInTheDocument();
 
       fireEvent.blur(trigger);
-      await waitForEuiToolTipHidden();
-      expect(queryByRole('tooltip')).not.toBeInTheDocument();
-      cleanup();
-    });
-
-    it('does not show on mouse-click focus', () => {
-      const { getByTestSubject, queryByRole } = render(
-        <EuiToolTip content="Tooltip content">
-          <button data-test-subj="trigger">Trigger</button>
-        </EuiToolTip>
-      );
-
-      // Intentionally using plain `fireEvent.focus` (no `:focus-visible`) to simulate mouse-click focus
-      // eslint-disable-next-line @elastic/eui/prefer-tooltip-trigger-focus-test-utility
-      fireEvent.focus(getByTestSubject('trigger'));
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('persists tooltip on mouseout when trigger was keyboard-focused', async () => {
+    it('persists tooltip on mouseout when trigger was keyboard-focused', () => {
       const { getByTestSubject, queryByRole } = render(
         <EuiToolTip content="Tooltip content">
           <button data-test-subj="trigger">Trigger</button>
@@ -140,16 +114,17 @@ describe('EuiToolTip', () => {
       );
 
       const trigger = getByTestSubject('trigger');
-      const cleanup = focusEuiToolTipTrigger(trigger);
-      await waitForEuiToolTipVisible();
+      focusEuiToolTipTrigger(trigger);
 
       fireEvent.mouseOut(getByTestSubject('trigger'));
       // Tooltip stays visible because `hasFocus=true` (keyboard focus)
       expect(queryByRole('tooltip')).toBeInTheDocument();
-      cleanup();
+
+      fireEvent.blur(getByTestSubject('trigger'));
+      expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('hides tooltip on mouseout when trigger was mouse-click focused', async () => {
+    it('hides tooltip on mouseout when trigger was mouse-click focused', () => {
       const { getByTestSubject, queryByRole } = render(
         <EuiToolTip content="Tooltip content">
           <button data-test-subj="trigger">Trigger</button>
@@ -158,19 +133,16 @@ describe('EuiToolTip', () => {
 
       // Show on hover first, then click-focus (no `:focus-visible`)
       fireEvent.mouseOver(getByTestSubject('trigger'));
-      await waitForEuiToolTipVisible();
       // Intentionally using plain `fireEvent.focus` (no `:focus-visible`) to simulate mouse-click focus
       // eslint-disable-next-line @elastic/eui/prefer-tooltip-trigger-focus-test-utility
       fireEvent.focus(getByTestSubject('trigger'));
 
       fireEvent.mouseOut(getByTestSubject('trigger'));
       // Tooltip hides because `hasFocus` was not set (click focus, not keyboard)
-      await waitForEuiToolTipHidden();
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
     it('does not render when neither content nor title are provided', () => {
-      jest.useFakeTimers();
       const { queryByRole, getByTestSubject } = render(
         <EuiToolTip>
           <button data-test-subj="trigger">Trigger</button>
@@ -178,13 +150,11 @@ describe('EuiToolTip', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('trigger'));
-      // Flush tooltip delay and state queue
-      act(() => jest.runAllTimers());
 
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
     });
 
-    it('renders with title only and no content', async () => {
+    it('renders with title only and no content', () => {
       const { getByTestSubject, getByRole } = render(
         <EuiToolTip title="Tooltip title">
           <button data-test-subj="trigger">Trigger</button>
@@ -192,7 +162,6 @@ describe('EuiToolTip', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('trigger'));
-      await waitForEuiToolTipVisible();
 
       expect(getByRole('tooltip')).toHaveTextContent('Tooltip title');
     });
@@ -233,7 +202,7 @@ describe('EuiToolTip', () => {
       expect(blockAnchor.className).not.toEqual(inlineBlockAnchor.className);
     });
 
-    it('calls the onMouseOut prop callback on mouseout', async () => {
+    it('calls the onMouseOut prop callback on mouseout', () => {
       const onMouseOut = jest.fn();
       const { getByTestSubject } = render(
         <EuiToolTip content="content" onMouseOut={onMouseOut}>
@@ -242,7 +211,6 @@ describe('EuiToolTip', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('trigger'));
-      await waitForEuiToolTipVisible();
 
       fireEvent.mouseOut(getByTestSubject('trigger'));
       expect(onMouseOut).toHaveBeenCalledTimes(1);
@@ -250,14 +218,13 @@ describe('EuiToolTip', () => {
   });
 
   describe('aria-describedby', () => {
-    it('by default, sets an `aria-describedby` on the anchor when the tooltip is visible', async () => {
+    it('by default, sets an `aria-describedby` on the anchor when the tooltip is visible', () => {
       const { getByTestSubject } = render(
         <EuiToolTip content="Tooltip content" id="toolTipId">
           <button data-test-subj="anchor" />
         </EuiToolTip>
       );
       fireEvent.mouseOver(getByTestSubject('anchor'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('anchor')).toHaveAttribute(
         'aria-describedby',
@@ -265,7 +232,7 @@ describe('EuiToolTip', () => {
       );
     });
 
-    it('removes `aria-describedby` when the tooltip is hidden', async () => {
+    it('removes `aria-describedby` when the tooltip is hidden', () => {
       const { getByTestSubject } = render(
         <EuiToolTip content="Tooltip content" id="toolTipId">
           <button data-test-subj="anchor" />
@@ -273,20 +240,18 @@ describe('EuiToolTip', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('anchor'));
-      await waitForEuiToolTipVisible();
       expect(getByTestSubject('anchor')).toHaveAttribute(
         'aria-describedby',
         'toolTipId'
       );
 
       fireEvent.mouseOut(getByTestSubject('anchor'));
-      await waitForEuiToolTipHidden();
       expect(getByTestSubject('anchor')).not.toHaveAttribute(
         'aria-describedby'
       );
     });
 
-    it('does not add `aria-describedby` when `disableScreenReaderOutput` is `true`', async () => {
+    it('does not add `aria-describedby` when `disableScreenReaderOutput` is `true`', () => {
       const { getByTestSubject } = render(
         <EuiToolTip
           content="Tooltip content"
@@ -297,21 +262,19 @@ describe('EuiToolTip', () => {
         </EuiToolTip>
       );
       fireEvent.mouseOver(getByTestSubject('anchor'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('anchor')).not.toHaveAttribute(
         'aria-describedby'
       );
     });
 
-    it('merges with custom consumer `aria-describedby`s', async () => {
+    it('merges with custom consumer `aria-describedby`s', () => {
       const { getByTestSubject } = render(
         <EuiToolTip content="Tooltip content" id="toolTipId">
           <button data-test-subj="anchor" aria-describedby="customId" />
         </EuiToolTip>
       );
       fireEvent.mouseOver(getByTestSubject('anchor'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('anchor')).toHaveAttribute(
         'aria-describedby',
@@ -319,7 +282,7 @@ describe('EuiToolTip', () => {
       );
     });
 
-    it('adds custom consumer `aria-describedby` when `disableScreenReaderOutput` is `true`', async () => {
+    it('adds custom consumer `aria-describedby` when `disableScreenReaderOutput` is `true`', () => {
       const { getByTestSubject } = render(
         <EuiToolTip
           content="Tooltip content"
@@ -330,7 +293,6 @@ describe('EuiToolTip', () => {
         </EuiToolTip>
       );
       fireEvent.mouseOver(getByTestSubject('anchor'));
-      await waitForEuiToolTipVisible();
 
       expect(getByTestSubject('anchor')).toHaveAttribute(
         'aria-describedby',
@@ -340,7 +302,7 @@ describe('EuiToolTip', () => {
   });
 
   describe('disableScreenReaderOutput', () => {
-    it('when false (default), Escape stops event propagation while tooltip is visible', async () => {
+    it('when false (default), Escape stops event propagation while tooltip is visible', () => {
       const parentKeyDown = jest.fn();
       const { getByTestSubject } = render(
         <div onKeyDown={parentKeyDown}>
@@ -352,16 +314,14 @@ describe('EuiToolTip', () => {
 
       const trigger = getByTestSubject('trigger');
       const cleanup = focusEuiToolTipTrigger(trigger);
-      await waitForEuiToolTipVisible();
 
       fireEvent.keyDown(getByTestSubject('trigger'), { key: 'Escape' });
-      await waitForEuiToolTipHidden();
 
       expect(parentKeyDown).not.toHaveBeenCalled();
       cleanup();
     });
 
-    it('when true, Escape does not stop event propagation', async () => {
+    it('when true, Escape does not stop event propagation', () => {
       const parentKeyDown = jest.fn();
       const { getByTestSubject } = render(
         <div onKeyDown={parentKeyDown}>
@@ -373,16 +333,14 @@ describe('EuiToolTip', () => {
 
       const trigger = getByTestSubject('trigger');
       const cleanup = focusEuiToolTipTrigger(trigger);
-      await waitForEuiToolTipVisible();
 
       fireEvent.keyDown(getByTestSubject('trigger'), { key: 'Escape' });
-      await waitForEuiToolTipHidden();
 
       expect(parentKeyDown).toHaveBeenCalledTimes(1);
       cleanup();
     });
 
-    it('when true, tooltip still renders visually', async () => {
+    it('when true, tooltip still renders visually', () => {
       const { getByTestSubject, getByRole } = render(
         <EuiToolTip content="Tooltip content" disableScreenReaderOutput={true}>
           <button data-test-subj="trigger" />
@@ -390,7 +348,6 @@ describe('EuiToolTip', () => {
       );
 
       fireEvent.mouseOver(getByTestSubject('trigger'));
-      await waitForEuiToolTipVisible();
 
       expect(getByRole('tooltip')).toBeInTheDocument();
     });
@@ -401,7 +358,7 @@ describe('EuiToolTip', () => {
       // Although we don't publicly recommend it, consumers may need to reach into EuiToolTip
       // to manually control visibility state via `show/hideToolTip`, exposed via `useImperativeHandle`.
 
-      test('showToolTip', async () => {
+      test('showToolTip', () => {
         const ConsumerToolTip = () => {
           const toolTipRef = useRef<EuiToolTipRef>(null);
 
@@ -430,12 +387,11 @@ describe('EuiToolTip', () => {
         expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
         fireEvent.click(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
 
         expect(getByRole('tooltip')).toBeInTheDocument();
       });
 
-      test('hideToolTip', async () => {
+      test('hideToolTip', () => {
         // Consumers appear to mostly want this after modal/flyout/focus trap close, when
         // focus is returned to toggling buttons with a tooltip, & said tooltip blocks UI
         // @see https://github.com/elastic/eui/issues/5883#issuecomment-1120908605 for example
@@ -459,11 +415,9 @@ describe('EuiToolTip', () => {
         const { getByTestSubject, queryByRole } = render(<ConsumerToolTip />);
 
         fireEvent.mouseOver(getByTestSubject('trigger'));
-        await waitForEuiToolTipVisible();
         expect(queryByRole('tooltip')).toBeInTheDocument();
 
         fireEvent.click(getByTestSubject('trigger'));
-        await waitForEuiToolTipHidden();
 
         expect(queryByRole('tooltip')).not.toBeInTheDocument();
       });

--- a/packages/eui/src/components/tool_tip/tool_tip.test.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.test.tsx
@@ -89,9 +89,7 @@ describe('EuiToolTip', () => {
       const { getByTestSubject, queryByRole } = render(
         <StrictMode>
           <EuiToolTip content="Tooltip content">
-            <button data-test-subj="trigger" autoFocus>
-              Trigger
-            </button>
+            <button data-test-subj="trigger">Trigger</button>
           </EuiToolTip>
         </StrictMode>
       );
@@ -99,7 +97,8 @@ describe('EuiToolTip', () => {
       expect(queryByRole('tooltip')).not.toBeInTheDocument();
 
       const trigger = getByTestSubject('trigger');
-      focusEuiToolTipTrigger(trigger);
+      fireEvent.keyPress(trigger, { key: 'Tab' });
+
       expect(queryByRole('tooltip')).toBeInTheDocument();
 
       fireEvent.blur(trigger);

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -52,18 +52,6 @@ const isFocusVisible = (element: Element): boolean => {
   }
 };
 
-/**
- * `:focus-visible` may throw in browsers that don't support the selector,
- * fall back to treating all focus as visible so tooltips still appear.
- */
-const isFocusVisible = (element: Element): boolean => {
-  try {
-    return element.matches(':focus-visible');
-  } catch {
-    return element.matches(':focus');
-  }
-};
-
 interface ToolTipStyles {
   top: number;
   left: number | 'auto';

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -26,7 +26,6 @@ import { CommonProps } from '../common';
 import { findPopoverPosition, htmlIdGenerator, keys } from '../../services';
 import { getRepositionOnScroll } from '../../services/popover/reposition_on_scroll';
 import { type EuiPopoverPosition } from '../../services/popover';
-import { enqueueStateChange } from '../../services/react';
 import { EuiResizeObserver } from '../observer/resize_observer';
 import { EuiPortal } from '../portal';
 import { EuiComponentDefaultsContext } from '../provider/component_defaults';
@@ -39,12 +38,18 @@ import { toolTipManager } from './tool_tip_manager';
 export const POSITIONS = ['top', 'right', 'bottom', 'left'] as const;
 const DISPLAYS = ['inlineBlock', 'block'] as const;
 
-export type ToolTipDelay = 'regular' | 'long';
 export const DEFAULT_TOOLTIP_OFFSET = 16;
 
-const delayToMsMap: { [key in ToolTipDelay]: number } = {
-  regular: 250,
-  long: 250 * 5,
+/**
+ * `:focus-visible` may throw in browsers that don't support the selector,
+ * fall back to treating all focus as visible so tooltips still appear.
+ */
+const isFocusVisible = (element: Element): boolean => {
+  try {
+    return element.matches(':focus-visible');
+  } catch {
+    return element.matches(':focus');
+  }
 };
 
 /**
@@ -106,10 +111,6 @@ export interface EuiToolTipProps extends CommonProps {
    */
   display?: (typeof DISPLAYS)[number];
   /**
-   * Delay before showing tooltip. Good for repeatable items.
-   */
-  delay?: ToolTipDelay;
-  /**
    * An optional title for your tooltip.
    */
   title?: ReactNode;
@@ -165,7 +166,6 @@ export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
       anchorProps,
       content,
       title,
-      delay = 'regular',
       display = 'inlineBlock',
       repositionOnScroll,
       disableScreenReaderOutput = false,
@@ -195,10 +195,6 @@ export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
 
     const anchorRef = useRef<HTMLSpanElement | null>(null);
     const popoverRef = useRef<HTMLDivElement | null>(null);
-    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-      undefined
-    );
-    const isMounted = useRef(false);
 
     const positionToolTip = useCallback(() => {
       if (!anchorRef.current || !popoverRef.current) {
@@ -253,33 +249,16 @@ export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
     );
 
     const hideToolTip = useCallback(() => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = undefined;
-      }
-
-      enqueueStateChange(() => {
-        if (isMounted.current) {
-          setVisible(false);
-          setToolTipStyles(DEFAULT_TOOLTIP_STYLES);
-          setArrowStyles(undefined);
-          toolTipManager.deregisterToolTip(hideToolTip);
-        }
-      });
+      setVisible(false);
+      setToolTipStyles(DEFAULT_TOOLTIP_STYLES);
+      setArrowStyles(undefined);
+      toolTipManager.deregisterToolTip(hideToolTip);
     }, []);
 
     const showToolTip = useCallback(() => {
-      if (!timeoutRef.current) {
-        timeoutRef.current = setTimeout(() => {
-          enqueueStateChange(() => {
-            if (isMounted.current) {
-              setVisible(true);
-              toolTipManager.registerTooltip(hideToolTip);
-            }
-          });
-        }, delayToMsMap[delay]);
-      }
-    }, [delay, hideToolTip]);
+      setVisible(true);
+      toolTipManager.registerTooltip(hideToolTip);
+    }, [hideToolTip]);
 
     useImperativeHandle(ref, () => ({ showToolTip, hideToolTip, id }), [
       showToolTip,
@@ -301,13 +280,7 @@ export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
     }, [showToolTip]);
 
     useEffect(() => {
-      isMounted.current = true;
       return () => {
-        isMounted.current = false;
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-          timeoutRef.current = undefined;
-        }
         toolTipManager.deregisterToolTip(hideToolTip);
       };
     }, [hideToolTip]);

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -218,7 +218,6 @@ export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
           : 'auto',
       };
 
-      setVisible(true);
       setCalculatedPosition(position);
       setToolTipStyles(newToolTipStyles);
       setArrowStyles(arrow);

--- a/packages/eui/src/components/tool_tip/tool_tip_manager.test.ts
+++ b/packages/eui/src/components/tool_tip/tool_tip_manager.test.ts
@@ -33,6 +33,15 @@ describe('ToolTipManager', () => {
       expect(hide1).toHaveBeenCalledTimes(1);
       expect(hide2).not.toHaveBeenCalled();
     });
+
+    it('does not call the callback when re-registering the same tooltip', () => {
+      const hide = jest.fn();
+
+      toolTipManager.registerTooltip(hide);
+      toolTipManager.registerTooltip(hide);
+
+      expect(hide).not.toHaveBeenCalled();
+    });
   });
 
   describe('deregisterToolTip', () => {

--- a/packages/eui/src/components/tool_tip/tool_tip_manager.ts
+++ b/packages/eui/src/components/tool_tip/tool_tip_manager.ts
@@ -19,6 +19,7 @@ class ToolTipManager {
   toolTipsToHide = new Set<Function>();
 
   registerTooltip = (hideCallback: Function) => {
+    if (this.toolTipsToHide.has(hideCallback)) return;
     this.toolTipsToHide.forEach((hide) => hide());
     this.toolTipsToHide.clear();
     this.toolTipsToHide.add(hideCallback);

--- a/packages/eui/src/test/rtl/component_helpers.d.ts
+++ b/packages/eui/src/test/rtl/component_helpers.d.ts
@@ -6,9 +6,6 @@
 export declare const waitForEuiPopoverOpen: () => Promise<void>;
 export declare const waitForEuiPopoverClose: () => Promise<void>;
 
-export declare const waitForEuiToolTipVisible: () => Promise<void>;
-export declare const waitForEuiToolTipHidden: () => Promise<void>;
-
 export declare const showEuiComboBoxOptions: () => Promise<void>;
 
 export declare const waitForEuiContextMenuPanelTransition: () => Promise<void>;

--- a/packages/eui/src/test/rtl/component_helpers.ts
+++ b/packages/eui/src/test/rtl/component_helpers.ts
@@ -60,38 +60,6 @@ export const focusEuiToolTipTrigger = (element: Element): (() => void) => {
 };
 
 /**
- * jsdom does not track keyboard vs. mouse input modality, so `:focus-visible`
- * always returns false. Call this before `fireEvent.focus()` on an element that
- * should be treated as keyboard-focused.
- *
- * Returns a cleanup function, call it after test assertions to restore the spy.
- */
-export const simulateFocusVisible = (element: Element): (() => void) => {
-  const originalMatches = Element.prototype.matches.bind(element);
-  const spy = jest
-    .spyOn(element, 'matches')
-    .mockImplementation((selector: string) =>
-      selector === ':focus-visible' ? true : originalMatches(selector)
-    );
-
-  return () => spy.mockRestore();
-};
-
-/**
- * Prefer this over `fireEvent.focus()` in tooltip tests. Plain `fireEvent.focus`
- * does not set `:focus-visible` in jsdom and will not trigger the tooltip.
- *
- * Returns a cleanup function to restore the mock after assertions.
- */
-export const focusEuiToolTipTrigger = (element: Element): (() => void) => {
-  const cleanup = simulateFocusVisible(element);
-
-  fireEvent.focus(element);
-
-  return cleanup;
-};
-
-/**
  * EuiComboBox
  */
 

--- a/packages/eui/src/test/rtl/component_helpers.ts
+++ b/packages/eui/src/test/rtl/component_helpers.ts
@@ -28,22 +28,36 @@ export const waitForEuiPopoverClose = async () =>
   });
 
 /**
- * Ensure the EuiToolTip being tested is open and visible before continuing
+ * jsdom does not track keyboard vs. mouse input modality, so `:focus-visible`
+ * always returns false. Call this before `fireEvent.focus()` on an element that
+ * should be treated as keyboard-focused.
+ *
+ * Returns a cleanup function, call it after test assertions to restore the spy.
  */
-export const waitForEuiToolTipVisible = async () =>
-  await waitFor(
-    () => {
-      const tooltip = document.querySelector('.euiToolTipPopover');
-      expect(tooltip).toBeVisible();
-    },
-    { timeout: 3000 } // Account for long delay on tooltips
-  );
+export const simulateFocusVisible = (element: Element): (() => void) => {
+  const originalMatches = Element.prototype.matches.bind(element);
+  const spy = jest
+    .spyOn(element, 'matches')
+    .mockImplementation((selector: string) =>
+      selector === ':focus-visible' ? true : originalMatches(selector)
+    );
 
-export const waitForEuiToolTipHidden = async () =>
-  await waitFor(() => {
-    const tooltip = document.querySelector('.euiToolTipPopover');
-    expect(tooltip).toBeNull();
-  });
+  return () => spy.mockRestore();
+};
+
+/**
+ * Prefer this over `fireEvent.focus()` in tooltip tests. Plain `fireEvent.focus`
+ * does not set `:focus-visible` in jsdom and will not trigger the tooltip.
+ *
+ * Returns a cleanup function to restore the mock after assertions.
+ */
+export const focusEuiToolTipTrigger = (element: Element): (() => void) => {
+  const cleanup = simulateFocusVisible(element);
+
+  fireEvent.focus(element);
+
+  return cleanup;
+};
 
 /**
  * jsdom does not track keyboard vs. mouse input modality, so `:focus-visible`

--- a/packages/website/docs/components/display/list-group.mdx
+++ b/packages/website/docs/components/display/list-group.mdx
@@ -304,7 +304,6 @@ export default () => (
       wrapText
       label="Fourth very long item with wrapping enabled, custom props, and will not force truncation."
       toolTipProps={{
-        delay: 'regular',
         position: 'top',
         title: 'Title of record',
       }}

--- a/packages/website/docs/components/display/tooltip.mdx
+++ b/packages/website/docs/components/display/tooltip.mdx
@@ -51,15 +51,6 @@ export default () => (
       </p>
 
       <p>
-        This tooltip has a long <EuiCode>delay</EuiCode> because it might be in
-        a repeatable component{' '}
-        <EuiToolTip delay="long" content="Here is some tooltip text">
-          <EuiLink href="#">wink</EuiLink>
-        </EuiToolTip>
-        .
-      </p>
-
-      <p>
         This tooltip appears on the bottom of this icon:{' '}
         <EuiToolTip position="bottom" content="Here is some tooltip text">
           <EuiIcon tabIndex="0" type="warning" title="Icon with tooltip" />

--- a/packages/website/docs/components/navigation/buttons/split-button.mdx
+++ b/packages/website/docs/components/navigation/buttons/split-button.mdx
@@ -274,7 +274,6 @@ export default () => {
         tooltipProps={{
           content: 'Primary action tooltip',
           position: 'bottom',
-          delay: 'regular'
         }}
       >
         Save


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

- **What:**
  - removed `delay` prop from `EuiToolTip`
  - updated `EuiToolTip` animation to work only on opacity
  - removed `waitForEuiToolTipVisible`, `waitForEuiToolTipHidden` because tooltip is now synchronous
- **Why:** Closes https://github.com/elastic/eui/issues/9623  https://github.com/elastic/eui/issues/9283 https://github.com/elastic/eui/issues/9338
- **How:**
  - all `delay`-related logic was removed, including `enqueueStateChange` and `setTimeout`, now it's synchronous `setVisible` calls,
  - 150ms `animation-delay` with `fill-mode: both` acts as the new "delay" to avoid jarring flickering when hovering over multiple triggers
  - `toolTipManager.registerTooltip` now bails if the same callback is already registered, it was an existing bug hidden by the delay of `mouseover` bubbling from child elements
  - tooltip toggling is moved out of `render` in `EuiFilterSelectIemClass` into `componentDidMount`/`componentDidUpdate`; tooltip didn't work after removing the delay

### API Changes

<!--
List any change to the public EUI API here.

Example:

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiOverlayMask       | hasAnimation                 | Added      | Conditionally add animation                                             |
| EuiBadge             | fill                         | Default    | Default is now "false" -- Makes all badges have a light fill by default |
| Tokens               | colors.severity.someOldColor | Deprecated | Use `colors.severity.someOtherColor` instead                            |
| Global CSS Variables | --my-variable                | Added      | Some reason listed here                                                 |

-->

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiToolTip` | `delay` | removed | Tooltip show timing is now controlled with `animation-delay`. It's consistent, not customizable. Migration: remove all `delay` usages |
| `EuiIconTip` | `delay` | removed | Same as above |
| Types | `ToolTipDelay` | removed | No longer needed |
| RTL helper | `waitForEuiToolTipVisible` | removed | Tooltip show/hide is now synchronous. Migration: assert directly |
| RTL helper | `waitForEuiToolTipHidden` | removed | Same as above |

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->

| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/e1226265-e5f1-4f0a-a0c5-845f65dab9b5" /> | <video src="https://github.com/user-attachments/assets/1c584ec4-6cb7-4558-8c32-24b01c815750" /> |

### VoiceOver + Chrome

| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/0400c4e1-f10e-46b4-b20d-42ed89e1be22" /> | <video src="https://github.com/user-attachments/assets/888c6dc9-b2d3-40fa-8c74-fc9a77fb6ffe" /> |

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

- https://github.com/elastic/kibana/pull/266413

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [x] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [x] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [x] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🔴 High

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [x] **Documentation:** EuiToolTip
- [x] **Figma:** [EuiToolTip](https://www.figma.com/design/FHys7gLzyvD1gc9DrJM6D8/Elastic-UI--Borealis-?node-id=12358-53539&p=f&t=Ir1W6MaQOhC93vBU-0)
- [x] **Migration guide:** (see [notes](https://github.com/elastic/eui/pull/9626#issuecomment-4352893338))
  - remove `waitForEuiToolTipVisible` and `waitForEuiToolTipHidden` in tests,
  - remove `delay` in `EuiToolTip` and `EuiIconTip` usages.
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Open the tooltip demo in Storybook.

- [x] Tooltip appears on hover after a brief (~150ms) delay
- [x] Quickly hovering over multiple tooltip triggers does not cause _jarring_ flickering
- [x] Tooltip appears on keyboard <kbd>Tab</kbd> focus, does not appear on mouse-click focus
- [x] Tooltip disappears on blur/mouseout
- [x] Tooltip animation is opacity-only (no slide movement)
- [x] With `prefers-reduced-motion: reduce`, tooltip appears instantly (no animation, no delay)

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested ~[light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile,~ Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [x] **QA:** Tested in ~[CodeSandbox](https://codesandbox.io/) and~ [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [x] **QA:** Tested docs changes
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), ~[Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [x] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
