### PR TITLE
Allow skipping tests in snapshot release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
     name: Create a snapshot release
     runs-on: ubuntu-latest
     if: |
+      always() &&
       inputs.type == 'snapshot' &&
       (needs.lint_and_unit_tests.result == 'success' || needs.lint_and_unit_tests.result == 'skipped') &&
       (needs.cypress_tests.result == 'success' || needs.cypress_tests.result == 'skipped')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ on:
         description: Dry run (do not publish the packages)
         required: true
         type: boolean
+      skip_tests:
+        description: Skip tests (snapshots only)
+        default: false
+        type: boolean
       npm_tag:
         description: "[Custom releases only] npm tag to use"
         required: false
@@ -45,6 +49,10 @@ on:
         description: Dry run (do not publish the packages)
         required: true
         type: boolean
+      skip_tests:
+        description: Skip tests (snapshots only)
+        default: false
+        type: boolean
       npm_tag:
         description: "[Custom releases only] npm tag to use"
         required: false
@@ -62,6 +70,7 @@ jobs:
   lint_and_unit_tests:
     name: Run lint and unit tests
     runs-on: ubuntu-latest
+    if: ${{ !(inputs.type == 'snapshot' && inputs.skip_tests) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,6 +91,7 @@ jobs:
   cypress_tests:
     name: Run cypress tests
     runs-on: ubuntu-latest
+    if: ${{ !(inputs.type == 'snapshot' && inputs.skip_tests) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,7 +110,10 @@ jobs:
   release_snapshot:
     name: Create a snapshot release
     runs-on: ubuntu-latest
-    if: ${{ inputs.type == 'snapshot' }}
+    if: |
+      inputs.type == 'snapshot' &&
+      (needs.lint_and_unit_tests.result == 'success' || needs.lint_and_unit_tests.result == 'skipped') &&
+      (needs.cypress_tests.result == 'success' || needs.cypress_tests.result == 'skipped')
     needs: [ lint_and_unit_tests, cypress_tests ]
     outputs:
       published_packages_json: ${{ steps.published_packages_info.outputs.json }}
@@ -169,7 +182,10 @@ jobs:
   release_official:
     name: Create an official release
     runs-on: ubuntu-latest
-    if: ${{ inputs.type == 'official' }}
+    if: |
+      inputs.type == 'official' &&
+      needs.lint_and_unit_tests.result == 'success' &&
+      needs.cypress_tests.result == 'success'
     needs: [ lint_and_unit_tests, cypress_tests ]
     outputs:
       published_packages_json: ${{ steps.published_packages_info.outputs.json }}


### PR DESCRIPTION
## Summary

This PR adds a new boolean input to the release workflow that allows skipping lint, jest, and Cypress jobs during snapshot releases. It's meant to be used when creating snapshot releases from PRs when it's clear that the tests are passing and another run isn't necessary. It's also a speed-up thing when you want to quickly test something externally.

### API Changes

N/A

## Screenshots

N/A

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->~

### QA instructions for reviewer

- [x] Confirm that a snapshot release with `skip_tests=false` ran all testing jobs - [test run](https://github.com/elastic/eui/actions/runs/25763783259)
- [x] Confirm that a snapshot release with `skip_tests=true` ran without executing the testing jobs - [test run](https://github.com/elastic/eui/actions/runs/25741271068)

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] ~**QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [ ] ~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
