### PR TITLE
[EuiTable/EuiBasicTable/EuiInMemoryTable] Add always-visible sticky scrollbar

### DIFF
--- a/packages/eui/changelogs/upcoming/9674.md
+++ b/packages/eui/changelogs/upcoming/9674.md
@@ -1,0 +1,1 @@
+- Added experimental support for always-visible sticky horizontal scrollbars in `EuiTable`, `EuiBasicTable` and `EuiInMemoryTable` useful for dense tables that exceed the height of the viewport. This feature is currently opt-in and can be enabled by setting `stickyScrollbar: true`.

--- a/packages/eui/src/components/basic_table/basic_table.stories.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.stories.tsx
@@ -75,7 +75,7 @@ type User = {
 
 const users: User[] = [];
 
-for (let i = 0; i < 5; i++) {
+for (let i = 0; i < 75; i++) {
   users.push({
     id: i + 1,
     firstName: faker.person.firstName(),

--- a/packages/eui/src/components/basic_table/basic_table.stories.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.stories.tsx
@@ -51,6 +51,7 @@ const meta: Meta<EuiBasicTableProps<User>> = {
     },
     noItemsMessage: '',
     scrollableInline: false,
+    stickyScrollbar: false,
   },
 };
 moveStorybookControlsToCategory(
@@ -608,6 +609,7 @@ export const Scrollable: Story = {
   args: {
     ...Playground.args,
     scrollableInline: true,
+    stickyScrollbar: true,
     responsiveBreakpoint: false,
     tableLayout: 'auto',
     columns: scrollableColumns,

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -12,16 +12,8 @@ import React, {
   HTMLAttributes,
   ReactNode,
   ContextType,
-  createRef,
-  useState,
-  RefObject,
-  useEffect,
-  useCallback,
-  useRef,
-  PointerEventHandler,
 } from 'react';
 import classNames from 'classnames';
-import { css } from '@emotion/react';
 import moment from 'moment';
 import {
   Direction,
@@ -36,9 +28,6 @@ import {
   RenderWithEuiTheme,
   OverrideCopiedTabularContent,
   tabularCopyMarkers,
-  UseEuiTheme,
-  useEuiMemoizedStyles,
-  transparentize,
 } from '../../services';
 import { CommonProps } from '../common';
 import { isFunction } from '../../services/predicate';
@@ -320,152 +309,6 @@ function hasPagination<T extends object>(
   return x.hasOwnProperty('pagination') && !!x.pagination;
 }
 
-const getMiniMapStyles = (_euiTheme: UseEuiTheme) => {
-  const { euiTheme } = _euiTheme;
-
-  return {
-    wrapper: css`
-      block-size: ${euiTheme.size.base};
-      background: ${euiTheme.colors.backgroundBaseDisabled};
-      padding: ${euiTheme.size.xs};
-      position: sticky;
-      inset-block-end: var(--euiBasicTableVirtualScrollOffsetBottom, 0);
-      z-index: var(--euiBasicTableVirtualScrollZIndex, 0);
-    `,
-    marker: css`
-      block-size: 100%;
-      background: ${transparentize(euiTheme.colors.darkShade, 0.5)};
-      border-radius: ${euiTheme.border.radius.small};
-    `,
-  };
-};
-
-const MiniMap = ({
-  wrapperElementRef,
-}: {
-  wrapperElementRef: RefObject<HTMLDivElement>;
-}) => {
-  const styles = useEuiMemoizedStyles(getMiniMapStyles);
-  const trackElementRef = useRef<HTMLDivElement>(null);
-  const rafPending = useRef(false);
-  const [active, setActive] = useState(false);
-
-  const updateTrack = useCallback((element: HTMLDivElement) => {
-    const { clientWidth, scrollWidth, scrollLeft } = element;
-
-    if (!rafPending.current) {
-      rafPending.current = true;
-
-      requestAnimationFrame(() => {
-        const el = trackElementRef.current;
-        if (el) {
-          el.style.inlineSize = `${(clientWidth / scrollWidth) * 100}%`;
-          el.style.marginInlineStart = `${(scrollLeft / scrollWidth) * 100}%`;
-        }
-
-        rafPending.current = false;
-      });
-    }
-  }, []);
-
-  const handleScroll = useCallback(
-    (event: Event) => {
-      if (event.target) {
-        updateTrack(event.target as HTMLDivElement);
-      }
-    },
-    [updateTrack]
-  );
-
-  const handleResize = useCallback<ResizeObserverCallback>(
-    (entries) => {
-      if (entries.length === 0) {
-        return;
-      }
-
-      const element = entries[0].target;
-      updateTrack(element as HTMLDivElement);
-
-      if (element.clientWidth < element.scrollWidth) {
-        setActive(true);
-      } else {
-        setActive(false);
-      }
-    },
-    [updateTrack]
-  );
-
-  useEffect(() => {
-    const element = wrapperElementRef.current;
-
-    if (element == null) {
-      return;
-    }
-
-    updateTrack(element);
-    element.addEventListener('scroll', handleScroll, { passive: true });
-
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(element);
-
-    return () => {
-      element.removeEventListener('scroll', handleScroll);
-      resizeObserver.disconnect();
-    };
-  }, [wrapperElementRef, updateTrack, handleScroll, handleResize]);
-
-  const dragStartRef = useRef<{ x: number; scrollLeft: number } | null>(null);
-
-  const handlePointerDown = useCallback<PointerEventHandler<HTMLDivElement>>(
-    (event) => {
-      const el = wrapperElementRef.current;
-      dragStartRef.current = {
-        x: event.clientX,
-        scrollLeft: el?.scrollLeft ?? 0,
-      };
-
-      event.currentTarget.setPointerCapture(event.pointerId);
-    },
-    [wrapperElementRef]
-  );
-
-  const handlePointerUp = useCallback(() => {
-    dragStartRef.current = null;
-  }, [dragStartRef]);
-
-  const handlePointerMove = useCallback<PointerEventHandler<HTMLDivElement>>(
-    (event) => {
-      const el = wrapperElementRef.current;
-
-      if (!dragStartRef.current || !el) {
-        return;
-      }
-
-      const diff = event.clientX - dragStartRef.current.x;
-      const ratio = el.scrollWidth / el.clientWidth;
-
-      el.scrollLeft = dragStartRef.current.scrollLeft + diff * ratio;
-    },
-    [wrapperElementRef]
-  );
-
-  if (!active) {
-    return null;
-  }
-
-  return (
-    <div css={styles.wrapper}>
-      <div
-        ref={trackElementRef}
-        css={styles.marker}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-      />
-    </div>
-  );
-};
-
 export class EuiBasicTable<T extends object = any> extends Component<
   EuiBasicTableProps<T>,
   State<T>
@@ -479,8 +322,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
       <EuiI18n token="euiBasicTable.noItemsMessage" default="No items found" />
     ),
   };
-
-  private tableWrapperElementRef = createRef<HTMLDivElement>();
 
   static getDerivedStateFromProps<T extends object>(
     nextProps: EuiBasicTableProps<T>,
@@ -697,7 +538,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
     return (
       <div className={classes} {...rest}>
         {table}
-        <MiniMap wrapperElementRef={this.tableWrapperElementRef} />
         {paginationBar}
       </div>
     );
@@ -721,7 +561,6 @@ export class EuiBasicTable<T extends object = any> extends Component<
         </EuiTableHeaderMobile>
         <OverrideCopiedTabularContent>
           <EuiTable
-            tableWrapperElementRef={this.tableWrapperElementRef}
             id={this.tableId}
             tableLayout={tableLayout}
             responsiveBreakpoint={responsiveBreakpoint}

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -995,8 +995,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
           colSpan={colSpan}
           mobileOptions={{ width: '100%' }}
         >
-          <EuiIcon type="minusCircle" color="danger" aria-hidden={true} />{' '}
-          {error}
+          <EuiIcon type="minusCircle" color="danger" /> {error}
         </EuiTableRowCell>
       </EuiTableRow>
     );

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -12,8 +12,16 @@ import React, {
   HTMLAttributes,
   ReactNode,
   ContextType,
+  createRef,
+  useState,
+  RefObject,
+  useEffect,
+  useCallback,
+  useRef,
+  PointerEventHandler,
 } from 'react';
 import classNames from 'classnames';
+import { css } from '@emotion/react';
 import moment from 'moment';
 import {
   Direction,
@@ -28,6 +36,9 @@ import {
   RenderWithEuiTheme,
   OverrideCopiedTabularContent,
   tabularCopyMarkers,
+  UseEuiTheme,
+  useEuiMemoizedStyles,
+  transparentize,
 } from '../../services';
 import { CommonProps } from '../common';
 import { isFunction } from '../../services/predicate';
@@ -309,6 +320,152 @@ function hasPagination<T extends object>(
   return x.hasOwnProperty('pagination') && !!x.pagination;
 }
 
+const getMiniMapStyles = (_euiTheme: UseEuiTheme) => {
+  const { euiTheme } = _euiTheme;
+
+  return {
+    wrapper: css`
+      block-size: ${euiTheme.size.base};
+      background: ${euiTheme.colors.backgroundBaseDisabled};
+      padding: ${euiTheme.size.xs};
+      position: sticky;
+      inset-block-end: var(--euiBasicTableVirtualScrollOffsetBottom, 0);
+      z-index: var(--euiBasicTableVirtualScrollZIndex, 0);
+    `,
+    marker: css`
+      block-size: 100%;
+      background: ${transparentize(euiTheme.colors.darkShade, 0.5)};
+      border-radius: ${euiTheme.border.radius.small};
+    `,
+  };
+};
+
+const MiniMap = ({
+  wrapperElementRef,
+}: {
+  wrapperElementRef: RefObject<HTMLDivElement>;
+}) => {
+  const styles = useEuiMemoizedStyles(getMiniMapStyles);
+  const trackElementRef = useRef<HTMLDivElement>(null);
+  const rafPending = useRef(false);
+  const [active, setActive] = useState(false);
+
+  const updateTrack = useCallback((element: HTMLDivElement) => {
+    const { clientWidth, scrollWidth, scrollLeft } = element;
+
+    if (!rafPending.current) {
+      rafPending.current = true;
+
+      requestAnimationFrame(() => {
+        const el = trackElementRef.current;
+        if (el) {
+          el.style.inlineSize = `${(clientWidth / scrollWidth) * 100}%`;
+          el.style.marginInlineStart = `${(scrollLeft / scrollWidth) * 100}%`;
+        }
+
+        rafPending.current = false;
+      });
+    }
+  }, []);
+
+  const handleScroll = useCallback(
+    (event: Event) => {
+      if (event.target) {
+        updateTrack(event.target as HTMLDivElement);
+      }
+    },
+    [updateTrack]
+  );
+
+  const handleResize = useCallback<ResizeObserverCallback>(
+    (entries) => {
+      if (entries.length === 0) {
+        return;
+      }
+
+      const element = entries[0].target;
+      updateTrack(element as HTMLDivElement);
+
+      if (element.clientWidth < element.scrollWidth) {
+        setActive(true);
+      } else {
+        setActive(false);
+      }
+    },
+    [updateTrack]
+  );
+
+  useEffect(() => {
+    const element = wrapperElementRef.current;
+
+    if (element == null) {
+      return;
+    }
+
+    updateTrack(element);
+    element.addEventListener('scroll', handleScroll, { passive: true });
+
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(element);
+
+    return () => {
+      element.removeEventListener('scroll', handleScroll);
+      resizeObserver.disconnect();
+    };
+  }, [wrapperElementRef, updateTrack, handleScroll, handleResize]);
+
+  const dragStartRef = useRef<{ x: number; scrollLeft: number } | null>(null);
+
+  const handlePointerDown = useCallback<PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      const el = wrapperElementRef.current;
+      dragStartRef.current = {
+        x: event.clientX,
+        scrollLeft: el?.scrollLeft ?? 0,
+      };
+
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [wrapperElementRef]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    dragStartRef.current = null;
+  }, [dragStartRef]);
+
+  const handlePointerMove = useCallback<PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      const el = wrapperElementRef.current;
+
+      if (!dragStartRef.current || !el) {
+        return;
+      }
+
+      const diff = event.clientX - dragStartRef.current.x;
+      const ratio = el.scrollWidth / el.clientWidth;
+
+      el.scrollLeft = dragStartRef.current.scrollLeft + diff * ratio;
+    },
+    [wrapperElementRef]
+  );
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <div css={styles.wrapper}>
+      <div
+        ref={trackElementRef}
+        css={styles.marker}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      />
+    </div>
+  );
+};
+
 export class EuiBasicTable<T extends object = any> extends Component<
   EuiBasicTableProps<T>,
   State<T>
@@ -322,6 +479,8 @@ export class EuiBasicTable<T extends object = any> extends Component<
       <EuiI18n token="euiBasicTable.noItemsMessage" default="No items found" />
     ),
   };
