### PR TITLE
[EuiCardPanel][A11y] add role="group" and aria-labelledby to card container for clear card-level semantics

### DIFF
--- a/packages/eui/changelogs/upcoming/9657.md
+++ b/packages/eui/changelogs/upcoming/9657.md
@@ -1,0 +1,3 @@
+**Accessibility**
+
+Added `role="group"` and `aria-labelledby` to the `EuiCardPanel` to provide clearer card-level accessibility semantics.

--- a/packages/eui/changelogs/upcoming/9657.md
+++ b/packages/eui/changelogs/upcoming/9657.md
@@ -1,3 +1,3 @@
 **Accessibility**
 
-Added `role="group"` and `aria-labelledby` to the `EuiCardPanel` to provide clearer card-level accessibility semantics.
+- Added `role="group"` and `aria-labelledby` to the `EuiCard` to provide clearer card-level accessibility semantics.

--- a/packages/eui/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/packages/eui/src/components/card/__snapshots__/card.test.tsx.snap
@@ -102,7 +102,6 @@ exports[`EuiCard horizontal selectable 1`] = `
 exports[`EuiCard is rendered 1`] = `
 <div
   aria-label="aria-label"
-  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-euiTestCss"
   data-test-subj="test subject string"
   role="group"

--- a/packages/eui/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/packages/eui/src/components/card/__snapshots__/card.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`EuiCard betaBadgeProps renders href 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-hasBetaBadge"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -48,7 +50,9 @@ exports[`EuiCard betaBadgeProps renders href 1`] = `
 
 exports[`EuiCard horizontal selectable 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-left"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-horizontal"
@@ -98,8 +102,10 @@ exports[`EuiCard horizontal selectable 1`] = `
 exports[`EuiCard is rendered 1`] = `
 <div
   aria-label="aria-label"
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard testClass1 testClass2 emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center-euiTestCss"
   data-test-subj="test subject string"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -132,7 +138,9 @@ exports[`EuiCard is rendered 1`] = `
 
 exports[`EuiCard props a null icon 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -165,7 +173,9 @@ exports[`EuiCard props a null icon 1`] = `
 
 exports[`EuiCard props accepts div props like style 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
   style="min-width: 0;"
 >
   <div
@@ -199,7 +209,9 @@ exports[`EuiCard props accepts div props like style 1`] = `
 
 exports[`EuiCard props an avatar icon 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -248,7 +260,9 @@ exports[`EuiCard props an avatar icon 1`] = `
 
 exports[`EuiCard props children 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -278,7 +292,9 @@ exports[`EuiCard props children 1`] = `
 
 exports[`EuiCard props children with description 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -316,7 +332,9 @@ exports[`EuiCard props children with description 1`] = `
 
 exports[`EuiCard props display accent is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--accent euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-accent-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -349,7 +367,9 @@ exports[`EuiCard props display accent is rendered 1`] = `
 
 exports[`EuiCard props display accentSecondary is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--accentSecondary euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-accentSecondary-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -382,7 +402,9 @@ exports[`EuiCard props display accentSecondary is rendered 1`] = `
 
 exports[`EuiCard props display danger is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--danger euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-danger-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -415,7 +437,9 @@ exports[`EuiCard props display danger is rendered 1`] = `
 
 exports[`EuiCard props display highlighted is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--highlighted euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-highlighted-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -448,7 +472,9 @@ exports[`EuiCard props display highlighted is rendered 1`] = `
 
 exports[`EuiCard props display neutral is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--neutral euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-neutral-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -481,7 +507,9 @@ exports[`EuiCard props display neutral is rendered 1`] = `
 
 exports[`EuiCard props display plain is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -514,7 +542,9 @@ exports[`EuiCard props display plain is rendered 1`] = `
 
 exports[`EuiCard props display primary is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--primary euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-primary-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -547,7 +577,9 @@ exports[`EuiCard props display primary is rendered 1`] = `
 
 exports[`EuiCard props display risk is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--risk euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-risk-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -580,7 +612,9 @@ exports[`EuiCard props display risk is rendered 1`] = `
 
 exports[`EuiCard props display subdued is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--subdued euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-subdued-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -613,7 +647,9 @@ exports[`EuiCard props display subdued is rendered 1`] = `
 
 exports[`EuiCard props display success is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--success euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-success-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -646,7 +682,9 @@ exports[`EuiCard props display success is rendered 1`] = `
 
 exports[`EuiCard props display transparent is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--transparent euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-transparent-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -679,7 +717,9 @@ exports[`EuiCard props display transparent is rendered 1`] = `
 
 exports[`EuiCard props display warning is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--warning euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-warning-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -712,7 +752,9 @@ exports[`EuiCard props display warning is rendered 1`] = `
 
 exports[`EuiCard props footer 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -752,7 +794,9 @@ exports[`EuiCard props footer 1`] = `
 
 exports[`EuiCard props hasBorder 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasBorder-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -785,7 +829,9 @@ exports[`EuiCard props hasBorder 1`] = `
 
 exports[`EuiCard props horizontal 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-left"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-horizontal"
@@ -818,7 +864,9 @@ exports[`EuiCard props horizontal 1`] = `
 
 exports[`EuiCard props href supports href as a link 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -854,7 +902,9 @@ exports[`EuiCard props href supports href as a link 1`] = `
 
 exports[`EuiCard props icon 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -895,7 +945,9 @@ exports[`EuiCard props icon 1`] = `
 
 exports[`EuiCard props image 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -942,7 +994,9 @@ exports[`EuiCard props image 1`] = `
 
 exports[`EuiCard props isDisabled 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--subdued euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-subdued-euiCard-center-disabled"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -955,7 +1009,7 @@ exports[`EuiCard props isDisabled 1`] = `
         id="generated-idTitle"
       >
         <button
-          aria-describedby=" generated-idDescription"
+          aria-describedby="generated-idDescription"
           class="euiCard__titleButton emotion-euiCard__text-center-disabled"
           disabled=""
         >
@@ -977,7 +1031,9 @@ exports[`EuiCard props isDisabled 1`] = `
 
 exports[`EuiCard props paddingSize l is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingLarge euiCard emotion-euiPanel-grow-m-l-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1010,7 +1066,9 @@ exports[`EuiCard props paddingSize l is rendered 1`] = `
 
 exports[`EuiCard props paddingSize m is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1043,7 +1101,9 @@ exports[`EuiCard props paddingSize m is rendered 1`] = `
 
 exports[`EuiCard props paddingSize none is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1076,7 +1136,9 @@ exports[`EuiCard props paddingSize none is rendered 1`] = `
 
 exports[`EuiCard props paddingSize s is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingSmall euiCard emotion-euiPanel-grow-m-s-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1109,7 +1171,9 @@ exports[`EuiCard props paddingSize s is rendered 1`] = `
 
 exports[`EuiCard props paddingSize xl is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-xl-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1142,7 +1206,9 @@ exports[`EuiCard props paddingSize xl is rendered 1`] = `
 
 exports[`EuiCard props paddingSize xs is rendered 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiCard emotion-euiPanel-grow-m-xs-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1175,7 +1241,9 @@ exports[`EuiCard props paddingSize xs is rendered 1`] = `
 
 exports[`EuiCard props selectable 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-isClickable-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1224,7 +1292,9 @@ exports[`EuiCard props selectable 1`] = `
 
 exports[`EuiCard props textAlign center 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1257,7 +1327,9 @@ exports[`EuiCard props textAlign center 1`] = `
 
 exports[`EuiCard props textAlign left 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-left"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1290,7 +1362,9 @@ exports[`EuiCard props textAlign left 1`] = `
 
 exports[`EuiCard props textAlign right 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-right"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1323,7 +1397,9 @@ exports[`EuiCard props textAlign right 1`] = `
 
 exports[`EuiCard props titleElement 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1356,7 +1432,9 @@ exports[`EuiCard props titleElement 1`] = `
 
 exports[`EuiCard props titleElement with nodes 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"
@@ -1389,7 +1467,9 @@ exports[`EuiCard props titleElement with nodes 1`] = `
 
 exports[`EuiCard props titleSize 1`] = `
 <div
+  aria-labelledby="generated-idTitle"
   class="euiPanel euiPanel--plain euiPanel--paddingMedium euiCard emotion-euiPanel-grow-m-m-plain-hasShadow-euiCard-center"
+  role="group"
 >
   <div
     class="euiCard__main emotion-euiCard__main-vertical"

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -69,6 +69,10 @@ type EuiCardPropsLayout = ExclusiveUnion<
   }
 >;
 
+const joinAriaIds = (...ids: Array<string | undefined>) =>
+  ids.filter((id): id is string => Boolean(id)).join(' ') || undefined;
+
+
 export type EuiCardProps = Omit<CommonProps, 'aria-label'> &
   Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'title' | 'onClick'> &
   EuiCardPropsLayout & {
@@ -216,8 +220,6 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   const ariaId = useGeneratedHtmlId();
   const titleId = `${ariaId}Title`;
   const ariaDesc = description ? `${ariaId}Description` : undefined;
-  const joinAriaIds = (...ids: Array<string | undefined>) =>
-    ids.filter((id): id is string => Boolean(id)).join(' ') || undefined;
 
   /**
    * Top area containing image, icon or both

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -214,7 +214,10 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   const classes = classNames('euiCard', className);
 
   const ariaId = useGeneratedHtmlId();
+  const titleId = `${ariaId}Title`;
   const ariaDesc = description ? `${ariaId}Description` : '';
+  const joinAriaIds = (...ids: Array<string | undefined>) =>
+    ids.filter((id): id is string => Boolean(id)).join(' ');
 
   /**
    * Top area containing image, icon or both
@@ -310,11 +313,12 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
 
   let optionalSelectButton;
   if (selectable) {
+    const selectDescribedBy = joinAriaIds(titleId, ariaDesc);
     optionalSelectButton = (
       <>
         {paddingSize !== 'none' && <EuiSpacer size={paddingSize || 'm'} />}
         <EuiCardSelect
-          aria-describedby={`${ariaId}Title ${ariaDesc}`}
+          aria-describedby={selectDescribedBy}
           {...selectable}
           buttonRef={(node: HTMLAnchorElement | HTMLButtonElement | null) => {
             link = node;
@@ -350,13 +354,14 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
       </a>
     );
   } else if (isDisabled || onClick) {
+    const buttonDescribedBy = joinAriaIds(optionalBetaBadgeID, ariaDesc);
     theTitle = (
       <button
         className="euiCard__titleButton"
         css={textCSS}
         onClick={onClick as React.MouseEventHandler<HTMLButtonElement>}
         disabled={isDisabled}
-        aria-describedby={`${optionalBetaBadgeID} ${ariaDesc}`}
+        aria-describedby={buttonDescribedBy}
         ref={(node) => {
           link = node;
         }}
@@ -399,6 +404,8 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   return (
     <EuiPanel
       element="div"
+      role="group"
+      aria-labelledby={titleId}
       className={classes}
       css={[...cardStyles, optionalBetaCSS]}
       onClick={isClickable ? outerOnClick : undefined}
@@ -413,7 +420,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
 
         <div className="euiCard__content" css={contentStyles}>
           <EuiTitle
-            id={`${ariaId}Title`}
+            id={titleId}
             className="euiCard__title"
             size={titleSize}
           >

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -419,11 +419,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
         {optionalCardTop}
 
         <div className="euiCard__content" css={contentStyles}>
-          <EuiTitle
-            id={titleId}
-            className="euiCard__title"
-            size={titleSize}
-          >
+          <EuiTitle id={titleId} className="euiCard__title" size={titleSize}>
             <TitleElement>{theTitle}</TitleElement>
           </EuiTitle>
 

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -72,7 +72,6 @@ type EuiCardPropsLayout = ExclusiveUnion<
 const joinAriaIds = (...ids: Array<string | undefined>) =>
   ids.filter((id): id is string => Boolean(id)).join(' ') || undefined;
 
-
 export type EuiCardProps = Omit<CommonProps, 'aria-label'> &
   Omit<HTMLAttributes<HTMLDivElement>, 'color' | 'title' | 'onClick'> &
   EuiCardPropsLayout & {

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -215,7 +215,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
 
   const ariaId = useGeneratedHtmlId();
   const titleId = `${ariaId}Title`;
-  const ariaDesc = description ? `${ariaId}Description` : '';
+  const ariaDesc = description ? `${ariaId}Description` : undefined;
   const joinAriaIds = (...ids: Array<string | undefined>) =>
     (ids.filter((id): id is string => Boolean(id)).join(' ')) || undefined;
 

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -217,7 +217,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   const titleId = `${ariaId}Title`;
   const ariaDesc = description ? `${ariaId}Description` : '';
   const joinAriaIds = (...ids: Array<string | undefined>) =>
-    ids.filter((id): id is string => Boolean(id)).join(' ');
+    (ids.filter((id): id is string => Boolean(id)).join(' ')) || undefined;
 
   /**
    * Top area containing image, icon or both

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -401,11 +401,16 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
     optionalFooter = <div css={footerStyles}>{footer}</div>;
   }
 
+  const rootAriaLabelledby =
+    rest['aria-label'] == null && rest['aria-labelledby'] == null
+      ? titleId
+      : undefined;
+
   return (
     <EuiPanel
       element="div"
       role="group"
-      aria-labelledby={titleId}
+      aria-labelledby={rootAriaLabelledby}
       className={classes}
       css={[...cardStyles, optionalBetaCSS]}
       onClick={isClickable ? outerOnClick : undefined}

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -217,7 +217,7 @@ export const EuiCard: FunctionComponent<EuiCardProps> = ({
   const titleId = `${ariaId}Title`;
   const ariaDesc = description ? `${ariaId}Description` : undefined;
   const joinAriaIds = (...ids: Array<string | undefined>) =>
-    (ids.filter((id): id is string => Boolean(id)).join(' ')) || undefined;
+    ids.filter((id): id is string => Boolean(id)).join(' ') || undefined;
 
   /**
    * Top area containing image, icon or both


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

- **What:** Improves `EuiCard` accessibility by adding clearer card-level semantics to the outer container. The card panel now renders with `role="group"` and `aria-labelledby` pointing to the card title, and related ARIA descriptions were cleaned up for clickable/selectable variants.

- **Why:** This helps assistive technologies understand each card as a labeled group with an explicit relationship to its title, instead of treating it as only a generic styled container. It also avoids malformed `aria-describedby` values caused by empty IDs or extra spaces.

- **How:** Added a stable `titleId` derived from the generated card ID and used it both on the title element and the outer `EuiPanel` via `aria-labelledby`. Introduced a small helper to safely join ARIA IDs for `aria-describedby` so only defined values are included. Updated snapshots to reflect the new accessibility attributes.

- **Other context:** This is a focused accessibility change with low consumer impact. The main behavior change is improved semantics for screen reader users. 
How A11Y tree looks in case of multiple EUICard's: 

<img width="1339" height="800" alt="image" src="https://github.com/user-attachments/assets/e8a4eadf-29c4-43ba-912c-59a5216a2f64" />
 


### API Changes

<!--
List any change to the public EUI API here.

Example:

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiOverlayMask       | hasAnimation                 | Added      | Conditionally add animation                                             |
| EuiBadge             | fill                         | Default    | Default is now "false" -- Makes all badges have a light fill by default |
| Tokens               | colors.severity.someOldColor | Deprecated | Use `colors.severity.someOtherColor` instead                            |
| Global CSS Variables | --my-variable                | Added      | Some reason listed here                                                 |

-->

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiCard | root panel semantics | Added | Adds role="group" and aria-labelledby for clearer card semantics | | EuiCard | internal ARIA wiring | Updated | Normalizes id composition and prevents malformed aria-describedby output |v


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->~

### QA instructions for reviewer

- [ ] Verify aria attributes are passing to EuiCard

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] ~**QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [ ] ~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
