### PR TITLE
fix(EuiMarkdownEditor): update types to allow UI plugins to not have a button

### DIFF
--- a/packages/eui/changelogs/upcoming/9634.md
+++ b/packages/eui/changelogs/upcoming/9634.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `uiPlugins[].button` type to allow UI plugins to not have a toolbar button in `EuiMarkdownEditor`

--- a/packages/eui/src/components/markdown_editor/markdown_editor_toolbar.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor_toolbar.tsx
@@ -28,6 +28,17 @@ import { EuiMarkdownContext } from './markdown_context';
 import MarkdownActions from './markdown_actions';
 import { euiMarkdownEditorToolbarStyles } from './markdown_editor_toolbar.styles';
 
+/**
+ * A helper type to ensure the `button` property is defined
+ * on an ` EuiMarkdownEditorUiPlugin ` object.
+ */
+type EuiMarkdownEditorUiPluginWithButton = Omit<
+  EuiMarkdownEditorUiPlugin,
+  'button'
+> & {
+  button: NonNullable<EuiMarkdownEditorUiPlugin['button']>;
+};
+
 export type EuiMarkdownEditorToolbarProps = HTMLAttributes<HTMLDivElement> &
   CommonProps & {
     selectedNode?: null | any;
@@ -145,7 +156,7 @@ export const EuiMarkdownEditorToolbar = forwardRef<
       markdownActions,
       viewMode,
       onClickPreview,
-      uiPlugins,
+      uiPlugins: _uiPlugins,
       selectedNode,
       right,
     },
@@ -165,6 +176,10 @@ export const EuiMarkdownEditorToolbar = forwardRef<
     const isEditable = !isPreviewing && !readOnly;
 
     const styles = useEuiMemoizedStyles(euiMarkdownEditorToolbarStyles);
+
+    const uiPlugins = _uiPlugins.filter(
+      (uiPlugin) => !!uiPlugin.button
+    ) as EuiMarkdownEditorUiPluginWithButton[];
 
     return (
       <div

--- a/packages/eui/src/components/markdown_editor/markdown_types.ts
+++ b/packages/eui/src/components/markdown_editor/markdown_types.ts
@@ -68,7 +68,7 @@ export interface PluginWithDelayedFormatting<NodeShape> {
 
 export type EuiMarkdownEditorUiPlugin<NodeShape = any> = {
   name: string;
-  button: {
+  button?: {
     label: string;
     iconType: IconType;
     isDisabled?: boolean;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/9557

This PR updates the `EuiMarkdownEditorUiPlugin` type to make the `button` property optional per our documentation, and applies necessary adjustments to the internal `EuiMarkdownEditorToolbar`.

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiMarkdownEditor` | `uiPlugins[].button` | `button` is now optional | The `button` property is now correctly marked as optional in the type definition. When unset, the button won't be rendered in the toolbar, allowing for formatting-only plugins. |

## Screenshots

N/A

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 ~**Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None, because the type becomes less strict.

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->~

### QA instructions for reviewer

- [x] Type correctness
    - Checkout this PR, install dependencies and confirm that the `EuiMarkdownEditorUiPlugin` type allows for skipping the `button` property.
- [x] UI correctness
    - Go to https://eui.elastic.co/pr_9634/docs/components/editors-and-syntax/markdown/editor/#base-editor
    - Update the interactive example to the following:
        ```tsx
       import React, { useCallback, useState } from 'react';
       import { EuiMarkdownEditor, getDefaultEuiMarkdownPlugins } from '@elastic/eui';
       
       const { uiPlugins } = getDefaultEuiMarkdownPlugins();
       uiPlugins.push({
         name: 'PR test',
         formatting: { prefix: '!{blah[', suffix: ']()}' },
         helpText: 'Thanks for testing my PR!'
       })
       
       export default () => {
         const [value, setValue] = useState('## Hello, World!');
         const [messages, setMessages] = useState([]);
         const onParse = useCallback((err, { messages, ast }) => {
           setMessages(err ? [err] : messages);
         }, []);
       
         const [isReadOnly, setIsReadOnly] = useState(false);
       
         const onChange = (e) => {
           setIsReadOnly(e.target.checked);
         };
       
         return (
           <EuiMarkdownEditor
             aria-label="EUI markdown editor demo"
             placeholder="Your markdown here..."
             value={value}
             onChange={setValue}
             height={400}
             onParse={onParse}
             errors={messages}
             readOnly={isReadOnly}
             initialViewMode="viewing"
             uiPlugins={uiPlugins}
           />
         );
       };
        ```
    - Confirm that the toolbar doesn't render any extra icons when compared with the default example and that `TypeError: Cannot read properties of undefined (reading 'label')` is not thrown (it is on main)

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] ~**QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