+
+  private tableWrapperElementRef = createRef<HTMLDivElement>();
 
   static getDerivedStateFromProps<T extends object>(
     nextProps: EuiBasicTableProps<T>,
@@ -538,6 +697,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
     return (
       <div className={classes} {...rest}>
         {table}
+        <MiniMap wrapperElementRef={this.tableWrapperElementRef} />
         {paginationBar}
       </div>
     );
@@ -561,6 +721,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
         </EuiTableHeaderMobile>
         <OverrideCopiedTabularContent>
           <EuiTable
+            tableWrapperElementRef={this.tableWrapperElementRef}
             id={this.tableId}
             tableLayout={tableLayout}
             responsiveBreakpoint={responsiveBreakpoint}
@@ -992,7 +1153,8 @@ export class EuiBasicTable<T extends object = any> extends Component<
           colSpan={colSpan}
           mobileOptions={{ width: '100%' }}
         >
-          <EuiIcon type="minusCircle" color="danger" /> {error}
+          <EuiIcon type="minusCircle" color="danger" aria-hidden={true} />{' '}
+          {error}
         </EuiTableRowCell>
       </EuiTableRow>
     );

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -523,6 +523,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
       tableLayout,
       hasBackground,
       scrollableInline,
+      stickyScrollbar,
       ...rest
     } = this.props;
 
@@ -551,6 +552,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
       hasBackground,
       loading,
       scrollableInline,
