### PR TITLE
[EuiSelectable][EuiComboBox] Fix group label append not being clickable

### DIFF
--- a/packages/eui/changelogs/upcoming/9678.md
+++ b/packages/eui/changelogs/upcoming/9678.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed an issue in `EuiSelectable` and `EuiComboBox` where interactive content in group labels wasn't clickable due to overlapping content.

--- a/packages/eui/src/components/combo_box/combo_box.stories.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.stories.tsx
@@ -17,6 +17,7 @@ import {
 import { LOKI_SELECTORS, lokiPlayDecorator } from '../../../.storybook/loki';
 import { EuiCode } from '../code';
 import { EuiFlexItem } from '../flex';
+import { EuiLink } from '../link';
 
 import { EuiComboBoxOptionMatcher } from './types';
 import { EuiComboBox, EuiComboBoxProps } from './combo_box';
@@ -244,7 +245,9 @@ export const Groups: Story = {
         isGroupLabelOption: true,
         prepend: '#prepend ',
         append: (
-          <EuiFlexItem css={{ alignItems: 'flex-end' }}>(append)</EuiFlexItem>
+          <EuiFlexItem css={{ alignItems: 'flex-end' }}>
+            <EuiLink>(append)</EuiLink>
+          </EuiFlexItem>
         ),
       },
       ...[...options].splice(3, options.length),
@@ -275,7 +278,9 @@ export const NestedOptionsGroups: Story = {
         isGroupLabelOption: true,
         prepend: '#prepend ',
         append: (
-          <EuiFlexItem css={{ alignItems: 'flex-end' }}>(append)</EuiFlexItem>
+          <EuiFlexItem css={{ alignItems: 'flex-end' }}>
+            <EuiLink>(append)</EuiLink>
+          </EuiFlexItem>
         ),
         options: [...options].splice(3, options.length),
       },

--- a/packages/eui/src/components/selectable/selectable.stories.tsx
+++ b/packages/eui/src/components/selectable/selectable.stories.tsx
@@ -22,6 +22,7 @@ import {
   EuiSelectableOnChangeEvent,
   EuiSelectableProps,
 } from './selectable';
+import { EuiLink } from '../link/link';
 
 const toolTipProps = {
   toolTipContent: 'This is a tooltip!',
@@ -157,7 +158,9 @@ export const WithSearchAndGroups: Story = {
         isGroupLabel: true,
         prepend: <EuiIcon type="warning" />,
         append: (
-          <EuiFlexItem css={{ alignItems: 'flex-end' }}>(append)</EuiFlexItem>
+          <EuiFlexItem css={{ alignItems: 'flex-end' }}>
+            <EuiLink>append</EuiLink>
+          </EuiFlexItem>
         ),
       },
       ...[...options].splice(4, options.length),

--- a/packages/eui/src/components/selectable/selectable.stories.tsx
+++ b/packages/eui/src/components/selectable/selectable.stories.tsx
@@ -22,7 +22,7 @@ import {
   EuiSelectableOnChangeEvent,
   EuiSelectableProps,
 } from './selectable';
-import { EuiLink } from '../link/link';
+import { EuiLink } from '../link';
 
 const toolTipProps = {
   toolTipContent: 'This is a tooltip!',

--- a/packages/eui/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
+++ b/packages/eui/src/components/selectable/selectable_list/__snapshots__/selectable_list.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`EuiSelectableListItem group labels handles updating aria attrs correctl
       tabindex="0"
     >
       <li
-        class="euiSelectableList__groupLabel css-1ku7zw3-groupLabel-EuiSelectableList"
+        class="euiSelectableList__groupLabel css-rtav68-groupLabel-EuiSelectableList"
         role="presentation"
       >
         Moons
@@ -73,7 +73,7 @@ exports[`EuiSelectableListItem group labels handles updating aria attrs correctl
         </span>
       </li>
       <li
-        class="euiSelectableList__groupLabel css-1ku7zw3-groupLabel-EuiSelectableList"
+        class="euiSelectableList__groupLabel css-rtav68-groupLabel-EuiSelectableList"
         role="presentation"
       >
         Planets
@@ -129,7 +129,7 @@ exports[`EuiSelectableListItem group labels handles updating aria attrs correctl
         </span>
       </li>
       <li
-        class="euiSelectableList__groupLabel css-1ku7zw3-groupLabel-EuiSelectableList"
+        class="euiSelectableList__groupLabel css-rtav68-groupLabel-EuiSelectableList"
         role="presentation"
       >
         Suns
@@ -212,7 +212,7 @@ exports[`EuiSelectableListItem group labels renders with correct aria-setsize an
           </span>
         </li>
         <li
-          class="euiSelectableList__groupLabel css-1ku7zw3-groupLabel-EuiSelectableList"
+          class="euiSelectableList__groupLabel css-rtav68-groupLabel-EuiSelectableList"
           role="presentation"
           style="position: absolute; left: 0px; top: 32px; height: 48px; width: 100%;"
         >
@@ -271,7 +271,7 @@ exports[`EuiSelectableListItem group labels renders with correct aria-setsize an
           </span>
         </li>
         <li
-          class="euiSelectableList__groupLabel css-1ku7zw3-groupLabel-EuiSelectableList"
+          class="euiSelectableList__groupLabel css-rtav68-groupLabel-EuiSelectableList"
           role="presentation"
           style="position: absolute; left: 0px; top: 144px; height: 48px; width: 100%;"
         >
@@ -330,7 +330,7 @@ exports[`EuiSelectableListItem group labels renders with correct aria-setsize an
           </span>
         </li>
         <li
-          class="euiSelectableList__groupLabel css-1ku7zw3-groupLabel-EuiSelectableList"
+          class="euiSelectableList__groupLabel css-rtav68-groupLabel-EuiSelectableList"
           role="presentation"
           style="position: absolute; left: 0px; top: 256px; height: 48px; width: 100%;"
         >

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.stories.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.stories.tsx
@@ -21,6 +21,7 @@ import { EuiIcon } from '../../icon';
 import { EuiText } from '../../text';
 import { EuiBadge } from '../../badge';
 import { EuiSelectableOption } from '../selectable_option';
+import { EuiLink } from '../../link';
 
 import { EuiSelectableList, EuiSelectableListProps } from './selectable_list';
 
@@ -168,7 +169,9 @@ export const Groups: Story = {
         isGroupLabel: true,
         prepend: <EuiIcon type="warning" />,
         append: (
-          <EuiFlexItem css={{ alignItems: 'flex-end' }}>(append)</EuiFlexItem>
+          <EuiFlexItem css={{ alignItems: 'flex-end' }}>
+            <EuiLink>(append)</EuiLink>
+          </EuiFlexItem>
         ),
       },
       ...[...options].splice(4, options.length),

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.styles.ts
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.styles.ts
@@ -86,6 +86,7 @@ export const euiSelectableListGroupLabelStyles = (
         &::before {
           content: '';
           position: absolute;
+          z-index: ${Number(euiTheme.levels.content) - 1};
           inset: 0;
           inset-block-start: ${spacingVertical};
           ${logicalCSS(

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.styles.ts
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.styles.ts
@@ -86,7 +86,7 @@ export const euiSelectableListGroupLabelStyles = (
         &::before {
           content: '';
           position: absolute;
-          z-index: ${Number(euiTheme.levels.content) - 1};
+          z-index: -1;
           inset: 0;
           inset-block-start: ${spacingVertical};
           ${logicalCSS(


### PR DESCRIPTION
## Summary

This PR fixes an issue in `EuiSelectable` and `EuiComboBox`, where interactive content (specifically links) passed into group labels with `append` wouldn't be clickable. The issue resulted from the update done in https://github.com/elastic/eui/pull/9515 which introduced decor pseudo elements for the separator elements. These would overlap the content. This PR adds a `z-index` to ensure correct layering.

### API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/24158d12-7c00-44cb-8a25-cca3cf0d9f0f" />  | <video src="https://github.com/user-attachments/assets/397b1155-dca2-4d1d-902b-07e57809ad4d" />  |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

ℹ️ The Kibana code base has been checked for cases that might be affected by this bug: There seem to be none.
There are cases of interactive content (`EuiButtonIcon`) in the label, which works fine. And there is one case of an `EuiIconTip` in the `append` which also works as expected (tested on EUI side).

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
- [ ] ~~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [ ] verify interactive content in group labels is clickable (EuiSelectable, EuiComboBox)
- [ ] verify there is no unexpected regression for EuiSelectable between [production](https://eui.elastic.co/next/storybook/?path=/story/forms-euiselectable--with-search-and-groups&globals=colorMode:light) and [staging](https://eui.elastic.co/pr_9678/storybook/?path=/story/forms-euiselectable--with-search-and-groups)
- [ ] verify there is no unexpected regression for EuiComboBox between [production](https://eui.elastic.co/next/storybook/?path=/story/forms-euicombobox--groups&globals=colorMode:light) and [staging](https://eui.elastic.co/pr_9678/storybook/?path=/story/forms-euicombobox--groups)

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] ~~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana]~~(https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] ~~**QA:** Tested docs changes~~
- [ ] ~~**Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)~~
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~~**Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
