### PR TITLE
[EuiContextMenuPanel] Change lifecycle update condition to reduce unnecessary re-renders

### DIFF
--- a/packages/eui/changelogs/upcoming/9656.md
+++ b/packages/eui/changelogs/upcoming/9656.md
@@ -1,0 +1,1 @@
+- Updates the guard condition in `EuiContextMenuPanel`'s update lifecycle method to use input props instead of internal state to reduce unnecessary re-renders.

--- a/packages/eui/src/components/context_menu/context_menu_panel.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_panel.tsx
@@ -327,8 +327,8 @@ export class EuiContextMenuPanelClass extends Component<
     }
   };
 
-  componentDidUpdate(_: Props, prevState: State) {
-    if (prevState.menuItems !== this.state.menuItems) {
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.items !== this.props.items) {
       this.findMenuItems();
     }
     // Focus isn't always ready to be taken on mount, so we need to call it


### PR DESCRIPTION
## Summary

This PR updates `EuiContextMenuPanel` changing the guard condition in `componentDidUpdate` from internal state to input props.
The reasoning for this is to reduce unnecessary renders due to internal state updates, which seem to result in max re-render errors in certain (edge) cases (seen in a [Cloud-UI CI cypress test](https://buildkite.com/elastic/cloud-ui-cypress-tests/builds/9676)).

Previous flow in `componentDidUpdate`:
- `items` prop changes
- `getDerivedStateFromProps` sets `state.menuItems` to `[]`
- `findMenuItems` sets `state.menuItems` according to available items
- `componentDidUpdate` runs again because `[] !== state.menuItems` (unnecessary)

ℹ️ This is a patch to adjust to how class components work. Once this component is migrated to a function component, we can more easily memoize all parts individually.

### API Changes

⚪  No API changes

## Screenshots

No visual changes.

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None 

ℹ️ To ensure there is no unexpected regression, the change was tested in Kibana CI (🟢 [CI run](https://buildkite.com/elastic/kibana-pull-request/builds/442037)).

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [x] verify there is no functional regression with production

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