+      stickyScrollbar,
     } = this.props;
 
     return (
@@ -567,6 +569,7 @@ export class EuiBasicTable<T extends object = any> extends Component<
             compressed={compressed}
             hasBackground={hasBackground}
             scrollableInline={scrollableInline}
+            stickyScrollbar={stickyScrollbar}
             css={loading && safariLoadingWorkaround}
           >
             {this.renderTableCaption()}

--- a/packages/eui/src/components/provider/component_defaults/component_defaults.tsx
+++ b/packages/eui/src/components/provider/component_defaults/component_defaults.tsx
@@ -47,7 +47,10 @@ export type EuiComponentDefaults = {
    */
   EuiTable?: Pick<
     EuiTableProps,
-    'responsiveBreakpoint' | 'scrollableInline' | 'tableLayout'
+    | 'responsiveBreakpoint'
+    | 'scrollableInline'
+    | 'tableLayout'
+    | 'stickyScrollbar'
   >;
 
   /**

--- a/packages/eui/src/components/table/sticky_scrollbar/index.ts
+++ b/packages/eui/src/components/table/sticky_scrollbar/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export { EuiTableStickyScrollbar } from './sticky_scrollbar';

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.styles.ts
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.styles.ts
@@ -18,6 +18,9 @@ export const euiTableStickyScrollbarStyles = ({ euiTheme }: UseEuiTheme) => ({
     inset-block-end: var(--euiTableStickyScrollbarOffsetBottom, 0);
     z-index: var(--euiTableStickyScrollbarZIndex, 0);
   `,
+  wrapperHidden: css`
+    display: none;
+  `,
   track: css`
     block-size: 100%;
     background: ${transparentize(euiTheme.colors.darkShade, 0.5)};

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.styles.ts
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.styles.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { css } from '@emotion/react';
+import { transparentize, type UseEuiTheme } from '../../../services';
+
+export const euiTableStickyScrollbarStyles = ({ euiTheme }: UseEuiTheme) => ({
+  wrapper: css`
+    block-size: ${euiTheme.size.base};
+    padding: ${euiTheme.size.xs};
+    position: sticky;
+    background: ${euiTheme.components.scrollbarTrackColor};
+    inset-block-end: var(--euiTableStickyScrollbarOffsetBottom, 0);
+    z-index: var(--euiTableStickyScrollbarZIndex, 0);
+  `,
+  track: css`
+    block-size: 100%;
+    background: ${transparentize(euiTheme.colors.darkShade, 0.5)};
+    border-radius: ${euiTheme.border.radius.small};
+  `,
+});

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
@@ -1,0 +1,536 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { createRef } from 'react';
+import { render } from '../../../test/rtl';
+import { act, fireEvent, waitFor } from '@testing-library/react';
+
+import { EuiTableStickyScrollbar } from './sticky_scrollbar';
+
+describe('EuiTableStickyScrollbar', () => {
+  let mockResizeObserver: jest.Mock;
+  let mockIntersectionObserver: jest.Mock;
+  let resizeObserverCallback: ResizeObserverCallback;
+  let intersectionObserverCallback: IntersectionObserverCallback;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockResizeObserver = jest.fn((callback) => {
+      resizeObserverCallback = callback;
+      return {
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+        unobserve: jest.fn(),
+      };
+    });
+
+    mockIntersectionObserver = jest.fn((callback) => {
+      intersectionObserverCallback = callback;
+      return {
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+        unobserve: jest.fn(),
+        root: null,
+        rootMargin: '',
+        thresholds: [],
+        takeRecords: jest.fn(),
+      };
+    });
+
+    global.ResizeObserver = mockResizeObserver as any;
+    global.IntersectionObserver = mockIntersectionObserver as any;
+
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const createMockTableWrapper = (overrides?: {
+    clientWidth?: number;
+    scrollWidth?: number;
+    scrollLeft?: number;
+  }): HTMLDivElement => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'clientWidth', {
+      configurable: true,
+      value: overrides?.clientWidth ?? 500,
+    });
+    Object.defineProperty(div, 'scrollWidth', {
+      configurable: true,
+      value: overrides?.scrollWidth ?? 1000,
+    });
+    Object.defineProperty(div, 'scrollLeft', {
+      configurable: true,
+      writable: true,
+      value: overrides?.scrollLeft ?? 0,
+    });
+    return div;
+  };
+
+  const createMockResizeObserverEntry = (
+    target: Element
+  ): ResizeObserverEntry => {
+    const contentRect = {
+      x: 0,
+      y: 0,
+      width: 500,
+      height: 100,
+      top: 0,
+      right: 500,
+      bottom: 100,
+      left: 0,
+      toJSON: () => ({}),
+    };
+
+    return {
+      target,
+      contentRect,
+      borderBoxSize: [] as any,
+      contentBoxSize: [] as any,
+      devicePixelContentBoxSize: [] as any,
+    };
+  };
+
+  const createMockIntersectionObserverEntry = (
+    target: Element,
+    isIntersecting: boolean
+  ): IntersectionObserverEntry => {
+    const boundingClientRect = {
+      x: 0,
+      y: 0,
+      width: 500,
+      height: 100,
+      top: 0,
+      right: 500,
+      bottom: 100,
+      left: 0,
+      toJSON: () => ({}),
+    };
+
+    return {
+      target,
+      isIntersecting,
+      boundingClientRect,
+      intersectionRect: boundingClientRect,
+      rootBounds: null,
+      intersectionRatio: isIntersecting ? 1 : 0,
+      time: Date.now(),
+    };
+  };
+
+  it('renders the scrollbar when content is scrollable', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+    const mockElement = createMockTableWrapper();
+
+    (tableWrapperRef as any).current = mockElement;
+
+    const { getByTestSubject } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    const resizeObserver = mockResizeObserver.mock.results[0].value;
+    act(() => {
+      resizeObserverCallback(
+        [createMockResizeObserverEntry(mockElement)],
+        resizeObserver
+      );
+    });
+
+    waitFor(() => {
+      expect(getByTestSubject('euiTableStickyScrollbar')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render when content does not need scrolling', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+    const mockElement = createMockTableWrapper({
+      clientWidth: 1000,
+      scrollWidth: 1000,
+    });
+
+    (tableWrapperRef as any).current = mockElement;
+
+    const { queryByTestSubject } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    const resizeObserver = mockResizeObserver.mock.results[0].value;
+    act(() => {
+      resizeObserverCallback(
+        [createMockResizeObserverEntry(mockElement)],
+        resizeObserver
+      );
+    });
+
+    expect(
+      queryByTestSubject('euiTableStickyScrollbar')
+    ).not.toBeInTheDocument();
+  });
+
+  it('returns null early if tableWrapperRef.current is null', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+
+    const { container } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('updates track position on scroll', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+    const mockElement = createMockTableWrapper();
+
+    (tableWrapperRef as any).current = mockElement;
+
+    const { getByTestSubject } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    const resizeObserver = mockResizeObserver.mock.results[0].value;
+    act(() => {
+      resizeObserverCallback(
+        [createMockResizeObserverEntry(mockElement)],
+        resizeObserver
+      );
+    });
+
+    Object.defineProperty(mockElement, 'scrollLeft', {
+      configurable: true,
+      writable: true,
+      value: 250,
+    });
+
+    fireEvent.scroll(mockElement);
+
+    waitFor(() => {
+      const track = getByTestSubject('euiTableStickyScrollbarTrack');
+      expect(track).toHaveStyle({
+        inlineSize: '50%',
+        marginInlineStart: '25%',
+      });
+    });
+  });
+
+  it('updates track size on resize', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+    const mockElement = createMockTableWrapper();
+
+    (tableWrapperRef as any).current = mockElement;
+
+    const { getByTestSubject } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    const resizeObserver = mockResizeObserver.mock.results[0].value;
+
+    Object.defineProperty(mockElement, 'clientWidth', {
+      configurable: true,
+      value: 400,
+    });
+
+    act(() => {
+      resizeObserverCallback(
+        [createMockResizeObserverEntry(mockElement)],
+        resizeObserver
+      );
+    });
+
+    waitFor(() => {
+      const track = getByTestSubject('euiTableStickyScrollbarTrack');
+      expect(track).toHaveStyle({
+        inlineSize: '40%',
+      });
+    });
+  });
+
+  it('hides scrollbar when not intersecting', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+    const mockElement = createMockTableWrapper();
+
+    (tableWrapperRef as any).current = mockElement;
+
+    const { getByTestSubject } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    const resizeObserver = mockResizeObserver.mock.results[0].value;
+    act(() => {
+      resizeObserverCallback(
+        [createMockResizeObserverEntry(mockElement)],
+        resizeObserver
+      );
+    });
+
+    const intersectionObserver = mockIntersectionObserver.mock.results[0].value;
+    act(() => {
+      intersectionObserverCallback(
+        [createMockIntersectionObserverEntry(mockElement, false)],
+        intersectionObserver
+      );
+    });
+
+    waitFor(() => {
+      expect(getByTestSubject('euiTableStickyScrollbar')).toHaveAttribute(
+        'hidden'
+      );
+    });
+  });
+
+  it('shows scrollbar when intersecting', () => {
+    const tableWrapperRef = createRef<HTMLDivElement>();
+    const mockElement = createMockTableWrapper();
+
+    (tableWrapperRef as any).current = mockElement;
+
+    const { getByTestSubject } = render(
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    );
+
+    const resizeObserver = mockResizeObserver.mock.results[0].value;
+    act(() => {
+      resizeObserverCallback(
+        [createMockResizeObserverEntry(mockElement)],
+        resizeObserver
+      );
+    });
+
+    const intersectionObserver = mockIntersectionObserver.mock.results[0].value;
+    act(() => {
+      intersectionObserverCallback(
+        [createMockIntersectionObserverEntry(mockElement, true)],
+        intersectionObserver
+      );
+    });
+
+    waitFor(() => {
+      expect(getByTestSubject('euiTableStickyScrollbar')).not.toHaveAttribute(
+        'hidden'
+      );
+    });
+  });
+
+  describe('pointer drag functionality', () => {
+    it('handles pointer down event', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+
+      (tableWrapperRef as any).current = mockElement;
+
+      const { getByTestSubject } = render(
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      );
+
+      const resizeObserver = mockResizeObserver.mock.results[0].value;
+      act(() => {
+        resizeObserverCallback(
+          [createMockResizeObserverEntry(mockElement)],
+          resizeObserver
+        );
+      });
+
+      waitFor(() => {
+        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+        const mockPointerEvent = {
+          clientX: 100,
+          pointerId: 1,
+          currentTarget: {
+            setPointerCapture: jest.fn(),
+          },
+        };
+
+        fireEvent.pointerDown(track, mockPointerEvent);
+
+        expect(
+          mockPointerEvent.currentTarget.setPointerCapture
+        ).toHaveBeenCalledWith(1);
+      });
+    });
+
+    it('handles pointer move to scroll table', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+
+      (tableWrapperRef as any).current = mockElement;
+
+      const { getByTestSubject } = render(
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      );
+
+      const resizeObserver = mockResizeObserver.mock.results[0].value;
+      act(() => {
+        resizeObserverCallback(
+          [createMockResizeObserverEntry(mockElement)],
+          resizeObserver
+        );
+      });
+
+      waitFor(() => {
+        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+
+        fireEvent.pointerDown(track, {
+          clientX: 100,
+          pointerId: 1,
+          currentTarget: { setPointerCapture: jest.fn() },
+        });
+
+        fireEvent.pointerMove(track, {
+          clientX: 150,
+        });
+
+        expect(mockElement.scrollLeft).toBe(100);
+      });
+    });
+
+    it('does not scroll when pointer not captured', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+
+      (tableWrapperRef as any).current = mockElement;
+
+      const { getByTestSubject } = render(
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      );
+
+      const resizeObserver = mockResizeObserver.mock.results[0].value;
+      act(() => {
+        resizeObserverCallback(
+          [createMockResizeObserverEntry(mockElement)],
+          resizeObserver
+        );
+      });
+
+      waitFor(() => {
+        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+
+        fireEvent.pointerMove(track, {
+          clientX: 150,
+        });
+
+        expect(mockElement.scrollLeft).toBe(0);
+      });
+    });
+
+    it('handles pointer up to release capture', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+
+      (tableWrapperRef as any).current = mockElement;
+
+      const { getByTestSubject } = render(
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      );
+
+      const resizeObserver = mockResizeObserver.mock.results[0].value;
+      act(() => {
+        resizeObserverCallback(
+          [createMockResizeObserverEntry(mockElement)],
+          resizeObserver
+        );
+      });
+
+      waitFor(() => {
+        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+
+        fireEvent.pointerDown(track, {
+          clientX: 100,
+          pointerId: 1,
+          currentTarget: { setPointerCapture: jest.fn() },
+        });
+
+        fireEvent.pointerUp(track);
+
+        fireEvent.pointerMove(track, {
+          clientX: 150,
+        });
+
+        expect(mockElement.scrollLeft).toBe(0);
+      });
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes event listeners on unmount', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+      const removeEventListenerSpy = jest.spyOn(
+        mockElement,
+        'removeEventListener'
+      );
+
+      (tableWrapperRef as any).current = mockElement;
+
+      const { unmount } = render(
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      );
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'scroll',
+        expect.any(Function)
+      );
+    });
+
+    it('disconnects observers on unmount', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+
+      (tableWrapperRef as any).current = mockElement;
+
+      const { unmount } = render(
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      );
+
+      const resizeObserver = mockResizeObserver.mock.results[0].value;
+      const intersectionObserver =
+        mockIntersectionObserver.mock.results[0].value;
+
+      unmount();
+
+      expect(resizeObserver.disconnect).toHaveBeenCalled();
+      expect(intersectionObserver.disconnect).toHaveBeenCalled();
+    });
+  });
+
+  describe('requestAnimationFrame throttling', () => {
+    it('throttles multiple scroll updates using RAF', () => {
+      const tableWrapperRef = createRef<HTMLDivElement>();
+      const mockElement = createMockTableWrapper();
+
+      (tableWrapperRef as any).current = mockElement;
+
+      render(<EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />);
+
+      const resizeObserver = mockResizeObserver.mock.results[0].value;
+
+      act(() => {
+        resizeObserverCallback(
+          [createMockResizeObserverEntry(mockElement)],
+          resizeObserver
+        );
+      });
+
+      const rafSpy = window.requestAnimationFrame as jest.Mock;
+      rafSpy.mockClear();
+      rafSpy.mockImplementation(() => 0);
+
+      fireEvent.scroll(mockElement);
+      fireEvent.scroll(mockElement);
+      fireEvent.scroll(mockElement);
+
+      expect(rafSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
@@ -198,7 +198,7 @@ describe('EuiTableStickyScrollbar', () => {
     await waitFor(() => {
       expect(
         screen.getByTestSubject('euiTableStickyScrollbar')
-      ).toHaveAttribute('hidden');
+      ).not.toBeVisible();
     });
   });
 
@@ -220,9 +220,7 @@ describe('EuiTableStickyScrollbar', () => {
     ]);
 
     await waitFor(() => {
-      expect(
-        screen.getByTestSubject('euiTableStickyScrollbar')
-      ).not.toHaveAttribute('hidden');
+      expect(screen.getByTestSubject('euiTableStickyScrollbar')).toBeVisible();
     });
   });
 

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
@@ -82,14 +82,14 @@ describe('EuiTableStickyScrollbar', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders the scrollbar when content is scrollable', () => {
+  it('renders the scrollbar when content is scrollable', async () => {
     const { wrapperElement } = renderComponent();
 
     resizeObserverMock.triggerCallback([
       createMockResizeObserverEntry(wrapperElement),
     ]);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(
         screen.getByTestSubject('euiTableStickyScrollbar')
       ).toBeInTheDocument();
@@ -122,17 +122,23 @@ describe('EuiTableStickyScrollbar', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('updates track position on scroll', () => {
+  it('updates track position on scroll', async () => {
     const { wrapperElement } = renderComponent({});
 
     resizeObserverMock.triggerCallback([
       createMockResizeObserverEntry(wrapperElement),
     ]);
 
+    await waitFor(() => {
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbarTrack')
+      ).toBeInTheDocument();
+    });
+
     wrapperElement.scrollLeft = 250;
     fireEvent.scroll(wrapperElement);
 
-    waitFor(() => {
+    await waitFor(() => {
       const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
       expect(track).toHaveStyle({
         inlineSize: '50%',
@@ -141,8 +147,18 @@ describe('EuiTableStickyScrollbar', () => {
     });
   });
 
-  it('updates track size on resize', () => {
+  it('updates track size on resize', async () => {
     const { wrapperElement } = renderComponent();
+
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbarTrack')
+      ).toBeInTheDocument();
+    });
 
     // clientWidth is readonly
     Object.defineProperty(wrapperElement, 'clientWidth', {
@@ -154,7 +170,7 @@ describe('EuiTableStickyScrollbar', () => {
       createMockResizeObserverEntry(wrapperElement),
     ]);
 
-    waitFor(() => {
+    await waitFor(() => {
       const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
       expect(track).toHaveStyle({
         inlineSize: '40%',
@@ -162,36 +178,48 @@ describe('EuiTableStickyScrollbar', () => {
     });
   });
 
-  it('hides scrollbar when not intersecting', () => {
+  it('hides scrollbar when not intersecting', async () => {
     const { wrapperElement } = renderComponent();
 
     resizeObserverMock.triggerCallback([
       createMockResizeObserverEntry(wrapperElement),
     ]);
 
+    await waitFor(() => {
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbar')
+      ).toBeInTheDocument();
+    });
+
     intersectionObserverMock.triggerCallback([
       createMockIntersectionObserverEntry(wrapperElement, false),
     ]);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(
         screen.getByTestSubject('euiTableStickyScrollbar')
       ).toHaveAttribute('hidden');
     });
   });
 
-  it('shows scrollbar when intersecting', () => {
+  it('shows scrollbar when intersecting', async () => {
     const { wrapperElement } = renderComponent();
 
     resizeObserverMock.triggerCallback([
       createMockResizeObserverEntry(wrapperElement),
     ]);
 
+    await waitFor(() => {
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbar')
+      ).toBeInTheDocument();
+    });
+
     intersectionObserverMock.triggerCallback([
       createMockIntersectionObserverEntry(wrapperElement, true),
     ]);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(
         screen.getByTestSubject('euiTableStickyScrollbar')
       ).not.toHaveAttribute('hidden');
@@ -199,97 +227,143 @@ describe('EuiTableStickyScrollbar', () => {
   });
 
   describe('track dragging', () => {
-    it('handles pointer down event', () => {
+    it('handles pointer down event', async () => {
       const { wrapperElement } = renderComponent();
 
       resizeObserverMock.triggerCallback([
         createMockResizeObserverEntry(wrapperElement),
       ]);
 
-      waitFor(() => {
-        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
-        const mockPointerEvent = {
-          clientX: 100,
-          pointerId: 1,
-          currentTarget: {
-            setPointerCapture: jest.fn(),
-          },
-        };
-
-        fireEvent.pointerDown(track, mockPointerEvent);
-
+      await waitFor(() => {
         expect(
-          mockPointerEvent.currentTarget.setPointerCapture
-        ).toHaveBeenCalledWith(1);
+          screen.getByTestSubject('euiTableStickyScrollbarTrack')
+        ).toBeInTheDocument();
       });
+
+      const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
+      const setPointerCaptureSpy = jest.fn();
+      track.setPointerCapture = setPointerCaptureSpy;
+
+      const pointerEvent = new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 100,
+      });
+      Object.defineProperty(pointerEvent, 'pointerId', {
+        value: 1,
+        writable: false,
+      });
+
+      fireEvent(track, pointerEvent);
+
+      expect(setPointerCaptureSpy).toHaveBeenCalledWith(1);
     });
 
-    it('handles pointer move to scroll table', () => {
+    it('handles pointer move to scroll table', async () => {
       const { wrapperElement } = renderComponent();
 
       resizeObserverMock.triggerCallback([
         createMockResizeObserverEntry(wrapperElement),
       ]);
 
-      waitFor(() => {
-        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
-
-        fireEvent.pointerDown(track, {
-          clientX: 100,
-          pointerId: 1,
-          currentTarget: { setPointerCapture: jest.fn() },
-        });
-
-        fireEvent.pointerMove(track, {
-          clientX: 150,
-        });
-
-        expect(wrapperElement.scrollLeft).toBe(100);
+      await waitFor(() => {
+        expect(
+          screen.getByTestSubject('euiTableStickyScrollbarTrack')
+        ).toBeInTheDocument();
       });
+
+      const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
+      track.setPointerCapture = jest.fn();
+
+      const pointerDownEvent = new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 100,
+      });
+      Object.defineProperty(pointerDownEvent, 'pointerId', {
+        value: 1,
+        writable: false,
+      });
+
+      fireEvent(track, pointerDownEvent);
+
+      const pointerMoveEvent = new MouseEvent('pointermove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 150,
+      });
+
+      fireEvent(track, pointerMoveEvent);
+
+      expect(wrapperElement.scrollLeft).toBe(100);
     });
 
-    it('does not scroll when pointer not captured', () => {
+    it('does not scroll when pointer not captured', async () => {
       const { wrapperElement } = renderComponent();
 
       resizeObserverMock.triggerCallback([
         createMockResizeObserverEntry(wrapperElement),
       ]);
 
-      waitFor(() => {
-        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
-
-        fireEvent.pointerMove(track, {
-          clientX: 150,
-        });
-
-        expect(wrapperElement.scrollLeft).toBe(0);
+      await waitFor(() => {
+        expect(
+          screen.getByTestSubject('euiTableStickyScrollbarTrack')
+        ).toBeInTheDocument();
       });
+
+      const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
+
+      fireEvent.pointerMove(track, {
+        clientX: 150,
+      });
+
+      expect(wrapperElement.scrollLeft).toBe(0);
     });
 
-    it('handles pointer up to release capture', () => {
+    it('handles pointer up to release capture', async () => {
       const { wrapperElement } = renderComponent();
 
       resizeObserverMock.triggerCallback([
         createMockResizeObserverEntry(wrapperElement),
       ]);
 
-      waitFor(() => {
-        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
-
-        fireEvent.pointerDown(track, {
-          clientX: 100,
-          pointerId: 1,
-          currentTarget: { setPointerCapture: jest.fn() },
-        });
-
-        fireEvent.pointerUp(track);
-
-        fireEvent.pointerMove(track, {
-          clientX: 150,
-        });
-
-        expect(wrapperElement.scrollLeft).toBe(0);
+      await waitFor(() => {
+        expect(
+          screen.getByTestSubject('euiTableStickyScrollbarTrack')
+        ).toBeInTheDocument();
       });
+
+      const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
+      track.setPointerCapture = jest.fn();
+
+      const pointerDownEvent = new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 100,
+      });
+      Object.defineProperty(pointerDownEvent, 'pointerId', {
+        value: 1,
+        writable: false,
+      });
+
+      fireEvent(track, pointerDownEvent);
+
+      const pointerUpEvent = new MouseEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+      });
+
+      fireEvent(track, pointerUpEvent);
+
+      const pointerMoveEvent = new MouseEvent('pointermove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 150,
+      });
+
+      fireEvent(track, pointerMoveEvent);
+
+      expect(wrapperElement.scrollLeft).toBe(0);
     });
   });
 

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.test.tsx
@@ -6,45 +6,71 @@
  * Side Public License, v 1.
  */
 
-import React, { createRef } from 'react';
-import { render } from '../../../test/rtl';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '../../../test/rtl';
+import {
+  createResizeObserverMock,
+  createMockResizeObserverEntry,
+  createIntersectionObserverMock,
+  createMockIntersectionObserverEntry,
+} from '../../../test/internal';
 
 import { EuiTableStickyScrollbar } from './sticky_scrollbar';
 
+const createMockTableWrapper = (overrides?: {
+  clientWidth?: number;
+  scrollWidth?: number;
+  scrollLeft?: number;
+}): HTMLDivElement => {
+  const div = document.createElement('div');
+  Object.defineProperty(div, 'clientWidth', {
+    configurable: true,
+    value: overrides?.clientWidth ?? 500,
+  });
+  Object.defineProperty(div, 'scrollWidth', {
+    configurable: true,
+    value: overrides?.scrollWidth ?? 1000,
+  });
+  Object.defineProperty(div, 'scrollLeft', {
+    configurable: true,
+    writable: true,
+    value: overrides?.scrollLeft ?? 0,
+  });
+  return div;
+};
+
+const renderComponent = (overrides?: {
+  clientWidth?: number;
+  scrollWidth?: number;
+  scrollLeft?: number;
+}) => {
+  const wrapperElement = createMockTableWrapper(overrides);
+
+  const Component = () => {
+    const tableWrapperRef = useRef<HTMLDivElement>(wrapperElement);
+    return <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />;
+  };
+
+  const { unmount } = render(<Component />);
+
+  return { wrapperElement, unmount };
+};
+
 describe('EuiTableStickyScrollbar', () => {
-  let mockResizeObserver: jest.Mock;
-  let mockIntersectionObserver: jest.Mock;
-  let resizeObserverCallback: ResizeObserverCallback;
-  let intersectionObserverCallback: IntersectionObserverCallback;
+  let resizeObserverMock: ReturnType<typeof createResizeObserverMock>;
+  let intersectionObserverMock: ReturnType<
+    typeof createIntersectionObserverMock
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockResizeObserver = jest.fn((callback) => {
-      resizeObserverCallback = callback;
-      return {
-        observe: jest.fn(),
-        disconnect: jest.fn(),
-        unobserve: jest.fn(),
-      };
-    });
+    resizeObserverMock = createResizeObserverMock();
+    intersectionObserverMock = createIntersectionObserverMock();
 
-    mockIntersectionObserver = jest.fn((callback) => {
-      intersectionObserverCallback = callback;
-      return {
-        observe: jest.fn(),
-        disconnect: jest.fn(),
-        unobserve: jest.fn(),
-        root: null,
-        rootMargin: '',
-        thresholds: [],
-        takeRecords: jest.fn(),
-      };
-    });
-
-    global.ResizeObserver = mockResizeObserver as any;
-    global.IntersectionObserver = mockIntersectionObserver as any;
+    global.ResizeObserver = resizeObserverMock.ResizeObserver;
+    global.IntersectionObserver = intersectionObserverMock.IntersectionObserver;
 
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
       cb(0);
@@ -56,166 +82,58 @@ describe('EuiTableStickyScrollbar', () => {
     jest.restoreAllMocks();
   });
 
-  const createMockTableWrapper = (overrides?: {
-    clientWidth?: number;
-    scrollWidth?: number;
-    scrollLeft?: number;
-  }): HTMLDivElement => {
-    const div = document.createElement('div');
-    Object.defineProperty(div, 'clientWidth', {
-      configurable: true,
-      value: overrides?.clientWidth ?? 500,
-    });
-    Object.defineProperty(div, 'scrollWidth', {
-      configurable: true,
-      value: overrides?.scrollWidth ?? 1000,
-    });
-    Object.defineProperty(div, 'scrollLeft', {
-      configurable: true,
-      writable: true,
-      value: overrides?.scrollLeft ?? 0,
-    });
-    return div;
-  };
-
-  const createMockResizeObserverEntry = (
-    target: Element
-  ): ResizeObserverEntry => {
-    const contentRect = {
-      x: 0,
-      y: 0,
-      width: 500,
-      height: 100,
-      top: 0,
-      right: 500,
-      bottom: 100,
-      left: 0,
-      toJSON: () => ({}),
-    };
-
-    return {
-      target,
-      contentRect,
-      borderBoxSize: [] as any,
-      contentBoxSize: [] as any,
-      devicePixelContentBoxSize: [] as any,
-    };
-  };
-
-  const createMockIntersectionObserverEntry = (
-    target: Element,
-    isIntersecting: boolean
-  ): IntersectionObserverEntry => {
-    const boundingClientRect = {
-      x: 0,
-      y: 0,
-      width: 500,
-      height: 100,
-      top: 0,
-      right: 500,
-      bottom: 100,
-      left: 0,
-      toJSON: () => ({}),
-    };
-
-    return {
-      target,
-      isIntersecting,
-      boundingClientRect,
-      intersectionRect: boundingClientRect,
-      rootBounds: null,
-      intersectionRatio: isIntersecting ? 1 : 0,
-      time: Date.now(),
-    };
-  };
-
   it('renders the scrollbar when content is scrollable', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
-    const mockElement = createMockTableWrapper();
+    const { wrapperElement } = renderComponent();
 
-    (tableWrapperRef as any).current = mockElement;
-
-    const { getByTestSubject } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
-
-    const resizeObserver = mockResizeObserver.mock.results[0].value;
-    act(() => {
-      resizeObserverCallback(
-        [createMockResizeObserverEntry(mockElement)],
-        resizeObserver
-      );
-    });
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
 
     waitFor(() => {
-      expect(getByTestSubject('euiTableStickyScrollbar')).toBeInTheDocument();
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbar')
+      ).toBeInTheDocument();
     });
   });
 
   it('does not render when content does not need scrolling', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
-    const mockElement = createMockTableWrapper({
+    const { wrapperElement } = renderComponent({
       clientWidth: 1000,
       scrollWidth: 1000,
     });
 
-    (tableWrapperRef as any).current = mockElement;
-
-    const { queryByTestSubject } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
-
-    const resizeObserver = mockResizeObserver.mock.results[0].value;
-    act(() => {
-      resizeObserverCallback(
-        [createMockResizeObserverEntry(mockElement)],
-        resizeObserver
-      );
-    });
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
 
     expect(
-      queryByTestSubject('euiTableStickyScrollbar')
+      screen.queryByTestSubject('euiTableStickyScrollbar')
     ).not.toBeInTheDocument();
   });
 
   it('returns null early if tableWrapperRef.current is null', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
+    const Component = () => {
+      const tableWrapperRef = useRef<HTMLDivElement>(null);
+      return <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />;
+    };
 
-    const { container } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
+    const { container } = render(<Component />);
 
     expect(container.firstChild).toBeNull();
   });
 
   it('updates track position on scroll', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
-    const mockElement = createMockTableWrapper();
+    const { wrapperElement } = renderComponent({});
 
-    (tableWrapperRef as any).current = mockElement;
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
 
-    const { getByTestSubject } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
-
-    const resizeObserver = mockResizeObserver.mock.results[0].value;
-    act(() => {
-      resizeObserverCallback(
-        [createMockResizeObserverEntry(mockElement)],
-        resizeObserver
-      );
-    });
-
-    Object.defineProperty(mockElement, 'scrollLeft', {
-      configurable: true,
-      writable: true,
-      value: 250,
-    });
-
-    fireEvent.scroll(mockElement);
+    wrapperElement.scrollLeft = 250;
+    fireEvent.scroll(wrapperElement);
 
     waitFor(() => {
-      const track = getByTestSubject('euiTableStickyScrollbarTrack');
+      const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
       expect(track).toHaveStyle({
         inlineSize: '50%',
         marginInlineStart: '25%',
@@ -224,31 +142,20 @@ describe('EuiTableStickyScrollbar', () => {
   });
 
   it('updates track size on resize', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
-    const mockElement = createMockTableWrapper();
+    const { wrapperElement } = renderComponent();
 
-    (tableWrapperRef as any).current = mockElement;
-
-    const { getByTestSubject } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
-
-    const resizeObserver = mockResizeObserver.mock.results[0].value;
-
-    Object.defineProperty(mockElement, 'clientWidth', {
+    // clientWidth is readonly
+    Object.defineProperty(wrapperElement, 'clientWidth', {
       configurable: true,
       value: 400,
     });
 
-    act(() => {
-      resizeObserverCallback(
-        [createMockResizeObserverEntry(mockElement)],
-        resizeObserver
-      );
-    });
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
 
     waitFor(() => {
-      const track = getByTestSubject('euiTableStickyScrollbarTrack');
+      const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
       expect(track).toHaveStyle({
         inlineSize: '40%',
       });
@@ -256,92 +163,51 @@ describe('EuiTableStickyScrollbar', () => {
   });
 
   it('hides scrollbar when not intersecting', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
-    const mockElement = createMockTableWrapper();
+    const { wrapperElement } = renderComponent();
 
-    (tableWrapperRef as any).current = mockElement;
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
 
-    const { getByTestSubject } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
-
-    const resizeObserver = mockResizeObserver.mock.results[0].value;
-    act(() => {
-      resizeObserverCallback(
-        [createMockResizeObserverEntry(mockElement)],
-        resizeObserver
-      );
-    });
-
-    const intersectionObserver = mockIntersectionObserver.mock.results[0].value;
-    act(() => {
-      intersectionObserverCallback(
-        [createMockIntersectionObserverEntry(mockElement, false)],
-        intersectionObserver
-      );
-    });
+    intersectionObserverMock.triggerCallback([
+      createMockIntersectionObserverEntry(wrapperElement, false),
+    ]);
 
     waitFor(() => {
-      expect(getByTestSubject('euiTableStickyScrollbar')).toHaveAttribute(
-        'hidden'
-      );
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbar')
+      ).toHaveAttribute('hidden');
     });
   });
 
   it('shows scrollbar when intersecting', () => {
-    const tableWrapperRef = createRef<HTMLDivElement>();
-    const mockElement = createMockTableWrapper();
+    const { wrapperElement } = renderComponent();
 
-    (tableWrapperRef as any).current = mockElement;
+    resizeObserverMock.triggerCallback([
+      createMockResizeObserverEntry(wrapperElement),
+    ]);
 
-    const { getByTestSubject } = render(
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-    );
-
-    const resizeObserver = mockResizeObserver.mock.results[0].value;
-    act(() => {
-      resizeObserverCallback(
-        [createMockResizeObserverEntry(mockElement)],
-        resizeObserver
-      );
-    });
-
-    const intersectionObserver = mockIntersectionObserver.mock.results[0].value;
-    act(() => {
-      intersectionObserverCallback(
-        [createMockIntersectionObserverEntry(mockElement, true)],
-        intersectionObserver
-      );
-    });
+    intersectionObserverMock.triggerCallback([
+      createMockIntersectionObserverEntry(wrapperElement, true),
+    ]);
 
     waitFor(() => {
-      expect(getByTestSubject('euiTableStickyScrollbar')).not.toHaveAttribute(
-        'hidden'
-      );
+      expect(
+        screen.getByTestSubject('euiTableStickyScrollbar')
+      ).not.toHaveAttribute('hidden');
     });
   });
 
-  describe('pointer drag functionality', () => {
+  describe('track dragging', () => {
     it('handles pointer down event', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+      const { wrapperElement } = renderComponent();
 
-      (tableWrapperRef as any).current = mockElement;
-
-      const { getByTestSubject } = render(
-        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-      );
-
-      const resizeObserver = mockResizeObserver.mock.results[0].value;
-      act(() => {
-        resizeObserverCallback(
-          [createMockResizeObserverEntry(mockElement)],
-          resizeObserver
-        );
-      });
+      resizeObserverMock.triggerCallback([
+        createMockResizeObserverEntry(wrapperElement),
+      ]);
 
       waitFor(() => {
-        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
         const mockPointerEvent = {
           clientX: 100,
           pointerId: 1,
@@ -359,25 +225,14 @@ describe('EuiTableStickyScrollbar', () => {
     });
 
     it('handles pointer move to scroll table', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+      const { wrapperElement } = renderComponent();
 
-      (tableWrapperRef as any).current = mockElement;
-
-      const { getByTestSubject } = render(
-        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-      );
-
-      const resizeObserver = mockResizeObserver.mock.results[0].value;
-      act(() => {
-        resizeObserverCallback(
-          [createMockResizeObserverEntry(mockElement)],
-          resizeObserver
-        );
-      });
+      resizeObserverMock.triggerCallback([
+        createMockResizeObserverEntry(wrapperElement),
+      ]);
 
       waitFor(() => {
-        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
 
         fireEvent.pointerDown(track, {
           clientX: 100,
@@ -389,59 +244,37 @@ describe('EuiTableStickyScrollbar', () => {
           clientX: 150,
         });
 
-        expect(mockElement.scrollLeft).toBe(100);
+        expect(wrapperElement.scrollLeft).toBe(100);
       });
     });
 
     it('does not scroll when pointer not captured', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+      const { wrapperElement } = renderComponent();
 
-      (tableWrapperRef as any).current = mockElement;
-
-      const { getByTestSubject } = render(
-        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-      );
-
-      const resizeObserver = mockResizeObserver.mock.results[0].value;
-      act(() => {
-        resizeObserverCallback(
-          [createMockResizeObserverEntry(mockElement)],
-          resizeObserver
-        );
-      });
+      resizeObserverMock.triggerCallback([
+        createMockResizeObserverEntry(wrapperElement),
+      ]);
 
       waitFor(() => {
-        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
 
         fireEvent.pointerMove(track, {
           clientX: 150,
         });
 
-        expect(mockElement.scrollLeft).toBe(0);
+        expect(wrapperElement.scrollLeft).toBe(0);
       });
     });
 
     it('handles pointer up to release capture', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+      const { wrapperElement } = renderComponent();
 
-      (tableWrapperRef as any).current = mockElement;
-
-      const { getByTestSubject } = render(
-        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-      );
-
-      const resizeObserver = mockResizeObserver.mock.results[0].value;
-      act(() => {
-        resizeObserverCallback(
-          [createMockResizeObserverEntry(mockElement)],
-          resizeObserver
-        );
-      });
+      resizeObserverMock.triggerCallback([
+        createMockResizeObserverEntry(wrapperElement),
+      ]);
 
       waitFor(() => {
-        const track = getByTestSubject('euiTableStickyScrollbarTrack');
+        const track = screen.getByTestSubject('euiTableStickyScrollbarTrack');
 
         fireEvent.pointerDown(track, {
           clientX: 100,
@@ -455,24 +288,17 @@ describe('EuiTableStickyScrollbar', () => {
           clientX: 150,
         });
 
-        expect(mockElement.scrollLeft).toBe(0);
+        expect(wrapperElement.scrollLeft).toBe(0);
       });
     });
   });
 
   describe('cleanup', () => {
     it('removes event listeners on unmount', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+      const { wrapperElement, unmount } = renderComponent();
       const removeEventListenerSpy = jest.spyOn(
-        mockElement,
+        wrapperElement,
         'removeEventListener'
-      );
-
-      (tableWrapperRef as any).current = mockElement;
-
-      const { unmount } = render(
-        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
       );
 
       unmount();
@@ -484,18 +310,12 @@ describe('EuiTableStickyScrollbar', () => {
     });
 
     it('disconnects observers on unmount', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+      const { unmount } = renderComponent();
 
-      (tableWrapperRef as any).current = mockElement;
-
-      const { unmount } = render(
-        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
-      );
-
-      const resizeObserver = mockResizeObserver.mock.results[0].value;
+      const resizeObserver =
+        resizeObserverMock.ResizeObserver.mock.results[0].value;
       const intersectionObserver =
-        mockIntersectionObserver.mock.results[0].value;
+        intersectionObserverMock.IntersectionObserver.mock.results[0].value;
 
       unmount();
 
@@ -505,30 +325,20 @@ describe('EuiTableStickyScrollbar', () => {
   });
 
   describe('requestAnimationFrame throttling', () => {
-    it('throttles multiple scroll updates using RAF', () => {
-      const tableWrapperRef = createRef<HTMLDivElement>();
-      const mockElement = createMockTableWrapper();
+    it('throttles multiple scroll updates happening during a single frame', () => {
+      const { wrapperElement } = renderComponent();
 
-      (tableWrapperRef as any).current = mockElement;
-
-      render(<EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />);
-
-      const resizeObserver = mockResizeObserver.mock.results[0].value;
-
-      act(() => {
-        resizeObserverCallback(
-          [createMockResizeObserverEntry(mockElement)],
-          resizeObserver
-        );
-      });
+      resizeObserverMock.triggerCallback([
+        createMockResizeObserverEntry(wrapperElement),
+      ]);
 
       const rafSpy = window.requestAnimationFrame as jest.Mock;
       rafSpy.mockClear();
       rafSpy.mockImplementation(() => 0);
 
-      fireEvent.scroll(mockElement);
-      fireEvent.scroll(mockElement);
-      fireEvent.scroll(mockElement);
+      fireEvent.scroll(wrapperElement);
+      fireEvent.scroll(wrapperElement);
+      fireEvent.scroll(wrapperElement);
 
       expect(rafSpy).toHaveBeenCalledTimes(1);
     });

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, {
+  PointerEventHandler,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useEuiMemoizedStyles } from '../../../services';
+import { euiTableStickyScrollbarStyles } from './sticky_scrollbar.styles';
+
+export interface EuiTableStickyScrollbarProps {
+  tableWrapperRef: RefObject<HTMLDivElement>;
+}
+
+export const EuiTableStickyScrollbar = ({
+  tableWrapperRef,
+}: EuiTableStickyScrollbarProps) => {
+  const styles = useEuiMemoizedStyles(euiTableStickyScrollbarStyles);
+
+  const trackElementRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef<{ x: number; scrollLeft: number } | null>(null);
+  const requestAnimationFramePendingRef = useRef(false);
+  const [isActive, setIsActive] = useState(false);
+  const [isHidden, setIsHidden] = useState(false);
+
+  const updateTrack = useCallback((element: Element) => {
+    const { clientWidth, scrollWidth, scrollLeft } = element;
+
+    if (!requestAnimationFramePendingRef.current) {
+      requestAnimationFramePendingRef.current = true;
+
+      requestAnimationFrame(() => {
+        const el = trackElementRef.current;
+        if (el) {
+          el.style.inlineSize = `${(clientWidth / scrollWidth) * 100}%`;
+          el.style.marginInlineStart = `${(scrollLeft / scrollWidth) * 100}%`;
+        }
+
+        requestAnimationFramePendingRef.current = false;
+      });
+    }
+  }, []);
+
+  const handleScroll = useCallback(
+    (event: Event) => {
+      if (event.target) {
+        updateTrack(event.target as Element);
+      }
+    },
+    [updateTrack]
+  );
+
+  const handleResize = useCallback<ResizeObserverCallback>(
+    (entries) => {
+      const element = entries[0].target;
+      if (!element) {
+        return;
+      }
+
+      updateTrack(element);
+      setIsActive(element.clientWidth < element.scrollWidth);
+    },
+    [updateTrack]
+  );
+
+  const handleBottomCornerIntersection =
+    useCallback<IntersectionObserverCallback>((entries) => {
+      const entry = entries[0];
+      const element = entry.target;
+      if (!element) {
+        return;
+      }
+
+      setIsHidden(!entry.isIntersecting);
+    }, []);
+
+  const handlePointerDown = useCallback<PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      const el = tableWrapperRef.current;
+      dragStartRef.current = {
+        x: event.clientX,
+        scrollLeft: el?.scrollLeft ?? 0,
+      };
+
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [tableWrapperRef]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    dragStartRef.current = null;
+  }, [dragStartRef]);
+
+  const handlePointerMove = useCallback<PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      const el = tableWrapperRef.current;
+
+      if (!dragStartRef.current || !el) {
+        return;
+      }
+
+      const diff = event.clientX - dragStartRef.current.x;
+      const ratio = el.scrollWidth / el.clientWidth;
+
+      el.scrollLeft = dragStartRef.current.scrollLeft + diff * ratio;
+    },
+    [tableWrapperRef]
+  );
+
+  useEffect(() => {
+    const element = tableWrapperRef.current;
+    if (!element) {
+      return;
+    }
+
+    updateTrack(element);
+
+    element.addEventListener('scroll', handleScroll, { passive: true });
+
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(element);
+
+    const intersectionObserver = new IntersectionObserver(
+      handleBottomCornerIntersection,
+      {
+        threshold: 0,
+        rootMargin: '-100% 0px 0px 0px',
+      }
+    );
+    intersectionObserver.observe(element);
+
+    return () => {
+      element.removeEventListener('scroll', handleScroll);
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+    };
+  }, [
+    tableWrapperRef,
+    updateTrack,
+    handleResize,
+    handleScroll,
+    handleBottomCornerIntersection,
+  ]);
+
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <div css={styles.wrapper} hidden={isHidden}>
+      <div
+        css={styles.track}
+        ref={trackElementRef}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      />
+    </div>
+  );
+};

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
@@ -167,13 +167,19 @@ export const EuiTableStickyScrollbar = ({
   }
 
   return (
-    <div css={styles.wrapper} hidden={isHidden}>
+    <div
+      css={styles.wrapper}
+      hidden={isHidden}
+      data-test-subj="euiTableStickyScrollbar"
+      aria-hidden
+    >
       <div
         css={styles.track}
         ref={trackElementRef}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        data-test-subj="euiTableStickyScrollbarTrack"
       />
     </div>
   );

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
@@ -126,22 +126,33 @@ export const EuiTableStickyScrollbar = ({
 
     element.addEventListener('scroll', handleScroll, { passive: true });
 
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(element);
+    // ResizeObserver is available in all supported browsers,
+    // but jsdom and jest don't provide a polyfill for it.
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof window.ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(element);
+    }
 
-    const intersectionObserver = new IntersectionObserver(
-      handleBottomCornerIntersection,
-      {
-        threshold: 0,
-        rootMargin: '-100% 0px 0px 0px',
-      }
-    );
-    intersectionObserver.observe(element);
+    // IntersectionOserver is available in all supported browsers,
+    // but jsdom and jest don't provide a polyfill for it.
+    let intersectionObserver: IntersectionObserver | undefined;
+    if (typeof window.IntersectionObserver !== 'undefined') {
+      intersectionObserver = new IntersectionObserver(
+        handleBottomCornerIntersection,
+        {
+          threshold: 0,
+          rootMargin: '-100% 0px 0px 0px',
+        }
+      );
+      intersectionObserver.observe(element);
+    }
 
     return () => {
       element.removeEventListener('scroll', handleScroll);
-      resizeObserver.disconnect();
-      intersectionObserver.disconnect();
+
+      resizeObserver?.disconnect();
+      intersectionObserver?.disconnect();
     };
   }, [
     tableWrapperRef,

--- a/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
+++ b/packages/eui/src/components/table/sticky_scrollbar/sticky_scrollbar.tsx
@@ -168,8 +168,7 @@ export const EuiTableStickyScrollbar = ({
 
   return (
     <div
-      css={styles.wrapper}
-      hidden={isHidden}
+      css={[styles.wrapper, isHidden && styles.wrapperHidden]}
       data-test-subj="euiTableStickyScrollbar"
       aria-hidden
     >

--- a/packages/eui/src/components/table/table.tsx
+++ b/packages/eui/src/components/table/table.tsx
@@ -21,7 +21,7 @@ import { euiTableStyles } from './table.styles';
 import { usePropsWithComponentDefaults } from '../provider/component_defaults';
 import { euiContainerCSS } from '../../global_styling';
 import { EUI_TABLE_CSS_CONTAINER_NAME } from './const';
-import { EuiTableStickyScrollbar } from './sticky_scrollbar/sticky_scrollbar';
+import { EuiTableStickyScrollbar } from './sticky_scrollbar';
 
 export interface EuiTableProps
   extends CommonProps,

--- a/packages/eui/src/components/table/table.tsx
+++ b/packages/eui/src/components/table/table.tsx
@@ -57,6 +57,16 @@ export interface EuiTableProps
    * @default false
    */
   scrollableInline?: boolean;
+  /**
+   * Make the horizontal scrollbar visible even if the table is larger
+   * than the viewport height. Useful for long tables when the native browser
+   * scrollbar is at the bottom of the table and hard to reach.
+   *
+   * This prop requires [`scrollableInline`](#scrollableInline) to be `true`.
+   * @beta
+   * @default false
+   */
+  stickyScrollbar?: boolean;
 }
 
 /**
@@ -78,6 +88,7 @@ export const EuiTable: FunctionComponent<EuiTableProps> = (originalProps) => {
     hasBackground = true,
     responsiveBreakpoint,
     scrollableInline = false,
+    stickyScrollbar = false,
     ...rest
   } = usePropsWithComponentDefaults('EuiTable', originalProps);
   const tableWrapperRef = useRef<HTMLDivElement>(null);
@@ -111,7 +122,9 @@ export const EuiTable: FunctionComponent<EuiTableProps> = (originalProps) => {
           </EuiTableIsResponsiveContext.Provider>
         </table>
       </div>
-      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      {scrollableInline && stickyScrollbar && (
+        <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+      )}
     </>
   );
 };

--- a/packages/eui/src/components/table/table.tsx
+++ b/packages/eui/src/components/table/table.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, TableHTMLAttributes, Ref } from 'react';
+import React, { FunctionComponent, TableHTMLAttributes, useRef } from 'react';
 import classNames from 'classnames';
 
 import { useEuiMemoizedStyles, type EuiBreakpointSize } from '../../services';
@@ -21,6 +21,7 @@ import { euiTableStyles } from './table.styles';
 import { usePropsWithComponentDefaults } from '../provider/component_defaults';
 import { euiContainerCSS } from '../../global_styling';
 import { EUI_TABLE_CSS_CONTAINER_NAME } from './const';
+import { EuiTableStickyScrollbar } from './sticky_scrollbar/sticky_scrollbar';
 
 export interface EuiTableProps
   extends CommonProps,
@@ -56,7 +57,6 @@ export interface EuiTableProps
    * @default false
    */
   scrollableInline?: boolean;
-  tableWrapperElementRef?: Ref<HTMLDivElement>;
 }
 
 /**
@@ -78,9 +78,9 @@ export const EuiTable: FunctionComponent<EuiTableProps> = (originalProps) => {
     hasBackground = true,
     responsiveBreakpoint,
     scrollableInline = false,
-    tableWrapperElementRef,
     ...rest
   } = usePropsWithComponentDefaults('EuiTable', originalProps);
+  const tableWrapperRef = useRef<HTMLDivElement>(null);
   const isResponsive = useIsEuiTableResponsive(responsiveBreakpoint);
 
   const classes = classNames('euiTable', className);
@@ -101,14 +101,17 @@ export const EuiTable: FunctionComponent<EuiTableProps> = (originalProps) => {
   ];
 
   return (
-    <div css={cssStyles} ref={tableWrapperElementRef}>
-      <table tabIndex={-1} css={tableStyles} className={classes} {...rest}>
-        <EuiTableIsResponsiveContext.Provider value={isResponsive}>
-          <EuiTableVariantContext.Provider value={{ hasBackground }}>
-            {children}
-          </EuiTableVariantContext.Provider>
-        </EuiTableIsResponsiveContext.Provider>
-      </table>
-    </div>
+    <>
+      <div css={cssStyles} ref={tableWrapperRef}>
+        <table tabIndex={-1} css={tableStyles} className={classes} {...rest}>
+          <EuiTableIsResponsiveContext.Provider value={isResponsive}>
+            <EuiTableVariantContext.Provider value={{ hasBackground }}>
+              {children}
+            </EuiTableVariantContext.Provider>
+          </EuiTableIsResponsiveContext.Provider>
+        </table>
+      </div>
+      <EuiTableStickyScrollbar tableWrapperRef={tableWrapperRef} />
+    </>
   );
 };

--- a/packages/eui/src/components/table/table.tsx
+++ b/packages/eui/src/components/table/table.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { FunctionComponent, TableHTMLAttributes } from 'react';
+import React, { FunctionComponent, TableHTMLAttributes, Ref } from 'react';
 import classNames from 'classnames';
 
 import { useEuiMemoizedStyles, type EuiBreakpointSize } from '../../services';
@@ -56,6 +56,7 @@ export interface EuiTableProps
    * @default false
    */
   scrollableInline?: boolean;
+  tableWrapperElementRef?: Ref<HTMLDivElement>;
 }
 
 /**
@@ -77,6 +78,7 @@ export const EuiTable: FunctionComponent<EuiTableProps> = (originalProps) => {
     hasBackground = true,
     responsiveBreakpoint,
     scrollableInline = false,
+    tableWrapperElementRef,
     ...rest
   } = usePropsWithComponentDefaults('EuiTable', originalProps);
   const isResponsive = useIsEuiTableResponsive(responsiveBreakpoint);
@@ -99,7 +101,7 @@ export const EuiTable: FunctionComponent<EuiTableProps> = (originalProps) => {
   ];
 
   return (
-    <div css={cssStyles}>
+    <div css={cssStyles} ref={tableWrapperElementRef}>
       <table tabIndex={-1} css={tableStyles} className={classes} {...rest}>
         <EuiTableIsResponsiveContext.Provider value={isResponsive}>
           <EuiTableVariantContext.Provider value={{ hasBackground }}>

--- a/packages/eui/src/test/internal/index.ts
+++ b/packages/eui/src/test/internal/index.ts
@@ -8,3 +8,11 @@
 
 export * from './render_custom_styles';
 export * from './react_version';
+export {
+  createResizeObserverMock,
+  createMockResizeObserverEntry,
+} from './resize_observer_mock';
+export {
+  createIntersectionObserverMock,
+  createMockIntersectionObserverEntry,
+} from './intersection_observer_mock';

--- a/packages/eui/src/test/internal/intersection_observer_mock.test.ts
+++ b/packages/eui/src/test/internal/intersection_observer_mock.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  createIntersectionObserverMock,
+  createMockIntersectionObserverEntry,
+} from './intersection_observer_mock';
+
+describe('createIntersectionObserverMock', () => {
+  it('works with a single IntersectionObserver', () => {
+    const mock = createIntersectionObserverMock();
+    const callback = jest.fn();
+
+    const observer = new mock.IntersectionObserver(callback);
+    const element = document.createElement('div');
+    const entry = createMockIntersectionObserverEntry(element, true);
+
+    mock.triggerCallback([entry]);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith([entry], observer);
+  });
+
+  it('works with multiple IntersectionObservers independently', () => {
+    const mock = createIntersectionObserverMock();
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+
+    const observer1 = new mock.IntersectionObserver(callback1);
+    const observer2 = new mock.IntersectionObserver(callback2);
+
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('div');
+    const entry1 = createMockIntersectionObserverEntry(element1, true);
+    const entry2 = createMockIntersectionObserverEntry(element2, false);
+
+    // Trigger first observer
+    mock.triggerCallback([entry1], observer1);
+
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith([entry1], observer1);
+    expect(callback2).not.toHaveBeenCalled();
+
+    // Trigger second observer
+    mock.triggerCallback([entry2], observer2);
+
+    expect(callback1).toHaveBeenCalledTimes(1); // Still only called once
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledWith([entry2], observer2);
+  });
+
+  it('defaults to the first observer when no observer is specified', () => {
+    const mock = createIntersectionObserverMock();
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+
+    const observer1 = new mock.IntersectionObserver(callback1);
+    new mock.IntersectionObserver(callback2); // Create second but don't use
+
+    const element = document.createElement('div');
+    const entry = createMockIntersectionObserverEntry(element, true);
+
+    // Trigger without specifying observer - should use first
+    mock.triggerCallback([entry]);
+
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith([entry], observer1);
+    expect(callback2).not.toHaveBeenCalled();
+  });
+
+  it('throws an error when triggering with an invalid observer', () => {
+    const mock = createIntersectionObserverMock();
+    const callback = jest.fn();
+    new mock.IntersectionObserver(callback);
+
+    const element = document.createElement('div');
+    const entry = createMockIntersectionObserverEntry(element, true);
+
+    // Create a fake observer not from this mock
+    const fakeObserver = {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+      unobserve: jest.fn(),
+      root: null,
+      rootMargin: '',
+      thresholds: [],
+      takeRecords: jest.fn(),
+    } as IntersectionObserver;
+
+    expect(() => {
+      mock.triggerCallback([entry], fakeObserver);
+    }).toThrow(
+      'No callback found for observer. Make sure the observer was created by this mock.'
+    );
+  });
+});

--- a/packages/eui/src/test/internal/intersection_observer_mock.ts
+++ b/packages/eui/src/test/internal/intersection_observer_mock.ts
@@ -25,11 +25,13 @@ import { act } from '@testing-library/react';
  * @internal
  */
 export const createIntersectionObserverMock = () => {
-  let callback: IntersectionObserverCallback;
+  const callbackMap = new WeakMap<
+    IntersectionObserver,
+    IntersectionObserverCallback
+  >();
 
   const mockConstructor = jest.fn((cb: IntersectionObserverCallback) => {
-    callback = cb;
-    return {
+    const observer: IntersectionObserver = {
       observe: jest.fn(),
       disconnect: jest.fn(),
       unobserve: jest.fn(),
@@ -38,6 +40,10 @@ export const createIntersectionObserverMock = () => {
       thresholds: [],
       takeRecords: jest.fn(),
     };
+
+    callbackMap.set(observer, cb);
+
+    return observer;
   }) as jest.MockedClass<typeof IntersectionObserver>;
 
   return {
@@ -53,6 +59,14 @@ export const createIntersectionObserverMock = () => {
       observer?: IntersectionObserver
     ) => {
       const obs = observer || mockConstructor.mock.results[0]?.value;
+      const callback = callbackMap.get(obs);
+
+      if (!callback) {
+        throw new Error(
+          'No callback found for observer. Make sure the observer was created by this mock.'
+        );
+      }
+
       act(() => {
         callback(entries, obs);
       });

--- a/packages/eui/src/test/internal/intersection_observer_mock.ts
+++ b/packages/eui/src/test/internal/intersection_observer_mock.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act } from '@testing-library/react';
+
+/**
+ * Create a mock IntersectionObserver for testing.
+ *
+ * @example
+ * const intersectionObserverMock = createIntersectionObserverMock();
+ * global.IntersectionObserver = intersectionObserverMock.IntersectionObserver;
+ *
+ * // Later in test
+ * intersectionObserverMock.triggerCallback([
+ *   createMockIntersectionObserverEntry(element, true)
+ * ]);
+ * @internal
+ */
+export const createIntersectionObserverMock = () => {
+  let callback: IntersectionObserverCallback;
+
+  const mockConstructor = jest.fn((cb: IntersectionObserverCallback) => {
+    callback = cb;
+    return {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+      unobserve: jest.fn(),
+      root: null,
+      rootMargin: '',
+      thresholds: [],
+      takeRecords: jest.fn(),
+    };
+  }) as jest.MockedClass<typeof IntersectionObserver>;
+
+  return {
+    IntersectionObserver: mockConstructor,
+    /**
+     * Manually trigger the IntersectionObserver callback.
+     *
+     * @param entries - Array of IntersectionObserverEntry objects
+     * @param observer - Optional observer instance. Defaults to the first mock result
+     */
+    triggerCallback: (
+      entries: IntersectionObserverEntry[],
+      observer?: IntersectionObserver
+    ) => {
+      const obs = observer || mockConstructor.mock.results[0]?.value;
+      act(() => {
+        callback(entries, obs);
+      });
+    },
+  };
+};
+
+/**
+ * Create a mock IntersectionObserverEntry for testing IntersectionObserver.
+ *
+ * @param target - The element being observed
+ * @param isIntersecting - Whether the element is intersecting
+ * @returns A mock IntersectionObserverEntry object
+ * @internal
+ */
+export const createMockIntersectionObserverEntry = (
+  target: Element,
+  isIntersecting: boolean
+): IntersectionObserverEntry => {
+  const boundingClientRect = {
+    x: 0,
+    y: 0,
+    width: 500,
+    height: 100,
+    top: 0,
+    right: 500,
+    bottom: 100,
+    left: 0,
+    toJSON: () => ({}),
+  };
+
+  return {
+    target,
+    isIntersecting,
+    boundingClientRect,
+    intersectionRect: boundingClientRect,
+    rootBounds: null,
+    intersectionRatio: isIntersecting ? 1 : 0,
+    time: Date.now(),
+  };
+};

--- a/packages/eui/src/test/internal/intersection_observer_mock.ts
+++ b/packages/eui/src/test/internal/intersection_observer_mock.ts
@@ -10,6 +10,9 @@ import { act } from '@testing-library/react';
 
 /**
  * Create a mock IntersectionObserver for testing.
+ * This mock doesn't provide a real IntersectionObserver implementation
+ * and should only be used for simple assertions.
+ * Use Cypress to test more complex scenarios end to end.
  *
  * @example
  * const intersectionObserverMock = createIntersectionObserverMock();
@@ -62,14 +65,18 @@ export const createIntersectionObserverMock = () => {
  *
  * @param target - The element being observed
  * @param isIntersecting - Whether the element is intersecting
+ * @param boundingClientRect - Customize values in the returned `boundingClientRect` and `intersectionRect` objects
  * @returns A mock IntersectionObserverEntry object
  * @internal
  */
 export const createMockIntersectionObserverEntry = (
   target: Element,
-  isIntersecting: boolean
+  isIntersecting: boolean,
+  boundingClientRect: Partial<
+    IntersectionObserverEntry['boundingClientRect']
+  > = {}
 ): IntersectionObserverEntry => {
-  const boundingClientRect = {
+  const _boundingClientRect = {
     x: 0,
     y: 0,
     width: 500,
@@ -79,13 +86,14 @@ export const createMockIntersectionObserverEntry = (
     bottom: 100,
     left: 0,
     toJSON: () => ({}),
+    ...boundingClientRect,
   };
 
   return {
     target,
     isIntersecting,
-    boundingClientRect,
-    intersectionRect: boundingClientRect,
+    boundingClientRect: _boundingClientRect,
+    intersectionRect: _boundingClientRect,
     rootBounds: null,
     intersectionRatio: isIntersecting ? 1 : 0,
     time: Date.now(),

--- a/packages/eui/src/test/internal/resize_observer_mock.test.ts
+++ b/packages/eui/src/test/internal/resize_observer_mock.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  createResizeObserverMock,
+  createMockResizeObserverEntry,
+} from './resize_observer_mock';
+
+describe('createResizeObserverMock', () => {
+  it('works with a single ResizeObserver', () => {
+    const mock = createResizeObserverMock();
+    const callback = jest.fn();
+
+    const observer = new mock.ResizeObserver(callback);
+    const element = document.createElement('div');
+    const entry = createMockResizeObserverEntry(element);
+
+    mock.triggerCallback([entry]);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith([entry], observer);
+  });
+
+  it('works with multiple ResizeObservers independently', () => {
+    const mock = createResizeObserverMock();
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+
+    const observer1 = new mock.ResizeObserver(callback1);
+    const observer2 = new mock.ResizeObserver(callback2);
+
+    const element1 = document.createElement('div');
+    const element2 = document.createElement('div');
+    const entry1 = createMockResizeObserverEntry(element1);
+    const entry2 = createMockResizeObserverEntry(element2);
+
+    // Trigger first observer
+    mock.triggerCallback([entry1], observer1);
+
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith([entry1], observer1);
+    expect(callback2).not.toHaveBeenCalled();
+
+    // Trigger second observer
+    mock.triggerCallback([entry2], observer2);
+
+    expect(callback1).toHaveBeenCalledTimes(1); // Still only called once
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledWith([entry2], observer2);
+  });
+
+  it('defaults to the first observer when no observer is specified', () => {
+    const mock = createResizeObserverMock();
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+
+    const observer1 = new mock.ResizeObserver(callback1);
+    new mock.ResizeObserver(callback2); // Create second but don't use
+
+    const element = document.createElement('div');
+    const entry = createMockResizeObserverEntry(element);
+
+    // Trigger without specifying observer - should use first
+    mock.triggerCallback([entry]);
+
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith([entry], observer1);
+    expect(callback2).not.toHaveBeenCalled();
+  });
+
+  it('throws an error when triggering with an invalid observer', () => {
+    const mock = createResizeObserverMock();
+    const callback = jest.fn();
+    new mock.ResizeObserver(callback);
+
+    const element = document.createElement('div');
+    const entry = createMockResizeObserverEntry(element);
+
+    // Create a fake observer not from this mock
+    const fakeObserver = {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+      unobserve: jest.fn(),
+    } as ResizeObserver;
+
+    expect(() => {
+      mock.triggerCallback([entry], fakeObserver);
+    }).toThrow(
+      'No callback found for observer. Make sure the observer was created by this mock.'
+    );
+  });
+});

--- a/packages/eui/src/test/internal/resize_observer_mock.ts
+++ b/packages/eui/src/test/internal/resize_observer_mock.ts
@@ -23,15 +23,18 @@ import { act } from '@testing-library/react';
  * @internal
  */
 export const createResizeObserverMock = () => {
-  let callback: ResizeObserverCallback;
+  const callbackMap = new WeakMap<ResizeObserver, ResizeObserverCallback>();
 
   const mockConstructor = jest.fn((cb: ResizeObserverCallback) => {
-    callback = cb;
-    return {
+    const observer = {
       observe: jest.fn(),
       disconnect: jest.fn(),
       unobserve: jest.fn(),
     } as ResizeObserver;
+
+    callbackMap.set(observer, cb);
+
+    return observer;
   }) as jest.MockedClass<typeof ResizeObserver>;
 
   return {
@@ -47,6 +50,14 @@ export const createResizeObserverMock = () => {
       observer?: ResizeObserver
     ) => {
       const obs = observer || mockConstructor.mock.results[0]?.value;
+      const callback = callbackMap.get(obs);
+
+      if (!callback) {
+        throw new Error(
+          'No callback found for observer. Make sure the observer was created by this mock.'
+        );
+      }
+
       act(() => {
         callback(entries, obs);
       });

--- a/packages/eui/src/test/internal/resize_observer_mock.ts
+++ b/packages/eui/src/test/internal/resize_observer_mock.ts
@@ -10,6 +10,9 @@ import { act } from '@testing-library/react';
 
 /**
  * Create a mock ResizeObserver for testing.
+ * This mock doesn't provide a real ResizeObserver implementation
+ * and should only be used for simple assertions.
+ * Use Cypress to test more complex scenarios end to end.
  *
  * @example
  * const resizeObserverMock = createResizeObserverMock();
@@ -55,13 +58,15 @@ export const createResizeObserverMock = () => {
  * Create a mock ResizeObserverEntry for testing ResizeObserver events
  *
  * @param target - The element being observed
+ * @param contentRect - Customize values in the returned `contentRect` object
  * @returns A mock ResizeObserverEntry object
  * @internal
  */
 export const createMockResizeObserverEntry = (
-  target: Element
+  target: Element,
+  contentRect: Partial<ResizeObserverEntry['contentRect']> = {}
 ): ResizeObserverEntry => {
-  const contentRect = {
+  const _contentRect = {
     x: 0,
     y: 0,
     width: 500,
@@ -71,11 +76,12 @@ export const createMockResizeObserverEntry = (
     bottom: 100,
     left: 0,
     toJSON: () => ({}),
+    ...contentRect,
   };
 
   return {
     target,
-    contentRect,
+    contentRect: _contentRect,
     borderBoxSize: [] as any,
     contentBoxSize: [] as any,
     devicePixelContentBoxSize: [] as any,

--- a/packages/eui/src/test/internal/resize_observer_mock.ts
+++ b/packages/eui/src/test/internal/resize_observer_mock.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { act } from '@testing-library/react';
+
+/**
+ * Create a mock ResizeObserver for testing.
+ *
+ * @example
+ * const resizeObserverMock = createResizeObserverMock();
+ * global.ResizeObserver = resizeObserverMock.ResizeObserver;
+ *
+ * // Later in test
+ * resizeObserverMock.triggerCallback([createMockResizeObserverEntry(element)]);
+ * @internal
+ */
+export const createResizeObserverMock = () => {
+  let callback: ResizeObserverCallback;
+
+  const mockConstructor = jest.fn((cb: ResizeObserverCallback) => {
+    callback = cb;
+    return {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+      unobserve: jest.fn(),
+    } as ResizeObserver;
+  }) as jest.MockedClass<typeof ResizeObserver>;
+
+  return {
+    ResizeObserver: mockConstructor,
+    /**
+     * Manually trigger the ResizeObserver callback.
+     *
+     * @param entries - Array of ResizeObserverEntry objects
+     * @param observer - Optional observer instance. Defaults to the first mock result
+     */
+    triggerCallback: (
+      entries: ResizeObserverEntry[],
+      observer?: ResizeObserver
+    ) => {
+      const obs = observer || mockConstructor.mock.results[0]?.value;
+      act(() => {
+        callback(entries, obs);
+      });
+    },
+  };
+};
+
+/**
+ * Create a mock ResizeObserverEntry for testing ResizeObserver events
+ *
+ * @param target - The element being observed
+ * @returns A mock ResizeObserverEntry object
+ * @internal
+ */
+export const createMockResizeObserverEntry = (
+  target: Element
+): ResizeObserverEntry => {
+  const contentRect = {
+    x: 0,
+    y: 0,
+    width: 500,
+    height: 100,
+    top: 0,
+    right: 500,
+    bottom: 100,
+    left: 0,
+    toJSON: () => ({}),
+  };
+
+  return {
+    target,
+    contentRect,
+    borderBoxSize: [] as any,
+    contentBoxSize: [] as any,
+    devicePixelContentBoxSize: [] as any,
+  };
+};

--- a/packages/eui/src/test/internal/resize_observer_mock.ts
+++ b/packages/eui/src/test/internal/resize_observer_mock.ts
@@ -26,11 +26,11 @@ export const createResizeObserverMock = () => {
   const callbackMap = new WeakMap<ResizeObserver, ResizeObserverCallback>();
 
   const mockConstructor = jest.fn((cb: ResizeObserverCallback) => {
-    const observer = {
+    const observer: ResizeObserver = {
       observe: jest.fn(),
       disconnect: jest.fn(),
       unobserve: jest.fn(),
-    } as ResizeObserver;
+    };
 
     callbackMap.set(observer, cb);
 

--- a/packages/website/docs/components/tables/basic.mdx
+++ b/packages/website/docs/components/tables/basic.mdx
@@ -1399,6 +1399,9 @@ relative length units (e.g., `%`, `vw` or `cqw`/`cqi`).
 Enabling inline scrolling automatically switches `tableLayout` to `auto`
 because in that configuration the table's width is dependent on its cell widths.
 
+Consider turning on the [`stickyScrollbar`](./custom.mdx#sticky-horizontal-scrollbar) prop together with inline
+scrolling for best results across all devices.
+
 ## Manual pagination and sorting
 
 **EuiBasicTable**'s `pagination` and `sorting` properties _only_ control the UI displayed on the table (like showing sorting arrows or pagination numbers). They don't actually handle paginating or sorting your `items` data.

--- a/packages/website/docs/components/tables/custom.mdx
+++ b/packages/website/docs/components/tables/custom.mdx
@@ -857,6 +857,16 @@ export default class extends Component<{}, State> {
 }
 ```
 
+```mdx-code-block
+import { EuiBetaBadge } from '@elastic/eui';
+```
+
+### Sticky horizontal scrollbar <EuiBetaBadge size="s" label="Beta" color="accent" /> {#sticky-horizontal-scrollbar}
+
+When a table is taller than the viewport, the horizontal scrollbar at the bottom becomes hard to reach.
+Enable [`stickyScrollbar`](#EuiTable-prop-stickyScrollbar) to display a scrollbar that sticks to the bottom
+of the viewport when needed.
+
 ## Props
 
 import docgen from '@elastic/eui-docgen/dist/components/table';


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/eui/issues/9620

This PR adds an opt-in, always-visible sticky horizontal scrollbar to EuiTable, EuiBasicTable, and EuiInMemoryTable to help users without trackpads scroll table contents horizontally.

Without this, scrolling the table horizontally requires one of the following:
1. Holding shift when scrolling using the scroll wheel
2. Using the middle mouse button (holding the scroll wheel button) on Windows
3. Scrolling to the bottom of the table to grab the native scrollbar track

This feature is disabled by default and can be enabled by setting the `stickyScrollbar` prop to `true`. When disabled, it doesn't register any event listeners or observers and doesn't modify the DOM.

Note: The styles applied to the virtual scrollbar are made to resemble the native scrollbar styles as closely as possible, however, every platform renders scrollbars differently. We standardize scrollbar background and track colors in our global styles. It is expected that the virtual scrollbar will not look 100% the same on Windows or Linux - Windows adds left and right buttons, and Linux differs by distro, GUI library, and more.

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiTable`, `EuiBasicTable`, `EuiInMemoryTable` | `stickyScrollbar` | Added | Enable the sticky scrollbar behavior. When enabled, a virtual scrollbar sticking to the bottom of the viewport will be rendered on top of the table when the total table height is larger than the viewport height. |

## Screenshots

| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/81e9d610-2f79-4c20-bb43-0a872f442cd1"> |  <video src="https://github.com/user-attachments/assets/6128d4a6-cf72-484a-a10a-237973c032be"> |

**Safari:**

https://github.com/user-attachments/assets/d3fc398f-4279-4d5f-acad-5d7176d86833

**Chromium on Ubuntu + Gnome:**

https://github.com/user-attachments/assets/7b86fd12-abaa-4494-ba2d-6f3ce4c077e9

**Chromium on Debian + KDE:**

https://github.com/user-attachments/assets/08675382-d29d-4936-bdb7-5979b0ef5b27

**Firefox on Debian + KDE:**

https://github.com/user-attachments/assets/46e927ea-20f3-4d31-a0cc-cfa7eb2301b1

**Chromium on Debian + XFCE:**

https://github.com/user-attachments/assets/1d00a425-82f8-4fff-b38d-be9f8daeb5fe

**Firefox on Debian + XFCE:**

https://github.com/user-attachments/assets/2014eee3-9d6d-4b8d-9ef8-82a05559e4ce

## Performance

| Before/Disabled | After/Enabled |
|--------|-------|
| <img width="1185" height="828" alt="stickyScrollbar performance - disabled" src="https://github.com/user-attachments/assets/ecb011d3-161c-4be6-8d70-f93c064cba49" /> | <img width="1115" height="816" alt="stickyScrollbar performance - enabled" src="https://github.com/user-attachments/assets/cd2addc6-60b1-4a2d-82a2-35f15fff9728" /> |

Measurements done by manually resizing the viewport - not suitable for 1:1 comparison.
When `stickyScrollbar` is enabled, rendering and painting time grows by ~60ms, and scripting by ~25ms. This is fully expected and considering that the virtual scrollbar element style refreshes on every resize and scroll event, the resource cost is actually pretty minimal. Using `ResizeObserver` and `IntersectionObserver` synchronized with `requestAnimationFrame` results in grade A performance. I consider these numbers good and see no objections shipping it as-is.

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ]~ 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [x] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 Low to None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [x] **Adoption plan** (new features): (see parent epic)

### QA instructions for reviewer

- [ ] Go to URL and verify the sticky scrollbar behavior
    - [ ] Confirm that the virtual scrollbar doesn't appear until the table overflows **and** `stickyScrollbar` is enabled
    - [ ] Confirm that the virtual scrollbar disappears as soon as the table overflow ends - resize browser window in and out
    - [ ] Confirm that the virtual scrollbar is draggable and simulates the native scrollbar behavior
    - [ ] Confirm that the virtual scrollbar works in supported browsers

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] ~**QA:** Tested docs changes~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
