### PR TITLE
[EuiSuperSelect] Prevent opening listbox if no options are available

### DIFF
--- a/packages/eui/changelogs/upcoming/9645.md
+++ b/packages/eui/changelogs/upcoming/9645.md
@@ -1,0 +1,1 @@
+- Updated `EuioSuperSelect` to no open the listbox if no `options` are passed.

--- a/packages/eui/changelogs/upcoming/9645.md
+++ b/packages/eui/changelogs/upcoming/9645.md
@@ -1,1 +1,1 @@
-- Updated `EuioSuperSelect` to no open the listbox if no `options` are passed.
+- Updated `EuiSuperSelect` to no open the listbox if no `options` are passed.

--- a/packages/eui/changelogs/upcoming/9645.md
+++ b/packages/eui/changelogs/upcoming/9645.md
@@ -1,1 +1,1 @@
-- Updated `EuiSuperSelect` to no open the listbox if no `options` are passed.
+- Updated `EuiSuperSelect` to not open the listbox if no `options` are passed.

--- a/packages/eui/src/components/form/super_select/super_select.test.tsx
+++ b/packages/eui/src/components/form/super_select/super_select.test.tsx
@@ -148,10 +148,12 @@ describe('EuiSuperSelect', () => {
       expect(getByTestSubject('option2')).toBeDisabled();
     });
 
-    it('does not open thje listbox if no options are provided', () => {
-      const { queryByRole } = render(<EuiSuperSelect options={[]} />);
+    it('does not open the listbox if no options are provided', () => {
+      const { queryByRole, getByRole } = render(
+        <EuiSuperSelect options={[]} />
+      );
 
-      fireEvent.click(queryByRole('button')!);
+      fireEvent.click(getByRole('button'));
       expect(queryByRole('listbox')).not.toBeInTheDocument();
     });
 

--- a/packages/eui/src/components/form/super_select/super_select.test.tsx
+++ b/packages/eui/src/components/form/super_select/super_select.test.tsx
@@ -148,6 +148,13 @@ describe('EuiSuperSelect', () => {
       expect(getByTestSubject('option2')).toBeDisabled();
     });
 
+    it('does not open thje listbox if no options are provided', () => {
+      const { queryByRole } = render(<EuiSuperSelect options={[]} />);
+
+      fireEvent.click(queryByRole('button')!);
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
     test('popoverProps', () => {
       render(
         <EuiSuperSelect

--- a/packages/eui/src/components/form/super_select/super_select.tsx
+++ b/packages/eui/src/components/form/super_select/super_select.tsx
@@ -139,7 +139,7 @@ export class EuiSuperSelect<T = string> extends Component<
     }
 
     this.setState({
-      isPopoverOpen: true,
+      isPopoverOpen: options.length > 0,
       currentIndex: initialIndex,
     });
 


### PR DESCRIPTION

## Summary

This PR updates `EuiSuperSelect` to only open the listbox when `options` are available to show. This prevents showing an empty listbox state. `EuiSuperSelect` does not support an empty state message like e.g. `EuiSelectable`, hence not showing the listbox might be the better solution. 
This is conceptually a similar change to https://github.com/elastic/eui/commit/f7b1fe62bfb88a87cd012f61503197f0826e7188 which prevents the `EuiComboBox` listbox from opening if `noSuggestions=true`.

### API Changes

⚪  No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <img width="422" height="84" alt="Screenshot 2026-05-11 at 09 57 26" src="https://github.com/user-attachments/assets/b7c20422-d87e-4b05-9ff0-b727d0cbb701" />| <img width="415" height="60" alt="Screenshot 2026-05-11 at 09 57 52" src="https://github.com/user-attachments/assets/f7b03710-f013-4b3b-bb03-aee9d6583aab" /> |

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None 

ℹ️ The changes have been run in Kibana CI (🟢  [CI run](https://buildkite.com/elastic/kibana-pull-request/builds/440461))

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:**~~ {steps or link, for breaking/visual changes or deprecations}
- [ ] ~~**Adoption plan**~~(new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- Open [Storybook](https://eui.elastic.co/pr_9645/storybook/?path=/story/forms-euisuperselect--playground) and set `options` to `[]`
  - [ ] confirm that the listbox on `EuiSuperSelect` doesn't open
- confirm there is no regression in functionality if `options` are set

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [x] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] ~~**QA:** Tested docs changes~~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~~**Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
