### PR TITLE
Update buildkite pull_request_test pipeline VM settings

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -40,7 +40,7 @@ steps:
       machineType: "c4d-standard-4"
       preemptible: true
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:17'
     if: build.branch != "main"
@@ -60,7 +60,7 @@ steps:
       machineType: "c4d-standard-4"
       preemptible: true
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:18'
     if: build.branch != "main"
@@ -80,7 +80,7 @@ steps:
       machineType: "c4d-standard-4"
       preemptible: true
       diskType: hyperdisk-balanced
-      zones: us-central1-a,us-central1-b,us-central1-c
+      spotZones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:a11y'
     if: build.branch != "main"

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -1,46 +1,52 @@
 # 🏠/.buildkite/pipelines/pipeline_pull_request_test.yml
 
+agents:
+  provider: gcp
+  machineType: c4d-standard-4
+  preemptible: true
+  diskType: hyperdisk-balanced
+  diskSizeGb: 30
+  # c4d instances are only available in some regions
+  spotZones: us-central1-a,us-central1-b,us-central1-c
+
+retry_policy: &retry_policy
+  automatic:
+    - exit_status: -1 # agent loss
+      limit: 3
+    - exit_status: "*"
+      limit: 2
+
 steps:
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":typescript: Linting"
-    agents:
-      provider: "gcp"
     env:
       TEST_TYPE: 'lint'
     if: build.branch != "main" # This job is triggered by the combined test and deploy docs for every PR
+    retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":jest: TS unit tests"
-    agents:
-      provider: "gcp"
     env:
       TEST_TYPE: 'unit:ts'
     if: build.branch != "main"
+    retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":jest: TSX unit tests on React 17"
-    agents:
-      provider: "gcp"
     env:
       TEST_TYPE: 'unit:tsx:17'
     if: build.branch != "main"
+    retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":jest: TSX unit tests on React 18"
-    agents:
-      provider: "gcp"
     env:
       TEST_TYPE: 'unit:tsx'
     if: build.branch != "main"
+    retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":cypress: Cypress tests on React 17"
-    agents:
-      provider: "gcp"
-      machineType: "c4d-standard-4"
-      preemptible: true
-      diskType: hyperdisk-balanced
-      spotZones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:17'
     if: build.branch != "main"
@@ -48,21 +54,10 @@ steps:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
     timeout_in_minutes: 45
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 3
-        - exit_status: "*"
-          limit: 2
+    retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":cypress: Cypress tests on React 18"
-    agents:
-      provider: "gcp"
-      machineType: "c4d-standard-4"
-      preemptible: true
-      diskType: hyperdisk-balanced
-      spotZones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:18'
     if: build.branch != "main"
@@ -70,21 +65,10 @@ steps:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
     timeout_in_minutes: 45
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 3
-        - exit_status: "*"
-          limit: 2
+    retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":axe: Cypress accessibility (a11y) tests on React 18"
-    agents:
-      provider: "gcp"
-      machineType: "c4d-standard-4"
-      preemptible: true
-      diskType: hyperdisk-balanced
-      spotZones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:a11y'
     if: build.branch != "main"
@@ -92,9 +76,4 @@ steps:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
     timeout_in_minutes: 45
-    retry:
-      automatic:
-        - exit_status: -1
-          limit: 3
-        - exit_status: "*"
-          limit: 2
+    retry: *retry_policy

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -52,6 +52,8 @@ steps:
       automatic:
         - exit_status: -1
           limit: 3
+        - exit_status: "*"
+          limit: 2
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":cypress: Cypress tests on React 18"
@@ -72,6 +74,8 @@ steps:
       automatic:
         - exit_status: -1
           limit: 3
+        - exit_status: "*"
+          limit: 2
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":axe: Cypress accessibility (a11y) tests on React 18"
@@ -92,3 +96,5 @@ steps:
       automatic:
         - exit_status: -1
           limit: 3
+        - exit_status: "*"
+          limit: 2

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -37,35 +37,55 @@ steps:
     label: ":cypress: Cypress tests on React 17"
     agents:
       provider: "gcp"
+      machineType: "c4d-standard-4"
+      preemptible: true
+      diskType: hyperdisk-balanced
     env:
       TEST_TYPE: 'cypress:17'
     if: build.branch != "main"
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+    timeout_in_minutes: 45
     retry:
-      automatic: true
+      automatic:
+        - exit_status: -1
+          limit: 3
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":cypress: Cypress tests on React 18"
     agents:
       provider: "gcp"
+      machineType: "c4d-standard-4"
+      preemptible: true
+      diskType: hyperdisk-balanced
     env:
       TEST_TYPE: 'cypress:18'
     if: build.branch != "main"
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+    timeout_in_minutes: 45
     retry:
-      automatic: true
+      automatic:
+        - exit_status: -1
+          limit: 3
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
     label: ":axe: Cypress accessibility (a11y) tests on React 18"
     agents:
       provider: "gcp"
+      machineType: "c4d-standard-4"
+      preemptible: true
+      diskType: hyperdisk-balanced
     env:
       TEST_TYPE: 'cypress:a11y'
     if: build.branch != "main"
     artifact_paths:
       - "cypress/screenshots/**/*.png"
       - "cypress/videos/**/*.mp4"
+    timeout_in_minutes: 45
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 3

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -40,6 +40,7 @@ steps:
       machineType: "c4d-standard-4"
       preemptible: true
       diskType: hyperdisk-balanced
+      zones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:17'
     if: build.branch != "main"
@@ -59,6 +60,7 @@ steps:
       machineType: "c4d-standard-4"
       preemptible: true
       diskType: hyperdisk-balanced
+      zones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:18'
     if: build.branch != "main"
@@ -78,6 +80,7 @@ steps:
       machineType: "c4d-standard-4"
       preemptible: true
       diskType: hyperdisk-balanced
+      zones: us-central1-a,us-central1-b,us-central1-c
     env:
       TEST_TYPE: 'cypress:a11y'
     if: build.branch != "main"

--- a/packages/eui/cypress.config.ts
+++ b/packages/eui/cypress.config.ts
@@ -10,6 +10,8 @@ const isBuildkiteReporterAvailable =
   typeof process.env.BUILDKITE_ANALYTICS_TOKEN === 'string' &&
   process.env.BUILDKITE_ANALYTICS_TOKEN !== '';
 
+const isCI = process.env.CI === 'true';
+
 if (isBuildkiteReporterAvailable) {
   console.log('Buildkite Test Analytics reporter available');
 }
@@ -27,8 +29,10 @@ export default defineConfig({
       webpackConfig,
     },
     setupNodeEvents(on, config) {
-      require('@cypress/code-coverage/task')(on, config);
-      on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
+      if (!isCI) {
+        require('@cypress/code-coverage/task')(on, config);
+        on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
+      }
 
       on('task', {
         log(message) {


### PR DESCRIPTION
## Summary

This PR updates the pull_request_test Buildkite pipeline to set new agents configuration for Cypress jobs. It switches from the old `n1-standard-4` GCP instances to the new `c4d-standard-4` with spot pricing enabled. This change itself cuts Cypress tests run time in ~half. Additionally, I'm now disabling code coverage generation in Cypress runs in CI, which speeds up things by another ~30%.

After this update, it takes about 8 minutes to run the whole Cypress test suite in CI.

### API Changes

N/A

## Screenshots

N/A

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->~

### QA instructions for reviewer

- [ ] Check the CI run on this PR and confirm it's passing

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] ~**QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [ ] ~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~
- [ ] ~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
