### PR TITLE
[EuiToolTip] Prevent intercepting pointer events, do not show when content or title empty

### DIFF
--- a/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
@@ -35,6 +35,27 @@ describe('EuiToolTip', () => {
     cy.get('[data-test-subj="tooltip"]').should('not.exist');
   });
 
+  it('does not intercept pointer events on the trigger while visible', () => {
+    const onClick = cy.stub().as('onClick');
+    cy.mount(
+      <EuiToolTip content="Tooltip text here" data-test-subj="tooltip">
+        <EuiButton data-test-subj="trigger" onClick={onClick}>
+          Show tooltip
+        </EuiButton>
+      </EuiToolTip>
+    );
+
+    cy.get('[data-test-subj="trigger"]').trigger('mouseover');
+    cy.get('[data-test-subj="tooltip"]').should('exist');
+    cy.get('[data-test-subj="tooltip"]').should(
+      'have.css',
+      'pointer-events',
+      'none'
+    );
+    cy.get('[data-test-subj="trigger"]').click();
+    cy.get('@onClick').should('have.been.calledOnce');
+  });
+
   it('shows the tooltip on hover and hides it on mouseout for a custom disabled trigger button', () => {
     cy.mount(
       <EuiToolTip

--- a/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.stories.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { enableFunctionToggleControls } from '../../../.storybook/utils';
@@ -19,6 +19,7 @@ import {
   EuiToolTipProps,
   DEFAULT_TOOLTIP_OFFSET,
 } from './tool_tip';
+import { EuiIconTip } from './icon_tip';
 
 const meta: Meta<EuiToolTipProps> = {
   title: 'Display/EuiToolTip',
@@ -93,4 +94,60 @@ export const HighContrastMode: Story = {
     ...Playground.args,
     position: 'left',
   },
+};
+
+/**
+ * TODO: REMOVE BEFORE MERGE
+ *
+ * Regression stories
+ */
+
+/**
+ * Reproduces the `pointer-events` regression: before the fix, the visible tooltip
+ * popover had no `pointer-events: none` and could intercept clicks on the trigger.
+ *
+ * Hover over the button to show the tooltip, then click. The counter should increment.
+ */
+const PointerEventsNoneStory = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <EuiToolTip content="The tooltip should not block the button click — hover and then click">
+      <EuiButton onClick={() => setCount((c) => c + 1)}>
+        Clicked {count} {count === 1 ? 'time' : 'times'}
+      </EuiButton>
+    </EuiToolTip>
+  );
+};
+
+export const PointerEventsNone: Story = {
+  render: () => {
+    return <PointerEventsNoneStory />;
+  },
+};
+
+/**
+ * Reproduces the nested-tooltip regression: `EuiTableHeaderCell` wraps every sortable
+ * column's sort button in an `EuiToolTip` with no content. Before the fix, hovering the
+ * inner `EuiIconTip` caused the outer empty tooltip to call `toolTipManager.registerTooltip()`,
+ * which immediately hid the inner tooltip.
+ *
+ * Hover the info icon. The inner tooltip should remain visible.
+ */
+export const NestedEmptyTooltip: Story = {
+  render: () => (
+    <EuiToolTip display="block">
+      <button
+        type="button"
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+      >
+        <span>Duration</span>
+        <EuiIconTip
+          content="The length of time it took for the rule to run (mm:ss)."
+          type="iInCircle"
+          size="s"
+        />
+      </button>
+    </EuiToolTip>
+  ),
 };

--- a/packages/eui/src/components/tool_tip/tool_tip.styles.ts
+++ b/packages/eui/src/components/tool_tip/tool_tip.styles.ts
@@ -47,6 +47,7 @@ export const euiToolTipStyles = (euiThemeContext: UseEuiTheme) => {
       ${euiFontSize(euiThemeContext, 'xs')}
 
       position: absolute;
+      pointer-events: none;
 
       ${euiPanelBorderStyles(euiThemeContext)}
 

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -243,9 +243,10 @@ export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
     }, []);
 
     const showToolTip = useCallback(() => {
+      if (!content && !title) return;
       setVisible(true);
       toolTipManager.registerTooltip(hideToolTip);
-    }, [hideToolTip]);
+    }, [content, title, hideToolTip]);
 
     useImperativeHandle(ref, () => ({ showToolTip, hideToolTip, id }), [
       showToolTip,


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

> [!IMPORTANT]
> https://github.com/elastic/eui/pull/9636/commits/f4f26c8847ae8f9558e17227eeaaa0d2af180eb1 has to be dropped before merge! 

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Fixes for E2E tests failing. See [Buildkite logs](https://buildkite.com/elastic/kibana-pull-request/builds/437924#019df73b-f009-47e3-bd6f-99462f5d362c).

I decided to put "skip-changelog" because it fixes to the currently upcoming logic, not to something that we have already released. That being said, I'm open to adding one.

### API Changes

<!--
List any change to the public EUI API here.

Example:

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiOverlayMask       | hasAnimation                 | Added      | Conditionally add animation                                             |
| EuiBadge             | fill                         | Default    | Default is now "false" -- Makes all badges have a light fill by default |
| Tokens               | colors.severity.someOldColor | Deprecated | Use `colors.severity.someOtherColor` instead                            |
| Global CSS Variables | --my-variable                | Added      | Some reason listed here                                                 |

-->

N/A

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->

N/A

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Use temporary stories to validate the tooltips display as expected.

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested ~[light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile,~ Chrome/Safari/Edge/Firefox, ~keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [ ] ~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
