### PR TITLE
[deps] Upgrade uuid to v14

### DIFF
--- a/packages/eui/changelogs/upcoming/9663.md
+++ b/packages/eui/changelogs/upcoming/9663.md
@@ -1,0 +1,3 @@
+**Dependency updates**
+
+- Updated `uuid` to v14.0.0

--- a/packages/eui/package.json
+++ b/packages/eui/package.json
@@ -87,7 +87,7 @@
     "unist-util-visit": "^2.0.3",
     "url-parse": "^1.5.10",
     "use-sync-external-store": "^1.6.0",
-    "uuid": "^8.3.0",
+    "uuid": "^14.0.0",
     "vfile": "^4.2.1"
   },
   "devDependencies": {
@@ -151,7 +151,6 @@
     "@types/stylis": "^4.2.1",
     "@types/testing-library__jest-dom": "^5.14.3",
     "@types/url-parse": "^1.4.8",
-    "@types/uuid": "^8.3.0",
     "@types/vfile-message": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",

--- a/packages/eui/scripts/jest/config.js
+++ b/packages/eui/scripts/jest/config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const jestConfig = require('jest-config');
 const getCacheDirectory = () => jestConfig.defaults.cacheDirectory;
 
@@ -44,7 +45,6 @@ const config = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/scripts/jest/mocks/file_mock.js',
     '\\.(css|less|scss)$': '<rootDir>/scripts/jest/mocks/style_mock.js',
-    '^uuid$': require.resolve('uuid'),
   },
   setupFiles: [
     '<rootDir>/scripts/jest/setup/enzyme.js',
@@ -62,8 +62,11 @@ const config = {
   testEnvironment: 'jsdom',
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.tsx'],
   transform: {
-    '^.+\\.(js|tsx?)$': 'babel-jest',
+    '^.+\\.(js|tsx?)$': ['babel-jest', {
+      configFile: path.resolve(__dirname, '../../.babelrc.js'),
+    }],
   },
+  transformIgnorePatterns: ['/node_modules/(?!(uuid)/)'],
   snapshotSerializers: [
     '<rootDir>/node_modules/enzyme-to-json/serializer',
     '<rootDir>/scripts/jest/setup/emotion',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7334,7 +7334,6 @@ __metadata:
     "@types/stylis": "npm:^4.2.1"
     "@types/testing-library__jest-dom": "npm:^5.14.3"
     "@types/url-parse": "npm:^1.4.8"
-    "@types/uuid": "npm:^8.3.0"
     "@types/vfile-message": "npm:^2.0.0"
     "@typescript-eslint/eslint-plugin": "npm:^5.59.7"
     "@typescript-eslint/parser": "npm:^5.59.7"
@@ -7450,7 +7449,7 @@ __metadata:
     unist-util-visit: "npm:^2.0.3"
     url-parse: "npm:^1.5.10"
     use-sync-external-store: "npm:^1.6.0"
-    uuid: "npm:^8.3.0"
+    uuid: "npm:^14.0.0"
     vfile: "npm:^4.2.1"
     webpack: "npm:^5.74.0"
     webpack-cli: "npm:^4.10.0"
@@ -11475,13 +11474,6 @@ __metadata:
   version: 0.0.3
   resolution: "@types/use-sync-external-store@npm:0.0.3"
   checksum: 10c0/82824c1051ba40a00e3d47964cdf4546a224e95f172e15a9c62aa3f118acee1c7518b627a34f3aa87298a2039f982e8509f92bfcc18bea7c255c189c293ba547
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "@types/uuid@npm:8.3.0"
-  checksum: 10c0/b39ede3212609c3460b14446629796ab6acb61227a249e89d4d188fed84acfe71569b7d01b30a39f4443703810bf2b0959e586e0334d7088f11ec8606d373cde
   languageName: node
   linkType: hard
 
@@ -40154,6 +40146,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.3.2, uuid@npm:^3.3.3":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
@@ -40163,7 +40164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
+"uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
## Summary

- Upgrades `uuid` from `^8.3.0` to `^14.0.0` in `@elastic/eui`
- Removes `@types/uuid` — uuid v14 ships its own TypeScript types
- Fixes Jest config to handle uuid v14's ESM-only builds: adds `transformIgnorePatterns` to opt uuid into Babel transformation, and passes `configFile` explicitly to `babel-jest` so the project `.babelrc.js` applies across the `node_modules` package boundary. Also removes a redundant `moduleNameMapper` entry for uuid.

## Test plan

- [x] TypeScript compiles without errors
- [x] Jest test suite passes (uuid v14 is now correctly transformed for CJS environments)
- [x] `html_id_generator` and `match_container` still function correctly (both use `v1` which remains available in v14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)