### PR TITLE
[EuiDataGridColumnResizer] Migrate from class to function component

### DIFF
--- a/packages/eui/changelogs/upcoming/9470.md
+++ b/packages/eui/changelogs/upcoming/9470.md
@@ -1,0 +1,3 @@
+**Refactoring**
+
+- Migrated `EuiDataGridColumnResizer` from a class to a function component

--- a/packages/eui/changelogs/upcoming/9680.md
+++ b/packages/eui/changelogs/upcoming/9680.md
@@ -1,3 +1,1 @@
-**Refactoring**
-
 - Migrated `EuiDataGridColumnResizer` from a class to a function component

--- a/packages/eui/src/components/datagrid/body/header/column_resizer.test.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_resizer.test.tsx
@@ -7,10 +7,22 @@
  */
 
 import React from 'react';
-import { act } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 import { render } from '../../../../test/rtl';
 
 import { EuiDataGridColumnResizer } from './column_resizer';
+
+// pageX is a read-only computed property on MouseEvent; helper to dispatch a
+// mouse event with a specific pageX value on any target.
+const dispatchMouseEventWithPageX = (
+  target: Element | Window,
+  type: string,
+  pageX: number
+) => {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'pageX', { value: pageX });
+  target.dispatchEvent(event);
+};
 
 describe('EuiDataGridHeaderResizer', () => {
   const props = {
@@ -32,24 +44,20 @@ describe('EuiDataGridHeaderResizer', () => {
   });
 
   describe('mouse events', () => {
-    const mouseEvent = {
-      preventDefault: () => {},
-    } as React.MouseEvent<HTMLDivElement>;
-
-    // Using a ref to reach into class methods/state directly -
-    // mocking mouse events in jsdom is too much of a headache
-    let classRef: EuiDataGridColumnResizer;
-    const setRef = (ref: EuiDataGridColumnResizer) => {
-      classRef = ref;
-    };
-
     describe('on mouse down', () => {
       it('adds mouse move & up listeners', () => {
-        render(<EuiDataGridColumnResizer {...props} ref={setRef} />);
+        const { getByTestSubject } = render(
+          <EuiDataGridColumnResizer {...props} />
+        );
         const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
 
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        expect(classRef.state.initialX).toEqual(100);
+        act(() => {
+          dispatchMouseEventWithPageX(
+            getByTestSubject('dataGridColumnResizer'),
+            'mousedown',
+            100
+          );
+        });
 
         const anyFn = expect.any(Function);
         expect(addEventListenerSpy).toHaveBeenCalledWith('mouseup', anyFn);
@@ -59,29 +67,44 @@ describe('EuiDataGridHeaderResizer', () => {
     });
 
     describe('on mouse move', () => {
-      it('does not allow an offset that would go under the mininum column width', () => {
+      it('does not allow an offset that would go under the minimum column width', () => {
         const { getByTestSubject } = render(
-          <EuiDataGridColumnResizer {...props} ref={setRef} />
+          <EuiDataGridColumnResizer {...props} />
         );
 
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        act(() => classRef.onMouseMove({ pageX: 0 }));
+        act(() => {
+          dispatchMouseEventWithPageX(
+            getByTestSubject('dataGridColumnResizer'),
+            'mousedown',
+            100
+          );
+        });
+        act(() => {
+          dispatchMouseEventWithPageX(window, 'mousemove', 0);
+        });
 
-        expect(classRef.state.offset).toEqual(-10);
+        // offset clamped to -(columnWidth - MINIMUM_COLUMN_WIDTH) = -(50 - 40) = -10
         expect(getByTestSubject('dataGridColumnResizer')).toHaveStyle(
           'margin-inline-end: 10px'
         );
       });
 
-      it('sets offset state to the difference of the moved pageX', () => {
+      it('sets offset to the difference of the moved pageX', () => {
         const { getByTestSubject } = render(
-          <EuiDataGridColumnResizer {...props} ref={setRef} />
+          <EuiDataGridColumnResizer {...props} />
         );
 
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        act(() => classRef.onMouseMove({ pageX: 200 }));
+        act(() => {
+          dispatchMouseEventWithPageX(
+            getByTestSubject('dataGridColumnResizer'),
+            'mousedown',
+            100
+          );
+        });
+        act(() => {
+          dispatchMouseEventWithPageX(window, 'mousemove', 200);
+        });
 
-        expect(classRef.state.offset).toEqual(100);
         expect(getByTestSubject('dataGridColumnResizer')).toHaveStyle(
           'margin-inline-end: -100px'
         );
@@ -89,19 +112,34 @@ describe('EuiDataGridHeaderResizer', () => {
     });
 
     describe('on mouse up', () => {
-      it('calls setColumnWidth, reset offset, and removes event listeners', () => {
-        render(<EuiDataGridColumnResizer {...props} ref={setRef} />);
+      it('calls setColumnWidth, resets offset, and removes event listeners', () => {
+        const { getByTestSubject } = render(
+          <EuiDataGridColumnResizer {...props} />
+        );
         const removeEventListenerSpy = jest.spyOn(
           window,
           'removeEventListener'
         );
 
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        act(() => classRef.onMouseMove({ pageX: 200 }));
-        act(() => classRef.onMouseUp());
+        act(() => {
+          dispatchMouseEventWithPageX(
+            getByTestSubject('dataGridColumnResizer'),
+            'mousedown',
+            100
+          );
+        });
+        act(() => {
+          dispatchMouseEventWithPageX(window, 'mousemove', 200);
+        });
+        act(() => {
+          fireEvent.mouseUp(window);
+        });
 
         expect(props.setColumnWidth).toHaveBeenCalledWith('someColumn', 150);
-        expect(classRef.state.offset).toEqual(0);
+        // offset reset — no margin style applied
+        expect(
+          getByTestSubject('dataGridColumnResizer').style.marginInlineEnd
+        ).toBe('');
 
         const anyFn = expect.any(Function);
         expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseup', anyFn);

--- a/packages/eui/src/components/datagrid/body/header/column_resizer.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_resizer.tsx
@@ -48,10 +48,7 @@ export const EuiDataGridColumnResizer = ({
   const onMouseUp = useCallback(() => {
     setColumnWidthRef.current(
       columnIdRef.current,
-      Math.max(
-        MINIMUM_COLUMN_WIDTH,
-        columnWidthRef.current + offsetRef.current
-      )
+      Math.max(MINIMUM_COLUMN_WIDTH, columnWidthRef.current + offsetRef.current)
     );
 
     offsetRef.current = 0;
@@ -91,9 +88,7 @@ export const EuiDataGridColumnResizer = ({
             className="euiDataGridColumnResizer"
             data-test-subj="dataGridColumnResizer"
             style={
-              offset
-                ? logicalStyle('margin-right', `${-offset}px`)
-                : undefined
+              offset ? logicalStyle('margin-right', `${-offset}px`) : undefined
             }
             onMouseDown={onMouseDown}
           >

--- a/packages/eui/src/components/datagrid/body/header/column_resizer.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_resizer.tsx
@@ -6,97 +6,103 @@
  * Side Public License, v 1.
  */
 
-import React, { Component } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { RenderWithEuiStylesMemoizer } from '../../../../services';
 import { logicalStyle } from '../../../../global_styling';
-import {
-  EuiDataGridColumnResizerProps,
-  EuiDataGridColumnResizerState,
-} from '../../data_grid_types';
+import { EuiDataGridColumnResizerProps } from '../../data_grid_types';
 import { DragOverlay } from './draggable_columns';
 import { euiDataGridColumnResizerStyles } from './column_resizer.styles';
 
 const MINIMUM_COLUMN_WIDTH = 40;
 
-export class EuiDataGridColumnResizer extends Component<
-  EuiDataGridColumnResizerProps,
-  EuiDataGridColumnResizerState
-> {
-  state = {
-    initialX: 0,
-    offset: 0,
-  };
+export const EuiDataGridColumnResizer = ({
+  columnId,
+  columnWidth,
+  setColumnWidth,
+  isLastColumn,
+}: EuiDataGridColumnResizerProps) => {
+  const [offset, setOffset] = useState(0);
 
-  onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.setState({
-      initialX: e.pageX,
-    });
+  // Refs keep the latest values accessible from stable event handler callbacks
+  // without re-registering window listeners on every render.
+  const initialXRef = useRef(0);
+  const offsetRef = useRef(0);
+  const columnWidthRef = useRef(columnWidth);
+  const columnIdRef = useRef(columnId);
+  const setColumnWidthRef = useRef(setColumnWidth);
 
-    window.addEventListener('mouseup', this.onMouseUp);
-    window.addEventListener('blur', this.onMouseUp);
-    window.addEventListener('mousemove', this.onMouseMove);
+  // Keep prop refs in sync on every render (synchronous, safe outside effects)
+  columnWidthRef.current = columnWidth;
+  columnIdRef.current = columnId;
+  setColumnWidthRef.current = setColumnWidth;
 
-    // don't let this action steal focus
-    e.preventDefault();
-  };
+  const onMouseMove = useCallback((e: { pageX: number }) => {
+    const newOffset = Math.max(
+      e.pageX - initialXRef.current,
+      -(columnWidthRef.current - MINIMUM_COLUMN_WIDTH)
+    );
+    offsetRef.current = newOffset;
+    setOffset(newOffset);
+  }, []);
 
-  onMouseUp = () => {
-    const { offset } = this.state;
-    const { columnId, columnWidth, setColumnWidth } = this.props;
-    setColumnWidth(
-      columnId,
-      Math.max(MINIMUM_COLUMN_WIDTH, columnWidth + offset)
+  const onMouseUp = useCallback(() => {
+    setColumnWidthRef.current(
+      columnIdRef.current,
+      Math.max(
+        MINIMUM_COLUMN_WIDTH,
+        columnWidthRef.current + offsetRef.current
+      )
     );
 
-    this.setState({ offset: 0 });
+    offsetRef.current = 0;
+    setOffset(0);
 
-    window.removeEventListener('mouseup', this.onMouseUp);
-    window.removeEventListener('blur', this.onMouseUp);
-    window.removeEventListener('mousemove', this.onMouseMove);
-  };
+    window.removeEventListener('mouseup', onMouseUp);
+    window.removeEventListener('blur', onMouseUp);
+    window.removeEventListener('mousemove', onMouseMove);
+  }, [onMouseMove]);
 
-  onMouseMove = (e: { pageX: number }) => {
-    const { columnWidth } = this.props;
-    this.setState(({ initialX }) => ({
-      offset: Math.max(
-        e.pageX - initialX,
-        -(columnWidth - MINIMUM_COLUMN_WIDTH)
-      ),
-    }));
-  };
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      initialXRef.current = e.pageX;
 
-  render() {
-    const { offset } = this.state;
-    const { isLastColumn } = this.props;
+      window.addEventListener('mouseup', onMouseUp);
+      window.addEventListener('blur', onMouseUp);
+      window.addEventListener('mousemove', onMouseMove);
 
-    return (
-      <RenderWithEuiStylesMemoizer>
-        {(stylesMemoizer) => {
-          const styles = stylesMemoizer(euiDataGridColumnResizerStyles);
-          const cssStyles = [
-            styles.euiDataGridColumnResizer,
-            isLastColumn && styles.isLastColumn,
-            offset && styles.isDragging,
-          ];
-          return (
-            <div
-              css={cssStyles}
-              className="euiDataGridColumnResizer"
-              data-test-subj="dataGridColumnResizer"
-              style={
-                offset
-                  ? logicalStyle('margin-right', `${-offset}px`)
-                  : undefined
-              }
-              onMouseDown={this.onMouseDown}
-            >
-              {/* UX polish: prevent other hover states from activating when
-                  dragging over other elements + maintain the resize cursor */}
-              <DragOverlay isDragging={!!offset} cursor="ew-resize" />
-            </div>
-          );
-        }}
-      </RenderWithEuiStylesMemoizer>
-    );
-  }
-}
+      // don't let this action steal focus
+      e.preventDefault();
+    },
+    [onMouseUp, onMouseMove]
+  );
+
+  return (
+    <RenderWithEuiStylesMemoizer>
+      {(stylesMemoizer) => {
+        const styles = stylesMemoizer(euiDataGridColumnResizerStyles);
+        const cssStyles = [
+          styles.euiDataGridColumnResizer,
+          isLastColumn && styles.isLastColumn,
+          offset && styles.isDragging,
+        ];
+        return (
+          <div
+            css={cssStyles}
+            className="euiDataGridColumnResizer"
+            data-test-subj="dataGridColumnResizer"
+            style={
+              offset
+                ? logicalStyle('margin-right', `${-offset}px`)
+                : undefined
+            }
+            onMouseDown={onMouseDown}
+          >
+            {/* UX polish: prevent other hover states from activating when
+                dragging over other elements + maintain the resize cursor */}
+            <DragOverlay isDragging={!!offset} cursor="ew-resize" />
+          </div>
+        );
+      }}
+    </RenderWithEuiStylesMemoizer>
+  );
+};

--- a/packages/eui/src/components/datagrid/data_grid.test.tsx
+++ b/packages/eui/src/components/datagrid/data_grid.test.tsx
@@ -14,7 +14,6 @@ import { getAllByTestSubject, render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { keys } from '../../services';
 
-import { EuiDataGridColumnResizer } from './body/header/column_resizer';
 import type { EuiDataGridProps, RenderCellValue } from './data_grid_types';
 import { EuiDataGrid } from './';
 
@@ -106,19 +105,32 @@ function resizeColumn(
   const widths = extractColumnWidths(datagrid);
   const originalWidth = widths[columnId];
 
-  const firstResizer = datagrid
-    .find(`EuiDataGridColumnResizer[columnId="${columnId}"]`)
-    .instance() as EuiDataGridColumnResizer;
+  // Find the resizer div within the specific column header
+  const resizer = datagrid
+    .find(`[data-test-subj="dataGridHeaderCell-${columnId}"]`)
+    .find('[data-test-subj="dataGridColumnResizer"]')
+    .hostNodes()
+    .first();
 
   act(() => {
-    firstResizer.onMouseDown({
+    resizer.simulate('mousedown', {
       pageX: originalWidth,
-      stopPropagation: () => {},
       preventDefault: () => {},
-    } as React.MouseEvent<HTMLDivElement>);
+    });
   });
-  act(() => firstResizer.onMouseMove({ pageX: columnWidth }));
-  act(() => firstResizer.onMouseUp());
+
+  act(() => {
+    const moveEvent = new MouseEvent('mousemove', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(moveEvent, 'pageX', { value: columnWidth });
+    window.dispatchEvent(moveEvent);
+  });
+
+  act(() => {
+    window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
 
   datagrid.update();
 }

--- a/packages/eui/src/components/datagrid/data_grid_types.ts
+++ b/packages/eui/src/components/datagrid/data_grid_types.ts
@@ -461,11 +461,6 @@ export interface EuiDataGridColumnResizerProps {
   isLastColumn: boolean;
 }
 
-export interface EuiDataGridColumnResizerState {
-  initialX: number;
-  offset: number;
-}
-
 export interface EuiDataGridColumnSortingDraggableProps {
   id: string;
   direction: string;


### PR DESCRIPTION
## Summary

**What:** Migrates `EuiDataGridColumnResizer` from a class component to a function component using `useState`, `useCallback`, and `useRef`.

**Why:** Closes #9470 — part of the [class component refactoring meta issue](https://github.com/elastic/eui/issues/9455).

**How:**
- `initialX` is now a `useRef` (no state needed — it doesn't affect rendering) with synchronous mutation in `onMouseDown`, fixing stale-closure issues
- `offset` uses both `useState` (for re-renders) and a `useRef` (for synchronous access in `onMouseUp`)
- All prop refs (`columnWidth`, `columnId`, `setColumnWidth`) are kept in sync via direct assignment on each render (safe outside effects), so event listeners always read the latest prop values without being re-registered
- Event handlers are stable `useCallback`s with no deps (everything accessed via refs)
- `EuiDataGridColumnResizerState` interface removed from `data_grid_types.ts` (no longer needed)

**Test updates:**
- `column_resizer.test.tsx`: Replaced class-ref-based tests (`classRef.onMouseDown(...)`) with DOM event dispatch. Since `pageX` is a read-only computed property on `MouseEvent`, events use `Object.defineProperty` to set it
- `data_grid.test.tsx`: Updated `resizeColumn` helper to use Enzyme `.simulate()` + window event dispatch instead of `.instance()`

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiDataGridColumnResizerState` | — | Removed | Internal type no longer needed; class state replaced by `useRef`/`useState` |

## Screenshots

N/A — internal refactor with no visual changes.

| Before | After |
| ------ | ----- |
| Class component | Function component |

## Impact Assessment

- [ ] 🔴 **Breaking changes** — `EuiDataGridColumnResizerState` was exported but only used internally; its removal is a technically breaking API change for anyone who imported it directly (unlikely in practice)
- [x] 💅 **Visual changes** — None
- [x] 🧪 **Test impact** — Tests updated; all pass
- [x] 🔧 **Hard to integrate** — None expected

**Impact level:** 🟢 Low

## Release Readiness

- ~~**Documentation:** N/A~~
- ~~**Figma:** N/A~~
- ~~**Migration guide:** N/A (internal type removal)~~
- ~~**Adoption plan:** N/A~~

### QA instructions for reviewer

- Open any DataGrid story in Storybook that has resizable columns
- [ ] Confirm column resize by drag still works correctly
- [ ] Confirm the resize cursor appears during drag
- [ ] Confirm the column snaps to minimum width (40px) when dragged far left
- [ ] Confirm the `DragOverlay` (cursor lock) activates during drag

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] **QA:** Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in CodeSandbox and Kibana
- [ ] **QA:** Tested docs changes
- [x] **Tests:** Updated Jest tests
- [x] **Changelog:** Added changelog entry
- [ ] **Breaking changes:** N/A